### PR TITLE
Fix bug marking too many packages as dirty in Iceberg

### DIFF
--- a/src/RPackage-Tests/PackageAnnouncementsTest.class.st
+++ b/src/RPackage-Tests/PackageAnnouncementsTest.class.st
@@ -42,6 +42,25 @@ PackageAnnouncementsTest >> testAddClassAnnounceClassRepackaged [
 ]
 
 { #category : 'tests' }
+PackageAnnouncementsTest >> testAddExtensionMethodHasTheRightPackage [
+
+	| xPackage yPackage class |
+	xPackage := self ensureXPackage.
+	yPackage := self ensureYPackage.
+
+	class := self newClassNamed: #NewClass1 in: xPackage.
+
+	self when: MethodAdded do: [ :ann |
+		self assert: ann methodAdded selector equals: #testMethod.
+		self assert: ann methodClass identicalTo: class.
+		self assert: ann methodPackage identicalTo: yPackage ].
+
+	class compile: 'testMethod ^ #kheego' classified: '*' , yPackage name.
+	
+	self assert: numberOfAnnouncements equals: 1
+]
+
+{ #category : 'tests' }
 PackageAnnouncementsTest >> testClassRepackagedNotFiredAtAClassAddition [
 
 	| xPackage class |

--- a/src/System-Announcements/MethodAnnouncement.class.st
+++ b/src/System-Announcements/MethodAnnouncement.class.st
@@ -5,8 +5,7 @@ Class {
 	#name : 'MethodAnnouncement',
 	#superclass : 'SystemAnnouncement',
 	#instVars : [
-		'method',
-		'methodPackage'
+		'method'
 	],
 	#category : 'System-Announcements-System-Methods',
 	#package : 'System-Announcements',
@@ -41,7 +40,7 @@ MethodAnnouncement >> affectsMethodsDefinedInClass: aClass [
 { #category : 'testing' }
 MethodAnnouncement >> affectsMethodsDefinedInPackage: aPackage [
 
-	^methodPackage == aPackage or: [ self methodAffected package == aPackage ]
+	^ self methodPackage == aPackage or: [ self methodAffected package == aPackage ]
 ]
 
 { #category : 'testing' }
@@ -81,8 +80,8 @@ MethodAnnouncement >> method [
 
 { #category : 'accessing' }
 MethodAnnouncement >> method: aCompiledMethod [
-	method := aCompiledMethod.
-	methodPackage := aCompiledMethod package
+
+	method := aCompiledMethod
 ]
 
 { #category : 'accessing' }
@@ -102,7 +101,8 @@ MethodAnnouncement >> methodOrigin [
 
 { #category : 'accessing' }
 MethodAnnouncement >> methodPackage [
-	^ methodPackage ifNil: [ methodPackage := method package ]
+
+	^ method package
 ]
 
 { #category : 'accessing' }

--- a/src/System-Announcements/MethodRemoved.class.st
+++ b/src/System-Announcements/MethodRemoved.class.st
@@ -8,7 +8,8 @@ Class {
 	#superclass : 'MethodAnnouncement',
 	#instVars : [
 		'protocol',
-		'methodOrigin'
+		'methodOrigin',
+		'methodPackage'
 	],
 	#category : 'System-Announcements-System-Methods',
 	#package : 'System-Announcements',
@@ -40,6 +41,12 @@ MethodRemoved >> methodOrigin [
 { #category : 'accessing' }
 MethodRemoved >> methodOrigin: anObject [
 	methodOrigin := anObject
+]
+
+{ #category : 'accessing' }
+MethodRemoved >> methodPackage [
+
+	^ methodPackage
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Too many packages end up bee marked as dirty while loading code in Iceberg. I traced the root of one of the problem happening. This problem comes from MethodAdded announcement that is pointing the wrong package as the package containing the method in case it is an extension.

I propose to not save in a variable the package of a method in the method annoucements (except for the MethodRemoved for now) but to jutst ask the method. 

I added a regression test about this behavior. I think this problem will be solved in an even cleaner way in the future when the MethodAdded will not be managed through announcements but directly in the code of the methods.