### PR TITLE
Monticello: Class/Trait definition creation shouldnt use categories

### DIFF
--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -219,7 +219,8 @@ MCClassDefinition >> createClass [
 			  traitComposition: self traitCompositionCompiled;
 			  classTraitComposition: self classTraitCompositionCompiled;
 			  comment: comment stamp: self commentStamp;
-			  category: self category;
+			  package: self packageName;
+			  tag: self tagName;
 			  environment: superClass environment ] ]
 		  on: Warning , DuplicatedVariableError
 		  do: [ :ex | ex resume ]

--- a/src/Monticello/MCTraitDefinition.class.st
+++ b/src/Monticello/MCTraitDefinition.class.st
@@ -69,7 +69,8 @@ MCTraitDefinition >> createClass [
 			  classTraitComposition: (Smalltalk compiler evaluate: self classTraitCompositionString);
 			  slots: self instanceVariables;
 			  classSlots: self classInstanceVariables;
-			  package: self category;
+			  package: self packageName;
+			  tag: self tagName;
 			  comment: comment stamp: commentStamp;
 			  beTrait ] ]
 		  on: Warning , DuplicatedVariableError


### PR DESCRIPTION
This change update the use of ShiftClassBuilder in MCClassDefinition and MCTraitDefinition to use packages and tags instead of categories.