### PR TITLE
Force rescheduling of inactive process when changing its priority (fixes #14701)

### DIFF
--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -48,6 +48,81 @@ ProcessTest >> testActiveProcessFromProcesorShouldUseInstalledEffectiveProcess [
 ]
 
 { #category : 'tests' }
+ProcessTest >> testChangingOtherPriorityAffectsScheduling [
+
+	| val sem proc1 proc2 |
+	val := #(  ).
+	sem := Semaphore new.
+	proc1 := [
+	         val := val copyWith: 1.
+	         sem signal ] forkAt: Processor activePriority - 3.
+	proc2 := [
+	         val := val copyWith: 2.
+	         sem signal ] forkAt: Processor activePriority - 2.
+
+	proc1 priority: Processor activePriority - 1.
+	self assert: val equals: #(  ). "Sanity check"
+	sem wait.
+	"proc1 is recognized as higher-priority than proc2.
+	We get the processor back before proc2 runs."
+	self assert: val equals: #( 1 ).
+	sem wait.
+	self assert: val equals: #( 1 2 )
+]
+
+{ #category : #tests }
+ProcessTest >> testChangingOtherPriorityLowerDuringSemaphoreWait [
+
+	| semaphore hasBlockRun backgroundProcess |
+	semaphore := Semaphore new.
+	hasBlockRun := false.
+	backgroundProcess := [
+	                     semaphore wait.
+	                     hasBlockRun := true ] forkAt:
+		                     Processor activePriority + 1.
+	self assert: backgroundProcess suspendingList equals: semaphore. 
+	self deny: hasBlockRun. "Process is blocked on Semaphore"
+	backgroundProcess priority: Processor activePriority - 1.
+	self deny: hasBlockRun. "Still waiting on Semaphore"
+	self assert: backgroundProcess suspendingList equals: semaphore.
+	semaphore signal.
+	self deny: hasBlockRun. "Lowered priority respected when signaling semaphore"
+	backgroundProcess priority: Processor activePriority + 1.
+	self assert: hasBlockRun. "Preempted as normal"
+]
+
+{ #category : #tests }
+ProcessTest >> testChangingOtherPriorityPreemptsCurrentProcess [
+
+	| hasBlockRun backgroundProcess |
+	hasBlockRun := false.
+	backgroundProcess := [ hasBlockRun := true ] forkAt:
+		                     Processor activePriority - 1.
+	self deny: hasBlockRun. "We continue running."
+	backgroundProcess priority: Processor activePriority + 1.
+	self assert: hasBlockRun "We have been preempted."
+]
+
+{ #category : #tests }
+ProcessTest >> testChangingOtherPriorityRaiseDuringSemaphoreWait [
+
+	| semaphore hasBlockRun backgroundProcess |
+	semaphore := Semaphore new.
+	hasBlockRun := false.
+	backgroundProcess := [
+	                     semaphore wait.
+	                     hasBlockRun := true ] forkAt:
+		                     Processor activePriority + 1.
+	self assert: backgroundProcess suspendingList equals: semaphore.
+	self deny: hasBlockRun. "Process is blocked on Semaphore"
+	backgroundProcess priority: Processor activePriority + 2.
+	self deny: hasBlockRun. "Still waiting on Semaphore"
+	self assert: backgroundProcess suspendingList equals: semaphore.
+	semaphore signal.
+	self assert: hasBlockRun
+]
+
+{ #category : #tests }
 ProcessTest >> testChangingPriorityRespectsTheProcessPreemptionSettings [
 	"test whether #priority: preempts active process to allow higher priority processes run;
 	#priority behavior reflects the processPreemptionYields setting - for false the active

--- a/src/Kernel/ProcessorScheduler.class.st
+++ b/src/Kernel/ProcessorScheduler.class.st
@@ -180,19 +180,27 @@ ProcessorScheduler >> highestPriority: newHighestPriority [
 
 { #category : 'private' }
 ProcessorScheduler >> interpriorityYield: modifiedProcess [
-
 	"The original yield only works within processes of the same priority.
 	The primitive does not try to resume a process in a higher priority.
-	By forcing the creation of a new process and suspending this one,
-	we force the rescheduling of processes.
+	By suspending and resuming the modified process, we force it to be rescheduled.
+	When modifying the active process, we must handle the resume from a forked process.
+	We must also be careful not to resume a process that was suspended to begin with.
+	(In particular, processes all receive #priority: as part of their creation, before
+	it is safe to resume them.)
 
 	This message should not be used directly.
 	The only application so far is when changing the priority of a process.
 	"
 
-	modifiedProcess isActiveProcess ifFalse: [ ^ self ].
-	[ modifiedProcess resume ] fork.
-	modifiedProcess suspend
+	modifiedProcess isActiveProcess
+		ifTrue: [
+			[ modifiedProcess resume ] fork.
+			modifiedProcess suspend ]
+		ifFalse: [
+			(modifiedProcess suspendingList isKindOf: ProcessList) ifTrue: [
+				modifiedProcess
+					suspend;
+					resume ] ]
 ]
 
 { #category : 'self evaluating' }


### PR DESCRIPTION
Need to reschedule only processes that are waiting in the ProcessorScheduler lists, not those that are suspended or waiting on a Semaphore. Seems like there should be a standard way to test for this condition.