### PR TITLE
Slots: Do not update class while building it

### DIFF
--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -67,6 +67,13 @@ Slot >> acceptVisitor: aProgramNodeVisitor node: aNode [
 	^ aProgramNodeVisitor visitInstanceVariableNode: aNode
 ]
 
+{ #category : 'private' }
+Slot >> addAdditionalSlotsTo: slots [
+	"Some slots internal behavior are relying one other slots. This method should add them in order to build the class with them."
+
+	^ #(  )
+]
+
 { #category : 'class building' }
 Slot >> asClassVariable [
 	self

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -264,7 +264,7 @@ ShiftClassBuilder >> createClass [
 		configureClass: newClass
 		superclass: self superclass
 		withLayoutType: self layoutClass
-		slots: self layoutDefinition slots.
+		slots: (self withAdditionalSlots: self slots).
 
 	newClass environment: self installingEnvironment.
 
@@ -273,13 +273,14 @@ ShiftClassBuilder >> createClass [
 
 { #category : 'building' }
 ShiftClassBuilder >> createMetaclass [
+
 	newMetaclass := self builderEnhancer newMetaclass: self.
 
 	self builderEnhancer
 		configureMetaclass: newMetaclass
 		superclass: self metaSuperclass
 		withLayoutType: FixedLayout
-		slots: self classSlots.
+		slots: (self withAdditionalSlots: self classSlots).
 
 	self builderEnhancer metaclassCreated: self
 ]
@@ -709,4 +710,16 @@ ShiftClassBuilder >> validateSuperclass [
 	self superclass withAllSuperclassesDo: [ :aSuperclass |
 		aSuperclass = oldClass ifTrue:[
 			CircularHierarchyError signalFor: oldClass ]]
+]
+
+{ #category : 'private' }
+ShiftClassBuilder >> withAdditionalSlots: aSlotCollection [
+	"Some slots are relying on additional slots for internal behavior. This method adds them to the list of slots of the class."
+
+	| slots |
+	slots := aSlotCollection asOrderedCollection.
+
+	aSlotCollection do: [ :slot | slot addAdditionalSlotsTo: slots ].
+
+	^ slots asArray
 ]

--- a/src/Slot-Examples/BooleanSlot.class.st
+++ b/src/Slot-Examples/BooleanSlot.class.st
@@ -14,6 +14,18 @@ Class {
 	#tag : 'Base'
 }
 
+{ #category : 'private' }
+BooleanSlot >> addAdditionalSlotsTo: slots [
+	"we reuse a baseSlot if it is already there, if not, we add it"
+
+	"TODO: this does not take into account adding BooleanSlots higher up in the Hierarchy"
+
+	slots
+		detect: [ :slot | slot name = #_booleanBaseSlot ]
+		ifFound: [ :slot | baseSlot := slot ]
+		ifNone: [ slots add: (baseSlot := #_booleanBaseSlot => BaseSlot default: 0) ]
+]
+
 { #category : 'accessing' }
 BooleanSlot >> baseSlotRead: anObject [
 	^ (baseSlot read: anObject) ifNil: [ 0 ]
@@ -49,15 +61,9 @@ BooleanSlot >> emitValue: methodBuilder [
 
 { #category : 'class building' }
 BooleanSlot >> installingIn: aClass [
+
 	| booleanSlots |
 	super installingIn: aClass.
-
-	"we reuse a baseSlot if it is already there, if not, we add it"
-	"TODO: this does not take into account adding BooleanSlots higher up in the Hierarchy"
-	aClass classLayout
-		resolveSlot: #'_booleanBaseSlot'
-		ifFound:  [: slot |  baseSlot := slot ]
-		ifNone: [aClass addSlot: (baseSlot := #'_booleanBaseSlot' => BaseSlot default: 0)].
 
 	"my offset in the base slot is defined by the order of all BooleanSlots in the Hierarchy"
 	booleanSlots := aClass allSlots select: [ :each | each isKindOf: self class ].

--- a/src/Slot-Examples/PropertySlot.class.st
+++ b/src/Slot-Examples/PropertySlot.class.st
@@ -13,6 +13,18 @@ Class {
 	#tag : 'Base'
 }
 
+{ #category : 'private' }
+PropertySlot >> addAdditionalSlotsTo: slots [
+	"we reuse a baseSlot if it is already there, if not, we add it"
+
+	"TODO: this does not take into account adding BooleanSlots higher up in the Hierarchy"
+
+	slots
+		detect: [ :slot | slots anySatisfy: [ :aSlot | aSlot name = #_propertyBaseSlot ] ]
+		ifFound: [ :slot | baseSlot := slot ]
+		ifNone: [ slots add: (baseSlot := #_propertyBaseSlot => BaseSlot default: Dictionary new) ]
+]
+
 { #category : 'code generation' }
 PropertySlot >> emitStore: methodBuilder [
 	"generate bytecode for 'baseSlot at: 1 put: <stackTop>'"
@@ -36,18 +48,6 @@ PropertySlot >> emitValue: methodBuilder [
 		pushLiteral: self name;
 		pushLiteral: nil;
 		send: #at:ifAbsent:
-]
-
-{ #category : 'class building' }
-PropertySlot >> installingIn: aClass [
-	super installingIn: aClass.
-
-	"we reuse a baselot if it is already there, if not, we add it"
-	"TODO: this does not take into account adding PropertySlot higher up in the Hierarchy"
-	aClass classLayout
-		resolveSlot: #'_propertyBaseSlot'
-		ifFound:  [: slot |  baseSlot := slot ]
-		ifNone: [aClass addSlot: (baseSlot := #'_propertyBaseSlot' => BaseSlot default: Dictionary new)]
 ]
 
 { #category : 'meta-object-protocol' }

--- a/src/Slot-Examples/PropertySlot.class.st
+++ b/src/Slot-Examples/PropertySlot.class.st
@@ -20,7 +20,7 @@ PropertySlot >> addAdditionalSlotsTo: slots [
 	"TODO: this does not take into account adding BooleanSlots higher up in the Hierarchy"
 
 	slots
-		detect: [ :slot | slots anySatisfy: [ :aSlot | aSlot name = #_propertyBaseSlot ] ]
+		detect: [ :slot | slot name = #_propertyBaseSlot ]
 		ifFound: [ :slot | baseSlot := slot ]
 		ifNone: [ slots add: (baseSlot := #_propertyBaseSlot => BaseSlot default: Dictionary new) ]
 ]

--- a/src/Slot-Examples/UnlimitedInstanceVariableSlot.class.st
+++ b/src/Slot-Examples/UnlimitedInstanceVariableSlot.class.st
@@ -12,6 +12,18 @@ Class {
 	#tag : 'Base'
 }
 
+{ #category : 'private' }
+UnlimitedInstanceVariableSlot >> addAdditionalSlotsTo: slots [
+	"we reuse a baseSlot if it is already there, if not, we add it"
+
+	"TODO: this does not take into account adding BooleanSlots higher up in the Hierarchy"
+
+	slots
+		detect: [ :slot | slot name = #_ivarArrayBaseSlot ]
+		ifFound: [ :slot | baseSlot := slot. self growBaseSlot ]
+		ifNone: [ slots add: (baseSlot := #_ivarArrayBaseSlot => BaseSlot default: (Array new: 1)) ]
+]
+
 { #category : 'code generation' }
 UnlimitedInstanceVariableSlot >> emitStore: methodBuilder [
 	"generate bytecode for 'baseSlot at: index put: <stackTop>'"
@@ -37,21 +49,15 @@ UnlimitedInstanceVariableSlot >> emitValue: methodBuilder [
 ]
 
 { #category : 'class building' }
-UnlimitedInstanceVariableSlot >> growBaseSlot: aClass [
+UnlimitedInstanceVariableSlot >> growBaseSlot [
 	baseSlot default: (baseSlot default grownBy: 1)
 ]
 
 { #category : 'class building' }
 UnlimitedInstanceVariableSlot >> installingIn: aClass [
+
 	| unlimitedSlots |
 	super installingIn: aClass.
-
-	"we reuse a baseSlot if it is already there, if not, we add it"
-	"TODO: this does not take into account adding BooleanSlots higher up in the Hierarchy"
-	aClass classLayout
-		resolveSlot: #'_ivarArrayBaseSlot'
-		ifFound:  [: slot |  baseSlot := slot. self growBaseSlot: aClass. ]
-		ifNone: [aClass addSlot: (baseSlot := #'_ivarArrayBaseSlot' => BaseSlot default: (Array new: 1))].
 
 	"my offset in the base slot is defined by the order of all BooleanSlots in the Hierarchy"
 	unlimitedSlots := aClass allSlots select: [ :each | each isKindOf: self class ].


### PR DESCRIPTION
#addSlot: updates a class and launch a building process. So we should avoid to use it during a building process or it will cause troubles. The trouble arise because it will update a class that does not have the full infos for #fillFor: and that is not installed in the system. This is the origin of #14958

This PR updates the way to create slots that depends on other hidden slots to not update the class while creating it but just adding the hidden slots alongside the visible ones.

Fixes #14958