### PR TITLE
Check: can we compile Dictionary>>at: block without outer context?

### DIFF
--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -336,6 +336,7 @@ Dictionary >> associationsSelect: aBlock [
 { #category : 'accessing' }
 Dictionary >> at: key [
 	"Answer the value associated with the key."
+	 <compilerOptions: #(+ optionBlockClosureOptionalOuter)>
 	^ self at: key ifAbsent: [self errorKeyNotFound: key]
 ]
 


### PR DESCRIPTION
Check if we can compile dictionary>>#at without outer context for the error block