### PR TITLE
Fix key combination sequence not printable instances

### DIFF
--- a/src/Keymapping-KeyCombinations/KMKeyCombinationSequence.class.st
+++ b/src/Keymapping-KeyCombinations/KMKeyCombinationSequence.class.st
@@ -75,7 +75,7 @@ KMKeyCombinationSequence >> hash [
 { #category : 'private' }
 KMKeyCombinationSequence >> haveShortcutsSameModifier [
 
-	^ (shortcuts collect: [ :s | s modifier ] as: Set) size = 1
+	^ self shortcutModifiers size = 1
 ]
 
 { #category : 'matching' }
@@ -93,7 +93,7 @@ KMKeyCombinationSequence >> next: aShortcut [
 	self addShortcut: aShortcut
 ]
 
-{ #category : 'printing' }
+{ #category : 'accessing - platform' }
 KMKeyCombinationSequence >> platformModifier [
 
 	self sequence do: [ :each | ^ each platformModifier ].
@@ -123,9 +123,13 @@ KMKeyCombinationSequence >> printOn: aStream [
 { #category : 'private' }
 KMKeyCombinationSequence >> printSequenceWithSameModifierOn: aStream [
 
-	aStream
-		nextPutAll: shortcuts first modifier name;
-		nextPutAll: ' + ('.
+	| modifier |
+	
+	modifier := self shortcutModifiers anyOne.
+	modifier name
+		ifNil: [ aStream nextPutAll: 'Composed' ]
+		ifNotNil: [ : modifierName | aStream nextPutAll: modifierName  ].
+	aStream nextPutAll: ' + ('.
 	shortcuts
 		do: [ :s | aStream nextPutAll: s key name ]
 		separatedBy: [ aStream nextPutAll: ' , ' ].
@@ -135,4 +139,11 @@ KMKeyCombinationSequence >> printSequenceWithSameModifierOn: aStream [
 { #category : 'accessing' }
 KMKeyCombinationSequence >> sequence [
 	^ shortcuts ifNil: [ shortcuts := OrderedCollection new ]
+]
+
+{ #category : 'private' }
+KMKeyCombinationSequence >> shortcutModifiers [
+	"Answer a <Set> of the receiver's modifiers, i.e. keys pressed to modify the value of a following key"
+
+	^ shortcuts collect: [ :s | s modifier ] as: Set
 ]

--- a/src/Keymapping-Tools-Spec/KMDescriptionPresenter.class.st
+++ b/src/Keymapping-Tools-Spec/KMDescriptionPresenter.class.st
@@ -35,19 +35,20 @@ KMDescriptionPresenter >> categories: aCollectionOfSymbols [
 ]
 
 { #category : 'initialization' }
-KMDescriptionPresenter >> initializePresenter [
+KMDescriptionPresenter >> connectPresenters [
+
 	categoryList
 		transmitTo: shortcutList
-		transform: [ :category | (category entriesAt: #all) keymaps sorted: [ :keymap | keymap shortcut asString ] ascending ]
+		transform: [ :category | (category model entriesAt: #all) keymaps sorted: [ :keymap | keymap shortcut asString ] ascending ]
 ]
 
-{ #category : 'initialization' }
+{ #category : 'initialization - deprecated' }
 KMDescriptionPresenter >> initializeWidgets [
 	categoryList := self newDropList.
 	shortcutList := self newTable.
 	actionBar := self newActionBar.
 
-	categoryList displayBlock: [ :category | category name ].
+	categoryList display: [ :category | category name ].
 
 	shortcutList
 		addColumn: (SpStringTableColumn title: 'Shortcut' evaluated: #shortcut);

--- a/src/Keymapping-Tools-Spec/KMDescriptionPresenter.class.st
+++ b/src/Keymapping-Tools-Spec/KMDescriptionPresenter.class.st
@@ -22,10 +22,43 @@ KMDescriptionPresenter class >> defaultLayout [
 		yourself
 ]
 
+{ #category : 'instance creation' }
+KMDescriptionPresenter class >> descriptionText [
+
+	^ 'Show the description of shortcuts for the system'
+]
+
 { #category : 'examples' }
 KMDescriptionPresenter class >> example [
 	self new
 		categories: #(GlobalShortcuts MonticelloShortcuts TextEditor);
+		open
+]
+
+{ #category : 'accessing' }
+KMDescriptionPresenter class >> icon [
+
+	^ self iconNamed: #keymapBrowser
+]
+
+{ #category : 'instance creation' }
+KMDescriptionPresenter class >> menuCommandOn: aBuilder [
+	<worldMenu>
+
+	(aBuilder item: 'Keymap Descriptions')
+		action: [ self open ];
+		order: 34;
+		parent: #Tools;
+		icon: self icon;
+		help: self descriptionText
+]
+
+{ #category : 'instance creation' }
+KMDescriptionPresenter class >> open [
+	"Open the receiver's on all the system keymap categories"
+	
+	^ self new
+		categories: KMRepository default categories keys;
 		open
 ]
 


### PR DESCRIPTION
Fix an [issue](#14838) printing modified key combinations where the composed modifier name was set to nil.
Add a Library menu item to open the Keymap browser.
Update the Keymap browser to Spec 2
