### PR TITLE
Baselines: No need to nuke RBRefactoryChangeManager

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -107,8 +107,6 @@ BaselineOfBasicTools >> postload: loader package: packageSpec [
 	"Ignore pre and post loads if already executed"
 	Initialized = true ifTrue: [ ^ self ].
 	
-	RBRefactoryChangeManager nuke.
-	
 	CompletionSorter register.
 	RubSmalltalkEditor completionEngineClass: CompletionEngine.
 	

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -76,7 +76,9 @@ RBRefactoryChangeManager class >> nextCounter [
 { #category : 'public' }
 RBRefactoryChangeManager class >> nuke [
 
-	Instance notNil ifTrue: [ Instance release ].
+	Instance ifNil: [ ^ self ].
+
+	Instance release.
 	Instance := nil
 ]
 


### PR DESCRIPTION
`RBRefactoryChangeManager nuke` never does anything since nothing used RBRefactoryChangeManager yet in the image