### PR TITLE
No need to remove empty protocols after loading morphic

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -147,15 +147,8 @@ BaselineOfMorphic >> cleanUpAfterMorphicInitialization [
 	HashedCollection rehashAll.
 	Symbol rehash.
 
-	"Remove empty packages and protocols"
-	self packageOrganizer removeEmptyPackagesAndTags.
-	Smalltalk allClassesAndTraitsDo: [ :class |
-		class removeEmptyProtocols.
-		class class removeEmptyProtocols ].
-
 	ChangeSet removeChangeSetsNamedSuchThat: [ :each | true ].
 	ChangeSet resetCurrentToNewUnnamedChangeSet.
-	Smalltalk garbageCollect.
 	Author reset
 ]
 


### PR DESCRIPTION
- No need to remove empty protocols after loading morphic (we do it for no other package)
- In addition, remove one explicit #garbageCollect