### PR TITLE
fixes #14715: RBNamespace >> classNamed: should convert strings to symbols

### DIFF
--- a/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
+++ b/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
@@ -53,7 +53,7 @@ RBChildrenToSiblingsRefactoring class >> name: aClassName class: aClass subclass
 
 { #category : 'private - accessing' }
 RBChildrenToSiblingsRefactoring >> abstractSuperclass [
-	^self model classNamed: className asSymbol
+	^self model classNamed: className
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -311,7 +311,7 @@ RBCondition class >> isClassNamed: className definedIn: aModel [
 
 	^ self new 
 		block: [ | aClassOrTrait |
-				aClassOrTrait := aModel classNamed: className asSymbol.
+				aClassOrTrait := aModel classNamed: className.
 				aClassOrTrait isNotNil ]
 		errorString: [ className , ' is <1?:not > defined' ]
 ]

--- a/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
@@ -98,7 +98,7 @@ RBInsertNewClassRefactoring >> privateTransform [
 		                         with: category asString.
 	self model
 		defineClass: classDefinitionString withComment: comment;
-		reparentClasses: subclasses to: (self model classNamed: className asSymbol)
+		reparentClasses: subclasses to: (self model classNamed: className)
 ]
 
 { #category : 'printing' }

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -280,7 +280,7 @@ RBNamespace >> classObjectFor: anObject [
 	(anObject isBehavior or: [anObject isTrait])
 		ifTrue: [ ^ self classFor: anObject ].
 	anObject isString
-		ifTrue: [ ^ self classNamed: anObject asSymbol ].
+		ifTrue: [ ^ self classNamed: anObject ].
 	^ anObject
 ]
 

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -258,8 +258,8 @@ RBNamespace >> classNameFor: aBehavior [
 { #category : 'accessing - classes' }
 RBNamespace >> classNamed: aSymbol [
 	| class classes index symb |
+	aSymbol ifNil: [ ^ nil ].
 	symb := aSymbol asSymbol.
-	symb ifNil: [ ^ nil ].
 	(self hasRemoved: symb) ifTrue: [ ^ nil ].
 	(newClasses includesKey: symb) ifTrue: [ ^ (newClasses at: symb) first ].
 	(changedClasses includesKey: symb) ifTrue: [ ^ (changedClasses at: symb) first ].

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -257,19 +257,20 @@ RBNamespace >> classNameFor: aBehavior [
 
 { #category : 'accessing - classes' }
 RBNamespace >> classNamed: aSymbol [
-	| class classes index |
-	aSymbol ifNil: [ ^ nil ].
-	(self hasRemoved: aSymbol) ifTrue: [ ^ nil ].
-	(newClasses includesKey: aSymbol) ifTrue: [ ^ (newClasses at: aSymbol) first ].
-	(changedClasses includesKey: aSymbol) ifTrue: [ ^ (changedClasses at: aSymbol) first ].
-	class := environment at: aSymbol ifAbsent: [ nil ].
+	| class classes index symb |
+	symb := aSymbol asSymbol.
+	symb ifNil: [ ^ nil ].
+	(self hasRemoved: symb) ifTrue: [ ^ nil ].
+	(newClasses includesKey: symb) ifTrue: [ ^ (newClasses at: symb) first ].
+	(changedClasses includesKey: symb) ifTrue: [ ^ (changedClasses at: symb) first ].
+	class := environment at: symb ifAbsent: [ nil ].
 	(class isBehavior or: [ class isTrait ])
 		ifTrue: [ classes := self createNewClassFor: class.
 			^ class isMeta
 				ifTrue: [ classes last ]
 				ifFalse: [ classes first ] ].
-	index := aSymbol indexOfSubCollection: ' class' startingAt: 1 ifAbsent: [ ^ nil ].
-	class := self classNamed: (aSymbol copyFrom: 1 to: index - 1) asSymbol.
+	index := symb indexOfSubCollection: ' class' startingAt: 1 ifAbsent: [ ^ nil ].
+	class := self classNamed: (symb copyFrom: 1 to: index - 1) asSymbol.
 	^ class ifNotNil: [ class classSide ]
 ]
 

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -71,7 +71,7 @@ RBRefactoring >> classObjectFor: anObject [
 	(anObject isBehavior or: [ anObject isTrait ]) ifTrue: [
 		^ self model classFor: anObject ].
 	anObject isString ifTrue: [
-		^ self model classNamed: anObject asSymbol ].
+		^ self model classNamed: anObject ].
 	^ anObject
 ]
 

--- a/src/Refactoring-Core/RBRefactoryTyper.class.st
+++ b/src/Refactoring-Core/RBRefactoryTyper.class.st
@@ -202,7 +202,7 @@ RBRefactoryTyper >> guessTypeFromAssignment: aNode [
 			].
 	aNode value isMessage
 		ifTrue: [ aNode value receiver isVariable
-				ifTrue: [ type := model classNamed: aNode value receiver name asSymbol ].
+				ifTrue: [ type := model classNamed: aNode value receiver name ].
 			aNode value selector = #asValue
 				ifTrue: [ type := model classNamed: #ValueHolder ].
 			( #(#and: #or: #= #== #~= #~~ #<= #< #~~ #> #>=) includes: aNode value selector )

--- a/src/Refactoring-Core/RBRemoveClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveClassRefactoring.class.st
@@ -161,7 +161,7 @@ RBRemoveClassRefactoring >> preconditions [
 RBRemoveClassRefactoring >> prepareForExecution [
 
 	classesDictionary := (classNames collect: [ :className |
-		            className -> (self model classNamed: className asSymbol) ])
+		            className -> (self model classNamed: className) ])
 		           asDictionary
 ]
 

--- a/src/Refactoring-Core/RBSplitClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBSplitClassRefactoring.class.st
@@ -103,7 +103,7 @@ RBSplitClassRefactoring >> addClass [
 				superclass: Object
 				subclasses: #()
 				category: class category).
-	newClass := self model classNamed: newClassName asSymbol
+	newClass := self model classNamed: newClassName
 ]
 
 { #category : 'private - transforming' }

--- a/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddAccessorsForClassTransformationTest.class.st
@@ -34,8 +34,7 @@ RBAddAccessorsForClassTransformationTest >> testTransform [
 
 	self assert: transformation model changes changes size equals: 2.
 
-	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self
 		assert: (class parseTreeForSelector: #instVar)
 		equals: (self parseMethod: 'instVar ^instVar').

--- a/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBAddSubtreeTransformationTest.class.st
@@ -54,8 +54,7 @@ RBAddSubtreeTransformationTest >> testTransform [
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self assert: (class directlyDefinesMethod: #one).
 	self
 		assert: (class parseTreeForSelector: #one) body statements size

--- a/src/Refactoring2-Transformations-Tests/RBMoveClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBMoveClassTransformationTest.class.st
@@ -36,6 +36,6 @@ RBMoveClassTransformationTest >> testTransform [
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed: self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self assert: class category equals: #'Refactoring2-Transformations-Tests-Test'
 ]

--- a/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBProtectVariableTransformationTest.class.st
@@ -259,8 +259,7 @@ RBProtectVariableTransformationTest >> testVariableIsNotAccessed [
 		                  instanceVariable: 'instVar'
 		                  class: self changeMockClass name.
 
-	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self deny: (class directlyDefinesLocalMethod: #instVar).
 	self deny: (class directlyDefinesLocalMethod: #instVar:).
 

--- a/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRemoveSubtreeTransformationTest.class.st
@@ -81,7 +81,7 @@ RBRemoveSubtreeTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+		         self changeMockClass name.
 	self assert: (class directlyDefinesMethod: #one).
 	self assertEmpty: (class parseTreeForSelector: #one) body statements
 ]
@@ -105,7 +105,7 @@ RBRemoveSubtreeTransformationTest >> testTransformNotSequenceNode [
 	self assert: transformation model changes changes size equals: 2.
 
 	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+		         self changeMockClass name.
 	self assert: (class directlyDefinesMethod: #printString1).
 	self assertEmpty:
 		(class parseTreeForSelector: #printString1) body statements

--- a/src/Refactoring2-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
@@ -17,8 +17,7 @@ RBRenameAndDeprecateClassTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 7.
 
 	"old class"
-	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self deny: class isNil.
 	self assertEmpty: class selectors.
 	self assert: class superclass name equals: #RBRefactoringChangeMock2.

--- a/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBReplaceSubtreeTransformationTest.class.st
@@ -85,7 +85,7 @@ RBReplaceSubtreeTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+		         self changeMockClass name.
 	self assert: (class directlyDefinesMethod: #one).
 	self
 		assert: (class parseTreeForSelector: #one) body statements size

--- a/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring2-Transformations-Tests/RBTransformationsTest.class.st
@@ -83,9 +83,7 @@ RBTransformationsTest >> testAddTemporaryVariableTransform [
 		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
-
-	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self assert: (class directlyDefinesMethod: #one).
 	self
 		assert: (class parseTreeForSelector: #one) temporaries size
@@ -103,8 +101,7 @@ RBTransformationsTest >> testAddVariableAccessorTransform [
 
 	self assert: transformation model changes changes size equals: 2.
 
-	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self
 		assert: (class parseTreeForSelector: #instVar)
 		equals: (self parseMethod: 'instVar ^instVar').
@@ -123,9 +120,7 @@ RBTransformationsTest >> testAddVariableTransform [
 		                  generateChanges.
 
 	self assert: transformation model changes changes size equals: 1.
-
-	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self assert: (class directlyDefinesInstanceVariable: 'asdf')
 ]
 
@@ -154,7 +149,7 @@ RBTransformationsTest >> testCompositeTransform [
 	self assert: transformation model changes changes size equals: 3.
 
 	class := transformation model classNamed:
-		         (self changeMockClass name , 'Temporary') asSymbol.
+		         (self changeMockClass name , 'Temporary').
 	self assert: (class directlyDefinesInstanceVariable: 'asdf').
 	self
 		assert: (class parseTreeForSelector: #printString1)
@@ -197,8 +192,7 @@ RBTransformationsTest >> testDeprecateClassTransform [
 
 	self assert: transformation model changes changes size equals: 4.
 
-	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self assert: class comment equals: 'Deprecated!!! Use superclass'.
 
 	class := transformation model metaclassNamed:
@@ -234,8 +228,7 @@ RBTransformationsTest >> testMoveInstanceVariableToClassTransform [
 		                  toClass: self changeMockClass name.
 
 	oldClass := transformation model classNamed: #FOOBAR.
-	newClass := transformation model classNamed:
-		            self changeMockClass name asSymbol.
+	newClass := transformation model classNamed: self changeMockClass name.
 	self assert: (oldClass directlyDefinesInstanceVariable: 'asdf').
 	self deny: (newClass directlyDefinesInstanceVariable: 'asdf').
 
@@ -289,8 +282,7 @@ RBTransformationsTest >> testRemoveClassTransform [
 	transformation := (RBRemoveClassTransformation className:
 		                   self changeMockClass name) generateChanges.
 	self assert: transformation model changes changes size equals: 1.
-	newClass := transformation model classNamed:
-		            self changeMockClass name asSymbol.
+	newClass := transformation model classNamed: self changeMockClass name.
 	superclass := transformation model classNamed: #Object.
 	self assert: newClass isNil.
 	newClass := self changeMockClass name.
@@ -331,8 +323,7 @@ RBTransformationsTest >> testRemoveMethodTransform [
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self deny: (class directlyDefinesMethod: #one)
 ]
 
@@ -347,8 +338,7 @@ RBTransformationsTest >> testRemoveVariableTransform [
 
 	self assert: transformation model changes changes size equals: 1.
 
-	class := transformation model classNamed:
-		         self changeMockClass name asSymbol.
+	class := transformation model classNamed: self changeMockClass name.
 	self deny: (class directlyDefinesInstanceVariable: 'instVar')
 ]
 

--- a/src/Refactoring2-Transformations/RBRemoveClassTransformation.class.st
+++ b/src/Refactoring2-Transformations/RBRemoveClassTransformation.class.st
@@ -78,7 +78,7 @@ RBRemoveClassTransformation class >> model: aRBModel classNames: aCollection [
 RBRemoveClassTransformation >> applicabilityPreconditions [ 
 
 		| aClassOrTrait |
-		aClassOrTrait := self model classNamed: className asSymbol.
+		aClassOrTrait := self model classNamed: className.
 		aClassOrTrait ifNil: [ self refactoringError: 'No such class or trait named ', className ].
 		^ (self preconditionIsNotMetaclass: aClassOrTrait)
 			


### PR DESCRIPTION
just using inforcing asSymbol in the right place