### PR TITLE
14365-Cleanup-ASTCachestatistics 

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -184,10 +184,7 @@ ASTCache >> reset [
 { #category : 'accessing' }
 ASTCache >> statistics [
 
-	^ statistics ifNil: [ "CacheStatistics comes from another package. It does not worth the dependency"
-		  Smalltalk globals
-			  at: #CacheStatistics
-			  ifPresent: [ :CS | statistics := CS new ] ]
+	^ statistics ifNil: [ statistics := CacheStatistics new ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
fixes #14365

As the class is a subclass from the same package, we can just add a hard reference