### PR TITLE
Remove-recompile-Morphic-baseline 

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -275,8 +275,6 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 
 	Stdio stdout nextPutAll: Smalltalk ui asString; lf.
 
-	SparseLargeTable recompile. 
-	
 	PNGReadWriter initialize.
 	self loadBitmapDejaVuSans.
 	self loadBitmapSourcePro.

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -101,8 +101,6 @@ BaselineOfMorphicCore >> postload: loader package: packageSpec [
 	ExternalDropHandler initialize.
 	PasteUpMorph initialize.
 	DefaultExternalDropHandler initialize.
-	
-	WorldMorph recompile.
 
 	Initialized := true.
 ]


### PR DESCRIPTION
we recomile some classes in the Morphic Baselines... not clear why.
Remove so we can see and either remove or document