### PR TITLE
Fix bug in the context interpreter for clean block

### DIFF
--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -594,7 +594,7 @@ Context >> doPrimitive: primitiveIndex method: meth receiver: aReceiver args: ar
 			[^aReceiver simulateValueWithArguments: arguments first caller: self]].
 
 	((primitiveIndex between: 207 and: 209) "FullBlockClosure primitives"
-	  and: [(self objectClass: aReceiver) includesBehavior: FullBlockClosure]) ifTrue:
+	  and: [(self objectClass: aReceiver) includesBehavior: BlockClosure]) ifTrue:
 		[^primitiveIndex = 208
 			ifTrue: [aReceiver simulateValueWithArguments: arguments first caller: self]
 			ifFalse: [aReceiver simulateValueWithArguments: arguments caller: self]].


### PR DESCRIPTION
The context implements a bytecode interpreter and this one has problems with CleanBlocks. For example, if you try to interpret the #value on a clean block, the resulting context will miss its senders. 

This change propose a fix making this interpreter accept more kind of objects for primitive 207, 208 and 209