### PR TITLE
Fix #magnifyBy:smoothing: on AthensCairoSurfaceForm

### DIFF
--- a/src/Athens-Cairo/AthensCairoSurfaceForm.class.st
+++ b/src/Athens-Cairo/AthensCairoSurfaceForm.class.st
@@ -14,6 +14,16 @@ Class {
 	#tag : 'Surface'
 }
 
+{ #category : 'scaling, rotation' }
+AthensCairoSurfaceForm >> magnifyBy: scale smoothing: cellSize [
+
+	| form |
+	
+	form := Form extent: self extent depth: self depth.
+	form getCanvas image: self at: 0@0 sourceRect: self boundingBox rule: 34.
+	^ form magnifyBy: scale smoothing: cellSize
+]
+
 { #category : 'accessing' }
 AthensCairoSurfaceForm >> surface [
 	^ surface


### PR DESCRIPTION
This pull request fixes `#magnifyBy:smoothing:` on AthensCairoSurfaceForm: the implementation inherited from Form does not seem to work for that subclass, it’s slow and the ‘newForm’ it gives is still blank. The fix is an override: it first draws the AthensCairoSurfaceForm on a Form with the same extent through a FormCanvas, and it then delegates the `#magnifyBy:smoothing:` message to that Form. Note that the result is therefore a Form rather than an AthensCairoSurfaceForm. The class comment of AthensCairoSurfaceForm says: “I'm a form that keeps a surface with the only purpose of prevent GC […]”.