### PR TITLE
Deprecate MetacelloPlatfrom>>#authorName:

### DIFF
--- a/src/Deprecated12/MetacelloPlatform.extension.st
+++ b/src/Deprecated12/MetacelloPlatform.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'MetacelloPlatform' }
+
+{ #category : '*Deprecated12' }
+MetacelloPlatform >> authorName: aString [
+
+	self deprecated: 'Use `Author fullName: aString` instead.' transformWith: '`@rcv authorName: `@arg' -> 'Author fullName: `@arg'.
+	Author fullName: aString
+]


### PR DESCRIPTION
This mehod was recently removed but it is called by smalltalkCI. I propose to add it back as deprecated.