### PR TITLE
Some cleanup of `#cleanUp*` code

### DIFF
--- a/src/Kernel/Delay.class.st
+++ b/src/Kernel/Delay.class.st
@@ -99,6 +99,12 @@ Delay class >> nextWakeUpTime [
 ]
 
 { #category : 'timer process' }
+Delay class >> restartMethods [
+
+	self restartTimerEventLoop
+]
+
+{ #category : 'timer process' }
 Delay class >> restartTimerEventLoop [
 	self stopTimerEventLoop.
 	self startTimerEventLoop

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -223,6 +223,15 @@ WorldState class >> quitSession [
 		ifFalse: [Smalltalk snapshot: false andQuit: true]
 ]
 
+{ #category : 'cleanup' }
+WorldState class >> restartMethods [
+
+	self allInstancesDo: [ :ws |
+		ws
+			convertAlarms;
+			cleanStepList ]
+]
+
 { #category : 'world menu items' }
 WorldState class >> saveAndQuit [
 	Cursor write showWhile: [

--- a/src/System-Finalization/WeakArray.extension.st
+++ b/src/System-Finalization/WeakArray.extension.st
@@ -63,6 +63,12 @@ WeakArray class >> restartFinalizationProcess [
 ]
 
 { #category : '*System-Finalization' }
+WeakArray class >> restartMethods [
+
+	self restartFinalizationProcess
+]
+
+{ #category : '*System-Finalization' }
 WeakArray class >> startUp: resuming [
 	resuming ifFalse: [ ^self ].
 	self restartFinalizationProcess

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -49,9 +49,6 @@ Class {
 SmalltalkImage class >> cleanUp [
 	"Flush caches"
 
-	"should probably distribute cleaning to systemDictionary"
-
-	Smalltalk globals flushClassNameCache.
 	Undeclared removeUnreferencedKeys
 ]
 

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -33,6 +33,12 @@ Class {
 	#tag : 'Utilities'
 }
 
+{ #category : 'cleanup' }
+SystemDictionary class >> cleanUp [
+
+	Smalltalk globals flushClassNameCache
+]
+
 { #category : 'accessing - classes and traits' }
 SystemDictionary >> allBehaviors [
 	"Return all the classes and traits defined in the Smalltalk SystemDictionary"

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -117,15 +117,6 @@ ImageCleaner >> cleanUpForRelease [
 ImageCleaner >> cleanUpMethods [
 	"Make sure that all methods in use are restarted"
 	<script: 'self new cleanUpMethods'>
-	WeakArray restartFinalizationProcess.
-	ToolRegistry allSubInstances do: [:each | each resetAnnouncer].
-
-	WorldState
-		allInstancesDo: [ :ws | ws convertAlarms; cleanStepList].
-
-	ProcessBrowser initialize.
-	Delay restartTimerEventLoop.
-	"We are moving all the restart code to the classes"
 	Smalltalk restartMethods
 ]
 

--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -265,6 +265,12 @@ ProcessBrowser class >> registerWellKnownProcesses [
 		allowDebug: false
 ]
 
+{ #category : 'cleanup' }
+ProcessBrowser class >> restartMethods [
+
+	self registerWellKnownProcesses
+]
+
 { #category : 'process control' }
 ProcessBrowser class >> resumeProcess: aProcess [
 	| priority |

--- a/src/Tool-Registry/ToolRegistry.class.st
+++ b/src/Tool-Registry/ToolRegistry.class.st
@@ -48,6 +48,13 @@ Class {
 	#package : 'Tool-Registry'
 }
 
+{ #category : 'cleanup' }
+ToolRegistry class >> cleanUp: aggressive [
+
+	aggressive ifTrue: [
+		self allSubInstancesDo: [ :each | each resetAnnouncer ] ]
+]
+
 { #category : 'announcer' }
 ToolRegistry >> announcer [
 	announcer ifNil: [ announcer := Announcer new ].


### PR DESCRIPTION
Just following through on the comments in `ImageCleaner>>cleanUpMethods` and `SystemDictionary class>>cleanUp` to move individual bits to their respective classes' `#restartMethods`/`#cleanUp[:]` methods.