### PR TITLE
Bootstrap should use P10 VM for small image 

### DIFF
--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -37,6 +37,17 @@ if [ ! -e "${BOOTSTRAP_VMTARGET}" ]; then
 	echo "Target VM: $(${VM} --version)"
 fi
 
+if [ ! -e "${BOOTSTRAP_DOWNLOADS}/vmBootstrap/pharo" ]; then
+
+	rm -rf "${BOOTSTRAP_DOWNLOADS}/vmBootstrap"
+	mkdir ${BOOTSTRAP_DOWNLOADS}/vmBootstrap
+	cd ${BOOTSTRAP_DOWNLOADS}/vmBootstrap
+
+	${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 100 vm $BOOTSTRAP_ARCH
+	cd -
+	echo "Bootstrap VM: $(${VM_BOOTSTRAP} --version)"
+fi 
+
 if [ ! -e "${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip" ]; then
 	download_to https://github.com/guillep/PharoBootstrap/releases/download/v1.7.8/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip
 fi 

--- a/bootstrap/scripts/3-prepare.sh
+++ b/bootstrap/scripts/3-prepare.sh
@@ -11,5 +11,5 @@ SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 
 set_version_variables
 
-${VM} Pharo.image ${IMAGE_FLAGS} ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/prepare_image.st --save --quit
-${VM} Pharo.image ${IMAGE_FLAGS} ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/bootstrap.st --ARCH=${BOOTSTRAP_ARCH} --BUILD_NUMBER=${BUILD_NUMBER} --VERSION_INFO="${PHARO_NAME_PREFIX}-${PHARO_COMMIT_HASH}" --quit
+${VM_BOOTSTRAP} Pharo.image ${IMAGE_FLAGS} ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/prepare_image.st --save --quit
+${VM_BOOTSTRAP} Pharo.image ${IMAGE_FLAGS} ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/bootstrap.st --ARCH=${BOOTSTRAP_ARCH} --BUILD_NUMBER=${BUILD_NUMBER} --VERSION_INFO="${PHARO_NAME_PREFIX}-${PHARO_COMMIT_HASH}" --quit

--- a/bootstrap/scripts/envvars.sh
+++ b/bootstrap/scripts/envvars.sh
@@ -49,13 +49,17 @@ then
 fi
 export BOOTSTRAP_DOWNLOADS
 
-# This is the VM used to bootstrap, i.e. the target VM
+# This is the VM used to load the code, i.e. the target VM
 if [ -z ${BOOTSTRAP_VMTARGET+x} ]
 then
     VM="${BOOTSTRAP_DOWNLOADS}/vmtarget/pharo --headless"
 else
     VM="${BOOTSTRAP_VMTARGET} --headless"
 fi
+
+#This is the VM to use during the bootstrap (initialization of the small image)
+VM_BOOTSTRAP="${BOOTSTRAP_DOWNLOADS}/vmBootstrap/pharo --headless"
+
 
 # Flags to run the image
 IMAGE_FLAGS="--no-default-preferences"


### PR DESCRIPTION
- Boostrapping of small image should use P10 (using Espell)
- Adding a P10 VM download so we can run the build

