### PR TITLE
Unsubscribe announcements from finalization registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ package-cache/
 iceberg-cache/
 play-cache/
 
+build/
+
 github--*.zip
 
 **/.DS_STORE

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-*.image
-*.changes
 *.log
 *.sources
 *.dmp
@@ -21,8 +19,6 @@ github-cache/
 package-cache/
 iceberg-cache/
 play-cache/
-
-bootstrap-cache/
 
 github--*.zip
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,12 +152,12 @@ def bootstrapImage(architectures){
 
           stage ("Full Image-${architecture}") {
             shell "BUILD_NUMBER=${BUILD_NUMBER} BOOTSTRAP_ARCH=${architecture} bash ./bootstrap/scripts/4-build.sh"
-            stash includes: "bootstrap-cache/*.zip,bootstrap-cache/*.sources,bootstrap/scripts/**", name: "bootstrap${architecture}"
+            stash includes: "build/bootstrap-cache/*.zip,build/bootstrap-cache/*.sources,bootstrap/scripts/**", name: "bootstrap${architecture}"
           }
 
           if( isDevelopmentBranch() ) {
             stage("Upload to files.pharo.org-${architecture}") {
-              dir("bootstrap-cache") {
+              dir("build/bootstrap-cache") {
                   shell "BUILD_NUMBER=${env.BUILD_ID} bash ../bootstrap/scripts/prepare_for_upload.sh ${architecture}"
                 sshagent (credentials: ['b5248b59-a193-4457-8459-e28e9eb29ed7']) {
                   shell "bash ../bootstrap/scripts/upload_to_files.pharo.org.sh"
@@ -176,7 +176,7 @@ def bootstrapImage(architectures){
               archiveArtifacts allowEmptyArchive: true, artifacts: "crash-bootstrap.dmp", fingerprint: true
           }
 
-        archiveArtifacts artifacts: 'bootstrap-cache/*.zip,bootstrap-cache/*.sources', fingerprint: true
+        archiveArtifacts artifacts: 'build/bootstrap-cache/*.zip,build/bootstrap-cache/*.sources', fingerprint: true
         cleanWs()
       }
       }

--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -72,11 +72,13 @@ fi
 
 # bootstrap image
 if [ ! -e "./Pharo.image" ]; then
+    cd ${BOOTSTRAP_CACHE}
 	unzip -u ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip -d .
 fi
 
 # PharoV6 sources
 if [ ! -e "${BOOTSTRAP_CACHE}/PharoV60.sources" ]; then
+    cd ${BOOTSTRAP_CACHE}
 	unzip -u ${BOOTSTRAP_DOWNLOADS}/PharoV60.sources.zip -d ${BOOTSTRAP_CACHE}
 fi
 

--- a/bootstrap/scripts/3-prepare.sh
+++ b/bootstrap/scripts/3-prepare.sh
@@ -13,5 +13,6 @@ SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 
 set_version_variables
 
+cd ${BOOTSTRAP_CACHE}
 ${VM_BOOTSTRAP} Pharo.image ${IMAGE_FLAGS} ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/prepare_image.st --save --quit
 ${VM_BOOTSTRAP} Pharo.image ${IMAGE_FLAGS} ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/bootstrap.st --ARCH=${BOOTSTRAP_ARCH} --BUILD_NUMBER=${BUILD_NUMBER} --VERSION_INFO="${PHARO_NAME_PREFIX}-${PHARO_COMMIT_HASH}" --quit

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -221,16 +221,10 @@ ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Smalltalk vm sav
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Smalltalk vm parameterAt: 43 put: 32"
 
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "MCCacheRepository uniqueInstance enable. FFIMethodRegistry resetAll. PharoSourcesCondenser condenseNewSources. Smalltalk garbageCollect"
-${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" clean --release
+#${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" clean --release
 
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save "Pharo"
 echo "${PHARO_SHORT_VERSION}" > pharo.version
-
-# clean bak sources files
-rm -f *.bak
-
-# delete Pharo60 sources files
-rm PharoV60.sources*
 
 PHARO_SOURCES_PREFIX=$(echo "${PHARO_NAME_PREFIX}" | cut -d'-' -f 1 | cut -d'.' -f 1-2)
 zip "${PHARO_IMAGE_NAME}.zip" ${PHARO_IMAGE_NAME}.* ${PHARO_SOURCES_PREFIX}*.sources pharo.version

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -221,7 +221,7 @@ ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Smalltalk vm sav
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Smalltalk vm parameterAt: 43 put: 32"
 
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "MCCacheRepository uniqueInstance enable. FFIMethodRegistry resetAll. PharoSourcesCondenser condenseNewSources. Smalltalk garbageCollect"
-#${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" clean --release
+${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" clean --release
 
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save "Pharo"
 echo "${PHARO_SHORT_VERSION}" > pharo.version

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -226,6 +226,12 @@ ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" clean --release
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save "Pharo"
 echo "${PHARO_SHORT_VERSION}" > pharo.version
 
+# clean bak sources files
+rm -f *.bak
+
+# delete Pharo60 sources files
+rm PharoV60.sources*
+
 PHARO_SOURCES_PREFIX=$(echo "${PHARO_NAME_PREFIX}" | cut -d'-' -f 1 | cut -d'.' -f 1-2)
 zip "${PHARO_IMAGE_NAME}.zip" ${PHARO_IMAGE_NAME}.* ${PHARO_SOURCES_PREFIX}*.sources pharo.version
 

--- a/bootstrap/scripts/envvars.sh
+++ b/bootstrap/scripts/envvars.sh
@@ -30,11 +30,10 @@ fi
 
 if [ -z ${BOOTSTRAP_REPOSITORY+x} ]
 then
-  ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." ; pwd -P)"
-  export BOOTSTRAP_REPOSITORY="${ROOT_DIR}"
-else
-  ROOT_DIR="$(pwd -P)"
+  export BOOTSTRAP_REPOSITORY="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." ; pwd -P)"
 fi
+
+ROOT_DIR="$(pwd -P)/build"
 
 if [ -z ${BOOTSTRAP_CACHE+x} ]
 then

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -22,7 +22,7 @@ find ${CACHE}
 # WARNING: I'm assuming CACHE=bootstrap-cache
 # WARNING: If you change this, you will need to change "runTests.sh" too
 #
-TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2 | cut -d'-' -f 1-2)
+TEST_NAME_PREFIX=$(basename `find ${CACHE} -name "Pharo*.zip" | head -n 1` | cut -d'-' -f 1-2)
 
 # Extract the VM version from the image file version, avoiding going to git to extract the tags
 # This is handy in later stages of the build process when no repository is available, e.g., to run the tests

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -9,10 +9,10 @@ set -o xtrace
 # The first parameter is the architecture
 # The second parameter is the stage name
 
-CACHE="${BOOTSTRAP_CACHE:-bootstrap-cache}"
-
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 . ${SCRIPTS}/envvars.sh
+
+CACHE="${BOOTSTRAP_CACHE}"
 
 
 find ${CACHE}

--- a/bootstrap/scripts/runTests.sh
+++ b/bootstrap/scripts/runTests.sh
@@ -9,10 +9,11 @@ set -o xtrace
 # The first parameter is the architecture
 # The second parameter is the stage name
 
-CACHE="${BOOTSTRAP_CACHE:-bootstrap-cache}"
 
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)"
 . ${SCRIPTS}/envvars.sh
+
+CACHE="${BOOTSTRAP_CACHE}"
 
 find ${CACHE}
 

--- a/bootstrap/scripts/runTests.sh
+++ b/bootstrap/scripts/runTests.sh
@@ -22,7 +22,7 @@ find ${CACHE}
 # WARNING: I'm assuming CACHE=bootstrap-cache
 # WARNING: If you change this, you will need to change "runKernelTests.sh" too
 #
-TEST_NAME_PREFIX=$(find ${CACHE} -name "Pharo*.zip" | head -n 1 | cut -d'/' -f 2 | cut -d'-' -f 1-2)
+TEST_NAME_PREFIX=$(basename `find ${CACHE} -name "Pharo*.zip" | head -n 1` | cut -d'-' -f 1-2)
 
 # Extract the VM version from the image file version, avoiding going to git to extract the tags
 # This is handy in later stages of the build process when no repository is available, e.g., to run the tests

--- a/src/Announcements-Core/AnnouncementSubscription.class.st
+++ b/src/Announcements-Core/AnnouncementSubscription.class.st
@@ -35,6 +35,7 @@ AnnouncementSubscription >> makeWeak [
 			announcementClass: announcementClass)
 ]
 
+
 { #category : 'accessing' }
 AnnouncementSubscription >> subscriber [
 
@@ -45,4 +46,10 @@ AnnouncementSubscription >> subscriber [
 AnnouncementSubscription >> subscriber: aSubscriber [
 
 	subscriber := aSubscriber
+]
+
+{ #category : 'finalization' }
+AnnouncementSubscription >> unregister [
+
+	"Nothing, for compatibility with weak subscriptions"
 ]

--- a/src/Announcements-Core/SubscriptionRegistry.class.st
+++ b/src/Announcements-Core/SubscriptionRegistry.class.st
@@ -95,8 +95,10 @@ SubscriptionRegistry >> remove: subscription [
 { #category : 'add/remove' }
 SubscriptionRegistry >> removeSubscriber: subscriber [
 
-	^ self protected: [
-		subscriptions removeAllSuchThat: [:subscription | subscription subscriber == subscriber ]]
+	^ self protected: [ | toRemove |
+		toRemove := subscriptions select: [ :subscription | subscription subscriber == subscriber ].
+		toRemove do: [ :e | e unregister ].
+		subscriptions removeAll: toRemove ]
 ]
 
 { #category : 'add/remove' }

--- a/src/Announcements-Core/WeakAnnouncementSubscription.class.st
+++ b/src/Announcements-Core/WeakAnnouncementSubscription.class.st
@@ -82,5 +82,8 @@ WeakAnnouncementSubscription >> subscriber: anObject [
 { #category : 'finalization' }
 WeakAnnouncementSubscription >> unregister [
 
-	self subscriber ifNotNil: [:sub |  self finalizationRegistry remove: sub ]
+	self subscriber ifNotNil: [:sub | 
+		self finalizationRegistry 
+			remove: sub 
+			ifAbsent: ["I will ignore if the subscription has been already removed"]]
 ]

--- a/src/System-Finalization/FinalizationRegistry.class.st
+++ b/src/System-Finalization/FinalizationRegistry.class.st
@@ -181,6 +181,12 @@ FinalizationRegistry >> protected: aBlock [
 ]
 
 { #category : 'adding' }
+FinalizationRegistry >> remove: aKey [
+
+	^ self remove: aKey ifAbsent: [ NotFound signalFor: aKey ]
+]
+
+{ #category : 'adding' }
 FinalizationRegistry >> remove: aKey ifAbsent: aBlock [
 	| ephemeron |
 	ephemeron := self ephemeronAtKey: aKey.


### PR DESCRIPTION
Announcements are not correctly removed from the finalization registry when explicitly removed.
This causes a bloat of ephemerons related to change sets that are created during the bootstrap.

Also, improve a bit the bootstrap to allow out of source builds.

I'll produce a backport to Pharo11