### PR TITLE
unify-cleanup-empty-protocols 

### DIFF
--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1521,9 +1521,8 @@ SmalltalkImage >> removeClassNamed: aName [
 
 { #category : 'housekeeping' }
 SmalltalkImage >> removeEmptyMessageCategories [
-	"Smalltalk removeEmptyMessageCategories"
-
-	self garbageCollect.
+	<script>
+	
 	SystemNavigation default allBehaviorsDo: [ :class | class removeEmptyProtocols ].
 	self packageOrganizer removeEmptyPackagesAndTags
 ]

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -198,13 +198,9 @@ ImageCleaner >> packagesForCleanUpInProduction [
 
 { #category : 'cleaning' }
 ImageCleaner >> removeEmptyCategories [
-	"Remove empty categories, which are not in MC packages, because MC does
-	not do this (this script does not make packages dirty)"
-
-	self packageOrganizer removeEmptyPackagesAndTags.
-	Smalltalk allClassesAndTraitsDo: [ :class |
-		class removeEmptyProtocols.
-		class class removeEmptyProtocols ]
+	"Remove empty categories"
+	
+	Smalltalk image removeEmptyMessageCategories
 ]
 
 { #category : 'literal sharing' }

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -96,14 +96,12 @@ ImageCleaner >> cleanUpForRelease [
 		allObjectsDo: [ :each |
 			((each respondsTo: #releaseCachedState) and: [ (each isKindOf: RubAbstractTextArea) not ])
 				ifTrue: [ each releaseCachedState ] ].
-
-	self removeEmptyCategories.
-	self packageOrganizer removeEmptyPackagesAndTags.
-
+	
 	Smalltalk
 		garbageCollect;
 		cleanOutUndeclared;
 		fixObsoleteReferences;
+		removeEmptyMessageCategories;
 		cleanUp: true except: #() confirming: false.
 
 	FreeTypeFontProvider current prepareForRelease.
@@ -194,13 +192,6 @@ ImageCleaner >> packagesForCleanUpInProduction [
 	 WARNING, ORDER IS IMPORTANT"
 
 	^#('MonticelloMocks')
-]
-
-{ #category : 'cleaning' }
-ImageCleaner >> removeEmptyCategories [
-	"Remove empty categories"
-	
-	Smalltalk image removeEmptyMessageCategories
 ]
 
 { #category : 'literal sharing' }


### PR DESCRIPTION
- re-use  #removeEmptyMessageCategories from in ImageCleaner
- no need to do gc (as it iterates classes from the global scope)
- add script tag

Doe not yet change the name