### PR TITLE
RPackage: Deprecated RPackage>>#packageName

### DIFF
--- a/src/Calypso-NavigationModel/RPackage.extension.st
+++ b/src/Calypso-NavigationModel/RPackage.extension.st
@@ -3,5 +3,5 @@ Extension { #name : 'RPackage' }
 { #category : '*Calypso-NavigationModel' }
 RPackage >> calypsoName [
 
-	^ name
+	^ self name
 ]

--- a/src/Manifest-Core/RPackage.extension.st
+++ b/src/Manifest-Core/RPackage.extension.st
@@ -30,5 +30,5 @@ RPackage >> packageComment: aDescription [
 RPackage >> packageManifest [
 	^ self definedClasses
 		detect: [ :each | each isManifest ]
-		ifNone: [ TheManifestBuilder new createManifestNamed: name]
+		ifNone: [ TheManifestBuilder new createManifestNamed: self name]
 ]

--- a/src/Monticello/RPackage.extension.st
+++ b/src/Monticello/RPackage.extension.st
@@ -30,7 +30,7 @@ RPackage >> mcPackage [
 { #category : '*Monticello-RPackage' }
 RPackage >> mcWorkingCopy [
 
-	^ (MCWorkingCopy hasPackageNamed: name)
-		  ifTrue: [ MCWorkingCopy forPackageNamed: name ]
+	^ (MCWorkingCopy hasPackageNamed: self name)
+		  ifTrue: [ MCWorkingCopy forPackageNamed: self name ]
 		  ifFalse: [ nil ]
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -607,7 +607,8 @@ RPackage >> packageManifestOrNil [
 { #category : 'accessing' }
 RPackage >> packageName [
 
-	^ name
+	self deprecated: 'Use #name instead.' transformWith: '`@rcv packageName' -> '`@rcv name'.
+	^ self name
 ]
 
 { #category : 'system compatibility' }


### PR DESCRIPTION
This method is equivalent to #name. I propose to remove it. I also remove some direct accesses to #name since I plan to introduce a subclass to RPackage that will override #name.