### PR TITLE
RPackage: remove private import method

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -382,26 +382,6 @@ RPackage >> hierarchyRoots [
 ]
 
 { #category : 'private' }
-RPackage >> importClass: aClass inTag: aTag [
-	"Import a class already created but not attached to a package to the receiver. It will import the class and its methods.
-
-	Handle also *- convention. Methods defined in *category are not added to the package.
-	
-	If the class had an extension to us, then all methods in that extension are moved to 'as yet unclassified' and the extension protocol is deleted"
-
-	"Question: should we check that for each extension, there is a real package behind or not?"
-
-	self removeAllMethodsFromClass: aClass.
-	
-	(self ensureTag: aTag) addClass: aClass instanceSide.
-
-	{ aClass . aClass classSide } do: [ :class |
-		(self extensionProtocolsForClass: class) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
-
-		class protocols reject: [ :protocol | protocol isExtensionProtocol ] thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ]
-]
-
-{ #category : 'private' }
 RPackage >> importProtocol: aProtocol forClass: aClass [
 	"import all the local methods of a protocol as defined in the receiver."
 
@@ -553,7 +533,15 @@ RPackage >> moveClass: aClass toTag: aTag [
 	oldPackage := aClass package.
 
 	oldPackage removeClass: aClass.
-	self importClass: aClass inTag: tag.
+	
+	self removeAllMethodsFromClass: aClass.
+	
+	tag addClass: aClass instanceSide.
+
+	{ aClass . aClass classSide } do: [ :class |
+		(self extensionProtocolsForClass: class) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
+
+		class protocols reject: [ :protocol | protocol isExtensionProtocol ] thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ].
 
 	SystemAnnouncer uniqueInstance classRepackaged: aClass from: oldPackage to: self
 ]

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -170,8 +170,8 @@ RPackageIncrementalTest >> testClassDefinitionWithTagsRemoval [
 	b1 := self newClassNamed: #B1InPAckageP1 in: p.
 	self assert: p definedClasses size equals: 2.
 
-	p importClass: a1 inTag: 'a1-tag'.
-	p importClass: b1 inTag: 'b1-tag'.
+	p moveClass: a1 toTag: 'a1-tag'.
+	p moveClass: b1 toTag: 'b1-tag'.
 	self assert: p classTags size equals: 2.
 
 	self assert: (p includesClass: a1).

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -67,8 +67,8 @@ RPackageReadOnlyCompleteSetupTest >> testAddTag [
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: p1 classTags size equals: 2.
 
-	p1 importClass: a1 inTag: #foo.
-	p1 importClass: b1 inTag: #foo.
+	p1 moveClass: a1 toTag: #foo.
+	p1 moveClass: b1 toTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: p1 classTags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
 	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
@@ -91,8 +91,8 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagNames [
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: p1 classTags size equals: 2.
 
-	p1 importClass: a1 inTag: #foo.
-	p1 importClass: b1 inTag: #foo.
+	p1 moveClass: a1 toTag: #foo.
+	p1 moveClass: b1 toTag: #foo.
 	self assert: (p1 classTags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: p1 classTags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
 	self assert: ((p1 classTagNamed: #foo) classNames includes: #A1DefinedInP1).
@@ -112,15 +112,15 @@ RPackageReadOnlyCompleteSetupTest >> testAddTagsToAClass [
 
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
-	p1 importClass: a1 inTag: #foo.
+	p1 moveClass: a1 toTag: #foo.
 	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
 	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
 
-	p1 importClass: b1 inTag: #foo.
+	p1 moveClass: b1 toTag: #foo.
 	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesTaggedWith: #foo) size equals: 2.
 
-	p1 importClass: b1 inTag: #zork.
+	p1 moveClass: b1 toTag: #zork.
 	self assert: (((p1 classesTaggedWith: #zork) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
 	self assert: (p1 classesTaggedWith: #zork) size equals: 1
@@ -291,9 +291,9 @@ RPackageReadOnlyCompleteSetupTest >> testPackagesOfClass [
 { #category : 'tests - tag class' }
 RPackageReadOnlyCompleteSetupTest >> testRemoveTaggedClasses [
 
-	p1 importClass: a1 inTag: #foo.
-	p1 importClass: b1 inTag: #foo.
-	p1 importClass: b1 inTag: #zork.
+	p1 moveClass: a1 toTag: #foo.
+	p1 moveClass: b1 toTag: #foo.
+	p1 moveClass: b1 toTag: #zork.
 	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
 	self deny: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesTaggedWith: #foo) size equals: 1.

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -290,11 +290,11 @@ RPackageTest >> testRemoveTag [
 	b1 := self newClassNamed: #B1DefinedInP1 in: p1.
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
-	p1 importClass: a1 inTag: #foo.
+	p1 moveClass: a1 toTag: #foo.
 	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
 	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
 
-	p1 importClass: b1 inTag: #foo.
+	p1 moveClass: b1 toTag: #foo.
 	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInP1).
 	self assert: (p1 classesTaggedWith: #foo) size equals: 2.
 
@@ -316,7 +316,7 @@ RPackageTest >> testRemoveTagRemoveClasses [
 	a1 := self newClassNamed: #A1DefinedInP1 in: p1.
 	self assert: p1 classTags size equals: 1. "We start with the root tag"
 
-	p1 importClass: a1 inTag: #foo.
+	p1 moveClass: a1 toTag: #foo.
 	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInP1).
 	self assert: (p1 classesTaggedWith: #foo) size equals: 1.
 


### PR DESCRIPTION
Remove RPackage>>importClass:inTag: because this private method is called only in one place in RPackage and the fact that it is here made some people want to use it. Instead people should use #addClass: to add a class to a package without caring about the tag or #moveClass:toTag: if they care about the tag. Like this, we are removing the class from the old package/tag and announcing the repackaging