### PR TITLE
FileReference-deleteIfAbsent-optimzied-ifTrue

### DIFF
--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -169,7 +169,7 @@ FileReference >> delete [
 FileReference >> deleteIfAbsent: aBlock [
 	self exists
 		ifTrue: [ self delete ]
-		ifFalse: aBlock
+		ifFalse: [ aBlock value ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
make sure to use the optimized ifTrue: in FileReference>>#deleteIfAbsent: