### PR TITLE
Simplify Monticello tests

### DIFF
--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -10,9 +10,6 @@ and try to uncomment it
 Class {
 	#name : 'RPackageMCSynchronisationTest',
 	#superclass : 'RPackageTestCase',
-	#instVars : [
-		'oldAnnouncer'
-	],
 	#category : 'Monticello-Tests-RPackage',
 	#package : 'Monticello-Tests',
 	#tag : 'RPackage'
@@ -68,27 +65,6 @@ RPackageMCSynchronisationTest >> ensureYPackage [
 RPackageMCSynchronisationTest >> ensureZPackage [
 
 	^ self organizer ensurePackage: #ZZZZZ
-]
-
-{ #category : 'announcer handling' }
-RPackageMCSynchronisationTest >> initializeAnnouncers [
-
-	oldAnnouncer := MCWorkingCopy announcer.
-	MCWorkingCopy announcer: SystemAnnouncer uniqueInstance
-]
-
-{ #category : 'announcer handling' }
-RPackageMCSynchronisationTest >> restoreAnnouncers [
-
-	MCWorkingCopy announcer: oldAnnouncer
-]
-
-{ #category : 'running' }
-RPackageMCSynchronisationTest >> runCase [
-
-	[
-	self initializeAnnouncers.
-	super runCase ] ensure: [ self restoreAnnouncers ]
 ]
 
 { #category : 'running' }

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -11,7 +11,6 @@ Class {
 	#name : 'RPackageMCSynchronisationTest',
 	#superclass : 'RPackageTestCase',
 	#instVars : [
-		'emptyOrganizer',
 		'oldAnnouncer'
 	],
 	#category : 'Monticello-Tests-RPackage',
@@ -45,12 +44,6 @@ RPackageMCSynchronisationTest >> createMethodNamed: methodName inClass: aClass i
 RPackageMCSynchronisationTest >> createMethodNamed: methodName inClassSideOfClass: aClass inCategory: aCategoryName [ 
 
 	^ aClass classSide compile: (methodName, ' ^nil') classified: aCategoryName.
-]
-
-{ #category : 'accessing' }
-RPackageMCSynchronisationTest >> emptyOrganizer [ 
-
-	^ emptyOrganizer
 ]
 
 { #category : 'utilities' }
@@ -99,20 +92,8 @@ RPackageMCSynchronisationTest >> runCase [
 ]
 
 { #category : 'running' }
-RPackageMCSynchronisationTest >> setUp [
-
-	super setUp.
-
-	emptyOrganizer := self organizer.
-	emptyOrganizer ensurePackage: 'as yet unclassified'.
-
-	Author fullName ifNil: [ Author fullName: 'Tester' ]
-]
-
-{ #category : 'running' }
 RPackageMCSynchronisationTest >> tearDown [
 
-	MCWorkingCopy removeDependent: self emptyOrganizer.
 	self cleanClassesPackagesAndCategories.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
 	super tearDown

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -43,20 +43,6 @@ RPackageIncrementalTest >> removeClassNamedIfExists: aClassNameSymbol [
 	testingEnvironment at: aClassNameSymbol asSymbol ifPresent: [:c| c removeFromSystem]
 ]
 
-{ #category : 'running' }
-RPackageIncrementalTest >> setUp [
-	super setUp.
-	Author fullName ifNil: [Author fullName: 'RPackage']
-]
-
-{ #category : 'running' }
-RPackageIncrementalTest >> tearDown [
-
-	self organizer packages do: [ :package | package removeFromSystem ].
-
-	super tearDown
-]
-
 { #category : 'tests - class addition removal' }
 RPackageIncrementalTest >> testAddClassNoDuplicate [
 

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -103,6 +103,7 @@ RPackageTestCase >> runCase [
 RPackageTestCase >> tearDown [
 
 	self organizer environment allClasses do: [ :cls | cls removeFromSystem ].
+	self organizer packages do: [ :package | package removeFromSystem ].
 
 	super tearDown
 ]


### PR DESCRIPTION
Monticello does a lot of things that seems useless in their setup/teardown. I'm trying to remove most of them. While doing that I found out that some of them are hiding really vicious bugs! 

I'm still fighting to find the root of those bugs but here is a first cleaning of things that seems to not trigger those bugs in order to not lose those improvements