### PR TITLE
Zinc synch

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
@@ -359,6 +359,7 @@ ZnBufferedReadStream >> skip: count [
 	"Skip over count elements.
 	This could be further optimzed."
 
+	count < 0 ifTrue: [ self error: 'cannot skip backwards' ].
 	count timesRepeat: [ self next ]
 ]
 

--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
@@ -49,11 +49,22 @@ ZnBufferedReadStream >> back [
 	^ position > limit
 		ifTrue: [
 			stream back ]
-		ifFalse: [ | char |
-			position = 1 ifTrue: [ self error: 'Cannot move back from beginning' ].
-			char := buffer at: position.
-			position := position - 1.
-			char ]
+		ifFalse: [ | targetPosition bufferPosition char |
+			position = 1 ifTrue: 
+				[ stream position = 0 ifTrue:
+					[ self error: 'Cannot move back from beginning' ]
+				ifFalse:
+					[ targetPosition := self position - 1.
+					"Assume that the caller may want to go back a few elements before reading forward again"
+					bufferPosition := targetPosition - 10 max: 0.
+					self position: bufferPosition.
+					self nextBuffer.
+					self position: targetPosition.
+					self peek ] ]
+			ifFalse:
+				[ char := buffer at: position.
+				position := position - 1.
+				char ] ]
 ]
 
 { #category : 'initialize-release' }

--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadWriteStream.class.st
@@ -193,7 +193,7 @@ ZnBufferedReadWriteStream >> sizeBuffer: anInteger [
 
 { #category : 'accessing' }
 ZnBufferedReadWriteStream >> skip: anInteger [
-
+	anInteger < 0 ifTrue: [ self error: 'cannot skip backwards' ].
 	self readingActionDo: [
 		readStream skip: anInteger ]
 ]

--- a/src/Zinc-Character-Encoding-Core/ZnCharacterEncoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCharacterEncoder.class.st
@@ -219,6 +219,11 @@ ZnCharacterEncoder >> encodedByteCountForString: string [
 			sum + (self encodedByteCountFor: each) ]
 ]
 
+{ #category : 'accessing' }
+ZnCharacterEncoder >> endianness [
+	^ #'N/A'
+]
+
 { #category : 'encoding - decoding' }
 ZnCharacterEncoder >> ensureAtBeginOfCodePointOnStream: stream [
 	"Ensure that the current position of stream is a the beginning of an encoded code point,
@@ -258,6 +263,11 @@ ZnCharacterEncoder >> isFixedLength [
 	"Return true when I am a fixed length encoding"
 
 	^ true
+]
+
+{ #category : 'testing' }
+ZnCharacterEncoder >> isStrict [
+	^ false
 ]
 
 { #category : 'testing' }

--- a/src/Zinc-Character-Encoding-Core/ZnCharacterReadWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCharacterReadWriteStream.class.st
@@ -136,7 +136,7 @@ ZnCharacterReadWriteStream >> size [
 
 { #category : 'accessing' }
 ZnCharacterReadWriteStream >> skip: anInteger [
-
+	anInteger < 0 ifTrue: [ self error: 'cannot skip backwards' ].
 	readStream skip: anInteger
 ]
 

--- a/src/Zinc-Character-Encoding-Core/ZnEncodedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnEncodedReadStream.class.st
@@ -170,6 +170,7 @@ ZnEncodedReadStream >> readStream [
 
 { #category : 'accessing' }
 ZnEncodedReadStream >> skip: count [
+	count < 0 ifTrue: [ self error: 'cannot skip backwards' ].
 	count timesRepeat: [ self next ]
 ]
 

--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
@@ -9,6 +9,28 @@ Class {
 }
 
 { #category : 'tests' }
+ZnBufferedReadStreamTest >> testBack [
+	"Check that ZnBufferedReadStream>>#back behaves as expected"
+	<gtExample>
+	| stream source |
+
+	"Allocate a buffer larger than the default size (65536)"
+	self assert: ZnBufferedReadStream basicNew defaultBufferSize < 66000.
+	source := ByteArray new: 70000.
+	1 to: 70000 do: [ :i |
+		source at: i put: i \\ 256 ].
+
+	stream := ZnBufferedReadStream on: source readStream.
+	stream position: 1.
+	self assert: stream peek equals: (source at: 2).
+	self assert: stream back equals: (source at: 1).
+	"Position the stream beyond the end of the initial buffer"
+	stream position: 66000.
+	self assert: stream peek equals: (source at: 66001).
+	self assert: stream back equals: (source at: 66000).
+]
+
+{ #category : 'tests' }
 ZnBufferedReadStreamTest >> testBuffering [
 	| stream |
 	stream := ZnBufferedReadStream on: '01234567890123456789' readStream.

--- a/src/Zinc-HTTP/ZnByteArrayEntity.class.st
+++ b/src/Zinc-HTTP/ZnByteArrayEntity.class.st
@@ -78,22 +78,20 @@ ZnByteArrayEntity >> printContentsOn: stream [
 
 { #category : 'initialize-release' }
 ZnByteArrayEntity >> readFrom: stream [
-
 	self contentLength
 		ifNil: [
 			self bytes: (ZnUtils readUpToEnd: stream limit: (ZnCurrentOptions at: #maximumEntitySize)).
-			self contentLength: self bytes size
-			]
-		ifNotNil: [ | byteArray |
-
+			self contentLength: self bytes size ]
+		ifNotNil: [ | byteArray readCount |
 			self contentLength > (ZnCurrentOptions at: #maximumEntitySize)
 				ifTrue: [ ZnEntityTooLarge signal ].
 			byteArray := ByteArray ofSize: self contentLength.
-			self contentLength > ZnUtils streamingBufferSize
+			readCount := self contentLength > ZnUtils streamingBufferSize
 				ifTrue: [ ZnUtils streamFrom: stream to: byteArray writeStream size: self contentLength ]
-				ifFalse: [ stream next: self contentLength into: byteArray ].
-			self bytes: byteArray
-			]
+				ifFalse: [ stream readInto: byteArray startingAt: 1 count: self contentLength ].
+			readCount = self contentLength 
+				ifTrue: [ self bytes: byteArray ]
+				ifFalse: [ self bytes: (byteArray copyFrom: 1 to: readCount); contentLength: readCount ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnChunkedReadStream.class.st
+++ b/src/Zinc-HTTP/ZnChunkedReadStream.class.st
@@ -252,6 +252,7 @@ ZnChunkedReadStream >> reset [
 
 { #category : 'accessing' }
 ZnChunkedReadStream >> skip: count [
+	count < 0 ifTrue: [ self error: 'cannot skip backwards' ].
 	count timesRepeat: [ self next ]
 ]
 

--- a/src/Zinc-HTTP/ZnClientConnectionClosedEvent.class.st
+++ b/src/Zinc-HTTP/ZnClientConnectionClosedEvent.class.st
@@ -36,7 +36,7 @@ ZnClientConnectionClosedEvent >> port: anObject [
 { #category : 'printing' }
 ZnClientConnectionClosedEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Connection Closed '.
+	stream << 'Connection Closed '.
 	address
 		ifNil: [
 			stream print: address ]

--- a/src/Zinc-HTTP/ZnClientFollowingRedirectEvent.class.st
+++ b/src/Zinc-HTTP/ZnClientFollowingRedirectEvent.class.st
@@ -15,7 +15,7 @@ Class {
 { #category : 'printing' }
 ZnClientFollowingRedirectEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Following Redirect '; print: target
+	stream << 'Following Redirect '; print: target
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnClientIgnoringExceptionOnConnectionReuseEvent.class.st
+++ b/src/Zinc-HTTP/ZnClientIgnoringExceptionOnConnectionReuseEvent.class.st
@@ -26,5 +26,5 @@ ZnClientIgnoringExceptionOnConnectionReuseEvent >> exception: anObject [
 { #category : 'printing' }
 ZnClientIgnoringExceptionOnConnectionReuseEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Ignoring Exception On Connection Reuse '; print: exception
+	stream << 'Ignoring Exception On Connection Reuse '; print: exception
 ]

--- a/src/Zinc-HTTP/ZnClientLogEvent.class.st
+++ b/src/Zinc-HTTP/ZnClientLogEvent.class.st
@@ -26,7 +26,7 @@ ZnClientLogEvent >> clientId: anObject [
 ]
 
 { #category : 'printing' }
-ZnClientLogEvent >> printContentsOn: stream [
-	super printContentsOn: stream.
+ZnClientLogEvent >> printHeaderOn: stream [
+	super printHeaderOn: stream.
 	clientId ifNotNil: [ stream space; << clientId ]
 ]

--- a/src/Zinc-HTTP/ZnClientRetryingEvent.class.st
+++ b/src/Zinc-HTTP/ZnClientRetryingEvent.class.st
@@ -26,5 +26,5 @@ ZnClientRetryingEvent >> exception: anObject [
 { #category : 'printing' }
 ZnClientRetryingEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Retrying '; print: exception
+	stream << 'Retrying '; print: exception
 ]

--- a/src/Zinc-HTTP/ZnClientTransactionEvent.class.st
+++ b/src/Zinc-HTTP/ZnClientTransactionEvent.class.st
@@ -31,7 +31,6 @@ ZnClientTransactionEvent >> duration [
 { #category : 'printing' }
 ZnClientTransactionEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream space.
 	request requestLine printMethodAndUriOn: stream.
 	stream space; print: response code.
 	response hasEntity

--- a/src/Zinc-HTTP/ZnConnectionAcceptedEvent.class.st
+++ b/src/Zinc-HTTP/ZnConnectionAcceptedEvent.class.st
@@ -25,7 +25,8 @@ ZnConnectionAcceptedEvent >> address: anObject [
 { #category : 'printing' }
 ZnConnectionAcceptedEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Connection Accepted '.
+	stream << 'Connection Accepted'.
 	address ifNotNil: [
+		stream space.
 		address do: [ :each | stream print: each ] separatedBy: [ stream nextPut: $. ] ]
 ]

--- a/src/Zinc-HTTP/ZnConnectionEstablishedEvent.class.st
+++ b/src/Zinc-HTTP/ZnConnectionEstablishedEvent.class.st
@@ -59,10 +59,12 @@ ZnConnectionEstablishedEvent >> port: anObject [
 { #category : 'printing' }
 ZnConnectionEstablishedEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Connection Established '; nextPutAll: hostname; nextPut: $:; print: port; space.
-	proxy ifNotNil: [ stream << 'via proxy '; print: proxy; space ].
-	address do: [ :each | stream print: each ] separatedBy: [ stream nextPut: $. ].
-	stream space; print: duration; << 'ms '
+	stream << 'Connection Established '; nextPutAll: hostname asString; nextPut: $:; print: port.
+	proxy ifNotNil: [ stream << ' via proxy '; print: proxy ].
+	address ifNotNil: [ 
+		stream space. 
+		address do: [ :each | stream print: each ] separatedBy: [ stream nextPut: $. ] ].
+	stream space; print: duration; << 'ms'
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnConnectionRejectedEvent.class.st
+++ b/src/Zinc-HTTP/ZnConnectionRejectedEvent.class.st
@@ -25,7 +25,8 @@ ZnConnectionRejectedEvent >> address: anObject [
 { #category : 'printing' }
 ZnConnectionRejectedEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Connection Rejected '.
+	stream << 'Connection Rejected'.
 	address ifNotNil: [
+		stream space.
 		address do: [ :each | stream print: each ] separatedBy: [ stream nextPut: $. ] ]
 ]

--- a/src/Zinc-HTTP/ZnConstants.class.st
+++ b/src/Zinc-HTTP/ZnConstants.class.st
@@ -42,6 +42,11 @@ ZnConstants class >> frameworkLicense [
 ]
 
 { #category : 'accessing' }
+ZnConstants class >> frameworkMCVersion [
+	MCWorkingCopy managersForClass: self class do: [ :each | ^ each ancestors first name ]
+]
+
+{ #category : 'accessing' }
 ZnConstants class >> frameworkName [
 	^ 'Zinc HTTP Components'
 ]

--- a/src/Zinc-HTTP/ZnLimitedReadStream.class.st
+++ b/src/Zinc-HTTP/ZnLimitedReadStream.class.st
@@ -202,6 +202,7 @@ ZnLimitedReadStream >> reset [
 
 { #category : 'accessing' }
 ZnLimitedReadStream >> skip: count [
+	count < 0 ifTrue: [ self error: 'cannot skip backwards' ].
 	count timesRepeat: [ self next ]
 ]
 

--- a/src/Zinc-HTTP/ZnLogEvent.class.st
+++ b/src/Zinc-HTTP/ZnLogEvent.class.st
@@ -12,7 +12,8 @@ Class {
 	#superclass : 'Announcement',
 	#instVars : [
 		'timestamp',
-		'id'
+		'id',
+		'processId'
 	],
 	#classVars : [
 		'IdCounter',
@@ -40,7 +41,7 @@ ZnLogEvent class >> initialize [
 { #category : 'convenience' }
 ZnLogEvent class >> logToTranscript [
 	self stopLoggingToTranscript.
-	^ self announcer when: ZnLogEvent do: [ :event | self crTrace: event ] for: self
+	^ self announcer when: ZnLogEvent do: [ :event | self crTrace: event ]
 ]
 
 { #category : 'accessing' }
@@ -80,6 +81,8 @@ ZnLogEvent >> emit [
 
 { #category : 'accessing' }
 ZnLogEvent >> id [
+	"Return my numerical id or sequence number, unique in this image session."
+	
 	^ id
 ]
 
@@ -87,7 +90,8 @@ ZnLogEvent >> id [
 ZnLogEvent >> initialize [
 	super initialize.
 	timestamp := DateAndTime now.
-	id := self nextId
+	id := self nextId.
+	processId := ZnUtils currentProcessID
 ]
 
 { #category : 'accessing' }
@@ -101,16 +105,40 @@ ZnLogEvent >> printContentsOn: stream [
 ]
 
 { #category : 'printing' }
-ZnLogEvent >> printOn: stream [
+ZnLogEvent >> printHeaderOn: stream [
+	"Print my generic context part, <date> <time> <seq-nr> <process> [ subclass addition], to stream"
+	
 	timestamp printYMDOn: stream.
 	stream space.
 	timestamp printHMSOn: stream.
 	stream space.
 	id \\ 1000 printOn: stream base: 10 length: 3 padded: true.
+	stream space.
+	processId printOn: stream base: 10 length: 6 padded: true
+]
+
+{ #category : 'printing' }
+ZnLogEvent >> printOn: stream [
+	self printHeaderOn: stream.
+	stream space.
 	self printContentsOn: stream
 ]
 
 { #category : 'accessing' }
+ZnLogEvent >> processId [
+	"Return a numeric process id"
+	
+	^ processId
+]
+
+{ #category : 'initialize' }
+ZnLogEvent >> processId: anObject [
+	processId := anObject
+]
+
+{ #category : 'accessing' }
 ZnLogEvent >> timestamp [
+	"Return the point in time when I was created"
+
 	^ timestamp
 ]

--- a/src/Zinc-HTTP/ZnRequestReadEvent.class.st
+++ b/src/Zinc-HTTP/ZnRequestReadEvent.class.st
@@ -28,7 +28,7 @@ ZnRequestReadEvent >> duration: anObject [
 { #category : 'printing' }
 ZnRequestReadEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Request Read '; print: request; space; print: duration; << 'ms'
+	stream << 'Request Read '; print: request; space; print: duration; << 'ms'
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnRequestResponseHandledEvent.class.st
+++ b/src/Zinc-HTTP/ZnRequestResponseHandledEvent.class.st
@@ -27,7 +27,7 @@ ZnRequestResponseHandledEvent >> duration: anObject [
 { #category : 'printing' }
 ZnRequestResponseHandledEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Request Handled '; print: request; space; print: duration; << 'ms'
+	stream << 'Request Handled '; print: request; space; print: duration; << 'ms'
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnRequestWrittenEvent.class.st
+++ b/src/Zinc-HTTP/ZnRequestWrittenEvent.class.st
@@ -26,7 +26,7 @@ ZnRequestWrittenEvent >> duration: anObject [
 { #category : 'printing' }
 ZnRequestWrittenEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Request Written '; print: request; space; print: duration; << 'ms'
+	stream << 'Request Written '; print: request; space; print: duration; << 'ms'
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnResponseReadEvent.class.st
+++ b/src/Zinc-HTTP/ZnResponseReadEvent.class.st
@@ -26,7 +26,7 @@ ZnResponseReadEvent >> duration: anObject [
 { #category : 'printing' }
 ZnResponseReadEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Response Read '; print: response; space; print: duration; << 'ms'
+	stream << 'Response Read '; print: response; space; print: duration; << 'ms'
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnResponseWrittenEvent.class.st
+++ b/src/Zinc-HTTP/ZnResponseWrittenEvent.class.st
@@ -26,7 +26,7 @@ ZnResponseWrittenEvent >> duration: anObject [
 { #category : 'printing' }
 ZnResponseWrittenEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Response Written '; print: response; space; print: duration; << 'ms'
+	stream << 'Response Written '; print: response; space; print: duration; << 'ms'
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnServer.class.st
+++ b/src/Zinc-HTTP/ZnServer.class.st
@@ -457,6 +457,24 @@ ZnServer >> scheme [
 	^ #http
 ]
 
+{ #category : 'options' }
+ZnServer >> serverId [
+	"Return my serverId.
+	This is a short identification string used in my name and while logging.
+	The default is nil, meaning there is no serverId."
+
+	^ self optionAt: #serverId ifAbsent: [ nil ]
+]
+
+{ #category : 'options' }
+ZnServer >> serverId: object [
+	"Set my serverId.
+	This is a short identification string used in my name and while logging.
+	The default is nil, meaning there is no serverId."
+
+	self optionAt: #serverId put: object
+]
+
 { #category : 'accessing' }
 ZnServer >> serverSocket [
 	"Return the server socket that I am using.

--- a/src/Zinc-HTTP/ZnServerConnectionClosedEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerConnectionClosedEvent.class.st
@@ -25,6 +25,6 @@ ZnServerConnectionClosedEvent >> address: anObject [
 { #category : 'printing' }
 ZnServerConnectionClosedEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Server Connection Closed '.
+	stream << 'Server Connection Closed '.
 	address do: [ :each | stream print: each ] separatedBy: [ stream nextPut: $. ]
 ]

--- a/src/Zinc-HTTP/ZnServerGenericLogEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerGenericLogEvent.class.st
@@ -31,7 +31,7 @@ ZnServerGenericLogEvent class >> subject: object [
 { #category : 'printing' }
 ZnServerGenericLogEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream space; nextPutAll: subject asString
+	stream nextPutAll: subject asString
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnServerHandlerErrorEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerHandlerErrorEvent.class.st
@@ -12,5 +12,5 @@ Class {
 { #category : 'printing' }
 ZnServerHandlerErrorEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Server Handler Error ';  print: exception
+	stream << 'Server Handler Error ';  print: exception
 ]

--- a/src/Zinc-HTTP/ZnServerLogEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerLogEvent.class.st
@@ -8,8 +8,7 @@ Class {
 	#name : 'ZnServerLogEvent',
 	#superclass : 'ZnLogEvent',
 	#instVars : [
-		'serverId',
-		'processId'
+		'serverId'
 	],
 	#category : 'Zinc-HTTP-Logging',
 	#package : 'Zinc-HTTP',
@@ -23,21 +22,9 @@ ZnServerLogEvent >> initialize [
 ]
 
 { #category : 'printing' }
-ZnServerLogEvent >> printContentsOn: stream [
-	super printContentsOn: stream.
-	serverId ifNotNil: [ stream space; << serverId ].
-	stream space.
-	processId printOn: stream base: 10 length: 6 padded: true
-]
-
-{ #category : 'accessing' }
-ZnServerLogEvent >> processId [
-	^ processId
-]
-
-{ #category : 'initialize' }
-ZnServerLogEvent >> processId: anObject [
-	processId := anObject
+ZnServerLogEvent >> printHeaderOn: stream [
+	super printHeaderOn: stream.
+	serverId ifNotNil: [ stream space; << serverId ]
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnServerReadErrorEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerReadErrorEvent.class.st
@@ -13,5 +13,5 @@ Class {
 { #category : 'printing' }
 ZnServerReadErrorEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Server Read Error ';  print: exception
+	stream << 'Server Read Error ';  print: exception
 ]

--- a/src/Zinc-HTTP/ZnServerSocketBoundEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerSocketBoundEvent.class.st
@@ -36,7 +36,7 @@ ZnServerSocketBoundEvent >> port: anObject [
 { #category : 'printing' }
 ZnServerSocketBoundEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Server Socket Bound '.
+	stream << 'Server Socket Bound '.
 	address do: [ :each | stream print: each ] separatedBy: [ stream nextPut: $. ].
 	stream nextPut: $:; print: port
 ]

--- a/src/Zinc-HTTP/ZnServerSocketReleasedEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerSocketReleasedEvent.class.st
@@ -36,7 +36,7 @@ ZnServerSocketReleasedEvent >> port: anObject [
 { #category : 'printing' }
 ZnServerSocketReleasedEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Server Socket Released '.
+	stream << 'Server Socket Released '.
 	address do: [ :each | stream print: each ] separatedBy: [ stream nextPut: $. ].
 	stream nextPut: $:; print: port
 ]

--- a/src/Zinc-HTTP/ZnServerStartedEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerStartedEvent.class.st
@@ -26,5 +26,5 @@ ZnServerStartedEvent >> description: anObject [
 { #category : 'printing' }
 ZnServerStartedEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Started '; << description
+	stream << 'Started '; << description
 ]

--- a/src/Zinc-HTTP/ZnServerStoppedEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerStoppedEvent.class.st
@@ -25,5 +25,5 @@ ZnServerStoppedEvent >> description: anObject [
 { #category : 'printing' }
 ZnServerStoppedEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Stopped '; << description
+	stream << 'Stopped '; << description
 ]

--- a/src/Zinc-HTTP/ZnServerTransactionEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerTransactionEvent.class.st
@@ -29,7 +29,6 @@ ZnServerTransactionEvent >> duration [
 { #category : 'printing' }
 ZnServerTransactionEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream space.
 	request requestLine printMethodAndUriOn: stream.
 	stream space; print: response code.
 	response hasEntity

--- a/src/Zinc-HTTP/ZnServerTransactionTiming.class.st
+++ b/src/Zinc-HTTP/ZnServerTransactionTiming.class.st
@@ -33,6 +33,12 @@ ZnServerTransactionTiming >> initialize [
 	requestDuration := handlerDuration := responseDuration := 0
 ]
 
+{ #category : 'printing' }
+ZnServerTransactionTiming >> printOn: stream [
+	super printOn: stream.
+	stream nextPut: $(; print: self totalDuration; nextPut: $)
+]
+
 { #category : 'accessing' }
 ZnServerTransactionTiming >> requestDuration [
 	^ requestDuration

--- a/src/Zinc-HTTP/ZnServerWriteErrorEvent.class.st
+++ b/src/Zinc-HTTP/ZnServerWriteErrorEvent.class.st
@@ -13,5 +13,5 @@ Class {
 { #category : 'printing' }
 ZnServerWriteErrorEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream << ' Server Write Error ';  print: exception
+	stream << 'Server Write Error ';  print: exception
 ]

--- a/src/Zinc-HTTP/ZnSimplifiedClientTransactionEvent.class.st
+++ b/src/Zinc-HTTP/ZnSimplifiedClientTransactionEvent.class.st
@@ -44,8 +44,7 @@ ZnSimplifiedClientTransactionEvent >> method [
 { #category : 'printing' }
 ZnSimplifiedClientTransactionEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream space; nextPutAll: method.
-	stream space.
+	stream nextPutAll: method; space.
 	url printPathQueryFragmentOn: stream.
 	stream space; print: response.
 	size ifNotNil: [

--- a/src/Zinc-HTTP/ZnSimplifiedServerTransactionEvent.class.st
+++ b/src/Zinc-HTTP/ZnSimplifiedServerTransactionEvent.class.st
@@ -39,8 +39,7 @@ ZnSimplifiedServerTransactionEvent >> method [
 { #category : 'printing' }
 ZnSimplifiedServerTransactionEvent >> printContentsOn: stream [
 	super printContentsOn: stream.
-	stream space; nextPutAll: method.
-	stream space.
+	stream nextPutAll: method; space.
 	url printPathQueryFragmentOn: stream.
 	stream space; print: response.
 	size ifNotNil: [

--- a/src/Zinc-HTTP/ZnSingleThreadedServer.class.st
+++ b/src/Zinc-HTTP/ZnSingleThreadedServer.class.st
@@ -282,7 +282,7 @@ ZnSingleThreadedServer >> logConnectionClosed: socketStream [
 		emit
 ]
 
-{ #category : 'private logging' }
+{ #category : 'private - logging' }
 ZnSingleThreadedServer >> logConnectionRejected: socketStream [
 	logLevel < 3 ifTrue: [ ^ nil ].
 	^ (self newLogEvent: ZnConnectionRejectedEvent)
@@ -442,7 +442,7 @@ ZnSingleThreadedServer >> loggingOn [
 { #category : 'private - logging' }
 ZnSingleThreadedServer >> newLogEvent: logEventClass [
 	^ logEventClass new
-		serverId: self route;
+		serverId: (self serverId ifNil: [ self route ]);
 		yourself
 ]
 
@@ -478,6 +478,8 @@ ZnSingleThreadedServer >> printOn: stream [
 	stream nextPutAll: (self isRunning ifTrue: [ 'running' ] ifFalse: [ 'stopped' ]).
 	self port ifNotNil: [ :port | stream space; print: port ].
 	self bindingAddress ifNotNil: [ :bindingAddress | stream space; print: bindingAddress ].
+	self serverId ifNotNil: [ :id | stream space; print: id ].
+	self route ifNotNil: [ :id | stream space; print: id ].
 	stream nextPut: $)
 ]
 
@@ -542,7 +544,9 @@ ZnSingleThreadedServer >> serveConnectionOn: listeningSocket [
 { #category : 'private' }
 ZnSingleThreadedServer >> serverProcessName [
 	^ String streamContents: [ :stream |
-		stream nextPutAll: self class name; nextPutAll: ' HTTP port '; print: self port ]
+		stream nextPutAll: self class name; nextPutAll: ' HTTP port '; print: self port.
+		self serverId ifNotNil: [ :id | stream space; << id ].
+		self route ifNotNil: [ :id | stream space; << id ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Zinc-HTTP/ZnStringEntity.class.st
+++ b/src/Zinc-HTTP/ZnStringEntity.class.st
@@ -174,7 +174,7 @@ ZnStringEntity >> readFrom: stream [
 	readStream := total ifNotNil: [ ZnLimitedReadStream on: stream limit: total ] ifNil: [ stream ].
 	buffer := String new: (ZnUtils streamingBufferSize min: (total ifNil: [ ZnUtils streamingBufferSize ])).
 	stringStream := nil.
-	totalRead := 0.
+	totalRead := read := 0.
 	self initializeEncoder.
 	[ readStream atEnd ] whileFalse: [
 		[ read := encoder readInto: buffer startingAt: 1 count: buffer size fromStream: readStream ]
@@ -191,7 +191,7 @@ ZnStringEntity >> readFrom: stream [
 			ifTrue: [ ZnEntityTooLarge signal ].
 		stringStream ifNil: [
 			readStream atEnd
-				ifTrue: [ ^ self string: (buffer copyFrom: 1 to: read) ]
+				ifTrue: [ ^ self string: (buffer copyFrom: 1 to: read); computeContentLength ]
 				ifFalse: [ stringStream := (total ifNil: [ buffer species new ] ifNotNil: [ buffer species new: total ]) writeStream ] ].
 		stringStream next: read putAll: buffer startingAt: 1.
 		ZnUtils signalProgress: totalRead total: total ].

--- a/src/Zinc-HTTP/ZnUtils.class.st
+++ b/src/Zinc-HTTP/ZnUtils.class.st
@@ -227,16 +227,17 @@ ZnUtils class >> streamFrom: inputStream to: outputStream size: totalSize [
 	bufferSize := self streamingBufferSize min: totalSize.
 	buffer := (inputStream isBinary ifTrue: [ ByteArray ] ifFalse: [ String ]) new: bufferSize.
 	leftToRead := totalSize.
-	[ leftToRead > 0 ]
-		whileTrue: [ | readCount |
-			readCount := bufferSize min: leftToRead.
-			inputStream next: readCount into: buffer.
+	[ leftToRead > 0 and: [ inputStream atEnd not ] ]
+		whileTrue: [ | toReadCount readCount |
+			toReadCount := bufferSize min: leftToRead.
+			readCount := inputStream readInto: buffer startingAt: 1 count: toReadCount.
 			leftToRead := leftToRead - readCount.
 			outputStream next: readCount putAll: buffer startingAt: 1.
 			leftToRead > 0
 				ifTrue: [
 					self signalProgress: (totalSize - leftToRead) total: totalSize.
-					outputStream flush ] ]
+					outputStream flush ] ].
+	^ totalSize - leftToRead
 ]
 
 { #category : 'streaming' }


### PR DESCRIPTION
First half of #11150

- Add guard to skip: to report negative count (19dbf9e000122281fcd174528111f318956e1942)
- Improve ZnLogEvent. (3b35e0fce1df033f5a2f9bc5c381ad635cadd42f)
- Add #endianness and #isStrict default implementations to ZnCharacterEncoder (866d316f33f529f010db0074a92a2217c820dc0d)
- A fix for #118 (f8c23a64f0a7ccd23716dab3bacb59060c1a69f7)
- Modify ZnBufferedReadStream>>back to correctly move back when the buffer is at the start but the stream is not (66b919a23ee720eb447b6533b318fdc461b12a47)