### PR TITLE
Calypso: Remove duplicated registration of SycRemoveClassCommand

### DIFF
--- a/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
@@ -8,20 +8,6 @@ Class {
 	#package : 'SystemCommands-ClassCommands'
 }
 
-{ #category : 'activation' }
-SycRemoveClassCommand class >> fullBrowserMenuActivation [
-	<classAnnotation>
-
-	^CmdContextMenuActivation byRootGroupItemOrder: 10000 for: ClyFullBrowserClassContext
-]
-
-{ #category : 'activation' }
-SycRemoveClassCommand class >> fullBrowserShortcutActivation [
-	<classAnnotation>
-
-	^CmdShortcutActivation removalFor: ClyFullBrowserClassContext
-]
-
 { #category : 'accessing' }
 SycRemoveClassCommand >> defaultMenuIconName [
 	^#removeIcon


### PR DESCRIPTION
SycRemoveClassCommand has the same methods in the class and as extension of Calypso-SystemTools-FullBrowser. 

I propose to remove this clash