### PR TITLE
Revert "Check: can we compile Dictionary>>at: block without outer context?"

### DIFF
--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -336,7 +336,6 @@ Dictionary >> associationsSelect: aBlock [
 { #category : 'accessing' }
 Dictionary >> at: key [
 	"Answer the value associated with the key."
-	 <compilerOptions: #(+ optionBlockClosureOptionalOuter)>
 	^ self at: key ifAbsent: [self errorKeyNotFound: key]
 ]
 


### PR DESCRIPTION
Reverts pharo-project/pharo#15017

We need to improve the debugger before we can do it ( fixes #15059)