### PR TITLE
fix: SystemDictionary keys must now be symbols

### DIFF
--- a/src/Fuel-Core-Tests/FLCreateClassSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLCreateClassSerializationTest.class.st
@@ -58,7 +58,7 @@ FLCreateClassSerializationTest >> testCreateByteArrayWithInstance [
 
 { #category : 'tests' }
 FLCreateClassSerializationTest >> testCreateClassAndMetaclass [
-	"Tests materialization a class or trait not defined in the image and that the metaclass is also created."
+	"Tests materialization of a class or trait not defined in the image and that the metaclass is also created."
 
 	| class materializedClassOrTrait environment category name metaclassName metaclass |
 	class := self classFactory silentlyNewClass.
@@ -70,8 +70,7 @@ FLCreateClassSerializationTest >> testCreateClassAndMetaclass [
 
 	materializedClassOrTrait := self resultOfSerializeRemoveAndMaterialize: class.
 
-	"This is the test environment, so we have to cheat"
-	self assertCollection: environment associations hasSameElements: materializedClassOrTrait environment associations.
+	self assert: environment identicalTo: materializedClassOrTrait environment.
 
 	self assert: category equals: materializedClassOrTrait category.
 	self assert: name equals: materializedClassOrTrait name.
@@ -474,7 +473,7 @@ FLCreateClassSerializationTest >> testCreateWithNilEnvironment [
 
 { #category : 'tests' }
 FLCreateClassSerializationTest >> testCreateWithSmalltalkGlobalsEnvironment [
-	"Tests materialization a class or trait not defined in the image, and with Smalltalk globals  in the instance variable 'environment '. In that case, the whole Smalltalk globals should NOT be fully serialized but instead just store a reference to it. "
+	"Tests materialization of a class or trait not defined in the image, and with Smalltalk globals  in the instance variable 'environment'. In that case, the whole Smalltalk globals should NOT be fully serialized but only a reference to the globals should be stored. "
 
 	| aClassOrTrait materializedClassOrTrait category name |
 	aClassOrTrait := self classFactory silentlyNewClass.

--- a/src/Fuel-Core-Tests/FLFullBasicSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLFullBasicSerializationTest.class.st
@@ -27,7 +27,7 @@ FLFullBasicSerializationTest >> defaultTimeLimit [
 { #category : 'initialization' }
 FLFullBasicSerializationTest >> initialize [
 		<ignoreUnusedClassVariables: #( ClassVariableForTesting )>
-		super initialize.
+		super initialize
 ]
 
 { #category : 'tests' }

--- a/src/Fuel-Core-Tests/FLSerializerTest.class.st
+++ b/src/Fuel-Core-Tests/FLSerializerTest.class.st
@@ -343,38 +343,6 @@ FLSerializerTest >> testLookUpInGlobalsMustBeGlobal [
 ]
 
 { #category : 'tests-configuring-globals' }
-FLSerializerTest >> testLookUpInGlobalsObjectKey [
-	| object marge |
-	object := Object new.
-	marge := 'Marge'.
-	self environmentOfTest
-		at: object
-		put: marge.
-	addedGlobals add: object.
-	self serializer lookUpInGlobals: object.
-
-	self assert: (self serializer globals includesKey: object).
-	self assert: (self serializer globals at: object) identicalTo: marge.
-	self deny: (self serializer globals includesKey: marge)
-]
-
-{ #category : 'tests-configuring-globals' }
-FLSerializerTest >> testLookUpInGlobalsPassingValue [
-	| object1 object2 |
-	object1 := Object new.
-	object2 := Object new.
-	self environmentOfTest
-		at: object1
-		put: object2.
-	addedGlobals add: object1.
-	self serializer lookUpInGlobals: object2.
-	
-	self assert: (self serializer globals includesKey: object1).
-	self assert: (self serializer globals at: object1) identicalTo: object2.
-	self deny: (self serializer globals includesKey: object2)
-]
-
-{ #category : 'tests-configuring-globals' }
 FLSerializerTest >> testLookUpInGlobalsSymbolKey [
 	| object |
 	object := Object new.
@@ -391,15 +359,17 @@ FLSerializerTest >> testLookUpInGlobalsSymbolKey [
 
 { #category : 'tests-configuring-globals' }
 FLSerializerTest >> testLookupAllInGlobals [
-	| globals global1 global2 marge |
+	| globals global1 marge |
 	global1 := Object new.
-	global2 := Object new.
 	marge := 'Marge'.
 	globals := { Object. Class. Smalltalk. #World. global1. marge }.
 	self serializer lookUpAllInGlobals: globals.
 	self environmentOfTest
 		at: #global1 put: global1;
-		at: global2 put: marge.
+		at: #global2 put: marge.
+	addedGlobals
+		add: #global1;
+		add: #global2.
 	
 	{
 		#Object -> Object.
@@ -407,7 +377,6 @@ FLSerializerTest >> testLookupAllInGlobals [
 		#Smalltalk -> Smalltalk.
 		#World -> World.
 		#global1 -> global1.
-		global2 -> marge
 	} do: [ :assoc |
 		self assert: (self serializer globals includesAssociation: assoc) ]
 ]

--- a/src/Fuel-Core-Tests/FLSystemGlobalsTestResource.class.st
+++ b/src/Fuel-Core-Tests/FLSystemGlobalsTestResource.class.st
@@ -1,5 +1,7 @@
 "
-In order to be sure Fuel tests will not impact the global system, I copy the globals and add them back after the tests are done
+I create a deep copy of the system globals to prevent their pollution. When I am cleaned up, I simply forget the copy and the system globals will remain in their original state.
+
+Note that copying the system globals is very expensive, so only use me where necessary.
 "
 Class {
 	#name : 'FLSystemGlobalsTestResource',

--- a/src/Fuel-Core-Tests/FLTCreateClassOrTraitSerializationTest.trait.st
+++ b/src/Fuel-Core-Tests/FLTCreateClassOrTraitSerializationTest.trait.st
@@ -82,7 +82,7 @@ FLTCreateClassOrTraitSerializationTest >> testCompiledMethodClassBinding [
 
 { #category : 'tests' }
 FLTCreateClassOrTraitSerializationTest >> testCreateBasic [
-	"Tests materialization a class or trait not defined in the image."
+	"Tests materialization of a class or trait not defined in the image."
 
 	| aClassOrTrait materializedClassOrTrait environment category name |
 	aClassOrTrait := self newClassOrTrait.
@@ -93,8 +93,7 @@ FLTCreateClassOrTraitSerializationTest >> testCreateBasic [
 	materializedClassOrTrait := self resultOfSerializeRemoveAndMaterialize: aClassOrTrait.
 
 	self deny: aClassOrTrait identicalTo: materializedClassOrTrait.
-	"This is the test environment wrapper, so we need to cheat"
-	self assertCollection: environment associations hasSameElements: materializedClassOrTrait environment associations.
+	self assert: environment identicalTo: materializedClassOrTrait environment.
 	self assert: category equals: materializedClassOrTrait category.
 	self assert: name equals: materializedClassOrTrait name.
 


### PR DESCRIPTION
Some Fuel tests still expected that having objects as keys in the globals dictionary was legal.

Fixes #14818.