### PR TITLE
Clean test on repackaging

### DIFF
--- a/src/Deprecated12/ClassRepackaged.extension.st
+++ b/src/Deprecated12/ClassRepackaged.extension.st
@@ -3,8 +3,8 @@ Extension { #name : 'ClassRepackaged' }
 { #category : '*Deprecated12' }
 ClassRepackaged >> classRecategorized [
 
-	self deprecated: 'Use #classRepackaged instead.' transformWith: '`@rcv classRecategorized' -> '`@rcv classRecategorized'.
-	^ self classRecategorized
+	self deprecated: 'Use #classRepackaged instead.' transformWith: '`@rcv classRecategorized' -> '`@rcv classRepackaged'.
+	^ self classRepackaged
 ]
 
 { #category : '*Deprecated12' }

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerAnnouncementsTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerAnnouncementsTest.class.st
@@ -20,8 +20,30 @@ ShClassInstallerAnnouncementsTest >> setUp [
 ShClassInstallerAnnouncementsTest >> tearDown [
 
 	SystemAnnouncer uniqueInstance unsubscribe: self.
-	{ newTrait } do: [ :class | class ifNotNil: [ class removeFromSystem ] ].
 	super tearDown
+]
+
+{ #category : 'tests' }
+ShClassInstallerAnnouncementsTest >> testClassRepackagingShouldAnnounceClassModified [
+
+	| aClass |
+	aClass := ShiftClassInstaller make: [ :builder |
+		          builder
+			          name: #SHClass;
+			          package: self generatedClassesPackageName ].
+
+	self when: ClassRepackaged do: [ :ann |
+		self assert: ann oldPackage name equals: self generatedClassesPackageName.
+		self assert: ann newPackage name equals: self generatedClassesPackageName , '2'.
+		self assert: ann classRepackaged name equals: #SHClass ].
+
+	[
+	ShiftClassInstaller make: [ :builder |
+		builder
+			fillFor: aClass;
+			package: self generatedClassesPackageName , '2' ].
+
+	self assert: numberOfAnnouncements equals: 1 ] ensure: [ self packageOrganizer removePackage: self generatedClassesPackageName , '2' ]
 ]
 
 { #category : 'tests' }

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -53,12 +53,6 @@ ShClassInstallerTest >> newClass: className superclass: aSuperclass slots: slots
 ShClassInstallerTest >> tearDown [
 
 	self packageOrganizer removePackage: self generatedClassesPackageName.
-	{
-		newClass.
-		superClass.
-		subClass.
-		newClass2.
-		superClass2 } do: [ :class | class ifNotNil: [ class removeFromSystem ] ].
 	super tearDown
 ]
 

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -194,21 +194,6 @@ SlotAnnouncementsTest >> testClassCreationShouldAnnounceClassAdded [
 	self assert: self collectedAnnouncements first classAdded equals: aClass
 ]
 
-{ #category : 'tests' }
-SlotAnnouncementsTest >> testClassRecategorizationShouldAnnounceClassModified [
-
-	self subscribeOn: ClassRecategorized.
-
-	aClass := self make: [ :builder | builder package: self slotTestPackageName ].
-	anotherClass := self make: [ :builder | builder package: self slotTestPackageName , '2' ].
-
-	self assert: self collectedAnnouncements size equals: 1.
-	announcement := self collectedAnnouncements first.
-	self assert: announcement oldCategory equals: self slotTestPackageName.
-	self assert: announcement newCategory equals: self slotTestPackageName , '2'.
-	self assert: announcement classRecategorized identicalTo: anotherClass
-]
-
 { #category : 'tests - comments' }
 SlotAnnouncementsTest >> testCreateAndChangeWithCommentDoesAnnounceBoth [
 


### PR DESCRIPTION
SlotAnnouncementTest contains a test that has nothing to do with slots about recategorization of methods.

I removed it and instead I implemented a new test in ShClassInstallerAnnouncementsTest to test teh repackaging. It is in a better place than the previous test and rely on repackaging and not recategorization that I am trying to remove. I also removed some things in the tearDown methods that should not be needed anymore since a recent fix I did in RPackage

Finally I fix a problem in a deprecation