### PR TITLE
Fix Deprecation for methods that use #runtimeUndeclaredRead

### DIFF
--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -7,10 +7,8 @@ CompiledMethod >> ast [
 	"Workaround, see https://github.com/pharo-project/pharo/issues/14871
 	We force recompile to make sure the next call creates a correct BC to AST mapping"
 	
-	(self isDoIt not 
-		and: [(self hasLiteral: #runtimeUndeclaredRead)
-			 or: [self hasLiteral: #runtimeUndeclaredWrite:]])
- 			ifTrue: [self recompile].
+	 ((self hasLiteral: #runtimeUndeclaredRead) or: [self hasLiteral: #runtimeUndeclaredWrite:])
+ 			ifTrue: [self isInstalled ifTrue: [self recompile]].
 	
 	^ ASTCache at: self
 ]

--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -3,6 +3,15 @@ Extension { #name : 'CompiledMethod' }
 { #category : '*AST-Core' }
 CompiledMethod >> ast [
 	"return an AST for this method. The AST is cached. see class comment of ASTCache"
+	
+	"Workaround, see https://github.com/pharo-project/pharo/issues/14871
+	We force recompile to make sure the next call creates a correct BC to AST mapping"
+	
+	(self isDoIt not 
+		and: [(self hasLiteral: #runtimeUndeclaredRead)
+			 or: [self hasLiteral: #runtimeUndeclaredWrite:]])
+ 			ifTrue: [self recompile].
+	
 	^ ASTCache at: self
 ]
 


### PR DESCRIPTION
We recompile the method  that uses reflective undeclared read if we call #ast.

Workaround for #14697