### PR TITLE
Ring-Cleanup-isMetaSide 

### DIFF
--- a/src/Epicea/CompiledMethod.extension.st
+++ b/src/Epicea/CompiledMethod.extension.st
@@ -5,7 +5,7 @@ CompiledMethod >> asEpiceaRingDefinition [
 
 	^ (RGMethodDefinition named: self selector)
 		  parentName: self methodClass name;
-		  isMetaSide: self methodClass isMeta;
+		  isMeta: self methodClass isMeta;
 		  protocol: self protocolName;
 		  sourceCode: self sourceCode;
 		  stamp: self timeStamp;

--- a/src/Epicea/TestCase.extension.st
+++ b/src/Epicea/TestCase.extension.st
@@ -1,14 +1,14 @@
 Extension { #name : 'TestCase' }
 
 { #category : '*Epicea' }
+TestCase >> shouldLogWithEpicea [
+
+	^ self class shouldLogWithEpicea
+]
+
+{ #category : '*Epicea' }
 TestCase class >> shouldLogWithEpicea [
 	"When running a test, we disable the loggings of Epicea to run the tests silently. In case a TestCase explicitly wants to Epicea logs, then I can be overriden to return true and enable the logs."
 
 	^ false
-]
-
-{ #category : '*Epicea' }
-TestCase >> shouldLogWithEpicea [
-
-	^ self class shouldLogWithEpicea
 ]

--- a/src/Manifest-Core/RGMethodDefinition.extension.st
+++ b/src/Manifest-Core/RGMethodDefinition.extension.st
@@ -5,7 +5,7 @@ RGMethodDefinition >> arrayStringForManifest [
 	| array |
 	array := Array new: 2.
 	array at: 1 put: (self class asString asSymbol).
-	array at: 2 put: {self parentName asSymbol. self selector asSymbol. self isMetaSide asString  asSymbol}.
+	array at: 2 put: {self parentName asSymbol. self selector asSymbol. self isMeta asString asSymbol}.
 	^ array
 ]
 
@@ -14,7 +14,7 @@ RGMethodDefinition class >> manifestReadOn: aArray [
 
  	^ self className: (aArray at: 1)
 		selector: (aArray at: 2)
-		isMetaSide: ((aArray at: 3) = #true)
+		isMeta: ((aArray at: 3) = #true)
 ]
 
 { #category : '*Manifest-Core' }
@@ -25,7 +25,7 @@ RGMethodDefinition >> storeOn: aStream [
 	aStream nextPutAll: self parentName.
 	aStream nextPutAll: ''' selector: '.
 	aStream nextPutAll: self selector printString.
-	aStream nextPutAll: ' isMetaSide: '.
-	aStream nextPutAll: self isMetaSide printString.
+	aStream nextPutAll: ' isMeta: '.
+	aStream nextPutAll: self isMeta printString.
 	aStream nextPut: $)
 ]

--- a/src/Manifest-Tests/RGMethodDefinitionTest.extension.st
+++ b/src/Manifest-Tests/RGMethodDefinitionTest.extension.st
@@ -41,5 +41,5 @@ RGMethodDefinitionTest >> testStoreOn [
 		streamContents: [ :s |
 			(Point >> #x) asRingDefinition storeOn: s.
 			s contents ].
-	self assert: st equals: '(RGMethodDefinition className: ''Point'' selector: #x isMetaSide: false)'
+	self assert: st equals: '(RGMethodDefinition className: ''Point'' selector: #x isMeta: false)'
 ]

--- a/src/Monticello/RGMethodDefinition.extension.st
+++ b/src/Monticello/RGMethodDefinition.extension.st
@@ -45,7 +45,7 @@ RGMethodDefinition >> basicAsMCMethodDefinition [
 		ifFalse: [
 		   ^ MCMethodDefinition
 				className: self instanceSideParentName
-		 	   	classIsMeta: self isMetaSide
+		 	   	classIsMeta: self isMeta
 				selector: self selector
 				category: self protocol
 				timeStamp: self stamp

--- a/src/Ring-Core/RGMethod.class.st
+++ b/src/Ring-Core/RGMethod.class.st
@@ -247,9 +247,15 @@ RGMethod >> isLiteralMethod [
 ]
 
 { #category : 'testing' }
-RGMethod >> isMetaSide [
+RGMethod >> isMeta [
 
 	^ self parent isMeta
+]
+
+{ #category : 'testing' }
+RGMethod >> isMetaSide [
+
+	^ self isMeta
 ]
 
 { #category : 'testing' }

--- a/src/Ring-Definitions-Core/ChangeRecord.extension.st
+++ b/src/Ring-Definitions-Core/ChangeRecord.extension.st
@@ -27,7 +27,7 @@ ChangeRecord >> createMethodDefinition [
 
 	^(RGMethodDefinition named: self methodSelector)
 		parentName: self methodClassName;
-		isMetaSide: meta;
+		isMeta: meta;
 		sourceCode: self string;
 		protocol: protocol;
 		stamp: stamp;

--- a/src/Ring-Definitions-Core/CompiledMethod.extension.st
+++ b/src/Ring-Definitions-Core/CompiledMethod.extension.st
@@ -8,7 +8,7 @@ CompiledMethod >> asActiveRingDefinition [
 	^ RGMethodDefinition new
 			name: self selector;
 			parentName: self methodClass name;
-			isMetaSide: self methodClass isMeta;
+			isMeta: self methodClass isMeta;
 			asActive
 ]
 
@@ -33,7 +33,7 @@ CompiledMethod >> asHistoricalRingDefinition [
 	| ring |
 	ring := (RGMethodDefinition named: self selector)
 				parentName: self methodClass name;
-				isMetaSide: self methodClass isMeta.
+				isMeta: self methodClass isMeta.
 
 	self sourcePointer isZero
 		ifTrue: [ "this should not happen but sometimes the system looks corrupted"
@@ -55,7 +55,7 @@ CompiledMethod >> asPassiveRingDefinition [
 	^RGMethodDefinition new
 		 	name: self selector;
 			parentName: self methodClass name;
-			isMetaSide: self methodClass isMeta;
+			isMeta: self methodClass isMeta;
 			protocol: self protocolName;
 			sourceCode: self sourceCode;
 			stamp: self timeStamp;

--- a/src/Ring-Definitions-Core/RGClassInstanceVariableDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGClassInstanceVariableDefinition.class.st
@@ -13,7 +13,7 @@ Class {
 RGClassInstanceVariableDefinition >> initialize [
 
 	super initialize.
-	self isMetaSide: true
+	self isMeta: true
 ]
 
 { #category : 'testing' }

--- a/src/Ring-Definitions-Core/RGElementDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGElementDefinition.class.st
@@ -145,9 +145,9 @@ RGElementDefinition class >> isAbstract [
 ]
 
 { #category : 'elements-annotations' }
-RGElementDefinition class >> isMetaSideKey [
+RGElementDefinition class >> isMetaKey [
 
-	^#isMetaSide
+	^#isMeta
 ]
 
 { #category : 'parsing stamp' }
@@ -224,7 +224,7 @@ RGElementDefinition >> = aRGElementDefinition [
 
 	^self class = aRGElementDefinition class
 		and:[ self parentName == aRGElementDefinition parentName
-			and:[ self isMetaSide = aRGElementDefinition isMetaSide ] ]
+			and:[ self isMeta = aRGElementDefinition isMeta ] ]
 ]
 
 { #category : 'backward compatibility' }
@@ -256,7 +256,7 @@ RGElementDefinition >> fullName: aString [
 RGElementDefinition >> hash [
 	"Hash is re-implemented because #= is re-implemented"
 
-	^self class hash bitXor: (self parentName hash bitXor: self isMetaSide hash)
+	^self class hash bitXor: (self parentName hash bitXor: self isMeta hash)
 ]
 
 { #category : 'generic parent api' }
@@ -281,18 +281,30 @@ RGElementDefinition >> isDefined [
 ]
 
 { #category : 'accessing' }
-RGElementDefinition >> isMetaSide [
+RGElementDefinition >> isMeta [
 	"Even thought several class elements do not define this property (ie. class variables, pool variables) they understand it"
 	"This is a derived property from the class definining the receiver and thus its value is kept as an annotation"
 	"Default value is false"
 
-	^self annotationNamed: self class isMetaSideKey ifAbsentPut: [ false ]
+	^self annotationNamed: self class isMetaKey ifAbsentPut: [ false ]
+]
+
+{ #category : 'accessing' }
+RGElementDefinition >> isMeta: aBoolean [
+
+	self annotationNamed: self class isMetaKey put: aBoolean
+]
+
+{ #category : 'accessing' }
+RGElementDefinition >> isMetaSide [
+	
+	^self isMeta
 ]
 
 { #category : 'accessing' }
 RGElementDefinition >> isMetaSide: aBoolean [
 
-	self annotationNamed: self class isMetaSideKey put: aBoolean
+	self isMeta: aBoolean
 ]
 
 { #category : 'testing' }
@@ -353,7 +365,7 @@ RGElementDefinition >> realParent [
 		          ifNil: [ self rootEnvironment classNamed: self parentName ].
 	parent ifNil: [ ^ nil ].
 	
-	self isMetaSide ifTrue: [ parent := parent classSide ].
+	self isMeta ifTrue: [ parent := parent classSide ].
 	^ parent
 ]
 
@@ -369,5 +381,5 @@ RGElementDefinition >> setParentInfo: anObject [
 	"anObject is aRGBehaviorDefinition or aClass/aTrait"
 
 	self parentName: anObject name.
-	self isMetaSide: anObject isMeta
+	self isMeta: anObject isMeta
 ]

--- a/src/Ring-Definitions-Core/RGMethodDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGMethodDefinition.class.st
@@ -97,9 +97,15 @@ RGMethodDefinition class >> class: aRGBehaviorDefinition selector: aString [
 ]
 
 { #category : 'instance creation' }
+RGMethodDefinition class >> className: aString selector: aSelector isMeta: aBoolean [
+
+	^ (self class: (RGClassDefinition named: aString) selector: aSelector) isMeta: aBoolean; yourself
+]
+
+{ #category : 'instance creation' }
 RGMethodDefinition class >> className: aString selector: aSelector isMetaSide: aBoolean [
 
-	^ (self class: (RGClassDefinition named: aString) selector: aSelector) isMetaSide: aBoolean; yourself
+	^ self className: aString selector: aSelector isMeta: aBoolean
 ]
 
 { #category : 'elements-annotations' }
@@ -218,7 +224,7 @@ RGMethodDefinition >> category [
 { #category : 'to remove as soon as possible' }
 RGMethodDefinition >> classIsMeta [
 
-	^self isMetaSide
+	^self isMeta
 ]
 
 { #category : 'accessing' }

--- a/src/Ring-Definitions-Monticello/MCMethodDefinition.extension.st
+++ b/src/Ring-Definitions-Monticello/MCMethodDefinition.extension.st
@@ -6,7 +6,7 @@ MCMethodDefinition >> asRingDefinition [
 	^RGMethodDefinition new
 		name: self selector;
 		parentName: self className;
-		isMetaSide: self classIsMeta;
+		isMeta: self classIsMeta;
 		protocol: self protocol;
 		sourceCode: self source;
 		stamp: self timeStamp

--- a/src/Ring-Definitions-Monticello/RGMethodDefinition.extension.st
+++ b/src/Ring-Definitions-Monticello/RGMethodDefinition.extension.st
@@ -8,7 +8,7 @@ RGMethodDefinition >> sameAsMCDefinition: anMCMethodDefinition [
 			anMCMethodDefinition className = self className
 				and:
 					[
-					anMCMethodDefinition classIsMeta = self isMetaSide
+					anMCMethodDefinition classIsMeta = self isMeta
 						and:
 							[
 							anMCMethodDefinition category = self protocol

--- a/src/Ring-Definitions-Tests-Core/RGClassDefinitionTest.class.st
+++ b/src/Ring-Definitions-Tests-Core/RGClassDefinitionTest.class.st
@@ -20,7 +20,7 @@ RGClassDefinitionTest >> testAddingMethods [
 			'add: newObject
 									^self addLast: newObject'.
 
-	self assert: newMethod isMetaSide not.
+	self assert: newMethod isMeta not.
 	self assert: newClass hasMethods not.
 
 	newClass addMethod: newMethod.

--- a/src/Ring-Definitions-Tests-Core/RGMethodDefinitionTest.class.st
+++ b/src/Ring-Definitions-Tests-Core/RGMethodDefinitionTest.class.st
@@ -179,13 +179,13 @@ RGMethodDefinitionTest >> testAsPassive [
 ]
 
 { #category : 'testing' }
-RGMethodDefinitionTest >> testClassNameSelectorIsMetaSide [
+RGMethodDefinitionTest >> testClassNameSelectorIsMeta [
 	| rg |
-	rg := RGMethodDefinition className: 'Point' selector: #x isMetaSide: false.
+	rg := RGMethodDefinition className: 'Point' selector: #x isMeta: false.
 	self assert: rg parentName equals: 'Point'.
 	self assert: (rg parent isKindOf: RGClassDefinition).
 	self assert: rg selector equals: #x.
-	self assert: rg isMetaSide not
+	self assert: rg isMeta not
 ]
 
 { #category : 'testing' }
@@ -241,7 +241,7 @@ RGMethodDefinitionTest >> testExistingMethodWithClass [
 
 	self assert: newMethod isMethod.
 	self assert: newMethod selector identicalTo: #add:.
-	self assert: newMethod isMetaSide not.
+	self assert: newMethod isMeta not.
 
 	self assert: newMethod parent equals: newClass.
 	self assert: newMethod parentName identicalTo: newClass name.
@@ -274,7 +274,7 @@ RGMethodDefinitionTest >> testExistingMethodWithoutClass [
 	newMethod := (RGMethodDefinition named: #add:)
 		parentName: #OrderedCollection;
 		selector: #add:;
-		isMetaSide: false;
+		isMeta: false;
 		protocol: 'adding';
 		sourceCode:
 			'add: newObject
@@ -282,7 +282,7 @@ RGMethodDefinitionTest >> testExistingMethodWithoutClass [
 
 	self assert: newMethod isMethod.
 	self assert: newMethod selector identicalTo: #add:.
-	self assert: newMethod isMetaSide not.
+	self assert: newMethod isMeta not.
 	self assert: newMethod protocol equals: #adding.
 	self assert: newMethod fullName equals: 'OrderedCollection>>add:'.
 	self
@@ -413,7 +413,7 @@ RGMethodDefinitionTest >> testNonExistingMethodWithClass [
 
 	self assert: newMethod isMethod.
 	self assert: newMethod selector identicalTo: #foo.
-	self assert: newMethod isMetaSide.
+	self assert: newMethod isMeta.
 	self assert: newMethod protocol equals: nil.
 
 	self assert: newMethod parent equals: newClass classSide.
@@ -442,7 +442,7 @@ RGMethodDefinitionTest >> testSorting [
 
 	| rgMethod1 rgMethod2 |
 	rgMethod1 := RGMethodDefinition realClass: RGInstanceVariableDefinition selector: #isInstanceVariable.
-	rgMethod2 := RGMethodDefinition realClass: RGElementDefinition selector: #isMetaSide.
+	rgMethod2 := RGMethodDefinition realClass: RGElementDefinition selector: #isMeta.
 	self assert: rgMethod2 <= rgMethod1.
 
 	rgMethod1 := RGMethodDefinition realClass: RGElementDefinition selector: #parentName.

--- a/src/Ring-Definitions-Tests-Core/RGTraitDefinitionTest.class.st
+++ b/src/Ring-Definitions-Tests-Core/RGTraitDefinitionTest.class.st
@@ -20,7 +20,7 @@ RGTraitDefinitionTest >> testAddingMethods [
 			'sort
 									self sort: [:a :b | a <= b]'.
 
-	self assert: newMethod isMetaSide not.
+	self assert: newMethod isMeta not.
 	self assert: newClass hasMethods not.
 
 	newClass addMethod: newMethod.

--- a/src/Ring-Definitions-Tests-Core/RGVariableDefinitionTest.class.st
+++ b/src/Ring-Definitions-Tests-Core/RGVariableDefinitionTest.class.st
@@ -18,7 +18,7 @@ RGVariableDefinitionTest >> testClassInstanceVariable [
 	self assert: instVar isVariable.
 	self assert: instVar name equals: 'sizes'.
 	self assert: instVar parent isNil.
-	self assert: instVar isMetaSide.
+	self assert: instVar isMeta.
 
 	newClass := RGClassDefinition named: #OrderedCollection.
 	newClass withMetaclass.
@@ -37,7 +37,7 @@ RGVariableDefinitionTest >> testClassVariable [
 	self assert: instVar isVariable.
 	self assert: instVar name equals: 'DependentsFields'.
 	self assert: instVar parent isNil.
-	self assert: instVar isMetaSide not.
+	self assert: instVar isMeta not.
 
 	newClass := RGClassDefinition named: #Object.
 	instVar := (RGClassVariableDefinition named: 'DependentsFields') parent: newClass.
@@ -58,7 +58,7 @@ RGVariableDefinitionTest >> testInstanceVariable [
 	self assert: instVar isVariable.
 	self assert: instVar name equals: 'size'.
 	self assert: instVar parent isNil.
-	self assert: instVar isMetaSide not.
+	self assert: instVar isMeta not.
 
 	newClass := RGClassDefinition named: #OrderedCollection.
 	instVar := newClass addInstVarNamed: 'array'.
@@ -75,7 +75,7 @@ RGVariableDefinitionTest >> testPoolVariable [
 	self assert: poolVar isVariable.
 	self assert: poolVar name equals: 'TextConstants'.
 	self assert: poolVar parent isNil.
-	self assert: poolVar isMetaSide not.
+	self assert: poolVar isMeta not.
 
 	newClass := RGClassDefinition named: #OrderedCollection.
 	poolVar := (RGPoolVariableDefinition named: 'TextConstants') parent: newClass.

--- a/src/Ring-OldChunkImporter/RingChunkImporter.class.st
+++ b/src/Ring-OldChunkImporter/RingChunkImporter.class.st
@@ -245,7 +245,7 @@ RingChunkImporter >> visitMethodChunk: aChunk [
 							stamp: aChunk stamp.
 	aChunk isMeta
 		ifTrue: [
-			theMethod isMetaSide: true.
+			theMethod isMeta: true.
 			theClass classSide addMethod: theMethod. ]
 		ifFalse:[ theClass addMethod: theMethod ]
 ]

--- a/src/Ring-Tests-Core/RGMethodTest.class.st
+++ b/src/Ring-Tests-Core/RGMethodTest.class.st
@@ -64,16 +64,16 @@ RGMethodTest >> testMetaSide [
 
 	anEnvironemnt := RGEnvironment new.
 	aMethod := (anEnvironemnt ensureClassNamed: 'SomeClass class') ensureLocalMethodNamed: #someMethod.
-	self assert: aMethod isMetaSide.
+	self assert: aMethod isMeta.
 	self deny: aMethod isFromTrait.
 	aMethod := (anEnvironemnt ensureClassNamed: 'SomeClass') ensureLocalMethodNamed: #someMethod.
-	self deny: aMethod isMetaSide.
+	self deny: aMethod isMeta.
 	self deny: aMethod isFromTrait.
 	aMethod := (anEnvironemnt ensureTraitNamed: 'SomeTrait classTrait') ensureLocalMethodNamed: #someMethod.
-	self assert: aMethod isMetaSide.
+	self assert: aMethod isMeta.
 	self assert: aMethod isFromTrait.
 	aMethod := (anEnvironemnt ensureTraitNamed: 'SomeTrait') ensureLocalMethodNamed: #someMethod.
-	self deny: aMethod isMetaSide.
+	self deny: aMethod isMeta.
 	self assert: aMethod isFromTrait
 ]
 
@@ -122,7 +122,7 @@ RGMethodTest >> testNewNamedMethod [
 	self assert: method selector equals: 'someMessage'.
 	self assert: method sourceCode lines first equals: 'someMessage'.
 
-	self deny: method isMetaSide
+	self deny: method isMeta
 ]
 
 { #category : 'tests' }

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -655,7 +655,7 @@ ChangeSet >> changedMessageList [
 				[messageList add:
 					((RGMethodDefinition named: mAssoc key)
 						parentName: className;
-						isMetaSide: classIsMeta) asActive ]]].
+						isMeta: classIsMeta) asActive ]]].
 	^ messageList asArray sort
 ]
 

--- a/src/System-Changes/SourceFileArray.extension.st
+++ b/src/System-Changes/SourceFileArray.extension.st
@@ -25,7 +25,7 @@ SourceFileArray >> changeRecordsFor: aMethodDefinition do: aUnaryBlock [
 	^ self
 		changeRecordsFrom: aMethodDefinition sourcePointer
 		className: aMethodDefinition instanceSideParentName
-		isMeta: aMethodDefinition isMetaSide
+		isMeta: aMethodDefinition isMeta
 		do: aUnaryBlock
 ]
 


### PR DESCRIPTION
This PR makes sure to use isMeta, not isMetaSide

The methods are not yet deprecated, that is the next step