### PR TITLE
Update DoItChunk to manage new package API

### DIFF
--- a/src/CodeImport/DoItChunk.class.st
+++ b/src/CodeImport/DoItChunk.class.st
@@ -57,5 +57,5 @@ DoItChunk >> isDoItDeclaration [
 DoItChunk >> isPackageAddition: ast [
 	"This is for backward compatibility to be able to import code with old way of creating a package."
 
-	^ ast isMessage and: [ ast receiver name = #SystemOrganization and: [ ast selector = #addCategory: ] ]
+	^ ast isMessage and: [ ast receiver isVariable and: [ ast receiver name = #SystemOrganization and: [ ast selector = #addCategory: ] ] ]
 ]

--- a/src/CodeImport/DoItChunk.class.st
+++ b/src/CodeImport/DoItChunk.class.st
@@ -28,22 +28,34 @@ DoItChunk >> description [
 { #category : 'importing' }
 DoItChunk >> importFor: requestor logSource: logSource [
 
-	(contents beginsWith: '----') ifTrue: [ ^self ].
+	| ast |
+	(contents beginsWith: '----') ifTrue: [ ^ self ].
 
 	SystemAnnouncer announce: (DoItChunkImported new
-		contents: contents;
-		logSource: logSource;
-		yourself).
+			 contents: contents;
+			 logSource: logSource;
+			 yourself).
 
-	^Smalltalk compiler class new
-		source: contents;
-		requestor: requestor;
-		logged: logSource;
-		evaluate
+	ast := RBParser parseExpression: contents onError: [ ^ self ].
+
+	(self isPackageAddition: ast) ifTrue: [ ^ self packageOrganizer ensurePackageMatching: ast arguments first value ].
+
+	^ Smalltalk compiler class new
+		  source: contents;
+		  requestor: requestor;
+		  logged: logSource;
+		  evaluate
 ]
 
 { #category : 'testing' }
 DoItChunk >> isDoItDeclaration [
 
 	^ true
+]
+
+{ #category : 'testing' }
+DoItChunk >> isPackageAddition: ast [
+	"This is for backward compatibility to be able to import code with old way of creating a package."
+
+	^ ast isMessage and: [ ast receiver name = #SystemOrganization and: [ ast selector = #addCategory: ] ]
 ]

--- a/src/CodeImport/DoItChunk.class.st
+++ b/src/CodeImport/DoItChunk.class.st
@@ -36,7 +36,7 @@ DoItChunk >> importFor: requestor logSource: logSource [
 			 logSource: logSource;
 			 yourself).
 
-	ast := RBParser parseExpression: contents onError: [ ^ self ].
+	ast := RBParser parseExpression: contents.
 
 	(self isPackageAddition: ast) ifTrue: [ ^ self packageOrganizer ensurePackageMatching: ast arguments first value ].
 

--- a/src/Deprecated12/RPackageOrganizer.extension.st
+++ b/src/Deprecated12/RPackageOrganizer.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : 'RPackageOrganizer' }
 
 { #category : '*Deprecated12' }
+RPackageOrganizer >> addCategory: aCategory [
+
+	self deprecated: 'The manipulation of categories got deprecated in Pharo 12. It is better to manipulate directly the packages and tags.'.
+	self ensurePackageMatching: aCategory
+]
+
+{ #category : '*Deprecated12' }
 RPackageOrganizer >> categories [
 
 	| categories |

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -75,8 +75,7 @@ ClassDescription >> packageTag [
 
 { #category : '*RPackage-Core' }
 ClassDescription >> packageTag: aTag [
-
-	(self package ensureTag: aTag) addClass: self
+	(aTag isString ifTrue: [ self package ensureTag: aTag ] ifFalse: [ aTag ]) addClass: self
 ]
 
 { #category : '*RPackage-Core' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -151,13 +151,6 @@ RPackageOrganizer class >> unregisterInterestToSystemAnnouncement [
 	self default unregisterInterestToSystemAnnouncement
 ]
 
-{ #category : 'adding' }
-RPackageOrganizer >> addCategory: aCategory [
-
-	self deprecated: 'The manipulation of categories got deprecated in Pharo 12. It is better to manipulate directly the packages and tags.'.
-	self ensurePackageMatching: aCategory
-]
-
 { #category : 'private' }
 RPackageOrganizer >> addMethod: method [
 	"we have to register the method in the parent RPackage of the class.


### PR DESCRIPTION
DoItChunk is used a lot to import code from Monticello and often this is to import a package or a class. The API used to import package had been deprecated and should be removed, but this might break all the old code export of Monticello. 

This change updates the code importer to check if we are in that case, and if we are, it uses the new API instead of evaluating the code.