### PR TITLE
Following symbolic links when canonicalising FileReferences.

### DIFF
--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -119,6 +119,13 @@ FileReference >> binaryWriteStream [
 	^ ZnBufferedWriteStream on: (filesystem binaryWriteStreamOn: self path)
 ]
 
+{ #category : 'delegated' }
+FileReference >> canonicalize [
+	"Answer the receiver with references to the current folder (.) and parent folder (..) removed"
+
+	^ self withPath: (self path canonicalizeOnFilesystem: filesystem)
+]
+
 { #category : 'accessing' }
 FileReference >> changeTime [
 	^ filesystem changeTimeOf: self path
@@ -160,7 +167,9 @@ FileReference >> delete [
 	"Deletes the referenced file or directory. If the directory is not empty,
 	raises an error. Use #deleteAll to delete with the children."
 
-	(self isDirectory and:[self hasChildren])
+	(self isDirectory and:
+	[ self isSymlink not and: 
+	[ self hasChildren ] ])
 		ifTrue:[DirectoryIsNotEmpty signalWith: self].
 	filesystem delete: path
 ]
@@ -564,9 +573,16 @@ FileReference >> symlinkUid: uid gid: gid [
 ]
 
 { #category : 'accessing' }
+FileReference >> targetFileReference [
+	"Return the target file of the File described by aPath.  For a regular file, this is itself, for a symbolic link, it is the file pointed to by the symbolic link"
+	^ self class fileSystem: filesystem path: self symlinkEntry targetPath
+]
+
+{ #category : 'accessing' }
 FileReference >> targetPath [
 	"Return the target file of the File described by aPath.  For a regular file, this is itself, for a symbolic link, it is the file pointed to by the symbolic link"
-	^ self class fileSystem: filesystem path: (filesystem targetPath: path)
+
+	^ self symlinkEntry targetPath
 ]
 
 { #category : 'accessing' }

--- a/src/FileSystem-Core/MemoryDirectoryEntry.class.st
+++ b/src/FileSystem-Core/MemoryDirectoryEntry.class.st
@@ -80,3 +80,11 @@ MemoryDirectoryEntry >> posixPermissions [
 MemoryDirectoryEntry >> size [
 	^reference size
 ]
+
+{ #category : 'accessing' }
+MemoryDirectoryEntry >> targetPath [
+	"Answer the Path pointing to the real file.
+	MemoryStore doesn't support symbolic links, answer the receivers file path"
+
+	^reference path
+]

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -312,14 +312,17 @@ DiskStore >> defaultWorkingDirectory [
 
 { #category : 'public' }
 DiskStore >> delete: path [
-	| pathString |
+	"Delete the supplied path on the receiver"
+	| pathString isSymlink |
 
-	((self exists: path) or: [ self isSymlink: path ])
+	isSymlink := self isSymlink: path.
+	((self exists: path) or: [ isSymlink ])
 		ifFalse: [ ^ FileDoesNotExistException signalWith: path ].
 
 	pathString := self stringFromPath: path.
 
-	(self isDirectory: path) ifTrue:
+	"Symbolic links answer true to isDirectory:, but must be deleted as a regular file"
+	((self isDirectory: path) and: [ isSymlink not ]) ifTrue:
 		[ File deleteDirectory: (File encodePathString: pathString) ]
 	ifFalse:
 		[ File deleteFile: pathString ]

--- a/src/FileSystem-Memory/MemoryStore.class.st
+++ b/src/FileSystem-Memory/MemoryStore.class.st
@@ -308,3 +308,10 @@ MemoryStore >> replaceFile: path in: aBlock [
 MemoryStore >> root [
 	^ root
 ]
+
+{ #category : 'private' }
+MemoryStore >> symlinkEntryAt: aPath fileSystem: aFilesystem [
+	"MemoryStore doesn't support symbolic links, so a standard entry can be used"
+
+	^ MemoryDirectoryEntry reference: (aFilesystem referenceTo: aPath)
+]

--- a/src/FileSystem-Path/AbsolutePath.class.st
+++ b/src/FileSystem-Path/AbsolutePath.class.st
@@ -14,6 +14,23 @@ Class {
 AbsolutePath class >> addEmptyElementTo: result [
 ]
 
+{ #category : 'private' }
+AbsolutePath class >> addParentElementTo: result on: filesystem [
+	"The parent directory may be a symbolic link, in which case it must be resolved to its target path before determining the result."
+
+	result ifNotEmpty:
+		[ | parentReference entry |
+		parentReference := filesystem referenceTo: (self withAll: result).
+		entry := parentReference symlinkEntry.
+		entry isSymlink ifTrue:
+			[ result removeAll.
+			result addAll: entry targetPath segments ] ].
+
+	(result isEmpty or: [ result last = '..' ])
+		ifTrue: [ result add: '..' ]
+		ifFalse: [ result removeLast ]
+]
+
 { #category : 'instance creation' }
 AbsolutePath class >> from: aString delimiter: aDelimiterCharater [
 	aString = '/'

--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -57,6 +57,16 @@ Path class >> addElement: element to: result [
 ]
 
 { #category : 'private' }
+Path class >> addElement: element to: result on: filesystem [
+	element = '..'
+		ifTrue: [ ^ self addParentElementTo: result on: filesystem ].
+	element = ''
+		ifTrue: [ ^ self addEmptyElementTo: result ].
+	element = '.'
+		ifFalse: [ result add: element ]
+]
+
+{ #category : 'private' }
 Path class >> addEmptyElementTo: result [
 	result isEmpty ifTrue: [result add: '']
 ]
@@ -69,11 +79,31 @@ Path class >> addParentElementTo: result [
 ]
 
 { #category : 'private' }
+Path class >> addParentElementTo: result on: filesystem [
+	"Since this path is relative we don't know what it will be resolved against.
+	Canonicalize assuming no symbolic links"
+
+	(result isEmpty or: [ result last = '..' ])
+		ifTrue: [ result add: '..' ]
+		ifFalse: [ result removeLast ]
+]
+
+{ #category : 'private' }
 Path class >> canonicalizeElements: aCollection [
 	| result |
 	result := OrderedCollection new.
 	aCollection do: [ :element |
 		self addElement: element to: result].
+	^ result
+]
+
+{ #category : 'private' }
+Path class >> canonicalizeElements: aCollection filesystem: filesystem [
+	| result |
+
+	result := OrderedCollection new.
+	aCollection do: [ :element |
+		self addElement: element to: result on: filesystem ].
 	^ result
 ]
 
@@ -304,6 +334,15 @@ Path >> canonicalize [
 	"Answer the receiver with references to the current folder (.) and parent folder (..) removed"
 
 	^self class withAll: (self class canonicalizeElements: self segments)
+]
+
+{ #category : 'navigating' }
+Path >> canonicalizeOnFilesystem: filesystem [
+	"Answer the receiver with references to the current folder (.) and parent folder (..) removed"
+
+	^self class withAll: (self class 
+		canonicalizeElements: self segments 
+		filesystem: filesystem)
 ]
 
 { #category : 'comparing' }

--- a/src/FileSystem-Tests-Attributes/FileReferenceAttributeTest.class.st
+++ b/src/FileSystem-Tests-Attributes/FileReferenceAttributeTest.class.st
@@ -183,11 +183,16 @@ FileReferenceAttributeTest >> testNLink [
 
 { #category : 'tests' }
 FileReferenceAttributeTest >> testTargetFile [
-	"The temporary file isn't a symbolic link, so the targetFile is the file itself"
+	"Linux & Mac: The temporary file isn't a symbolic link, so the targetFile is the file itself.
+	Windows: the attribute isn't supported."
 
-	self assert: self tempFileResource file targetFileReference equals: self tempFileResource file resolve.
-	self assert: self tempFileResource file symlinkEntry targetFileReference equals: self tempFileResource file resolve.
-	
+	[ self assert: self tempFileResource file targetFileReference equals: self tempFileResource file resolve ]
+		on: FileAttributeNotSupported
+		do: [ :ex | OSPlatform current isWindows ifFalse: [ ex pass ] ].
+	[ self assert: self tempFileResource file symlinkEntry targetFileReference equals: self tempFileResource file resolve ]
+		on: FileAttributeNotSupported
+		do: [ :ex | OSPlatform current isWindows ifFalse: [ ex pass ] ].
+
 	"However the DirectoryEntry doesn't have the information"
 	self should: [ self tempFileResource file entry targetPath ] raise: FileAttributeNotSupported.
 ]

--- a/src/FileSystem-Tests-Attributes/FileReferenceAttributeTest.class.st
+++ b/src/FileSystem-Tests-Attributes/FileReferenceAttributeTest.class.st
@@ -183,8 +183,11 @@ FileReferenceAttributeTest >> testNLink [
 
 { #category : 'tests' }
 FileReferenceAttributeTest >> testTargetFile [
+	"The temporary file isn't a symbolic link, so the targetFile is the file itself"
 
-	"The temporary file isn't a symbolic link, so the targetFile isn't supported"
-	self should: [ self tempFileResource file targetPath ] raise: FileAttributeNotSupported.
-	self should: [ self tempFileResource file entry targetPath ] raise: FileAttributeNotSupported
+	self assert: self tempFileResource file targetFileReference equals: self tempFileResource file resolve.
+	self assert: self tempFileResource file symlinkEntry targetFileReference equals: self tempFileResource file resolve.
+	
+	"However the DirectoryEntry doesn't have the information"
+	self should: [ self tempFileResource file entry targetPath ] raise: FileAttributeNotSupported.
 ]

--- a/src/FileSystem-Tests-Core/DeleteVisitorTest.class.st
+++ b/src/FileSystem-Tests-Core/DeleteVisitorTest.class.st
@@ -17,3 +17,32 @@ DeleteVisitorTest >> testBeta [
 	self assert: (filesystem isDirectory: '/alpha/epsilon').
 	self deny: (filesystem exists: '/alpha/beta')
 ]
+
+{ #category : 'tests' }
+DeleteVisitorTest >> testSymbolicLink [
+	"The delete visitor should not follow symbolic links and should delete them as a file."
+	| tempDir aDir bDir symbolicLink symlinkCommand status |
+
+	OSPlatform current isWindows ifTrue: [ ^ self ].
+
+	[ tempDir := FileReference newTempFilePrefix: 'testSymbolLinkTargetPath' suffix: 'dir'.
+	self deny: tempDir exists.
+	tempDir ensureCreateDirectory.
+	aDir := tempDir / 'a'.
+	bDir := tempDir / 'a/b'.
+	(bDir / 'c/d') ensureCreateDirectory.
+	symbolicLink := bDir / 'c/sl'.
+
+	symlinkCommand := 'cd ', (bDir / 'c') fullName, ' && ln -s ', aDir fullName, ' sl'.
+	status := LibC uniqueInstance system: symlinkCommand.
+	status = 0 ifFalse: [ self error: 'Unable to create symbolic link' ].
+
+	self assert: symbolicLink isSymlink.
+	self assert: symbolicLink isDirectory.
+	self assert: symbolicLink targetFileReference equals: aDir.
+	bDir ensureDeleteAll.
+	self assert: aDir exists.
+	self deny: bDir exists ]
+			ensure: [ tempDir ensureDeleteAll ].
+
+]

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -1106,6 +1106,78 @@ FileReferenceTest >> testSlash [
 ]
 
 { #category : 'tests' }
+FileReferenceTest >> testSymbolicLink [
+	"The delete visitor should not follow symbolic links and should delete them as a file."
+	| tempDir aDir bDir symbolicLink symlinkCommand status |
+
+	OSPlatform current isWindows ifTrue: [ ^ self ].
+
+	[ tempDir := FileReference newTempFilePrefix: 'testSymbolLinkTargetPath' suffix: 'dir'.
+	self deny: tempDir exists.
+	tempDir ensureCreateDirectory.
+	aDir := tempDir / 'a'.
+	bDir := tempDir / 'a/b'.
+	(bDir / 'c/d') ensureCreateDirectory.
+	symbolicLink := bDir / 'c/sl'.
+
+	symlinkCommand := 'cd ', (bDir / 'c') fullName, ' && ln -s ', aDir fullName, ' sl'.
+	status := LibC uniqueInstance system: symlinkCommand.
+	status = 0 ifFalse: [ self error: 'Unable to create symbolic link' ].
+
+	self assert: symbolicLink isSymlink.
+	self assert: symbolicLink isDirectory.
+	self assert: symbolicLink targetFileReference equals: aDir.
+	bDir ensureDeleteAll.
+	self assert: aDir exists.
+	self deny: bDir exists ]
+			ensure: [ tempDir ensureDeleteAll ].
+
+]
+
+{ #category : 'tests' }
+FileReferenceTest >> testSymbolicLinkInMemory [
+	"Confirm that in-memory files behave as expected with symbolic link requests.
+	That is... symbolic links aren't supported, to #isSymlink always returns false and the targetFileReference is always the original file"
+	| file |
+
+	file := FileSystem memory root / 'a.file'.
+	file writeStreamDo: [ :s | s << 'hello, world' ].
+
+	self deny: file isSymlink.
+	self assert: file targetFileReference equals: file.
+]
+
+{ #category : 'tests' }
+FileReferenceTest >> testSymbolicLinkTargetPath [
+	<gtExample>
+	| tempDir dDir symbolicLink symlinkCommand status |
+
+	OSPlatform current isWindows ifTrue: [ ^ self ].
+
+	[ tempDir := FileReference newTempFilePrefix: 'testSymbolLinkTargetPath' suffix: 'dir'.
+	tempDir ensureCreateDirectory.
+	dDir := tempDir / 'a/b/c/d'.
+	dDir ensureCreateDirectory.
+	symbolicLink := tempDir / 'a/sl'.
+
+	symlinkCommand := 'cd ', (tempDir / 'a') fullName, ' && ln -s ', dDir fullName, ' sl'.
+	status := LibC uniqueInstance system: symlinkCommand.
+	status = 0 ifFalse: [ self error: 'Unable to create symbolic link' ].
+
+	self assert: symbolicLink isSymlink.
+	self assert: (tempDir / 'a/sl/../abc') canonicalize path
+		equals: (tempDir / 'a/b/c/abc') path.
+
+	"Symbolic link operations shouldn't raise an error if the target doesn't exist"
+	dDir deleteAll.
+	self assert: symbolicLink isSymlink.
+	self assert: (tempDir / 'a/sl/../abc') canonicalize path
+		equals: (tempDir / 'a/b/c/abc') path ]
+			ensure: [ tempDir ensureDeleteAll ].
+
+]
+
+{ #category : 'tests' }
 FileReferenceTest >> testTempFilePrefixSuffix [
 	| fileRef |
 	fileRef := FileReference newTempFilePrefix: 'FileReference' suffix: 'Test'.

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -998,9 +998,11 @@ symbolic link information
 					self platformSupportsSymbolicLinksEgUnix]]]) ifTrue:
 						[DiskSymlinkDirectoryEntry fileSystem: DiskStore currentFileSystem path: aString asPath]"
 	error isPrimitiveError ifTrue: [
-		(attributeNumber = 16 and: [ error errorCode = self unsupportedOperation ]) ifTrue:
-			"If symlinks aren't supported, answer false"
-			[ ^false ]].
+		"If symlinks aren't supported or the supplied path doesn't exist, answer false"
+		(attributeNumber = 16 and: 
+			[ error errorCode = self unsupportedOperation or:
+			[ error errorCode = self cantStatPath ] ]) ifTrue:
+				[ ^false ] ].
 	^self signalError: error for: aByteArray
 ]
 


### PR DESCRIPTION
Fixes: https://github.com/pharo-project/pharo/issues/14757

Additional unit tests:

- DeleteVisitorTest >> testSymbolicLink
- FileReferenceTest >> testSymbolicLink
- FileReferenceTest >> testSymbolicLinkInMemory
- FileReferenceTest >> testSymbolicLinkTargetPath