### PR TITLE
Factor out methods for saving and restoring patches from HandMorph onto Canvas

### DIFF
--- a/src/Morphic-Core/Canvas.extension.st
+++ b/src/Morphic-Core/Canvas.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : 'Canvas' }
+
+{ #category : '*Morphic-Core' }
+Canvas >> allocateSavedPatch: extent [
+
+	^ self form allocateForm: extent
+]
+
+{ #category : '*Morphic-Core' }
+Canvas >> contentsOfArea: aRectangle intoSavedPatch: aForm [
+
+	self contentsOfArea: aRectangle into: aForm
+]
+
+{ #category : '*Morphic-Core' }
+Canvas >> restoreSavedPatch: aForm at: aPoint [
+
+	self drawImage: aForm at: aPoint
+]

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -1014,7 +1014,7 @@ HandMorph >> restoreSavedPatchOn: aCanvas [
 
 	hasChanged := false.
 	savedPatch ifNotNil:
-			[aCanvas drawImage: savedPatch at: savedPatch offset.
+			[aCanvas restoreSavedPatch: savedPatch at: savedPatch offset.
 			submorphs notEmpty ifTrue: [^self].
 			(temporaryCursor notNil and: [hardwareCursor isNil]) ifTrue: [^self].
 
@@ -1042,9 +1042,9 @@ HandMorph >> savePatchFrom: aCanvas [
 		ifTrue:
 			["allocate new patch form if needed"
 
-			savedPatch := aCanvas form allocateForm: myBnds extent].
+			savedPatch := aCanvas allocateSavedPatch: myBnds extent].
 	aCanvas contentsOfArea: (myBnds translateBy: aCanvas origin)
-		into: savedPatch.
+		intoSavedPatch: savedPatch.
 	savedPatch offset: myBnds topLeft.
 	^damageRect
 ]


### PR DESCRIPTION
This pull request factors out methods related to ‘savedPatch’ from HandMorph onto Canvas so that they can be overridden in subclasses of Canvas.