### PR TITLE
Migrate class parser tests to fluid

### DIFF
--- a/src/ClassParser-Tests/CDBehaviorParserTest.class.st
+++ b/src/ClassParser-Tests/CDBehaviorParserTest.class.st
@@ -26,6 +26,12 @@ CDBehaviorParserTest >> className [
 ]
 
 { #category : 'helpers' }
+CDBehaviorParserTest >> firstClassVariableName [
+
+	^ 'firstClass'
+]
+
+{ #category : 'helpers' }
 CDBehaviorParserTest >> firstInstanceVariableName [
 
 	^ 'first'
@@ -41,6 +47,12 @@ CDBehaviorParserTest >> nodeFor: aString [
 CDBehaviorParserTest >> parserClass [
 
 	^ CDFluidClassDefinitionParser
+]
+
+{ #category : 'helpers' }
+CDBehaviorParserTest >> secondClassVariableName [
+
+	^ 'secondClass'
 ]
 
 { #category : 'helpers' }
@@ -62,6 +74,14 @@ CDBehaviorParserTest >> setUp [
 
 	super setUp.
 	classDefinition := self parserClass parse: self classDefinitionString
+]
+
+{ #category : 'helpers' }
+CDBehaviorParserTest >> slotsArray [
+
+	^ '\{ #{instvar1} . #{instvar2} }' format: {
+			  ('instvar1' -> self firstInstanceVariableName).
+			  ('instvar2' -> self secondInstanceVariableName) } asDictionary
 ]
 
 { #category : 'tests' }

--- a/src/ClassParser-Tests/CDBehaviorParserTest.class.st
+++ b/src/ClassParser-Tests/CDBehaviorParserTest.class.st
@@ -92,6 +92,12 @@ CDBehaviorParserTest >> slotsArray [
 			  ('instvar2' -> self secondInstanceVariableName) } asDictionary
 ]
 
+{ #category : 'helpers' }
+CDBehaviorParserTest >> superclassName [
+
+	^ 'TheSuperClass'
+]
+
 { #category : 'tests' }
 CDBehaviorParserTest >> testBestNodeForClassNameSelectionShouldBeClassNameNode [
 

--- a/src/ClassParser-Tests/CDBehaviorParserTest.class.st
+++ b/src/ClassParser-Tests/CDBehaviorParserTest.class.st
@@ -77,6 +77,14 @@ CDBehaviorParserTest >> setUp [
 ]
 
 { #category : 'helpers' }
+CDBehaviorParserTest >> sharedVariablesArray [
+
+	^ '\{ #{classvar1} . #{classvar2} }' format: {
+			  ('classvar1' -> self firstClassVariableName).
+			  ('classvar2' -> self secondClassVariableName) } asDictionary
+]
+
+{ #category : 'helpers' }
 CDBehaviorParserTest >> slotsArray [
 
 	^ '\{ #{instvar1} . #{instvar2} }' format: {

--- a/src/ClassParser-Tests/CDBehaviorParserTest.class.st
+++ b/src/ClassParser-Tests/CDBehaviorParserTest.class.st
@@ -40,7 +40,7 @@ CDBehaviorParserTest >> nodeFor: aString [
 { #category : 'helpers' }
 CDBehaviorParserTest >> parserClass [
 
-	^ CDClassDefinitionParser
+	^ CDFluidClassDefinitionParser
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDClassDefinitionParserTest.class.st
+++ b/src/ClassParser-Tests/CDClassDefinitionParserTest.class.st
@@ -21,12 +21,6 @@ CDClassDefinitionParserTest >> packageName [
 	^  #MyPackage
 ]
 
-{ #category : 'helpers' }
-CDClassDefinitionParserTest >> superclassName [
-
-	^ 'TheSuperClass'
-]
-
 { #category : 'tests' }
 CDClassDefinitionParserTest >> testBestNodeForClassVariableSelectionShouldBeClassSlotNode [
 

--- a/src/ClassParser-Tests/CDClassDefinitionParserTest.class.st
+++ b/src/ClassParser-Tests/CDClassDefinitionParserTest.class.st
@@ -16,21 +16,9 @@ CDClassDefinitionParserTest >> firstClassVariableIndex [
 	^ self classDefinitionString findString: self firstClassVariableName
 ]
 
-{ #category : 'helpers' }
-CDClassDefinitionParserTest >> firstClassVariableName [
-
-	^ 'firstClass'
-]
-
 { #category : 'tests' }
 CDClassDefinitionParserTest >> packageName [
 	^  #MyPackage
-]
-
-{ #category : 'helpers' }
-CDClassDefinitionParserTest >> secondClassVariableName [
-
-	^ 'secondClass'
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDClassWithPoolDictionaryParserTest.class.st
+++ b/src/ClassParser-Tests/CDClassWithPoolDictionaryParserTest.class.st
@@ -7,22 +7,23 @@ Class {
 
 { #category : 'helpers' }
 CDClassWithPoolDictionaryParserTest >> classDefinitionString [
-	^ '{superclassName} subclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
-		classVariableNames: ''{classvar1} {classvar2}''
-		poolDictionaries: ''{sharedPoolName}''
-		package: #MyPackage'
-			format: {
-				'classname' -> self className.
-				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName.
-				'sharedPoolName' -> self sharedPoolName } asDictionary
+
+	^ '{superclassName} << #{classname}
+		slots: \{ #{instvar1} . #{instvar2} };
+		sharedVariables: \{ #{classvar1} . #{classvar2} };
+		sharedPools: {sharedPoolName}
+		package: #MyPackage' format: {
+			  ('classname' -> self className).
+			  ('superclassName' -> self superclassName).
+			  ('instvar1' -> self firstInstanceVariableName).
+			  ('instvar2' -> self secondInstanceVariableName).
+			  ('classvar1' -> self firstClassVariableName).
+			  ('classvar2' -> self secondClassVariableName).
+			  ('sharedPoolName' -> self sharedPools) } asDictionary
 ]
 
 { #category : 'helpers' }
-CDClassWithPoolDictionaryParserTest >> sharedPoolName [
-	^ 'TextConstants AnotherSharedPool'
+CDClassWithPoolDictionaryParserTest >> sharedPools [
+
+	^ '{ TextConstants. AnotherSharedPool }'
 ]

--- a/src/ClassParser-Tests/CDClassWithPoolDictionaryParserTest.class.st
+++ b/src/ClassParser-Tests/CDClassWithPoolDictionaryParserTest.class.st
@@ -10,14 +10,13 @@ CDClassWithPoolDictionaryParserTest >> classDefinitionString [
 
 	^ '{superclassName} << #{classname}
 		slots: {slots};
-		sharedVariables: \{ #{classvar1} . #{classvar2} };
+		sharedVariables: {sharedVariables};
 		sharedPools: {sharedPoolName}
 		package: #MyPackage' format: {
 			  'classname' -> self className.
 			  'superclassName' -> self superclassName.
 			  'slots' -> self slotsArray.
-			  'classvar1' -> self firstClassVariableName.
-			  'classvar2' -> self secondClassVariableName.
+			  'sharedVariables' -> self sharedVariablesArray.
 			  'sharedPoolName' -> self sharedPools } asDictionary
 ]
 

--- a/src/ClassParser-Tests/CDClassWithPoolDictionaryParserTest.class.st
+++ b/src/ClassParser-Tests/CDClassWithPoolDictionaryParserTest.class.st
@@ -9,17 +9,16 @@ Class {
 CDClassWithPoolDictionaryParserTest >> classDefinitionString [
 
 	^ '{superclassName} << #{classname}
-		slots: \{ #{instvar1} . #{instvar2} };
+		slots: {slots};
 		sharedVariables: \{ #{classvar1} . #{classvar2} };
 		sharedPools: {sharedPoolName}
 		package: #MyPackage' format: {
-			  ('classname' -> self className).
-			  ('superclassName' -> self superclassName).
-			  ('instvar1' -> self firstInstanceVariableName).
-			  ('instvar2' -> self secondInstanceVariableName).
-			  ('classvar1' -> self firstClassVariableName).
-			  ('classvar2' -> self secondClassVariableName).
-			  ('sharedPoolName' -> self sharedPools) } asDictionary
+			  'classname' -> self className.
+			  'superclassName' -> self superclassName.
+			  'slots' -> self slotsArray.
+			  'classvar1' -> self firstClassVariableName.
+			  'classvar2' -> self secondClassVariableName.
+			  'sharedPoolName' -> self sharedPools } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDCompiledBlockClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDCompiledBlockClassParserTest.class.st
@@ -8,9 +8,11 @@ Class {
 { #category : 'helpers' }
 CDCompiledBlockClassParserTest >> classDefinitionString [
 	"we just test the definition as it appears in the image"
-	^ 'CompiledCode variableByteSubclass: #CompiledBlock
-	instanceVariableNames: ''''
-	classVariableNames: ''''
+
+	^ 'CompiledCode << #CompiledBlock
+	layout: CompiledMethodLayout;
+	slots: {  };
+	sharedVariables: {  };
 	package: #MyPackage'
 ]
 
@@ -27,7 +29,8 @@ CDCompiledBlockClassParserTest >> superclassName [
 { #category : 'tests' }
 CDCompiledBlockClassParserTest >> testBestNodeForClassVariableSelectionShouldBeClassSlotNode [
 	"no Class Variables in CompileBlock"
-	self assert: classDefinition sharedVariableNodes isEmpty
+
+	self assertEmpty: classDefinition sharedVariableNodes
 ]
 
 { #category : 'tests' }

--- a/src/ClassParser-Tests/CDCompiledBlockClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDCompiledBlockClassParserTest.class.st
@@ -11,8 +11,6 @@ CDCompiledBlockClassParserTest >> classDefinitionString [
 
 	^ 'CompiledCode << #CompiledBlock
 	layout: CompiledMethodLayout;
-	slots: {  };
-	sharedVariables: {  };
 	package: #MyPackage'
 ]
 

--- a/src/ClassParser-Tests/CDCompiledMethodClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDCompiledMethodClassParserTest.class.st
@@ -8,9 +8,8 @@ Class {
 { #category : 'helpers' }
 CDCompiledMethodClassParserTest >> classDefinitionString [
 	"we just test the definition as it appears in the image"
-	^ 'CompiledCode variableByteSubclass: #CompiledMethod
-	instanceVariableNames: ''''
-	classVariableNames: ''''
+	^ 'CompiledCode << #CompiledMethod
+	layout: CompiledMethodLayout;
 	package: #MyPackage'
 ]
 

--- a/src/ClassParser-Tests/CDDoubleByteClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDDoubleByteClassParserTest.class.st
@@ -8,17 +8,16 @@ Class {
 { #category : 'helpers' }
 CDDoubleByteClassParserTest >> classDefinitionString [
 
-	^ '{superclassName} variableDoubleByteSubclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
-		classVariableNames: ''{classvar1} {classvar2}''
-		package: #MyPackage'
-			format: {
-				'classname' -> self className.
-				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName. } asDictionary
+	^ '{superclassName} << #{classname}
+		layout: DoubleByteLayout;
+		slots: {slots};
+		sharedVariables: \{ #{classvar1} . #{classvar2} };
+		package: #MyPackage' format: {
+			  ('classname' -> self className).
+			  ('superclassName' -> self superclassName).
+			  ('slots' -> self slotsArray).
+			  ('classvar1' -> self firstClassVariableName).
+			  ('classvar2' -> self secondClassVariableName) } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDDoubleByteClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDDoubleByteClassParserTest.class.st
@@ -11,13 +11,12 @@ CDDoubleByteClassParserTest >> classDefinitionString [
 	^ '{superclassName} << #{classname}
 		layout: DoubleByteLayout;
 		slots: {slots};
-		sharedVariables: \{ #{classvar1} . #{classvar2} };
+		sharedVariables: {sharedVariables};
 		package: #MyPackage' format: {
-			  ('classname' -> self className).
-			  ('superclassName' -> self superclassName).
-			  ('slots' -> self slotsArray).
-			  ('classvar1' -> self firstClassVariableName).
-			  ('classvar2' -> self secondClassVariableName) } asDictionary
+			  'classname' -> self className.
+			  'superclassName' -> self superclassName.
+			  'slots' -> self slotsArray.
+			  'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDDoubleWordClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDDoubleWordClassParserTest.class.st
@@ -8,7 +8,8 @@ Class {
 { #category : 'helpers' }
 CDDoubleWordClassParserTest >> classDefinitionString [
 
-	^ '{superclassName} variableDoubleWordSubclass: #{classname}
+	^ '{superclassName} << #{classname}
+		layout: DoubleWordLayout;
 		slots: {slots};
 		sharedVariables: {sharedVariables};
 		package: #MyPackage'

--- a/src/ClassParser-Tests/CDDoubleWordClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDDoubleWordClassParserTest.class.st
@@ -10,14 +10,13 @@ CDDoubleWordClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} variableDoubleWordSubclass: #{classname}
 		slots: {slots};
-		classVariableNames: ''{classvar1} {classvar2}''
+		sharedVariables: {sharedVariables};
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName. } asDictionary
+				'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDDoubleWordClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDDoubleWordClassParserTest.class.st
@@ -9,14 +9,13 @@ Class {
 CDDoubleWordClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} variableDoubleWordSubclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
+		slots: {slots};
 		classVariableNames: ''{classvar1} {classvar2}''
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classvar1' -> self firstClassVariableName.
 				'classvar2' -> self secondClassVariableName. } asDictionary
 ]

--- a/src/ClassParser-Tests/CDEphemeronClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDEphemeronClassParserTest.class.st
@@ -8,7 +8,8 @@ Class {
 { #category : 'helpers' }
 CDEphemeronClassParserTest >> classDefinitionString [
 
-	^ '{superclassName} ephemeronSubclass: #{classname}
+	^ '{superclassName} << #{classname}
+		layout: EphemeronLayout;
 		slots: {slots};
 		sharedVariables: {sharedVariables};
 		package: #MyPackage'

--- a/src/ClassParser-Tests/CDEphemeronClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDEphemeronClassParserTest.class.st
@@ -9,14 +9,13 @@ Class {
 CDEphemeronClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} ephemeronSubclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
+		slots: {slots};
 		classVariableNames: ''{classvar1} {classvar2}''
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classvar1' -> self firstClassVariableName.
 				'classvar2' -> self secondClassVariableName. } asDictionary
 ]

--- a/src/ClassParser-Tests/CDEphemeronClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDEphemeronClassParserTest.class.st
@@ -10,14 +10,13 @@ CDEphemeronClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} ephemeronSubclass: #{classname}
 		slots: {slots};
-		classVariableNames: ''{classvar1} {classvar2}''
+		sharedVariables: {sharedVariables};
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName. } asDictionary
+				'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
+++ b/src/ClassParser-Tests/CDExistingClassDefinitionTest.class.st
@@ -8,7 +8,7 @@ Class {
 { #category : 'helpers' }
 CDExistingClassDefinitionTest >> classDefinitionString [
 
-	^ (ClassDefinitionPrinter oldPharo for: CDClassWithFullDefinitionExample) definitionString
+	^ (ClassDefinitionPrinter fluid for: CDClassWithFullDefinitionExample) definitionString
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDExistingClassSideDefinitionTest.class.st
+++ b/src/ClassParser-Tests/CDExistingClassSideDefinitionTest.class.st
@@ -8,7 +8,7 @@ Class {
 { #category : 'helpers' }
 CDExistingClassSideDefinitionTest >> classDefinitionString [
 
-	^ (ClassDefinitionPrinter oldPharo for: CDClassWithFullDefinitionExample class) definitionString
+	^ (ClassDefinitionPrinter fluid for: CDClassWithFullDefinitionExample class) definitionString
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDImmediateClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDImmediateClassParserTest.class.st
@@ -9,14 +9,13 @@ Class {
 CDImmediateClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} immediateSubclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
+		slots: {slots};
 		classVariableNames: ''{classvar1} {classvar2}''
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classvar1' -> self firstClassVariableName.
 				'classvar2' -> self secondClassVariableName. } asDictionary
 ]

--- a/src/ClassParser-Tests/CDImmediateClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDImmediateClassParserTest.class.st
@@ -10,14 +10,13 @@ CDImmediateClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} immediateSubclass: #{classname}
 		slots: {slots};
-		classVariableNames: ''{classvar1} {classvar2}''
+		sharedVariables: {sharedVariables};
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName. } asDictionary
+				'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDImmediateClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDImmediateClassParserTest.class.st
@@ -8,7 +8,8 @@ Class {
 { #category : 'helpers' }
 CDImmediateClassParserTest >> classDefinitionString [
 
-	^ '{superclassName} immediateSubclass: #{classname}
+	^ '{superclassName} << #{classname}
+		layout: ImmediateLayout;
 		slots: {slots};
 		sharedVariables: {sharedVariables};
 		package: #MyPackage'

--- a/src/ClassParser-Tests/CDMetaclassWithTraitParserTest.class.st
+++ b/src/ClassParser-Tests/CDMetaclassWithTraitParserTest.class.st
@@ -8,11 +8,12 @@ Class {
 { #category : 'helpers' }
 CDMetaclassWithTraitParserTest >> classDefinitionString [
 
-	^ '{className} class
-		uses: {classTraitName} classTrait
+	^ '{superclassName} class << {className} class
+		traits: {classTraitName} classTrait;
 		slots: {slots}'
 			format: {
 				'className' -> self className.
+				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
 				'classTraitName' -> self classTraitName
 			 } asDictionary

--- a/src/ClassParser-Tests/CDMetaclassWithTraitParserTest.class.st
+++ b/src/ClassParser-Tests/CDMetaclassWithTraitParserTest.class.st
@@ -10,11 +10,10 @@ CDMetaclassWithTraitParserTest >> classDefinitionString [
 
 	^ '{className} class
 		uses: {classTraitName} classTrait
-		instanceVariableNames: ''{instvar1} {instvar2}'''
+		slots: {slots}'
 			format: {
 				'className' -> self className.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classTraitName' -> self classTraitName
 			 } asDictionary
 ]

--- a/src/ClassParser-Tests/CDNilSubclassParserTest.class.st
+++ b/src/ClassParser-Tests/CDNilSubclassParserTest.class.st
@@ -8,11 +8,10 @@ Class {
 { #category : 'helpers' }
 CDNilSubclassParserTest >> classDefinitionString [
 
-	^ 'ProtoObject << #ProtoObject
+	^ 'nil << #ProtoObject
 		slots: {slots};
 		sharedVariables: {sharedVariables};
-		package: #MyPackage.
-ProtoObject superclass: nil' format: {
+		package: #MyPackage' format: {
 			  'slots' -> self slotsArray.
 			  'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
@@ -34,5 +33,5 @@ CDNilSubclassParserTest >> testBestNodeForClassNameSelectionShouldBeClassNameNod
 	| selectedNode selection |
 	selection := self selectionOf: 'ProtoObject'.
 	selectedNode := classDefinition bestNodeFor: selection.
-	self assert: selectedNode equals: classDefinition
+	self assert: selectedNode equals: classDefinition classNameNode
 ]

--- a/src/ClassParser-Tests/CDNilSubclassParserTest.class.st
+++ b/src/ClassParser-Tests/CDNilSubclassParserTest.class.st
@@ -10,9 +10,11 @@ CDNilSubclassParserTest >> classDefinitionString [
 
 	^ 'ProtoObject subclass: #ProtoObject
 		slots: {slots};
-	classVariableNames: ''firstClass secondClass''
-	package: #MyPackage.
-ProtoObject superclass: nil' format: { 'slots' -> self slotsArray } asDictionary
+		sharedVariables: {sharedVariables};
+		package: #MyPackage.
+ProtoObject superclass: nil' format: {
+			  'slots' -> self slotsArray.
+			  'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDNilSubclassParserTest.class.st
+++ b/src/ClassParser-Tests/CDNilSubclassParserTest.class.st
@@ -7,11 +7,12 @@ Class {
 
 { #category : 'helpers' }
 CDNilSubclassParserTest >> classDefinitionString [
+
 	^ 'ProtoObject subclass: #ProtoObject
-	instanceVariableNames: ''first second''
+		slots: {slots};
 	classVariableNames: ''firstClass secondClass''
 	package: #MyPackage.
-ProtoObject superclass: nil'
+ProtoObject superclass: nil' format: { 'slots' -> self slotsArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDNilSubclassParserTest.class.st
+++ b/src/ClassParser-Tests/CDNilSubclassParserTest.class.st
@@ -8,7 +8,7 @@ Class {
 { #category : 'helpers' }
 CDNilSubclassParserTest >> classDefinitionString [
 
-	^ 'ProtoObject subclass: #ProtoObject
+	^ 'ProtoObject << #ProtoObject
 		slots: {slots};
 		sharedVariables: {sharedVariables};
 		package: #MyPackage.

--- a/src/ClassParser-Tests/CDNormalClassCategoryParserTest.class.st
+++ b/src/ClassParser-Tests/CDNormalClassCategoryParserTest.class.st
@@ -10,12 +10,11 @@ CDNormalClassCategoryParserTest >> classDefinitionString [
 
 	^ '{superclassName} subclass: #{classname}
 		slots: {slots};
-		classVariableNames: ''{classvar1} {classvar2}''
+		sharedVariables: {sharedVariables};
 		category: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName. } asDictionary
+				'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]

--- a/src/ClassParser-Tests/CDNormalClassCategoryParserTest.class.st
+++ b/src/ClassParser-Tests/CDNormalClassCategoryParserTest.class.st
@@ -9,14 +9,13 @@ Class {
 CDNormalClassCategoryParserTest >> classDefinitionString [
 
 	^ '{superclassName} subclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
+		slots: {slots};
 		classVariableNames: ''{classvar1} {classvar2}''
 		category: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classvar1' -> self firstClassVariableName.
 				'classvar2' -> self secondClassVariableName. } asDictionary
 ]

--- a/src/ClassParser-Tests/CDNormalClassCategoryParserTest.class.st
+++ b/src/ClassParser-Tests/CDNormalClassCategoryParserTest.class.st
@@ -8,10 +8,10 @@ Class {
 { #category : 'helpers' }
 CDNormalClassCategoryParserTest >> classDefinitionString [
 
-	^ '{superclassName} subclass: #{classname}
+	^ '{superclassName} << #{classname}
 		slots: {slots};
 		sharedVariables: {sharedVariables};
-		category: #MyPackage'
+		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.

--- a/src/ClassParser-Tests/CDNormalClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDNormalClassParserTest.class.st
@@ -9,14 +9,13 @@ Class {
 CDNormalClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} subclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
+		slots: {slots};
 		classVariableNames: ''{classvar1} {classvar2}''
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classvar1' -> self firstClassVariableName.
 				'classvar2' -> self secondClassVariableName. } asDictionary
 ]

--- a/src/ClassParser-Tests/CDNormalClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDNormalClassParserTest.class.st
@@ -8,7 +8,7 @@ Class {
 { #category : 'helpers' }
 CDNormalClassParserTest >> classDefinitionString [
 
-	^ '{superclassName} subclass: #{classname}
+	^ '{superclassName} << #{classname}
 		slots: {slots};
 		sharedVariables: {sharedVariables};
 		package: #MyPackage'

--- a/src/ClassParser-Tests/CDNormalClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDNormalClassParserTest.class.st
@@ -10,14 +10,13 @@ CDNormalClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} subclass: #{classname}
 		slots: {slots};
-		classVariableNames: ''{classvar1} {classvar2}''
+		sharedVariables: {sharedVariables};
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName. } asDictionary
+				'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDNormalMetaclassParserTest.class.st
+++ b/src/ClassParser-Tests/CDNormalMetaclassParserTest.class.st
@@ -8,11 +8,12 @@ Class {
 { #category : 'helpers' }
 CDNormalMetaclassParserTest >> classDefinitionString [
 
-	^ '{className} class
-		uses: {classTraitName} classTrait
-		instanceVariableNames: ''{instvar1} {instvar2}'''
+	^ '{superclassName} class << {className} class
+		traits: {classTraitName} classTrait;
+		slots: {slots}'
 			format: {
 				'className' -> self className.
+				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
 				'classTraitName' -> self classTraitName
 			 } asDictionary

--- a/src/ClassParser-Tests/CDNormalMetaclassParserTest.class.st
+++ b/src/ClassParser-Tests/CDNormalMetaclassParserTest.class.st
@@ -13,8 +13,7 @@ CDNormalMetaclassParserTest >> classDefinitionString [
 		instanceVariableNames: ''{instvar1} {instvar2}'''
 			format: {
 				'className' -> self className.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classTraitName' -> self classTraitName
 			 } asDictionary
 ]

--- a/src/ClassParser-Tests/CDPointClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDPointClassParserTest.class.st
@@ -8,9 +8,9 @@ Class {
 { #category : 'helpers' }
 CDPointClassParserTest >> classDefinitionString [
 
-	^ 'Object subclass: #Point
-	instanceVariableNames: ''x y''
-	classVariableNames: ''XX YY''
+	^ 'Object << #Point
+	slots: { #x. #y };
+	sharedVariables: { #XX . #YY };
 	package: ''Kernel-BasicObjects'''
 ]
 

--- a/src/ClassParser-Tests/CDTraitCompositionClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDTraitCompositionClassParserTest.class.st
@@ -13,8 +13,8 @@ CDTraitCompositionClassParserTest class >> isAbstract [
 { #category : 'helpers' }
 CDTraitCompositionClassParserTest >> classDefinitionString [
 
-^ '{superclassName} subclass: #{classname}
-		uses: {traitDefinition}
+^ '{superclassName} << #{classname}
+		traits: {traitDefinition};
 		slots: {slots};
 		sharedVariables: {sharedVariables};
 		package: #MyPackage'

--- a/src/ClassParser-Tests/CDTraitCompositionClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDTraitCompositionClassParserTest.class.st
@@ -15,16 +15,14 @@ CDTraitCompositionClassParserTest >> classDefinitionString [
 
 ^ '{superclassName} subclass: #{classname}
 		uses: {traitDefinition}
-		instanceVariableNames: ''{instvar1} {instvar2}''
-		classVariableNames: ''{classvar1} {classvar2}''
+		slots: {slots};
+		sharedVariables: {sharedVariables};
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName.
+				'slots' -> self slotsArray.
+				'sharedVariables' -> self sharedVariablesArray.
 				'traitDefinition' -> self traitDefinition } asDictionary
 ]
 

--- a/src/ClassParser-Tests/CDVariableByteClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDVariableByteClassParserTest.class.st
@@ -9,14 +9,13 @@ Class {
 CDVariableByteClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} variableByteSubclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
+		slots: {slots};
 		classVariableNames: ''{classvar1} {classvar2}''
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classvar1' -> self firstClassVariableName.
 				'classvar2' -> self secondClassVariableName. } asDictionary
 ]

--- a/src/ClassParser-Tests/CDVariableByteClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDVariableByteClassParserTest.class.st
@@ -8,7 +8,8 @@ Class {
 { #category : 'helpers' }
 CDVariableByteClassParserTest >> classDefinitionString [
 
-	^ '{superclassName} variableByteSubclass: #{classname}
+	^ '{superclassName} << #{classname}
+		layout: ByteLayout;
 		slots: {slots};
 		sharedVariables: {sharedVariables};
 		package: #MyPackage'

--- a/src/ClassParser-Tests/CDVariableByteClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDVariableByteClassParserTest.class.st
@@ -10,14 +10,13 @@ CDVariableByteClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} variableByteSubclass: #{classname}
 		slots: {slots};
-		classVariableNames: ''{classvar1} {classvar2}''
+		sharedVariables: {sharedVariables};
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName. } asDictionary
+				'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDVariableClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDVariableClassParserTest.class.st
@@ -9,14 +9,13 @@ Class {
 CDVariableClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} variableSubclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
+		slots: {slots};
 		classVariableNames: ''{classvar1} {classvar2}''
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classvar1' -> self firstClassVariableName.
 				'classvar2' -> self secondClassVariableName. } asDictionary
 ]

--- a/src/ClassParser-Tests/CDVariableClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDVariableClassParserTest.class.st
@@ -8,7 +8,8 @@ Class {
 { #category : 'helpers' }
 CDVariableClassParserTest >> classDefinitionString [
 
-	^ '{superclassName} variableSubclass: #{classname}
+	^ '{superclassName} << #{classname}
+		layout: VariableLayout;
 		slots: {slots};
 		sharedVariables: {sharedVariables};
 		package: #MyPackage'

--- a/src/ClassParser-Tests/CDVariableClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDVariableClassParserTest.class.st
@@ -10,14 +10,13 @@ CDVariableClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} variableSubclass: #{classname}
 		slots: {slots};
-		classVariableNames: ''{classvar1} {classvar2}''
+		sharedVariables: {sharedVariables};
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName. } asDictionary
+				'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDVariableWordClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDVariableWordClassParserTest.class.st
@@ -9,14 +9,13 @@ Class {
 CDVariableWordClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} variableWordSubclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
+		slots: {slots};
 		classVariableNames: ''{classvar1} {classvar2}''
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classvar1' -> self firstClassVariableName.
 				'classvar2' -> self secondClassVariableName. } asDictionary
 ]

--- a/src/ClassParser-Tests/CDVariableWordClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDVariableWordClassParserTest.class.st
@@ -8,7 +8,8 @@ Class {
 { #category : 'helpers' }
 CDVariableWordClassParserTest >> classDefinitionString [
 
-	^ '{superclassName} variableWordSubclass: #{classname}
+	^ '{superclassName} << #{classname}
+		layout: WordLayout;
 		slots: {slots};
 		sharedVariables: {sharedVariables};
 		package: #MyPackage'

--- a/src/ClassParser-Tests/CDVariableWordClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDVariableWordClassParserTest.class.st
@@ -10,14 +10,13 @@ CDVariableWordClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} variableWordSubclass: #{classname}
 		slots: {slots};
-		classVariableNames: ''{classvar1} {classvar2}''
+		sharedVariables: {sharedVariables};
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName. } asDictionary
+				'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDWeakClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDWeakClassParserTest.class.st
@@ -10,14 +10,13 @@ CDWeakClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} weakSubclass: #{classname}
 		slots: {slots};
-		classVariableNames: ''{classvar1} {classvar2}''
+		sharedVariables: {sharedVariables};
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
 				'slots' -> self slotsArray.
-				'classvar1' -> self firstClassVariableName.
-				'classvar2' -> self secondClassVariableName. } asDictionary
+				'sharedVariables' -> self sharedVariablesArray } asDictionary
 ]
 
 { #category : 'helpers' }

--- a/src/ClassParser-Tests/CDWeakClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDWeakClassParserTest.class.st
@@ -8,7 +8,8 @@ Class {
 { #category : 'helpers' }
 CDWeakClassParserTest >> classDefinitionString [
 
-	^ '{superclassName} weakSubclass: #{classname}
+	^ '{superclassName} << #{classname}
+		layout: WeakLayout;
 		slots: {slots};
 		sharedVariables: {sharedVariables};
 		package: #MyPackage'

--- a/src/ClassParser-Tests/CDWeakClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDWeakClassParserTest.class.st
@@ -9,14 +9,13 @@ Class {
 CDWeakClassParserTest >> classDefinitionString [
 
 	^ '{superclassName} weakSubclass: #{classname}
-		instanceVariableNames: ''{instvar1} {instvar2}''
+		slots: {slots};
 		classVariableNames: ''{classvar1} {classvar2}''
 		package: #MyPackage'
 			format: {
 				'classname' -> self className.
 				'superclassName' -> self superclassName.
-				'instvar1' -> self firstInstanceVariableName.
-				'instvar2' -> self secondInstanceVariableName.
+				'slots' -> self slotsArray.
 				'classvar1' -> self firstClassVariableName.
 				'classvar2' -> self secondClassVariableName. } asDictionary
 ]

--- a/src/ClassParser/CDBehaviorDefinitionNode.class.st
+++ b/src/ClassParser/CDBehaviorDefinitionNode.class.st
@@ -84,8 +84,10 @@ CDBehaviorDefinitionNode >> hasTraitComposition [
 
 { #category : 'initialization' }
 CDBehaviorDefinitionNode >> initialize [
+
 	super initialize.
-	slotNodes := OrderedCollection new
+	slotNodes := OrderedCollection new.
+	layoutClass := FixedLayout
 ]
 
 { #category : 'testing' }

--- a/src/ClassParser/CDClassDefinitionNode.class.st
+++ b/src/ClassParser/CDClassDefinitionNode.class.st
@@ -27,6 +27,13 @@ CDClassDefinitionNode >> binding [
 	^ self class environment associationAt: self className ifAbsent: [LiteralVariable key: nil value: self]
 ]
 
+{ #category : 'initialization' }
+CDClassDefinitionNode >> initialize [
+
+	super initialize.
+	sharedVariableNodes := OrderedCollection new
+]
+
 { #category : 'testing' }
 CDClassDefinitionNode >> isClassDefinition [
 
@@ -88,7 +95,8 @@ CDClassDefinitionNode >> sharedVariableNodes [
 
 { #category : 'accessing' }
 CDClassDefinitionNode >> sharedVariables [
-	^ sharedVariableNodes ifNil:[ sharedVariableNodes := OrderedCollection new ]
+
+	^ sharedVariableNodes
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Almost all the tests about the class parser are done on the old class definition parser. 

This change adapt all the tests to test the fluid definition instead of the old pharo definition.

This allowed me to fix two small missmatch between the results of the two parsers