### PR TITLE
Metacello: Simplify repository creation

### DIFF
--- a/src/Metacello-Bitbucket/MCBitbucketRepository.class.st
+++ b/src/Metacello-Bitbucket/MCBitbucketRepository.class.st
@@ -16,8 +16,9 @@ MCBitbucketRepository class >> basicFromUrl: aZnUrl [
 ]
 
 { #category : 'instance creation' }
-MCBitbucketRepository class >> createRepositoryFromSpec: aRepositorySpec on: aPlatform [
-	^ aPlatform createBitbucketRepository: aRepositorySpec
+MCBitbucketRepository class >> createRepositoryFromSpec: aRepositorySpec [
+
+	^ self location: aRepositorySpec description
 ]
 
 { #category : 'private' }

--- a/src/Metacello-Core/MCRepository.extension.st
+++ b/src/Metacello-Core/MCRepository.extension.st
@@ -1,8 +1,14 @@
 Extension { #name : 'MCRepository' }
 
 { #category : '*Metacello-Core' }
-MCRepository class >> createRepositoryFromSpec: aRepositorySpec on: aPlatform [
+MCRepository class >> createRepositoryFromSpec: aRepositorySpec [
 	self subclassResponsibility
+]
+
+{ #category : '*Metacello-Core' }
+MCRepository class >> createRepositoryFromSpec: aRepositorySpec on: aPlatform [
+
+	^ self createRepositoryFromSpec: aRepositorySpec
 ]
 
 { #category : '*Metacello-Core' }

--- a/src/Metacello-Core/MetacelloPlatform.class.st
+++ b/src/Metacello-Core/MetacelloPlatform.class.st
@@ -111,69 +111,6 @@ MetacelloPlatform >> copyClass: oldClass as: newName inCategory: newCategoryName
 ]
 
 { #category : 'repository creation' }
-MetacelloPlatform >> createBitbucketRepository: aRepositorySpec [
-	| cl |
-	
-	cl := Smalltalk at: #'MCBitbucketRepository'.
- 	^ cl location: aRepositorySpec description
-]
-
-{ #category : 'repository creation' }
-MetacelloPlatform >> createDictionaryRepository: aRepositorySpec [
-	| description headerSize globalName |
- 
-	description := aRepositorySpec description.
-	headerSize := 'dictionary://' size.
-	globalName := (description copyFrom: headerSize + 1 to: description size) asSymbol.
-   
-	^ Smalltalk
- 		at: globalName
- 		ifAbsent: [ 
-          Smalltalk
-            at: globalName
-            put: (MCDictionaryRepository new
-					description: description;
-					yourself) ]
-]
-
-{ #category : 'repository creation' }
-MetacelloPlatform >> createDirectoryRepository: aRepositorySpec [
-	^ MCDirectoryRepository new
-		directory: (self fileHandleOn: aRepositorySpec description);
-		yourself
-]
-
-{ #category : 'repository creation' }
-MetacelloPlatform >> createFiletreeRepository: aRepositorySpec [
-	| cl description headerSize |
-	
-	cl := Smalltalk at: #'MCFileTreeRepository'.
-	description := aRepositorySpec description.
- 	headerSize := 'filetree://' size.
-	^ cl new 
-		directory: (self fileHandleOn: (aRepositorySpec description 
-			copyFrom: headerSize + 1 
-			to: description size));
-		yourself
-]
-
-{ #category : 'repository creation' }
-MetacelloPlatform >> createGithubRepository: aRepositorySpec [
-	| cl |
-	
-	cl := Smalltalk at: #'MCGitHubRepository'.
-	^ cl location: aRepositorySpec description
-]
-
-{ #category : 'repository creation' }
-MetacelloPlatform >> createHttpRepository: aRepositorySpec [
-	^ MCHttpRepository
-        location: aRepositorySpec description
-        user: aRepositorySpec username
-        password: aRepositorySpec password
-]
-
-{ #category : 'repository creation' }
 MetacelloPlatform >> createRepository: aRepositorySpec [
 
 	^ MCRepository 
@@ -309,23 +246,16 @@ MetacelloPlatform >> extractRepositoryFrom: zipFile to: directory [
 
 { #category : 'repository creation' }
 MetacelloPlatform >> extractTypeFromDescription: description [
-  description == nil
-    ifTrue: [ ^ nil ].
-  ((description beginsWith: '/') or: [ description second = $: ])
-    ifTrue: [ ^ 'directory' ].
-  (description beginsWith: 'dictionary://')
-    ifTrue: [ ^ 'dictionary' ].
-  (description beginsWith: 'filetree://')
-    ifTrue: [ ^ 'filetree' ].
-  (description beginsWith: 'tonel://')
-    ifTrue: [ ^ 'tonel' ].
-  (description beginsWith: 'github://')
-    ifTrue: [ ^ 'github' ].
-  (description beginsWith: 'gitorious://')
-    ifTrue: [ ^ 'gitorious' ].
-  (description beginsWith: 'bitbucket://')
-    ifTrue: [ ^ 'bitbucket' ].
-  ^ 'http'
+
+	description ifNil: [ ^ nil ].
+	((description beginsWith: '/') or: [ description second = $: ]) ifTrue: [ ^ 'directory' ].
+	(description beginsWith: 'dictionary://') ifTrue: [ ^ 'dictionary' ].
+	(description beginsWith: 'filetree://') ifTrue: [ ^ 'filetree' ].
+	(description beginsWith: 'tonel://') ifTrue: [ ^ 'tonel' ].
+	(description beginsWith: 'github://') ifTrue: [ ^ 'github' ].
+	(description beginsWith: 'gitorious://') ifTrue: [ ^ 'gitorious' ].
+	(description beginsWith: 'bitbucket://') ifTrue: [ ^ 'bitbucket' ].
+	^ 'http'
 ]
 
 { #category : 'github/bitbucket support' }

--- a/src/Metacello-GitHub/MCGitHubRepository.class.st
+++ b/src/Metacello-GitHub/MCGitHubRepository.class.st
@@ -36,8 +36,9 @@ MCGitHubRepository class >> cacheDirectory: aDirectory [
 ]
 
 { #category : 'instance creation' }
-MCGitHubRepository class >> createRepositoryFromSpec: aRepositorySpec on: aPlatform [
-	^ aPlatform createGithubRepository: aRepositorySpec
+MCGitHubRepository class >> createRepositoryFromSpec: aRepositorySpec [
+
+	^ self location: aRepositorySpec description
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-MC/MCDictionaryRepository.extension.st
+++ b/src/Metacello-MC/MCDictionaryRepository.extension.st
@@ -13,8 +13,15 @@ MCDictionaryRepository >> asRepositorySpecFor: aMetacelloMCProject [
 ]
 
 { #category : '*Metacello-MC' }
-MCDictionaryRepository class >> createRepositoryFromSpec: aRepositorySpec on: aPlatform [
-	^ aPlatform createDictionaryRepository: aRepositorySpec
+MCDictionaryRepository class >> createRepositoryFromSpec: aRepositorySpec [
+
+	| globalName |
+	globalName := (aRepositorySpec description copyFrom: 'dictionary://' size + 1 to: aRepositorySpec description size) asSymbol.
+
+	^ Smalltalk at: globalName ifAbsentPut: [
+		  self new
+			  description: aRepositorySpec description;
+			  yourself ]
 ]
 
 { #category : '*Metacello-MC' }

--- a/src/Metacello-MC/MCDirectoryRepository.extension.st
+++ b/src/Metacello-MC/MCDirectoryRepository.extension.st
@@ -8,8 +8,11 @@ MCDirectoryRepository >> asRepositorySpecFor: aMetacelloMCProject [
 ]
 
 { #category : '*Metacello-MC' }
-MCDirectoryRepository class >> createRepositoryFromSpec: aRepositorySpec on: aPlatform [
-	^ aPlatform createDirectoryRepository: aRepositorySpec
+MCDirectoryRepository class >> createRepositoryFromSpec: aRepositorySpec [
+
+	^ self new
+		  directory: aRepositorySpec description asFileReference;
+		  yourself
 ]
 
 { #category : '*Metacello-MC' }

--- a/src/Metacello-MC/MCFileTreeRepository.extension.st
+++ b/src/Metacello-MC/MCFileTreeRepository.extension.st
@@ -2,7 +2,11 @@ Extension { #name : 'MCFileTreeRepository' }
 
 { #category : '*Metacello-MC' }
 MCFileTreeRepository class >> createRepositoryFromSpec: aRepositorySpec on: aPlatform [
-	^ aPlatform createFiletreeRepository: aRepositorySpec
+
+	MCRepository findFiletreeAlternateFormat: aRepositorySpec ifFound: [ :repository | ^ repository createRepositoryFromSpec: aRepositorySpec on: aPlatform ].
+	^ self new
+		  directory: (aRepositorySpec description copyFrom: 'filetree://' size + 1 to: aRepositorySpec description size) asFileReference;
+		  yourself
 ]
 
 { #category : '*Metacello-MC' }

--- a/src/Metacello-MC/MCFtpRepository.extension.st
+++ b/src/Metacello-MC/MCFtpRepository.extension.st
@@ -1,8 +1,18 @@
 Extension { #name : 'MCFtpRepository' }
 
 { #category : '*Metacello-MC' }
-MCFtpRepository class >> createRepositoryFromSpec: aRepositorySpec on: aPlatform [
-	^ aPlatform createFtpRepository: aRepositorySpec
+MCFtpRepository class >> createRepositoryFromSpec: aRepositorySpec [
+
+	| description headerSize index |
+	description := aRepositorySpec description.
+	headerSize := 'ftp://' size.
+	index := description indexOf: $/ startingAt: headerSize + 1.
+
+	^ self
+		  host: (description copyFrom: headerSize + 1 to: index - 1)
+		  directory: (description copyFrom: index + 1 to: description size)
+		  user: aRepositorySpec username
+		  password: aRepositorySpec password
 ]
 
 { #category : '*Metacello-MC' }

--- a/src/Metacello-MC/MCHttpRepository.extension.st
+++ b/src/Metacello-MC/MCHttpRepository.extension.st
@@ -10,8 +10,9 @@ MCHttpRepository >> asRepositorySpecFor: aMetacelloMCProject [
 ]
 
 { #category : '*Metacello-MC' }
-MCHttpRepository class >> createRepositoryFromSpec: aRepositorySpec on: aPlatform [
-	^ aPlatform createHttpRepository: aRepositorySpec
+MCHttpRepository class >> createRepositoryFromSpec: aRepositorySpec [
+
+	^ self location: aRepositorySpec description user: aRepositorySpec username password: aRepositorySpec password
 ]
 
 { #category : '*Metacello-MC' }

--- a/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
+++ b/src/Metacello-PharoCommonPlatform/MetacelloPharoCommonPlatform.class.st
@@ -65,33 +65,6 @@ MetacelloPharoCommonPlatform >> copyClass: oldClass as: newName inCategory: newC
 	^ class
 ]
 
-{ #category : 'repository creation' }
-MetacelloPharoCommonPlatform >> createFiletreeRepository: aRepositorySpec [
-	MCRepository 
-		findFiletreeAlternateFormat: aRepositorySpec
-		ifFound: [ :repository | 
-			^ repository createRepositoryFromSpec: aRepositorySpec on: self ].
-
-	^ super createFiletreeRepository: aRepositorySpec
-]
-
-{ #category : 'repository creation' }
-MetacelloPharoCommonPlatform >> createFtpRepository: aRepositorySpec [
- 	| description headerSize index host directory |
-	
-	description := aRepositorySpec description.
-	headerSize := 'ftp://' size.
-	index := description indexOf: $/ startingAt: headerSize + 1.
-	host := description copyFrom: headerSize + 1 to: index - 1.
-	directory := description copyFrom: index + 1 to: description size.
-	
-	^ MCFtpRepository
-		host: host 
-		directory: directory 
-		user: aRepositorySpec username
-		password: aRepositorySpec password
-]
-
 { #category : 'file system' }
 MetacelloPharoCommonPlatform >> defaultDirectory [
 	"Get the image default directory"


### PR DESCRIPTION
Metacello has a lot of code present for the compatibility with multiple smalltalk versions but the Pharo version already diverged and is not compatible with other smalltalk anymore. 

Here is a first step at a simplification we can do to not add complexity with this compatibility layer. It moves the repository creation from the Platfrom to the repositories. This is only the first step because Tonel needs to be updated after this PR gets integrated in order to finish this cleaning and remove all the references to the platform.