### PR TITLE
Fix Jump to test method from implementors view

### DIFF
--- a/src/Calypso-Browser/ClyBrowserContext.class.st
+++ b/src/Calypso-Browser/ClyBrowserContext.class.st
@@ -125,6 +125,12 @@ ClyBrowserContext >> isAboutSelectedItem: aDataSourceItem [
 ]
 
 { #category : 'testing' }
+ClyBrowserContext >> isQueryBrowserContext [
+
+	^ false.
+]
+
+{ #category : 'testing' }
 ClyBrowserContext >> isSimilarTo: anotherBrowserContext [
 	self class = anotherBrowserContext class ifFalse: [ ^false ].
 

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestMethodCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyJumpToTestMethodCommand.class.st
@@ -31,6 +31,15 @@ Class {
 
 { #category : 'testing' }
 ClyJumpToTestMethodCommand class >> canBeExecutedInContext: aBrowserContext [
+
+	aBrowserContext isQueryBrowserContext
+		ifTrue: [ ^ false ].
+	^ self hasInstanceSelectedItemsIn: aBrowserContext.
+]
+
+{ #category : 'testing' }
+ClyJumpToTestMethodCommand class >> hasInstanceSelectedItemsIn: aBrowserContext [
+
 	^ aBrowserContext isInstanceSideMethodSelected and: [ aBrowserContext selectedItems anySatisfy: [ :each | (each hasProperty: ClyTestResultProperty) not ] ]
 ]
 

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyOpenTestMethodCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyOpenTestMethodCommand.class.st
@@ -1,0 +1,50 @@
+"
+Implements a command available in the method context menu of Calypso. When activated a new system browser will be opened on the test method of the current browser's selected method.
+
+"
+Class {
+	#name : 'ClyOpenTestMethodCommand',
+	#superclass : 'ClyJumpToTestMethodCommand',
+	#category : 'Calypso-SystemPlugins-SUnit-Browser-Commands',
+	#package : 'Calypso-SystemPlugins-SUnit-Browser',
+	#tag : 'Commands'
+}
+
+{ #category : 'testing' }
+ClyOpenTestMethodCommand class >> canBeExecutedInContext: aBrowserContext [
+	"Only present this menu item in query results presenters"
+
+	^ 	aBrowserContext isQueryBrowserContext and: [ self hasInstanceSelectedItemsIn: aBrowserContext ]
+]
+
+{ #category : 'activation' }
+ClyOpenTestMethodCommand class >> methodMenuActivation [
+	<classAnnotation>
+
+	^ CmdContextMenuActivation 
+		byItemOf: ClySUnitMethodMenuGroup 
+		order: 12
+		for: ClyMethod asCalypsoItemContext
+]
+
+{ #category : 'activation' }
+ClyOpenTestMethodCommand class >> methodShortcutActivation [
+	<classAnnotation>
+	^ CmdShortcutActivation by: $t meta , $o meta for: ClyMethod asCalypsoItemContext
+]
+
+{ #category : 'accessing' }
+ClyOpenTestMethodCommand >> defaultMenuItemName [
+
+	^ 'Open test method'
+]
+
+{ #category : 'execution' }
+ClyOpenTestMethodCommand >> execute [
+
+	self methods do: [ :method | self generateTestMethodFor: method ].
+	testMethodToBrowse ifNotNil: [ :testMethod | 
+		browser 
+			spawnBrowser: ClyFullBrowserMorph 
+			withState: [ :b | b selectMethod: testMethod ] ]
+]

--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserContext.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserContext.class.st
@@ -35,6 +35,12 @@ ClyQueryBrowserContext >> isPackageSelected [
 	^self hasSelectedItems
 ]
 
+{ #category : 'testing' }
+ClyQueryBrowserContext >> isQueryBrowserContext [
+
+	^ true.
+]
+
 { #category : 'selection-classes' }
 ClyQueryBrowserContext >> lastSelectedClass [
 


### PR DESCRIPTION
This PR replaces the menu item of the implementors window with a new item named "Open test method", which spaws a browser with the test method of the current selection in Calypso. It proposes a fix to the issue reported in #14844. If the currently selected method has no test, then the previous behavior is preserved (currently creating a new test method and class if necessary).

The menu in the system browser is not affected.
The item replaces the non-working "Jump to test" item when launched from the implementors window.

To test it:

- Open implementors of`#printString` 
- Right-click on `Object>>printString`
- Select and click "Open test method"

