### PR TITLE
Make pseudo-variables prioritary in name resolution

### DIFF
--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -116,11 +116,14 @@ OCASTSemanticAnalyzer >> outerScope: anObject [
 
 { #category : 'variables' }
 OCASTSemanticAnalyzer >> resolveVariableNode: aVariableNode [
+
 	| var |
-	var := (scope lookupVar: aVariableNode name)
-		ifNil: [ self undeclaredVariable: aVariableNode ].
+	var := (OCPseudoVariableScope new
+		        outerScope: scope;
+		        lookupVar: aVariableNode name) ifNil: [
+		       self undeclaredVariable: aVariableNode ].
 	aVariableNode variable: var.
-	^var
+	^ var
 ]
 
 { #category : 'initialization' }

--- a/src/OpalCompiler-Core/OCPseudoVariableScope.class.st
+++ b/src/OpalCompiler-Core/OCPseudoVariableScope.class.st
@@ -1,0 +1,20 @@
+"
+I model a scope that resolves pharo pseudo-variables such as: `self`, `super` and `thisContext`.
+
+I should by default put at the beginning of the chain when resolving names so these names are resolved with more priority than others.
+"
+Class {
+	#name : 'OCPseudoVariableScope',
+	#superclass : 'OCAbstractScope',
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
+}
+
+{ #category : 'lookup' }
+OCPseudoVariableScope >> lookupVar: name [
+
+	^ PseudoVariable lookupDictionary
+		  at: name asSymbol
+		  ifAbsent: [ super lookupVar: name ]
+]

--- a/src/OpalCompiler-Tests/OCASTVariableTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTVariableTranslatorTest.class.st
@@ -101,6 +101,16 @@ OCASTVariableTranslatorTest >> testPushSelf [
 ]
 
 { #category : 'tests - variables' }
+OCASTVariableTranslatorTest >> testPushSelfRedefined [
+
+	self assert: instance result equals: nil.
+	instance class addClassVarNamed: #self.
+
+	self testExample: #exampleSelf.
+	self assert: instance result equals: instance
+]
+
+{ #category : 'tests - variables' }
 OCASTVariableTranslatorTest >> testPushSuper [
 
 	self assert: instance result equals: nil.

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -267,7 +267,8 @@ SystemDictionary >> hasClassOrTraitNamed: aString [
 { #category : 'accessing - variable lookup' }
 SystemDictionary >> lookupVar: name [
 	"Return a var with this name.  Return nil if none found"
-	^self pseudoVariables at: name ifAbsent: [self bindingOf: name]
+
+	^ self bindingOf: name
 ]
 
 { #category : 'accessing - system attributes' }


### PR DESCRIPTION
Pseudo-variables (self, super, thiscontext...) can be overridden by class variables and class pool variables.

With the following code, `Toto new wat` returns nil instead of the instance of `Toto`.

```smalltalk
Object << #Toto
	slots: {};
	sharedVariables: { #self };
	tag: 'Objects-';
	package: 'Kernel'.

Toto >> wat
 ^ self
```

 with tests