### PR TITLE
RPackage: ClassRepackaged announcement should know the package tags

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -532,7 +532,6 @@ RPackage >> moveClass: aClass toTag: aTag [
 	oldTag = newTag ifTrue: [ ^ self ].
 
 	aClass package removeClass: aClass.
-	self importClass: aClass inTag: newTag.
 
 	self removeAllMethodsFromClass: aClass.
 	

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -535,7 +535,7 @@ RPackage >> moveClass: aClass toTag: aTag [
 
 	self removeAllMethodsFromClass: aClass.
 	
-	tag addClass: aClass instanceSide.
+	newTag addClass: aClass instanceSide.
 
 	{ aClass . aClass classSide } do: [ :class |
 		(self extensionProtocolsForClass: class) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -546,16 +546,15 @@ RPackage >> methodsForClass: aClass [
 { #category : 'private' }
 RPackage >> moveClass: aClass toTag: aTag [
 
-	| oldPackage tag |
-	tag := self ensureTag: aTag.
-	aClass packageTag = tag ifTrue: [ ^ self ].
+	| newTag oldTag |
+	newTag := self ensureTag: aTag.
+	oldTag := aClass packageTag.
+	oldTag = newTag ifTrue: [ ^ self ].
 
-	oldPackage := aClass package.
+	aClass package removeClass: aClass.
+	self importClass: aClass inTag: newTag.
 
-	oldPackage removeClass: aClass.
-	self importClass: aClass inTag: tag.
-
-	SystemAnnouncer uniqueInstance classRepackaged: aClass from: oldPackage to: self
+	SystemAnnouncer uniqueInstance announce: (ClassRepackaged classRepackaged: aClass oldTag: oldTag newTag: newTag)
 ]
 
 { #category : 'accessing' }

--- a/src/Ring-Core/RGClassStrategy.class.st
+++ b/src/Ring-Core/RGClassStrategy.class.st
@@ -399,14 +399,10 @@ RGClassStrategy >> package: anRGPackage [
 	self owner announceDefinitionChangeDuring: [
 		self owner backend forBehavior setPackageFor: self owner to: anRGPackage.
 		self owner environment addPackage: anRGPackage.
-		(oldPackage hasResolved: #definedBehaviors)
-			ifTrue: [ oldPackage removeDefinedBehavior: self owner ].
-		anRGPackage addDefinedBehavior: self owner. ].
+		(oldPackage hasResolved: #definedBehaviors) ifTrue: [ oldPackage removeDefinedBehavior: self owner ].
+		anRGPackage addDefinedBehavior: self owner ].
 
-	self owner announce: (ClassRepackaged
-		classRepackaged: self owner
-		oldPackage: oldPackage
-		newPackage: anRGPackage)
+	self owner announce: (ClassRepackaged classRepackaged: self owner oldTag: oldPackage newTag: anRGPackage)
 ]
 
 { #category : 'accessing' }

--- a/src/Ring-Core/RGTraitV2Strategy.class.st
+++ b/src/Ring-Core/RGTraitV2Strategy.class.st
@@ -357,14 +357,10 @@ RGTraitV2Strategy >> package: anRGPackage [
 	self owner announceDefinitionChangeDuring: [
 		self owner backend forBehavior setPackageFor: self owner to: anRGPackage.
 		self owner environment addPackage: anRGPackage.
-		(oldPackage hasResolved: #definedBehaviors)
-			ifTrue: [ oldPackage removeDefinedBehavior: self owner ].
-		anRGPackage addDefinedBehavior: self owner. ].
+		(oldPackage hasResolved: #definedBehaviors) ifTrue: [ oldPackage removeDefinedBehavior: self owner ].
+		anRGPackage addDefinedBehavior: self owner ].
 
-	self owner announce: (ClassRepackaged
-		classRepackaged: self owner
-		oldPackage: oldPackage
-		newPackage: anRGPackage)
+	self owner announce: (ClassRepackaged classRepackaged: self owner oldTag: oldPackage newTag: anRGPackage)
 ]
 
 { #category : 'private - backend access' }

--- a/src/System-Announcements/ClassAnnouncement.class.st
+++ b/src/System-Announcements/ClassAnnouncement.class.st
@@ -41,7 +41,14 @@ ClassAnnouncement >> classAffected [
 
 { #category : 'accessing' }
 ClassAnnouncement >> classTagAffected [
-	^self packageAffected toTagName: self classAffected category
+
+	^ self classAffected packageTag
+]
+
+{ #category : 'accessing' }
+ClassAnnouncement >> classTagsAffected [
+
+	^ { self classTagAffected }
 ]
 
 { #category : 'accessing' }

--- a/src/System-Announcements/ClassRepackaged.class.st
+++ b/src/System-Announcements/ClassRepackaged.class.st
@@ -6,8 +6,8 @@ Class {
 	#superclass : 'ClassAnnouncement',
 	#instVars : [
 		'classRepackaged',
-		'newPackage',
-		'oldPackage'
+		'oldTag',
+		'newTag'
 	],
 	#category : 'System-Announcements-System-Packages',
 	#package : 'System-Announcements',
@@ -15,12 +15,13 @@ Class {
 }
 
 { #category : 'instance creation' }
-ClassRepackaged class >> classRepackaged: aClass oldPackage: oldPackage newPackage: newPackage [
-	^self new
-			classRepackaged: aClass;
-			oldPackage: oldPackage;
-			newPackage: newPackage;
-			yourself
+ClassRepackaged class >> classRepackaged: aClass oldTag: oldTag newTag: newTag [
+
+	^ self new
+		  classRepackaged: aClass;
+		  oldTag: oldTag;
+		  newTag: newTag;
+		  yourself
 ]
 
 { #category : 'testing' }
@@ -38,7 +39,7 @@ ClassRepackaged >> affectsMethodsDefinedInClass: aClass [
 { #category : 'testing' }
 ClassRepackaged >> affectsMethodsDefinedInPackage: aPackage [
 
-	^oldPackage == aPackage or: [ newPackage == aPackage ]
+	^self oldPackage == aPackage or: [ self newPackage == aPackage ]
 ]
 
 { #category : 'testing' }
@@ -66,30 +67,59 @@ ClassRepackaged >> classRepackaged: anObject [
 ]
 
 { #category : 'accessing' }
-ClassRepackaged >> newPackage [
+ClassRepackaged >> classTagsAffected [
 
-	^ newPackage
+	^ {
+		  self newTag.
+		  self oldTag }
 ]
 
 { #category : 'accessing' }
-ClassRepackaged >> newPackage: anObject [
+ClassRepackaged >> newPackage [
 
-	newPackage := anObject
+	^ self newTag package
+]
+
+{ #category : 'accessing' }
+ClassRepackaged >> newTag [
+
+	^ newTag
+]
+
+{ #category : 'accessing' }
+ClassRepackaged >> newTag: anObject [
+
+	newTag := anObject
 ]
 
 { #category : 'accessing' }
 ClassRepackaged >> oldPackage [
 
-	^ oldPackage
+	^ self oldTag package
 ]
 
 { #category : 'accessing' }
-ClassRepackaged >> oldPackage: anObject [
+ClassRepackaged >> oldTag [
 
-	oldPackage := anObject
+	^ oldTag
+]
+
+{ #category : 'accessing' }
+ClassRepackaged >> oldTag: anObject [
+
+	oldTag := anObject
+]
+
+{ #category : 'testing' }
+ClassRepackaged >> packagedChanged [
+
+	^ self oldPackage ~= self newPackage
 ]
 
 { #category : 'accessing' }
 ClassRepackaged >> packagesAffected [
-	^{oldPackage. newPackage}
+
+	^ {
+		  self oldPackage.
+		  self newPackage }
 ]

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -115,14 +115,6 @@ SystemAnnouncer >> classRenamed: aClass from: oldClassName to: newClassName [
 ]
 
 { #category : 'triggering' }
-SystemAnnouncer >> classRepackaged: aClass from: aPackage to: anotherPackage [
-	self announce: (ClassRepackaged
-						classRepackaged: aClass
-						oldPackage: aPackage
-						newPackage: anotherPackage)
-]
-
-{ #category : 'triggering' }
 SystemAnnouncer >> evaluated: textOrStream [
 	^ self evaluated: textOrStream context: nil
 ]


### PR DESCRIPTION
ClassRepackaged is fired when a class change of package OR when the class change of tag. But this announcement is configured only with the package. Because of this, some classes are relying on ClassRecategorized instead of ClassRepackaged. (I want to remove ClassRecategorized)

This change adds tags info in ClassRepackaged so that we can really remove ClassRecategorized