### PR TITLE
Going around on:fork: to debug announcement

### DIFF
--- a/src/RPackage-Core/PackageAdded.class.st
+++ b/src/RPackage-Core/PackageAdded.class.st
@@ -13,3 +13,9 @@ Class {
 PackageAdded class >> initialize [
 	self deprecatedAliases: { #RPackageRegistered }
 ]
+
+{ #category : 'accessing' }
+PackageAdded >> package [
+	"self error."
+	^super package
+]

--- a/src/RPackage-Core/PackageAdded.class.st
+++ b/src/RPackage-Core/PackageAdded.class.st
@@ -13,9 +13,3 @@ Class {
 PackageAdded class >> initialize [
 	self deprecatedAliases: { #RPackageRegistered }
 ]
-
-{ #category : 'accessing' }
-PackageAdded >> package [
-	"self error."
-	^super package
-]

--- a/src/Reflectivity-Tools/AnnouncementErrorController.class.st
+++ b/src/Reflectivity-Tools/AnnouncementErrorController.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : 'AnnouncementErrorController',
+	#superclass : 'Object',
+	#classInstVars : [
+		'link',
+		'active'
+	],
+	#category : 'Reflectivity-Tools-Announcements',
+	#package : 'Reflectivity-Tools',
+	#tag : 'Announcements'
+}
+
+{ #category : 'as yet unclassified' }
+AnnouncementErrorController class >> disable [
+
+	<script>
+	self removeLink
+]
+
+{ #category : 'as yet unclassified' }
+AnnouncementErrorController class >> makeAnnouncementUnhandledErrorsBlocking [
+ 
+	<script>
+	| ast |
+	self removeLink.
+	link := MetaLink new.
+	ast := (BlockClosure >> #on:fork:) ast.
+	link metaObject: [ :rcv :args |
+		rcv
+			on: args first
+			do: args second ].
+	link selector: #value:value:.
+	link control: #instead.
+	link arguments: #( receiver arguments ).
+	ast link: link
+]
+
+{ #category : 'as yet unclassified' }
+AnnouncementErrorController class >> removeLink [
+	link ifNil:[^self].
+	link uninstall
+]


### PR DESCRIPTION
This should not be considered for merging yet, but for review.

We're trying to make configurable the debugging of announcement, that use `on:fork:` to make unhandled errors non-blocking when happening during an announcement delivery.

The problem in case of bugs is that we lose the stack that led to the unhandled error, and we're left with few information.

Here we use a metalink to replace the `on:fork:` with an `on:do:` and see the full stack.
We now have the stack back, it becomes blocking again, but can be (de)activated at will. 

It works, but lots of questions:
- at which level should that be? In Pharo or in the tools?
- what other solutions than metalinks do we have? ==> the main advantage is that we're not modifying the `on:fork:` directly and we then do not impact the system for users not interested by such debugging feature
