### PR TITLE
Monticello: Make MethodAddition closer to system behavior

### DIFF
--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -51,7 +51,7 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 	self isAnonymous ifTrue: [ ^ self ].
 
 	(priorMethod isNil or: [ priorOrigin ~= compiledMethod origin ])
-		ifTrue: [ SystemAnnouncer uniqueInstance methodAdded: compiledMethod ]
+		ifTrue: [ SystemAnnouncer uniqueInstance announce: (MethodAdded method: compiledMethod) ]
 		ifFalse: [ "If protocol changed and someone is from different package, I need to throw a method recategorized"
 			newProtocol = oldProtocol ifFalse: [ SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: oldProtocol ].
 			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol ]

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -176,10 +176,6 @@ MCWorkingCopy class >> initialize [
 
 { #category : 'system changes' }
 MCWorkingCopy class >> methodModified: anEvent [
-	"If the method has just been loaded by monticello itself, do not mark it as dirty"
-
-	anEvent propertyAt: #eventSource ifPresent: [ :source | source == self class package name ifTrue: [ ^ self ] ].
-
 	"trait methods aren't handled here"
 	anEvent isProvidedByATrait ifTrue: [ ^ self ].
 

--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -68,7 +68,7 @@ MethodAddition >> notifyObservers [
 
 	SystemAnnouncer uniqueInstance suspendAllWhile: [ myClass classify: selector under: protocolName ].
 	(priorMethod isNil or: [ priorOrigin ~= compiledMethod origin ])
-		ifTrue: [ SystemAnnouncer uniqueInstance methodAdded: compiledMethod configuredWith: [ :event | event propertyAt: #eventSource put: #Monticello ] ]
+		ifTrue: [ SystemAnnouncer uniqueInstance announce: (MethodAdded method: compiledMethod) ]
 		ifFalse: [
 			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: priorProtocol.
 			priorProtocol name = protocolName ifFalse: [ SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: priorProtocol ] ].

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -121,23 +121,6 @@ SystemAnnouncer >> isSuspended [
 ]
 
 { #category : 'triggering' }
-SystemAnnouncer >> methodAdded: aMethod [
-	"A method with the given selector was added to aClass, but not put in a protocol."
-
-	^ self methodAdded: aMethod configuredWith: [ :method | ]
-]
-
-{ #category : 'triggering' }
-SystemAnnouncer >> methodAdded: aMethod configuredWith: aBlock [
-	"A method with the given selector was added to aClass, but not put in a protocol."
-
-	| event |
-	event := MethodAdded method: aMethod.
-	aBlock value: event.
-	self announce: event
-]
-
-{ #category : 'triggering' }
 SystemAnnouncer >> methodChangedFrom: oldMethod to: newMethod oldProtocol: oldProtocol [
 
 	self announce: (MethodModified methodChangedFrom: oldMethod to: newMethod oldProtocol: oldProtocol)


### PR DESCRIPTION
Monticello reimplement its own method compilation mecanism and I don't like this because it means that we have duplication and this can (and already has in the past) introduce bugs. 

I tried multiple things in the past to remove this duplication but it is not so easy. Here I'm trying the little step of making the announcements the same than the ones of the system.