### PR TITLE
speedup-runtimeUndeclaredRead

### DIFF
--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -214,7 +214,11 @@ LiteralVariable >> runtimeUndeclaredRead [
 	"Workaround, see https://github.com/pharo-project/pharo/issues/14871
 	 When we reach here, the Variable is not undeclared.
 	 We force recompile to recompile without the #runtimeUndeclaredRead"
-	Smalltalk hasCompiler ifTrue: [thisContext sender homeMethod recompile].
+	Smalltalk hasCompiler ifTrue: [
+		| method |
+		method := thisContext sender homeMethod.
+		method isInstalled ifTrue: [ method recompile]
+	].
 
 	^ self read
 ]
@@ -227,7 +231,11 @@ LiteralVariable >> runtimeUndeclaredWrite: anObject [
 	"Workaround, see https://github.com/pharo-project/pharo/issues/14871
 	 When we reach here, the Variable is not undeclared.
 	 We force recompile to recompile without the runtimeUndeclaredWrite:"
-	Smalltalk hasCompiler ifTrue: [thisContext sender homeMethod recompile].
+	Smalltalk hasCompiler ifTrue: [
+		| method |
+		method := thisContext sender homeMethod.
+		method isInstalled ifTrue: [ method recompile]
+	].
 	^ self write: anObject
 ]
 

--- a/src/Kernel/LiteralVariable.class.st
+++ b/src/Kernel/LiteralVariable.class.st
@@ -211,6 +211,11 @@ LiteralVariable >> runtimeUndeclaredRead [
 	"This method is used internally to compile polymorphic read on undeclared variables.
 	Do not call it youself to not polute senders."
 
+	"Workaround, see https://github.com/pharo-project/pharo/issues/14871
+	 When we reach here, the Variable is not undeclared.
+	 We force recompile to recompile without the #runtimeUndeclaredRead"
+	Smalltalk hasCompiler ifTrue: [thisContext sender homeMethod recompile].
+
 	^ self read
 ]
 
@@ -219,6 +224,10 @@ LiteralVariable >> runtimeUndeclaredWrite: anObject [
 	"This method is used internally to compile polymorphic write on undeclared variables.
 	Do not call it youself to not polute senders."
 
+	"Workaround, see https://github.com/pharo-project/pharo/issues/14871
+	 When we reach here, the Variable is not undeclared.
+	 We force recompile to recompile without the runtimeUndeclaredWrite:"
+	Smalltalk hasCompiler ifTrue: [thisContext sender homeMethod recompile].
 	^ self write: anObject
 ]
 


### PR DESCRIPTION
This adds a recompile when we call #runtimeUndeclaredRead (and write) on a Variable that is not Undeclared. As the Variable exists, the compiler can re-compile without the #runtimeUndeclaredRead send (and using pusLiteralVariable)