### PR TITLE
Deprecate Dictionary #removeUnreferencedKeys 

### DIFF
--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -870,9 +870,11 @@ Dictionary >> removeKey: key ifAbsent: aBlock [
 { #category : 'undeclared' }
 Dictionary >> removeUnreferencedKeys [
 	"This is private code for the Undeclared handling, not a general API."
-	"Undeclared removeUnreferencedKeys"
 
-	^ self unreferencedKeys do: [ :key | self removeKey: key ]
+	self
+		deprecated: 'Use "Smalltalk image cleanOutUndeclared" instead'
+		transformWith: '`@rcv removeUnreferencedKeys' -> 'Smalltalk image cleanOutUndeclared'.
+	Smalltalk image cleanOutUndeclared
 ]
 
 { #category : 'private' }
@@ -929,27 +931,6 @@ Dictionary >> storeOn: aStream [
 			aStream store: each].
 	noneYet ifFalse: [aStream nextPutAll: '; yourself'].
 	aStream nextPut: $)
-]
-
-{ #category : 'undeclared' }
-Dictionary >> unreferencedKeys [
-	"This is private code for the Undeclared handling.
-	Optimize for performance--examine each literal only once.
-	Since we know these are variable bindings, they cannot be
-	optimized selectors nor be elements of Arrays, but we do need
-	to traverse nested blocks."
-
-	| unreferenced |
-	unreferenced := self keys asSet.
-	self systemNavigation allBehaviorsDo: [ :class |
-		class methodsDo: [ :method |
-			method withAllNestedLiteralsDo: [ :lit |
-				(lit isKindOf: UndeclaredVariable) ifTrue: [
-					unreferenced
-						remove: lit key
-						ifAbsent: [ "Sanity check--a binding with more than one reference may already be gone from the unreferenced set, but should be present in Undeclared itself"
-							self at: lit key ] ] ] ] ].
-	^ unreferenced
 ]
 
 { #category : 'private' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -47,9 +47,8 @@ Class {
 
 { #category : 'cleanup' }
 SmalltalkImage class >> cleanUp [
-	"Flush caches"
 
-	Undeclared removeUnreferencedKeys
+	Smalltalk image cleanOutUndeclared
 ]
 
 { #category : 'settings' }
@@ -337,7 +336,18 @@ SmalltalkImage >> classOrTraitNamed: aString [
 
 { #category : 'housekeeping' }
 SmalltalkImage >> cleanOutUndeclared [
-	Undeclared removeUnreferencedKeys
+	| unreferenced |
+	unreferenced := Undeclared keys asSet.
+	self systemNavigation allBehaviorsDo: [ :class |
+		class methodsDo: [ :method |
+			method withAllNestedLiteralsDo: [ :lit |
+				(lit isKindOf: UndeclaredVariable) ifTrue: [
+					unreferenced
+						remove: lit key
+						ifAbsent: [ "Sanity check--a binding with more than one reference may already be gone from the unreferenced set, but should be present in Undeclared itself"
+							self at: lit key ] ] ] ] ].
+
+	unreferenced do: [ :key | Undeclared removeKey: key ]
 ]
 
 { #category : 'cleanup' }

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -340,7 +340,7 @@ SystemNavigation >> browseUndeclaredReferences [
 	SystemNavigation new browseUndeclaredReferences
 	"
 
-	Undeclared removeUnreferencedKeys.
+	Smalltalk image cleanOutUndeclared.
 	Undeclared associations do: [:binding |
 		self
 			browseMessageList: (self allReferencesTo: binding )


### PR DESCRIPTION
- make sure nobody uses #removeUnreferencedKeys
- deprecate it
- move #unreferencedKeys implementation to #cleanOutUndeclared