### PR TITLE
15074-Pragmas-lost-when-updating-methods

### DIFF
--- a/src/Kernel-Tests/PragmaTest.class.st
+++ b/src/Kernel-Tests/PragmaTest.class.st
@@ -97,6 +97,15 @@ PragmaTest >> testHash [
 ]
 
 { #category : 'tests - cache' }
+PragmaTest >> testRecompile [
+	self assert: (Pragma allNamed: #testPragmaArg1:arg2:arg3:) notEmpty.
+	self class compile: 'methodWithPragma
+	<testPragmaArg1: #toto arg2: 2 arg3: true>' classified: 'helper'.
+	Smalltalk garbageCollect.
+	self assert: (Pragma allNamed: #testPragmaArg1:arg2:arg3:) notEmpty.
+]
+
+{ #category : 'tests - cache' }
 PragmaTest >> testall [
 	self assert: Pragma all first class equals: Pragma
 ]

--- a/src/Kernel/AdditionalMethodState.class.st
+++ b/src/Kernel/AdditionalMethodState.class.st
@@ -158,6 +158,25 @@ AdditionalMethodState >> copyWithout: aPropertyOrPragma [ "<Association|Pragma>"
 	^copy
 ]
 
+{ #category : 'copying' }
+AdditionalMethodState >> copyWithoutNoShallowCopy: aPropertyOrPragma [ "<Association|Pragma>"
+	"Answer a copy of the receiver which no longer includes aPropertyOrPragma. Do not copy aPropertyOrPragma. This method is used to update existing state "
+	| bs copy offset |
+	"no need to initialize here; we're copying all inst vars"
+	copy := self class basicNew: (bs := self basicSize) - ((self includes: aPropertyOrPragma)
+															ifTrue: [1]
+															ifFalse: [0]).
+	offset := 0.
+	1 to: bs do:
+		[:i|
+		(self basicAt: i) = aPropertyOrPragma
+			ifTrue: [offset := 1]
+			ifFalse: [copy basicAt: i - offset put: (self basicAt: i)]].
+	1 to: self class instSize do:
+		[:i| copy instVarAt: i put: (self instVarAt: i)].
+	^copy
+]
+
 { #category : 'testing' }
 AdditionalMethodState >> includes: aPropertyOrPragma [ "<Association|Pragma>"
 	"Test if the property or pragma is present."

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -843,7 +843,7 @@ CompiledMethod >> removeProperty: propName [
 	 Do _not_ raise an error if the property is missing."
 	| value |
 	value := self propertyAt: propName ifAbsent: [^nil].
-	self penultimateLiteral: (self penultimateLiteral copyWithout:
+	self penultimateLiteral: (self penultimateLiteral copyWithoutNoShallowCopy:
 									(Association
 										key: propName
 										value: value)).
@@ -859,7 +859,7 @@ CompiledMethod >> removeProperty: propName ifAbsent: aBlock [
 	 Answer the evaluation of aBlock if the property is missing."
 	| value |
 	value := self propertyAt: propName ifAbsent: [^aBlock value].
-	self penultimateLiteral: (self penultimateLiteral copyWithout:
+	self penultimateLiteral: (self penultimateLiteral copyWithoutNoShallowCopy:
 									(Association
 										key: propName
 										value: value)).


### PR DESCRIPTION
- add #testRecompile which fails without the fix
- add #copyWithoutNoShallowCopy: that does not copy
- use it when removing properties only

fixes #15074