### PR TITLE
Calypso: Show protocol edition bar only in edition

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -173,6 +173,14 @@ ClyMethodCodeEditorToolMorph >> extendingPackage: aPackage [
 	self hasUnacceptedEdits ifFalse: [self packageEditingMethod: editingMethod]
 ]
 
+{ #category : 'building' }
+ClyMethodCodeEditorToolMorph >> fillStatusBar [
+
+	super fillStatusBar.
+
+	statusBar addCommandItem: (ClyProtocolEditorMorph for: self)
+]
+
 { #category : 'selecting text' }
 ClyMethodCodeEditorToolMorph >> findAnySelectorInSourceCode: selectors [
 

--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -117,9 +117,7 @@ ClyMethodEditorToolMorph >> fillStatusBar [
 	position comeToFront.
 	statusBar addCommandItem: (ClyTextWrapModeSwitchMorph of: textMorph).
 	statusBar addCommandItem: (ClyTextLineNumbersSwitchMorph of: textMorph).
-	statusBar addCommandItem: (ClyFormatAsReadSwitchMorph of: textMorph).
-
-	statusBar addCommandItem: (ClyProtocolEditorMorph for: self)
+	statusBar addCommandItem: (ClyFormatAsReadSwitchMorph of: textMorph)
 ]
 
 { #category : 'operations' }

--- a/src/Calypso-SystemTools-Core/ClyProtocolEditorMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyProtocolEditorMorph.class.st
@@ -114,7 +114,7 @@ ClyProtocolEditorMorph >> isExtensionActive [
 
 { #category : 'operations' }
 ClyProtocolEditorMorph >> openEditor [
-
+1halt.
 	self requestChangeBy: [
 		self isExtensionActive
 			ifTrue: [ self requestPackage]

--- a/src/Calypso-SystemTools-Core/ClyProtocolEditorMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyProtocolEditorMorph.class.st
@@ -114,12 +114,11 @@ ClyProtocolEditorMorph >> isExtensionActive [
 
 { #category : 'operations' }
 ClyProtocolEditorMorph >> openEditor [
-1halt.
+
 	self requestChangeBy: [
 		self isExtensionActive
-			ifTrue: [ self requestPackage]
-			ifFalse: [ self requestProtocol ]
-	]
+			ifTrue: [ self requestPackage ]
+			ifFalse: [ self requestProtocol ] ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Calypso displays at the bottom of the edition pane a protocol editor. Sometimes I mess up and try to edit a protocol when no method is selected.  I propose to show this protocol editor only if a method is selected and not all the time.

Fixes #13910