### PR TITLE
Remove the use of categories in bootstrap class definition

### DIFF
--- a/src/Pharo30Bootstrap/PBClassLoader.class.st
+++ b/src/Pharo30Bootstrap/PBClassLoader.class.st
@@ -44,25 +44,27 @@ PBClassLoader >> classDefinitionFor: aClass [
 	newClass := ShiftClassInstaller make: [ :builder |
 		builder
 			superclass: {superClass};
-			name: ''{name}'';
+			name: {name};
 			layoutClass: {type};
-			slots: ''{instanceVariablesString}'' asSlotCollection;
-			sharedVariablesFromString: ''{classVariablesString}'';
-			sharedPools: ''{sharedPoolsString}'';
-			category: ''{category}'';
+			slots: {instanceVariablesString} asSlotCollection;
+			sharedVariablesFromString: {classVariablesString};
+			sharedPools: {sharedPoolsString};
+			package: {package};
+			tag: {tag};
 			environment: {superClass} environment;
-			classSlots: ''{classInstanceVariablesString}'' asSlotCollection ].
+			classSlots: {classInstanceVariablesString} asSlotCollection ].
 	newClass layout compactClassIndex: {compactIndex}.
 	newClass'
 		format: { 
 			'superClass' -> aClass superclass name.
-			'name' -> aClass name.
+			'name' -> aClass name printString.
 			'type' -> type.
-			'instanceVariablesString' -> (' ' join: aClass instVarNames).
-			'classVariablesString' -> aClass classVariablesString.
-			'sharedPoolsString' -> aClass sharedPoolsString.
-			'category' -> aClass category asString.
-			'classInstanceVariablesString' -> (' ' join: aClass classSide instVarNames).
+			'instanceVariablesString' -> (' ' join: aClass instVarNames) printString.
+			'classVariablesString' -> aClass classVariablesString printString.
+			'sharedPoolsString' -> aClass sharedPoolsString printString.
+			'package' -> aClass package name printString.
+			'tag' -> (aClass tags ifEmpty: [ 'nil' ] ifNotEmpty: [ :tags | tags anyOne printString ]).
+			'classInstanceVariablesString' -> (' ' join: aClass classSide instVarNames) printString.
 			'compactIndex' -> (self compactClassIndexForClass: aClass) } asDictionary.
 ]
 

--- a/src/Pharo30Bootstrap/PBSpurClassLoader.class.st
+++ b/src/Pharo30Bootstrap/PBSpurClassLoader.class.st
@@ -29,25 +29,27 @@ PBSpurClassLoader >> classDefinitionFor: aClass [
 	newClass := ShiftClassInstaller make: [ :builder |
 		builder
 			superclass: {superClass};
-			name: ''{name}'';
+			name: {name};
 			layoutClass: {type};
-			slots: ''{instanceVariablesString}'' asSlotCollection;
-			sharedVariablesFromString: ''{classVariablesString}'';
-			sharedPools: ''{sharedPoolsString}'';
-			category: ''{category}'';
+			slots: {instanceVariablesString} asSlotCollection;
+			sharedVariablesFromString: {classVariablesString};
+			sharedPools: {sharedPoolsString};
+			package: {package};
+			tag: {tag};
 			environment: {superClass} environment;
-			classSlots: ''{classInstanceVariablesString}'' asSlotCollection ].
+			classSlots: {classInstanceVariablesString} asSlotCollection ].
 	"newClass setTraitComposition: {aTraitComposition} asTraitComposition."
 	newClass'
 		format: { 
 			'superClass' -> (aClass superclass ifNil: ['nil'] ifNotNil: [ :superclass | superclass name ]).
-			'name' -> aClass name.
+			'name' -> aClass name printString.
 			'type' -> type.
-			'instanceVariablesString' -> (' ' join: aClass instVarNames).
-			'classVariablesString' -> aClass classVariablesString.
-			'sharedPoolsString' -> aClass sharedPoolsString.
-			'category' -> aClass category asString.
-			'classInstanceVariablesString' -> (' ' join: aClass classSide instVarNames).
+			'instanceVariablesString' -> (' ' join: aClass instVarNames) printString.
+			'classVariablesString' -> aClass classVariablesString printString.
+			'sharedPoolsString' -> aClass sharedPoolsString printString.
+			'package' -> aClass package name printString.
+			'tag' -> (aClass tags ifEmpty: [ 'nil' ] ifNotEmpty: [ :tags | tags anyOne printString ]).
+			'classInstanceVariablesString' -> (' ' join: aClass classSide instVarNames) printString.
 			'aTraitComposition' -> aClass traitCompositionString } asDictionary.
 ]
 


### PR DESCRIPTION
This change is removing the use of categories in the bootstrap class definition building. 

This will still merge everything into a category in the shift class builder for now, but it will make it easier to do the change in the shift class builder later