### PR TITLE
Fix moving a class from a tag in Calypso

### DIFF
--- a/src/Calypso-SystemQueries/ClyClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyClassGroup.class.st
@@ -98,6 +98,18 @@ ClyClassGroup >> = anObject [
 	^ classQuery = anObject classQuery
 ]
 
+{ #category : 'adding' }
+ClyClassGroup >> addClass: aClass [
+
+	| newPackages |
+	super addClass: aClass.
+	newPackages := OrderedCollection new.
+	classQuery scope packagesDo: [ :package | package = aClass package ifFalse: [ newPackages add: package ] ].
+	newPackages size > 1 ifTrue: [ self error: 'You should select single package for import!' ].
+	newPackages ifNotEmpty: [ aClass package: newPackages anyOne ].
+	aClass packageTag: self tag
+]
+
 { #category : 'accessing' }
 ClyClassGroup >> classQuery [
 	^ classQuery
@@ -133,16 +145,6 @@ ClyClassGroup >> hash [
 	^ classQuery hash
 ]
 
-{ #category : 'operations' }
-ClyClassGroup >> importClass: aClass [
-]
-
-{ #category : 'operations' }
-ClyClassGroup >> importClasses: classesCollection [
-
-	classesCollection do: [ :each | self importClass: each ]
-]
-
 { #category : 'initialization' }
 ClyClassGroup >> initialize [
 	super initialize.
@@ -171,4 +173,10 @@ ClyClassGroup >> subgroupsQuery [
 { #category : 'accessing' }
 ClyClassGroup >> subgroupsQuery: anObject [
 	subgroupsQuery := anObject
+]
+
+{ #category : 'accessing' }
+ClyClassGroup >> tag [
+
+	^ self subclassResponsibility
 ]

--- a/src/Calypso-SystemQueries/ClyNoTagClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyNoTagClassGroup.class.st
@@ -28,21 +28,14 @@ ClyNoTagClassGroup class >> priority [
 ]
 
 { #category : 'operations' }
-ClyNoTagClassGroup >> importClass: aClass [
-
-	| newPackages |
-	super importClass: aClass.
-	newPackages := OrderedCollection new.
-	classQuery scope packagesDo: [ :each | each = aClass package ifFalse: [ newPackages add: each ] ].
-	newPackages size > 1 ifTrue: [ ^ self error: 'You should select single package for import!' ].
-
-	newPackages ifNotEmpty: [ ^ newPackages first addClass: aClass ].
-	self flag: #package. "I'm not sure this next line even makes sens after moving the class from package. The tag should be removed automatically?"
-	aClass removePackageTag
-]
-
-{ #category : 'operations' }
 ClyNoTagClassGroup >> renameClassTagTo: newTag [
 
 	self classes do: [ :class | class packageTag: newTag ]
+]
+
+{ #category : 'accessing' }
+ClyNoTagClassGroup >> tag [
+	"Uncategorized classes are going to the root tag."
+
+	^ RPackage rootTagName
 ]

--- a/src/Calypso-SystemQueries/ClyTaggedClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedClassGroup.class.st
@@ -41,19 +41,6 @@ ClyTaggedClassGroup class >> withClassesFrom: aPackageScope taggedBy: tagName [
 ]
 
 { #category : 'operations' }
-ClyTaggedClassGroup >> importClass: aClass [
-	| newPackages |
-	super importClass: aClass.
-
-	newPackages := OrderedCollection new.
-	classQuery scope packagesDo: [ :each |
-		each = aClass package ifFalse: [ newPackages add: each ]].
-	newPackages size > 1 ifTrue: [ ^self error: 'You should select single package for import!' ].
-	newPackages ifNotEmpty: [ newPackages first addClass: aClass].
-	aClass packageTag: self tag
-]
-
-{ #category : 'operations' }
 ClyTaggedClassGroup >> removeWithClasses [
 
 	super removeWithClasses.

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -94,9 +94,9 @@ ClassDescription >> packages [
 
 { #category : '*RPackage-Core' }
 ClassDescription >> removePackageTag [
+	"Removing a package tag is the same as moving it to the root tag that is the uncategorized tag."
 
-	self packageTag isRoot ifTrue: [ "Cannot remove root tag" ^ self ].
-
-	self packageTag removeClass: self.
-	self package addClass: self
+	| package |
+	package := self package.
+	package moveClass: self toTag: package rootTag
 ]


### PR DESCRIPTION
Fixes #15076 reported by esteban

The problem is that calypso was using polymorphism between RPackage and ClasClassGroup to move classes in different situations and I broke this. I'm fixing thix problem and cleaning a little the code, for example removing duplicated code or dead code