### PR TITLE
10066-Cleanup-deprecated-method-in-Trait 

### DIFF
--- a/src/TraitsV2/Trait.class.st
+++ b/src/TraitsV2/Trait.class.st
@@ -66,7 +66,7 @@ Trait class >> named: aName uses: aCompositionOrArray [
 			  beTrait ]
 ]
 
-{ #category : 'deprecated' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection category: aPackageName [
 
 	^ self classInstaller make: [ :builder |
@@ -77,7 +77,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection category: aPacka
 			  beTrait ]
 ]
 
-{ #category : 'deprecated' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection category: aPackageName env: anEnvironment [
 
 	^ self classInstaller make: [ :builder |
@@ -134,7 +134,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection package: aString
 			  beTrait ]
 ]
 
-{ #category : 'deprecated' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots category: aCategory [
 
 	^ self classInstaller make: [ :builder |
@@ -146,7 +146,7 @@ Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots
 			  beTrait ]
 ]
 
-{ #category : 'deprecated' }
+{ #category : 'old pharo 8 syntax' }
 Trait class >> named: aName uses: aTraitCompositionOrCollection slots: someSlots category: aCategory env: anEnvironment [
 
 	^ self classInstaller make: [ :builder |


### PR DESCRIPTION
There are two categories: deprecated and "old syntax", this PR moves the deprecated ones to the old syntax category, we can later then treat them together

fixes #10066