### PR TITLE
Refactor: move precondition checking code to `checkPreconditions`

### DIFF
--- a/src/Refactoring-Core/RBAddMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddMethodRefactoring.class.st
@@ -53,18 +53,22 @@ RBAddMethodRefactoring class >> sourceCode: aString in: aClass withProtocol: aPr
 ]
 
 { #category : 'preconditions' }
-RBAddMethodRefactoring >> preconditions [
+RBAddMethodRefactoring >> checkPreconditions [
 	"We should have same preconditions checking API for all refactorings.
 	Some of them do it like: 
 	preconditions
-
 	^ self applicabilityPreconditions & self breakingChangePreconditions
 	
 	and refactorings that are decorators do it like this method:
 	"
 
 	transformation checkPreconditions.
-	
+	super checkPreconditions 
+]
+
+{ #category : 'preconditions' }
+RBAddMethodRefactoring >> preconditions [
+
 	^ (RBCondition canUnderstand: transformation selector in: class) not
 ]
 

--- a/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
@@ -81,6 +81,13 @@ RBRemoveMethodRefactoring >> checkBrowseOccurrences: anCollectionOfOccurrences [
 ]
 
 { #category : 'preconditions' }
+RBRemoveMethodRefactoring >> checkPreconditions [ 
+
+	transformation checkPreconditions.
+	super checkPreconditions 
+]
+
+{ #category : 'preconditions' }
 RBRemoveMethodRefactoring >> checkReferencesToAnyOf: aSelector [
 
 	| occurrences |
@@ -154,8 +161,6 @@ RBRemoveMethodRefactoring >> justSendsSuper: aSelector [
 
 { #category : 'preconditions' }
 RBRemoveMethodRefactoring >> preconditions [
-
-	transformation checkPreconditions.
 
 	^ self breakingChangePreconditions 
 ]


### PR DESCRIPTION
Previously it was in `preconditions` and this didn't make sense, since preconditions should only return precondition instance.