### PR TITLE
Enhance roassal with version v1.04b #14985

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -142,7 +142,7 @@ BaselineOfIDE >> baseline: spec [
 		self beautifulComments: spec.
 		self documentBrowserCore: spec.
 		self welcomeBrowser: spec.
-		self roassal3: spec.
+		self roassal: spec.
 
 		spec baseline: 'ThreadedFFI' with: [ spec repository: repository ].
 		spec baseline: 'ProfilerUI' with: [ spec repository: repository ].
@@ -224,7 +224,7 @@ BaselineOfIDE >> loadIceberg [
 	self registerPharo.
 	self registerProject: 'Spec2' baseline: 'Spec2' otherBaselines: #('SpecCore').
 	self registerProject: 'NewTools'.
-	self registerProject: 'Roassal3'.
+	self registerProject: 'Roassal'.
 	self registerProject: 'Microdown'.
 	self registerProject: 'BeautifulComments'.
 	self registerProject: 'DocumentBrowser' baseline: 'NewToolsDocumentBrowser' otherBaselines: #().
@@ -401,13 +401,13 @@ BaselineOfIDE >> registerProject: projectName externalProject: externalProject b
 ]
 
 { #category : 'baselines' }
-BaselineOfIDE >> roassal3: spec [
+BaselineOfIDE >> roassal: spec [
 
 	spec 
-		baseline: 'Roassal3' 
+		baseline: 'Roassal' 
  		with: [ 
 			spec 
-				repository: (self class environment at: #BaselineOfPharo) roassal3Repository;
+				repository: (self class environment at: #BaselineOfPharo) roassalRepository;
     			loads: #( 'Core' 'Tests') ]
 ]
 

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -127,7 +127,7 @@ BaselineOfPharo class >> roassal [
 		newName: 'Roassal' 
 		owner: 'pharo-graphics' 
 		project: 'Roassal' 
-		version: 'v1.04'
+		version: 'v1.04b'
 ]
 
 { #category : 'repository urls' }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -124,16 +124,16 @@ BaselineOfPharo class >> roassal [
 	<externalProject>	
 
 	^ PharoExternalProject 
-		newName: 'Roassal3' 
-		owner: 'ObjectProfile' 
-		project: 'Roassal3' 
-		version: 'v1.03'
+		newName: 'Roassal' 
+		owner: 'pharo-graphics' 
+		project: 'Roassal' 
+		version: 'v1.04'
 ]
 
 { #category : 'repository urls' }
-BaselineOfPharo class >> roassal3Repository [
+BaselineOfPharo class >> roassalRepository [
 
-	^ (self externalProjectNamed: 'Roassal3') repository
+	^ (self externalProjectNamed: 'Roassal') repository
 ]
 
 { #category : 'external projects' }


### PR DESCRIPTION
The current version of Roassal in Pharo 12 is v1.03, in object profile.
v1.04b is in pharo-graphics https://github.com/pharo-graphics/Roassal/releases/tag/v1.04b

this pull request addresses this issue https://github.com/pharo-project/pharo/issues/14985