### PR TITLE
Fix announcements during class creation 

### DIFF
--- a/src/Announcements-Core/AbstractAnnouncementSubscription.class.st
+++ b/src/Announcements-Core/AbstractAnnouncementSubscription.class.st
@@ -60,7 +60,7 @@ AbstractAnnouncementSubscription >> deliver: anAnnouncement [
 	(self handlesAnnouncement: anAnnouncement) ifTrue: [
 		[ action cull: anAnnouncement cull: announcer ]
 			on: UnhandledError
-			fork: [ :ex | ex pass ] ]
+			do: [ :ex | ex pass ] ]
 ]
 
 { #category : 'error handling' }

--- a/src/Announcements-Core/AbstractAnnouncementSubscription.class.st
+++ b/src/Announcements-Core/AbstractAnnouncementSubscription.class.st
@@ -60,7 +60,7 @@ AbstractAnnouncementSubscription >> deliver: anAnnouncement [
 	(self handlesAnnouncement: anAnnouncement) ifTrue: [
 		[ action cull: anAnnouncement cull: announcer ]
 			on: UnhandledError
-			do: [ :ex | ex pass ] ]
+			fork: [ :ex | ex pass ] ]
 ]
 
 { #category : 'error handling' }

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerAnnouncementsTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerAnnouncementsTest.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : 'ShClassInstallerAnnouncementsTest',
+	#superclass : 'ShClassInstallerTest',
+	#instVars : [
+		'numberOfAnnouncements',
+		'newTrait'
+	],
+	#category : 'Shift-ClassInstaller-Tests',
+	#package : 'Shift-ClassInstaller-Tests'
+}
+
+{ #category : 'running' }
+ShClassInstallerAnnouncementsTest >> setUp [
+
+	super setUp.
+	numberOfAnnouncements := 0
+]
+
+{ #category : 'running' }
+ShClassInstallerAnnouncementsTest >> tearDown [
+
+	SystemAnnouncer uniqueInstance unsubscribe: self.
+	{ newTrait } do: [ :class | class ifNotNil: [ class removeFromSystem ] ].
+	super tearDown
+]
+
+{ #category : 'tests' }
+ShClassInstallerAnnouncementsTest >> testRecompilingClassUsingTraitsDoesNotAnnounceProtocolChange [
+	"Regression test because recompiling a class with trait was announcing protocol creations."
+
+	newTrait := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #TSHTrait;
+			            package: self generatedClassesPackageName;
+			            beTrait ].
+
+	self when: ProtocolAnnouncement do: [ :ann | self fail: 'Recreating a class should not announce anything.' ].
+	self when: MethodAnnouncement do: [ :ann | self fail: 'Recreating a class should not announce anything.' ].
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #SHClassWithTrait;
+			            superclass: Object;
+			            traitComposition: newTrait;
+			            package: self generatedClassesPackageName ]
+]
+
+{ #category : 'protocol' }
+ShClassInstallerAnnouncementsTest >> when: anAnnouncement do: aBlock [
+
+	SystemAnnouncer uniqueInstance
+		when: anAnnouncement
+		do: [ :ann |
+			numberOfAnnouncements := numberOfAnnouncements + 1.
+			aBlock cull: ann ]
+		for: self
+]

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -196,9 +196,8 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 	 - The trait defining the method is not the same.
 	 - If both methods have source code and if the source codes are not the same.
 	"
-	aClass methodDict at: aSelector ifPresent: [ :originalMethod |
-		((replacing not and: [ originalMethod traitSource = traitDefining and: [ originalMethod hasSourceCode ] ]) and: [
-			 source isNotNil and: [ source = originalMethod sourceCode ] ]) ifTrue: [ ^ false ] ].
+	aClass compiledMethodAt: aSelector ifPresent: [ :originalMethod |
+		(replacing not and: [ originalMethod traitSource = traitDefining and: [ originalMethod hasSourceCode and: [ source isNotNil and: [ source = originalMethod sourceCode ] ] ] ]) ifTrue: [ ^ false ] ].
 
 	newMethod := aCompiledMethod copy.
 	newMethod selector: aSelector.
@@ -207,7 +206,9 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 	newMethod setSourcePointer: aCompiledMethod sourcePointer.
 
 	"This step should not announce anything in the system."
-	SystemAnnouncer uniqueInstance suspendAllWhile: [ aClass addAndClassifySelector: aSelector withMethod: newMethod inProtocol: aCompiledMethod protocol ].
+	SystemAnnouncer uniqueInstance suspendAllWhile: [ aClass classify: aSelector under: aCompiledMethod protocolName ].
+
+	aClass addSelectorSilently: aSelector withMethod: newMethod.
 
 	aClass >> aSelector propertyAt: #traitSource put: traitDefining.
 

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -196,8 +196,9 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 	 - The trait defining the method is not the same.
 	 - If both methods have source code and if the source codes are not the same.
 	"
-	aClass compiledMethodAt: aSelector ifPresent: [ :originalMethod |
-		(replacing not and: [ originalMethod traitSource = traitDefining and: [ originalMethod hasSourceCode and: [ source isNotNil and: [ source = originalMethod sourceCode ] ] ] ]) ifTrue: [ ^ false ] ].
+	aClass methodDict at: aSelector ifPresent: [ :originalMethod |
+		((replacing not and: [ originalMethod traitSource = traitDefining and: [ originalMethod hasSourceCode ] ]) and: [
+			 source isNotNil and: [ source = originalMethod sourceCode ] ]) ifTrue: [ ^ false ] ].
 
 	newMethod := aCompiledMethod copy.
 	newMethod selector: aSelector.

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -196,9 +196,8 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 	 - The trait defining the method is not the same.
 	 - If both methods have source code and if the source codes are not the same.
 	"
-	aClass methodDict at: aSelector ifPresent: [ :originalMethod |
-		((replacing not and: [ originalMethod traitSource = traitDefining and: [ originalMethod hasSourceCode ] ]) and: [
-			 source isNotNil and: [ source = originalMethod sourceCode ] ]) ifTrue: [ ^ false ] ].
+	aClass compiledMethodAt: aSelector ifPresent: [ :originalMethod |
+		(replacing not and: [ originalMethod traitSource = traitDefining and: [ originalMethod hasSourceCode and: [ source isNotNil and: [ source = originalMethod sourceCode ] ] ] ]) ifTrue: [ ^ false ] ].
 
 	newMethod := aCompiledMethod copy.
 	newMethod selector: aSelector.
@@ -206,9 +205,8 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 
 	newMethod setSourcePointer: aCompiledMethod sourcePointer.
 
-	aClass classify: aSelector under: aCompiledMethod protocolName.
-
-	aClass addSelectorSilently: aSelector withMethod: newMethod.
+	"This step should not announce anything in the system."
+	SystemAnnouncer uniqueInstance suspendAllWhile: [ aClass addAndClassifySelector: aSelector withMethod: newMethod inProtocol: aCompiledMethod protocol ].
 
 	aClass >> aSelector propertyAt: #traitSource put: traitDefining.
 

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -108,10 +108,9 @@ TraitBuilderEnhancer >> beforeMigratingClass: aBuilder installer: anInstaller [
 { #category : 'events' }
 TraitBuilderEnhancer >> classCreated: aBuilder [
 
-	(self isTraitedMetaclass: aBuilder)
-		ifFalse: [ ^ self ].
+	(self isTraitedMetaclass: aBuilder) ifFalse: [ ^ self ].
 
-	builder newMetaclass initializeBasicMethods.
+	SystemAnnouncer uniqueInstance prevent: ProtocolAnnouncement during: [ builder newMetaclass initializeBasicMethods ].
 
 	builder newClass traitComposition: self traitComposition.
 	builder newMetaclass traitComposition: self classTraitComposition

--- a/src/TraitsV2/TraitBuilderEnhancer.class.st
+++ b/src/TraitsV2/TraitBuilderEnhancer.class.st
@@ -110,7 +110,7 @@ TraitBuilderEnhancer >> classCreated: aBuilder [
 
 	(self isTraitedMetaclass: aBuilder) ifFalse: [ ^ self ].
 
-	SystemAnnouncer uniqueInstance prevent: ProtocolAnnouncement during: [ builder newMetaclass initializeBasicMethods ].
+	builder newMetaclass initializeBasicMethods.
 
 	builder newClass traitComposition: self traitComposition.
 	builder newMetaclass traitComposition: self classTraitComposition


### PR DESCRIPTION
If we create a class with traits in the system, the class builder is installing some basic methods in the class. This operation should be silent but in fact we are raising some announcements currently. 

This fixes the problem and adds a tests to ensure the behavior is not reverted.