### PR TITLE
Adding debug test setup debug menu entry

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyBrowseCoveringTestCaseCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyBrowseCoveringTestCaseCommand.class.st
@@ -2,22 +2,24 @@
 I am a command that opens a new browser on the test class corresponding to the selected class.
 "
 Class {
-	#name : #ClyBrowseCoveringTestCaseCommand,
-	#superclass : #ClyBrowserCommand,
+	#name : 'ClyBrowseCoveringTestCaseCommand',
+	#superclass : 'ClyBrowserCommand',
 	#instVars : [
 		'selectedClassItem'
 	],
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyBrowseCoveringTestCaseCommand class >> canBeExecutedInContext: aBrowserContext [
 	(super canBeExecutedInContext: aBrowserContext) ifFalse: [ ^false ].
 
 	^ aBrowserContext lastSelectedItem hasProperty: ClyTestedClassProperty
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyBrowseCoveringTestCaseCommand class >> fullBrowserMenuActivation [
 	<classAnnotation>
 	^ CmdContextMenuActivation
@@ -25,12 +27,12 @@ ClyBrowseCoveringTestCaseCommand class >> fullBrowserMenuActivation [
 		for: ClyClass asCalypsoItemContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyBrowseCoveringTestCaseCommand >> defaultMenuItemName [
 	^ 'Browse test class'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyBrowseCoveringTestCaseCommand >> execute [
 	| testCase |
 	testCase := (selectedClassItem getProperty: ClyTestedClassProperty) coveringTestCase.
@@ -39,7 +41,7 @@ ClyBrowseCoveringTestCaseCommand >> execute [
 		b selectClass: testCase]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyBrowseCoveringTestCaseCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyDebugTestSetupCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyDebugTestSetupCommand.class.st
@@ -1,9 +1,9 @@
 "
-I am a command to debug selected test method.
+I am a command that debug the setup method of the selected test, then I executed the selected test method.
 I install breakpoint to the start of method which opens debugger during following test run
 "
 Class {
-	#name : 'ClyDebugTestCommand',
+	#name : 'ClyDebugTestSetupCommand',
 	#superclass : 'ClyRunTestsFromMethodsCommand',
 	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
 	#package : 'Calypso-SystemPlugins-SUnit-Browser',
@@ -11,33 +11,33 @@ Class {
 }
 
 { #category : 'activation' }
-ClyDebugTestCommand class >> fullBrowserShortcutActivation [
+ClyDebugTestSetupCommand class >> fullBrowserShortcutActivation [
 	<classAnnotation>
 
-	^CmdShortcutActivation by: $d meta for: self contextClass
+	^CmdShortcutActivation by: $d shift meta for: self contextClass
 ]
 
 { #category : 'activation' }
-ClyDebugTestCommand class >> fullBrowserTableIconActivation [
+ClyDebugTestSetupCommand class >> fullBrowserTableIconActivation [
 	"It should not be as icon in table"
 ]
 
 { #category : 'execution' }
-ClyDebugTestCommand >> defaultMenuIcon [
+ClyDebugTestSetupCommand >> defaultMenuIcon [
 	^Smalltalk ui iconNamed: #smallDebug
 ]
 
 { #category : 'accessing' }
-ClyDebugTestCommand >> defaultMenuItemName [
-	^'Debug tests'
+ClyDebugTestSetupCommand >> defaultMenuItemName [
+	^'Debug test setup'
 ]
 
 { #category : 'execution' }
-ClyDebugTestCommand >> runTest: testSelector of: testClass [
+ClyDebugTestSetupCommand >> runTest: testSelector of: testClass [
 
 	| breakpoint |
 	breakpoint := Breakpoint new
-		              node: (testClass lookupSelector: testSelector) ast;
+		              node: (testClass lookupSelector: #setUp) ast;
 		              install.
 	[ super runTest: testSelector of: testClass ] ensure: [
 		[ breakpoint remove ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyFailedTestMethodsQuery.extension.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyFailedTestMethodsQuery.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ClyFailedTestMethodsQuery }
+Extension { #name : 'ClyFailedTestMethodsQuery' }
 
-{ #category : #'*Calypso-SystemPlugins-SUnit-Browser' }
+{ #category : '*Calypso-SystemPlugins-SUnit-Browser' }
 ClyFailedTestMethodsQuery >> decorateMethodGroupTableCell: anItemCellMorph of: groupItem [
 	super decorateMethodGroupTableCell: anItemCellMorph of: groupItem.
 

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyInvalidClassForTestClassGeneration.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyInvalidClassForTestClassGeneration.class.st
@@ -5,39 +5,41 @@ Description
 I am an exception raised when we want to generate a test class from an invalid class. (For example if the class is a metaclass)
 "
 Class {
-	#name : #ClyInvalidClassForTestClassGeneration,
-	#superclass : #Error,
+	#name : 'ClyInvalidClassForTestClassGeneration',
+	#superclass : 'Error',
 	#instVars : [
 		'baseClass'
 	],
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Exceptions'
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Exceptions',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Exceptions'
 }
 
-{ #category : #signalling }
+{ #category : 'signalling' }
 ClyInvalidClassForTestClassGeneration class >> signalFor: aClass [
 	^ self new
 		baseClass: aClass;
 		signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyInvalidClassForTestClassGeneration >> baseClass [
 	^ baseClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyInvalidClassForTestClassGeneration >> baseClass: anObject [
 	baseClass := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyInvalidClassForTestClassGeneration >> messageText [
 	"Overwritten to initialiaze the message text to a standard text if it has not yet been set"
 
 	^ messageText ifNil: [ messageText := self standardMessageText ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 ClyInvalidClassForTestClassGeneration >> standardMessageText [
 	^ String streamContents: [ :stream |
 		stream print: self baseClass.

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestClassCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestClassCommand.class.st
@@ -13,42 +13,44 @@ Internal Representation and Key Implementation Points.
 	testClass:		<aClass>		Test class corresponding to the class I was activated with
 "
 Class {
-	#name : #ClyJumpToTestClassCommand,
-	#superclass : #SycSingleClassCommand,
+	#name : 'ClyJumpToTestClassCommand',
+	#superclass : 'SycSingleClassCommand',
 	#traits : 'TClyGenerateTestClass',
 	#classTraits : 'TClyGenerateTestClass classTrait',
 	#instVars : [
 		'browser',
 		'systemEnvironment'
 	],
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyJumpToTestClassCommand class >> fullBrowserMenuActivation [
 	<classAnnotation>
 
 	^ CmdContextMenuActivation byRootGroupItemOrder: 5 for: ClyFullBrowserClassContext
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyJumpToTestClassCommand class >> fullBrowserShortcutActivation [
 	<classAnnotation>
 
 	^ CmdShortcutActivation by: $g meta, $j meta for: ClyFullBrowserClassContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyJumpToTestClassCommand >> defaultMenuIconName [
 	^#jump
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyJumpToTestClassCommand >> defaultMenuItemName [
 	^ 'Jump to test class'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyJumpToTestClassCommand >> execute [
 
 	self systemEnvironment 
@@ -62,14 +64,14 @@ ClyJumpToTestClassCommand >> execute [
 		do: [ :ex | self inform: 'Cannot generate test class for ' , ex baseClass printString , '.' ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyJumpToTestClassCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	browser := aToolContext browser.
 	systemEnvironment := aToolContext systemEnvironment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyJumpToTestClassCommand >> systemEnvironment [
 	^ systemEnvironment
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestMethodCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestMethodCommand.class.st
@@ -15,8 +15,8 @@ Internal Representation and Key Implementation Points.
 
 "
 Class {
-	#name : #ClyJumpToTestMethodCommand,
-	#superclass : #SycMethodCommand,
+	#name : 'ClyJumpToTestMethodCommand',
+	#superclass : 'SycMethodCommand',
 	#traits : 'TClyGenerateTestClass',
 	#classTraits : 'TClyGenerateTestClass classTrait',
 	#instVars : [
@@ -24,39 +24,41 @@ Class {
 		'browser',
 		'systemEnvironment'
 	],
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyJumpToTestMethodCommand class >> canBeExecutedInContext: aBrowserContext [
 	^ aBrowserContext isInstanceSideMethodSelected and: [ aBrowserContext selectedItems anySatisfy: [ :each | (each hasProperty: ClyTestResultProperty) not ] ]
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyJumpToTestMethodCommand class >> methodMenuActivation [
 	<classAnnotation>
 	^ CmdContextMenuActivation byItemOf: ClySUnitMethodMenuGroup order: 10 for: ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyJumpToTestMethodCommand class >> methodShortcutActivation [
 	<classAnnotation>
 	^ CmdShortcutActivation by: $h meta , $j meta for: ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyJumpToTestMethodCommand >> defaultMenuItemName [
 	^ 'Jump to test method'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyJumpToTestMethodCommand >> execute [
 	self methods do: [ :method | self generateTestMethodFor: method ].
 
 	testMethodToBrowse ifNotNil: [ :testMethod | browser selectMethod: testMethod ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyJumpToTestMethodCommand >> generateTestMethodFor: aMethod [
 	[
 	| testClass selector |
@@ -70,7 +72,7 @@ ClyJumpToTestMethodCommand >> generateTestMethodFor: aMethod [
 		do: [ :ex | self inform: 'Impossible to create test class for ' , ex baseClass printString , '.' ]
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 ClyJumpToTestMethodCommand >> generateTestMethodNamed: aSymbol in: aClass [
 	| body |
 	body := '{1}
@@ -80,19 +82,19 @@ ClyJumpToTestMethodCommand >> generateTestMethodNamed: aSymbol in: aClass [
 	aClass compile: body classified: 'tests'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyJumpToTestMethodCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	browser := aToolContext browser.
 	systemEnvironment := aToolContext systemEnvironment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyJumpToTestMethodCommand >> systemEnvironment [
 	^ systemEnvironment
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyJumpToTestMethodCommand >> testMethodNameFor: aMethod [
 	^ aMethod selector asTestSelector
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunAllTestsFromMethodDataSourceCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunAllTestsFromMethodDataSourceCommand.class.st
@@ -2,12 +2,14 @@
 I am a command to run all tests available in given data source
 "
 Class {
-	#name : #ClyRunAllTestsFromMethodDataSourceCommand,
-	#superclass : #ClyRunTestsFromMethodDataSourceCommand,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#name : 'ClyRunAllTestsFromMethodDataSourceCommand',
+	#superclass : 'ClyRunTestsFromMethodDataSourceCommand',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunAllTestsFromMethodDataSourceCommand >> buildTestSuite [
 
 	| suite |
@@ -19,7 +21,7 @@ ClyRunAllTestsFromMethodDataSourceCommand >> buildTestSuite [
 	^suite
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyRunAllTestsFromMethodDataSourceCommand >> defaultMenuItemName [
 	self hasTestResult ifFalse: [ ^'Run all' ].
 

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunCoveringTestMethodsCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunCoveringTestMethodsCommand.class.st
@@ -2,31 +2,33 @@
 I am a command to run all covering tests of selected methods
 "
 Class {
-	#name : #ClyRunCoveringTestMethodsCommand,
-	#superclass : #ClyRunTestsFromMethodsCommand,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#name : 'ClyRunCoveringTestMethodsCommand',
+	#superclass : 'ClyRunTestsFromMethodsCommand',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyRunCoveringTestMethodsCommand class >> canBeExecutedInContext: aToolContext [
 
 	^aToolContext selectedMethodItems anySatisfy: [ :each |
 		each hasProperty: ClyTestedMethodProperty ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunCoveringTestMethodsCommand >> readParametersFromContext: aToolContext [
 	super readParametersFromContext: aToolContext.
 	testItems := aToolContext selectedItems
 		select: [ :each | each hasProperty: ClyTestedMethodProperty ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunCoveringTestMethodsCommand >> testResultOf: methodItem [
 	^(methodItem getProperty: ClyTestedMethodProperty) testResult
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunCoveringTestMethodsCommand >> testSelectorOf: methodItem [
 
 	^(methodItem getProperty: ClyTestedMethodProperty) coveringTest selector

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunFailedTestsFromMethodDataSourceCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunFailedTestsFromMethodDataSourceCommand.class.st
@@ -2,12 +2,14 @@
 I am a command to run all failed tests available in given data source
 "
 Class {
-	#name : #ClyRunFailedTestsFromMethodDataSourceCommand,
-	#superclass : #ClyRunTestsFromMethodDataSourceCommand,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#name : 'ClyRunFailedTestsFromMethodDataSourceCommand',
+	#superclass : 'ClyRunTestsFromMethodDataSourceCommand',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyRunFailedTestsFromMethodDataSourceCommand class >> canBeExecutedInContext: aBrowserContext [
 	| testResult |
 	(super canBeExecutedInContext: aBrowserContext) ifFalse: [ ^false].
@@ -16,12 +18,12 @@ ClyRunFailedTestsFromMethodDataSourceCommand class >> canBeExecutedInContext: aB
 	^testResult hasBrokenTests
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunFailedTestsFromMethodDataSourceCommand class >> menuOrder [
 	^super menuOrder + 1
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunFailedTestsFromMethodDataSourceCommand >> buildTestSuite [
 
 	| suite |
@@ -34,7 +36,7 @@ ClyRunFailedTestsFromMethodDataSourceCommand >> buildTestSuite [
 	^suite
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyRunFailedTestsFromMethodDataSourceCommand >> defaultMenuItemName [
 	self hasTestResult ifFalse: [ ^'Run failed' ].
 

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsForPackageOrClassGroupCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsForPackageOrClassGroupCommand.class.st
@@ -2,22 +2,24 @@
 I provide an abstract class for class group/package 'run tests' commands.
 "
 Class {
-	#name : #ClyRunTestsForPackageOrClassGroupCommand,
-	#superclass : #ClyRunTestsFromSelectedItemsCommand,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#name : 'ClyRunTestsForPackageOrClassGroupCommand',
+	#superclass : 'ClyRunTestsFromSelectedItemsCommand',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsForPackageOrClassGroupCommand >> decorateTableCell: anItemCellMorph using: aCommandActivator [
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsForPackageOrClassGroupCommand >> execute [
 
 	testItems do: [ :each | self runTestsOf: each actualObject ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsForPackageOrClassGroupCommand >> runTestsOf: aClassGroup [
 	| testResult testClasses |
 
@@ -34,6 +36,6 @@ ClyRunTestsForPackageOrClassGroupCommand >> runTestsOf: aClassGroup [
 		with: aClassGroup name
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClyRunTestsForPackageOrClassGroupCommand >> setUpIconForMenuItem: aMenuItemMorph [
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromClassGroupCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromClassGroupCommand.class.st
@@ -2,12 +2,14 @@
 I run all tests from selected classGroup (package tags)
 "
 Class {
-	#name : #ClyRunTestsFromClassGroupCommand,
-	#superclass : #ClyRunTestsForPackageOrClassGroupCommand,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#name : 'ClyRunTestsFromClassGroupCommand',
+	#superclass : 'ClyRunTestsForPackageOrClassGroupCommand',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromClassGroupCommand class >> contextClass [
 	^ ClyClassGroup asCalypsoItemContext
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromClassesCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromClassesCommand.class.st
@@ -2,23 +2,25 @@
 I run all selected test cases
 "
 Class {
-	#name : #ClyRunTestsFromClassesCommand,
-	#superclass : #ClyRunTestsFromSelectedItemsCommand,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#name : 'ClyRunTestsFromClassesCommand',
+	#superclass : 'ClyRunTestsFromSelectedItemsCommand',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromClassesCommand class >> contextClass [
 	^ClyClass asCalypsoItemContext
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromClassesCommand >> execute [
 
 	testItems do: [ :each | self runTestCase: each actualObject]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromClassesCommand >> runTestCase: testCase [
 
 	| testResult |

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromMethodDataSourceCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromMethodDataSourceCommand.class.st
@@ -9,32 +9,34 @@ Internal Representation and Key Implementation Points.
 	methodDataSource:		<ClyDataSource>
 "
 Class {
-	#name : #ClyRunTestsFromMethodDataSourceCommand,
-	#superclass : #ClyTestCommand,
+	#name : 'ClyRunTestsFromMethodDataSourceCommand',
+	#superclass : 'ClyTestCommand',
 	#instVars : [
 		'methodDataSource'
 	],
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyRunTestsFromMethodDataSourceCommand class >> canBeExecutedInContext: aBrowserContext [
 
 	^aBrowserContext browser resultView dataSource hasMetaProperty: ClyTestResultProperty
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyRunTestsFromMethodDataSourceCommand class >> isAbstract [
 	^self = ClyRunTestsFromMethodDataSourceCommand
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromMethodDataSourceCommand class >> menuOrder [
 	<classAnnotationDependency>
 	^10000
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromMethodDataSourceCommand class >> queryBrowserToolbarActivation [
 	<classAnnotation>
 
@@ -42,13 +44,13 @@ ClyRunTestsFromMethodDataSourceCommand class >> queryBrowserToolbarActivation [
 		byItemOf: ClyButtonToolbarGroup order: self menuOrder for: ClyQueryBrowserContext
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodDataSourceCommand >> buildTestSuite [
 
 	self subclassResponsibility
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodDataSourceCommand >> execute [
 	| testSuite result |
 	testSuite := self buildTestSuite.
@@ -62,20 +64,20 @@ ClyRunTestsFromMethodDataSourceCommand >> execute [
 		with: 'Tests complete'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyRunTestsFromMethodDataSourceCommand >> hasTestResult [
 
 	^methodDataSource hasMetaProperty: ClyTestResultProperty
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodDataSourceCommand >> readParametersFromContext: aBrowserContext [
 	super readParametersFromContext: aBrowserContext.
 
 	methodDataSource := aBrowserContext browser resultView dataSource
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodDataSourceCommand >> testMethodsDo: aBlock [
 
 	methodDataSource queryResult rawItemsDo: [ :eachMethod |
@@ -83,7 +85,7 @@ ClyRunTestsFromMethodDataSourceCommand >> testMethodsDo: aBlock [
 			ifTrue: [ aBlock value: eachMethod]]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyRunTestsFromMethodDataSourceCommand >> testResult [
 
 	^methodDataSource getMetaProperty: ClyTestResultProperty

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromMethodsCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromMethodsCommand.class.st
@@ -8,20 +8,22 @@ Internal Representation and Key Implementation Points.
 	runTestCases:		<Collection of<TestCase class>>
 "
 Class {
-	#name : #ClyRunTestsFromMethodsCommand,
-	#superclass : #ClyRunTestsFromSelectedItemsCommand,
+	#name : 'ClyRunTestsFromMethodsCommand',
+	#superclass : 'ClyRunTestsFromSelectedItemsCommand',
 	#instVars : [
 		'runTestCases'
 	],
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromMethodsCommand class >> contextClass [
 	^ClyMethod asCalypsoItemContext
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodsCommand >> defaultMenuIcon [
 
 	| fullResult |
@@ -33,19 +35,19 @@ ClyRunTestsFromMethodsCommand >> defaultMenuIcon [
 	^fullResult createIcon
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodsCommand >> execute [
 	testItems do: [:each | self runTestItem: each ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodsCommand >> readParametersFromContext: aToolContext [
 	super readParametersFromContext: aToolContext.
 
 	runTestCases := aToolContext selectedClasses
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodsCommand >> runTest: testSelector of: testClass [
 
 	| testResult |
@@ -56,7 +58,7 @@ ClyRunTestsFromMethodsCommand >> runTest: testSelector of: testClass [
 		with: 'Method: ' , testClass asString , '>>#' , testSelector asString
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodsCommand >> runTestItem: testItem [
 
 	| testSelector |
@@ -66,7 +68,7 @@ ClyRunTestsFromMethodsCommand >> runTestItem: testItem [
 		self runTest: testSelector of: each ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodsCommand >> targetTestCasesFor: testItem [
 	| fullResult itemTestCases |
 	itemTestCases := IdentitySet new.
@@ -79,7 +81,7 @@ ClyRunTestsFromMethodsCommand >> targetTestCasesFor: testItem [
 	^itemTestCases ifEmpty: [fullResult testCases ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromMethodsCommand >> testSelectorOf: testMethodItem [
 
 	^testMethodItem name asSymbol

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromPackagesCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromPackagesCommand.class.st
@@ -2,17 +2,19 @@
 I run all tests from selected packages
 "
 Class {
-	#name : #ClyRunTestsFromPackagesCommand,
-	#superclass : #ClyRunTestsForPackageOrClassGroupCommand,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#name : 'ClyRunTestsFromPackagesCommand',
+	#superclass : 'ClyRunTestsForPackageOrClassGroupCommand',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromPackagesCommand class >> contextClass [
 	^RPackage asCalypsoItemContext
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromPackagesCommand class >> fullBrowserClassGroupTableIconActivation [
 	<classAnnotation>
 

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromSelectedItemsCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromSelectedItemsCommand.class.st
@@ -9,88 +9,90 @@ Internal Representation and Key Implementation Points.
 	testItems:		<Collection of<ClyDataSourceItem>>
 "
 Class {
-	#name : #ClyRunTestsFromSelectedItemsCommand,
-	#superclass : #ClyTestCommand,
+	#name : 'ClyRunTestsFromSelectedItemsCommand',
+	#superclass : 'ClyTestCommand',
 	#instVars : [
 		'testItems'
 	],
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyRunTestsFromSelectedItemsCommand class >> canBeExecutedInContext: aToolContext [
 
 	^aToolContext selectedItems	anySatisfy: [ :each |
 			each hasProperty: ClyTestResultProperty ]
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromSelectedItemsCommand class >> contextClass [
 	self subclassResponsibility
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromSelectedItemsCommand class >> fullBrowserMenuActivation [
 	<classAnnotation>
 
 	^CmdContextMenuActivation byRootGroupItemFor: self contextClass
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromSelectedItemsCommand class >> fullBrowserShortcutActivation [
 	<classAnnotation>
 
 	^CmdShortcutActivation by: $t meta for: self contextClass
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyRunTestsFromSelectedItemsCommand class >> fullBrowserTableIconActivation [
 	<classAnnotation>
 
 	^ClyTableIconCommandActivation priority: 1000 for: self contextClass
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyRunTestsFromSelectedItemsCommand class >> isAbstract [
 	^self = ClyRunTestsFromSelectedItemsCommand
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyRunTestsFromSelectedItemsCommand >> defaultMenuItemName [
 	^'Run tests'
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromSelectedItemsCommand >> readParametersFromContext: aToolContext [
 	super readParametersFromContext: aToolContext.
 	testItems := aToolContext selectedItems
 		select: [ :each | each hasProperty: ClyTestResultProperty ]
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyRunTestsFromSelectedItemsCommand >> runTestCase: testCase results: testResult [
 
 	testCase resetHistory.
 	testCase suite run: testResult
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyRunTestsFromSelectedItemsCommand >> testItems [
 	^ testItems
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyRunTestsFromSelectedItemsCommand >> testItems: anObject [
 	testItems := anObject
 ]
 
-{ #category : #'context menu support' }
+{ #category : 'context menu support' }
 ClyRunTestsFromSelectedItemsCommand >> testResult [
 
 	^self testResultOf: testItems first
 ]
 
-{ #category : #'context menu support' }
+{ #category : 'context menu support' }
 ClyRunTestsFromSelectedItemsCommand >> testResultOf: anItem [
 
 	^anItem getProperty: ClyTestResultProperty

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClySUnitMethodMenuGroup.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClySUnitMethodMenuGroup.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #ClySUnitMethodMenuGroup,
-	#superclass : #CmdMenuGroup,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-MenuGroups'
+	#name : 'ClySUnitMethodMenuGroup',
+	#superclass : 'CmdMenuGroup',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-MenuGroups',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'MenuGroups'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClySUnitMethodMenuGroup >> isInlined [
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClySUnitMethodMenuGroup >> name [
 	^ 'SUnit'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClySUnitMethodMenuGroup >> order [
 	^ 1.5
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestCommand.class.st
@@ -2,17 +2,19 @@
 I am a root of hierarchy of commands to run any kind of tests
 "
 Class {
-	#name : #ClyTestCommand,
-	#superclass : #CmdCommand,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Commands'
+	#name : 'ClyTestCommand',
+	#superclass : 'CmdCommand',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyTestCommand class >> isAbstract [
 	^self = ClyTestCommand
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyTestCommand >> applyResultInContext: aToolContext [
 	super applyResultInContext: aToolContext.
 	"Following code forces browser update to not wait for deferred updating logic
@@ -22,13 +24,13 @@ ClyTestCommand >> applyResultInContext: aToolContext [
 	aToolContext activeQueryView dataSource runUpdate
 ]
 
-{ #category : #'context menu support' }
+{ #category : 'context menu support' }
 ClyTestCommand >> defaultMenuIcon [
 
 	^self testResult createIcon
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 ClyTestCommand >> notifyUserAboutResults: testResult with: message [
 
 	| color |
@@ -47,7 +49,7 @@ ClyTestCommand >> notifyUserAboutResults: testResult with: message [
 		labelColor: Color black
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ClyTestCommand >> testResult [
 	self subclassResponsibility
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorToolMorph.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorToolMorph.class.st
@@ -8,15 +8,17 @@ Internal Representation and Key Implementation Points.
 	testClass:		<TestCase>
 "
 Class {
-	#name : #ClyTestSetUpEditorToolMorph,
-	#superclass : #ClyMethodCodeEditorToolMorph,
+	#name : 'ClyTestSetUpEditorToolMorph',
+	#superclass : 'ClyMethodCodeEditorToolMorph',
 	#instVars : [
 		'testClass'
 	],
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Tools'
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Tools',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Tools'
 }
 
-{ #category : #activation }
+{ #category : 'activation' }
 ClyTestSetUpEditorToolMorph class >> browserTabActivation [
 	"This declaration specifies that in any browser when classes are selected, a test setup editor will be available in a tab."
 
@@ -24,7 +26,7 @@ ClyTestSetUpEditorToolMorph class >> browserTabActivation [
 	^ ClyTabActivationStrategyAnnotation for: ClyClass asCalypsoItemContext
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyTestSetUpEditorToolMorph class >> shouldBeActivatedInContext: aBrowserContext [
 	aBrowserContext isClassSelected ifFalse: [ ^false ].
 
@@ -36,22 +38,22 @@ ClyTestSetUpEditorToolMorph class >> shouldBeActivatedInContext: aBrowserContext
 	^aBrowserContext browser methodSelection lastSelectedItem name ~= 'setUp'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyTestSetUpEditorToolMorph class >> tabOrder [
 	^ ClyClassDefinitionEditorToolMorph tabOrder + 1
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyTestSetUpEditorToolMorph >> activationPriority [
 	^-100
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyTestSetUpEditorToolMorph >> belongsToCurrentBrowserContext [
 	^browser isClassSelected: testClass
 ]
 
-{ #category : #building }
+{ #category : 'building' }
 ClyTestSetUpEditorToolMorph >> buildTextMorph [
 	super buildTextMorph.
 
@@ -59,7 +61,7 @@ ClyTestSetUpEditorToolMorph >> buildTextMorph [
 		self setUpDefaultTemplate ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClyTestSetUpEditorToolMorph >> defaultTemplateForNewSetUp [
 
 	^'setUp
@@ -68,18 +70,18 @@ ClyTestSetUpEditorToolMorph >> defaultTemplateForNewSetUp [
 	"Put here a common initialization logic for tests"'
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClyTestSetUpEditorToolMorph >> defaultTitle [
 	^'setUp'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyTestSetUpEditorToolMorph >> isSimilarTo: anotherBrowserTool [
 	^self class = anotherBrowserTool class
 		and: [ testClass == anotherBrowserTool testClass ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 ClyTestSetUpEditorToolMorph >> isValidInContext: aClyFullBrowserContext [
 	self context class = aClyFullBrowserContext class
 		ifFalse: [ ^ false ].
@@ -87,34 +89,34 @@ ClyTestSetUpEditorToolMorph >> isValidInContext: aClyFullBrowserContext [
 	^ aClyFullBrowserContext selectedClasses includes: self testClass
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClyTestSetUpEditorToolMorph >> setUpDefaultTemplate [
 
 	textModel setInitialText: self defaultTemplateForNewSetUp.
 	targetClasses := { testClass }
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClyTestSetUpEditorToolMorph >> setUpModelFromContext [
 
 	testClass := context lastSelectedClass
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 ClyTestSetUpEditorToolMorph >> setUpParametersFromModel [
 
 	editingMethod := testClass lookupSelector: #setUp.
 	super setUpParametersFromModel
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 ClyTestSetUpEditorToolMorph >> switchToMethod: aMethod [
 
 	browser selectMethod: aMethod.
 	self removeFromBrowser
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 ClyTestSetUpEditorToolMorph >> testClass [
 	^ testClass
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ManifestCalypsoSystemPluginsSUnitBrowser.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ManifestCalypsoSystemPluginsSUnitBrowser.class.st
@@ -6,12 +6,14 @@ I add tools and commands to Calypso related to SUnit.
 For example I add commands to run tests or commands to generate and jump to tests.
 "
 Class {
-	#name : #ManifestCalypsoSystemPluginsSUnitBrowser,
-	#superclass : #PackageManifest,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Manifest'
+	#name : 'ManifestCalypsoSystemPluginsSUnitBrowser',
+	#superclass : 'PackageManifest',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Manifest',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Manifest'
 }
 
-{ #category : #'code-critics' }
+{ #category : 'code-critics' }
 ManifestCalypsoSystemPluginsSUnitBrowser class >> ruleRBTempsReadBeforeWrittenRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#TClyGenerateTestClass #testClassFor: #false)) #'2018-11-12T15:00:23.227476+01:00') )
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/TClyGenerateTestClass.trait.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/TClyGenerateTestClass.trait.st
@@ -7,11 +7,13 @@ I am a trait containing the behavior or retrieving the test class of a class.
 If the test class does not exists I am able to generate it.
 "
 Trait {
-	#name : #TClyGenerateTestClass,
-	#category : #'Calypso-SystemPlugins-SUnit-Browser-Traits'
+	#name : 'TClyGenerateTestClass',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Traits',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Traits'
 }
 
-{ #category : #action }
+{ #category : 'action' }
 TClyGenerateTestClass >> addNewCommentForTestClass: aClass basedOn: baseClass [
 	aClass
 		comment:
@@ -28,12 +30,12 @@ TClyGenerateTestClass >> addNewCommentForTestClass: aClass basedOn: baseClass [
 						nextPutAll: baseClass name ])
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TClyGenerateTestClass >> isValidClass: inputClass [
 	^ (inputClass isTestCase or: [ inputClass isMeta ]) not
 ]
 
-{ #category : #action }
+{ #category : 'action' }
 TClyGenerateTestClass >> newTestClassCategoryFor: aClass [
 
 	| tag |
@@ -48,12 +50,12 @@ TClyGenerateTestClass >> newTestClassCategoryFor: aClass [
 				  nextPutAll: tag name ] ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TClyGenerateTestClass >> systemEnvironment [
 	^ self explicitRequirement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TClyGenerateTestClass >> testClassFor: inputClass [
 
 	| className resultClass |
@@ -76,7 +78,7 @@ TClyGenerateTestClass >> testClassFor: inputClass [
 	^ resultClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TClyGenerateTestClass >> testClassNameFor: inputClass [
 	^ (inputClass name , 'Test') asSymbol
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/package.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Calypso-SystemPlugins-SUnit-Browser' }
+Package { #name : 'Calypso-SystemPlugins-SUnit-Browser' }


### PR DESCRIPTION
I force myself to do small improvements every friday, so: fixes #14867

Looks like that:
![Capture d’écran 2023-10-13 à 15 20 38](https://github.com/pharo-project/pharo/assets/26929529/084aceeb-341e-45eb-9c6e-61cd9ca22fa4)

It actually just moves the breakpoint up into the setup method, and then executes the selected test.

I could make the code better, but I prefer to wait for feedback.

