### PR TITLE
RPackage: Remove users of ClassRecatogrized

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -287,7 +287,7 @@ Class >> category: aString [
 
 	oldCategory = Class unclassifiedCategory
 		ifTrue: [ SystemAnnouncer uniqueInstance announce: (ClassAdded class: self) ]
-		ifFalse: [ SystemAnnouncer uniqueInstance class: self recategorizedFrom: oldCategory to: self category ]
+		ifFalse: [ SystemAnnouncer uniqueInstance announce: (ClassRecategorized class: self recategorizedFrom: oldCategory to: self category) ]
 ]
 
 { #category : 'subclass creation - variableByte' }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -145,8 +145,8 @@ RPackageTag >> privateAddClass: aClass [
 	classes add: aClass.
 	self organizer registerPackage: self package forClass: aClass.
 
-	self flag: #package. "Next line should first use #basicCategory: to not start a ping pong then be totally removed once we will not need the category"
-	aClass category: self categoryName
+	self flag: #package. "Next line should be removed once we will not need the category"
+	aClass basicCategory: self categoryName
 ]
 
 { #category : 'converting' }

--- a/src/RPackage-Tests/PackageAnnouncementsTest.class.st
+++ b/src/RPackage-Tests/PackageAnnouncementsTest.class.st
@@ -23,16 +23,18 @@ PackageAnnouncementsTest >> tearDown [
 ]
 
 { #category : 'tests' }
-PackageAnnouncementsTest >> testAddClassAnnounceClassRecategorized [
+PackageAnnouncementsTest >> testAddClassAnnounceClassRepackaged [
 
 	| xPackage yPackage class |
-	self flag: #package. "This announcement should be removed in the future."
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 
 	class := self newClassNamed: #NewClass in: xPackage.
 
-	self when: ClassRecategorized do: [ :ann | self assert: ann classRecategorized name equals: #NewClass ].
+	self when: ClassRepackaged do: [ :ann |
+		self assert: ann classRepackaged name equals: #NewClass.
+		self assert: ann newPackage identicalTo: yPackage.
+		self assert: ann oldPackage identicalTo: xPackage ].
 
 	yPackage addClass: class.
 

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -69,15 +69,6 @@ RGEnvironmentAnnouncer >> behaviorParentRenamed: anRGBehavior from: oldName [
 ]
 
 { #category : 'triggering' }
-RGEnvironmentAnnouncer >> behaviorRecategorized: anRGBehavior [
-
-	self announce: (ClassRecategorized
-		class: anRGBehavior
-		recategorizedFrom: nil
-		to: anRGBehavior category)
-]
-
-{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorRemoved: anRGBehavior [
 
 	self announce: (ClassRemoved class: anRGBehavior packageTag: anRGBehavior packageTag)

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -76,12 +76,6 @@ SystemAnnouncer >> class: aClass oldComment: oldComment newComment: newComment o
 ]
 
 { #category : 'triggering' }
-SystemAnnouncer >> class: aClass recategorizedFrom: oldPackageName to: newPackageName [
-
-	self announce: (ClassRecategorized class: aClass recategorizedFrom: oldPackageName to: newPackageName)
-]
-
-{ #category : 'triggering' }
 SystemAnnouncer >> classCommented: aClass [
 	"A class with the given name was commented in the system."
 


### PR DESCRIPTION
ClassRecategorized should not be used anymore. Instead we should use ClassRepackaged. 

This change remove the last users of the announcement except RPackageOrganizer. To remove this one it will be trickier