### PR TITLE
14848-BasicDatePrinter-class--default-should-define-a-default-subclass-instead-of-returning-an-arbitrary-subclass

### DIFF
--- a/src/Kernel/BasicDatePrinter.class.st
+++ b/src/Kernel/BasicDatePrinter.class.st
@@ -18,10 +18,7 @@ Class {
 
 { #category : 'accessing' }
 BasicDatePrinter class >> default [
-	" I prefer to use any of my subclasses than myself.
-	I am a really basic implementation."
-	self subclassesDo: [ :subClass | subClass isAbstract ifFalse: [ ^ subClass new ]].
-	^ self new
+	^ ExtendedDatePrinter new
 ]
 
 { #category : 'printing' }


### PR DESCRIPTION
Fixes #14848 with the suggested solution