### PR TITLE
Refactor message send

### DIFF
--- a/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
+++ b/src/Kernel-Tests-Extended/WriteBarrierTest.class.st
@@ -245,7 +245,7 @@ WriteBarrierTest >> testMutateObjectInstVarShouldCatchRightFailure [
 
 	self assert: failure object identicalTo: guineaPig.
 	self assert: failure newValue equals: #test.
-	self assert: failure fieldIndex equals: 1
+	self assert: failure fieldIndex equals: 4
 ]
 
 { #category : 'tests - object' }

--- a/src/Kernel/Message.class.st
+++ b/src/Kernel/Message.class.st
@@ -1,7 +1,12 @@
 "
 I represent a selector and its argument values.
-	
+
 Generally, the system does not use instances of Message for efficiency reasons. However, when a message is not understood by its receiver, the interpreter will make up an instance of me in order to capture the information involved in an actual message transmission. This instance is sent it as an argument with the message doesNotUnderstand: to the receiver.
+
+## Structure
+
+- selector: `Symbol` -- message selector
+- arguments: `Array` -- bound arguments
 "
 Class {
 	#name : 'Message',
@@ -69,6 +74,12 @@ Message >> arguments [
 	^arguments
 ]
 
+{ #category : 'accessing' }
+Message >> arguments: anArray [
+	<reflection: 'Message sending and code execution - Message send reification'>
+	arguments := anArray
+]
+
 { #category : 'converting' }
 Message >> asSendTo: anObject [
 
@@ -118,6 +129,12 @@ Message >> selector [
 	"Answer the selector of the receiver."
 	<reflection: 'Message sending and code execution - Message send reification'>
 	^selector
+]
+
+{ #category : 'accessing' }
+Message >> selector: aSymbol [
+	<reflection: 'Message sending and code execution - Message send reification'>
+	selector := aSymbol
 ]
 
 { #category : 'sending' }

--- a/src/Kernel/MessageSend.class.st
+++ b/src/Kernel/MessageSend.class.st
@@ -1,20 +1,18 @@
 "
-Instances of MessageSend encapsulate messages send to objects. Arguments can be either predefined or supplied when the message send is performed. 
+Instances of `MessageSend` encapsulate messages send to objects. Arguments can be either predefined or supplied when the message send is performed. 
 
 Use #value to perform a message send with its predefined arguments and #valueWithArguments: if additonal arguments have to supplied.
 
-Structure:
- receiver		Object -- object receiving the message send
- selector		Symbol -- message selector
- arguments		Array -- bound arguments
+## Structure
+
+- receiver: 	Object -- object receiving the message send
+
 "
 Class {
 	#name : 'MessageSend',
-	#superclass : 'Object',
+	#superclass : 'Message',
 	#instVars : [
-		'receiver',
-		'selector',
-		'arguments'
+		'receiver'
 	],
 	#category : 'Kernel-Messaging',
 	#package : 'Kernel',
@@ -50,18 +48,6 @@ MessageSend >> = anObject [
 		and: [receiver == anObject receiver
 		and: [selector == anObject selector
 		and: [arguments = anObject arguments]]]
-]
-
-{ #category : 'accessing' }
-MessageSend >> arguments [
-	<reflection: 'Message sending and code execution - Message send reification'>
-	^ arguments
-]
-
-{ #category : 'accessing' }
-MessageSend >> arguments: anArray [
-	<reflection: 'Message sending and code execution - Message send reification'>
-	arguments := anArray
 ]
 
 { #category : 'converting' }
@@ -140,13 +126,6 @@ MessageSend >> message [
 	^Message selector: selector arguments: arguments
 ]
 
-{ #category : 'accessing' }
-MessageSend >> numArgs [
-	"Answer the number of arguments in this message"
-	<reflection: 'Message sending and code execution - Message send reification'>
-	^arguments size
-]
-
 { #category : 'printing' }
 MessageSend >> printOn: aStream [
 
@@ -169,18 +148,6 @@ MessageSend >> receiver [
 MessageSend >> receiver: anObject [
 	<reflection: 'Message sending and code execution - Message send reification'>
 	receiver := anObject
-]
-
-{ #category : 'accessing' }
-MessageSend >> selector [
-	<reflection: 'Message sending and code execution - Message send reification'>
-	^ selector
-]
-
-{ #category : 'accessing' }
-MessageSend >> selector: aSymbol [
-	<reflection: 'Message sending and code execution - Message send reification'>
-	selector := aSymbol
 ]
 
 { #category : 'evaluating' }

--- a/src/Kernel/WeakMessageSend.class.st
+++ b/src/Kernel/WeakMessageSend.class.st
@@ -12,12 +12,10 @@ and it also has
 "
 Class {
 	#name : 'WeakMessageSend',
-	#superclass : 'Object',
+	#superclass : 'MessageSend',
 	#type : 'weak',
 	#instVars : [
-		'selector',
-		'shouldBeNil',
-		'arguments'
+		'shouldBeNil'
 	],
 	#category : 'Kernel-Messaging',
 	#package : 'Kernel',
@@ -27,24 +25,6 @@ Class {
 { #category : 'instance creation' }
 WeakMessageSend class >> new [
 	^self new: 1
-]
-
-{ #category : 'instance creation' }
-WeakMessageSend class >> receiver: anObject selector: aSymbol [
-	^ self receiver: anObject selector: aSymbol arguments: #()
-]
-
-{ #category : 'instance creation' }
-WeakMessageSend class >> receiver: anObject selector: aSymbol argument: aParameter [
-	^ self receiver: anObject selector: aSymbol arguments: (Array with: aParameter)
-]
-
-{ #category : 'instance creation' }
-WeakMessageSend class >> receiver: anObject selector: aSymbol arguments: anArray [
-	^ self new
-		receiver: anObject;
-		selector: aSymbol;
-		arguments: anArray
 ]
 
 { #category : 'comparing' }
@@ -97,30 +77,6 @@ WeakMessageSend >> collectArguments: anArgArray [
 				  to: (anArgArray size min: staticArgs size)
 				  with: anArgArray
 				  startingAt: 1 ]
-]
-
-{ #category : 'evaluating' }
-WeakMessageSend >> cull: arg [
-	<reflection: 'Message sending and code execution - Runtime and Evaluation'>
-	^ selector numArgs = 0
-		ifTrue: [ self value ]
-		ifFalse: [ self value: arg ]
-]
-
-{ #category : 'evaluating' }
-WeakMessageSend >> cull: arg1 cull: arg2 [
-	<reflection: 'Message sending and code execution - Runtime and Evaluation'>
-	^ selector numArgs < 2
-		ifTrue: [ self cull: arg1]
-		ifFalse: [ self value: arg1 value: arg2 ]
-]
-
-{ #category : 'evaluating' }
-WeakMessageSend >> cull: arg1 cull: arg2 cull: arg3 [
-	<reflection: 'Message sending and code execution - Runtime and Evaluation'>
-	^ selector numArgs < 3
-		ifTrue: [ self cull: arg1 cull: arg2 ]
-		ifFalse: [ self value: arg1 value: arg2 value: arg3 ]
 ]
 
 { #category : 'private' }
@@ -188,12 +144,6 @@ WeakMessageSend >> ensureReceiverAndArguments: aReceiver [
   ^true
 ]
 
-{ #category : 'comparing' }
-WeakMessageSend >> hash [
-	"work like MessageSend>>hash"
-	^self receiver hash bitXor: selector hash
-]
-
 { #category : 'private' }
 WeakMessageSend >> isAnyArgumentGarbage [
 	"Make sure that my arguments haven't gone away"
@@ -204,11 +154,6 @@ WeakMessageSend >> isAnyArgumentGarbage [
 		]
 	].
 	^false
-]
-
-{ #category : 'testing' }
-WeakMessageSend >> isMessageSend [
-	^true
 ]
 
 { #category : 'private' }
@@ -253,18 +198,6 @@ WeakMessageSend >> receiver [
 WeakMessageSend >> receiver: anObject [
 	<reflection: 'Message sending and code execution - Message send reification'>
 	self at: 1 put: anObject
-]
-
-{ #category : 'accessing' }
-WeakMessageSend >> selector [
-	<reflection: 'Message sending and code execution - Message send reification'>
-	^selector
-]
-
-{ #category : 'accessing' }
-WeakMessageSend >> selector: aSymbol [
-	<reflection: 'Message sending and code execution - Message send reification'>
-	selector := aSymbol
 ]
 
 { #category : 'evaluating' }

--- a/src/ReflectionMirrors-Primitives-Tests/MirrorPrimitivesTest.class.st
+++ b/src/ReflectionMirrors-Primitives-Tests/MirrorPrimitivesTest.class.st
@@ -63,11 +63,11 @@ MirrorPrimitivesTest >> testChangingFixedFieldOfWeakMessageSend [
 	MirrorPrimitives fixedFieldOf: arrayWithInstVars at: 1 put: #newSelector.
 	self assert: arrayWithInstVars selector equals: #newSelector.
 
-	MirrorPrimitives fixedFieldOf: arrayWithInstVars at: 3 put: #newArgs.
+	MirrorPrimitives fixedFieldOf: arrayWithInstVars at: 2 put: #newArgs.
 	self assert: arrayWithInstVars arguments equals: #newArgs.
 
 	self
-	 	should: [ MirrorPrimitives fixedFieldOf: arrayWithInstVars at: 5 put: 100 ]
+	 	should: [ MirrorPrimitives fixedFieldOf: arrayWithInstVars at: 6 put: 100 ]
 		raise: PrimitiveFailed
 ]
 
@@ -113,11 +113,11 @@ MirrorPrimitivesTest >> testChangingGeneralFieldOfWeakMessageSend [
 	MirrorPrimitives fieldOf: arrayWithInstVars at: 2 put: #newSelector.
 	self assert: arrayWithInstVars selector equals: #newSelector.
 
-	MirrorPrimitives fieldOf: arrayWithInstVars at: 4 put: #newArgs.
+	MirrorPrimitives fieldOf: arrayWithInstVars at: 3 put: #newArgs.
 	self assert: arrayWithInstVars arguments equals: #newArgs.
 
 	self
-	 	should: [MirrorPrimitives fieldOf: arrayWithInstVars at: 5 put: 100]
+	 	should: [MirrorPrimitives fieldOf: arrayWithInstVars at: 7 put: 100]
 		raise: PrimitiveFailed
 ]
 
@@ -224,10 +224,10 @@ MirrorPrimitivesTest >> testGettingFixedFieldOfWeakMessageSend [
 	actual := MirrorPrimitives fixedFieldOf: arrayWithInstVars at: 1.
 	self assert: actual equals: #selector. "receiver is stored as first array item"
 
-	actual := MirrorPrimitives fixedFieldOf: arrayWithInstVars at: 3.
+	actual := MirrorPrimitives fixedFieldOf: arrayWithInstVars at: 2.
 	self assert: actual first equals: #args.
 
-	self should: [ MirrorPrimitives fixedFieldOf: arrayWithInstVars at: 5 ] raise: PrimitiveFailed
+	self should: [ MirrorPrimitives fixedFieldOf: arrayWithInstVars at: 6 ] raise: PrimitiveFailed
 ]
 
 { #category : 'tests - fields accessing' }
@@ -332,10 +332,10 @@ MirrorPrimitivesTest >> testGettingGeneralFieldOfWeakMessageSend [
 	actual := MirrorPrimitives fieldOf: arrayWithInstVars at: 2.
 	self assert: actual equals: #selector.
 
-	actual := MirrorPrimitives fieldOf: arrayWithInstVars at: 4.
+	actual := MirrorPrimitives fieldOf: arrayWithInstVars at: 3.
 	self assert: actual first equals: #args.
 
-	self should: [ MirrorPrimitives fieldOf: arrayWithInstVars at: 5 ] raise: PrimitiveFailed
+	self should: [ MirrorPrimitives fieldOf: arrayWithInstVars at: 7 ] raise: PrimitiveFailed
 ]
 
 { #category : 'tests - hashes' }


### PR DESCRIPTION
This PR refactors MessageSend as subclass of Message and WeakMessageSend as subclass of MessageSend, as suggested in [this issue](https://github.com/pharo-project/pharo/issues/13607), which allows to remove duplicated methods, and clean duplicated slots.

Class comments were updated and one tests which depended of the field index number of the `receiver` instance variable was also updated.
