### PR TITLE
#BaselineOfIDE recompiles some classes in the postload

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -67,10 +67,6 @@ BaselineOfIDE >> additionalInitialization [
 	
 	RubTextFieldArea defaultFindReplaceServiceClass: SpRubFindReplaceService.
 	RubEditingArea defaultFindReplaceServiceClass: SpRubFindReplaceService.
-
-	ASTTransformExamplePluginActive recompile.
-	PharoCommandLineHandler recompile.
-	SmalltalkImage recompile.
 	
 	RubCharacterScanner initialize.
 	


### PR DESCRIPTION
It is not clear why (there are no comments).

This PR removes the recompile as it seems to be not needed