### PR TITLE
Turn off Error hander on  #computeFullBounds  for a while to find a bug

### DIFF
--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -1921,12 +1921,15 @@ Morph >> computeBounds [
 
 { #category : 'layout' }
 Morph >> computeFullBounds [
+	"turn off error handler to track down https://github.com/pharo-project/pharo/issues/12502"
+	self doLayoutIn: self layoutBounds
+	"
 	[ self doLayoutIn: self layoutBounds ]
 		on: Error
 		do: [ :ex |
-			"This should do it unless you don't screw up the bounds"
+			This should do it unless you don't screw up the bounds
 			fullBounds := bounds.
-			ex pass ]
+			ex pass ]"
 ]
 
 { #category : 'geometry testing' }


### PR DESCRIPTION
we see often a SubscriptOutOfBounds (see #12502) on the CI.

The error handler of #computeFullBounds makes this very gard to track down... this PR turns it off.

I propose to run a bit without this and later make this a preference to turn on in deployment but let it off on the CI?