### PR TITLE
Monticello: Unloading a package should not load it in the change model

### DIFF
--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -39,9 +39,8 @@ MCPackageLoader class >> installSnapshot: aSnapshot [
 
 { #category : 'public' }
 MCPackageLoader class >> unloadPackage: aPackage [
-	self new
-		unloadPackage: aPackage;
-		loadWithNameLike: aPackage name, '-unload'
+
+	self new unloadPackage: aPackage
 ]
 
 { #category : 'public' }


### PR DESCRIPTION
Removing a monticello working copy was comiting the code in the change set with a new name - unload. But this feature does not work since a while anymore and just slow things down. I propose to just remove it