### PR TITLE
Fix release tests and improve rules

### DIFF
--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyInheritanceAnalysisEnvironmentPlugin.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyInheritanceAnalysisEnvironmentPlugin.class.st
@@ -227,17 +227,15 @@ ClyInheritanceAnalysisEnvironmentPlugin >> processFullClassChange: aClassModific
 
 { #category : 'controlling' }
 ClyInheritanceAnalysisEnvironmentPlugin >> processMethodChange: aMethodAnnouncement [
+
 	| method |
 	self updateCacheForMethod: aMethodAnnouncement methodAffected.
 
 	method := aMethodAnnouncement methodAffected.
-	method methodClass superclass ifNotNil: [ :superclass |
-		(superclass lookupSelector: method selector) ifNotNil: [:overriddenMethod |
-			^environment systemChanged: (ClyOverriddenMethodChanged method: overriddenMethod)]
-	].
-	method methodClass subclasses ifEmpty: [ ^self ].
-	environment systemChanged: (
-		ClyOverridingMethodsChanged initiatedBy: self forOverriddenMethod: method)
+	method overriddenMethod ifNotNil: [ :overriddenMethod | ^ environment systemChanged: (ClyOverriddenMethodChanged method: overriddenMethod) ].
+	method methodClass subclasses ifEmpty: [ ^ self ].
+
+	environment systemChanged: (ClyOverridingMethodsChanged initiatedBy: self forOverriddenMethod: method)
 ]
 
 { #category : 'implementors cache' }

--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/CompiledMethod.extension.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/CompiledMethod.extension.st
@@ -3,5 +3,5 @@ Extension { #name : 'CompiledMethod' }
 { #category : '*Calypso-SystemPlugins-InheritanceAnalysis-Queries' }
 CompiledMethod >> isOverriding [
 
-	^(self origin superclass ifNotNil: [ :c | c lookupSelector: self selector]) notNil
+	^ self overriddenMethod isNotNil
 ]

--- a/src/ClassAnnotation/ClassAnnotationRegistry.class.st
+++ b/src/ClassAnnotation/ClassAnnotationRegistry.class.st
@@ -101,15 +101,13 @@ ClassAnnotationRegistry class >> default [
 { #category : 'system changes' }
 ClassAnnotationRegistry class >> doesMethodAffectAnnotations: aMethod [
 
-	(self doesMethodDefineAnnotation: aMethod) ifTrue: [ ^true ].
+	(self doesMethodDefineAnnotation: aMethod) ifTrue: [ ^ true ].
 
-	aMethod methodClass superclass ifNotNil: [ :parentClass |
+	aMethod overriddenMethod ifNotNil: [ :overriddenMethod |
 		"check if there is overridden method which defines annotation"
-		(parentClass lookupSelector: aMethod selector) ifNotNil: [:overriddenMethod |
-			(self doesMethodDefineAnnotation: overriddenMethod) ifTrue: [^true]].
-	].
+		(self doesMethodDefineAnnotation: overriddenMethod) ifTrue: [ ^ true ] ].
 
-	^false
+	^ false
 ]
 
 { #category : 'system changes' }

--- a/src/GeneralRules/ReClassVariableNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReClassVariableNeitherReadNorWrittenRule.class.st
@@ -1,5 +1,7 @@
 "
 This smell arises when a class variable is not both read and written. If a class variable is only read, the reads can be replaced by nil, since it could not have been assigned a value. If the variable is only written, then it does not need to store the result since it is never used.
+
+If you really intend to have an unused variable (for example, for testing purpose), you can add a #ignoreUnusedClassVariables: pragma to your initialize method with an array of unused variables. Example: `<ignoreUnusedClassVariables: #( ClassVar1 ClassVar2 )>`.
 "
 Class {
 	#name : 'ReClassVariableNeitherReadNorWrittenRule',

--- a/src/GeneralRules/ReEquivalentSuperclassMethodsRule.class.st
+++ b/src/GeneralRules/ReEquivalentSuperclassMethodsRule.class.st
@@ -25,13 +25,12 @@ ReEquivalentSuperclassMethodsRule class >> uniqueIdentifierName [
 
 { #category : 'running' }
 ReEquivalentSuperclassMethodsRule >> basicCheck: aMethod [
+
 	(self ignoredSelectors includes: aMethod selector) ifTrue: [ ^ false ].
 
-	^ aMethod methodClass superclass
-		ifNotNil: [ :superclass | (superclass lookupSelector: aMethod selector)
-			ifNotNil: [ :overridenMethod | aMethod equivalentTo: overridenMethod ]
-			ifNil: [ false ] ]
-		ifNil: [ false ]
+	^ aMethod overriddenMethod
+		  ifNotNil: [ :overridenMethod | aMethod equivalentTo: overridenMethod ]
+		  ifNil: [ false ]
 ]
 
 { #category : 'accessing' }

--- a/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/GeneralRules/ReInconsistentMethodClassificationRule.class.st
@@ -31,29 +31,19 @@ ReInconsistentMethodClassificationRule >> check: aMethod forCritiquesDo: aCritiq
 
 	(ownerProtocol isUnclassifiedProtocol or: [ ownerProtocol isExtensionProtocol ]) ifTrue: [ ^ self ].
 
-	aMethod methodClass superclass ifNotNil: [ :superclass |
-		(superclass lookupSelector: aMethod selector) ifNotNil: [ :superMethod |
-			| superProtocol |
-			superProtocol := superMethod protocol ifNil: [ ^ self ].
-			(superProtocol isUnclassifiedProtocol or: [ superProtocol isExtensionProtocol ]) ifTrue: [ ^ self ].
-			ownerProtocol name ~= superProtocol name ifTrue: [
-				aCritiqueBlock cull: ((self critiqueFor: aMethod) tinyHint: 'superclass categorizes as: ' , superProtocol name) ] ] ]
+	aMethod overriddenMethod ifNotNil: [ :overriddenMethod |
+		| superProtocol |
+		superProtocol := overriddenMethod protocol ifNil: [ ^ self ].
+		(superProtocol isUnclassifiedProtocol or: [ superProtocol isExtensionProtocol ]) ifTrue: [ ^ self ].
+		ownerProtocol name ~= superProtocol name ifTrue: [
+			aCritiqueBlock cull: ((self critiqueFor: aMethod) tinyHint: 'superclass categorizes as: ' , superProtocol name) ] ]
 ]
 
 { #category : 'helpers' }
 ReInconsistentMethodClassificationRule >> critiqueFor: aMethod [
 
-	| protocolInSuperclass |
-	protocolInSuperclass := (aMethod methodClass superclass
-		                         lookupSelector: aMethod selector)
-		                        protocolName.
-
-	^ (ReRefactoringCritique
-		   withAnchor: (self anchorFor: aMethod)
-		   by: self) refactoring: (RBMethodProtocolTransformation
-			   protocol: { protocolInSuperclass }
-			   inMethod: aMethod selector
-			   inClass: aMethod methodClass name)
+	^ (ReRefactoringCritique withAnchor: (self anchorFor: aMethod) by: self) refactoring:
+		  (RBMethodProtocolTransformation protocol: { aMethod overriddenMethod protocolName } inMethod: aMethod selector inClass: aMethod methodClass name)
 ]
 
 { #category : 'accessing' }

--- a/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
+++ b/src/GeneralRules/ReIvarNeitherReadNorWrittenRule.class.st
@@ -1,5 +1,7 @@
 "
 This smell arises when an instance variable is not both read and written. If an instance variable is only read, the reads can be replaced by nil, since it could not have been assigned a value. If the variable is only written, then it does not need to store the result since it is never used.
+
+If you really intend to have an unused variable (for example, for testing purpose), you can add a #ignoreUnusedVariables: pragma to your initialize method with an array of unused variables. Example: `<ignoreUnusedVariables: #( instVar1 instVar2 )>`.
 "
 Class {
 	#name : 'ReIvarNeitherReadNorWrittenRule',

--- a/src/GeneralRules/ReJustSendsSuperRule.class.st
+++ b/src/GeneralRules/ReJustSendsSuperRule.class.st
@@ -26,7 +26,13 @@ ReJustSendsSuperRule class >> uniqueIdentifierName [
 
 { #category : 'running' }
 ReJustSendsSuperRule >> basicCheck: aMethod [
-	^ aMethod ast isPrimitive not and: [ matcher executeMethod: aMethod ast initialAnswer: false ]
+
+	aMethod ast isPrimitive ifTrue: [ ^ false ].
+
+	"If a method has pragmas, it is not doing nothing."
+	aMethod pragmas ifNotEmpty: [ ^ false ].
+
+	^ matcher executeMethod: aMethod ast initialAnswer: false
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -490,28 +490,23 @@ CompiledMethodTest >> testIsFaulty [
 
 { #category : 'tests - testing' }
 CompiledMethodTest >> testIsInstalled [
-|  method cls |
 
-	method := (self class)>>#returnTrue.
+	| method |
+	method := self class >> #returnTrue.
 	self assert: method isInstalled.
 
+	class := self class classInstaller make: [ :aBuilder |
+		         aBuilder
+			         name: #TUTU;
+			         package: self packageNameForTests ].
 
-
-	Smalltalk removeClassNamed: #TUTU.
-
-	cls := self class classInstaller make: [ :aBuilder |
-		aBuilder
-			name: #TUTU;
-			package: self packageNameForTests].
-
-	cls compile: 'foo ^ 10'.
-	method := cls >> #foo.
+	class compile: 'foo ^ 10'.
+	method := class >> #foo.
 
 	"now make an orphaned method by just deleting the method."
-	cls removeSelector: #foo.
+	class removeSelector: #foo.
 
-	self deny: method isInstalled.
-	Smalltalk removeClassNamed: #TUTU
+	self deny: method isInstalled
 ]
 
 { #category : 'tests - testing' }
@@ -656,23 +651,23 @@ CompiledMethodTest >> testLiterals [
 
 { #category : 'tests - accessing' }
 CompiledMethodTest >> testMethodClass [
-	| method cls |
+
+	| method |
 	method := self class >> #returnTrue.
 	self assert: method selector equals: #returnTrue.
+
 	"now make an orphaned method by just deleting the class.
 	old: #unknown
 	new semantics: return Absolete class"
-	Smalltalk removeClassNamed: #TUTU.
+	class := self class classInstaller make: [ :aBuilder |
+		         aBuilder
+			         name: #TUTU;
+			         package: self packageNameForTests ].
 
-	cls := self class classInstaller make: [ :aBuilder |
-		aBuilder
-			name: #TUTU;
-			package: self packageNameForTests].
-
-	cls compile: 'foo ^ 10'.
-	method := cls >> #foo.
-	Smalltalk removeClassNamed: #TUTU.
-	self assert: method methodClass equals: cls
+	class compile: 'foo ^ 10'.
+	method := class >> #foo.
+	class removeFromSystem.
+	self assert: method methodClass equals: class
 ]
 
 { #category : 'tests - comparing' }
@@ -696,6 +691,13 @@ CompiledMethodTest >> testOrigin [
 
 	self assert: regularMethod origin identicalTo: regularMethod originMethod methodClass.
 	self assert: methodFromTrait origin identicalTo: methodFromTrait originMethod methodClass
+]
+
+{ #category : 'tests - accessing' }
+CompiledMethodTest >> testOverriddenMethod [
+
+	self assert: (self class >> #classToBeTested) overriddenMethod identicalTo: ClassTestCase >> #classToBeTested.
+	self assert: (self class >> #testOverriddenMethod) overriddenMethod isNil
 ]
 
 { #category : 'tests - performing' }
@@ -818,27 +820,24 @@ CompiledMethodTest >> testReadsSlot [
 
 { #category : 'tests - accessing' }
 CompiledMethodTest >> testSelector [
-	Author
-		useAuthor: 'TUTU_TEST'
-		during: [ | method cls |
-			method := self class >> #returnTrue.
-			self assert: method selector equals: #returnTrue.
 
-			"now make an orphaned method. new semantics: return corrent name"
-			Smalltalk removeClassNamed: #TUTU.
+	| method |
+	method := self class >> #returnTrue.
+	self assert: method selector equals: #returnTrue.
 
-			cls := self class classInstaller make: [ :aBuilder |
-				aBuilder
-					name: #TUTU;
-					package: self packageNameForTests].
+	"now make an orphaned method. new semantics: return corrent name"
+	class := self class classInstaller make: [ :aBuilder |
+		         aBuilder
+			         name: #TUTU;
+			         package: self packageNameForTests ].
 
-			cls compile: 'foo ^ 10'.
+	class compile: 'foo ^ 10'.
 
-			method := cls >> #foo.
+	method := class >> #foo.
 
-			Smalltalk removeClassNamed: #TUTU.
+	Smalltalk removeClassNamed: #TUTU.
 
-			self assert: method selector equals: #foo ]
+	self assert: method selector equals: #foo
 ]
 
 { #category : 'tests - testing' }

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -580,6 +580,12 @@ CompiledMethod >> name [
 	^ self printString
 ]
 
+{ #category : 'accessing' }
+CompiledMethod >> overriddenMethod [
+
+	^ self methodClass superclass ifNotNil: [ :class | class lookupSelector: self selector ]
+]
+
 { #category : 'private' }
 CompiledMethod >> penultimateLiteral [
 	"Answer the penultimate literal of the receiver, which holds either

--- a/src/Refactoring-DataForTesting/MyClassARoot.class.st
+++ b/src/Refactoring-DataForTesting/MyClassARoot.class.st
@@ -19,3 +19,11 @@ MyClassARoot >> accessing [
 
 	^ instVarName1 
 ]
+
+{ #category : 'initialization' }
+MyClassARoot >> initialize [
+
+	<ignoreUnusedClassVariables: #( ClassVarName2 ClassVarName1 )>
+	<ignoreUnusedVariables: #( instVarName1 instVarName2 )>
+	super initialize
+]

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -256,7 +256,7 @@ ReleaseTest >> testNoEquivalentSuperclassMethods [
 		           method overriddenMethod
 			           ifNotNil: [ :overridenMethod | method equivalentTo: overridenMethod ]
 			           ifNil: [ false ] ].
-	self assert: methods size <= 369
+	self assert: methods size <= 326
 ]
 
 { #category : 'tests - variables' }

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -250,24 +250,13 @@ ReleaseTest >> testNoEquivalentSuperclassMethods [
 
 	| methods |
 	"we do not care about methods that are installed from traits"
-	methods := SystemNavigation new allMethods reject: [:method | method isFromTrait].
+	methods := SystemNavigation new allMethods reject: [ :method | method isFromTrait ].
 
-	methods := methods select: [:method |
-	method methodClass superclass
-		ifNotNil: [ :superclass | (superclass lookupSelector: method selector)
-			ifNotNil: [ :overridenMethod | method equivalentTo: overridenMethod ]
-			ifNil: [ false ] ]
-		ifNil: [ false ]
-	].
-	self assert: methods size <= 369.
-
-
-	"there should be no method left"
-	"self assert: methods isEmpty description: [
-		String streamContents: [ :stream |
-			stream
-				nextPutAll: 'Found methods that are the same as in a superclass';
-				print: methods ] ]"
+	methods := methods select: [ :method |
+		           method overriddenMethod
+			           ifNotNil: [ :overridenMethod | method equivalentTo: overridenMethod ]
+			           ifNil: [ false ] ].
+	self assert: methods size <= 369
 ]
 
 { #category : 'tests - variables' }


### PR DESCRIPTION
This PR has multiple changes:
- Fix release tests in Refactorings
- Implement CompiledMethod>>overriddenMethod and use it to simplify some methods including rules (also add a test)
- ReClassVariableNeitherReadNorWrittenRule now hint to how to declare an unused variable normal
- ReIvarNeitherReadNorWrittenRule now hint to how to declare an unused variable normal
- ReJustSendsSuperRule now check if a method has pragmas
- Reduce the allowed number of violations of testNoEquivalentSuperclassMethods