### PR TITLE
RPackage: Update meaning of #removePackage: 

### DIFF
--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -360,12 +360,6 @@ ClySystemEnvironment >> registerProjectManager: aPackageManager [
 	projectManager registerProjectManager: aPackageManager
 ]
 
-{ #category : 'package management' }
-ClySystemEnvironment >> removePackage: aPackage [
-
-	packageOrganizer removePackage: aPackage
-]
-
 { #category : 'subscription' }
 ClySystemEnvironment >> subscribe: anObject [
 	self subscribe: anObject for: SystemAnnouncement

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -7,7 +7,6 @@ Public API and Key Messages
 
 - packages
 - createPackageNamed: aString
-- removePackage: aPackage
 - includesClassNamed: aString 
 - defaultClassCompiler
 - subscribe: aNavigationEnvironment

--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -228,7 +228,7 @@ RPackage >> unregister [
 
 	self
 		deprecated: 'Tihs method will be removed because the name does not conform with the naming convensions of this class.'
-		transformWith: '`@rcv unregister' -> '`@rcv organizer removePackage: `@rcv'.
+		transformWith: '`@rcv unregister' -> '`@rcv organizer unregisterPackage: `@rcv'.
 
-	self organizer removePackage: self
+	self organizer unregisterPackage: self
 ]

--- a/src/Deprecated12/RPackageOrganizer.extension.st
+++ b/src/Deprecated12/RPackageOrganizer.extension.st
@@ -145,15 +145,8 @@ RPackageOrganizer >> tagForCategory: category [
 ]
 
 { #category : '*Deprecated12' }
-RPackageOrganizer >> unregisterPackage: aPackage [
-
-	self deprecated: 'Use #removePackage: instead.' transformWith: '`@rcv unregisterPackage: `@arg' -> '`@rcv removePackage: `@arg'.
-	^ self removePackage: aPackage
-]
-
-{ #category : '*Deprecated12' }
 RPackageOrganizer >> unregisterPackageNamed: symbol [
 
-	self deprecated: 'Use #removePackage: instead.' transformWith: '`@rcv unregisterPackageNamed: `@arg' -> '`@rcv removePackage: `@arg'.
-	^ self removePackage: symbol
+	self deprecated: 'Use #unregisterPackage: instead.' transformWith: '`@rcv unregisterPackageNamed: `@arg' -> '`@rcv unregisterPackage: `@arg'.
+	^ self unregisterPackage: symbol
 ]

--- a/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
+++ b/src/FluidClassBuilder-Tests/FluidClassBuilderAbstractTest.class.st
@@ -33,7 +33,7 @@ FluidClassBuilderAbstractTest >> packageNameForTest [
 { #category : 'running' }
 FluidClassBuilderAbstractTest >> tearDown [
 
-	self packageOrganizer packageNamed: self packageNameForTest ifPresent: [ :x | x removeFromSystem ].
+	self packageOrganizer removePackage: self packageNameForTest.
 
 	super tearDown
 ]

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -13,13 +13,6 @@ Class {
 	#tag : 'Classes'
 }
 
-{ #category : 'setup' }
-ClassTest >> categoryNameForTemporaryClasses [
-	"Answer the category where to classify temporarily created classes"
-
-	^'Dummy-Tests-Class'
-]
-
 { #category : 'coverage' }
 ClassTest >> classToBeTested [
 
@@ -28,13 +21,17 @@ ClassTest >> classToBeTested [
 
 { #category : 'setup' }
 ClassTest >> deleteClass [
-	| cl |
-	cl := testEnvironment at: className ifAbsent: [ ^ self ].
 
-	testingEnvironment at: #ChangeSet ifPresent: [
-		cl removeFromChanges ].
+	testEnvironment at: className ifPresent: [ :class |
+		testingEnvironment at: #ChangeSet ifPresent: [ class removeFromChanges ].
+		class removeFromSystemUnlogged ]
+]
 
-	cl removeFromSystemUnlogged
+{ #category : 'setup' }
+ClassTest >> packageNameForTest [
+	"Answer the category where to classify temporarily created classes"
+
+	^'Dummy-Tests-Class'
 ]
 
 { #category : 'referencing methods' }
@@ -66,16 +63,16 @@ ClassTest >> setUp [
 	self class classInstaller make: [ :aBuilder |
 		aBuilder
 			name: className;
-			package: self categoryNameForTemporaryClasses]
+			package: self packageNameForTest]
 ]
 
 { #category : 'running' }
 ClassTest >> tearDown [
 
 	self deleteClass.
-	{
-		self unclassifiedCategory.
-		self categoryNameForTemporaryClasses } do: [ :category | self packageOrganizer removePackage: category ].
+
+	self packageOrganizer packageNamed: self packageNameForTest ifPresent: [ :package | package removeFromSystem ].
+
 	super tearDown
 ]
 
@@ -172,7 +169,7 @@ ClassTest >> testClassVariableEntanglement [
 		aBuilder
 			name: firstClassName;
 			sharedVariablesFromString: 'MyVar';
-			package: self categoryNameForTemporaryClasses ].
+			package: self packageNameForTest ].
 
 	[
 
@@ -187,7 +184,7 @@ ClassTest >> testClassVariableEntanglement [
 			aBuilder
 				name: secondClassName;
 				sharedVariablesFromString: 'MyVar';
-				package: self categoryNameForTemporaryClasses ].
+				package: self packageNameForTest ].
 
 		[
 
@@ -385,16 +382,16 @@ ClassTest >> testMethodsReferencingClasses [
 
 { #category : 'tests - class creation' }
 ClassTest >> testNewSubclass [
-	| cls |
-	cls := Point newSubclass.
-	self assert: cls isBehavior.
-	self assert: cls superclass identicalTo: Point.
-	self assert: (Point allSubclasses includes: cls).
-	self assert: cls instVarNames equals: #().
-	self assert: cls category equals: self unclassifiedCategory.
-	self assert: cls classVarNames equals: #().
 
-	cls removeFromSystem
+	| class |
+	[
+	class := Point newSubclass.
+	self assert: class isBehavior.
+	self assert: class superclass identicalTo: Point.
+	self assert: (Point allSubclasses includes: class).
+	self assert: class instVarNames equals: #(  ).
+	self assert: class package isUndefined.
+	self assert: class classVarNames equals: #(  ) ] ensure: [ class ifNotNil: [ class removeFromSystem ] ]
 ]
 
 { #category : 'tests - file in/out' }
@@ -513,40 +510,40 @@ ClassTest >> testSharedPools [
 
 { #category : 'tests - class creation' }
 ClassTest >> testSubclass [
-	| cls |
+
+	| class |
 	(testEnvironment includesKey: #SubclassExample) ifTrue: [ (testEnvironment at: #SubclassExample) removeFromSystem ].
 
 	self deny: (testEnvironment includesKey: #SubclassExample).
-	cls := self class classInstaller make: [ :aBuilder | aBuilder name: #SubclassExample ].
+	[
+	class := self class classInstaller make: [ :aBuilder | aBuilder name: #SubclassExample ].
 
 	self assert: (testEnvironment includesKey: #SubclassExample).
 
-	self assert: (testEnvironment at: #SubclassExample) identicalTo: cls.
-	self assert: cls category equals: self unclassifiedCategory.
-	self assert: cls instVarNames equals: #().
-
-	cls removeFromSystem
+	self assert: (testEnvironment at: #SubclassExample) identicalTo: class.
+	self assert: class package isUndefined.
+	self assert: class instVarNames equals: #(  ) ] ensure: [ class ifNotNil: [ class removeFromSystem ] ]
 ]
 
 { #category : 'tests - class creation' }
 ClassTest >> testSubclassInstanceVariableNames [
-	| cls |
+
+	| class |
 	(testEnvironment includesKey: #SubclassExample) ifTrue: [ (testEnvironment at: #SubclassExample) removeFromSystem ].
 
 	self deny: (testEnvironment includesKey: #SubclassExample).
 
-	cls := self class classInstaller make: [ :aBuilder |
-		aBuilder
-			name: #SubclassExample;
-			slotsFromString: 'x y'].
+	[
+	class := self class classInstaller make: [ :aBuilder |
+		       aBuilder
+			       name: #SubclassExample;
+			       slotsFromString: 'x y' ].
 
 	self assert: (testEnvironment includesKey: #SubclassExample).
 
-	self assert: (testEnvironment at: #SubclassExample) identicalTo: cls.
-	self assert: cls category equals: self unclassifiedCategory.
-	self assert: cls instVarNames equals: #('x' 'y').
-
-	cls removeFromSystem
+	self assert: (testEnvironment at: #SubclassExample) identicalTo: class.
+	self assert: class package isUndefined.
+	self assert: class instVarNames equals: #( 'x' 'y' ) ] ensure: [ class ifNotNil: [ class removeFromSystem ] ]
 ]
 
 { #category : 'tests - file in/out' }
@@ -609,10 +606,4 @@ ClassTest >> testclassVariables [
 
 	"A class and it's meta-class share the class variables"
 	self assert: Object classVariables equals: Object class classVariables
-]
-
-{ #category : 'tests - class creation' }
-ClassTest >> unclassifiedCategory [
-
-	^ Class unclassifiedCategory
 ]

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -71,7 +71,7 @@ ClassTest >> tearDown [
 
 	self deleteClass.
 
-	self packageOrganizer packageNamed: self packageNameForTest ifPresent: [ :package | package removeFromSystem ].
+	self packageOrganizer removePackage: self packageNameForTest.
 
 	super tearDown
 ]

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -31,13 +31,6 @@ CompiledMethodTest >> abstractMethod [
 	^ self subclassResponsibility
 ]
 
-{ #category : 'private - accessing' }
-CompiledMethodTest >> categoryNameForTemporaryClasses [
-	"Answer the category where to classify temporarily created classes"
-
-	^'Dummy-Tests-Class'
-]
-
 { #category : 'coverage' }
 CompiledMethodTest >> classToBeTested [
 
@@ -217,6 +210,13 @@ CompiledMethodTest >> nonAbstractMethod [
 	^ 4 + 5
 ]
 
+{ #category : 'private - accessing' }
+CompiledMethodTest >> packageNameForTests [
+	"Answer the category where to classify temporarily created classes"
+
+	^'Dummy-Tests-Class'
+]
+
 { #category : 'examples' }
 CompiledMethodTest >> readX [
 	| tmp |
@@ -250,7 +250,7 @@ CompiledMethodTest >> shouldNotImplementMethod [
 { #category : 'running' }
 CompiledMethodTest >> tearDown [
 
-	self packageOrganizer removePackage: self categoryNameForTemporaryClasses.
+	self packageOrganizer packageNamed: self packageNameForTests ifPresent: [ :package | package removeFromSystem ].
 	class ifNotNil: [ class removeFromSystem ].
 	super tearDown
 ]
@@ -502,7 +502,7 @@ CompiledMethodTest >> testIsInstalled [
 	cls := self class classInstaller make: [ :aBuilder |
 		aBuilder
 			name: #TUTU;
-			package: self categoryNameForTemporaryClasses].
+			package: self packageNameForTests].
 
 	cls compile: 'foo ^ 10'.
 	method := cls >> #foo.
@@ -667,7 +667,7 @@ CompiledMethodTest >> testMethodClass [
 	cls := self class classInstaller make: [ :aBuilder |
 		aBuilder
 			name: #TUTU;
-			package: self categoryNameForTemporaryClasses].
+			package: self packageNameForTests].
 
 	cls compile: 'foo ^ 10'.
 	method := cls >> #foo.
@@ -830,7 +830,7 @@ CompiledMethodTest >> testSelector [
 			cls := self class classInstaller make: [ :aBuilder |
 				aBuilder
 					name: #TUTU;
-					package: self categoryNameForTemporaryClasses].
+					package: self packageNameForTests].
 
 			cls compile: 'foo ^ 10'.
 

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -250,7 +250,7 @@ CompiledMethodTest >> shouldNotImplementMethod [
 { #category : 'running' }
 CompiledMethodTest >> tearDown [
 
-	self packageOrganizer packageNamed: self packageNameForTests ifPresent: [ :package | package removeFromSystem ].
+	self packageOrganizer removePackage: self packageNameForTests.
 	class ifNotNil: [ class removeFromSystem ].
 	super tearDown
 ]
@@ -473,7 +473,7 @@ CompiledMethodTest >> testIsExtension [
 
 	self class removeSelector: #isExtensionTestMethod.
 	self deny: method isExtension ] ensure: [
-		self packageOrganizer packageNamed: 'Kernel-Tests-Generated-Package' ifPresent: [ :package | package removeFromSystem ].
+		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
 ]
 

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -34,7 +34,7 @@ ClassDescriptionTest >> createTestClass [
 { #category : 'running' }
 ClassDescriptionTest >> tearDown [
 
-	RPackageOrganizer default packageNamed: self compilationTestPackageName ifPresent: [ :package | package removeFromSystem ].
+	self packageOrganizer removePackage: self compilationTestPackageName.
 
 	super tearDown
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -690,7 +690,7 @@ RPackage >> removeFromSystem [
 	self classTags do: [ :tag | tag removeFromSystem ].
 	self extensionMethods do: [ :method | method removeFromSystem ].
 
-	self organizer removePackage: self
+	self organizer unregisterPackage: self
 ]
 
 { #category : 'add method - compiled method' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -481,19 +481,11 @@ RPackageOrganizer >> removeEmptyPackagesAndTags [
 { #category : 'registration' }
 RPackageOrganizer >> removePackage: aPackage [
 
-	| package |
-	(self hasPackage: aPackage) ifFalse: [ ^ self ].
-
-	package := aPackage isString
-		           ifTrue: [ self packageNamed: aPackage ]
-		           ifFalse: [ aPackage ].
-
-	self basicUnregisterPackage: package.
-	package extendedClasses do: [ :extendedClass | self unregisterExtendingPackage: package forClass: extendedClass ].
-	package definedClasses do: [ :definedClass | self unregisterPackage: package forClass: definedClass ].
-	SystemAnnouncer announce: (PackageRemoved to: package).
-
-	^ package
+	self
+		packageNamed: (aPackage isString
+				 ifTrue: [ aPackage ]
+				 ifFalse: [ aPackage name ])
+		ifPresent: [ :package | package removeFromSystem ]
 ]
 
 { #category : 'system integration' }
@@ -613,6 +605,25 @@ RPackageOrganizer >> unregisterInterestToSystemAnnouncement [
 	"self unregisterInterestToSystemAnnouncement"
 
 	SystemAnnouncer uniqueInstance unsubscribe: self
+]
+
+{ #category : 'private' }
+RPackageOrganizer >> unregisterPackage: aPackage [
+	"I am a private method to unregister a package from myself without removing its contents fro the image."
+
+	| package |
+	(self hasPackage: aPackage) ifFalse: [ ^ self ].
+
+	package := aPackage isString
+		           ifTrue: [ self packageNamed: aPackage ]
+		           ifFalse: [ aPackage ].
+
+	self basicUnregisterPackage: package.
+	package extendedClasses do: [ :extendedClass | self unregisterExtendingPackage: package forClass: extendedClass ].
+	package definedClasses do: [ :definedClass | self unregisterPackage: package forClass: definedClass ].
+	SystemAnnouncer announce: (PackageRemoved to: package).
+
+	^ package
 ]
 
 { #category : 'private - registration' }

--- a/src/Shift-Changes-Tests/ShAbstractChangeDetectorTest.class.st
+++ b/src/Shift-Changes-Tests/ShAbstractChangeDetectorTest.class.st
@@ -85,10 +85,12 @@ ShAbstractChangeDetectorTest >> setUp [
 { #category : 'running' }
 ShAbstractChangeDetectorTest >> tearDown [
 
-	self packageOrganizer packageNamed: self packageName ifPresent: [ :package | package removeFromSystem ].
 	{
 		usedTrait.
 		superClass.
 		originClass } do: [ :class | class removeFromSystem ].
+
+	self packageOrganizer removePackage: self packageName.
+
 	super tearDown
 ]

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -52,8 +52,13 @@ ShClassInstallerTest >> newClass: className superclass: aSuperclass slots: slots
 { #category : 'running' }
 ShClassInstallerTest >> tearDown [
 
-	self packageOrganizer packageNamed: self generatedClassesPackageName ifPresent: [ :package | package removeFromSystem ].
-	{ newClass . superClass . subClass . newClass2 . superClass2 } do: [ :class | class ifNotNil: [ class removeFromSystem ] ].
+	self packageOrganizer removePackage: self generatedClassesPackageName.
+	{
+		newClass.
+		superClass.
+		subClass.
+		newClass2.
+		superClass2 } do: [ :class | class ifNotNil: [ class removeFromSystem ] ].
 	super tearDown
 ]
 
@@ -318,7 +323,7 @@ ShClassInstallerTest >> testInstallInSpecificEnvironment [
 	self deny: (self packageOrganizer hasPackage: self generatedClassesPackageName).
 	self assert: (newEnvironment organization hasPackage: self generatedClassesPackageName) ] ensure: [
 		"The tear down will not remove the class in the other environment"
-		newEnvironment organization packageNamed: self generatedClassesPackageName ifPresent: [ :package | package removeFromSystem ] ]
+		newEnvironment organization removePackage: self generatedClassesPackageName ]
 ]
 
 { #category : 'tests' }

--- a/src/TraitsV2-Tests/TraitFileOutTest.class.st
+++ b/src/TraitsV2-Tests/TraitFileOutTest.class.st
@@ -55,7 +55,7 @@ TraitFileOutTest >> tearDown [
 	dir := FileSystem workingDirectory.
 	self createdClassesAndTraits , self resourceClassesAndTraits do: [ :each | (dir / each asString , 'st') ensureDelete ].
 	(dir / self packageName , 'st') ensureDelete.
-	self packageOrganizer packageNamed: self packageName ifPresent: [ :package | package removeFromSystem ].
+	self packageOrganizer removePackage: self packageName.
 	"Ensure cleaning of obsoletes refs"
 	ca := cb := ta := tb := tc := td := nil.
 	super tearDown


### PR DESCRIPTION
In the past we had #unregisterPackage: that was unregistering a package from the package organizer. Often the vocabulary about registration was missused and I removed all those method to use "add/remove" instead. But in the case of this particular method I think I mess up because it is really unregistering in the sens that it does not remove the content of the package. 

To replace it I introduced #removePackage:. In this commit I add back #unregisterPackage: to do the unregistration but as a private method that should not be used if possible. And I updated #removePackage: to remove also the content of the package to remove. 

I updated all the senders in the image to use the right one. This will leave less orphan classes in the system.