### PR TITLE
Fix index out of range during Calypso editor tab updates

### DIFF
--- a/src/Calypso-Browser/ClyNotebookMorph.class.st
+++ b/src/Calypso-Browser/ClyNotebookMorph.class.st
@@ -109,6 +109,18 @@ ClyNotebookMorph >> toolbarMorph [
 	^ toolbarMorph
 ]
 
+{ #category : 'private' }
+ClyNotebookMorph >> updateContentMorph: aMorph with: newMorph [
+	| pageBounds |
+
+	pageBounds := self pageMorph bounds.
+	"We should replace aMorph which comes from pageMorph ONLY if it is present in the contentMorph (a PanelMorph), which is a container in the receiver"
+	(self contentMorph findA: aMorph class)
+		ifNotNil: [ : replaceMorph | self contentMorph replaceSubmorph: aMorph by: newMorph ].
+	self pageMorph bounds: pageBounds.
+	self pageMorph layoutChanged
+]
+
 { #category : 'accessing' }
 ClyNotebookMorph >> useSortedTabsBy: aBlock [
 


### PR DESCRIPTION
This PR prevents Calypso from replacing non-existant morphs in tab group submorphs, which was causing an "index out of range" exception as reported in #12821.

See this use case to reproduce:

https://github.com/pharo-project/pharo/assets/4825959/0a553875-8688-46f3-8116-ed75fafeeaf9

This happens because when Calypso wants to update the its page content, the ClyMethodCreationToolMorph (which is used during the method creation) is no longer present in ClyNotebookMorph(SpNotebookMorph) submorphs - which is manifested by the fact the index of the Calypso tab group PanelMorph submorphs returning 0, meaning it is not found. This means that ClyMethodCreationToolMorph is replaced with a ClyClassDefinitionEditorToolMorph and then with a ClyRichTextClassCommentEditorToolMorph. It was also already reported that replacements are done twice in #10466, so the source of desynchronization is still yet to be found.

And this after the PR is applied:


https://github.com/pharo-project/pharo/assets/4825959/28f105ea-a55f-4983-b87a-cbc605f969c0


