### PR TITLE
Refactor ImageMorph to support more than one Form depicting the same image at different scales

### DIFF
--- a/src/Athens-Morphic/CheckboxButtonMorph.extension.st
+++ b/src/Athens-Morphic/CheckboxButtonMorph.extension.st
@@ -9,12 +9,12 @@ CheckboxButtonMorph >> drawOnAthensCanvas: anAthensCanvas [
 	anAthensCanvas drawShape: self bounds.
 	anAthensCanvas setPaint: self borderStyle.
 	anAthensCanvas drawShape: self bounds.
-	img := self imageToUse.
+	img := self formSetToUse ifNotNil: [ :formSetToUse | formSetToUse asForm ].
 	img
 		ifNotNil: [
 			anAthensCanvas setPaint: img.
 			anAthensCanvas drawShape: (self innerBounds center - (img extent // 2) extent: img extent) ].
-	((self state == #pressed or: [ self state == #repressed ]) and: [ image isNil ])
+	((self state == #pressed or: [ self state == #repressed ]) and: [ formSet isNil ])
 		ifTrue: [
 			anAthensCanvas setPaint: (self paneColor alpha: 0.3).
 			anAthensCanvas drawShape: self innerBounds ].

--- a/src/Athens-Morphic/ImageMorph.extension.st
+++ b/src/Athens-Morphic/ImageMorph.extension.st
@@ -5,8 +5,8 @@ ImageMorph >> drawOnAthensCanvas: aCanvas [
 
 	| cached style|
 
-	cached := aCanvas cacheAt: image ifAbsentPut: [
-		image asAthensPaintOn: aCanvas.
+	cached := aCanvas cacheAt: formSet ifAbsentPut: [
+		formSet asForm asAthensPaintOn: aCanvas.
 		].
 
 	aCanvas setPaint: cached.

--- a/src/Athens-Morphic/ThreePhaseButtonMorph.extension.st
+++ b/src/Athens-Morphic/ThreePhaseButtonMorph.extension.st
@@ -3,12 +3,12 @@ Extension { #name : 'ThreePhaseButtonMorph' }
 { #category : '*Athens-Morphic' }
 ThreePhaseButtonMorph >> drawOnAthensCanvas: anAthensCanvas [
 	| paint |
-	paint := offImage.
+	paint := self offImage.
 
 	state == #pressed
-		ifTrue: [ paint := pressedImage ].
+		ifTrue: [ paint := self pressedImage ].
 	state == #on
-		ifTrue: [ paint := image ].
+		ifTrue: [ paint := self onImage ].
 	paint ifNil: [ ^ self ].
 
 	anAthensCanvas setPaint: paint.

--- a/src/Graphics-Canvas/Canvas.class.st
+++ b/src/Graphics-Canvas/Canvas.class.st
@@ -79,6 +79,12 @@ Canvas >> draw: anObject [
 ]
 
 { #category : 'drawing - images' }
+Canvas >> drawFormSet: formSet at: point [
+
+	^ self drawImage: formSet asForm at: point
+]
+
+{ #category : 'drawing - images' }
 Canvas >> drawImage: aForm at: aPoint [
 	"Draw the given Form, which is assumed to be a Form or ColorForm"
 
@@ -711,6 +717,12 @@ Canvas >> translateTo: newOrigin clippingTo: aRectangle during: aBlock [
 	self translateBy: newOrigin - self origin
 		clippingTo: (aRectangle translateBy: self origin negated)
 		during: aBlock
+]
+
+{ #category : 'drawing - images' }
+Canvas >> translucentFormSet: formSet at: point [
+
+	^ self translucentImage: formSet asForm at: point
 ]
 
 { #category : 'drawing - images' }

--- a/src/Graphics-Display Objects/Cursor.class.st
+++ b/src/Graphics-Display Objects/Cursor.class.st
@@ -1030,6 +1030,17 @@ Cursor >> printOn: aStream [
 ]
 
 { #category : 'primitives' }
+Cursor >> scaledToExactSize: newExtent [
+
+	"We need to override, so we can scale also the offset."
+
+	| newOne |
+	newOne := super scaledToExactSize: newExtent.
+	newOne offset: offset * (newExtent / self extent).
+	^ newOne
+]
+
+{ #category : 'primitives' }
 Cursor >> scaledToSize: newExtent [
 
 	"We need to override, so we can scale also the offset."

--- a/src/Graphics-Display Objects/Form.class.st
+++ b/src/Graphics-Display Objects/Form.class.st
@@ -2075,6 +2075,16 @@ f display
 ]
 
 { #category : 'scaling, rotation' }
+Form >> scaledToExactSize: newExtent [
+
+	| scale |
+
+	newExtent = self extent ifTrue: [^self].
+	scale := newExtent / self extent.
+	^self magnifyBy: scale smoothing: 2
+]
+
+{ #category : 'scaling, rotation' }
 Form >> scaledToSize: newExtent [
 
 	| scale |

--- a/src/Graphics-Display Objects/FormSet.class.st
+++ b/src/Graphics-Display Objects/FormSet.class.st
@@ -1,0 +1,80 @@
+"
+A class for representing images for which there can be more than one Form depicting the same image at different scales.
+"
+Class {
+	#name : 'FormSet',
+	#superclass : 'Object',
+	#instVars : [
+		'extent',
+		'depth',
+		'forms'
+	],
+	#category : 'Graphics-Display Objects-Forms',
+	#package : 'Graphics-Display Objects',
+	#tag : 'Forms'
+}
+
+{ #category : 'instance creation' }
+FormSet class >> extent: extent depth: depth forms: forms [
+
+	^ self basicNew initializeWithExtent: extent depth: depth forms: forms
+]
+
+{ #category : 'instance creation' }
+FormSet class >> form: form [
+
+	^ self forms: { form }
+]
+
+{ #category : 'instance creation' }
+FormSet class >> forms: forms [
+
+	^ self extent: forms first extent depth: forms first depth forms: forms
+]
+
+{ #category : 'converting' }
+FormSet >> asForm [
+
+	^ self asFormAtScale: 1
+]
+
+{ #category : 'converting' }
+FormSet >> asFormAtScale: scale [
+
+	^ self asFormWithExtent: extent * scale
+]
+
+{ #category : 'converting' }
+FormSet >> asFormWithExtent: formExtent [
+
+	^ (forms detect: [ :form | form extent = formExtent ]
+		ifFound: [ :form | form asFormOfDepth: depth ]
+		ifNone: [ (forms first asFormOfDepth: depth) scaledToExactSize: formExtent ])
+]
+
+{ #category : 'accessing' }
+FormSet >> depth [
+
+	^ depth
+]
+
+{ #category : 'accessing' }
+FormSet >> extent [
+
+	^ extent
+]
+
+{ #category : 'accessing' }
+FormSet >> forms [
+
+	^ forms
+]
+
+{ #category : 'initialization' }
+FormSet >> initializeWithExtent: initialExtent depth: initialDepth forms: initialForms [
+
+	self initialize.
+	extent := initialExtent.
+	depth := initialDepth.
+	forms := initialForms.
+]

--- a/src/Graphics-Display Objects/FormSet.class.st
+++ b/src/Graphics-Display Objects/FormSet.class.st
@@ -1,5 +1,7 @@
 "
-A class for representing images for which there can be more than one Form depicting the same image at different scales.
+A class for representing images for which there can be more than one Form depicting the same image at different scales. A FormSet is created through #extent:depth:forms: with a given extent and depth and a SequenceableCollection containing at least one Form. There’s a convenience instance creation method #forms: that takes only the collection, the extent and depth are taken from the collection’s first Form. The convenience instance creation method #form: takes a single Form and uses the extent and depth of that Form.
+
+A FormSet can be converted to a Form with a given extent through #asFormWithExtent: which either returns an element from the FormSet’s forms or converts one of them to the FormSet’s extent and depth. The convenience method #asForm uses the FormSet’s own extent, while the convenience method #asFormAtScale: uses the FormSet’s extent scaled by the given scale.
 "
 Class {
 	#name : 'FormSet',

--- a/src/Graphics-Display Objects/FormSet.class.st
+++ b/src/Graphics-Display Objects/FormSet.class.st
@@ -70,6 +70,12 @@ FormSet >> forms [
 	^ forms
 ]
 
+{ #category : 'file in/out' }
+FormSet >> hibernate [
+
+	forms do: [ :form | form hibernate ]
+]
+
 { #category : 'initialization' }
 FormSet >> initializeWithExtent: initialExtent depth: initialDepth forms: initialForms [
 
@@ -77,4 +83,10 @@ FormSet >> initializeWithExtent: initialExtent depth: initialDepth forms: initia
 	extent := initialExtent.
 	depth := initialDepth.
 	forms := initialForms.
+]
+
+{ #category : 'copying' }
+FormSet >> veryDeepCopyWith: deepCopier [
+	"Return self.  I am immutable in the Morphic world.  Do not record me."
+	^ self
 ]

--- a/src/Graphics-Tests/FormSetTest.class.st
+++ b/src/Graphics-Tests/FormSetTest.class.st
@@ -1,0 +1,234 @@
+"
+SUnit tests for class FormSet
+"
+Class {
+	#name : 'FormSetTest',
+	#superclass : 'ClassTestCase',
+	#category : 'Graphics-Tests-Primitives',
+	#package : 'Graphics-Tests',
+	#tag : 'Primitives'
+}
+
+{ #category : 'asserting' }
+FormSetTest >> assert: form isFilledWith: color [
+
+	self assert:
+		((0 to: form width - 1) allSatisfy: [ :x |
+			(0 to: form height - 1) allSatisfy: [ :y |
+				(form colorAt: x @ y) = color ] ])
+]
+
+{ #category : 'coverage' }
+FormSetTest >> classToBeTested [
+
+	^ FormSet
+]
+
+{ #category : 'tests - converting' }
+FormSetTest >> testAsForm [
+
+	| form1 form2 formSet result |
+
+	(form1 := Form extent: 1@2 depth: 32)
+		fillColor: Color red translucent.
+	(form2 := Form extent: 2@4 depth: 32)
+		fillColor: Color red translucent.
+
+	formSet := FormSet form: form1.
+	self assert: formSet asForm identicalTo: form1.
+
+	formSet := FormSet forms: { form1. form2 }.
+	self assert: formSet asForm identicalTo: form1.
+
+	formSet := FormSet forms: { form2. form1 }.
+	self assert: formSet asForm identicalTo: form2.
+
+	formSet := FormSet extent: 2@4 depth: 32 forms: { form1. form2 }.
+	self assert: formSet asForm identicalTo: form2.
+
+	formSet := FormSet extent: 3@6 depth: 32 forms: { form1. form2 }.
+	result := formSet asForm.
+	self assert: result extent equals: 3@6.
+	self assert: result depth equals: 32.
+	self assert: result isFilledWith: Color red translucent.
+
+	formSet := FormSet extent: 2@4 depth: 8 forms: { form1. form2 }.
+	result := formSet asForm.
+	self assert: result extent equals: 2@4.
+	self assert: result depth equals: 8.
+	self assert: result isFilledWith: Color red.
+]
+
+{ #category : 'tests - converting' }
+FormSetTest >> testAsFormAtScale [
+
+	| form1 form2 form3 formSet result |
+
+	(form1 := Form extent: 1@2 depth: 32)
+		fillColor: Color green translucent.
+	(form2 := Form extent: 2@4 depth: 32)
+		fillColor: Color green translucent.
+	(form3 := Form extent: 4@8 depth: 32)
+		fillColor: Color green translucent.	
+
+	formSet := FormSet form: form1.
+	self assert: (formSet asFormAtScale: 1) identicalTo: form1.
+
+	formSet := FormSet forms: { form1. form2. form3 }.
+	self assert: (formSet asFormAtScale: 1) identicalTo: form1.
+	self assert: (formSet asFormAtScale: 2) identicalTo: form2.
+	self assert: (formSet asFormAtScale: 4) identicalTo: form3.
+
+	formSet := FormSet forms: { form2. form1. form3 }.
+	self assert: (formSet asFormAtScale: 1) identicalTo: form2.
+	self assert: (formSet asFormAtScale: 2) identicalTo: form3.
+
+	formSet := FormSet extent: 2@4 depth: 32 forms: { form1. form2. form3 }.
+	self assert: (formSet asFormAtScale: 1) identicalTo: form2.
+	self assert: (formSet asFormAtScale: 2) identicalTo: form3.
+
+	formSet := FormSet extent: 3@6 depth: 32 forms: { form1. form2. form3 }.
+	result := formSet asFormAtScale: 1.
+	self assert: result extent equals: 3@6.
+	self assert: result depth equals: 32.
+	self assert: result isFilledWith: Color green translucent.
+
+	formSet := FormSet extent: 1@2 depth: 8 forms: { form1. form2. form3 }.
+	result := formSet asFormAtScale: 1.
+	self assert: result extent equals: 1@2.
+	self assert: result depth equals: 8.
+	self assert: result isFilledWith: Color green.
+	result := formSet asFormAtScale: 2.
+	self assert: result extent equals: 2@4.
+	self assert: result depth equals: 8.
+	self assert: result isFilledWith: Color green.
+]
+
+{ #category : 'tests - converting' }
+FormSetTest >> testAsFormWithExtent [
+
+	| form1 form2 form3 formSet result |
+
+	(form1 := Form extent: 1@2 depth: 32)
+		fillColor: Color blue translucent.
+	(form2 := Form extent: 2@4 depth: 32)
+		fillColor: Color blue translucent.
+	(form3 := Form extent: 4@8 depth: 32)
+		fillColor: Color blue translucent.
+
+	formSet := FormSet form: form1.
+	self assert: (formSet asFormWithExtent: 1@2) identicalTo: form1.
+	result := formSet asFormWithExtent: 2@4.
+	self assert: result extent equals: 2@4.
+	self assert: result depth equals: 32.
+	self assert: result isFilledWith: Color blue translucent.
+
+	formSet := FormSet forms: { form2. form1. form3 }.
+	self assert: (formSet asFormWithExtent: 1@2) identicalTo: form1.
+	self assert: (formSet asFormWithExtent: 2@4) identicalTo: form2.
+	self assert: (formSet asFormWithExtent: 4@8) identicalTo: form3.
+	result := formSet asFormWithExtent: 3@6.
+	self assert: result extent equals: 3@6.
+	self assert: result depth equals: 32.
+	self assert: result isFilledWith: Color blue translucent.
+
+	formSet := FormSet extent: 2@4 depth: 32 forms: { form3. form2. form1 }.
+	self assert: (formSet asFormWithExtent: 1@2) identicalTo: form1.
+	self assert: (formSet asFormWithExtent: 2@4) identicalTo: form2.
+	self assert: (formSet asFormWithExtent: 4@8) identicalTo: form3.
+	result := formSet asFormWithExtent: 3@6.
+	self assert: result extent equals: 3@6.
+	self assert: result depth equals: 32.
+	self assert: result isFilledWith: Color blue translucent.
+	result := formSet asFormWithExtent: 4@5.
+	self assert: result extent equals: 4@5.
+	self assert: result depth equals: 32.
+	self assert: result isFilledWith: Color blue translucent.
+
+	formSet := FormSet extent: 1@2 depth: 8 forms: { form1. form2. form3 }.
+	result := formSet asFormWithExtent: 1@2.
+	self assert: result extent equals: 1@2.
+	self assert: result depth equals: 8.
+	self assert: result isFilledWith: Color blue.
+]
+
+{ #category : 'tests - accessing' }
+FormSetTest >> testDepth [
+
+	| form1 form2 formSet |
+
+	form1 := Form extent: 1@2 depth: 32.
+	form2 := Form extent: 2@4 depth: 8.
+
+	formSet := FormSet form: form1.
+	self assert: formSet depth equals: 32.
+
+	formSet := FormSet form: form2.
+	self assert: formSet depth equals: 8.
+
+	formSet := FormSet forms: { form1. form2 }.
+	self assert: formSet depth equals: 32.
+
+	formSet := FormSet forms: { form2. form1 }.
+	self assert: formSet depth equals: 8.
+
+	formSet := FormSet extent: 1@2 depth: 32 forms: { form1. form2 }.
+	self assert: formSet depth equals: 32.
+
+	formSet := FormSet extent: 2@4 depth: 16 forms: { form2. form1 }.
+	self assert: formSet depth equals: 16.
+]
+
+{ #category : 'tests - accessing' }
+FormSetTest >> testExtent [
+
+	| form1 form2 formSet |
+
+	form1 := Form extent: 1@2 depth: 32.
+	form2 := Form extent: 2@4 depth: 8.
+
+	formSet := FormSet form: form1.
+	self assert: formSet extent equals: 1@2.
+
+	formSet := FormSet form: form2.
+	self assert: formSet extent equals: 2@4.
+
+	formSet := FormSet forms: { form1. form2 }.
+	self assert: formSet extent equals: 1@2.
+
+	formSet := FormSet forms: { form2. form1 }.
+	self assert: formSet extent equals: 2@4.
+
+	formSet := FormSet extent: 1@2 depth: 32 forms: { form1. form2 }.
+	self assert: formSet extent equals: 1@2.
+
+	formSet := FormSet extent: 3@4 depth: 32 forms: { form2. form1 }.
+	self assert: formSet extent equals: 3@4.
+]
+
+{ #category : 'tests - accessing' }
+FormSetTest >> testForms [
+
+	| form1 form2 formSet |
+
+	form1 := Form extent: 1@2 depth: 32.
+	form2 := Form extent: 2@4 depth: 8.
+
+	formSet := FormSet form: form1.
+	self assert: formSet forms equals: { form1 }.
+
+	formSet := FormSet form: form2.
+	self assert: formSet forms equals: { form2 }.
+
+	formSet := FormSet forms: { form1. form2 }.
+	self assert: formSet forms equals: { form1. form2 }.
+
+	formSet := FormSet forms: { form2. form1 }.
+	self assert: formSet forms equals: { form2. form1 }.
+
+	formSet := FormSet extent: 2@4 depth: 8 forms: { form1. form2 }.
+	self assert: formSet forms equals: { form1. form2 }.
+
+	formSet := FormSet extent: 3@6 depth: 1 forms: { form2. form1 }.
+	self assert: formSet forms equals: { form2. form1 }.
+]

--- a/src/Morphic-Base/AlphaImageMorph.class.st
+++ b/src/Morphic-Base/AlphaImageMorph.class.st
@@ -189,7 +189,7 @@ AlphaImageMorph >> image: aForm size: aPoint [
 	f := f scaledToSize: aPoint.
 	self autoSize
 		ifTrue: [super image: f]
-		ifFalse: [image := f.
+		ifFalse: [formSet := FormSet form: f.
 				self changed].
 	self cachedForm: nil.
 	self changed: #imageExtent

--- a/src/Morphic-Base/ImageMorph.class.st
+++ b/src/Morphic-Base/ImageMorph.class.st
@@ -5,7 +5,7 @@ Use #image: to set my picture.
 
 Structure:
  instance var		Type 		Description
- image				Form		The Form to use when drawing
+ formSet			FormSet	The FormSet to use when drawing
 
 Code examples:
 	ImageMorph new openInWorld; grabFromScreen
@@ -21,7 +21,7 @@ Class {
 	#traits : 'TAbleToRotate',
 	#classTraits : 'TAbleToRotate classTrait',
 	#instVars : [
-		'image'
+		'formSet'
 	],
 	#classVars : [
 		'DefaultForm'
@@ -73,7 +73,13 @@ ImageMorph class >> initialize [
 { #category : 'instance creation' }
 ImageMorph class >> withForm: aForm [
 
-	^ self new form: aForm ; yourself
+	^ self withFormSet: (FormSet form: aForm)
+]
+
+{ #category : 'instance creation' }
+ImageMorph class >> withFormSet: aFormSet [
+
+	^ self new formSet: aFormSet; yourself
 ]
 
 { #category : 'menus' }
@@ -113,7 +119,7 @@ ImageMorph >> borderStyle: newStyle [
 
 	| newExtent |
 	self borderStyle = newStyle ifTrue: [^self].
-	newExtent := 2 * newStyle width + image extent.
+	newExtent := 2 * newStyle width + formSet extent.
 	bounds extent = newExtent ifFalse: [super extent: newExtent].
 	super borderStyle: newStyle
 ]
@@ -122,7 +128,7 @@ ImageMorph >> borderStyle: newStyle [
 ImageMorph >> borderWidth: bw [
 
 	| newExtent |
-	newExtent := 2 * bw + image extent.
+	newExtent := 2 * bw + formSet extent.
 	bounds extent = newExtent ifFalse: [super extent: newExtent].
 	super borderWidth: bw
 ]
@@ -138,11 +144,13 @@ ImageMorph >> color: aColor [
 	Change to a ColorForm here if depth 1."
 
 	super color: aColor.
-    (image depth = 1 and: [aColor isColor]) ifTrue: [
-		image isColorForm ifFalse: [
-			image := ColorForm mappingWhiteToTransparentFrom: image].
-			image colors: {Color transparent. aColor}.
-			self changed]
+	(formSet depth = 1 and: [aColor isColor]) ifTrue: [
+		formSet := FormSet extent: formSet extent depth: formSet depth
+			forms: (formSet forms collect: [ :form |
+				| colorForm |
+				colorForm := form isColorForm ifTrue: [ form ] ifFalse: [ ColorForm mappingWhiteToTransparentFrom: (form asFormOfDepth: 1) ].
+				colorForm colors: {Color transparent. aColor} ]) ].
+	self changed
 ]
 
 { #category : 'initialization' }
@@ -158,8 +166,8 @@ ImageMorph >> drawOn: aCanvas [
 
 	| style |
 	self isOpaque
-		ifTrue: [aCanvas drawImage: image at: self innerBounds origin]
-		ifFalse: [aCanvas translucentImage: image at: self innerBounds origin].
+		ifTrue: [aCanvas drawFormSet: formSet at: self innerBounds origin]
+		ifFalse: [aCanvas translucentFormSet: formSet at: self innerBounds origin].
 	(style := self borderStyle) ifNotNil: [style frameRectangle: bounds on: aCanvas]
 ]
 
@@ -172,13 +180,26 @@ ImageMorph >> extent: aPoint [
 
 { #category : 'accessing' }
 ImageMorph >> form [
-	^ image
+	^ formSet asForm
 ]
 
 { #category : 'accessing' }
 ImageMorph >> form: aForm [
-	image := aForm.
-	super extent: (2 * self borderWidth) asPoint + image extent.
+
+	self formSet: (FormSet form: aForm)
+]
+
+{ #category : 'accessing' }
+ImageMorph >> formSet [
+
+	^ formSet
+]
+
+{ #category : 'accessing' }
+ImageMorph >> formSet: aFormSet [
+
+	formSet := aFormSet.
+	super extent: (2 * self borderWidth) asPoint + formSet extent.
 	self changed
 ]
 
@@ -191,9 +212,7 @@ ImageMorph >> grabFromScreen [
 { #category : 'accessing' }
 ImageMorph >> image: anImage [
 
-	image := anImage.
-	super extent: (2 * self borderWidth) asPoint + image extent.
-	self changed
+	self form: anImage
 ]
 
 { #category : 'other' }
@@ -247,13 +266,17 @@ ImageMorph >> readFromFile [
 ImageMorph >> releaseCachedState [
 
 	super releaseCachedState.
-	image hibernate
+	formSet hibernate
 ]
 
 { #category : 'other' }
 ImageMorph >> resize: newSize [
 
-	self form: (image scaledToSize: newSize)
+	| newExtent |
+
+	newExtent := (newSize / formSet extent) min * formSet extent truncated.
+	self formSet: (FormSet extent: newExtent depth: formSet depth
+		forms: (formSet forms collect: [ :form | form scaledToSize: (form extent * (newExtent / formSet extent)) ]))
 ]
 
 { #category : 'testing' }
@@ -263,7 +286,7 @@ ImageMorph >> shouldFlex [
 
 { #category : 'testing' }
 ImageMorph >> wantsRecolorHandle [
-	^ image notNil and: [image depth = 1]
+	^ formSet notNil and: [formSet depth = 1]
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Widgets-Basic/CheckboxButtonMorph.class.st
+++ b/src/Morphic-Widgets-Basic/CheckboxButtonMorph.class.st
@@ -7,10 +7,10 @@ Class {
 	#traits : 'TEnableOnHaloMenu',
 	#classTraits : 'TEnableOnHaloMenu classTrait',
 	#instVars : [
-		'repressedImage',
+		'repressedFormSet',
 		'enabled',
 		'isRadioButton',
-		'images'
+		'formSets'
 	],
 	#category : 'Morphic-Widgets-Basic-Buttons',
 	#package : 'Morphic-Widgets-Basic',
@@ -79,7 +79,7 @@ CheckboxButtonMorph >> borderStyle: newStyle [
 	| newExtent |
 	self borderStyle = newStyle ifTrue: [^self].
 	super borderStyle: newStyle.
-	newExtent := 2 * newStyle width + image extent min asPoint.
+	newExtent := 2 * newStyle width + formSet extent min asPoint.
 	bounds extent = newExtent ifFalse: [self extent: newExtent]
 ]
 
@@ -98,7 +98,7 @@ CheckboxButtonMorph >> borderWidth: bw [
 
 	| newExtent |
 	super borderWidth: bw.
-	newExtent := 2 * bw + image extent min asPoint.
+	newExtent := 2 * bw + formSet extent min asPoint.
 	bounds extent = newExtent ifFalse: [super extent: newExtent]
 ]
 
@@ -148,12 +148,12 @@ CheckboxButtonMorph >> drawOn: aCanvas [
 
 	|img|
 	aCanvas fillRectangle: self bounds fillStyle: self fillStyle borderStyle: self borderStyle.
-	img := self imageToUse.
+	img := self formSetToUse.
 	img ifNotNil: [
 		aCanvas
-			translucentImage: img
+			translucentFormSet: img
 			at: self innerBounds center - (img extent // 2)].
-	((self state == #pressed or: [self state == #repressed]) and: [image isNil]) ifTrue: [
+	((self state == #pressed or: [self state == #repressed]) and: [formSet isNil]) ifTrue: [
 		aCanvas fillRectangle: self innerBounds fillStyle: (self paneColor alpha: 0.3)].
 	(self enabled not and: [self theme fadeCheckboxWhenDisabled]) ifTrue: [
 		aCanvas fillRectangle: self innerBounds fillStyle: (self paneColor alpha: 0.4)]
@@ -195,39 +195,41 @@ CheckboxButtonMorph >> fillStyleToUse [
 ]
 
 { #category : 'accessing' }
-CheckboxButtonMorph >> image: anImage [
+CheckboxButtonMorph >> formSet: aFormSet [
 	"Fixed to take account of border width. Use narrowest
 	dimanesion of image to allow a little flexibility."
 
-	image := anImage depth = 1
-				ifTrue: [ColorForm mappingWhiteToTransparentFrom: anImage]
-				ifFalse: [anImage].
-	self extent: 2 * self borderWidth + image extent min asPoint.
+	formSet := aFormSet depth = 1
+		ifTrue: [
+			FormSet extent: aFormSet extent depth: aFormSet depth forms: (aFormSet forms collect: [ :form |
+				ColorForm mappingWhiteToTransparentFrom: (form asFormOfDepth: 1) ]) ]
+		ifFalse: [ aFormSet ].
+	self extent: 2 * self borderWidth + formSet extent min asPoint.
 	self changed
 ]
 
 { #category : 'private' }
-CheckboxButtonMorph >> imageFromName: aSymbol [
-	^ self images
+CheckboxButtonMorph >> formSetFromName: aSymbol [
+	^ self formSets
 		at: aSymbol
 		ifPresent: [:block | block value]
 		ifAbsent: []
 ]
 
 { #category : 'private' }
-CheckboxButtonMorph >> imageToUse [
+CheckboxButtonMorph >> formSetToUse [
 	"Answer the image we should use."
 
-	^ self imageFromName: state
+	^ self formSetFromName: state
 ]
 
 { #category : 'accessing' }
-CheckboxButtonMorph >> images [
-	^ images ifNil: [images := Dictionary newFromPairs: {
-								#off . [self offImage] .
-								#pressed . [self pressedImage] .
-								#on . [self onImage] .
-								#repressed . [self repressedImage ifNil: [self onImage]] }]
+CheckboxButtonMorph >> formSets [
+	^ formSets ifNil: [formSets := Dictionary newFromPairs: {
+								#off . [self offFormSet] .
+								#pressed . [self pressedFormSet] .
+								#on . [self onFormSet] .
+								#repressed . [self repressedFormSet ifNil: [self onFormSet]] }]
 ]
 
 { #category : 'initialization' }
@@ -331,19 +333,30 @@ CheckboxButtonMorph >> radioFillStyleToUse [
 ]
 
 { #category : 'accessing' }
-CheckboxButtonMorph >> repressedImage [
-	"Answer the value of repressedImage"
+CheckboxButtonMorph >> repressedFormSet [
 
-	^ repressedImage
+	^ repressedFormSet
 ]
 
 { #category : 'accessing' }
-CheckboxButtonMorph >> repressedImage: anObject [
-	"Set the value of repressedImage. This is shown when
+CheckboxButtonMorph >> repressedFormSet: aFormSet [
+	"Set the value of repressedFormSet. This is shown when
 	pressed after being off."
 
-	repressedImage := anObject.
+	repressedFormSet := aFormSet.
 	self invalidRect: self bounds
+]
+
+{ #category : 'accessing' }
+CheckboxButtonMorph >> repressedImage [
+
+	^ repressedFormSet ifNotNil: [ repressedFormSet asForm ]
+]
+
+{ #category : 'accessing' }
+CheckboxButtonMorph >> repressedImage: aForm [
+
+	self repressedFormSet: (aForm ifNotNil: [ FormSet form: aForm ])
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Widgets-Basic/ThreePhaseButtonMorph.class.st
+++ b/src/Morphic-Widgets-Basic/ThreePhaseButtonMorph.class.st
@@ -17,8 +17,8 @@ Class {
 	#name : 'ThreePhaseButtonMorph',
 	#superclass : 'ImageMorph',
 	#instVars : [
-		'offImage',
-		'pressedImage',
+		'offFormSet',
+		'pressedFormSet',
 		'state',
 		'target',
 		'actionSelector',
@@ -122,11 +122,11 @@ ThreePhaseButtonMorph >> doButtonAction: evt [
 ThreePhaseButtonMorph >> drawOn: aCanvas [
 
 	state == #off ifTrue: [
-		offImage ifNotNil: [aCanvas translucentImage: offImage at: bounds origin]].
+		offFormSet ifNotNil: [aCanvas translucentFormSet: offFormSet at: bounds origin]].
 	state == #pressed ifTrue: [
-		pressedImage ifNotNil: [aCanvas translucentImage: pressedImage at: bounds origin]].
+		pressedFormSet ifNotNil: [aCanvas translucentFormSet: pressedFormSet at: bounds origin]].
 	state == #on ifTrue: [
-		image ifNotNil: [aCanvas translucentImage: image at: bounds origin]]
+		formSet ifNotNil: [aCanvas translucentFormSet: formSet at: bounds origin]]
 ]
 
 { #category : 'geometry' }
@@ -225,19 +225,45 @@ ThreePhaseButtonMorph >> mouseUp: evt [
 ]
 
 { #category : 'accessing' }
-ThreePhaseButtonMorph >> offImage [
-	^ offImage
+ThreePhaseButtonMorph >> offFormSet [
+
+	^ offFormSet
 ]
 
 { #category : 'accessing' }
-ThreePhaseButtonMorph >> offImage: aForm [
-	offImage := aForm.
+ThreePhaseButtonMorph >> offFormSet: aFormSet [
+
+	offFormSet := aFormSet.
 	self invalidRect: self bounds
 ]
 
 { #category : 'accessing' }
+ThreePhaseButtonMorph >> offImage [
+
+	^ offFormSet ifNotNil: [ offFormSet asForm ]
+]
+
+{ #category : 'accessing' }
+ThreePhaseButtonMorph >> offImage: aForm [
+
+	self offFormSet: (aForm ifNotNil: [ FormSet form: aForm ])
+]
+
+{ #category : 'accessing' }
+ThreePhaseButtonMorph >> onFormSet [
+
+	^ formSet
+]
+
+{ #category : 'accessing' }
+ThreePhaseButtonMorph >> onFormSet: aFormSet [
+
+	self formSet: aFormSet
+]
+
+{ #category : 'accessing' }
 ThreePhaseButtonMorph >> onImage [
-	^ image
+	^ formSet asForm
 ]
 
 { #category : 'button' }
@@ -249,14 +275,28 @@ ThreePhaseButtonMorph >> onImage: aForm [
 ]
 
 { #category : 'accessing' }
+ThreePhaseButtonMorph >> pressedFormSet [
+
+	^ pressedFormSet
+]
+
+{ #category : 'accessing' }
+ThreePhaseButtonMorph >> pressedFormSet: aFormSet [
+
+	pressedFormSet := aFormSet.
+	self invalidRect: self bounds
+]
+
+{ #category : 'accessing' }
 ThreePhaseButtonMorph >> pressedImage [
-	^ pressedImage
+
+	^ pressedFormSet ifNotNil: [ pressedFormSet asForm ]
 ]
 
 { #category : 'accessing' }
 ThreePhaseButtonMorph >> pressedImage: aForm [
-	pressedImage := aForm.
-	self invalidRect: self bounds
+
+	self pressedFormSet: (aForm ifNotNil: [ FormSet form: aForm ])
 ]
 
 { #category : 'printing' }
@@ -330,8 +370,8 @@ ThreePhaseButtonMorph >> veryDeepInner: deepCopier [
 	"Copy all of my instance variables.  Some need to be not copied at all, but shared.  	Warning!!  Every instance variable defined in this class must be handled.  We must also implement veryDeepFixupWith:.  See DeepCopier class comment."
 
 super veryDeepInner: deepCopier.
-offImage := offImage veryDeepCopyWith: deepCopier.
-pressedImage := pressedImage veryDeepCopyWith: deepCopier.
+offFormSet := offFormSet veryDeepCopyWith: deepCopier.
+pressedFormSet := pressedFormSet veryDeepCopyWith: deepCopier.
 state := state veryDeepCopyWith: deepCopier.
 "target := target.		Weakly copied"
 "actionSelector := actionSelector.		Symbol"

--- a/src/Morphic-Widgets-Scrolling/ScrollBarMorph.class.st
+++ b/src/Morphic-Widgets-Scrolling/ScrollBarMorph.class.st
@@ -31,8 +31,8 @@ Class {
 
 { #category : 'images' }
 ScrollBarMorph class >> arrowOfDirection: aSymbol size: finalSizeInteger color: aColor [
-	"answer a form with an arrow based on the parameters"
-	^ ArrowImagesCache at: {aSymbol. finalSizeInteger. aColor}
+
+	^ (self formSetArrowOfDirection: aSymbol size: finalSizeInteger color: aColor) asForm
 ]
 
 { #category : 'images - samples' }
@@ -118,6 +118,12 @@ ScrollBarMorph class >> cleanUp [
 	"Re-initialize the image cache"
 
 	self initializeImagesCache
+]
+
+{ #category : 'images' }
+ScrollBarMorph class >> formSetArrowOfDirection: aSymbol size: finalSizeInteger color: aColor [
+	"answer a FormSet with an arrow based on the parameters"
+	^ ArrowImagesCache at: {aSymbol. finalSizeInteger. aColor}
 ]
 
 { #category : 'class initialization' }
@@ -234,9 +240,9 @@ ScrollBarMorph >> doScrollUp [
 
 { #category : 'initialize' }
 ScrollBarMorph >> downImage [
-	"answer a form to be used in the down button"
+	"answer a FormSet to be used in the down button"
 	^ self class
-		arrowOfDirection: (bounds isWide
+		formSetArrowOfDirection: (bounds isWide
 				ifTrue: [#right]
 				ifFalse: [#bottom])
 		size: (self buttonExtent x min: self buttonExtent y)
@@ -1013,9 +1019,9 @@ ScrollBarMorph >> totalSliderArea [
 
 { #category : 'initialize' }
 ScrollBarMorph >> upImage [
-	"answer a form to be used in the up button"
+	"answer a FormSet to be used in the up button"
 	^ self class
-		arrowOfDirection: (bounds isWide
+		formSetArrowOfDirection: (bounds isWide
 				ifTrue: [#left]
 				ifFalse: [#top])
 		size: (self buttonExtent x min: self buttonExtent y)
@@ -1034,7 +1040,7 @@ ScrollBarMorph >> updateDownButtonImage [
 	"update the receiver's downButton.  put a new image inside"
 	downButton removeAllMorphs.
 	downButton
-		addMorphCentered: (ImageMorph new form: self downImage)
+		addMorphCentered: (ImageMorph new formSet: self downImage)
 ]
 
 { #category : 'update' }
@@ -1067,7 +1073,7 @@ ScrollBarMorph >> updateUpButtonImage [
 "update the receiver's upButton. put a new image inside"
 	upButton removeAllMorphs.
 	upButton
-		addMorphCentered: (ImageMorph new form: self upImage)
+		addMorphCentered: (ImageMorph new formSet: self upImage)
 ]
 
 { #category : 'scroll timing' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -1105,10 +1105,16 @@ UITheme >> createArrowImagesCache [
 	^ LRUCache new
 		maximumWeight: 40;
 		factory: [ :key |
-			self
-				scrollbarArrowOfDirection: key first
+			| form1 form2 |
+			form1 := self scrollbarArrowOfDirection: key first
 				size: key second
-				color: key third ];
+				color: key third.
+			form2 := self scrollbarArrowOfDirection: key first
+				size: key second * 2
+				color: key third.
+			FormSet forms: {
+				form1.
+				form2 scaledToExactSize: form1 extent * 2 } ];
 		yourself
 ]
 


### PR DESCRIPTION
This pull request:

* Introduces a class FormSet for representing images for which there can be more than one Form depicting the same image at different scales
* Adds methods to Canvas for drawing a FormSet
* Refactors the ImageMorph hierarchy to replace instance variables that hold a Form by ones that hold a FormSet instead
* Makes ScrollBarMorph use FormSet for the arrows on the buttons at scale 1 and 2

The distinction between FormSet and Form is akin to that between [NSImage](https://developer.apple.com/documentation/appkit/nsimage?language=objc) and [NSImageRep](https://developer.apple.com/documentation/appkit/nsimagerep?language=objc) in macOS’s AppKit. A similar concept is that of an [`<img>` element with a ‘srcset’ attribute in HTML](https://webkit.org/blog/2910/improved-support-for-high-resolution-displays-with-the-srcset-image-attribute/).

I initially used ‘Image’ as the name for the class but found that that got confusing as ‘image’ is already used in many selectors and variable names as a synonym for ‘form’. Once FormSet is used more and ‘image’ becomes more of a synonym for ‘form set’, the class could still be renamed to ‘Image’ as well.

The handling of the ‘none’ case in `FormSet>>#asFormWithExtent:` could be improved by scaling the Form that most closely matches the given extent rather than just the first Form, and the result should perhaps be cached, but there’s no need for either of that at the moment.

Note that loading these changes into an existing Pharo image probably requires using headless mode.
