### PR TITLE
10094-SourceFileArraychangeRecordsFordo-is-Ring1-specific 

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -479,11 +479,6 @@ CompiledMethod >> isInstalled [
 ]
 
 { #category : 'testing' }
-CompiledMethod >> isMeta [
-	^self isClassSide
-]
-
-{ #category : 'testing' }
 CompiledMethod >> isOverridden [
 	| selector|
 	selector := self selector.

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -479,6 +479,11 @@ CompiledMethod >> isInstalled [
 ]
 
 { #category : 'testing' }
+CompiledMethod >> isMeta [
+	^self isClassSide
+]
+
+{ #category : 'testing' }
 CompiledMethod >> isOverridden [
 	| selector|
 	selector := self selector.

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -280,7 +280,7 @@ MCMethodDefinition >> overridenMethodOrNil [
 		ifAbsent: [ ^ nil ].
 		
 	^ SourceFiles
-		changeRecordsFor: realMethod asRingDefinition
+		changeRecordsFor: realMethod
 		detect: [ :protocol | protocol ~= category ]
 ]
 

--- a/src/System-Changes/SourceFileArray.extension.st
+++ b/src/System-Changes/SourceFileArray.extension.st
@@ -25,7 +25,7 @@ SourceFileArray >> changeRecordsFor: aMethod do: aUnaryBlock [
 	^ self
 		changeRecordsFrom: aMethod sourcePointer
 		className: aMethod methodClass instanceSide name
-		isMeta: aMethod isMeta
+		isMeta: aMethod methodClass isMeta
 		do: aUnaryBlock
 ]
 

--- a/src/System-Changes/SourceFileArray.extension.st
+++ b/src/System-Changes/SourceFileArray.extension.st
@@ -1,31 +1,31 @@
 Extension { #name : 'SourceFileArray' }
 
 { #category : '*System-Changes' }
-SourceFileArray >> changeRecordsFor: aMethodDefinition [
+SourceFileArray >> changeRecordsFor: aMethod [
 
 	^ self
-		changeRecordsFrom: aMethodDefinition sourcePointer
-		className: aMethodDefinition methodClass instanceSide name
-		isMeta: aMethodDefinition methodClass isMeta
+		changeRecordsFrom: aMethod sourcePointer
+		className: aMethod methodClass instanceSide name
+		isMeta: aMethod methodClass isMeta
 ]
 
 { #category : '*System-Changes' }
-SourceFileArray >> changeRecordsFor: aMethodDefinition detect: aUnaryBlock [
+SourceFileArray >> changeRecordsFor: aMethod detect: aUnaryBlock [
 	"Try to detect the most recent ChangeRecord that satisfies aUnaryBlock. Answer nil if none satisfies."
 
-	self changeRecordsFor: aMethodDefinition do: [ :changeRecord |
+	self changeRecordsFor: aMethod do: [ :changeRecord |
 		(aUnaryBlock value: changeRecord protocol) ifTrue: [ ^ changeRecord ] ].
 	^ nil
 ]
 
 { #category : '*System-Changes' }
-SourceFileArray >> changeRecordsFor: aMethodDefinition do: aUnaryBlock [
+SourceFileArray >> changeRecordsFor: aMethod do: aUnaryBlock [
 	"Evaluate aUnaryBlock with each of the ChangeRecords of aMethodDefinition. Most recent changes are evaluated first."
 
 	^ self
-		changeRecordsFrom: aMethodDefinition sourcePointer
-		className: aMethodDefinition instanceSideParentName
-		isMeta: aMethodDefinition isMeta
+		changeRecordsFrom: aMethod sourcePointer
+		className: aMethod methodClass instanceSide name
+		isMeta: aMethod isMeta
 		do: aUnaryBlock
 ]
 


### PR DESCRIPTION
changeRecordsFor:do:  was sending #instanceSideParentName, which is Ring1 specific (the concept of "parent" does not exist in the main meta model).

The only user was creating a Ring Method, just to then extract sourcePointer, name and non-Meta class name (the API if SourcesFile is bad).

This PR fixes the sitation: we now can use CompiledMethods, too, and thus we do not rely on Ring anymore.

fixes #10094