### PR TITLE
Improving precision in humanReadableByteSizeString

### DIFF
--- a/src/FileSystem-Core/Integer.extension.st
+++ b/src/FileSystem-Core/Integer.extension.st
@@ -12,8 +12,8 @@ Integer >> humanReadableByteSizeString [
 		inject: self
 		into: [ :value :each |
 			value < 1024
-				ifFalse: [ value // 1024 ]
-				ifTrue: [ ^ value asString , ' ' , each ] ]
+				ifFalse: [( value / 1024) asFloat ]
+				ifTrue: [ ^ (value printShowingDecimalPlaces: 2) , ' ' , each ] ]
 ]
 
 { #category : '*FileSystem-Core' }

--- a/src/FileSystem-Core/Integer.extension.st
+++ b/src/FileSystem-Core/Integer.extension.st
@@ -2,18 +2,26 @@ Extension { #name : 'Integer' }
 
 { #category : '*FileSystem-Core' }
 Integer >> humanReadableByteSizeString [
-	"Return the receiver as a string with the adequate file size identified, e.g. '50 KB'. The difference with humanReadableByteSISizeString is that the current one counts by 1024 and not 1000."
+	"Return the receiver as a string with the adequate file size identified, e.g. '50 KB'. The
+	difference with humanReadableByteSISizeString is that the current one counts by 1024 and
+	not 1000."
 
-	"(1000 * 1000 * 1000) humanReadableByteSizeString >>> '953 MB'"
+	"(1000 * 1000 * 1000) humanReadableByteSizeString >>> '953.67 MB'"
 	"(1000 * 1000 * 1000) humanReadableSISizeString >>> '1.00 GB'"
-	"(1024 * 1024 * 1024) humanReadableByteSizeString >>> '1 GB'"
+	"(1024 * 1024 * 1024) humanReadableByteSizeString >>> '1.00 GB'"
+
+	^ self humanReadableByteSizeStringPrecision: 2
+]
+
+{ #category : '*FileSystem-Core' }
+Integer >> humanReadableByteSizeStringPrecision: n [
 
 	#( 'B' 'KB' 'MB' 'GB' 'TB' 'PB' 'EB' 'ZB' 'YB' )
 		inject: self
 		into: [ :value :each |
 			value < 1024
-				ifFalse: [value / 1024 ]
-				ifTrue: [ ^ (value printShowingDecimalPlaces: 2) , ' ' , each ] ]
+				ifFalse: [ value / 1024 ]
+				ifTrue: [ ^ (value printShowingDecimalPlaces: n) , ' ' , each ] ]
 ]
 
 { #category : '*FileSystem-Core' }

--- a/src/FileSystem-Core/Integer.extension.st
+++ b/src/FileSystem-Core/Integer.extension.st
@@ -12,7 +12,7 @@ Integer >> humanReadableByteSizeString [
 		inject: self
 		into: [ :value :each |
 			value < 1024
-				ifFalse: [( value / 1024) ]
+				ifFalse: [value / 1024 ]
 				ifTrue: [ ^ (value printShowingDecimalPlaces: 2) , ' ' , each ] ]
 ]
 

--- a/src/FileSystem-Core/Integer.extension.st
+++ b/src/FileSystem-Core/Integer.extension.st
@@ -12,7 +12,7 @@ Integer >> humanReadableByteSizeString [
 		inject: self
 		into: [ :value :each |
 			value < 1024
-				ifFalse: [( value / 1024) asFloat ]
+				ifFalse: [( value / 1024) ]
 				ifTrue: [ ^ (value printShowingDecimalPlaces: 2) , ' ' , each ] ]
 ]
 

--- a/src/FileSystem-Tests-Core/IntegerTest.extension.st
+++ b/src/FileSystem-Tests-Core/IntegerTest.extension.st
@@ -2,15 +2,18 @@ Extension { #name : 'IntegerTest' }
 
 { #category : '*FileSystem-Tests-Core' }
 IntegerTest >> testHumanReadableByteSizeString [
-	self assert: 1000 humanReadableByteSizeString equals: '1000 B'.
-	self assert: 1024 humanReadableByteSizeString equals: '1 KB'.
+	self assert: 1000 humanReadableByteSizeString equals: '1000.00 B'.
+	self assert: 1024 humanReadableByteSizeString equals: '1.00 KB'.
 
-	self assert: (1000 * 1000) humanReadableByteSizeString equals: '976 KB'.
-	self assert: (1024 * 1024) humanReadableByteSizeString equals: '1 MB'.
+	self assert: (1000 * 1000) humanReadableByteSizeString equals: '976.56 KB'.
+	self assert: (1024 * 1024) humanReadableByteSizeString equals: '1.00 MB'.
+	self assert: (1.25 * 1024 * 1024) asInteger humanReadableByteSizeString equals: '1.25 MB'.
 
-	self assert: (1000 * 1000 * 1000) humanReadableByteSizeString equals: '953 MB'.
-	self assert: (1024 * 1024 * 1024) humanReadableByteSizeString equals: '1 GB'.
+	self assert: (1000 * 1000 * 1000) humanReadableByteSizeString equals: '953.67 MB'.
+	self assert: (1024 * 1024 * 1024) humanReadableByteSizeString equals: '1.00 GB'.
+	self assert: (2.36 * 1024 * 1024 * 1024) asInteger humanReadableByteSizeString equals: '2.36 GB'.
 
-	self assert: (1000 * 1000 * 1000 * 1000) humanReadableByteSizeString equals: '931 GB'.
-	self assert: (1024 * 1024 * 1024 * 1024) humanReadableByteSizeString equals: '1 TB'
+	self assert: (1000 * 1000 * 1000 * 1000) humanReadableByteSizeString equals: '931.32 GB'.
+	self assert: (1024 * 1024 * 1024 * 1024) humanReadableByteSizeString equals: '1.00 TB'.
+	self assert: (4.56 * 1024 * 1024 * 1024 * 1024) asInteger humanReadableByteSizeString equals: '4.56 TB'
 ]

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -1111,7 +1111,7 @@ Integer >> humanReadableSISizeString [
 	"Return the receiver as a string with SI binary (International System of Units) file size, e.g. '50 KB'. It means that it takes 1000 and not 1024 as unit as humanReadableByteSizeString does."
 
 	"(1000 * 1000 * 1000) humanReadableSISizeString >>> '1.00 GB'"
-	"(1000 * 1000 * 1000) humanReadableByteSizeString >>> '953 MB'"
+	"(1000 * 1000 * 1000) humanReadableByteSizeString >>> '953.67 MB'"
 	"(1024 * 1024 * 1024) humanReadableSISizeString >>> '1.07 GB'"
 
 


### PR DESCRIPTION
The method `humanReadableByteSizeString` returns a string representing the byte string taking the binary value 1024. In the implementation it uses the integer division. The problem is that gives an imprecision of 1. It can be of 1 MB, 1 GB, etc. 

For example,
If one tries`6367000000 humanReadableByteSizeString "5 GB"`. But, the real binary value is `5.92 GB`. So, it can be misleading. This PR adds a precision of 2 decimal points. So now it correctly shows  `6367000000 humanReadableByteSizeString "5.92 GB"`