### PR TITLE
reduce the amount of calls to #cleanOutUndeclared during full image load

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -106,8 +106,6 @@ BaselineOfBasicTools >> postload: loader package: packageSpec [
 	Initialized = true ifTrue: [ ^ self ].
 	
 	RBRefactoryChangeManager nuke.
-	Smalltalk garbageCollect.
-	Smalltalk cleanOutUndeclared. 
 	
 	CompletionSorter register.
 	RubSmalltalkEditor completionEngineClass: CompletionEngine.

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -81,10 +81,6 @@ BaselineOfIDE >> additionalInitialization [
 	SDL_Event initialize.
 	
 	HiRulerBuilderTest initialize.
-		
-	3 timesRepeat: [
-		Smalltalk garbageCollect.
-		Undeclared removeUnreferencedKeys.].
 	
 	"Making HeuristicCompletion the default completion engine"
 	RubSmalltalkEditor completionEngineClass: CoCompletionEngine.

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -348,8 +348,7 @@ BaselineOfIDE >> postload: loader package: packageSpec [
 	gofer load.
 	
 	MCMethodDefinition initializersEnabled: initializersEnabled.
-	
-	Smalltalk cleanOutUndeclared. 
+
 
 	Stdio stdout 
 		nextPutAll: ' ------------ Obsolete ------------';

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -141,8 +141,6 @@ BaselineOfMorphic >> cleanUpAfterMorphicInitialization [
 	MCFileBasedRepository flushAllCaches.
 	MCMethodDefinition shutDown.
 	ExternalDropHandler resetRegisteredHandlers.
-	Undeclared removeUnreferencedKeys.
-	Smalltalk globals flushClassNameCache.
 	ScrollBarMorph initializeImagesCache.
 
 	Smalltalk garbageCollect.

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -273,7 +273,6 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 
 	SystemNotification signal: 'Starting postload action'.
 
-	Smalltalk cleanOutUndeclared.
 	Author fullName: self class name.
 
 	TextConstants initialize.
@@ -334,8 +333,6 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	PolymorphSystemSettings showDesktopLogo: false.
 	PolymorphSystemSettings showDesktopLogo: true.
 	PolymorphSystemSettings desktopColor: Color white.
-
-	Smalltalk cleanOutUndeclared.
 
 	#(#AbstractFont #BalloonMorph #Clipboard #EditorFindReplaceDialogWindow #EmbeddedFreeTypeFontInstaller #FLCompiledMethodCluster #FLLargeIdentityHashedCollection #FreeTypeFontProvider #GradientFillStyle #IconicButtonMorph #KMLog #LogicalFont #LucidaGrandeRegular #OSEnvironment #ScrollBarMorph #StrikeFont #SystemSettingsPersistence #TabMorph #TaskbarMorph #Text #TextAction #TextConstants #TextStyle) do: [:each |
 		 (Smalltalk globals at: each) initialize. ].


### PR DESCRIPTION
- We do it for some packages, but not all, which is odd.
- We do it again at the end of the full image build (ImageCleaner does it)