### PR TITLE
RPackage: Simplify protocol management

### DIFF
--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -434,7 +434,7 @@ RPackageOrganizer >> registerInterestToAnnouncer: anAnnouncer [
 	anAnnouncer weak
 		when: ClassAdded send: #systemClassAddedActionFrom: to: self;
 		when: ClassRecategorized send: #systemClassRecategorizedActionFrom: to: self;
-		when: ProtocolAnnouncement send: #systemClassReorganizedActionFrom: to: self;
+		when: ProtocolAdded send: #systemProtocolAddedActionFrom: to: self;
 		when: MethodAdded send: #systemMethodAddedActionFrom: to: self;
 		when: MethodRecategorized send: #systemMethodRecategorizedActionFrom: to: self
 ]
@@ -520,13 +520,6 @@ RPackageOrganizer >> systemClassRecategorizedActionFrom: announcement [
 ]
 
 { #category : 'system integration' }
-RPackageOrganizer >> systemClassReorganizedActionFrom: ann [
-	"when a class is reorganized, we have to check if an extension has not been added"
-
-	ann classReorganized extensionProtocols do: [ :protocol | self ensurePackageOfExtensionProtocol: protocol ]
-]
-
-{ #category : 'system integration' }
 RPackageOrganizer >> systemMethodAddedActionFrom: ann [
 
 	| method |
@@ -541,7 +534,7 @@ RPackageOrganizer >> systemMethodAddedActionFrom: ann [
 RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 
 	| method |
-	method := ann method ifNil: [ ^ self ].
+	method := ann method.
 
 	method origin = ann methodClass ifFalse: [ ^ self ]. "Methods from traits are not treated"
 
@@ -562,6 +555,13 @@ RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 		newPackage addMethod: method.
 
 		SystemAnnouncer uniqueInstance methodRepackaged: method from: oldPackage to: newPackage ]
+]
+
+{ #category : 'system integration' }
+RPackageOrganizer >> systemProtocolAddedActionFrom: ann [
+	"When a protocol is added we should ensure extensions protocols have their matching package."
+
+	ann protocol isExtensionProtocol ifTrue: [ self ensurePackageOfExtensionProtocol: ann protocol ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
RPackage currently listens to all announcements related to protocols and when they receive one they ensure we have a package for every extension protocol of the class. 

This is doing too much work. First we are not doing anything when a protocol gets removed. And when a protocol gets added, we don't need to do things for every protocols of the class, just for the one that got added.

This cfange simplifies what RPackage is doing on protocol management