### PR TITLE
Fix failing tests on RPackage

### DIFF
--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -75,8 +75,7 @@ ClassDescription >> packageTag [
 
 { #category : '*RPackage-Core' }
 ClassDescription >> packageTag: aTag [
-
-	(self package ensureTag: aTag) addClass: self
+	(aTag isString ifTrue: [ self package ensureTag: aTag ] ifFalse: [ aTag ]) addClass: self
 ]
 
 { #category : '*RPackage-Core' }


### PR DESCRIPTION
I think that merging two independent PR on package changes recently broke two tests in the CI. Here is a fix.

The problem comes from the fact that the tag as parameter can come from another package. In that case we should not call the #ensureTag: on the current package.