### PR TITLE
outer context is not sender context

### DIFF
--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -1292,10 +1292,9 @@ Context >> objectSize: anObject [
 
 { #category : 'accessing' }
 Context >> outerContext [
-	"Answer the context within which the receiver is nested."
+	"Answer the outerContext if this is a block context, nil else"
 	<reflection: 'Stack Manipulation - Context'>
-	^closureOrNil ifNotNil:
-		[closureOrNil outerContext ifNil: ["if the outer is nil, this is a CleanBlock" self sender]]
+	^closureOrNil ifNotNil: [ closureOrNil outerContext ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Context outerContext falls back on #sender. This is not a good idea as the two are really different concepts. A Context of a closure without an outerContext (Clean Blocks, methods) should return nil