### PR TITLE
Move regex core loading

### DIFF
--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -3,7 +3,6 @@ mcPackages := #(
  'ScriptingExtensions'
  'System-FileRegistry'
  'FileSystem-Memory'
- 'Regex-Core'
  'Ring-Definitions-Containers'
  'StartupPreferences'
  'ConfigurationCommandLineHandler-Core'
@@ -37,10 +36,6 @@ MCMethodDefinition initializersEnabled: true.
 
 "For now, it happens that the bootstrap does not caches the pragmas. This should be fixed later by reloading the packages after Metacello and Monticello are reloaded but we need them for reseting the system announcer for example."
 CompiledMethod allInstancesDo: [ :m | m cachePragmas ].
-
-RxMatcher initialize.
-RxParser initialize.
-RxsPredicate initialize.
 
 MCFileTreeStCypressWriter initialize.
 MCFileTreeFileSystemUtils initialize.

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -66,6 +66,7 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'NECompletion'.
 		spec package: 'NECompletion-Morphic'.
 		spec package: 'NECompletion-Preferences'.
+		spec package: 'Regex-Core'.
 		spec package: 'Metacello-FileTree'.
 		spec package: 'Metacello-Cypress'.
 		spec package: 'Metacello-Reference'.

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -66,7 +66,6 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'NECompletion'.
 		spec package: 'NECompletion-Morphic'.
 		spec package: 'NECompletion-Preferences'.
-		spec package: 'Regex-Core'.
 		spec package: 'Metacello-FileTree'.
 		spec package: 'Metacello-Cypress'.
 		spec package: 'Metacello-Reference'.

--- a/src/BaselineOfMetacello/BaselineOfMetacello.class.st
+++ b/src/BaselineOfMetacello/BaselineOfMetacello.class.st
@@ -14,7 +14,6 @@ BaselineOfMetacello >> baseline: spec [
 			package: 'ScriptingExtensions';
 			package: 'System-FileRegistry';
 			package: 'FileSystem-Memory';
-			package: 'Regex-Core';
 			package: 'StartupPreferences';
 			package: 'ConfigurationCommandLineHandler-Core';
 			package: 'PragmaCollector';

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -72,6 +72,8 @@ BaselineOfMorphic >> baseline: spec [
 
 		spec package: 'Native-Browser'.
 		
+		spec package: 'Regex-Core'.
+		
 		spec package: 'Morphic-Base'.
 		spec package: 'Morphic-Examples'.
 		spec package: 'Morphic-Widgets-Basic'.


### PR DESCRIPTION
Regex-Core is in baseline of Metacello but is not used by Metacello. Let's try to load it in Baseline of morphic so that we load it normally and not in the first steps of the bootstrap. Morphic is the first thing using regex for the widgets