### PR TITLE
Cleanup-methodsWithUnboundGlobals 

### DIFF
--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -219,23 +219,6 @@ ReleaseTest >> testMethodsContainNoHalt [
 				print: methods ] ]
 ]
 
-{ #category : 'tests - variables' }
-ReleaseTest >> testMethodsWithUnboundGlobals [
-	| methodsWithUnboundGlobals |
-	"Ensure the environment is clean"
-	3 timesRepeat: [ Smalltalk garbageCollect ].
-
-	Smalltalk cleanOutUndeclared.
-	methodsWithUnboundGlobals := SystemNavigation new methodsWithUnboundGlobals.
-
-	self
-		assert: methodsWithUnboundGlobals isEmpty
-		description: [ String streamContents: [ :s |
-			s
-				nextPutAll: 'Found methods with unbound globals: ';
-				print: methodsWithUnboundGlobals ]]
-]
-
 { #category : 'tests' }
 ReleaseTest >> testNoEmptyPackages [
 	"Test that we have no empty packages left"

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -351,25 +351,6 @@ SystemNavigation >> methodsReferencingObsoleteClasses [
 								ifTrue: [methods nextPut: meth]]]]]]
 ]
 
-{ #category : 'query' }
-SystemNavigation >> methodsWithUnboundGlobals [
-	"This says that for any global, it should match either the class's notion of what bindingOf: the key is, or bindingOf: should be nil and the binding should be in Undeclared. If the class answers a different binding through bindingOf: or answers no binding and the binding is not in Undeclared then the variable in the method is wrong.
-	For a clean image the result should be empty. If it is not empty, evaluating Compiler recompileAll probably solves the problem. However, we should investigate why the method gets an incorrect state."
-
-	"SystemNavigation new methodsWithUnboundGlobals"
-
-	^self allMethodsSelect:
-		[:m|
-		m allLiterals anySatisfy:
-			[:l|
-			l isVariableBinding
-			and: [l key isSymbol "avoid class-side methodClass literals"
-			and: [ (l isKindOf: AdditionalBinding) not
-			and: [(m methodClass classBindingOf: l key)
-					ifNil: [(Undeclared associationAt: l key ifAbsent: []) ~~ l]
-					ifNotNil: [:b| b ~~ l]]]]]]
-]
-
 { #category : 'identifying obsoletes' }
 SystemNavigation >> obsoleteClasses [
 	"SystemNavigation new obsoleteClasses inspect"


### PR DESCRIPTION
We have #testMethodsWithUnboundGlobals, which did not fail since years. If we look at "methodsWithUnboundGlobals", we see:

"However, we should investigate why the method gets an incorrect state."

So this is  for a bug that we fixed a long time ago... we can just remove the method and test