### PR TITLE
unskip tests using ProvideAnswerNotification

### DIFF
--- a/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCCodeReparatorTest.class.st
@@ -291,15 +291,13 @@ OCCodeReparatorTest >> testUndeclaredVariable [
 
 { #category : 'tests' }
 OCCodeReparatorTest >> testdefineClass [
-	self skip.
-	"we need to resume: not with true, but the code, ProvideAnswerNotification needs to be improved
-	to provide the defaultAnswer, too"
+
 	[ OCCodeReparator new
 		node: (self class>>#testdefineClass) ast;
 		defineClass: 'MyTestClassForDefineClass'
 	]
 		on: ProvideAnswerNotification
-		do: [ :e | e resume: true ].
+		do: [ :e | e resume: #default ].
 		
 	self assert: (Smalltalk globals hasClassNamed: #MyTestClassForDefineClass).
 	Smalltalk globals removeClassNamed:  #MyTestClassForDefineClass
@@ -307,15 +305,12 @@ OCCodeReparatorTest >> testdefineClass [
 
 { #category : 'tests' }
 OCCodeReparatorTest >> testdefineTrait [
-	self skip.
-	"we need to resume: not with true, but the code, ProvideAnswerNotification needs to be improved
-	to provide the defaultAnswer, too"
 	[ OCCodeReparator new
 		node: (self class>>#testdefineTrait) ast;
 		defineTrait: 'MyTestTraitForDefineTrait'
 	]
 		on: ProvideAnswerNotification
-		do: [ :e | e resume: true ].
+		do: [ :e | e resume: #default ].
 		
 	self assert: (Smalltalk traitNames includes: #MyTestTraitForDefineTrait).
 	Smalltalk globals removeClassNamed:  #MyTestTraitForDefineTrait


### PR DESCRIPTION
the method check for a symbol #default to be returned... so it has a mechanism for it (even though maybe adding the defaultAnswer as state to ProvideAnswerNotification might be an interesting future improvement...)

But this fixes 14978 by using the existing mechanism