### PR TITLE
Ensure filesystem code is initialized before opening source files (fixes #14850)

### DIFF
--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -73,8 +73,10 @@ DiskStore class >> delimiter [
 
 { #category : 'class initialization' }
 DiskStore class >> initialize [
+
 	SessionManager default
 		registerSystemClassNamed: self name
+		atPriority: 90
 ]
 
 { #category : 'current' }

--- a/src/System-SessionManager/SessionManager.class.st
+++ b/src/System-SessionManager/SessionManager.class.st
@@ -131,8 +131,8 @@ SessionManager class >> initializeKernelRegistrations [
 		registerSystemClassNamed: #OSPlatform atPriority: 50;
 		registerSystemClassNamed: #ExternalObject atPriority: 60;
 		registerSystemClassNamed: #FFIBackend atPriority: 60;
+		registerSystemClassNamed: #File atPriority: 90;
 		registerSystemClassNamed: #WeakArray;
-		registerSystemClassNamed: #File;
 		registerSystemClassNamed: #Stdio;
 		registerSystemClassNamed: #SharedRandom;
 		registerSystemClassNamed: #EndianDetector;


### PR DESCRIPTION
I don't actually know why the problem in #14850 only occurs in a cleaned image—it certainly looks like `SourceFileArray>>startUp` should run before `DiskStore` has had a chance to choose the correct path delimiter, even in a stock development image. Clearly this is not the case, and that does make me a bit uncomfortable, but also, it seems entirely reasonable to ensure the filesystem code is fully initialized for the correct platform before using it.