### PR TITLE
Replace extracted expression only in containing scope (fixes #14771)

### DIFF
--- a/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
@@ -63,7 +63,7 @@ RBExtractToTemporaryRefactoring >> compileNewMethod [
 RBExtractToTemporaryRefactoring >> constructAssignmentFrom: aNode [
 	| valueNode |
 	valueNode := RBVariableNode named: newVariableName.
-	^RBAssignmentNode variable: valueNode value: aNode
+	^RBAssignmentNode variable: valueNode value: aNode copy.
 ]
 
 { #category : 'initialization' }
@@ -76,21 +76,19 @@ RBExtractToTemporaryRefactoring >> extract: anInterval to: aString from: aSelect
 
 { #category : 'transforming' }
 RBExtractToTemporaryRefactoring >> insertTemporary [
-	| node statementNode nodeReferences children |
+
+	| node statementNode nodeReferences |
 	node := self parseTree whichNodeIsContainedBy: sourceInterval.
-	(node notNil and: [ node isValue ])
-		ifFalse: [ self refactoringError: 'Cannot assign to non-value nodes' ].
-	children := self parseTree body allChildren.
-	nodeReferences := children select: [ :each | each = node ] thenCollect: [ :each | each ].
+	(node notNil and: [ node isValue ]) ifFalse: [
+		self refactoringError: 'Cannot assign to non-value nodes' ].
+	nodeReferences := node methodOrBlockNode allChildren select: [ :each |
+		                  each = node ].
 	statementNode := node statementNode.
-	nodeReferences do: [ :each | each replaceWith: (RBVariableNode named: newVariableName) ].
 	statementNode parent
-		addNode: (self constructAssignmentFrom: node)
-			before:
-				(node == statementNode
-						ifTrue: [ RBVariableNode named: newVariableName ]
-						ifFalse: [ statementNode ]);
-		addTemporaryNamed: newVariableName
+		addNode: (self constructAssignmentFrom: node) before: statementNode;
+		addTemporaryNamed: newVariableName.
+	nodeReferences do: [ :each |
+		each replaceWith: (RBVariableNode named: newVariableName) ]
 ]
 
 { #category : 'private - accessing' }

--- a/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
@@ -63,6 +63,9 @@ RBExtractToTemporaryRefactoring >> compileNewMethod [
 RBExtractToTemporaryRefactoring >> constructAssignmentFrom: aNode [
 	| valueNode |
 	valueNode := RBVariableNode named: newVariableName.
+	"Use a copy so aNode retains its original parent.
+	In this case the caller is done making use of the parent backlink,
+	but it seems sensible to keep it intact whenever possible."
 	^RBAssignmentNode variable: valueNode value: aNode copy.
 ]
 

--- a/src/Refactoring-DataForTesting/RBClassDataForRefactoringTest.class.st
+++ b/src/Refactoring-DataForTesting/RBClassDataForRefactoringTest.class.st
@@ -152,6 +152,14 @@ RBClassDataForRefactoringTest >> demoMethodWithDuplicates [
 ]
 
 { #category : 'tests' }
+RBClassDataForRefactoringTest >> demoMethodWithDuplicatesInBlocks [
+
+	(1 to: 10) do: [ :i | (i + 1) odd ifTrue: [ (i + 1) doSomething ] ].
+	(1 to: 10) do: [ :i |
+		(i + 1) even ifTrue: [ (i + 1) doSomethingElse ] ]
+]
+
+{ #category : #tests }
 RBClassDataForRefactoringTest >> demoRenameMethod: arg1 PermuteArgs: arg2 [
 	self do: arg1.
 	self do: arg2.

--- a/src/Refactoring-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
@@ -64,6 +64,22 @@ RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicates [
 	^ answer')
 ]
 
+{ #category : 'tests' }
+RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicatesInOtherScopes [
+	| refactoring |
+	refactoring := self createRefactoringWithArguments:
+		{ (58 to: 64) . 'j' . #demoMethodWithDuplicatesInBlocks . RBClassDataForRefactoringTest }.
+	self executeRefactoring: refactoring.
+	self assert: ((refactoring model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #demoMethodWithDuplicatesInBlocks) equals: (self parseMethod: 'demoMethodWithDuplicatesInBlocks
+
+	(1 to: 10) do: [ :i |
+		| j |
+		j := i + 1.
+		j odd ifTrue: [ j doSomething ] ].
+	(1 to: 10) do: [ :i |
+		(i + 1) even ifTrue: [ (i + 1) doSomethingElse ] ]')
+]
+
 { #category : 'failure tests' }
 RBExtractToTemporaryParametrizedTest >> testFailureBadInterval [
 	self shouldFail:

--- a/src/Refactoring-Transformations/RBExtractToTemporaryTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractToTemporaryTransformation.class.st
@@ -73,6 +73,9 @@ RBExtractToTemporaryTransformation >> checkVariableName [
 RBExtractToTemporaryTransformation >> constructAssignmentFrom: aNode [
 	| valueNode |
 	valueNode := RBVariableNode named: newVariableName.
+	"Use a copy so aNode retains its original parent.
+	In this case the caller is done making use of the parent backlink,
+	but it seems sensible to keep it intact whenever possible."
 	^RBAssignmentNode variable: valueNode value: aNode copy.
 ]
 

--- a/src/Refactoring-Transformations/RBExtractToTemporaryTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractToTemporaryTransformation.class.st
@@ -73,7 +73,7 @@ RBExtractToTemporaryTransformation >> checkVariableName [
 RBExtractToTemporaryTransformation >> constructAssignmentFrom: aNode [
 	| valueNode |
 	valueNode := RBVariableNode named: newVariableName.
-	^RBAssignmentNode variable: valueNode value: aNode
+	^RBAssignmentNode variable: valueNode value: aNode copy.
 ]
 
 { #category : 'api' }
@@ -86,21 +86,19 @@ RBExtractToTemporaryTransformation >> extract: anInterval to: aString from: aSel
 
 { #category : 'executing' }
 RBExtractToTemporaryTransformation >> insertTemporary [
-	^ {RBCustomTransformation
-	model: self model
-	with: [ :rbMode | | node statementNode nodeReferences  |
-	node := self nodeContainedBy: sourceInterval.
-	nodeReferences := self referencesTo: node.
-	statementNode := node statementNode.
-	nodeReferences do: [ :each | each replaceWith: (RBVariableNode named: newVariableName) ].
-	statementNode parent
-		addNode: (self constructAssignmentFrom: node)
-			before:
-				(node == statementNode
-						ifTrue: [ RBVariableNode named: newVariableName ]
-						ifFalse: [ statementNode ]);
-		addTemporaryNamed: newVariableName.
-		class compileTree: self parseTree]}
+
+	^ { (RBCustomTransformation model: self model with: [ :rbMode |
+		   | node statementNode nodeReferences |
+		   node := self nodeContainedBy: sourceInterval.
+		   nodeReferences := self referencesTo: node.
+		   statementNode := node statementNode.
+		   statementNode parent
+			   addNode: (self constructAssignmentFrom: node)
+			   before: statementNode;
+			   addTemporaryNamed: newVariableName.
+		   nodeReferences do: [ :each |
+			   each replaceWith: (RBVariableNode named: newVariableName) ].
+		   class compileTree: self parseTree ]) }
 ]
 
 { #category : 'accessing' }
@@ -125,9 +123,8 @@ RBExtractToTemporaryTransformation >> parseTree [
 
 { #category : 'accessing' }
 RBExtractToTemporaryTransformation >> referencesTo: aNode [
-	| children |
-	children := self parseTree body allChildren.
-	^ children select: [ :each | each = aNode ]
+
+	^ aNode methodOrBlockNode allChildren select: [ :each | each = aNode ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
When extracting a temporary, replace only those occurrences of the extracted expression that are in the scope in which the temp is now declared, not others elsewhere in the method.

Also avoid reassigning the parent of a node we may modify later--better to use a copy, I think.

Worth noting that there remains a hole if the expression selected to extract is not the _first_ occurrence within the containing scope—all of them will still be replaced even though, for the earlier ones, the temp will not have been initialized. This is easy enough to fix, the question is, do I fix it by moving the temp assignment ahead of the first occurrence of the expression, or by only replacing occurrences after the selected one?