### PR TITLE
14864-Recompiling-a-method-when-a-tool-looks-at-it-DNU-name-is-nil 

### DIFF
--- a/src/RPackage-Core/CompiledCode.extension.st
+++ b/src/RPackage-Core/CompiledCode.extension.st
@@ -18,6 +18,6 @@ CompiledCode >> extensionPackage [
 CompiledCode >> package [
 	"This method returns the package this method belongs to. It takes into account classes and traits.
 	If the method is in no package, returns nil"
-
+	self isDoIt ifTrue: [ ^ nil ].
 	^ self extensionPackage ifNil: [ self origin package ]
 ]

--- a/src/RPackage-Core/CompiledCode.extension.st
+++ b/src/RPackage-Core/CompiledCode.extension.st
@@ -19,6 +19,5 @@ CompiledCode >> package [
 	"This method returns the package this method belongs to. It takes into account classes and traits.
 	If the method is in no package, returns nil"
 
-	self isInstalled ifFalse: [ ^ nil ].
 	^ self extensionPackage ifNil: [ self origin package ]
 ]


### PR DESCRIPTION
Even a compiledMethod that is not installed (e.g. because a new version was compiled) should know it's package


fixes #14864