### PR TITLE
13652-Installing-a-breakpoint-in-the-message-browser-crashes 

### DIFF
--- a/src/Reflectivity/RBProgramNode.extension.st
+++ b/src/Reflectivity/RBProgramNode.extension.st
@@ -157,7 +157,7 @@ RBProgramNode >> link: aMetaLink [
 		add: aMetaLink.
 	aMetaLink installOn: self.
 	self clearReflectivityAnnotations.
-	self methodNode compiledMethod installLink: aMetaLink.
+	(self methodNode methodClass>>self methodNode selector) installLink: aMetaLink.
 	aMetaLink linkInstaller
 		propagateLinkAddition: aMetaLink
 		forNode: self.


### PR DESCRIPTION
make sure to re-lookup the compiledMethod when installing a link, as it can be re-generated from another browser.

(we used to re-compile in this case, while keeping the source pointer the same. Using the one installed method is better...)

fixes #13652