### PR TITLE
Initialize CaseInsensitiveOrder in the bootstrap

### DIFF
--- a/src/Pharo30Bootstrap/PBImageBuilder50.class.st
+++ b/src/Pharo30Bootstrap/PBImageBuilder50.class.st
@@ -311,9 +311,19 @@ PBImageBuilder50 >> createInitialObjects [
 		((self classNamed: #Character) classPool at: #CharacterTable).
 	objectSpace characterTable: characterTable.
 
-	PBSubStepFinishedSignal emit: 'Initializing String AsciiTable'.
+	PBSubStepFinishedSignal emit: 'Initializing String Ascii and CaseInsensitive Table'.
 	self bootstrapInterpreter evaluateCode:
-		'String classPool at: #AsciiOrder put: ((0 to: 255) as: ByteArray).'.
+			'| asciiOrder caseInsesitiveOrder |
+		asciiOrder := ((0 to: 255) as: ByteArray).
+	caseInsesitiveOrder := asciiOrder copy.
+    (0 to: 255) do:[ :v |
+            | char lower |
+            char := v asCharacter.
+            lower := char asLowercase.
+            caseInsesitiveOrder at: lower asciiValue + 1 put: (caseInsesitiveOrder at: char asciiValue + 1) ].
+		
+		String classPool at: #AsciiOrder put: asciiOrder.
+		String classPool at: #CaseInsensitiveOrder put: caseInsesitiveOrder'.
 
 	PBSubStepFinishedSignal emit: 'Initializing SmallInteger constants'.
 	self bootstrapInterpreter evaluateCode: 'SmallInteger instVarAt: '


### PR DESCRIPTION
In order to replace categories by packages and tags we will need to use RPackage in the early steps of the bootstrap and this will require the case insensitive comparison to work. I'm adding the initialization of the case insensitive order so that we can do this kind of comparison when the packages will be used