### PR TITLE
Defer change list update to avoid a race condition

### DIFF
--- a/src/EpiceaBrowsers/EpLogBrowserPresenter.class.st
+++ b/src/EpiceaBrowsers/EpLogBrowserPresenter.class.st
@@ -734,7 +734,9 @@ EpLogBrowserPresenter >> refresh [
 
 { #category : 'refreshing' }
 EpLogBrowserPresenter >> refreshEntryContent [
-	self refreshEntryContentWith: self selectedEntryItems
+	"Refresh the change list. I defer this action, so I'm prepated to be called from a non-UI process, such as the one of `OmDeferrer`. See: https://github.com/pharo-project/pharo/issues/9638"
+
+	self defer: [ self refreshEntryContentWith: self selectedEntryItems ]
 ]
 
 { #category : 'refreshing' }


### PR DESCRIPTION
Fix #9638

The OmDeferrer postpones the refresh, and sends it from a Process that is not the Morphic world's one.

@pavel-krivanek 