### PR TITLE
Morphic-load-no-rehash 

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -143,10 +143,6 @@ BaselineOfMorphic >> cleanUpAfterMorphicInitialization [
 	ExternalDropHandler resetRegisteredHandlers.
 	ScrollBarMorph initializeImagesCache.
 
-	Smalltalk garbageCollect.
-	HashedCollection rehashAll.
-	Symbol rehash.
-
 	ChangeSet removeChangeSetsNamedSuchThat: [ :each | true ].
 	ChangeSet resetCurrentToNewUnnamedChangeSet.
 	Author reset


### PR DESCRIPTION
Morphic is the onky package that rehashes all sets in the cleanup.

We do that at the end of the load