### PR TITLE
Zodiac synch

### DIFF
--- a/src/Zodiac-Core/ZdcAbstractSocketStream.class.st
+++ b/src/Zodiac-Core/ZdcAbstractSocketStream.class.st
@@ -299,6 +299,7 @@ ZdcAbstractSocketStream >> skip: count [
 	"Skip over count bytes.
 	This is an inefficient abstract implementation skipping bytes one by one."
 
+	count < 0 ifTrue: [ self error: 'cannot skip backwards' ].
 	count timesRepeat: [ self next ]
 ]
 

--- a/src/Zodiac-Core/ZdcOptimizedSocketStream.class.st
+++ b/src/Zodiac-Core/ZdcOptimizedSocketStream.class.st
@@ -18,6 +18,7 @@ ZdcOptimizedSocketStream >> next: count putAll: collection startingAt: offset [
 	"Write count bytes from collection starting at offset. Overwritten, optimized"
 
 	| totalWritten |
+	writeBuffer isFull ifTrue: [ self flushWriteBuffer ].
 	totalWritten := 0.
 	[ | toWrite |
 		toWrite := (count - totalWritten) min: writeBuffer availableForWriting.
@@ -50,6 +51,7 @@ ZdcOptimizedSocketStream >> skip: count [
 	"Skip over count bytes. Overwritten, optimized"
 
 	| skipCount |
+	count < 0 ifTrue: [ self error: 'cannot skip backwards' ].
 	skipCount := 0.
 	[ | leftToSkip skipping |
 		leftToSkip := count - skipCount.

--- a/src/Zodiac-Extra/ZdcSecureSMTPClient.class.st
+++ b/src/Zodiac-Extra/ZdcSecureSMTPClient.class.st
@@ -3,6 +3,7 @@ I am ZdcSecureSMTPClient.
 
 I open a ZdcSecureSocketStream to the SMTP server and connect it at the SSL level.
 
+```
 | mailMessage |
 mailMessage := MailMessage empty.
 mailMessage setField: 'subject' toString: 'ZdcSecureSMTPClient Test'.
@@ -12,13 +13,15 @@ ZdcSecureSMTPClient
 	password: '<your-password>'
 	to: '<email-address>' 
 	message: mailMessage
+```
 "
 Class {
 	#name : 'ZdcSecureSMTPClient',
 	#superclass : 'SMTPClient',
 	#instVars : [
 		'variant',
-		'lineReader'
+		'lineReader',
+		'skipRequireStartTLS'
 	],
 	#category : 'Zodiac-Extra',
 	#package : 'Zodiac-Extra'
@@ -100,7 +103,8 @@ ZdcSecureSMTPClient >> fetchNextResponse [
 { #category : 'initialization' }
 ZdcSecureSMTPClient >> initialize [
 	super initialize.
-	self useSSL
+	self useSSL.
+	skipRequireStartTLS := false
 ]
 
 { #category : 'testing' }
@@ -128,6 +132,12 @@ ZdcSecureSMTPClient >> nextLineFromStream [
 
 { #category : 'private - protocol' }
 ZdcSecureSMTPClient >> requireStartTLS [
+	"Normally, the server advertises is capabilities before the upgrade from plain to TLS.
+	It should list STARTTLS as one of its capabilities. If not, we signal an error.
+	The option skipRequireStartTLS allows for this test to be skipped,
+	assuming STARTTLS capability even though it was not advertised."
+
+	skipRequireStartTLS ifTrue: [ ^ self ].
 	(self lastResponse includesSubstring: 'STARTTLS')
 		ifFalse: [ ^ self error: 'Server does not seem to support STARTTLS' ]
 ]
@@ -165,6 +175,16 @@ ZdcSecureSMTPClient >> setupStreamForStartTLS [
 	self initiateSession.
 	self requireStartTLS.
 	self startTLS
+]
+
+{ #category : 'initialize-release' }
+ZdcSecureSMTPClient >> skipRequireStartSSL [
+	"Normally, the server advertises is capabilities before the upgrade from plain to TLS.
+	It should list STARTTLS as one of its capabilities. If not, we signal an error.
+	The option skipRequireStartTLS allows for this test to be skipped,
+	assuming STARTTLS capability even though it was not advertised."
+
+	skipRequireStartTLS := true
 ]
 
 { #category : 'private - protocol' }


### PR DESCRIPTION
- Add guard to skip: to report negative count (b77f7d3e69ce8040c3ad465ea49ebc7d7e322dbd)
- Fix an edge case in ZdcOptimizedSocketStream>>#next:putAll:startingAt: (ad0458cde7e536f59e9fe4ca41afdfee0c39bf95)
- Add the option skipRequireStartSSL to ZdcSecureSMTPClient  (2d61315a6b42a56308234016f7caf61b3e095f0d)

Fixes #11150