### PR TITLE
Do not recompile methods if slots did not change

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -306,7 +306,6 @@ BaselineOfIDE >> postload: loader package: packageSpec [
 	RubTextFieldArea defaultFindReplaceServiceClass: SpRubFindReplaceService.
 	RubEditingArea defaultFindReplaceServiceClass: SpRubFindReplaceService.
 
-	ASTTransformExamplePluginActive recompile.
 	PharoCommandLineHandler recompile.
 	SmalltalkImage recompile.
 

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -44,9 +44,13 @@ Behavior >> compileAll [
 { #category : '*OpalCompiler-Core' }
 Behavior >> compileAllFrom: oldClass [
 	"Compile all the methods in the receiver's method dictionary.
-	This validates sourceCode and variable references and forces
-	all methods to use the current bytecode set"
-	oldClass localSelectors do: [:sel | self recompile: sel from: oldClass]
+	This validates sourceCode and variable references and forces all methods to use the current bytecode set"
+
+	"If the slots changed, we need to recompile the methods. Ideally only the methods that changed, but for now we recompile everything. Else we can just use the old methods."
+
+	oldClass allSlots = self allSlots
+		ifTrue: [ oldClass localSelectors do: [ :selector | self addSelectorSilently: selector withMethod: (oldClass compiledMethodAt: selector) ] ]
+		ifFalse: [ oldClass localSelectors do: [ :selector | self recompile: selector from: oldClass ] ]
 ]
 
 { #category : '*OpalCompiler-Core' }

--- a/src/OpalCompiler-Tests/OCStaticASTCompilerPluginTest.class.st
+++ b/src/OpalCompiler-Tests/OCStaticASTCompilerPluginTest.class.st
@@ -9,9 +9,9 @@ Class {
 { #category : 'tests' }
 OCStaticASTCompilerPluginTest >> testClassWithPluginEnabled [
 
-	self
-		assert: ASTTransformExamplePluginActive new example42
-		equals: 'meaning of life'
+	"It is possible that the method was loaded before the plugin was active. Thus we recompile to be sure the plugin was active."
+	ASTTransformExamplePluginActive recompile.
+	self assert: ASTTransformExamplePluginActive new example42 equals: 'meaning of life'
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
When a class changes we recompile all the methods because the slots index might have changed. This change checks that slots changed before doing this because if no slot changed we can just keep the old methods and avid recompilations