### PR TITLE
remove #braceArray, #braceArray: and #braceStream:

### DIFF
--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -55,14 +55,6 @@ Class {
 	#tag : 'Base'
 }
 
-{ #category : 'brace support' }
-Array class >> braceStream: nElements [
-	"This method is used in compilation of brace constructs.
-	It MUST NOT be deleted or altered."
-
-	^ WriteStream basicNew braceArray: (self new: nElements)
-]
-
 { #category : 'instance creation' }
 Array class >> empty [
 	"A canonicalized empty Array instance."

--- a/src/Collections-Streams/WriteStream.class.st
+++ b/src/Collections-Streams/WriteStream.class.st
@@ -46,25 +46,6 @@ WriteStream >> << anObject [
 		ifFalse: [ anObject putOn: self ]
 ]
 
-{ #category : 'private' }
-WriteStream >> braceArray [
-	"This method is used in compilation of brace constructs.
-	It MUST NOT be deleted or altered."
-
-	^ collection
-]
-
-{ #category : 'private' }
-WriteStream >> braceArray: anArray [
-	"This method is used in compilation of brace constructs.
-	It MUST NOT be deleted or altered."
-
-	collection := anArray.
-	position := 0.
-	readLimit := 0.
-	writeLimit := anArray size
-]
-
 { #category : 'accessing' }
 WriteStream >> contents [
 


### PR DESCRIPTION
remove #braceArray, #braceArray: and #braceStream:, no senders in the image (and private methods, so no deprecation)