### PR TITLE
RPackage: New step at cleaning tests

### DIFF
--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -43,6 +43,12 @@ ClassDescription >> package [
 ]
 
 { #category : '*RPackage-Core' }
+ClassDescription >> package: aPackage [
+
+	^ aPackage addClass: self
+]
+
+{ #category : '*RPackage-Core' }
 ClassDescription >> packageFromOrganizer: anOrganizer [
 	"returns the package that defines this class"
 	^ anOrganizer packageOf: self
@@ -62,10 +68,11 @@ ClassDescription >> packageTag [
 ]
 
 { #category : '*RPackage-Core' }
-ClassDescription >> packageTag: aSymbol [
+ClassDescription >> packageTag: aTag [
 
-	self flag: #package. "In the future this method should work with a real package tag also."
-	(self package ensureTag: aSymbol) addClass: self
+	(aTag isString
+		 ifTrue: [ self package ensureTag: aTag ]
+		 ifFalse: [ aTag ]) addClass: self
 ]
 
 { #category : '*RPackage-Core' }

--- a/src/RPackage-Tests/PackageAnnouncementsTest.class.st
+++ b/src/RPackage-Tests/PackageAnnouncementsTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : 'PackageAnnouncementsTest',
+	#superclass : 'RPackageTestCase',
+	#instVars : [
+		'numberOfAnnouncements'
+	],
+	#category : 'RPackage-Tests',
+	#package : 'RPackage-Tests'
+}
+
+{ #category : 'running' }
+PackageAnnouncementsTest >> setUp [
+
+	super setUp.
+	numberOfAnnouncements := 0
+]
+
+{ #category : 'running' }
+PackageAnnouncementsTest >> tearDown [
+
+	SystemAnnouncer uniqueInstance unsubscribe: self.
+	super tearDown
+]
+
+{ #category : 'tests' }
+PackageAnnouncementsTest >> testAddClassAnnounceClassRecategorized [
+
+	| xPackage yPackage class |
+	self flag: #package. "This announcement should be removed in the future."
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+
+	class := self newClassNamed: #NewClass in: xPackage.
+
+	self when: ClassRecategorized do: [ :ann | self assert: ann classRecategorized name equals: #NewClass ].
+
+	yPackage addClass: class.
+
+	self assert: numberOfAnnouncements equals: 1
+]
+
+{ #category : 'running' }
+PackageAnnouncementsTest >> when: anAnnouncement do: aBlock [
+
+	SystemAnnouncer uniqueInstance
+		when: anAnnouncement
+		do: [ :ann |
+			numberOfAnnouncements := numberOfAnnouncements + 1.
+			aBlock cull: ann ]
+		for: self
+]

--- a/src/RPackage-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageClassesSynchronisationTest.class.st
@@ -8,91 +8,6 @@ Class {
 	#package : 'RPackage-Tests'
 }
 
-{ #category : 'tests - adding classes' }
-RPackageClassesSynchronisationTest >> testAddClassAddItIntoPackageBestMatchName [
-
-	| package tag class |
-	tag := self ensureTagYinX.
-	package := tag package.
-
-	class := self newClassNamed: 'NewClass' inTag: tag.
-
-	self assert: (package includesClass: class).
-	self assert: class package equals: package
-]
-
-{ #category : 'tests - adding classes' }
-RPackageClassesSynchronisationTest >> testAddClassAddItIntoPackageExactName [
-
-	| xPackage class |
-	xPackage := self ensureXPackage.
-	self ensureTagYinX.
-
-	class := self newClassNamed: 'NewClass' in: xPackage.
-
-	self assert: (xPackage includesClass: class).
-	self assert: class package equals: xPackage
-]
-
-{ #category : 'tests - adding classes' }
-RPackageClassesSynchronisationTest >> testAddClassUpdateTheOrganizerMappings [
-	"test that when we add a class, the organizer 'classPackageMapping' dictionary is updated, so that the class is linked to its package and so that we can access its owning package"
-
-	| xPackage class |
-	xPackage := self ensureXPackage.
-
-	class := self newClassNamed: 'NewClass' in: xPackage.
-
-	self assert: class package equals: xPackage
-]
-
-{ #category : 'tests - recategorizing class' }
-RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInTheBestMatchPackage [
-	"test that when we recategorize a class, the new package in which it is defined include it"
-
-	| xPackage yPackage class |
-	xPackage := self ensureXPackage.
-	self ensureTagYinX.
-	yPackage := self ensureYPackage.
-
-	class := self newClassNamed: 'NewClass' in: yPackage.
-
-	class category: 'XXXXX-YYYY'.
-	self assert: (self organizer packageOf: class) equals: xPackage.
-	self deny: (self organizer packageOf: class) equals: yPackage
-]
-
-{ #category : 'tests - recategorizing class' }
-RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInTheExactMatchPackage [
-	"test that when we recategorize a class, the new package in which it is defined include it"
-
-	| xPackage yPackage class |
-	xPackage := self ensureXPackage.
-	self ensureTagYinX.
-	yPackage := self ensureYPackage.
-	class := self newClassNamed: 'NewClass' in: yPackage.
-
-	class category: 'XXXXX'.
-
-	self assert: (self organizer packageOf: class) equals: xPackage.
-	self deny: (self organizer packageOf: class) equals: yPackage
-]
-
-{ #category : 'tests - recategorizing class' }
-RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassInTheMatchingPackage [
-	"test that when we recategorize a class, the new package in which it is defined include it"
-
-	| xPackage yPackage class |
-	xPackage := self ensureXPackage.
-	yPackage := self ensureYPackage.
-
-	class := self newClassNamed: 'NewClass' in: yPackage.
-
-	class category: 'XXXXX'.
-	self deny: (self organizer packageOf: class) equals: yPackage.
-	self assert: (self organizer packageOf: class) equals: xPackage
-]
-
 { #category : 'tests - recategorizing class' }
 RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassMethodsInTheNewPackage [
 	"test that when we recategorize a class, the new package in which it is defined include all the methods defined in this class (not extensions)"
@@ -123,20 +38,6 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassRegisterTheClassMetho
 ]
 
 { #category : 'tests - recategorizing class' }
-RPackageClassesSynchronisationTest >> testRecategorizeClassUnregisterTheClassFromTheOldPackage [
-	"test that when we recategorize a class, the old package in which it was defined don't include it anymore"
-
-	| xPackage yPackage class |
-	xPackage := self ensureXPackage.
-	yPackage := self ensureYPackage.
-
-	class := self newClassNamed: 'NewClass' in: xPackage.
-
-	class category: 'YYYYY'.
-	self deny: (xPackage includesClass: class)
-]
-
-{ #category : 'tests - recategorizing class' }
 RPackageClassesSynchronisationTest >> testRecategorizeClassUnregisterTheClassMethodsFromTheOldPackage [
 	"test that when we recategorize a class, the old package in which it was defined don't include its defined methods (not extensions) anymore"
 
@@ -154,18 +55,6 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassUnregisterTheClassMet
 	self deny: (xPackage includesSelector: #method1 ofClass: class).
 	self deny: (xPackage includesSelector: #method2 ofClass: class).
 	self deny: (xPackage includesSelector: #method3 ofClass: class)
-]
-
-{ #category : 'tests - recategorizing class' }
-RPackageClassesSynchronisationTest >> testRecategorizeClassUpdateTheOrganizerMappings [
-	"test that when we recategorize a class, the organizer is updated so that the class name point the the new RPackage"
-
-	| xPackage yPackage class |
-	xPackage := self ensureXPackage.
-	yPackage := self ensureYPackage.
-	class := self newClassNamed: 'NewClass' in: xPackage.
-	class category: 'YYYYY'.
-	self assert: (self organizer packageOf: class) equals: yPackage
 ]
 
 { #category : 'tests - recategorizing class' }
@@ -189,23 +78,6 @@ RPackageClassesSynchronisationTest >> testRecategorizeClassWithMetaClassMethodsR
 	self assert: (yPackage includesDefinedSelector: #method1 ofClass: class class).
 	self assert: (yPackage includesDefinedSelector: #method2 ofClass: class class).
 	self assert: (zPackage includesExtensionSelector: #method3 ofClass: class class)
-]
-
-{ #category : 'tests - recategorizing class' }
-RPackageClassesSynchronisationTest >> testRecategorizeClassWithUnexistingPackageNameRegisterTheClassInANewPackage [
-	"test that when we recategorize a class in category not yet registered in RPackage, a new rPackage is created with the class inside"
-
-	| xPackage yYPackage class |
-	xPackage := self ensureXPackage.
-
-	class := self newClassNamed: 'NewClass' in: xPackage.
-	self assert: (self organizer packageOf: class) equals: xPackage.
-
-	class category: 'YYYYY'.
-	yYPackage := self organizer packageNamed: #YYYYY.
-
-	self assert: (self organizer packageOf: class) equals: yYPackage.
-	self deny: (self organizer packageOf: class) equals: xPackage
 ]
 
 { #category : 'tests - removing classes' }
@@ -233,30 +105,6 @@ RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassExtension
 
 	self organizer environment removeClassNamed: 'NewClass'.
 	self deny: (yPackage includesSelector: #stubMethod ofClass: class)
-]
-
-{ #category : 'tests - removing classes' }
-RPackageClassesSynchronisationTest >> testRemoveClassUnregisterTheClassFromItsPackage [
-	"test that when we remove a class, the class is removed from its parent Package"
-
-	| xPackage class |
-	xPackage := self ensureXPackage.
-	class := self newClassNamed: 'NewClass' in: xPackage.
-
-	self organizer environment removeClassNamed: 'NewClass'.
-	self deny: (xPackage includesClass: class)
-]
-
-{ #category : 'tests - removing classes' }
-RPackageClassesSynchronisationTest >> testRemoveClassUpdateTheOrganizerMappings [
-	"test that when we remove a class, the organizer is updated so that the class is no longer present in the  'classPackageDictionary' dictionary"
-
-	| xPackage class |
-	xPackage := self ensureXPackage.
-	class := self newClassNamed: 'NewClass' in: xPackage.
-
-	self organizer environment removeClassNamed: 'NewClass'.
-	self deny: (self organizer packageOf: class) isNil
 ]
 
 { #category : 'tests - operations on classes' }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -225,6 +225,21 @@ RPackageOrganizerTest >> testPackageNamedWithoutMatchingPackage [
 ]
 
 { #category : 'tests' }
+RPackageOrganizerTest >> testPackageOf [
+
+	| xPackage yPackage class |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: #NewClass in: xPackage.
+
+	self assert: (self organizer packageOf: class) identicalTo: xPackage.
+
+	yPackage := self ensureYPackage.
+	yPackage addClass: class.
+
+	self assert: (self organizer packageOf: class) identicalTo: yPackage
+]
+
+{ #category : 'tests' }
 RPackageOrganizerTest >> testRegisterPackageConflictWithPackage [
 
 	self ensurePackage: 'P1'.
@@ -298,6 +313,17 @@ RPackageOrganizerTest >> testRegistrationExtendingPackages [
 	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
 	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
 	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #P1
+]
+
+{ #category : 'tests' }
+RPackageOrganizerTest >> testRemoveClassUsingEnvironment [
+
+	| xPackage class |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: #NewClass in: xPackage.
+
+	self organizer environment removeClassNamed: #NewClass.
+	self assert: (self organizer packageOf: class) isUndefined
 ]
 
 { #category : 'tests' }

--- a/src/RPackage-Tests/RPackageTagTest.class.st
+++ b/src/RPackage-Tests/RPackageTagTest.class.st
@@ -11,44 +11,93 @@ Class {
 { #category : 'tests' }
 RPackageTagTest >> testAddClass [
 
-	| package1 package2 tag class |
-	package1 := self ensurePackage: #Test1.
-	class := self newClassNamed: 'TestClass' in: package1.
+	| xPackage yPackage yTag class |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: #NewClass in: xPackage tag: #TAG.
 
-	self assert: (package1 includesClass: class).
+	self assert: (xPackage includesClass: class).
+	self assert: (xPackage hasTag: #TAG).
+	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
 
-	package2 := self ensurePackage: #Test2.
+	yPackage := self ensureYPackage.
+	yTag := yPackage ensureTag: #YTag.
+	yTag addClass: class.
 
-	tag := package2 ensureTag: #TAG.
-
-	tag addClass: class.
-
-	self assert: class packageTag equals: tag.
-	self deny: (package1 includesClass: class).
-	self assert: (package2 includesClass: class).
-	self assert: (package2 hasTag: #TAG).
-	self assert: ((package2 classTagNamed: #TAG) includesClass: class)
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: (yTag includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag equals: yTag.
+	self assert: class packageTag package equals: yPackage
 ]
 
 { #category : 'tests' }
-RPackageTagTest >> testAddClassFromTag [
+RPackageTagTest >> testAddClassSettingPackageTag [
 
-	| package1 package2 class |
-	package1 := self ensurePackage: #Test1.
-	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG1'.
+	| xPackage yPackage yTag class |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: #NewClass in: xPackage tag: #TAG.
 
-	self assert: (package1 includesClass: class).
-	self assert: (package1 hasTag: #TAG1).
-	self assert: ((package1 classTagNamed: #TAG1) includesClass: class).
+	self assert: (xPackage includesClass: class).
+	self assert: (xPackage hasTag: #TAG).
+	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
 
-	package2 := self ensurePackage: #Test2.
+	yPackage := self ensureYPackage.
+	yTag := yPackage ensureTag: #YTag.
+	class packageTag: yTag.
 
-	(package2 ensureTag: #TAG2) addClass: class.
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: (yTag includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag equals: yTag.
+	self assert: class packageTag package equals: yPackage
+]
 
-	self deny: (package1 includesClass: class).
-	self assert: (package2 includesClass: class).
-	self assert: (package2 hasTag: #TAG2).
-	self assert: ((package2 classTagNamed: #TAG2) includesClass: class)
+{ #category : 'tests' }
+RPackageTagTest >> testAddTrait [
+
+	| xPackage yPackage yTag class |
+	xPackage := self ensureXPackage.
+	class := self newTraitNamed: #NewClass in: xPackage tag: #TAG.
+
+	self assert: (xPackage includesClass: class).
+	self assert: (xPackage hasTag: #TAG).
+	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
+
+	yPackage := self ensureYPackage.
+	yTag := yPackage ensureTag: #YTag.
+	yTag addClass: class.
+
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: (yTag includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag equals: yTag.
+	self assert: class packageTag package equals: yPackage
+]
+
+{ #category : 'tests' }
+RPackageTagTest >> testAddTraitSettingPackageTag [
+
+	| xPackage yPackage yTag class |
+	xPackage := self ensureXPackage.
+	class := self newTraitNamed: #NewClass in: xPackage tag: #TAG.
+
+	self assert: (xPackage includesClass: class).
+	self assert: (xPackage hasTag: #TAG).
+	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
+
+	yPackage := self ensureYPackage.
+	yTag := yPackage ensureTag: #YTag.
+	class packageTag: yTag.
+
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: (yTag includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag equals: yTag.
+	self assert: class packageTag package equals: yPackage
 ]
 
 { #category : 'tests' }

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -8,32 +8,27 @@ Class {
 	#package : 'RPackage-Tests'
 }
 
-{ #category : 'tests' }
+{ #category : 'tests - adding classes' }
 RPackageTest >> testAddClass [
 
-	| package1 package2 class done |
+	| package1 package2 class |
 	package1 := self ensurePackage: #Test1.
-	done := 0.
 	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG'.
-
 
 	self assert: (package1 includesClass: class).
 	self assert: (package1 hasTag: #TAG).
 	self assert: ((package1 classTagNamed: #TAG) includesClass: class).
 
 	package2 := self ensurePackage: #Test2.
-	[
-	SystemAnnouncer uniqueInstance when: ClassRecategorized do: [ done := done + 1 ] for: self.
-	package2 addClass: class ] ensure: [ SystemAnnouncer uniqueInstance unsubscribe: self ].
+	package2 addClass: class.
 
-	self assert: done equals: 1.
 	self deny: (package1 includesClass: class).
 	self assert: (package2 includesClass: class).
 	self assert: (package2 hasTag: #Test2).
 	self assert: ((package2 classTagNamed: #Test2) includesClass: class)
 ]
 
-{ #category : 'tests' }
+{ #category : 'tests - adding classes' }
 RPackageTest >> testAddClassFromTag [
 
 	| package1 package2 class |

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -8,43 +8,92 @@ Class {
 	#package : 'RPackage-Tests'
 }
 
-{ #category : 'tests - adding classes' }
+{ #category : 'tests - classes' }
 RPackageTest >> testAddClass [
 
-	| package1 package2 class |
-	package1 := self ensurePackage: #Test1.
-	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG'.
+	| xPackage yPackage class |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: #NewClass in: xPackage.
 
-	self assert: (package1 includesClass: class).
-	self assert: (package1 hasTag: #TAG).
-	self assert: ((package1 classTagNamed: #TAG) includesClass: class).
+	self assert: (xPackage includesClass: class).
+	self assert: class package equals: xPackage.
+	self assert: class packageTag isRoot.
+	self assert: class packageTag package equals: xPackage.
 
-	package2 := self ensurePackage: #Test2.
-	package2 addClass: class.
+	yPackage := self ensureYPackage.
+	yPackage addClass: class.
 
-	self deny: (package1 includesClass: class).
-	self assert: (package2 includesClass: class).
-	self assert: (package2 hasTag: #Test2).
-	self assert: ((package2 classTagNamed: #Test2) includesClass: class)
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag isRoot.
+	self assert: class packageTag package equals: yPackage
 ]
 
-{ #category : 'tests - adding classes' }
-RPackageTest >> testAddClassFromTag [
+{ #category : 'tests - classes' }
+RPackageTest >> testAddClassSettingPackage [
 
-	| package1 package2 class |
-	package1 := self ensurePackage: #Test1.
-	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG'.
+	| xPackage yPackage class |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: #NewClass in: xPackage.
 
-	self assert: (package1 includesClass: class).
+	self assert: (xPackage includesClass: class).
+	self assert: class package equals: xPackage.
+	self assert: class packageTag isRoot.
+	self assert: class packageTag package equals: xPackage.
 
-	package2 := self ensurePackage: #Test2.
+	yPackage := self ensureYPackage.
+	class package: yPackage.
 
-	package2 addClass: class.
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag isRoot.
+	self assert: class packageTag package equals: yPackage
+]
 
-	self deny: (package1 includesClass: class).
-	self assert: (package2 includesClass: class).
-	self assert: (package2 hasTag: #Test2).
-	self assert: ((package2 classTagNamed: #Test2) includesClass: class)
+{ #category : 'tests - classes' }
+RPackageTest >> testAddTrait [
+
+	| xPackage yPackage class |
+	xPackage := self ensureXPackage.
+	class := self newTraitNamed: #NewClass in: xPackage.
+
+	self assert: (xPackage includesClass: class).
+	self assert: class package equals: xPackage.
+	self assert: class packageTag isRoot.
+	self assert: class packageTag package equals: xPackage.
+
+	yPackage := self ensureYPackage.
+	yPackage addClass: class.
+
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag isRoot.
+	self assert: class packageTag package equals: yPackage
+]
+
+{ #category : 'tests - classes' }
+RPackageTest >> testAddTraitSettingPackage [
+
+	| xPackage yPackage class |
+	xPackage := self ensureXPackage.
+	class := self newTraitNamed: #NewClass in: xPackage.
+
+	self assert: (xPackage includesClass: class).
+	self assert: class package equals: xPackage.
+	self assert: class packageTag isRoot.
+	self assert: class packageTag package equals: xPackage.
+
+	yPackage := self ensureYPackage.
+	class package: yPackage.
+
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag isRoot.
+	self assert: class packageTag package equals: yPackage
 ]
 
 { #category : 'tests' }
@@ -234,6 +283,74 @@ RPackageTest >> testMcWorkingCopy [
 	self assert: rPackage mcWorkingCopy identicalTo: (MCWorkingCopy forPackageNamed: #Test1)
 ]
 
+{ #category : 'tests - classes' }
+RPackageTest >> testMoveClassToTag [
+
+	| xPackage yPackage yTag class |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: #NewClass in: xPackage tag: #TAG.
+
+	self assert: (xPackage includesClass: class).
+	self assert: (xPackage hasTag: #TAG).
+	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
+
+	yPackage := self ensureYPackage.
+	yTag := yPackage ensureTag: #YTag.
+	yPackage moveClass: class toTag: yTag.
+
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: (yTag includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag equals: yTag.
+	self assert: class packageTag package equals: yPackage
+]
+
+{ #category : 'tests - classes' }
+RPackageTest >> testMoveClassToTagInDefaultTag [
+
+	| xPackage yPackage class |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: #NewClass in: xPackage.
+
+	self assert: (xPackage includesClass: class).
+	self assert: class package equals: xPackage.
+	self assert: class packageTag isRoot.
+	self assert: class packageTag package equals: xPackage.
+
+	yPackage := self ensureYPackage.
+	yPackage moveClass: class toTag: yPackage rootTag.
+
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag isRoot.
+	self assert: class packageTag package equals: yPackage
+]
+
+{ #category : 'tests - classes' }
+RPackageTest >> testMoveClassToTagName [
+
+	| xPackage yPackage yTag class |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: #NewClass in: xPackage tag: #TAG.
+
+	self assert: (xPackage includesClass: class).
+	self assert: (xPackage hasTag: #TAG).
+	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
+
+	yPackage := self ensureYPackage.
+	yPackage moveClass: class toTag: #YTag.
+	yTag := yPackage classTagNamed: #YTag.
+
+	self deny: (xPackage includesClass: class).
+	self assert: (yPackage includesClass: class).
+	self assert: (yTag includesClass: class).
+	self assert: class package equals: yPackage.
+	self assert: class packageTag equals: yTag.
+	self assert: class packageTag package equals: yPackage
+]
+
 { #category : 'tests - properties' }
 RPackageTest >> testPropertyAtPut [
 
@@ -249,6 +366,17 @@ RPackageTest >> testPropertyAtPut [
 
 	package removeProperty: #testKeySelector.
 	self assert: package properties isNil
+]
+
+{ #category : 'tests - classes' }
+RPackageTest >> testRemoveClassUsingEnvironment [
+
+	| xPackage class |
+	xPackage := self ensureXPackage.
+	class := self newClassNamed: #NewClass in: xPackage.
+
+	self organizer environment removeClassNamed: #NewClass.
+	self deny: (xPackage includesClass: class)
 ]
 
 { #category : 'tests' }

--- a/src/RPackage-Tests/RPackageTestCase.class.st
+++ b/src/RPackage-Tests/RPackageTestCase.class.st
@@ -105,6 +105,22 @@ RPackageTestCase >> newTraitNamed: aName in: aPackage [
 ]
 
 { #category : 'utilities' }
+RPackageTestCase >> newTraitNamed: aName in: aPackage tag: aTag [
+
+	^ self class classInstaller make: [ :aClassBuilder |
+		  aClassBuilder
+			  name: aName;
+			  installingEnvironment: testEnvironment;
+			  beTrait;
+			  package: (aPackage isString
+					   ifTrue: [ aPackage ]
+					   ifFalse: [ aPackage name ]);
+			  tag: (aTag isString
+					   ifTrue: [ aTag ]
+					   ifFalse: [ aTag name ]) ]
+]
+
+{ #category : 'utilities' }
 RPackageTestCase >> newTraitNamed: aName inTag: aTag [
 
 	^ self class classInstaller make: [ :aBuilder |

--- a/src/RPackage-Tests/RPackageTraitSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageTraitSynchronisationTest.class.st
@@ -27,44 +27,6 @@ RPackageTraitSynchronisationTest >> testAddMethodByUsingATraitDoesNotAddTheMetho
 	self assertEmpty: xPackage methods
 ]
 
-{ #category : 'tests - operations on traits' }
-RPackageTraitSynchronisationTest >> testAddTraitAddItIntoPackageBestMatchName [
-
-	| xPackage tag class |
-	tag := self ensureTagYinX.
-	xPackage := tag package.
-
-	class := self newTraitNamed: 'NewClass' inTag: tag.
-
-	self assert: (xPackage includesClass: class).
-	self assert: xPackage equals: class package
-]
-
-{ #category : 'tests - operations on traits' }
-RPackageTraitSynchronisationTest >> testAddTraitAddItIntoPackageExactName [
-
-	| xPackage class |
-	xPackage := self ensureXPackage.
-	self ensureTagYinX.
-
-	class := self newTraitNamed: 'NewClass' in: xPackage.
-
-	self assert: (xPackage includesClass: class).
-	self assert: xPackage equals: class package
-]
-
-{ #category : 'tests - operations on traits' }
-RPackageTraitSynchronisationTest >> testAddTraitUpdateTheOrganizerMappings [
-	"test that when we add a Trait, the organizer 'classPackageMapping' dictionary is updated, so that the trait is linked to its package and so that we can access its owning package"
-
-	| xPackage class |
-	xPackage := self ensureXPackage.
-
-	class := self newTraitNamed: 'NewClass' in: xPackage.
-
-	self assert: class package equals: xPackage
-]
-
 { #category : 'tests - operations on methods' }
 RPackageTraitSynchronisationTest >> testRemoveMethodComingFromTraitDoesNotRemoveMethodFromTraitPackage [
 	"test that when we remove a class method coming from a trait, the method is not removed from the parent package of the trait"


### PR DESCRIPTION
This change keeps cleaning tests:
- Add missing test
- Fix some bugs found with the new tests
- Remove tests duplicated from classes coming from Monticello
- Introduce package announcement tests