### PR TITLE
Simplify postload of BaselineOfBasicTools

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -22,9 +22,6 @@ Installs:
 Class {
 	#name : 'BaselineOfBasicTools',
 	#superclass : 'BaselineOf',
-	#classVars : [
-		'Initialized'
-	],
 	#category : 'BaselineOfBasicTools',
 	#package : 'BaselineOfBasicTools'
 }
@@ -104,17 +101,12 @@ BaselineOfBasicTools >> baseline: spec [
 { #category : 'actions' }
 BaselineOfBasicTools >> postload: loader package: packageSpec [
 
-	"Ignore pre and post loads if already executed"
-	Initialized = true ifTrue: [ ^ self ].
-	
 	RBRefactoryChangeManager nuke.
-	
+
 	CompletionSorter register.
 	RubSmalltalkEditor completionEngineClass: CompletionEngine.
-	
-	Author reset.
 
-	Initialized := true.
+	Author reset
 ]
 
 { #category : 'baseline' }


### PR DESCRIPTION
The baseline seems to expect the postload to be executed multiple times but this is not the case (I bootstraped an image that was set to fail if it was going two times there and it did not fail).

I propose to simplify it