### PR TITLE
RPackage: Simplify tests and fix bug in package removal

### DIFF
--- a/src/Deprecated12/RPackage.extension.st
+++ b/src/Deprecated12/RPackage.extension.st
@@ -96,6 +96,14 @@ RPackage >> definedClassesDo: aBlock [
 ]
 
 { #category : '*Deprecated12' }
+RPackage >> definesClass: aClass [
+
+	self deprecated: 'Use #includesClass: instead.' transformWith: '`@rcv definesClass: `@arg' -> '`@rcv includesClass: `@arg'.
+
+	^ self includesClass: aClass
+]
+
+{ #category : '*Deprecated12' }
 RPackage >> extensionCategoriesForClass: aClass [
 
 	self

--- a/src/Deprecated12/RPackageTag.extension.st
+++ b/src/Deprecated12/RPackageTag.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'RPackageTag' }
+
+{ #category : '*Deprecated12' }
+RPackageTag >> hasClass: aClass [
+
+	self deprecated: 'Use #includesClass: instead' transformWith: '`@rcv hasClass: `@arg' -> '`@rcv includesClass: `@arg'.
+	^ self includesClass: aClass
+]

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -31,18 +31,6 @@ MCClassDefinitionTest >> classAComment [
 	^ self class classAComment
 ]
 
-{ #category : 'running' }
-MCClassDefinitionTest >> setUp [
-	super setUp.
-	testingEnvironment at: #MCMockClassC ifPresent: [ :c | c removeFromSystem ]
-]
-
-{ #category : 'running' }
-MCClassDefinitionTest >> tearDown [
-	testingEnvironment at: #MCMockClassC ifPresent: [ :c | c removeFromSystem ].
-	super tearDown
-]
-
 { #category : 'tests' }
 MCClassDefinitionTest >> testCannotLoad [
 	| d |
@@ -194,7 +182,7 @@ MCClassDefinitionTest >> testValidTraitComposition [
 MCClassDefinitionTest >> testValidTraitComposition2 [
 	"Related to http://code.google.com/p/pharo/issues/detail?id=2148"
 
-	| d className cls |
+	| d className class |
 	className := 'MCMockClassC'.
 	d := (MCClassDefinition named: className)
 		     traitComposition: 'MCTraitMock1';
@@ -202,18 +190,20 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
+	[
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
-	cls := testingEnvironment at: #MCMockClassC.
-	self assert: (cls includesSelector: #c1).
-	self assert: ((testingEnvironment at: #MCMockClassC) traitComposition allTraits includes: MCTraitMock1)
+	class := testingEnvironment at: #MCMockClassC.
+	self assert: (class includesSelector: #c1).
+	self assert: ((testingEnvironment at: #MCMockClassC) traitComposition allTraits includes: MCTraitMock1) ] ensure: [
+		testingEnvironment at: #MCMockClassC ifPresent: [ :c | c removeFromSystem ] ]
 ]
 
 { #category : 'tests' }
 MCClassDefinitionTest >> testValidTraitComposition3 [
 	"Related to http://code.google.com/p/pharo/issues/detail?id=2148"
 
-	| d className cls |
+	| d className class |
 	className := 'MCMockClassC'.
 	d := (MCClassDefinition named: className)
 		     traitComposition: 'MCTraitMock1 + MCTraitMock2';
@@ -221,13 +211,15 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
+	[
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
-	cls := testingEnvironment at: #MCMockClassC.
-	self assert: (cls includesSelector: #c1).
-	self assert: (cls includesSelector: #c2).
+	class := testingEnvironment at: #MCMockClassC.
+	self assert: (class includesSelector: #c1).
+	self assert: (class includesSelector: #c2).
 	self assert: ((testingEnvironment at: #MCMockClassC) traitComposition allTraits includes: MCTraitMock1).
-	self assert: ((testingEnvironment at: #MCMockClassC) traitComposition allTraits includes: MCTraitMock2)
+	self assert: ((testingEnvironment at: #MCMockClassC) traitComposition allTraits includes: MCTraitMock2) ] ensure: [
+		testingEnvironment at: #MCMockClassC ifPresent: [ :c | c removeFromSystem ] ]
 ]
 
 { #category : 'tests' }
@@ -242,9 +234,10 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 		     comment: (self commentForClass: className);
 		     commentStamp: (self commentStampForClass: className);
 		     yourself.
+	[
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
 	cls := testingEnvironment at: #MCMockClassC.
 	self assert: (cls selectors includesAll: { #c }).
-	self deny: (cls selectors includesAnyOf: { #c1 })
+	self deny: (cls selectors includesAnyOf: { #c1 }) ] ensure: [ testingEnvironment at: #MCMockClassC ifPresent: [ :c | c removeFromSystem ] ]
 ]

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -32,6 +32,29 @@ MCClassDefinitionTest >> classAComment [
 ]
 
 { #category : 'tests' }
+MCClassDefinitionTest >> mockClass: className super: superclassName [
+
+	^ (MCClassDefinition named: className)
+		  superclassName: superclassName;
+		  packageName: self packageForTestName;
+		  comment: (self commentForClass: className);
+		  commentStamp: (self commentStampForClass: className);
+		  yourself
+]
+
+{ #category : 'private' }
+MCClassDefinitionTest >> packageForTestName [
+	^ 'Generated-Monticello-Tests'
+]
+
+{ #category : 'running' }
+MCClassDefinitionTest >> tearDown [
+
+	self packageOrganizer removePackage: self packageForTestName.
+	super tearDown
+]
+
+{ #category : 'tests' }
 MCClassDefinitionTest >> testCannotLoad [
 	| d |
 	self deny: (Smalltalk hasClassNamed: 'MCMockClassC').
@@ -142,6 +165,7 @@ MCClassDefinitionTest >> testKindOfSubclass [
 
 { #category : 'tests' }
 MCClassDefinitionTest >> testLoadAndUnload [
+
 	| d c |
 	d := self mockClass: 'MCMockClassC' super: 'Object'.
 	d load.
@@ -152,7 +176,7 @@ MCClassDefinitionTest >> testLoadAndUnload [
 	self assertEmpty: c instVarNames.
 	self assertEmpty: c classVarNames.
 	self assertEmpty: c sharedPools.
-	self assert: c category equals: self mockCategoryName.
+	self assert: c category equals: self packageForTestName.
 	self assert: c comment equals: (self commentForClass: 'MCMockClassC').
 	self assert: c commentStamp equals: (self commentStampForClass: 'MCMockClassC').
 	d unload.
@@ -165,12 +189,8 @@ MCClassDefinitionTest >> testValidTraitComposition [
 
 	| d className cls |
 	className := 'MCMockClassC'.
-	d := (MCClassDefinition named: className)
-		     traitComposition: '{MCTraitMock1}';
-		     packageName: self mockCategoryName;
-		     comment: (self commentForClass: className);
-		     commentStamp: (self commentStampForClass: className);
-		     yourself.
+	d := self mockClass: className super: 'Object'.
+	d traitComposition: '{MCTraitMock1}'.
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
 	cls := testingEnvironment at: #MCMockClassC.
@@ -184,19 +204,13 @@ MCClassDefinitionTest >> testValidTraitComposition2 [
 
 	| d className class |
 	className := 'MCMockClassC'.
-	d := (MCClassDefinition named: className)
-		     traitComposition: 'MCTraitMock1';
-		     packageName: self mockCategoryName;
-		     comment: (self commentForClass: className);
-		     commentStamp: (self commentStampForClass: className);
-		     yourself.
-	[
+	d := self mockClass: className super: 'Object'.
+	d traitComposition: '{MCTraitMock1}'.
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
 	class := testingEnvironment at: #MCMockClassC.
 	self assert: (class includesSelector: #c1).
-	self assert: ((testingEnvironment at: #MCMockClassC) traitComposition allTraits includes: MCTraitMock1) ] ensure: [
-		testingEnvironment at: #MCMockClassC ifPresent: [ :c | c removeFromSystem ] ]
+	self assert: ((testingEnvironment at: #MCMockClassC) traitComposition allTraits includes: MCTraitMock1)
 ]
 
 { #category : 'tests' }
@@ -205,21 +219,15 @@ MCClassDefinitionTest >> testValidTraitComposition3 [
 
 	| d className class |
 	className := 'MCMockClassC'.
-	d := (MCClassDefinition named: className)
-		     traitComposition: 'MCTraitMock1 + MCTraitMock2';
-		     packageName: self mockCategoryName;
-		     comment: (self commentForClass: className);
-		     commentStamp: (self commentStampForClass: className);
-		     yourself.
-	[
+	d := self mockClass: className super: 'Object'.
+	d traitComposition: 'MCTraitMock1 + MCTraitMock2'.
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
 	class := testingEnvironment at: #MCMockClassC.
 	self assert: (class includesSelector: #c1).
 	self assert: (class includesSelector: #c2).
 	self assert: ((testingEnvironment at: #MCMockClassC) traitComposition allTraits includes: MCTraitMock1).
-	self assert: ((testingEnvironment at: #MCMockClassC) traitComposition allTraits includes: MCTraitMock2) ] ensure: [
-		testingEnvironment at: #MCMockClassC ifPresent: [ :c | c removeFromSystem ] ]
+	self assert: ((testingEnvironment at: #MCMockClassC) traitComposition allTraits includes: MCTraitMock2)
 ]
 
 { #category : 'tests' }
@@ -228,16 +236,12 @@ MCClassDefinitionTest >> testValidTraitComposition4 [
 
 	| d className cls |
 	className := 'MCMockClassC'.
-	d := (MCClassDefinition named: className)
-		     traitComposition: 'MCTraitMock1 - {#c1}';
-		     packageName: self mockCategoryName;
-		     comment: (self commentForClass: className);
-		     commentStamp: (self commentStampForClass: className);
-		     yourself.
-	[
+	d := self mockClass: className super: 'Object'.
+	d traitComposition: 'MCTraitMock1 - {#c1}'.
+
 	d load.
 	self assert: (testingEnvironment hasClassNamed: 'MCMockClassC').
 	cls := testingEnvironment at: #MCMockClassC.
 	self assert: (cls selectors includesAll: { #c }).
-	self deny: (cls selectors includesAnyOf: { #c1 }) ] ensure: [ testingEnvironment at: #MCMockClassC ifPresent: [ :c | c removeFromSystem ] ]
+	self deny: (cls selectors includesAnyOf: { #c1 })
 ]

--- a/src/Monticello-Tests/MCTestCase.class.st
+++ b/src/Monticello-Tests/MCTestCase.class.st
@@ -74,17 +74,6 @@ MCTestCase >> mockCategoryName [
 ]
 
 { #category : 'mocks' }
-MCTestCase >> mockClass: className super: superclassName [
-
-	^ (MCClassDefinition named: className)
-		  superclassName: superclassName;
-		  packageName: self mockCategoryName;
-		  comment: (self commentForClass: className);
-		  commentStamp: (self commentStampForClass: className);
-		  yourself
-]
-
-{ #category : 'mocks' }
 MCTestCase >> mockClassA [
 	^ testingEnvironment at: #MCMockClassA
 ]

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -24,7 +24,7 @@ RPackageMCSynchronisationTest >> allWorkingCopies [
 { #category : 'setup' }
 RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
 
-	#( 'OriginalCategory' 'XXXXX' 'XXXX' 'YYYYY' 'YYYY' 'Yyyyy' 'YyYyY' 'Y' 'ZZZZZ' 'Zzzzz' 'FooPackage-Core' 'FooPackage-Other' 'FooPackage' 'Zork' ) do: [
+	#( 'OriginalCategory' 'XXXXX' 'XXXX' 'YYYYY' 'YYYY' 'Yyyyy' 'YyYyY' 'Y' 'ZZZZZ' 'Zzzzz' 'FooPackage-Core' 'FooPackage-Other' 'FooPackage' ) do: [
 		:packageName |
 		self allWorkingCopies
 			detect: [ :each | each packageName = packageName ]

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -10,9 +10,6 @@ and try to uncomment it
 Class {
 	#name : 'RPackageMCSynchronisationTest',
 	#superclass : 'RPackageTestCase',
-	#instVars : [
-		'oldAnnouncer'
-	],
 	#category : 'Monticello-Tests-RPackage',
 	#package : 'Monticello-Tests',
 	#tag : 'RPackage'
@@ -68,27 +65,6 @@ RPackageMCSynchronisationTest >> ensureYPackage [
 RPackageMCSynchronisationTest >> ensureZPackage [
 
 	^ self organizer ensurePackage: #ZZZZZ
-]
-
-{ #category : 'announcer handling' }
-RPackageMCSynchronisationTest >> initializeAnnouncers [
-
-	oldAnnouncer := MCWorkingCopy announcer.
-	MCWorkingCopy announcer: SystemAnnouncer uniqueInstance
-]
-
-{ #category : 'announcer handling' }
-RPackageMCSynchronisationTest >> restoreAnnouncers [
-
-	MCWorkingCopy announcer: oldAnnouncer
-]
-
-{ #category : 'running' }
-RPackageMCSynchronisationTest >> runCase [
-
-	[
-	self initializeAnnouncers.
-	super runCase ] ensure: [ self restoreAnnouncers ]
 ]
 
 { #category : 'running' }

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -15,22 +15,6 @@ Class {
 	#tag : 'RPackage'
 }
 
-{ #category : 'accessing' }
-RPackageMCSynchronisationTest >> allWorkingCopies [
-
-	^ MCWorkingCopy allWorkingCopies
-]
-
-{ #category : 'setup' }
-RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
-
-	#(  'XXXXX' 'YYYYY' 'ZZZZZ' ) do: [
-		:packageName |
-		self allWorkingCopies
-			detect: [ :each | each packageName = packageName ]
-			ifFound: [ :mCPackage | mCPackage unregister ] ]
-]
-
 { #category : 'private' }
 RPackageMCSynchronisationTest >> createMethodNamed: methodName inClass: aClass inCategory: aCategoryName [ 
 
@@ -70,7 +54,6 @@ RPackageMCSynchronisationTest >> ensureZPackage [
 { #category : 'running' }
 RPackageMCSynchronisationTest >> tearDown [
 
-	self cleanClassesPackagesAndCategories.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
 	super tearDown
 ]

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -24,7 +24,7 @@ RPackageMCSynchronisationTest >> allWorkingCopies [
 { #category : 'setup' }
 RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
 
-	#( 'OriginalCategory' 'XXXXX' 'XXXX' 'YYYYY' 'YYYY' 'Yyyyy' 'YyYyY' 'Y' 'ZZZZZ' 'Zzzzz' 'FooPackage-Core' 'FooPackage-Other' 'FooPackage' ) do: [
+	#(  'XXXXX' 'XXXX' 'YYYYY' 'YYYY' 'Yyyyy' 'YyYyY' 'Y' 'ZZZZZ' 'Zzzzz' ) do: [
 		:packageName |
 		self allWorkingCopies
 			detect: [ :each | each packageName = packageName ]

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -11,7 +11,6 @@ Class {
 	#name : 'RPackageMCSynchronisationTest',
 	#superclass : 'RPackageTestCase',
 	#instVars : [
-		'emptyOrganizer',
 		'oldAnnouncer'
 	],
 	#category : 'Monticello-Tests-RPackage',
@@ -45,12 +44,6 @@ RPackageMCSynchronisationTest >> createMethodNamed: methodName inClass: aClass i
 RPackageMCSynchronisationTest >> createMethodNamed: methodName inClassSideOfClass: aClass inCategory: aCategoryName [ 
 
 	^ aClass classSide compile: (methodName, ' ^nil') classified: aCategoryName.
-]
-
-{ #category : 'accessing' }
-RPackageMCSynchronisationTest >> emptyOrganizer [ 
-
-	^ emptyOrganizer
 ]
 
 { #category : 'utilities' }
@@ -99,20 +92,8 @@ RPackageMCSynchronisationTest >> runCase [
 ]
 
 { #category : 'running' }
-RPackageMCSynchronisationTest >> setUp [
-
-	super setUp.
-
-	emptyOrganizer := self organizer.
-	emptyOrganizer ensurePackage: 'as yet unclassified'.
-
-	Author fullName ifNil: [ Author fullName: 'Tester' ]
-]
-
-{ #category : 'running' }
 RPackageMCSynchronisationTest >> tearDown [
 
-	MCWorkingCopy removeDependent: self emptyOrganizer.
 	self cleanClassesPackagesAndCategories.
 	SystemAnnouncer uniqueInstance unsubscribe: self.
 	super tearDown

--- a/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMCSynchronisationTest.class.st
@@ -24,7 +24,7 @@ RPackageMCSynchronisationTest >> allWorkingCopies [
 { #category : 'setup' }
 RPackageMCSynchronisationTest >> cleanClassesPackagesAndCategories [
 
-	#(  'XXXXX' 'XXXX' 'YYYYY' 'YYYY' 'Yyyyy' 'YyYyY' 'Y' 'ZZZZZ' 'Zzzzz' ) do: [
+	#(  'XXXXX' 'YYYYY' 'ZZZZZ' ) do: [
 		:packageName |
 		self allWorkingCopies
 			detect: [ :each | each packageName = packageName ]

--- a/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
@@ -9,6 +9,12 @@ Class {
 	#tag : 'RPackage'
 }
 
+{ #category : 'accessing' }
+RPackageMonticelloSynchronisationTest >> allWorkingCopies [
+
+	^ MCWorkingCopy allWorkingCopies
+]
+
 { #category : 'tests - operations on MCPackages' }
 RPackageMonticelloSynchronisationTest >> testAddMCPackageCreatesAPackage [
 	"test that when we create a MCPackage, a corresponding package is created"

--- a/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
+++ b/src/Monticello-Tests/RPackageMonticelloSynchronisationTest.class.st
@@ -3,7 +3,7 @@ SUnit tests for RPackage Monticello synchronization
 "
 Class {
 	#name : 'RPackageMonticelloSynchronisationTest',
-	#superclass : 'RPackageMCSynchronisationTest',
+	#superclass : 'RPackageTestCase',
 	#category : 'Monticello-Tests-RPackage',
 	#package : 'Monticello-Tests',
 	#tag : 'RPackage'

--- a/src/RPackage-Core/PackageRenamed.class.st
+++ b/src/RPackage-Core/PackageRenamed.class.st
@@ -47,8 +47,7 @@ PackageRenamed >> affectsMethods [
 { #category : 'testing' }
 PackageRenamed >> affectsMethodsDefinedInClass: aClass [
 
-	^(package definesClass: aClass)
-		or: [ package extendsClass: aClass ]
+	^ (package includesClass: aClass) or: [ package extendsClass: aClass ]
 ]
 
 { #category : 'testing' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -238,13 +238,6 @@ RPackage >> definedSelectorsForClass: aClass [
 ]
 
 { #category : 'testing' }
-RPackage >> definesClass: aClass [
-	"Returns true if the class, aClass, is one of the locally defined classes"
-	"should be probably removed since this is the same as includesClass: or the inverse"
-	^ self includesClass: aClass
-]
-
-{ #category : 'testing' }
 RPackage >> definesOrExtendsClass: aClass [
 	"Returns true whether the class, aClass, is one of the locally defined classes of the receiver or
 	if the receiver extends such class (that is defined in another package)"
@@ -848,7 +841,7 @@ RPackage >> tagNames [
 RPackage >> tagOf: aClass [
 
 	^ self classTags
-		  detect: [ :tag | tag hasClass: aClass ]
+		  detect: [ :tag | tag includesClass: aClass ]
 		  ifNone: [ nil ]
 ]
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -753,7 +753,8 @@ RPackage >> removeTag: aTag [
 		       ifTrue: [ self classTagNamed: aTag ifAbsent: [ ^ self ] ]
 		       ifFalse: [ aTag ].
 
-	tag classes do: [ :class | class removeFromSystem ].
+	"The #asArray is there to not remove elements from the #classes inst var while iterating it."
+	tag classes asArray do: [ :class | class removeFromSystem ].
 
 	classTags remove: tag ifAbsent: [ ^ self ].
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -583,7 +583,7 @@ RPackageOrganizer >> testPackages [
 	^ self packages select: [ :package | package isTestPackage ]
 ]
 
-{ #category : 'tests' }
+{ #category : 'accessing' }
 RPackageOrganizer >> undefinedPackage [
 
 	^ self packages detect: [ :package | package isUndefined ]

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -63,12 +63,6 @@ RPackageTag >> environment [
 ]
 
 { #category : 'testing' }
-RPackageTag >> hasClass: aClass [
-
-	^ self classes includes: aClass instanceSide
-]
-
-{ #category : 'testing' }
 RPackageTag >> hasClassNamed: aSymbol [
 	^ self classNames includes: aSymbol
 ]
@@ -77,7 +71,7 @@ RPackageTag >> hasClassNamed: aSymbol [
 RPackageTag >> includesClass: aClass [
 	"To deprecate in favor of #hasClass:"
 
-	^ self hasClass: aClass
+	^ self classes includes: aClass instanceSide
 ]
 
 { #category : 'initialization' }

--- a/src/RPackage-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageClassesSynchronisationTest.class.st
@@ -3,10 +3,9 @@ SUnit tests for RPackage classes synchronisation
 "
 Class {
 	#name : 'RPackageClassesSynchronisationTest',
-	#superclass : 'RPackageMCSynchronisationTest',
-	#category : 'Monticello-Tests-RPackage',
-	#package : 'Monticello-Tests',
-	#tag : 'RPackage'
+	#superclass : 'RPackageTestCase',
+	#category : 'RPackage-Tests',
+	#package : 'RPackage-Tests'
 }
 
 { #category : 'tests - adding classes' }
@@ -45,24 +44,6 @@ RPackageClassesSynchronisationTest >> testAddClassUpdateTheOrganizerMappings [
 	class := self newClassNamed: 'NewClass' in: xPackage.
 
 	self assert: class package equals: xPackage
-]
-
-{ #category : 'tests - recategorizing class' }
-RPackageClassesSynchronisationTest >> testRecategorizeClassRaisesClassRepackagedEvent [
-	"test that when we recategorize a class, the organizer is updated so that the class name point the the new RPackage"
-
-	| xPackage yPackage class ann |
-	SystemAnnouncer uniqueInstance when: ClassRepackaged do: [ :a | ann := a ] for: self.
-
-	xPackage := self ensureXPackage.
-	yPackage := self ensureYPackage.
-	class := self newClassNamed: 'NewClass' in: xPackage.
-	class category: 'YYYYY'.
-
-	self assert: ann isNotNil.
-	self assert: ann classRepackaged equals: class.
-	self assert: ann oldPackage equals: xPackage.
-	self assert: ann newPackage equals: yPackage
 ]
 
 { #category : 'tests - recategorizing class' }

--- a/src/RPackage-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageClassesSynchronisationTest.class.st
@@ -17,7 +17,7 @@ RPackageClassesSynchronisationTest >> testAddClassAddItIntoPackageBestMatchName 
 
 	class := self newClassNamed: 'NewClass' inTag: tag.
 
-	self assert: (package definesClass: class).
+	self assert: (package includesClass: class).
 	self assert: class package equals: package
 ]
 
@@ -30,7 +30,7 @@ RPackageClassesSynchronisationTest >> testAddClassAddItIntoPackageExactName [
 
 	class := self newClassNamed: 'NewClass' in: xPackage.
 
-	self assert: (xPackage definesClass: class).
+	self assert: (xPackage includesClass: class).
 	self assert: class package equals: xPackage
 ]
 

--- a/src/RPackage-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
@@ -3,10 +3,9 @@ SUnit tests for RPackage extension methods
 "
 Class {
 	#name : 'RPackageExtensionMethodsSynchronisationTest',
-	#superclass : 'RPackageMCSynchronisationTest',
-	#category : 'Monticello-Tests-RPackage',
-	#package : 'Monticello-Tests',
-	#tag : 'RPackage'
+	#superclass : 'RPackageTestCase',
+	#category : 'RPackage-Tests',
+	#package : 'RPackage-Tests'
 }
 
 { #category : 'we are not sure' }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -43,20 +43,6 @@ RPackageIncrementalTest >> removeClassNamedIfExists: aClassNameSymbol [
 	testingEnvironment at: aClassNameSymbol asSymbol ifPresent: [:c| c removeFromSystem]
 ]
 
-{ #category : 'running' }
-RPackageIncrementalTest >> setUp [
-	super setUp.
-	Author fullName ifNil: [Author fullName: 'RPackage']
-]
-
-{ #category : 'running' }
-RPackageIncrementalTest >> tearDown [
-
-	self organizer packages do: [ :package | package removeFromSystem ].
-
-	super tearDown
-]
-
 { #category : 'tests - class addition removal' }
 RPackageIncrementalTest >> testAddClassNoDuplicate [
 

--- a/src/RPackage-Tests/RPackageMethodsSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageMethodsSynchronisationTest.class.st
@@ -3,10 +3,9 @@ SUnit tests for RPackage method synchronization
 "
 Class {
 	#name : 'RPackageMethodsSynchronisationTest',
-	#superclass : 'RPackageMCSynchronisationTest',
-	#category : 'Monticello-Tests-RPackage',
-	#package : 'Monticello-Tests',
-	#tag : 'RPackage'
+	#superclass : 'RPackageTestCase',
+	#category : 'RPackage-Tests',
+	#package : 'RPackage-Tests'
 }
 
 { #category : 'tests - operations on methods' }

--- a/src/RPackage-Tests/RPackageSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageSynchronisationTest.class.st
@@ -1,65 +1,19 @@
-"
-I had some problems using the 'ensure:' method. There was some conflicts with the organizer used for the test when trying to clean the classes, categories and packages generated for the test. 
-There is something I don't get with this method. Therefore I choosed to clean by default all possible generated classes, categories and packages after each test using the tearDown method.
-
-For now, all that was in the 'ensure:' methods has been commented.
-Look for example at:
-    testAddMethodInClassicCategoryAddMethodToTheParentPackageOfItsClass
-and try to uncomment it
-"
 Class {
-	#name : 'RPackageMCSynchronisationTest',
+	#name : 'RPackageSynchronisationTest',
 	#superclass : 'RPackageTestCase',
-	#category : 'Monticello-Tests-RPackage',
-	#package : 'Monticello-Tests',
-	#tag : 'RPackage'
+	#category : 'RPackage-Tests',
+	#package : 'RPackage-Tests'
 }
 
-{ #category : 'private' }
-RPackageMCSynchronisationTest >> createMethodNamed: methodName inClass: aClass inCategory: aCategoryName [ 
-
-	^ aClass compile: (methodName, ' ^nil') classified: aCategoryName.
-]
-
-{ #category : 'private' }
-RPackageMCSynchronisationTest >> createMethodNamed: methodName inClassSideOfClass: aClass inCategory: aCategoryName [ 
-
-	^ aClass classSide compile: (methodName, ' ^nil') classified: aCategoryName.
-]
-
-{ #category : 'utilities' }
-RPackageMCSynchronisationTest >> ensureTagYinX [
-
-	^ self organizer ensureTagNamed: #YYYY inPackageNamed: #XXXXX
-]
-
-{ #category : 'utilities' }
-RPackageMCSynchronisationTest >> ensureXPackage [
-
-	^ self organizer ensurePackage: #XXXXX
-]
-
-{ #category : 'utilities' }
-RPackageMCSynchronisationTest >> ensureYPackage [
-
-	^ self organizer ensurePackage: #YYYYY
-]
-
-{ #category : 'utilities' }
-RPackageMCSynchronisationTest >> ensureZPackage [
-
-	^ self organizer ensurePackage: #ZZZZZ
-]
-
 { #category : 'running' }
-RPackageMCSynchronisationTest >> tearDown [
+RPackageSynchronisationTest >> tearDown [
 
 	SystemAnnouncer uniqueInstance unsubscribe: self.
 	super tearDown
 ]
 
 { #category : 'to move to a simple RPackage test case' }
-RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenModifyMethodByMovingInSameExtensionCategory [
+RPackageSynchronisationTest >> testNotRepackagedAnnouncementWhenModifyMethodByMovingInSameExtensionCategory [
 
 	| ann class |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
@@ -76,7 +30,7 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenModifyMethodBy
 ]
 
 { #category : 'to move to a simple RPackage test case' }
-RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenMovingClassicCategories [
+RPackageSynchronisationTest >> testNotRepackagedAnnouncementWhenMovingClassicCategories [
 
 	| ann class |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
@@ -92,8 +46,26 @@ RPackageMCSynchronisationTest >> testNotRepackagedAnnouncementWhenMovingClassicC
 	self assert: ann isNil
 ]
 
+{ #category : 'tests - recategorizing class' }
+RPackageSynchronisationTest >> testRecategorizeClassRaisesClassRepackagedEvent [
+	"test that when we recategorize a class, the organizer is updated so that the class name point the the new RPackage"
+
+	| xPackage yPackage class ann |
+	SystemAnnouncer uniqueInstance when: ClassRepackaged do: [ :a | ann := a ] for: self.
+
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+	class := self newClassNamed: 'NewClass' in: xPackage.
+	class category: 'YYYYY'.
+
+	self assert: ann isNotNil.
+	self assert: ann classRepackaged equals: class.
+	self assert: ann oldPackage equals: xPackage.
+	self assert: ann newPackage equals: yPackage
+]
+
 { #category : 'to move to a simple RPackage test case' }
-RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromClassicCategoryToExtensionCategory [
+RPackageSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromClassicCategoryToExtensionCategory [
 
 	| ann class xPackage yPackage |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
@@ -117,7 +89,7 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 ]
 
 { #category : 'to move to a simple RPackage test case' }
-RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromDifferentExtensionCategories [
+RPackageSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromDifferentExtensionCategories [
 
 	| ann class yPackage zPackage |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.
@@ -138,7 +110,7 @@ RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMov
 ]
 
 { #category : 'to move to a simple RPackage test case' }
-RPackageMCSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromExtensionCategoryToClassicCategory [
+RPackageSynchronisationTest >> testRepackagedAnnouncementWhenModifyMethodByMovingFromExtensionCategoryToClassicCategory [
 
 	| ann class xPackage yPackage |
 	SystemAnnouncer uniqueInstance when: MethodRepackaged do: [ :a | ann := a ] for: self.

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -52,7 +52,7 @@ RPackageTagTest >> testAddClassFromTag [
 ]
 
 { #category : 'tests' }
-RPackageTagTest >> testHasClass [
+RPackageTagTest >> testIncludesClass [
 
 	| package class tag |
 	package := self ensurePackage: #Test1.
@@ -63,9 +63,9 @@ RPackageTagTest >> testHasClass [
 	self assert: (package hasTag: tag).
 	self assert: tag name equals: 'TAG'.
 
-	self assert: (tag hasClass: class).
-	self assert: (tag hasClass: class class). "We want it to work with class side too"
-	self deny: (tag hasClass: self class)
+	self assert: (tag includesClass: class).
+	self assert: (tag includesClass: class class). "We want it to work with class side too"
+	self deny: (tag includesClass: self class)
 ]
 
 { #category : 'tests' }

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -103,6 +103,7 @@ RPackageTestCase >> runCase [
 RPackageTestCase >> tearDown [
 
 	self organizer environment allClasses do: [ :cls | cls removeFromSystem ].
+	self organizer packages do: [ :package | package removeFromSystem ].
 
 	super tearDown
 ]

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -11,10 +11,46 @@ Class {
 	#package : 'RPackage-Tests'
 }
 
+{ #category : 'private' }
+RPackageTestCase >> createMethodNamed: methodName inClass: aClass inCategory: aCategoryName [ 
+
+	^ aClass compile: (methodName, ' ^nil') classified: aCategoryName.
+]
+
+{ #category : 'private' }
+RPackageTestCase >> createMethodNamed: methodName inClassSideOfClass: aClass inCategory: aCategoryName [ 
+
+	^ aClass classSide compile: (methodName, ' ^nil') classified: aCategoryName.
+]
+
 { #category : 'utilities' }
 RPackageTestCase >> ensurePackage: aName [
 
 	^ self organizer ensurePackage: aName
+]
+
+{ #category : 'utilities' }
+RPackageTestCase >> ensureTagYinX [
+
+	^ self organizer ensureTagNamed: #YYYY inPackageNamed: #XXXXX
+]
+
+{ #category : 'utilities' }
+RPackageTestCase >> ensureXPackage [
+
+	^ self organizer ensurePackage: #XXXXX
+]
+
+{ #category : 'utilities' }
+RPackageTestCase >> ensureYPackage [
+
+	^ self organizer ensurePackage: #YYYYY
+]
+
+{ #category : 'utilities' }
+RPackageTestCase >> ensureZPackage [
+
+	^ self organizer ensurePackage: #ZZZZZ
 ]
 
 { #category : 'utilities' }

--- a/src/RPackage-Tests/RPackageTraitSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitSynchronisationTest.class.st
@@ -4,10 +4,9 @@ SUnit tests for RPackage trait synchronization
 "
 Class {
 	#name : 'RPackageTraitSynchronisationTest',
-	#superclass : 'RPackageMCSynchronisationTest',
-	#category : 'Monticello-Tests-RPackage',
-	#package : 'Monticello-Tests',
-	#tag : 'RPackage'
+	#superclass : 'RPackageTestCase',
+	#category : 'RPackage-Tests',
+	#package : 'RPackage-Tests'
 }
 
 { #category : 'tests - operations on methods' }

--- a/src/RPackage-Tests/RPackageTraitSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitSynchronisationTest.class.st
@@ -36,7 +36,7 @@ RPackageTraitSynchronisationTest >> testAddTraitAddItIntoPackageBestMatchName [
 
 	class := self newTraitNamed: 'NewClass' inTag: tag.
 
-	self assert: (xPackage definesClass: class).
+	self assert: (xPackage includesClass: class).
 	self assert: xPackage equals: class package
 ]
 
@@ -49,7 +49,7 @@ RPackageTraitSynchronisationTest >> testAddTraitAddItIntoPackageExactName [
 
 	class := self newTraitNamed: 'NewClass' in: xPackage.
 
-	self assert: (xPackage definesClass: class).
+	self assert: (xPackage includesClass: class).
 	self assert: xPackage equals: class package
 ]
 


### PR DESCRIPTION
This change simplifies the tests in RPackage and Monticello and fix a bug that was happening during the removal of a package or a tag. Some classes were skipped because the ivar of RPackageTag was updated while iterating on it

Another change is that tests about RPackage from Monticello are now in RPackage-Tests instead of Monticello-Tests.

I also deprecated some methods that had multiple versions