### PR TITLE
Add missing methods to ring for Hermes

### DIFF
--- a/src/Ring-Core/RGVariable.class.st
+++ b/src/Ring-Core/RGVariable.class.st
@@ -55,6 +55,12 @@ RGVariable >> isInstanceVariable [
 ]
 
 { #category : 'testing' }
+RGVariable >> isInvalidVariable [
+
+	^ false
+]
+
+{ #category : 'testing' }
 RGVariable >> isLocalVariable [
 	^false
 ]
@@ -80,6 +86,12 @@ RGVariable >> isSuperVariable [
 { #category : 'testing' }
 RGVariable >> isTempVariable [
 	^false
+]
+
+{ #category : 'testing' }
+RGVariable >> isUndeclaredVariable [
+
+	^ false
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
I'm trying to get Hermes tests to pass and in order to do that RGVariable and subclasses should understand22 some new testing message used in the compiler