### PR TITLE
Remove some unused methods from the Canvas hierarchy

### DIFF
--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -508,23 +508,6 @@ FormCanvas >> privatePort [
 	^port
 ]
 
-{ #category : 'private' }
-FormCanvas >> privateWarp: aForm transform: aTransform at: extraOffset sourceRect: sourceRect cellSize: cellSize [
-	"Warp the given using the appropriate transform and offset."
-	| globalRect sourceQuad warp tfm |
-	tfm := aTransform.
-	globalRect := tfm localBoundsToGlobal: sourceRect.
-	sourceQuad := (tfm sourceQuadFor: globalRect) collect: [:p| p - sourceRect topLeft].
-	extraOffset ifNotNil:[globalRect := globalRect translateBy: extraOffset].
-     warp := (WarpBlt toForm: port destForm)
-                combinationRule: Form paint;
-                sourceQuad: sourceQuad destRect: (globalRect origin corner: globalRect corner+(1@1));
-                clipRect: port clipRect.
-	warp cellSize: cellSize.
-	warp sourceForm: aForm.
-	warp warpBits
-]
-
 { #category : 'initialization' }
 FormCanvas >> reset [
 
@@ -747,12 +730,4 @@ FormCanvas >> warpFrom: sourceQuad toRect: destRect [
 		combinationRule: Form paint;
 		sourceQuad: sourceQuad destRect: (destRect translateBy: origin);
 		clipRect: clipRect
-]
-
-{ #category : 'drawing - images' }
-FormCanvas >> warpImage: aForm transform: aTransform at: extraOffset sourceRect: sourceRect cellSize: cellSize [
-	"Warp the given using the appropriate transform and offset."
-	| tfm |
-	tfm := (MatrixTransform2x3 withOffset: origin) composedWithLocal: aTransform.
-	^self privateWarp: aForm transform: tfm at: extraOffset sourceRect: sourceRect cellSize: cellSize
 ]

--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -364,12 +364,6 @@ FormCanvas >> flush [
 	engine ifNotNil:[engine flush]
 ]
 
-{ #category : 'other' }
-FormCanvas >> flushDisplay [
-
-	Display deferUpdates: false
-]
-
 { #category : 'accessing' }
 FormCanvas >> form [
 

--- a/src/Graphics-Canvas/Canvas.class.st
+++ b/src/Graphics-Canvas/Canvas.class.st
@@ -733,22 +733,3 @@ Canvas >> translucentImage: aForm at: aPoint sourceRect: sourceRect [
 		sourceRect: sourceRect
 		rule: Form blend
 ]
-
-{ #category : 'drawing - images' }
-Canvas >> warpImage: aForm transform: aTransform [
-	"Warp the given form using aTransform"
-	^self warpImage: aForm transform: aTransform at: 0@0
-]
-
-{ #category : 'drawing - images' }
-Canvas >> warpImage: aForm transform: aTransform at: extraOffset [
-	"Warp the given form using aTransform.
-	TODO: Use transform to figure out appropriate cell size"
-	^self warpImage: aForm transform: aTransform at: extraOffset sourceRect: aForm boundingBox cellSize: 1
-]
-
-{ #category : 'drawing - images' }
-Canvas >> warpImage: aForm transform: aTransform at: extraOffset sourceRect: sourceRect cellSize: cellSize [
-	"Warp the given using the appropriate transform and offset."
-	^self subclassResponsibility
-]

--- a/src/Graphics-Canvas/Canvas.class.st
+++ b/src/Graphics-Canvas/Canvas.class.st
@@ -255,11 +255,6 @@ Canvas >> finish [
 Canvas >> flush [
 ]
 
-{ #category : 'other' }
-Canvas >> flushDisplay [
-	"Empty hook method."
-]
-
 { #category : 'accessing' }
 Canvas >> form [
 

--- a/src/Graphics-Canvas/Canvas.class.st
+++ b/src/Graphics-Canvas/Canvas.class.st
@@ -630,12 +630,6 @@ Canvas >> paragraph: paragraph bounds: bounds color: c [
 	^self subclassResponsibility
 ]
 
-{ #category : 'drawing - support' }
-Canvas >> preserveStateDuring: aBlock [
-	"Preserve the full canvas state during the execution of aBlock"
-	^aBlock value: self copy
-]
-
 { #category : 'drawing' }
 Canvas >> render: anObject [
 	"Do some 3D operations with the object if possible"

--- a/src/Graphics-Canvas/Canvas.class.st
+++ b/src/Graphics-Canvas/Canvas.class.st
@@ -425,11 +425,6 @@ Canvas >> image: aForm at: aPoint sourceRect: sourceRect rule: rule alpha: sourc
 ]
 
 { #category : 'testing' }
-Canvas >> isBalloonCanvas [
-	^false
-]
-
-{ #category : 'testing' }
 Canvas >> isShadowDrawing [
 	^false
 ]

--- a/src/Graphics-Canvas/Canvas.class.st
+++ b/src/Graphics-Canvas/Canvas.class.st
@@ -630,11 +630,6 @@ Canvas >> paragraph: paragraph bounds: bounds color: c [
 	^self subclassResponsibility
 ]
 
-{ #category : 'drawing' }
-Canvas >> render: anObject [
-	"Do some 3D operations with the object if possible"
-]
-
 { #category : 'drawing - general' }
 Canvas >> roundCornersOf: aMorph during: aBlock [
 	^self roundCornersOf: aMorph in: aMorph bounds during: aBlock

--- a/src/Graphics-Canvas/Canvas.class.st
+++ b/src/Graphics-Canvas/Canvas.class.st
@@ -37,18 +37,6 @@ Canvas >> asShadowDrawingCanvas: aColor [
 ]
 
 { #category : 'drawing - support' }
-Canvas >> cache: aRectangle using: aCache during: aBlock [
-	"Cache the execution of aBlock by the given cache.
-	Note: At some point we may want to actually *create* the cache here;
-		for now we're only using it."
-
-	(aCache notNil
-		and: [(aCache isForm) and: [aCache extent = aRectangle extent]])
-			ifTrue: [^self paintImage: aCache at: aRectangle origin].
-	aBlock value: self
-]
-
-{ #category : 'drawing - support' }
 Canvas >> clipBy: aRectangle during: aBlock [
 	"Set a clipping rectangle active only during the execution of aBlock.
 	Note: In the future we may want to have more general clip shapes - not just rectangles"

--- a/src/Graphics-Canvas/ClippingCanvas.class.st
+++ b/src/Graphics-Canvas/ClippingCanvas.class.st
@@ -48,11 +48,6 @@ ClippingCanvas >> form [
 ]
 
 { #category : 'testing' }
-ClippingCanvas >> isBalloonCanvas [
-	^canvas isBalloonCanvas
-]
-
-{ #category : 'testing' }
 ClippingCanvas >> isShadowDrawing [
 	^canvas isShadowDrawing
 ]

--- a/src/Graphics-Canvas/PluggableCanvas.class.st
+++ b/src/Graphics-Canvas/PluggableCanvas.class.st
@@ -116,12 +116,6 @@ PluggableCanvas >> flush [
 		c flush ]
 ]
 
-{ #category : 'other' }
-PluggableCanvas >> flushDisplay [
-	self apply: [ :c |
-		c flushDisplay ]
-]
-
 { #category : 'drawing - rectangles' }
 PluggableCanvas >> frameAndFillRectangle: r fillColor: fillColor borderWidth: borderWidth borderColor: borderColor [
 	self apply: [ :c |

--- a/src/Graphics-Canvas/PluggableCanvas.class.st
+++ b/src/Graphics-Canvas/PluggableCanvas.class.st
@@ -164,12 +164,6 @@ PluggableCanvas >> paragraph: paragraph bounds: bounds color: color [
 		c paragraph: paragraph bounds: bounds color: color ]
 ]
 
-{ #category : 'drawing' }
-PluggableCanvas >> render: anObject [
-	self apply: [ :c |
-		c render: anObject ]
-]
-
 { #category : 'drawing - general' }
 PluggableCanvas >> roundCornersOf: aMorph in: bounds during: aBlock [
 	aMorph wantsRoundedCorners ifFalse:[^aBlock value].


### PR DESCRIPTION
This pull request removes some unused methods from classes in the Canvas hierarchy.