### PR TITLE
RPackage: #moveClass:toTag: can be simpler if the package do not change

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -531,7 +531,7 @@ RPackage >> moveClass: aClass toTag: aTag [
 	oldTag := aClass packageTag.
 	oldTag = newTag ifTrue: [ ^ self ].
 
-	aClass package removeClass: aClass.
+	oldPackage := aClass package.
 
 	"It is possible that we are just updating the tag and not the package.
 	If we update the package we should remove the class from the old one and update the methods"

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -526,22 +526,31 @@ RPackage >> methodsForClass: aClass [
 { #category : 'private' }
 RPackage >> moveClass: aClass toTag: aTag [
 
-	| oldPackage tag |
-	tag := self ensureTag: aTag.
-	aClass packageTag = tag ifTrue: [ ^ self ].
+	| oldPackage newTag oldTag |
+	newTag := self ensureTag: aTag.
+	oldTag := aClass packageTag.
+	oldTag = newTag ifTrue: [ ^ self ].
 
 	oldPackage := aClass package.
-
-	oldPackage removeClass: aClass.
 	
-	self removeAllMethodsFromClass: aClass.
-	
-	tag addClass: aClass instanceSide.
+	"It is possible that we are just updating the tag and not the package.
+	If we update the package we should remove the class from the old one and update the methods"
+	oldPackage = self
+		ifTrue: [ oldTag removeClass: aClass ]
+		ifFalse: [
+			oldPackage removeClass: aClass.
+			
+			"In case I contain extension methods."
+			self removeAllMethodsFromClass: aClass.
 
-	{ aClass . aClass classSide } do: [ :class |
-		(self extensionProtocolsForClass: class) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
+			{ aClass. aClass classSide } do: [ :class |
+				(self extensionProtocolsForClass: class) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
 
-		class protocols reject: [ :protocol | protocol isExtensionProtocol ] thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ].
+				class protocols
+					reject: [ :protocol | protocol isExtensionProtocol ]
+					thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ] ].
+
+	newTag addClass: aClass instanceSide.
 
 	SystemAnnouncer uniqueInstance classRepackaged: aClass from: oldPackage to: self
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -532,25 +532,23 @@ RPackage >> moveClass: aClass toTag: aTag [
 	oldTag = newTag ifTrue: [ ^ self ].
 
 	oldPackage := aClass package.
-	
+
 	"It is possible that we are just updating the tag and not the package.
 	If we update the package we should remove the class from the old one and update the methods"
-	oldPackage = self
-		ifTrue: [ oldTag removeClass: aClass ]
-		ifFalse: [
-			oldPackage removeClass: aClass.
-			
-			"In case I contain extension methods."
-			self removeAllMethodsFromClass: aClass.
-
-			{ aClass. aClass classSide } do: [ :class |
-				(self extensionProtocolsForClass: class) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
-
-				class protocols
-					reject: [ :protocol | protocol isExtensionProtocol ]
-					thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ] ].
+	oldPackage = self ifTrue: [ oldTag removeClass: aClass ] ifFalse: [ oldPackage removeClass: aClass ].
 
 	newTag addClass: aClass instanceSide.
+	
+	oldPackage = self ifFalse: [
+		"In case I contain extension methods."
+		self removeAllMethodsFromClass: aClass.
+		
+		{ aClass. aClass classSide } do: [ :class |
+			(self extensionProtocolsForClass: class) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
+
+			class protocols
+				reject: [ :protocol | protocol isExtensionProtocol ]
+				thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ] ].
 
 	SystemAnnouncer uniqueInstance classRepackaged: aClass from: oldPackage to: self
 ]


### PR DESCRIPTION
Currently #moveClass:toTag: is acting as if the package of the class always change. This updates the behavior so that we do a full update only if the package change. In case only the tag changed, we can just remove from the old tag and add to the new one.