### PR TITLE
Simplify ClassAdded

### DIFF
--- a/src/Deprecated12/ClassAdded.extension.st
+++ b/src/Deprecated12/ClassAdded.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'ClassAdded' }
+
+{ #category : '*Deprecated12' }
+ClassAdded >> classCategory [
+
+	self deprecated: 'We should not rely on class categories anymore but asking the class for its #package or #packageTag instead.'.
+	^ self classAffected category
+]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -286,7 +286,7 @@ Class >> category: aString [
 	self basicCategory: aString asSymbol.
 
 	oldCategory = Class unclassifiedCategory
-		ifTrue: [ SystemAnnouncer uniqueInstance classAdded: self inCategory: self category ]
+		ifTrue: [ SystemAnnouncer uniqueInstance announce: (ClassAdded class: self) ]
 		ifFalse: [ SystemAnnouncer uniqueInstance class: self recategorizedFrom: oldCategory to: self category ]
 ]
 

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -30,7 +30,7 @@ RGEnvironmentAnnouncer >> announce: anAnnouncement [
 { #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorAdded: anRGBehavior [
 
-	self announce: (ClassAdded class: anRGBehavior category: nil)
+	self announce: (ClassAdded class: anRGBehavior)
 ]
 
 { #category : 'triggering' }

--- a/src/Ring-Tests-Core/RGAnnouncementsTest.class.st
+++ b/src/Ring-Tests-Core/RGAnnouncementsTest.class.st
@@ -173,10 +173,11 @@ RGAnnouncementsTest >> testBehaviorParentRenamed [
 
 { #category : 'tests' }
 RGAnnouncementsTest >> testDirectAnnouncement [
+
 	| def announcements |
 	def := RGBehavior new.
-	announcements := self installAnnouncementsIn: def when: ClassAdded. 
-	def announce: (ClassAdded class: def category: nil).
+	announcements := self installAnnouncementsIn: def when: ClassAdded.
+	def announce: (ClassAdded class: def).
 
 	self assert: announcements size equals: 1.
 	self assert: announcements first classAffected identicalTo: def

--- a/src/System-Announcements/ClassAdded.class.st
+++ b/src/System-Announcements/ClassAdded.class.st
@@ -1,15 +1,11 @@
 "
-This announcement will be emitted when a class or a trait is added, using:
-	=> Trait >> named: (the notification is done in Trait >> named:uses:category:env:)
-	=> Class >> subclass:
-	
+This announcement will be emitted when a class or a trait is added in the system (when it is installed in a package)
 "
 Class {
 	#name : 'ClassAdded',
 	#superclass : 'ClassAnnouncement',
 	#instVars : [
-		'classAdded',
-		'classCategory'
+		'classAdded'
 	],
 	#category : 'System-Announcements-System-Classes',
 	#package : 'System-Announcements',
@@ -17,11 +13,11 @@ Class {
 }
 
 { #category : 'instance creation' }
-ClassAdded class >> class: aClass category: aClassCategoryName [
-	^self new
-			classAdded: aClass;
-			classCategory: aClassCategoryName;
-			yourself
+ClassAdded class >> class: aClass [
+
+	^ self new
+		  classAdded: aClass;
+		  yourself
 ]
 
 { #category : 'accessing' }
@@ -37,14 +33,4 @@ ClassAdded >> classAdded: aClass [
 { #category : 'accessing' }
 ClassAdded >> classAffected [
 	^self classAdded
-]
-
-{ #category : 'accessing' }
-ClassAdded >> classCategory [
-	^classCategory
-]
-
-{ #category : 'accessing' }
-ClassAdded >> classCategory: aClassCategoryName [
-	classCategory := aClassCategoryName
 ]

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -82,11 +82,6 @@ SystemAnnouncer >> class: aClass recategorizedFrom: oldPackageName to: newPackag
 ]
 
 { #category : 'triggering' }
-SystemAnnouncer >> classAdded: aClass inCategory: aCategoryName [
-	self announce: (ClassAdded class: aClass category: aCategoryName)
-]
-
-{ #category : 'triggering' }
 SystemAnnouncer >> classCommented: aClass [
 	"A class with the given name was commented in the system."
 


### PR DESCRIPTION
A class knows its category already so no need to give it the ClassAdded announcement. On top of that, we should not use categories anymore.