### PR TITLE
Allow formatting only part of a method or playground (fixes #14618)

### DIFF
--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -165,14 +165,22 @@ RubSmalltalkCodeMode >> classOrMetaClass: aBehavior [
 
 { #category : 'helper' }
 RubSmalltalkCodeMode >> formatMethodCode [
+
 	| source tree formatted |
-	source := self textArea text asString.
-	tree := self parseSource: source.
-	tree checkFaulty: [ :msg :pos | ^self editor notify: msg at: pos + 1 in: source].
+	self textArea hasSelection
+		ifTrue: [
+			source := self textArea selection.
+			tree := self parseExpression: source ]
+		ifFalse: [
+			source := self textArea text.
+			tree := self parseSource: source ].
+	tree checkFaulty: [ :msg :pos |
+		^ self editor notify: msg at: pos + 1 in: source ].
 	formatted := tree formattedCodeIn: classOrMetaclass.
-	formatted = source
-		ifTrue: [ ^ self ].
-	self textArea updateTextWith: formatted
+	formatted = source ifTrue: [ ^ self ].
+	self textArea hasSelection
+		ifTrue: [ self textArea replaceSelectionWith: formatted ]
+		ifFalse: [ self textArea updateTextWith: formatted ]
 ]
 
 { #category : 'shout' }

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -168,7 +168,7 @@ RubSmalltalkCodeMode >> formatMethodCode [
 	| source tree formatted |
 	source := self textArea text asString.
 	tree := self parseSource: source.
-	tree checkFaulty: [ :msg :pos | ^self ].
+	tree checkFaulty: [ :msg :pos | ^self editor notify: msg at: pos + 1 in: source].
 	formatted := tree formattedCodeIn: classOrMetaclass.
 	formatted = source
 		ifTrue: [ ^ self ].


### PR DESCRIPTION
First off, I added a basic implementation of notifying the user when the code fails to parse. Ideally I would use the nice pretty floating bubbles that a DoIt in a workspace uses, but I couldn't figure out how to make that work everywhere. In a Playground, saying `self model presenter interactionModel notify:at:in:` does the trick, but (a) law of Demeter, and (b) most other places, IIRC `self model` is a `RubScrolledTextModel` and DNU `#presenter`. I'm not sure the relevant objects are even instantiated, and I certainly don't know how to reach them. This is already an improvement over silently doing nothing, regardless.

Regarding partial formatting, there are some possible further enhancements, but all of them are much harder, yet probably less useful, than getting the basic functionality working:
* If the selection starts at or before the first non-whitespace character of a line, indent the entire formatted output starting with that line's indentation
* If the selection starts or ends in the middle of a token, automatically expand it to include the full token
* If the selection fails to parse, try expanding it to the closest containing parse node, if the method/workspace as a whoel *does* parse and such can be determined