### PR TITLE
Add back #keyword in Pragma for compatibility

### DIFF
--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -223,13 +223,16 @@ Pragma >> hash [
 Pragma >> key [
 	"Answer the keyword of the pragma (the selector of its message pattern).
 	 This accessor provides polymorphism with Associations used for properties."
-	^self selector
+	
+	^ self selector
 ]
 
 { #category : 'compatibility' }
 Pragma >> keyword [
-	"Compatibility, Pragma until Pharo9 did not implement #selector, but #keyword"
-	^self selector
+	"Compatibility, Pragma until Pharo9 did not implement #selector, but #keyword. Do not use it."
+	<backwardCompatible>
+	
+	^ self selector
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -219,10 +219,16 @@ Pragma >> hash [
 	^hash
 ]
 
-{ #category : 'querying' }
+{ #category : 'compatibility' }
 Pragma >> key [
 	"Answer the keyword of the pragma (the selector of its message pattern).
 	 This accessor provides polymorphism with Associations used for properties."
+	^self selector
+]
+
+{ #category : 'compatibility' }
+Pragma >> keyword [
+	"Compatibility, Pragma until Pharo9 did not implement #selector, but #keyword"
 	^self selector
 ]
 


### PR DESCRIPTION
add back #keyword as a compatibility method, we are thinking of  adding later a way to tag methods as compatibility similar to deprecation (that then will never be removed)

fixes #14303