### PR TITLE
RPackage: Always return undefined package for unpackaged class

### DIFF
--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -311,13 +311,13 @@ FluidClassDefinitionPrinter >> msgAndClassNameOn: s [
 FluidClassDefinitionPrinter >> packageOn: s [
 	"The code to get the package name is not nice but it is possible we are asking the definition to a class that was uninstalled from the system and in that case it does not know its package anymore. And some code in the image expect to have the package of the class with the same name instead."
 
+	self flag: #package. "The current way of getting the package is really slow but it is the only way to get a package for the removed classes. This is the wrong package then but we have breaking tests if we fix it for now :(
+	I'll come with a better fix once the classes will know their package tag"
 	s
 		crtab;
 		nextPutAll: 'package: ';
 		nextPut: $';
-		nextPutAll: ((forClass packageOrganizer packageOfClassNamed: forClass name)
-				 ifNotNil: [ :package | package name ]
-				 ifNil: [ UndefinedPackage undefinedPackageName ]);
+		nextPutAll: (forClass packageOrganizer packageOfClassNamed: forClass name) name;
 		nextPut: $'
 ]
 

--- a/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageClassesSynchronisationTest.class.st
@@ -371,12 +371,12 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassPackage
 
 	| xPackage class |
 	xPackage := self ensureXPackage.
-	class := self newClassNamed: 'RPackageOldStubClass' in: xPackage.
+	class := self newClassNamed: #RPackageOldStubClass in: xPackage.
 
-	class rename: 'RPackageNewStubClass'.
+	class rename: #RPackageNewStubClass.
 
 	self assert: (self organizer packageOf: class) equals: xPackage.
-	self assert: (self organizer packageOfClassNamed: 'RPackageOldStubClass' asSymbol) equals: nil
+	self assert: (self organizer packageOfClassNamed: #RPackageOldStubClass) equals: self organizer undefinedPackage
 ]
 
 { #category : 'tests - operations on protocols' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -402,10 +402,9 @@ RPackageOrganizer >> packageOf: aClass [
 { #category : 'package - access from class' }
 RPackageOrganizer >> packageOfClassNamed: aName [
 
-	self flag: #pharoFixMe. "Should probably return _UnunpackagedPackage instead of nil"
 	classPackageMapping keysAndValuesDo: [ :class :package | class originalName = aName ifTrue: [ ^ package ] ].
 
-	^ nil
+	^ self undefinedPackage
 ]
 
 { #category : 'accessing' }

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -83,13 +83,12 @@ RPackageTest >> testAnonymousClassAndSelector [
 
 	"Make sure we don't have a registration or a package for the method."
 
-	| ghost method uPackage |
+	| ghost method |
 	ghost := Object newAnonymousSubclass.
-	uPackage := self organizer packageNamed: #'_UnpackagedPackage'.
 	method := ghost compiler compile: 'rpackagetest'.
 	ghost addSelector: #rpackagetest withMethod: method.
-	self deny: (uPackage includesDefinedSelector: #rpackagetest ofClass: ghost).
-	self deny: (self organizer packageOfClassNamed: ghost name) notNil.
+	self deny: (self organizer undefinedPackage includesDefinedSelector: #rpackagetest ofClass: ghost).
+	self assert: (self organizer packageOfClassNamed: ghost name) equals: self organizer undefinedPackage.
 	ghost classify: #rpackagetest under: '*rpackagetest'
 ]
 

--- a/src/Shift-ClassInstaller-Tests/ShAnonymousClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShAnonymousClassInstallerTest.class.st
@@ -17,5 +17,5 @@ ShAnonymousClassInstallerTest >> testSubclasses [
 	self assert: aSubClass superclass equals: Point.
 	self deny: (Smalltalk hasClassNamed: #AnotherPoint).
 
-	self assert: (self packageOrganizer packageOfClassNamed: aSubClass name) isNil
+	self assert: (self packageOrganizer packageOfClassNamed: aSubClass name) equals: self packageOrganizer undefinedPackage
 ]

--- a/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
@@ -202,12 +202,12 @@ T2TraitWithPackagesTest >> testPackageOfRemovedTrait [
 	t2 removeFromSystem.
 
 	self assert: (self packageOrganizer packageOfClassNamed: #T1) equals: self packageUnderTest.
-	self assert: (self packageOrganizer packageOfClassNamed: #T2) isNil.
+	self assert: (self packageOrganizer packageOfClassNamed: #T2) equals: self packageOrganizer undefinedPackage.
 
 	t1 removeFromSystem.
 
-	self assert: (self packageOrganizer packageOfClassNamed: #T1) isNil.
-	self assert: (self packageOrganizer packageOfClassNamed: #T2) isNil
+	self assert: (self packageOrganizer packageOfClassNamed: #T1) equals: self packageOrganizer undefinedPackage.
+	self assert: (self packageOrganizer packageOfClassNamed: #T2) equals: self packageOrganizer undefinedPackage
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
RPackageOrganizer>>packageOfClassNamed: was returning nil in case of unpackages classes. Now it is returning the unpackaged package to have more cohreant behaviors