### PR TITLE
14400-allReferencesTo-aLiteral-do-aBlock-is-called-unknown-messages

### DIFF
--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -80,6 +80,21 @@ SystemNavigationTest >> testAllExistingProtocolsFor [
 ]
 
 { #category : 'tests' }
+SystemNavigationTest >> testAllReferencesToDo [
+	"test trying to not hard code numbers as they will be different"
+	| counterSymbol counterClass |
+	counterSymbol := 0.
+	SystemNavigation new allReferencesTo: #Object do: [:ref | counterSymbol := counterSymbol +1 ].
+	self assert: counterSymbol > 10.
+	counterClass := 0.
+	SystemNavigation new allReferencesTo: Object binding do: [:ref | counterClass := counterClass +1 ].
+	self assert: counterClass > 10.
+	"and there are more refs to the class then to the symbol"
+	self assert: counterClass > counterSymbol.
+	
+]
+
+{ #category : 'tests' }
 SystemNavigationTest >> testAllSendersOfASelector [
 
 	| senders selector class otherClass callers |

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -182,7 +182,7 @@ SystemNavigation >> allReferencesTo: aLiteral [
 
 { #category : 'query' }
 SystemNavigation >> allReferencesTo: aLiteral do: aBlock [
-	"Perform aBlock on all the references to aLiteral. As Literal Variables can not be in arrays or pragmas, use the faster nonp-thoroug version for them"
+	"Perform aBlock on all the references to aLiteral. As Literal Variables can not be in arrays or pragmas, use the faster non-thoroug version for them"
 
 	self allBehaviorsDo: [ :class |
 		aLiteral isSymbol

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -182,14 +182,12 @@ SystemNavigation >> allReferencesTo: aLiteral [
 
 { #category : 'query' }
 SystemNavigation >> allReferencesTo: aLiteral do: aBlock [
-	"Perform aBlock on all the references to aLiteral."
+	"Perform aBlock on all the references to aLiteral. As Literal Variables can not be in arrays or pragmas, use the faster nonp-thoroug version for them"
 
-	| symbol |
-	symbol := aLiteral isSymbol.
 	self allBehaviorsDo: [ :class |
-		symbol
-			ifFalse: [ class withMethodsReferTo: aLiteral do: aBlock ]
-			ifTrue: [ class withThorougMethodsReferTo: aLiteral do: aBlock ] ]
+		aLiteral isSymbol
+			ifFalse: [ (class whichMethodsReferTo: aLiteral) do: aBlock ]
+			ifTrue: [ (class thoroughWhichMethodsReferTo: aLiteral) do: aBlock ] ]
 ]
 
 { #category : 'query' }


### PR DESCRIPTION
The API is not nice, but as RB has it we should fix it for now and add a test

fixes #14400