### PR TITLE
Clean system after ClyBrowserToolValidityTest

### DIFF
--- a/src/Calypso-Browser-Tests/ClyBrowserToolValidityTest.class.st
+++ b/src/Calypso-Browser-Tests/ClyBrowserToolValidityTest.class.st
@@ -28,6 +28,14 @@ ClyBrowserToolValidityTest >> mockPackageName [
 	^ 'MockPackageForTestingCalypso'.
 ]
 
+{ #category : 'running' }
+ClyBrowserToolValidityTest >> tearDown [
+
+	self packageOrganizer removePackage: self mockPackageName.
+
+	super tearDown
+]
+
 { #category : 'tests' }
 ClyBrowserToolValidityTest >> testClassCommentToolIsNotValidWhenNotAClassContext [
 


### PR DESCRIPTION
Those tests are creating a package they never remove