### PR TITLE
RPackage: Deprecate RPackage>>#importClass:

### DIFF
--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -98,6 +98,13 @@ RPackage >> extensionCategoriesForClass: aClass [
 ]
 
 { #category : '*Deprecated12' }
+RPackage >> importClass: aClass [
+
+	self deprecated: 'Use #addClass: instead or #moveClass:toTag:' transformWith: '`@rcv importClass: `@arg' -> '`@rcv addClass: `@arg'.
+	^ self addClass: aClass
+]
+
+{ #category : '*Deprecated12' }
 RPackage >> includesDefinedSelector: aSelector ofClassName: aClassName [
 	"Return true if the receiver includes the method of selector aSelector. Only checks methods defined (not extended by other packages or package extensions)"
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -152,7 +152,7 @@ RPackage >> addClass: aClass [
 		- change the class category as appropriate.
 			(and by cascade, ensure systemClassRecategorizedAction: is called)."
 
-	aClass category: self rootTag categoryName
+	aClass instanceSide category: self rootTag categoryName
 ]
 
 { #category : 'add method - compiled method' }
@@ -396,16 +396,6 @@ RPackage >> hierarchyRoots [
 
 	^ self definedClasses
 		select: [ :each | (each superclass isNil or: [ each superclass package ~~ self ]) and: [ each hasSubclasses ] ]
-]
-
-{ #category : 'private' }
-RPackage >> importClass: aClass [
-	"import a class already created but not attached to a package to the receiver.
-	Handle also *- convention. Methods defined in *category are not added to the package.
-	Pay attention that it will not import anything from the metaClass side"
-
-	self flag: #package. "Do not rely on the category here in the future"
-	self importClass: aClass inTag: (self toTagName: aClass category)
 ]
 
 { #category : 'private' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -207,7 +207,10 @@ RPackageOrganizer >> basicInitializeFromPackagesList: aPackagesList [
 	aPackagesList do: [ :packageName | self ensurePackage: packageName ] displayingProgress: 'Importing monticello packages'.
 
 	Smalltalk allClassesAndTraits
-		do: [ :behavior | (self ensurePackageMatching: behavior category) importClass: behavior ]
+		do: [ :behavior |
+			| package |
+			package := self ensurePackageMatching: behavior category.
+			package moveClass: behavior toTag: (package toTagName: behavior category) ]
 		displayingProgress: 'Importing behaviors'.
 
 	Smalltalk allClassesAndTraits

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -57,6 +57,23 @@ RPackageIncrementalTest >> tearDown [
 	super tearDown
 ]
 
+{ #category : 'tests - class addition removal' }
+RPackageIncrementalTest >> testAddClassNoDuplicate [
+
+	| p a1 b1 |
+	p := self ensurePackage: self p1Name.
+	a1 := self newClassNamed: #A1InPackageP1 in: self p2Name.
+	self assertEmpty: p definedClasses.
+	p addClass: a1.
+	self assert: p definedClasses size equals: 1.
+	b1 := self newClassNamed: #B1InPackageP1 in: self p2Name.
+	p addClass: a1.
+	"adding the same class does not do anything - luckily"
+	self assert: p definedClasses size equals: 1.
+	p addClass: b1.
+	self assert: p definedClasses size equals: 2
+]
+
 { #category : 'tests - method addition removal' }
 RPackageIncrementalTest >> testAddRemoveMethod [
 
@@ -126,7 +143,7 @@ RPackageIncrementalTest >> testClassAddition [
 	p := self ensurePackage: self p1Name.
 	a1 := self newClassNamed: #A1InPAckageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
-	p importClass: a1.
+	p addClass: a1.
 	self assert: p definedClasses size equals: 1.
 	self assert: (p includesClass: a1).
 	self assert: (p includesClass: a1 class)
@@ -141,8 +158,8 @@ RPackageIncrementalTest >> testClassDefinitionRemoval [
 	b1 := self newClassNamed: #B1InPAckageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
 
-	p importClass: a1.
-	p importClass: b1.
+	p addClass: a1.
+	p addClass: b1.
 	self assert: p definedClasses size equals: 2.
 
 	self assert: (p includesClass: a1).
@@ -318,23 +335,6 @@ RPackageIncrementalTest >> testExtensionMethods [
 	self assert: p1 extensionSelectors size equals: 2
 ]
 
-{ #category : 'tests - class addition removal' }
-RPackageIncrementalTest >> testImportClassNoDuplicate [
-
-	| p a1 b1 |
-	p := self ensurePackage: self p1Name.
-	a1 := self newClassNamed: #A1InPackageP1 in: self p2Name.
-	self assertEmpty: p definedClasses.
-	p importClass: a1.
-	self assert: p definedClasses size equals: 1.
-	b1 := self newClassNamed: #B1InPackageP1 in: self p2Name.
-	p importClass: a1.
-	"adding the same class does not do anything - luckily"
-	self assert: p definedClasses size equals: 1.
-	p importClass: b1.
-	self assert: p definedClasses size equals: 2
-]
-
 { #category : 'tests - extension' }
 RPackageIncrementalTest >> testIncludeClass [
 
@@ -352,7 +352,7 @@ RPackageIncrementalTest >> testIncludeClass [
 	the class as defined. The reason is that like that the client controls the granularity
 	and moment of class registration."
 
-	p1 importClass: a2.
+	p1 addClass: a2.
 	self assert: (p1 includesClass: a2).
 	self assert: (p1 includesClassNamed: a2 name)
 ]
@@ -589,10 +589,10 @@ RPackageIncrementalTest >> testUniqueClassInDefinedClassesUsingAddClassDefinitio
 	p := self ensurePackage: self p1Name.
 	a1 := self newClassNamed: #A1InPackageP1 in: self p2Name.
 	self assertEmpty: p definedClasses.
-	p importClass: a1.
+	p addClass: a1.
 	self assert: p definedClasses size equals: 1.
-	p importClass: a1.
+	p addClass: a1.
 	self assert: p definedClasses size equals: 1.
-	p importClass: a1 class.
+	p addClass: a1 class.
 	self assert: p definedClasses size equals: 1
 ]

--- a/src/SUnit-Rules-Tests/ReTestClassNotInPackageWithTestEndingNameTest.class.st
+++ b/src/SUnit-Rules-Tests/ReTestClassNotInPackageWithTestEndingNameTest.class.st
@@ -14,7 +14,7 @@ ReTestClassNotInPackageWithTestEndingNameTest >> testBasicCheck [
 		assert: (testClass critiques anySatisfy: [ :critic | critic rule class = ReTestClassNotInPackageWithTestEndingNameRule ]).
 	
 	"move to correct package"
-	validTestPackage importClass: testClass.
+	validTestPackage addClass: testClass.
 	
 	self
 		assert: (testClass critiques noneSatisfy: [ :critic | critic rule class = ReTestClassNotInPackageWithTestEndingNameRule ])


### PR DESCRIPTION
#importClass: is a method relying on the category of a class. Since we want to remove it, here is a change to deprecate and replace this method.

All senders got replaced by #addClass: (which also need to be updated but it will be a leter PR) except one that got is now using #moveClass:toTag: and doing the category manipulation itself.

Requires #14770