### PR TITLE
Fix intersection of dictionaries

### DIFF
--- a/src/Collections-Unordered-Tests/DictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/DictionaryTest.class.st
@@ -546,6 +546,29 @@ DictionaryTest >> testIncludesElementIsNotThere [
 	self deny: (self empty includes: self elementNotInForOccurrences)
 ]
 
+{ #category : 'tests - set arithmetic' }
+DictionaryTest >> testIntersection [
+
+	| dic1 dic2 |
+	dic1 := self empty
+		        at: #a put: 1;
+		        at: #b put: 2;
+		        at: #c put: 3;
+		        at: #d put: 4;
+		        yourself.
+
+	dic2 := self empty
+		        at: #a put: 1;
+		        at: #b put: 3;
+		        at: #c put: 4;
+		        at: #e put: 4;
+		        yourself.
+
+	self assertCollection: (dic1 intersection: dic2) equals: (self empty
+			 at: #a put: 1;
+			 yourself)
+]
+
 { #category : 'tests - testing' }
 DictionaryTest >> testIsDictionary [
 	self deny: Object new isDictionary.

--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -615,6 +615,13 @@ Dictionary >> includesKey: key [
 	"We could use #notNil here, but ProtoObject doesn't understand it."
 ]
 
+{ #category : 'enumerating' }
+Dictionary >> intersection: aCollection [
+	"Answer the set theoretic intersection of two collections. "
+
+	^ self species newFrom: (self associations asSet intersection: aCollection associations)
+]
+
 { #category : 'testing' }
 Dictionary >> isDictionary [
 	^true

--- a/src/Collections-Unordered/SmallDictionary.class.st
+++ b/src/Collections-Unordered/SmallDictionary.class.st
@@ -527,6 +527,13 @@ SmallDictionary >> initialize [
 	size := 0
 ]
 
+{ #category : 'enumerating' }
+SmallDictionary >> intersection: aCollection [
+	"Answer the set theoretic intersection of two collections. "
+
+	^ self species newFrom: (self associations asSet intersection: aCollection associations)
+]
+
 { #category : 'testing' }
 SmallDictionary >> isDictionary [
 	^true


### PR DESCRIPTION
Before: 

```st
(Dictionary with: (#a -> 1)) intersection: (Dictionary with: (#a -> 1)) "a Dictionary(1->1 )"
```

After:

```st
(Dictionary with: (#a -> 1)) intersection: (Dictionary with: (#a -> 1)) "a Dictionary(#a->1 )"
```

Fixes #14808