### PR TITLE
RPackage: Remove categories from class removal announcement 

### DIFF
--- a/src/Deprecated12/ClassAnnouncement.extension.st
+++ b/src/Deprecated12/ClassAnnouncement.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'ClassAnnouncement' }
+
+{ #category : '*Deprecated12' }
+ClassAnnouncement >> classTagAffected [
+
+	self deprecated: 'Use #packageTagAffected that returns a real package tag instance instead.'.
+	^ self packagesAffected name
+]

--- a/src/Deprecated12/ClassRemoved.extension.st
+++ b/src/Deprecated12/ClassRemoved.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'ClassRemoved' }
+
+{ #category : '*Deprecated12' }
+ClassRemoved >> categoryName [
+
+	self deprecated: 'Use package and tag instead of the category.'.
+	^ self packageTagAffected categoryName
+]

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -200,11 +200,11 @@ EpMonitor >> behaviorRemoved: aClassRemovedAnnouncement [
 		             ifTrue: [ 'package: ' , '_UnpackagedPackage' printString ]
 		             ifFalse: [ 'package: ' , 'Unclassified' printString ].
 
-	classRemoved definitionSource: (classRemoved definitionSource copyReplaceAll: toReplace with: 'package: ' , aClassRemovedAnnouncement categoryName printString).
+	classRemoved definitionSource: (classRemoved definitionSource copyReplaceAll: toReplace with: 'package: ' , aClassRemovedAnnouncement packageTagAffected categoryName printString).
 
 	classRemoved name: aClassRemovedAnnouncement classRemoved originalName.
-	classRemoved category: aClassRemovedAnnouncement categoryName.
 	classRemoved package: aClassRemovedAnnouncement packageAffected name.
+	classRemoved packageTag: aClassRemovedAnnouncement packageTagAffected name.
 
 	aClassRemovedAnnouncement classRemoved methods , aClassRemovedAnnouncement classRemoved classSide methods do: [ :each |
 		self behaviorRemovedImpliesMethodRemoved: each defaultPackageName: classRemoved package ].

--- a/src/Epicea/TestCase.extension.st
+++ b/src/Epicea/TestCase.extension.st
@@ -1,14 +1,14 @@
 Extension { #name : 'TestCase' }
 
 { #category : '*Epicea' }
-TestCase >> shouldLogWithEpicea [
-
-	^ self class shouldLogWithEpicea
-]
-
-{ #category : '*Epicea' }
 TestCase class >> shouldLogWithEpicea [
 	"When running a test, we disable the loggings of Epicea to run the tests silently. In case a TestCase explicitly wants to Epicea logs, then I can be overriden to return true and enable the logs."
 
 	^ false
+]
+
+{ #category : '*Epicea' }
+TestCase >> shouldLogWithEpicea [
+
+	^ self class shouldLogWithEpicea
 ]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -995,24 +995,23 @@ Class >> removeFromSystem: logged [
 	Keep the class name and category for triggering the system change message. If we wait to long, then we get obsolete information which is not what we want.
 	Tell class to deactivate and unload itself-- two separate events in the module system"
 
-	| myCategory package |
+	| packageTag |
 	self release.
 	self unload.
 
 	self superclass ifNotNil: [ "If we have no superclass there's nothing to be remembered" self superclass addObsoleteSubclass: self ].
 
-	"we add the class to Undeclared so that if references still exist, they will  be automatically fixed
-	if this class is loaded again. We do not check if references exist as it is too slow"
+	"we add the class to Undeclared so that if references still exist, they will  be automatically fixed if this class is loaded again. We do not check if references exist as it is too slow"
 	Undeclared declare: self name asSymbol from: Smalltalk globals.
-	myCategory := self category.
-	package := self package.
+	self flag: #package. "For now the class cannot return its package tag after been removed. In the future the class should keep a reference to its package tag so we should not need that."
+	packageTag := self packageTag.
 	self environment forgetClass: self.
 
 	"In case the class has deprecated aliases we need to remove them from the system dictionary.
 	We deal also with a special case that is the case a class of the same name than the alias is installed in the image after the alias. In that case we do not remove it. It's the reason we check if the global of the alias is the same as self."
 	self deprecatedAliases do: [ :alias | self environment at: alias ifPresent: [ :class | class = self ifTrue: [ self environment removeKey: alias ] ] ].
 	self obsolete.
-	logged ifTrue: [ SystemAnnouncer announce: (ClassRemoved class: self package: package category: myCategory) ]
+	logged ifTrue: [ SystemAnnouncer announce: (ClassRemoved class: self packageTag: packageTag) ]
 ]
 
 { #category : 'initialization' }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1841,7 +1841,7 @@ Context >> runUntilErrorOrReturnFrom: aSender [
 	]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> runUntilReturnFrom: aContext [
 	"Run the receiver (which must be its stack top context) until aContext returns. Avoid a context that cannot return.
 	Note: to avoid infinite recursion of MNU error inside unwind blocks, implement e.g. a wrapper around the message
@@ -1865,7 +1865,7 @@ Context >> runUntilReturnFrom: aContext [
 	"Note 3: it doesn't matter newTop is not a proper stack top context because #terminate will use it only as a starting point in the search for the next unwind context and the computation will never return here. Cf. the pattern in #runUntilErrorOrReturnFrom:: removing the inserted ensure context by stepping until popped when executing non-local returns is not applicable here and would fail the tests testTerminationDuringNestedUnwindWithReturn1 and 2."
 ]
 
-{ #category : #'debugger access' }
+{ #category : 'debugger access' }
 Context >> selector [
 	"Answer the selector of the method that created the receiver."
 	<reflection: 'Stack Manipulation - Context'>
@@ -2294,7 +2294,7 @@ Context >> tryPrimitiveFor: aMethod receiver: aReceiver args: arguments [
 	^ self doPrimitive: primIndex method: aMethod receiver: aReceiver args: arguments
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Context >> unwindAndStop: aProcess [
 	"I'm a helper method to #terminate; I create and answer
 	 a helper stack for a terminating process to unwind itself from."
@@ -2304,7 +2304,7 @@ Context >> unwindAndStop: aProcess [
 
 ]
 
-{ #category : #'special context access' }
+{ #category : 'special context access' }
 Context >> unwindBlock [
 	"unwindContext only. access temporaries from BlockClosure>>#ensure: and BlockClosure>>#ifCurtailed:"
 

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -213,7 +213,7 @@ Process >> debugWithTitle: title [
 		inContext: context
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 Process >> doTerminationFromAnotherProcess [ 
 	"Stop this process forever from another process.
 	Unwind to execute pending ensure:/ifCurtailed: blocks before terminating.
@@ -704,7 +704,7 @@ Process >> suspendingList [
 	^myList
 ]
 
-{ #category : #'changing process state' }
+{ #category : 'changing process state' }
 Process >> terminate [ 
 	"Stop the process that the receiver represents forever. Unwind to execute pending ensure: and
 	ifCurtailed: blocks before terminating; allow all unwind blocks to run; if they are currently in

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -751,6 +751,12 @@ RGBehavior >> oldDefinition [
 		definitionString
 ]
 
+{ #category : 'accessing' }
+RGBehavior >> packageTag [
+
+	^ self tags ifEmpty: [ nil ] ifNotEmpty: [ :tgs | tgs anyOne ]
+]
+
 { #category : 'printing' }
 RGBehavior >> printOn: aStream [
 	aStream nextPutAll: self name

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -80,8 +80,7 @@ RGEnvironmentAnnouncer >> behaviorRecategorized: anRGBehavior [
 { #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorRemoved: anRGBehavior [
 
-	self announce: (ClassRemoved
-		class: anRGBehavior category: anRGBehavior category)
+	self announce: (ClassRemoved class: anRGBehavior packageTag: anRGBehavior packageTag)
 ]
 
 { #category : 'triggering' }

--- a/src/Ring-Definitions-Core/RGClassDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGClassDefinition.class.st
@@ -10,6 +10,7 @@ Class {
 		'classVariables',
 		'category',
 		'package',
+		'packageTag',
 		'sharedPools'
 	],
 	#category : 'Ring-Definitions-Core-Base',
@@ -116,7 +117,13 @@ RGClassDefinition >> allSharedPools [
 RGClassDefinition >> category [
 	"retrieves a tag for its package"
 
-	^category
+	^ category ifNil: [
+		  (self packageTag isNotNil and: [ self package isNotNil ])
+			  ifFalse: [ nil ]
+			  ifTrue: [
+				  self packageTag = self package
+					  ifTrue: [ self package ]
+					  ifFalse: [ self package , '-' , self packageTag ] ] ]
 ]
 
 { #category : 'accessing' }
@@ -267,6 +274,18 @@ RGClassDefinition >> package: aRGPackage [
 	"Sets the package in which this class is contained"
 
 	package:= aRGPackage
+]
+
+{ #category : 'accessing' }
+RGClassDefinition >> packageTag [
+
+	^ packageTag
+]
+
+{ #category : 'accessing' }
+RGClassDefinition >> packageTag: anObject [
+
+	packageTag := anObject
 ]
 
 { #category : 'class variables' }

--- a/src/Ring-Definitions-Core/RGTraitDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGTraitDefinition.class.st
@@ -8,7 +8,8 @@ Class {
 		'metaClass',
 		'comment',
 		'category',
-		'package'
+		'package',
+		'packageTag'
 	],
 	#category : 'Ring-Definitions-Core-Base',
 	#package : 'Ring-Definitions-Core',
@@ -19,7 +20,13 @@ Class {
 RGTraitDefinition >> category [
 	"Retrieves the tag-package associated to the receiver"
 
-	^category
+	^ category ifNil: [
+		  (self packageTag isNotNil and: [ self package isNotNil ])
+			  ifFalse: [ nil ]
+			  ifTrue: [
+				  self packageTag = self package
+					  ifTrue: [ self package ]
+					  ifFalse: [ self package , '-' , self packageTag ] ] ]
 ]
 
 { #category : 'accessing' }
@@ -119,6 +126,18 @@ RGTraitDefinition >> package: aRGPackage [
 	"Sets the package in which this trait is contained"
 
 	package:= aRGPackage
+]
+
+{ #category : 'accessing' }
+RGTraitDefinition >> packageTag [
+
+	^ packageTag
+]
+
+{ #category : 'accessing' }
+RGTraitDefinition >> packageTag: anObject [
+
+	packageTag := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/System-Announcements/ClassAnnouncement.class.st
+++ b/src/System-Announcements/ClassAnnouncement.class.st
@@ -40,20 +40,20 @@ ClassAnnouncement >> classAffected [
 ]
 
 { #category : 'accessing' }
-ClassAnnouncement >> classTagAffected [
+ClassAnnouncement >> packageAffected [
+	^self classAffected package
+]
+
+{ #category : 'accessing' }
+ClassAnnouncement >> packageTagAffected [
 
 	^ self classAffected packageTag
 ]
 
 { #category : 'accessing' }
-ClassAnnouncement >> classTagsAffected [
+ClassAnnouncement >> packageTagsAffected [
 
 	^ { self classTagAffected }
-]
-
-{ #category : 'accessing' }
-ClassAnnouncement >> packageAffected [
-	^self classAffected package
 ]
 
 { #category : 'accessing' }

--- a/src/System-Announcements/ClassRemoved.class.st
+++ b/src/System-Announcements/ClassRemoved.class.st
@@ -6,9 +6,8 @@ Class {
 	#name : 'ClassRemoved',
 	#superclass : 'ClassAnnouncement',
 	#instVars : [
-		'categoryName',
 		'classRemoved',
-		'affectedPackage'
+		'packageTag'
 	],
 	#category : 'System-Announcements-System-Classes',
 	#package : 'System-Announcements',
@@ -16,24 +15,13 @@ Class {
 }
 
 { #category : 'instance creation' }
-ClassRemoved class >> class: aClass category: aCategoryName [
-	^self new
-			classRemoved: aClass;
-			categoryName: aCategoryName;
-			yourself
-]
+ClassRemoved class >> class: aClass packageTag: aPackageTag [
 
-{ #category : 'instance creation' }
-ClassRemoved class >> class: aClass package: aPackage category: aCategoryName [
-
-	^ (self class: aClass category: aCategoryName)
-		  affectedPackage: aPackage;
+	self flag: #package. "For now the class cannot return its package tag after been removed. In the future the class should keep a reference to its package tag so we should not need to know the packageTag, we will be able to ask the class directly."
+	^ self new
+		  classRemoved: aClass;
+		  packageTag: aPackageTag;
 		  yourself
-]
-
-{ #category : 'accessing' }
-ClassRemoved >> affectedPackage: aPackage [
-	affectedPackage := aPackage
 ]
 
 { #category : 'testing' }
@@ -56,25 +44,13 @@ ClassRemoved >> affectsMethodsDefinedInClass: aClass [
 { #category : 'testing' }
 ClassRemoved >> affectsMethodsDefinedInPackage: aPackage [
 
-	^affectedPackage == aPackage
+	^ self packageAffected == aPackage
 ]
 
 { #category : 'testing' }
 ClassRemoved >> affectsMethodsInProtocol: protocol [
 
 	^ classRemoved protocolNames includes: protocol
-]
-
-{ #category : 'accessing' }
-ClassRemoved >> categoryName [
-
-	^ categoryName
-]
-
-{ #category : 'accessing' }
-ClassRemoved >> categoryName: anObject [
-
-	categoryName := anObject
 ]
 
 { #category : 'accessing' }
@@ -92,22 +68,29 @@ ClassRemoved >> classRemoved [
 ClassRemoved >> classRemoved: aClass [
 
 	classRemoved := aClass.
-	affectedPackage := aClass package
+	packageTag := aClass packageTag
 ]
 
 { #category : 'accessing' }
 ClassRemoved >> packageAffected [
-	^affectedPackage
+
+	^ self packageTag package
 ]
 
 { #category : 'accessing' }
-ClassRemoved >> packageAffected: aPackage [
+ClassRemoved >> packageTag [
 
-	affectedPackage := aPackage
+	^ packageTag
+]
+
+{ #category : 'accessing' }
+ClassRemoved >> packageTag: anObject [
+
+	packageTag := anObject
 ]
 
 { #category : 'accessing' }
 ClassRemoved >> packageTagAffected [
 
-	^ affectedPackage toTagName: categoryName
+	^ self packageTag
 ]

--- a/src/System-Announcements/ClassRemoved.class.st
+++ b/src/System-Announcements/ClassRemoved.class.st
@@ -96,11 +96,6 @@ ClassRemoved >> classRemoved: aClass [
 ]
 
 { #category : 'accessing' }
-ClassRemoved >> classTagAffected [
-	^affectedPackage toTagName: categoryName
-]
-
-{ #category : 'accessing' }
 ClassRemoved >> packageAffected [
 	^affectedPackage
 ]
@@ -109,4 +104,10 @@ ClassRemoved >> packageAffected [
 ClassRemoved >> packageAffected: aPackage [
 
 	affectedPackage := aPackage
+]
+
+{ #category : 'accessing' }
+ClassRemoved >> packageTagAffected [
+
+	^ affectedPackage toTagName: categoryName
 ]

--- a/src/System-Announcements/ClassRepackaged.class.st
+++ b/src/System-Announcements/ClassRepackaged.class.st
@@ -67,14 +67,6 @@ ClassRepackaged >> classRepackaged: anObject [
 ]
 
 { #category : 'accessing' }
-ClassRepackaged >> classTagsAffected [
-
-	^ {
-		  self newTag.
-		  self oldTag }
-]
-
-{ #category : 'accessing' }
 ClassRepackaged >> newPackage [
 
 	^ self newTag package
@@ -108,6 +100,14 @@ ClassRepackaged >> oldTag [
 ClassRepackaged >> oldTag: anObject [
 
 	oldTag := anObject
+]
+
+{ #category : 'accessing' }
+ClassRepackaged >> packageTagsAffected [
+
+	^ {
+		  self newTag.
+		  self oldTag }
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
This changes bring an update of ClassAnnouncement and especially ClassRemoved to reduce the usage of categories.

Instead we are basing things on package tags.
