### PR TITLE
Fix Jenkins file uploading stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,9 +158,9 @@ def bootstrapImage(architectures){
           if( isDevelopmentBranch() ) {
             stage("Upload to files.pharo.org-${architecture}") {
               dir("build/bootstrap-cache") {
-                  shell "BUILD_NUMBER=${env.BUILD_ID} bash ../bootstrap/scripts/prepare_for_upload.sh ${architecture}"
+                  shell "BUILD_NUMBER=${env.BUILD_ID} bash ../../bootstrap/scripts/prepare_for_upload.sh ${architecture}"
                 sshagent (credentials: ['b5248b59-a193-4457-8459-e28e9eb29ed7']) {
-                  shell "bash ../bootstrap/scripts/upload_to_files.pharo.org.sh"
+                  shell "bash ../../bootstrap/scripts/upload_to_files.pharo.org.sh"
                 }
               }
             }


### PR DESCRIPTION
This pull request tries to fix the Jenkins stage ‘Upload to files.pharo.org-64’ which is broken (see [build 900 of the ‘Pharo12’ job](https://ci.inria.fr/pharo-ci-jenkins2/blue/organizations/jenkins/Test%20pending%20pull%20request%20and%20branch%20Pipeline/detail/Pharo12/900/pipeline/31/)).