### PR TITLE
RPackage: depend less on categories in RPackage tests

### DIFF
--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -12,39 +12,39 @@ Class {
 { #category : 'tests - adding classes' }
 RPackageClassesSynchronisationTest >> testAddClassAddItIntoPackageBestMatchName [
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
-	self ensureTagYinX.
+	| package tag class |
+	tag := self ensureTagYinX.
+	package := tag package.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX-YYYY'.
+	class := self newClassNamed: 'NewClass' inTag: tag.
 
-	self assert: (tmpPackage definesClass: class).
-	self assert: class package equals: tmpPackage
+	self assert: (package definesClass: class).
+	self assert: class package equals: package
 ]
 
 { #category : 'tests - adding classes' }
 RPackageClassesSynchronisationTest >> testAddClassAddItIntoPackageExactName [
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
+	| xPackage class |
+	xPackage := self ensureXPackage.
 	self ensureTagYinX.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
-	self assert: (tmpPackage definesClass: class).
-	self assert: class package equals: tmpPackage
+	self assert: (xPackage definesClass: class).
+	self assert: class package equals: xPackage
 ]
 
 { #category : 'tests - adding classes' }
 RPackageClassesSynchronisationTest >> testAddClassUpdateTheOrganizerMappings [
 	"test that when we add a class, the organizer 'classPackageMapping' dictionary is updated, so that the class is linked to its package and so that we can access its owning package"
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
+	| xPackage class |
+	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
-	self assert: class package equals: tmpPackage
+	self assert: class package equals: xPackage
 ]
 
 { #category : 'tests - recategorizing class' }
@@ -56,7 +56,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRaisesClassRepackaged
 
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: yPackage.
 	class category: 'YYYYY'.
 
 	self assert: ann isNotNil.
@@ -74,7 +74,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInThe
 	self ensureTagYinX.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: yPackage.
 
 	class category: 'XXXXX-YYYY'.
 	self assert: (self organizer packageOf: class) equals: xPackage.
@@ -89,7 +89,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInThe
 	xPackage := self ensureXPackage.
 	self ensureTagYinX.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: yPackage.
 
 	class category: 'XXXXX'.
 
@@ -105,7 +105,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInThe
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: yPackage.
 
 	class category: 'XXXXX'.
 	self deny: (self organizer packageOf: class) equals: yPackage.
@@ -121,7 +121,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassMetho
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'method1' inClass: class inCategory: 'category'.
 	self createMethodNamed: 'method2' inClass: class inCategory: '*zzzzz'.
 	self createMethodNamed: 'method3' inClass: class inCategory: '*yyyyy'.
@@ -149,7 +149,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUnregisterTheClassFro
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	class category: 'YYYYY'.
 	self deny: (xPackage includesClass: class)
@@ -164,7 +164,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUnregisterTheClassMet
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'method1' inClass: class inCategory: 'category'.
 	self createMethodNamed: 'method2' inClass: class inCategory: '*zzzzz'.
 	self createMethodNamed: 'method3' inClass: class inCategory: '*yyyyy'.
@@ -179,10 +179,10 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUnregisterTheClassMet
 RPackageClassesSynchronisationTest >> testRecategorizeClassUpdateTheOrganizerMappings [
 	"test that when we recategorize a class, the organizer is updated so that the class name point the the new RPackage"
 
-	| yPackage class |
-	self ensureXPackage.
+	| xPackage yPackage class |
+	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	class category: 'YYYYY'.
 	self assert: (self organizer packageOf: class) equals: yPackage
 ]
@@ -196,7 +196,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassWithMetaClassMethodsR
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'method1' inClass: class class inCategory: 'category'.
 	self createMethodNamed: 'method2' inClass: class class inCategory: '*yyyyy'.
@@ -217,7 +217,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassWithUnexistingPackage
 	| xPackage yYPackage class |
 	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self assert: (self organizer packageOf: class) equals: xPackage.
 
 	class category: 'YYYYY'.
@@ -233,7 +233,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassDefinedMe
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	self organizer environment removeClassNamed: 'NewClass'.
@@ -247,7 +247,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassExtension
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	self organizer environment removeClassNamed: 'NewClass'.
@@ -260,7 +260,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassFromItsPa
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self organizer environment removeClassNamed: 'NewClass'.
 	self deny: (xPackage includesClass: class)
@@ -272,7 +272,7 @@ RPackageClassesSynchronisationTest >> testRemoveClassUpdateTheOrganizerMappings 
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self organizer environment removeClassNamed: 'NewClass'.
 	self deny: (self organizer packageOf: class) isNil
@@ -285,7 +285,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassDefinedInThePare
 	| xPackage class |
 	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'RPackageOldStubClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'RPackageOldStubClass' in: xPackage.
 	class rename: 'RPackageNewStubClass'.
 
 	self assert: (xPackage includesClassNamed: 'RPackageNewStubClass').
@@ -298,7 +298,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassDefinedSelectors
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self newClassNamed: 'RPackageOldStubClass' asSymbol in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	class rename: 'RPackageNewStubClass'.
@@ -313,7 +313,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateClassExtensionSelecto
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self newClassNamed: #RPackageOldStubClass in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	class rename: 'RPackageNewStubClass'.
@@ -327,7 +327,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateMetaclassDefinedSelec
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self newClassNamed: #RPackageOldStubClass in: xPackage.
 	self createMethodNamed: 'stubMethod' inClassSideOfClass: class inCategory: 'classic category'.
 
 	class rename: 'RPackageNewStubClass'.
@@ -342,7 +342,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateMetaclassExtensionSel
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' asSymbol inCategory: 'XXXXX'.
+	class := self newClassNamed: #RPackageOldStubClass in: xPackage.
 	self createMethodNamed: 'stubMethod' inClassSideOfClass: class inCategory: '*yyyyy'.
 
 	class rename: 'RPackageNewStubClass'.
@@ -357,7 +357,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassExtendi
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: #RPackageOldStubClass in: xPackage.
 	self createMethodNamed: #stubMethod inClass: class inCategory: '*yyyyy'.
 
 	class rename: 'RPackageNewStubClass'.
@@ -371,7 +371,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassPackage
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'RPackageOldStubClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'RPackageOldStubClass' in: xPackage.
 
 	class rename: 'RPackageNewStubClass'.
 
@@ -383,10 +383,10 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassPackage
 RPackageClassesSynchronisationTest >> testReorganizeClassByAddingExtensionProtocol [
 	"test that when we reoganized a class by adding a category, nothing change from  RPackage point of vue."
 
-	| class |
-	self ensureXPackage.
+	| class xPackage |
+	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'newMethod' inClass: class inCategory: 'xxxxx'.
 	class addProtocol: '*yyyyy'.
 
@@ -399,7 +399,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByAddingNewProtocolDoes
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'newMethod' inClass: class inCategory: 'xxxxx'.
 	class addProtocol: 'accessing'.
 
@@ -414,7 +414,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRemovingClassicCatego
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 	class removeProtocol: 'classic category'.
 	self deny: (xPackage includesDefinedSelector: #stubMethod ofClass: class)
@@ -427,7 +427,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRemovingExtensionCate
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
@@ -444,7 +444,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCatego
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 	self createMethodNamed: 'stubMethod2' inClass: class inCategory: 'classic category'.
@@ -464,7 +464,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingClassicCatego
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 	class renameProtocol: 'classic category' as: '*yyyyy'.
 	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
@@ -479,7 +479,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	class renameProtocol: '*yyyyy' as: '*zzzzz'.
 	self assert: (zPackage includesExtensionSelector: #stubMethod ofClass: class).
@@ -494,7 +494,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	self createMethodNamed: 'stubMethod2' inClass: class inCategory: '*yyyyy'.
@@ -514,7 +514,7 @@ RPackageClassesSynchronisationTest >> testReorganizeClassByRenamingExtensionCate
 	| xPackage yPackage class |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	class renameProtocol: '*yyyyy' as: 'classic category'.
 	self deny: (yPackage includesExtensionSelector: #stubMethod ofClass: class).

--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -56,7 +56,7 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRaisesClassRepackaged
 
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self newClassNamed: 'NewClass' in: yPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	class category: 'YYYYY'.
 
 	self assert: ann isNotNil.

--- a/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
@@ -13,13 +13,13 @@ Class {
 RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryBestMatchingNameAddMethodToTheExtendingPackage [
 	"test that when we add a method  in an extension category ( beginning with*) that enlarge a package name (for example *mondrian-accessing for Mondrian), this method is added to the corresponding extending package"
 
-	| class xPackage yPackage |
+	| class xPackage yPackage tag |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	self ensureTagYinX.
+	tag := self ensureTagYinX.
 
-	self createNewClassNamed: 'NewClass' inCategory: 'XXXXX-YYYY'.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'YYYYY'.
+	self newClassNamed: 'NewClass' inTag: tag.
+	class := self newClassNamed: 'NewClass' in: yPackage.
 
 	self createMethodNamed: #newMethod inClass: class inCategory: '*XXXXX-YYYY'.
 
@@ -36,7 +36,7 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryM
 	| class xPackage yPackage |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: #newMethod inClass: class inCategory: '*YYYYY-subcategory'.
 
@@ -50,10 +50,10 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryM
 RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryNotExistingCreateANewPackage [
 	"test that when we add a method  in an extension category ( beginning with *)that does not refer to an existing categorya new package with the name of this category is added, and that the method is added to this new package"
 
-	| class firstPackage |
-	firstPackage := self ensureXPackage.
+	| class xPackage |
+	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: #newMethod inClass: class inCategory: '*SomethingDifferentNothingToDoWithWhatWeHave'.
 
@@ -66,10 +66,10 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryN
 RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryNotExistingCreateANewPackageAndInstallsMethodInIt [
 	"test that when we add a method  in an extension category ( beginning with *)that does not refer to an existing categorya new package with the name of this category is added, and that the method is added to this new package"
 
-	| class firstPackage |
-	firstPackage := self ensureXPackage.
+	| class xPackage |
+	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: #newMethod inClass: class inCategory: '*SomethingDifferentNothingToDoWithWhatWeHave'.
 
@@ -83,83 +83,83 @@ RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryN
 RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryNotRespectingCaseAddMethodToTheExtendingPackage [
 	"test that when we add a method  in an extension category ( beginning with *)thae does not match the case of the corresponding package (for example *packagea for PackageA), this method is added to the corresponding extending package"
 
-	| class firstPackage secondPackage |
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	| class xPackage yPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyYyY'.
 
-	self assert: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self deny: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self deny: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
 
-	self assert: (class >> #stubMethod) package equals: secondPackage
+	self assert: (class >> #stubMethod) package equals: yPackage
 ]
 
 { #category : 'we are not sure' }
 RPackageExtensionMethodsSynchronisationTest >> testAddMethodInExtensionCategoryWithExactMatchAddMethodToTheExtendingPackage [
 	"test that when we add a method to a  class in an extension category ( beginning with *), this method is added to the corresponding extending package"
 
-	| class firstPackage secondPackage |
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
+	| class xPackage yPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
 	self ensureTagYinX.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*YYYYY'.
 
-	self assert: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self deny: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self deny: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
 
-	self assert: (class >> #stubMethod) package equals: secondPackage
+	self assert: (class >> #stubMethod) package equals: yPackage
 ]
 
 { #category : 'tests - operations on methods' }
 RPackageExtensionMethodsSynchronisationTest >> testModifyMethodByChangingCode [
 	"test that when we modify the code of a method, everything work well: NOTHING SHOULD HAPPEN REGARDING THE PACKAGING"
 
-	| class firstPackage |
-	firstPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	| class xPackage |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	class compile: 'stubMethod ^22222222222'.
 
 	"nothing should change"
 	self assert: (class >> #stubMethod) protocolName equals: 'classic category'.
-	self assert: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (firstPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: firstPackage
+	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (xPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: xPackage
 ]
 
 { #category : 'tests - operations on methods' }
 RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensionsOnClass [
 	"Move a class in package XXXXX (with extensions from YYYY) to package YYYYY."
 
-	| class secondPackage |
-	self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*' , secondPackage name.
+	| class yPackage xPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*' , yPackage name.
 
-	secondPackage addClass: class.
+	yPackage addClass: class.
 
 	"Everything should now be in second package (and not listed as an extension)."
 	self deny: (class >> #stubMethod) isClassified.
-	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: secondPackage
+	self assert: (yPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: yPackage
 ]
 
 { #category : 'tests - operations on methods' }
 RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensionsOnClassAndBack [
 	"Move a class in package XXXXX (with extensions from YYYY) to package YYYYY."
 
-	| class firstPackage secondPackage |
-	firstPackage := self ensureXPackage.
+	| class xPackage secondPackage |
+	xPackage := self ensureXPackage.
 	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*' , secondPackage name.
 
 	secondPackage addClass: class.
@@ -173,10 +173,10 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 
 	"Moving back, we should not see the extension reappear."
 
-	firstPackage addClass: class.
+	xPackage addClass: class.
 
 	self deny: (class >> #stubMethod) isClassified.
-	self assert: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
 	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class)
 ]
 
@@ -188,7 +188,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveAllExtensionMethodsFrom
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	self createMethodNamed: 'stubMethod2' inClass: class classSide inCategory: '*yyyyy'.
 
@@ -206,7 +206,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveAllExtensionMethodsRemo
 	| xPackage class yPackage |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	self createMethodNamed: 'stubMethod2' inClass: class inCategory: '*yyyyy'.
 
@@ -226,7 +226,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveExtensionMethodDoesNotR
 	| xPackage class yPackage |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 	self createMethodNamed: 'stubMethod2' inClass: class inCategory: '*yyyyy'.
 
@@ -247,7 +247,7 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveExtensionMethodRemoveMe
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	class removeSelector: #stubMethod.

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -56,7 +56,7 @@ RPackageMCSynchronisationTest >> emptyOrganizer [
 { #category : 'utilities' }
 RPackageMCSynchronisationTest >> ensureTagYinX [
 
-	self organizer ensureTagNamed: #YYYY inPackageNamed: #XXXXX
+	^ self organizer ensureTagNamed: #YYYY inPackageNamed: #XXXXX
 ]
 
 { #category : 'utilities' }

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -124,7 +124,7 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenModifyMethodBy
 	| ann class |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: 'XXXXX'.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
@@ -141,7 +141,7 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenMovingClassicC
 	| ann class |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: 'XXXXX'.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic'.
 
@@ -155,20 +155,20 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenMovingClassicC
 { #category : 'to move to a simple RPackage test case' }
 RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromClassicCategoryToExtensionCategory [
 
-	| ann class firstPackage secondPackage |
+	| ann class xPackage yPackage |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
 
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	class classify: #stubMethod under: '*yyyyy'.
 
 	self assert: ann isNotNil.
 	self assert: ann methodRepackaged selector equals: #stubMethod.
-	self assert: ann oldPackage equals: firstPackage.
-	self assert: ann newPackage equals: secondPackage.
+	self assert: ann oldPackage equals: xPackage.
+	self assert: ann newPackage equals: yPackage.
 	ann := nil.
 
 	class classify: #stubMethod under: '*yyyyy-suncategory'.
@@ -179,39 +179,39 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 { #category : 'to move to a simple RPackage test case' }
 RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromDifferentExtensionCategories [
 
-	| ann class secondPackage thirdPackage |
+	| ann class yPackage zPackage |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
 
 	self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	thirdPackage := self ensureZPackage.
+	yPackage := self ensureYPackage.
+	zPackage := self ensureZPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: 'XXXXX'.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	class classify: #stubMethod under: '*zzzzz'.
 
 	self assert: ann isNotNil.
 	self assert: ann methodRepackaged selector equals: #stubMethod.
-	self assert: ann oldPackage equals: secondPackage.
-	self assert: ann newPackage equals: thirdPackage
+	self assert: ann oldPackage equals: yPackage.
+	self assert: ann newPackage equals: zPackage
 ]
 
 { #category : 'to move to a simple RPackage test case' }
 RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromExtensionCategoryToClassicCategory [
 
-	| ann class firstPackage secondPackage |
+	| ann class xPackage yPackage |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
 
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	class classify: #stubMethod under: 'classic one'.
 
 	self assert: ann isNotNil.
 	self assert: ann methodRepackaged selector equals: #stubMethod.
-	self assert: ann oldPackage equals: secondPackage.
-	self assert: ann newPackage equals: firstPackage
+	self assert: ann oldPackage equals: yPackage.
+	self assert: ann newPackage equals: xPackage
 ]

--- a/src/Monticello-Tests/RPackageMethodsSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMethodsSynchronisationTest.class.st
@@ -13,10 +13,10 @@ Class {
 RPackageMethodsSynchronisationTest >> testAddMethodInClassicCategoryAddMethodToTheParentPackageOfItsClass [
 	"test that when we add a method to a  class in a classic category (not beginning with *), this method is added to the parent package of the class"
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
+	| xPackage class |
+	xPackage := self ensureXPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
@@ -28,10 +28,10 @@ RPackageMethodsSynchronisationTest >> testAddMethodInClassicCategoryAddMethodToT
 RPackageMethodsSynchronisationTest >> testAddMethodInClassicCategoryAddMethodToTheParentPackageOfItsTrait [
 	"test that when we add a method to a  trait in a classic category (*not beginning with *), this method is added to the parent package of the class"
 
-	| tmpPackage trait |
-	tmpPackage := self ensureXPackage.
+	| xPackage trait |
+	xPackage := self ensureXPackage.
 
-	trait := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX'.
+	trait := self newTraitNamed: 'NewClass' in: xPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'classic category'.
 
@@ -43,9 +43,9 @@ RPackageMethodsSynchronisationTest >> testAddMethodInClassicCategoryAddMethodToT
 RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromClassicCategoryToClassicCategoryDoesNothing [
 	"test that when we move a method from a classic category (not begining with *) to another classic category , the packaging keeps the same"
 
-	| class firstPackage |
-	firstPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	| class xPackage |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	"this we do"
@@ -53,46 +53,46 @@ RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromClassicCategor
 
 	"this we check"
 	self assert: (class >> #stubMethod) protocolName equals: 'new category'.
-	self assert: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (firstPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: firstPackage
+	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (xPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: xPackage
 ]
 
 { #category : 'tests - operations on methods' }
 RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromClassicCategoryToExtensionCategoryMoveItFromClassPackageToExtendingPackage [
 	"test that when we move a method from a classic category (not begining with *) to an extension category , the method is moved from the parent package of the class to the extending package"
 
-	| class firstPackage secondPackage |
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	| class xPackage yPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	class classify: #stubMethod under: '*yyyyy'.
-	self deny: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self assert: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: secondPackage.
+	self deny: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: yPackage.
 
 	class classify: #stubMethod under: '*yyyyy-subcategory'.
-	self deny: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self assert: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: secondPackage
+	self deny: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self assert: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: yPackage
 ]
 
 { #category : 'tests - operations on methods' }
 RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromExtensionCategoryToClassicCategoryMoveItFromExtendingPackageToClassPackage [
 	"test that when we move a method from an extension category ( begining with *) to a classic category , the method is moved from the extending package to the parent package of the class"
 
-	| class firstPackage secondPackage |
-	firstPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	| class xPackage yPackage |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*yyyyy'.
 
 	class classify: #stubMethod under: 'classic category'.
-	self assert: (firstPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: firstPackage
+	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: xPackage
 ]
 
 { #category : 'tests - operations on methods' }
@@ -103,7 +103,7 @@ RPackageMethodsSynchronisationTest >> testModifyMethodByMovingFromExtensionCateg
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: #newMethod inClass: class inCategory: '*yyyyy'.
 
 	class classify: #newMethod under: '*zzzzz'.
@@ -119,7 +119,7 @@ RPackageMethodsSynchronisationTest >> testRemoveMethodRemoveMethodFromItsPackage
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: class inCategory: 'classic category'.
 
 	class removeSelector: #stubMethod.

--- a/src/Monticello-Tests/RPackageTraitSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageTraitSynchronisationTest.class.st
@@ -17,8 +17,8 @@ RPackageTraitSynchronisationTest >> testAddMethodByUsingATraitDoesNotAddTheMetho
 	| xPackage yPackage class trait |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
+	trait := self newTraitNamed: 'NewTrait' in: yPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'trait category'.
 
 	self assertEmpty: xPackage methods.
@@ -31,39 +31,39 @@ RPackageTraitSynchronisationTest >> testAddMethodByUsingATraitDoesNotAddTheMetho
 { #category : 'tests - operations on traits' }
 RPackageTraitSynchronisationTest >> testAddTraitAddItIntoPackageBestMatchName [
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
-	self ensureTagYinX.
+	| xPackage tag class |
+	tag := self ensureTagYinX.
+	xPackage := tag package.
 
-	class := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX-YYYY'.
+	class := self newTraitNamed: 'NewClass' inTag: tag.
 
-	self assert: (tmpPackage definesClass: class).
-	self assert: tmpPackage equals: class package
+	self assert: (xPackage definesClass: class).
+	self assert: xPackage equals: class package
 ]
 
 { #category : 'tests - operations on traits' }
 RPackageTraitSynchronisationTest >> testAddTraitAddItIntoPackageExactName [
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
+	| xPackage class |
+	xPackage := self ensureXPackage.
 	self ensureTagYinX.
 
-	class := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newTraitNamed: 'NewClass' in: xPackage.
 
-	self assert: (tmpPackage definesClass: class).
-	self assert: tmpPackage equals: class package
+	self assert: (xPackage definesClass: class).
+	self assert: xPackage equals: class package
 ]
 
 { #category : 'tests - operations on traits' }
 RPackageTraitSynchronisationTest >> testAddTraitUpdateTheOrganizerMappings [
 	"test that when we add a Trait, the organizer 'classPackageMapping' dictionary is updated, so that the trait is linked to its package and so that we can access its owning package"
 
-	| tmpPackage class |
-	tmpPackage := self ensureXPackage.
+	| xPackage class |
+	xPackage := self ensureXPackage.
 
-	class := self createNewTraitNamed: 'NewClass' inCategory: 'XXXXX'.
+	class := self newTraitNamed: 'NewClass' in: xPackage.
 
-	self assert: class package equals: tmpPackage
+	self assert: class package equals: xPackage
 ]
 
 { #category : 'tests - operations on methods' }
@@ -74,8 +74,8 @@ RPackageTraitSynchronisationTest >> testRemoveMethodComingFromTraitDoesNotRemove
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	trait := self newTraitNamed: 'NewTrait' in: yPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'classic protocol'.
 	class setTraitComposition: trait asTraitComposition.
@@ -92,8 +92,8 @@ RPackageTraitSynchronisationTest >> testRemoveTraitMethod [
 	| xPackage yPackage class trait |
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	trait := self newTraitNamed: 'NewTrait' in: yPackage.
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'classic protocol'.
 	class setTraitComposition: trait asTraitComposition.
 
@@ -110,8 +110,8 @@ RPackageTraitSynchronisationTest >> testRemoveTraitMethodOverridenByClassDoesRem
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	trait := self newTraitNamed: 'NewTrait' in: yPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'classic protocol'.
 	class setTraitComposition: trait asTraitComposition.
@@ -129,8 +129,8 @@ RPackageTraitSynchronisationTest >> testTraitCompositionMethodsArePackagedWithTh
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
-	class := self createNewClassNamed: 'NewClass' inCategory: 'XXXXX'.
-	trait := self createNewTraitNamed: 'NewTrait' inCategory: 'YYYYY'.
+	class := self newClassNamed: 'NewClass' in: yPackage.
+	trait := self newTraitNamed: 'NewTrait' in: yPackage.
 
 	self createMethodNamed: 'stubMethod' inClass: trait inCategory: 'classic protocol'.
 	class setTraitComposition: trait asTraitComposition.

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -533,12 +533,13 @@ RPackage >> isTestPackage [
 	"1. Test package ends with suffix -Tests. Suffix is case sensitive.
 	 2. Or test package contains '-Tests-' in middle.
 	Some examples: "
+
 	"(RPackage named: 'MockPackage-Tests') isTestPackage >>> true"
-	"(RPackage named: 'MockPackage-tests') isTestPackage >>> false"
+	"(RPackage named: 'MockPackage-tests') isTestPackage >>> true"
 	"(RPackage named: 'MockPackage') isTestPackage >>> false"
 	"(RPackage named: 'MockPackage-Tests-Package') isTestPackage >>> true"
 
-	^ (self name endsWith: '-Tests') or: [self name includesSubstring: '-Tests-']
+	^ (self name endsWith: '-Tests' caseSensitive: false) or: [ self name includesSubstring: '-Tests-' caseSensitive: false ]
 ]
 
 { #category : 'accessing' }

--- a/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
+++ b/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
@@ -26,11 +26,11 @@ RPackageCompleteSetupButForModificationTest >> setUp [
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
-	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
-	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
-	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
+	b1 := self newClassNamed: #B1DefinedInP1 in: p1.
+	a2 := self newClassNamed: #A2DefinedInP2 in: p2.
+	b2 := self newClassNamed: #B2DefinedInP2 in: p2.
+	a3 := self newClassNamed: #A3DefinedInP3 in: p3.
 
 	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
 	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -64,7 +64,7 @@ RPackageIncrementalTest >> testAddRemoveMethod [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 
 	p2 addMethod: a2 >> #methodDefinedInP2.
@@ -97,7 +97,7 @@ RPackageIncrementalTest >> testAddRemoveSelector [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 
 	p2 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2').
 	p1 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1').
@@ -124,7 +124,7 @@ RPackageIncrementalTest >> testClassAddition [
 
 	| p a1 |
 	p := self ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1.
+	a1 := self newClassNamed: #A1InPAckageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
 	self assert: p definedClasses size equals: 1.
@@ -137,8 +137,8 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 
 	| p a1 b1 |
 	p := self ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1.
-	b1 := self createNewClassNamed: #B1InPAckageP1.
+	a1 := self newClassNamed: #A1InPAckageP1 in: self p2Name.
+	b1 := self newClassNamed: #B1InPAckageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
 
 	p importClass: a1.
@@ -163,8 +163,8 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 	| p a1 b1 |
 	p := self ensurePackage: self p1Name.
 
-	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: p.
-	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: p.
+	a1 := self newClassNamed: #A1InPAckageP1 in: p.
+	b1 := self newClassNamed: #B1InPAckageP1 in: p.
 	self assert: p definedClasses size equals: 2.
 
 	p importClass: a1 inTag: 'a1-tag'.
@@ -189,12 +189,12 @@ RPackageIncrementalTest >> testDefinedClassesAndDefinedClassNames [
 
 	| p a1 b1 |
 	p := self ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p.
+	a1 := self newClassNamed: #A1InPackageP1 in: p.
 	self assert: p definedClasses size equals: 1.
 	self assert: (p definedClasses includes: a1).
 	self assert: (p definedClassNames includes: a1 name).
 
-	b1 := self createNewClassNamed: #B1InPackageP1 inPackage: p.
+	b1 := self newClassNamed: #B1InPackageP1 in: p.
 	self assert: p definedClasses size equals: 2.
 	self assert: (p definedClasses includes: b1).
 	self assert: (p definedClassNames includes: b1 name)
@@ -206,8 +206,8 @@ RPackageIncrementalTest >> testExtensionClassNames [
 	| p1 p2 a2 b2 |
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
+	b2 := self newClassNamed: #B2InPackageP2 in: p2.
 	self deny: (p1 includesClass: a2).
 	self assert: (p2 includesClass: b2).
 	self assert: (p2 includesClass: a2).
@@ -242,8 +242,8 @@ RPackageIncrementalTest >> testExtensionClasses [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
+	b2 := self newClassNamed: #B2InPackageP2 in: p2.
 	self deny: (p1 includesClass: a2).
 	self assert: (p2 includesClass: a2).
 
@@ -270,8 +270,8 @@ RPackageIncrementalTest >> testExtensionClassesWithCompiledMethod [
 	| p1 p2 a2 b2 |
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
+	b2 := self newClassNamed: #B2InPackageP2 in: p2.
 	self deny: (p1 includesClass: a2).
 	self assert: (p2 includesClass: b2).
 	self assert: (p2 includesClass: b2).
@@ -306,8 +306,8 @@ RPackageIncrementalTest >> testExtensionMethods [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
+	b2 := self newClassNamed: #B2InPackageP2 in: p2.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 
 	self assert: p1 extensionSelectors size equals: 1.
@@ -323,11 +323,11 @@ RPackageIncrementalTest >> testImportClassNoDuplicate [
 
 	| p a1 b1 |
 	p := self ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPackageP1.
+	a1 := self newClassNamed: #A1InPackageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
 	self assert: p definedClasses size equals: 1.
-	b1 := self createNewClassNamed: #B1InPackageP1.
+	b1 := self newClassNamed: #B1InPackageP1 in: self p2Name.
 	p importClass: a1.
 	"adding the same class does not do anything - luckily"
 	self assert: p definedClasses size equals: 1.
@@ -342,7 +342,7 @@ RPackageIncrementalTest >> testIncludeClass [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 
 	self deny: (p1 includesClass: a2).
@@ -364,7 +364,7 @@ RPackageIncrementalTest >> testIncludeClassMore [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
@@ -381,7 +381,7 @@ RPackageIncrementalTest >> testIncludeSelectorOfClass [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
@@ -407,7 +407,7 @@ RPackageIncrementalTest >> testIncludeSelectorOfMetaClass [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 class compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	a2 class compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 	a2 class compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
@@ -434,7 +434,7 @@ RPackageIncrementalTest >> testIncludesMethodOfClassInPresenceOfOtherPackageExte
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 
 	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
@@ -459,7 +459,7 @@ RPackageIncrementalTest >> testIncludesOrTouches [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	self deny: (p1 includesClass: a2).
 	self assert: (p2 includesClass: a2).
 
@@ -477,7 +477,7 @@ RPackageIncrementalTest >> testMethodAddition [
 
 	| p1 a1 |
 	p1 := self ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
 	a1 compileSilently: 'foo ^ 10'.
 	p1 addMethod: a1 >> #foo.
 	self assert: (p1 includesSelector: #foo ofClass: a1)
@@ -488,7 +488,7 @@ RPackageIncrementalTest >> testMethodPackageResolution [
 
 	| p1 a1 |
 	p1 := self ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A2InPackageP1 inPackage: p1.
+	a1 := self newClassNamed: #A2InPackageP1 in: p1.
 	a1 compile: 'method ^ #methodDefinedInP1'.
 	a1 class compile: 'method ^ #methodDefinedInP1'.
 
@@ -503,7 +503,7 @@ RPackageIncrementalTest >> testPackageOfClassForClassesNotDefinedInPackageButJus
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
 	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
 
 	self assert: a2 package equals: p2.
@@ -517,8 +517,8 @@ RPackageIncrementalTest >> testPackageOfClassForDefinedClasses [
 
 	| p a1 b1 |
 	p := self ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1 inPackage: p.
-	b1 := self createNewClassNamed: #B1InPAckageP1 inPackage: p.
+	a1 := self newClassNamed: #A1InPAckageP1 in: p.
+	b1 := self newClassNamed: #B1InPAckageP1 in: p.
 
 	self assert: a1 package equals: p.
 	self assert: b1 package equals: p
@@ -531,7 +531,7 @@ RPackageIncrementalTest >> testRemoveClassRemovesExtensions [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 	"the class is created but not added to the package for now"
-	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p1.
+	a1 := self newClassNamed: #A1InPackageP1 in: p1.
 	self assert: p1 definedClasses size equals: 1.
 	a1 compile: 'methodDefinedInP2 ^ #methodDefinedInP2' classified: '*' , p2 name.
 
@@ -552,7 +552,7 @@ RPackageIncrementalTest >> testRemoveExtensionMethodRemovesExtensionsFromPackage
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 	"the class is created but not added to the package for now"
-	a1 := self createNewClassNamed: #A1InPackageP1 inPackage: p1.
+	a1 := self newClassNamed: #A1InPackageP1 in: p1.
 	self assert: p1 definedClasses size equals: 1.
 	a1 compile: 'methodDefinedInP2 ^ #methodDefinedInP2' classified: '*' , p2 name.
 
@@ -573,8 +573,8 @@ RPackageIncrementalTest >> testTwoClassesWithExtensions [
 	p1 := self ensurePackage: self p1Name.
 	p2 := self ensurePackage: self p2Name.
 
-	a2 := self createNewClassNamed: #A2InPackageP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2InPackageP2 inPackage: p2.
+	a2 := self newClassNamed: #A2InPackageP2 in: p2.
+	b2 := self newClassNamed: #B2InPackageP2 in: p2.
 	a2 compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 	b2 class compile: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*' , p1 name.
 
@@ -587,7 +587,7 @@ RPackageIncrementalTest >> testUniqueClassInDefinedClassesUsingAddClassDefinitio
 
 	| p a1 |
 	p := self ensurePackage: self p1Name.
-	a1 := self createNewClassNamed: #A1InPAckageP1.
+	a1 := self newClassNamed: #A1InPackageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
 	p importClass: a1.
 	self assert: p definedClasses size equals: 1.

--- a/src/RPackage-Tests/RPackageObsoleteTest.class.st
+++ b/src/RPackage-Tests/RPackageObsoleteTest.class.st
@@ -23,7 +23,7 @@ RPackageObsoleteTest >> testAnnouncementClassRemovedIsRaisedOnRemoveFromSystem [
 	[
 	notRun := false.
 	SystemAnnouncer uniqueInstance weak when: ClassRemoved send: #setNotRun to: self.
-	foo := self createNewClassNamed: #FooForTest2.
+	foo := self newClassNamed: #FooForTest2 in: self p1Name.
 	self deny: notRun.
 	foo removeFromSystem.
 	self assert: notRun ] ensure: [ SystemAnnouncer uniqueInstance unsubscribe: self ]
@@ -34,7 +34,7 @@ RPackageObsoleteTest >> testMethodPackageFromObsoleteClass [
 
 	| pack method foo |
 	pack := self ensurePackage: 'P1'.
-	foo := self createNewClassNamed: #FooForTest inPackage: pack.
+	foo := self newClassNamed: #FooForTest in: pack.
 	foo compile: 'bar ^42'.
 	method := foo >> #bar.
 
@@ -52,7 +52,7 @@ RPackageObsoleteTest >> testMethodPackageOfRemovedClass [
 
 	| pack method foo |
 	pack := self ensurePackage: 'P1'.
-	foo := self createNewClassNamed: #FooForTest2 inPackage: pack.
+	foo := self newClassNamed: #FooForTest2 in: pack.
 	foo compile: 'bar ^42'.
 	method := foo >> #bar.
 	foo removeFromSystem.

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -397,8 +397,8 @@ RPackageOrganizerTest >> testTestPackageNames [
 	| packages |
 	packages := #( 'MockPackage-Tests' 'MockPackage2-tests' 'MockPackage' 'MockPackage-Tests-Package' ) collect: [ :pName | self ensurePackage: pName ].
 
-	"Only 2 mock package names are test packages:  'MockPackage-Tests' 'MockPackage-Tests-Package'"
-	self assert: self organizer testPackageNames size equals: 2.
+	"Only 3 mock package names are test packages:  'MockPackage-Tests' 'MockPackage2-tests' 'MockPackage-Tests-Package'"
+	self assert: self organizer testPackageNames size equals: 3.
 
 	"Names of test packages are symbols."
 	self assert: (self organizer testPackageNames allSatisfy: #isSymbol)
@@ -410,8 +410,8 @@ RPackageOrganizerTest >> testTestPackages [
 	| packages |
 	packages := #( 'MockPackage-Tests' 'MockPackage2-tests' 'MockPackage' 'MockPackage-Tests-Package' ) collect: [ :pName | self ensurePackage: pName ].
 
-	"Only 2 mock packages are test packages:  'MockPackage-Tests' 'MockPackage-Tests-Package'."
-	self assert: self organizer testPackages size equals: 2.
+	"Only 2 mock packages are test packages:  'MockPackage-Tests' 'MockPackage2-tests' 'MockPackage-Tests-Package'."
+	self assert: self organizer testPackages size equals: 3.
 
 	"all items from resulting collection are test packages."
 	self assert: (self organizer testPackages allSatisfy: #isTestPackage)

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -66,7 +66,7 @@ RPackageOrganizerTest >> testDefinedClassesInstanceAndMetaSideAPI [
 
 	| p1 |
 	p1 := self ensurePackage: self p1Name.
-	self createNewClassNamed: #MyPoint inPackage: p1.
+	self newClassNamed: #MyPoint in: p1.
 	self assert: self organizer packageNames size equals: 2.
 	self assert: self organizer packages size equals: 2.
 	self assert: (self organizer packageNamed: self p1Name) definedClasses size equals: 1
@@ -101,7 +101,7 @@ RPackageOrganizerTest >> testExtensionMethodNotExactlyTheName [
 	p1 := self ensurePackage: 'P1'.
 	p2 := self ensurePackage: 'P2'.
 
-	c1 := self createNewClassNamed: #C1 inPackage: p2.
+	c1 := self newClassNamed: #C1 in: p2.
 
 	c1 compileSilently: 'methodPackagedInP1 ^ #methodPackagedInP1' classified: '*p1-something'.
 	self organizer addMethod: c1 >> #methodPackagedInP1.
@@ -119,11 +119,11 @@ RPackageOrganizerTest >> testFullRegistration [
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
-	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
-	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
-	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
+	b1 := self newClassNamed: #B1DefinedInP1 in: p1.
+	a2 := self newClassNamed: #A2DefinedInP2 in: p2.
+	b2 := self newClassNamed: #B2DefinedInP2 in: p2.
+	a3 := self newClassNamed: #A3DefinedInP3 in: p3.
 
 	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
 	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
@@ -292,7 +292,7 @@ RPackageOrganizerTest >> testRegisteredPackages [
 RPackageOrganizerTest >> testRegistrationExtendingPackages [
 
 	| p |
-	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
+	self newClassNamed: 'QuadrangleForTesting' in: self class package.
 	self assertEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
 	p := self ensurePackage: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
@@ -316,10 +316,10 @@ RPackageOrganizerTest >> testRemoveEmptyPackagesAndTags [
 	tag1 := package3 ensureTag: #Tag1.
 	tag2 := package3 ensureTag: #Tag2.
 
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1'.
+	class := self newClassNamed: 'TestClass' in: package1.
 	class compile: 'extension ^ 1' classified: '*Test2'.
 
-	class := self createNewClassNamed: 'TestClass2' inCategory: 'Test3-Tag1'.
+	class := self newClassNamed: 'TestClass2' inTag: tag1.
 
 	self assert: (self organizer hasPackage: package1).
 	self deny: package1 isEmpty.
@@ -353,11 +353,11 @@ RPackageOrganizerTest >> testRemovePackage [
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
-	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
-	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
-	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
+	b1 := self newClassNamed: #B1DefinedInP1 in: p1.
+	a2 := self newClassNamed: #A2DefinedInP2 in: p2.
+	b2 := self newClassNamed: #B2DefinedInP2 in: p2.
+	a3 := self newClassNamed: #A3DefinedInP3 in: p3.
 
 	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
 	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
@@ -395,7 +395,7 @@ RPackageOrganizerTest >> testRenameUpdateTheOrganizer [
 RPackageOrganizerTest >> testTestPackageNames [
 
 	| packages |
-	packages := self createMockTestPackages.
+	packages := #( 'MockPackage-Tests' 'MockPackage2-tests' 'MockPackage' 'MockPackage-Tests-Package' ) collect: [ :pName | self ensurePackage: pName ].
 
 	"Only 2 mock package names are test packages:  'MockPackage-Tests' 'MockPackage-Tests-Package'"
 	self assert: self organizer testPackageNames size equals: 2.
@@ -408,7 +408,7 @@ RPackageOrganizerTest >> testTestPackageNames [
 RPackageOrganizerTest >> testTestPackages [
 
 	| packages |
-	packages := self createMockTestPackages.
+	packages := #( 'MockPackage-Tests' 'MockPackage2-tests' 'MockPackage' 'MockPackage-Tests-Package' ) collect: [ :pName | self ensurePackage: pName ].
 
 	"Only 2 mock packages are test packages:  'MockPackage-Tests' 'MockPackage-Tests-Package'."
 	self assert: self organizer testPackages size equals: 2.
@@ -438,7 +438,7 @@ RPackageOrganizerTest >> testUnregister [
 RPackageOrganizerTest >> testUnregistrationExtendingPackages [
 
 	| p |
-	self createNewClassNamed: 'QuadrangleForTesting' inCategory: self class category.
+	self newClassNamed: 'QuadrangleForTesting' in: self class package.
 	p := self ensurePackage: 'P1'.
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -42,11 +42,11 @@ RPackageReadOnlyCompleteSetupTest >> setUp [
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
-	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
-	a2 := self createNewClassNamed: #A2DefinedInP2 inPackage: p2.
-	b2 := self createNewClassNamed: #B2DefinedInP2 inPackage: p2.
-	a3 := self createNewClassNamed: #A3DefinedInP3 inPackage: p3.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
+	b1 := self newClassNamed: #B1DefinedInP1 in: p1.
+	a2 := self newClassNamed: #A2DefinedInP2 in: p2.
+	b2 := self newClassNamed: #B2DefinedInP2 in: p2.
+	a3 := self newClassNamed: #A3DefinedInP3 in: p3.
 
 	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
 	a1 compile: 'anotherMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.

--- a/src/RPackage-Tests/RPackageRenameTest.class.st
+++ b/src/RPackage-Tests/RPackageRenameTest.class.st
@@ -15,7 +15,7 @@ RPackageRenameTest >> testRenamePackage [
 	| package workingCopy class |
 	package := self ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
-	class := self createNewClassNamed: #TestClass inCategory: 'Test1-TAG'.
+	class := self newClassNamed: #TestClass in: package tag: 'TAG'.
 
 	self assert: (package includesClass: class).
 	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
@@ -42,8 +42,8 @@ RPackageRenameTest >> testRenamePackageToOwnTagName [
 	| package workingCopy class1 class2 |
 	package := self ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
-	class1 := self createNewClassNamed: #TestClass1 inCategory: 'Test1-Core'.
-	class2 := self createNewClassNamed: #TestClass2 inCategory: 'Test1-Util'.
+	class1 := self newClassNamed: #TestClass1 in: package tag: 'Core'.
+	class2 := self newClassNamed: #TestClass2 in: package tag: 'Util'.
 
 	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) notNil.
 	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) notNil.
@@ -66,9 +66,9 @@ RPackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	| package workingCopy class1 class2 class3 |
 	package := self ensurePackage: 'Test1'.
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
-	class1 := self createNewClassNamed: #TestClass1 inCategory: 'Test1-Core'.
-	class2 := self createNewClassNamed: #TestClass2 inCategory: 'Test1-Util'.
-	class3 := self createNewClassNamed: #TestClass3 inCategory: 'Test1'.
+	class1 := self newClassNamed: #TestClass1 in: package tag: 'Core'.
+	class2 := self newClassNamed: #TestClass2 in: package tag: 'Util'.
+	class3 := self newClassNamed: #TestClass3 in: 'Test1'.
 
 	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) notNil.
 	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) notNil.
@@ -90,12 +90,12 @@ RPackageRenameTest >> testRenamePackageWithExtensions [
 	| package class extendedPackage extension |
 	package := self ensurePackage: 'OriginalPackage'.
 
-	class := self createNewClassNamed: #TestClass inCategory: 'OriginalPackage-TAG'.
+	class := self newClassNamed: #TestClass in: package tag: 'TAG'.
 
 	extendedPackage := self ensurePackage: 'ExtendedPackage'.
 
 
-	class := self createNewClassNamed: #TestExtendedClass inCategory: 'ExtendedPackage'.
+	class := self newClassNamed: #TestExtendedClass in: extendedPackage.
 
 	class compile: 'm ^ 42' classified: '*OriginalPackage'.
 	extension := class >> #m.
@@ -120,16 +120,10 @@ RPackageRenameTest >> testRenamePackageWithExtensionsInClassSide [
 
 	| package class extendedPackage extension |
 	package := self ensurePackage: 'OriginalPackage'.
-
-	class := self createNewClassNamed: #TestClass inCategory: 'OriginalPackage-TAG'.
-
+	class := self newClassNamed: #TestClass in: package tag: 'TAG'.
 	extendedPackage := self ensurePackage: 'ExtendedPackage'.
-
-
-	class := self createNewClassNamed: #TestExtendedClass inCategory: 'ExtendedPackage'.
-
+	class := self newClassNamed: #TestExtendedClass in: extendedPackage.
 	class := class class.
-
 	class compile: 'm ^ 42' classified: '*OriginalPackage'.
 	extension := class >> #m.
 
@@ -157,7 +151,7 @@ RPackageRenameTest >> testUnregisterPackage [
 	package := self ensurePackage: 'Test1'.
 
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
-	class := self createNewClassNamed: #TestClass inCategory: 'Test1-TAG'.
+	class := self newClassNamed: #TestClass in: package tag: 'TAG'.
 	self assert: (package includesClass: class).
 	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
 	self assert: ((package classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -13,7 +13,7 @@ RPackageTagTest >> testAddClass [
 
 	| package1 package2 tag class |
 	package1 := self ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inPackage: package1.
+	class := self newClassNamed: 'TestClass' in: package1.
 
 	self assert: (package1 includesClass: class).
 
@@ -35,7 +35,7 @@ RPackageTagTest >> testAddClassFromTag [
 
 	| package1 package2 class |
 	package1 := self ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG1'.
 
 	self assert: (package1 includesClass: class).
 	self assert: (package1 hasTag: #TAG1).
@@ -56,7 +56,7 @@ RPackageTagTest >> testHasClass [
 
 	| package class tag |
 	package := self ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
+	class := self newClassNamed: 'TestClass' in: package tag: 'TAG'.
 	tag := class packageTag.
 
 	self assert: (package includesClass: class).
@@ -73,7 +73,7 @@ RPackageTagTest >> testPromoteAsPackage [
 
 	| package1 package2 class tag1 |
 	package1 := self ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG1'.
+	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	tag1 := package1 classTagNamed: 'TAG1'.
@@ -92,7 +92,7 @@ RPackageTagTest >> testRemoveClass [
 	| package tag class |
 	package := self ensurePackage: #Test1.
 	tag := package ensureTag: #TAG.
-	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
+	class := self newClassNamed: 'TestClass' in: package tag: 'TAG'.
 
 	self assert: (tag includesClass: class).
 
@@ -109,7 +109,7 @@ RPackageTagTest >> testRemoveClassRemoveTagIfEmpty [
 	| package tag class |
 	package := self ensurePackage: #Test1.
 	tag := package ensureTag: #TAG.
-	class := self createNewClassNamed: 'TestClass' inCategory: package name , '-TAG'.
+	class := self newClassNamed: 'TestClass' in: package tag: 'TAG'.
 
 	self assert: (tag includesClass: class).
 	self assert: (package hasTag: tag).

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -14,7 +14,7 @@ RPackageTest >> testAddClass [
 	| package1 package2 class done |
 	package1 := self ensurePackage: #Test1.
 	done := 0.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
+	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG'.
 
 
 	self assert: (package1 includesClass: class).
@@ -38,7 +38,7 @@ RPackageTest >> testAddClassFromTag [
 
 	| package1 package2 class |
 	package1 := self ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
+	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG'.
 
 	self assert: (package1 includesClass: class).
 
@@ -58,8 +58,8 @@ RPackageTest >> testAllUnsentMessages [
 	| package class1 class2 |
 	package := self ensurePackage: #Test1.
 
-	class1 := self createNewClassNamed: 'TestClass' inCategory: 'Test1-TAG'.
-	class2 := self createNewClassNamed: 'TestClassOther' inCategory: 'Test1-TAG'.
+	class1 := self newClassNamed: 'TestClass' in: package tag: 'TAG'.
+	class2 := self newClassNamed: 'TestClassOther' in: package tag: 'TAG'.
 
 	class1
 		compile: 'nonexistingMethodName1 42';
@@ -98,7 +98,7 @@ RPackageTest >> testDemoteToRPackageNamed [
 
 	| package1 package2 class |
 	package1 := self ensurePackage: #'Test1-TAG1'.
-	class := self createNewClassNamed: 'TestClass' inPackage: package1.
+	class := self newClassNamed: 'TestClass' in: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackage.
@@ -116,7 +116,7 @@ RPackageTest >> testDemoteToRPackageNamedExistingPackage [
 	| package1 package2 packageExisting class |
 	package1 := self ensurePackage: #'Test1-TAG1'.
 	packageExisting := self ensurePackage: #Test1.
-	class := self createNewClassNamed: 'TestClass' inPackage: package1.
+	class := self newClassNamed: 'TestClass' in: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackage.
@@ -147,7 +147,7 @@ RPackageTest >> testDemoteToRPackageNamedMultilevelPackage [
 
 	| package1 package2 class |
 	package1 := self ensurePackage: #'Test1-TAG1-X1'.
-	class := self createNewClassNamed: 'TestClass' inPackage: package1.
+	class := self newClassNamed: 'TestClass' in: package1.
 	class compile: 'foo ^42' classified: 'accessing'.
 
 	package1 demoteToTagInPackage.
@@ -164,10 +164,10 @@ RPackageTest >> testDemoteToRPackageNamedWithExtension [
 
 	| packageOriginal packageDemoted class classOther |
 	packageOriginal := self ensurePackage: #'Test1-TAG1'.
-	class := self createNewClassNamed: 'TestClass' inPackage: packageOriginal.
+	class := self newClassNamed: 'TestClass' in: packageOriginal.
 	class compile: 'foo ^42' classified: 'accessing'.
 
-	classOther := self createNewClassNamed: 'TestClassOther' inCategory: 'XXXX'.
+	classOther := self newClassNamed: 'TestClassOther' in: 'XXXX'.
 	classOther compile: 'bar ^42' classified: #'*Test1-TAG1'.
 
 	packageOriginal demoteToTagInPackage.
@@ -210,21 +210,18 @@ RPackageTest >> testHierarchyRoots [
 { #category : 'tests' }
 RPackageTest >> testIsTestPackage [
 
-	|packages |
-	packages := self createMockTestPackages.
-	"Happy case: test package 'MockPackage-Tests' must contain -Tests suffix."
-	self assert: packages first isTestPackage equals: true.
+	| package |
+	package := self organizer ensurePackage: 'MockPackage-Tests'.
+	self assert: package isTestPackage. "Happy case: test package 'MockPackage-Tests' must contain -Tests suffix."
 
-	"Package 'MockPackage2-tests' is not test package, since it has lowercase suffix."
-	self assert: packages second isTestPackage  equals: false.
+	package := self organizer ensurePackage: 'MockPackage-tests'.
+	self deny: package isTestPackage. "Package 'MockPackage-tests' is not test package, since it has lowercase suffix."
 
-	"Happy case: regular package 'MockPackage' without -Tests suffix is not a test package."
-	self assert: packages third isTestPackage  equals: false.
+	package := self organizer ensurePackage: 'MockPackage'.
+	self deny: package isTestPackage. "Happy case: regular package 'MockPackage' without -Tests suffix is not a test package."
 
-	"Package 'MockPackage-Tests-Package' containting -Tests- in middle, so it is test package."
-	self assert: packages fourth isTestPackage equals: true.
-
-	"cleanup of inst.vars should be done in tearDown"
+	package := self organizer ensurePackage: 'MockPackage-Tests-Package'.
+	self assert: package isTestPackage "Package 'MockPackage-Tests-Package' containting -Tests- in middle, so it is test package."
 ]
 
 { #category : 'tests - MC' }
@@ -269,7 +266,7 @@ RPackageTest >> testRemoveEmptyTags [
 	tag1 := package ensureTag: #Tag1.
 	tag2 := package ensureTag: #Tag2.
 
-	class := self createNewClassNamed: 'TestClass' inCategory: 'Test1-Tag1'.
+	class := self newClassNamed: 'TestClass' inTag: tag1.
 
 	self assert: (tag1 includesClass: class).
 	self deny: tag1 isEmpty.
@@ -290,8 +287,8 @@ RPackageTest >> testRemoveTag [
 	| p1 a1 b1 |
 	p1 := self ensurePackage: #P1.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
-	b1 := self createNewClassNamed: #B1DefinedInP1 inPackage: p1.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
+	b1 := self newClassNamed: #B1DefinedInP1 in: p1.
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
 	p1 importClass: a1 inTag: #foo.
@@ -317,7 +314,7 @@ RPackageTest >> testRemoveTagRemoveClasses [
 	| p1 a1 |
 	p1 := self ensurePackage: #P1.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
 	p1 importClass: a1 inTag: #foo.
@@ -341,8 +338,8 @@ RPackageTest >> testRenamePackageAlsoRenameAllExtensionProtocols [
 	p2 := self ensurePackage: #Test2.
 	p3 := self ensurePackage: #Test3.
 
-	classInY := self createNewClassNamed: 'ClassInYPackage' inPackage: p2.
-	classInZ := self createNewClassNamed: 'ClassInZPackage' inPackage: p3.
+	classInY := self newClassNamed: 'ClassInYPackage' in: p2.
+	classInZ := self newClassNamed: 'ClassInZPackage' in: p3.
 
 	classInY compile: #extensionFromXInClassInY classified: '*' , p1 name.
 	classInY compile: #longNameExtensionFromXInClassInY classified: '*' , p1 name , '-subcategory'.

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -214,8 +214,8 @@ RPackageTest >> testIsTestPackage [
 	package := self organizer ensurePackage: 'MockPackage-Tests'.
 	self assert: package isTestPackage. "Happy case: test package 'MockPackage-Tests' must contain -Tests suffix."
 
-	package := self organizer ensurePackage: 'MockPackage-tests'.
-	self deny: package isTestPackage. "Package 'MockPackage-tests' is not test package, since it has lowercase suffix."
+	package := self organizer ensurePackage: 'MockPackage2-tests'.
+	self assert: package isTestPackage. "Package 'MockPackage-tests' is not test package, since it has lowercase suffix."
 
 	package := self organizer ensurePackage: 'MockPackage'.
 	self deny: package isTestPackage. "Happy case: regular package 'MockPackage' without -Tests suffix is not a test package."

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -12,70 +12,72 @@ Class {
 }
 
 { #category : 'utilities' }
-RPackageTestCase >> createMockTestPackages [
-
-	^ self namesOfMockTestPackages collect: [:pName | self ensurePackage: pName]
-]
-
-{ #category : 'utilities' }
-RPackageTestCase >> createNewClassNamed: aName [
-	^ self createNewClassNamed: aName inCategory: 'RPackageTest'
-]
-
-{ #category : 'utilities' }
-RPackageTestCase >> createNewClassNamed: aName inCategory: cat [
-
-	^ self class classInstaller make: [ :aClassBuilder |
-		  aClassBuilder
-			  name: aName;
-			  installingEnvironment: testEnvironment;
-			  package: cat ]
-]
-
-{ #category : 'utilities' }
-RPackageTestCase >> createNewClassNamed: aName inPackage: p [
-
-	| cls |
-	cls := self createNewClassNamed: aName inCategory: p name.
-	p importClass: cls.
-	^ cls
-]
-
-{ #category : 'utilities' }
-RPackageTestCase >> createNewTraitNamed: aName [
-	^ self createNewTraitNamed: aName inCategory: 'RPackageTest'
-]
-
-{ #category : 'utilities' }
-RPackageTestCase >> createNewTraitNamed: aName inCategory: cat [
-
-	^ self class classInstaller make: [ :aBuilder |
-		  aBuilder
-			  name: aName;
-			  package: cat;
-			  installingEnvironment: testEnvironment;
-			  beTrait ]
-]
-
-{ #category : 'utilities' }
-RPackageTestCase >> createNewTraitNamed: aName inPackage: p [
-
-	| cls |
-	cls := self createNewTraitNamed: aName.
-	p importClass: cls.
-	^ cls
-]
-
-{ #category : 'utilities' }
 RPackageTestCase >> ensurePackage: aName [
 
 	^ self organizer ensurePackage: aName
 ]
 
 { #category : 'utilities' }
-RPackageTestCase >> namesOfMockTestPackages [
+RPackageTestCase >> newClassNamed: aName in: aPackage [
 
-	^ #( 'MockPackage-Tests' 'MockPackage2-tests' 'MockPackage' 'MockPackage-Tests-Package')
+	^ self class classInstaller make: [ :aClassBuilder |
+		  aClassBuilder
+			  name: aName;
+			  installingEnvironment: testEnvironment;
+			  package: (aPackage isString
+					   ifTrue: [ aPackage ]
+					   ifFalse: [ aPackage name ]) ]
+]
+
+{ #category : 'utilities' }
+RPackageTestCase >> newClassNamed: aName in: aPackage tag: aTag [
+
+	^ self class classInstaller make: [ :aClassBuilder |
+		  aClassBuilder
+			  name: aName;
+			  installingEnvironment: testEnvironment;
+			  package: (aPackage isString
+					   ifTrue: [ aPackage ]
+					   ifFalse: [ aPackage name ]);
+			  tag: (aTag isString
+					   ifTrue: [ aTag ]
+					   ifFalse: [ aTag name ]) ]
+]
+
+{ #category : 'utilities' }
+RPackageTestCase >> newClassNamed: aName inTag: aTag [
+
+	^ self class classInstaller make: [ :aClassBuilder |
+		  aClassBuilder
+			  name: aName;
+			  installingEnvironment: testEnvironment;
+			  package: aTag package name;
+			  tag: aTag name ]
+]
+
+{ #category : 'utilities' }
+RPackageTestCase >> newTraitNamed: aName in: aPackage [
+
+	^ self class classInstaller make: [ :aBuilder |
+		  aBuilder
+			  name: aName;
+			  package: (aPackage isString
+					   ifTrue: [ aPackage ]
+					   ifFalse: [ aPackage name ]);
+			  installingEnvironment: testEnvironment;
+			  beTrait ]
+]
+
+{ #category : 'utilities' }
+RPackageTestCase >> newTraitNamed: aName inTag: aTag [
+
+	^ self class classInstaller make: [ :aBuilder |
+		  aBuilder
+			  name: aName;
+			  package: aTag package name;
+			  tag: aTag name;
+			  installingEnvironment: testEnvironment;
+			  beTrait ]
 ]
 
 { #category : 'accessing' }

--- a/src/RPackage-Tests/RPackageTraitTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitTest.class.st
@@ -25,19 +25,19 @@ RPackageTraitTest >> setUp [
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
 
-	a1 := self createNewClassNamed: #A1DefinedInP1 inPackage: p1.
+	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
 
 	"a1 defines two normal = local methods"
 	a1 compile: 'localMethodDefinedInP1 ^ #methodDefinedInP1'.
 	a1 compile: 'anotherLocalMethodDefinedInP1 ^ #anotherMethodDefinedInP1'.
 
-	t1 := self createNewTraitNamed: #TraitInPackageP1 inPackage: p1.
+	t1 := self newTraitNamed: #TraitInPackageP1 in: p1.
 	t1 compile: 'traitMethodDefinedInP1 ^ #traitMethodDefinedInP1'.
 
 	"P3 defines a new method extension on T1 (packaged in p1)"
 	t1 compile: 'traitMethodExtendedFromP3 ^ #traitMethodExtendedFromP3' classified: '*' , self p3Name.
 
-	t2 := self createNewTraitNamed: #TraitInPackageP2 inPackage: p2.
+	t2 := self newTraitNamed: #TraitInPackageP2 in: p2.
 	t2 compile: 'traitMethodDefinedInP2 ^ #traitMethodDefinedInP2'.
 
 	"Here P1 extends T2 from P2 with a new method"
@@ -51,7 +51,7 @@ RPackageTraitTest >> testMethodOverridingTraitMethodIsKnowByPackage [
 	"Regression test for a bug where adding a method to a class that overrides a method from a trait was not know by the package of the class"
 
 	| a2 |
-	a2 := self createNewClassNamed: #A2DefinedInP1 inPackage: p1.
+	a2 := self newClassNamed: #A2DefinedInP1 in: p1.
 
 	a2 setTraitComposition: t1 asTraitComposition.
 


### PR DESCRIPTION
This change remove a lot of users of categories. Everything end up in Fluid that still uses categories, but when it will not be the case, at least this part of the system will be clean.