### PR TITLE
AdditionalMethodState: do not copy the Associations/Pragmas when growing or shrinking

### DIFF
--- a/src/Kernel-Tests/PragmaTest.class.st
+++ b/src/Kernel-Tests/PragmaTest.class.st
@@ -97,6 +97,14 @@ PragmaTest >> testHash [
 ]
 
 { #category : 'tests - cache' }
+PragmaTest >> testPragmaAddingProperty [
+	self assert: (Pragma allNamed: #testPragmaArg1:arg2:arg3:) notEmpty.
+	(self class>>#methodWithPragma) propertyAt: #hello put: #something.
+	Smalltalk garbageCollect.
+	self assert: (Pragma allNamed: #testPragmaArg1:arg2:arg3:) notEmpty.
+]
+
+{ #category : 'tests - cache' }
 PragmaTest >> testRecompile [
 	self assert: (Pragma allNamed: #testPragmaArg1:arg2:arg3:) notEmpty.
 	self class compile: 'methodWithPragma

--- a/src/Kernel/AdditionalMethodState.class.st
+++ b/src/Kernel/AdditionalMethodState.class.st
@@ -132,7 +132,7 @@ AdditionalMethodState >> copyWith: aPropertyOrPragma [ "<Association|Pragma>"
 	copy := self class basicNew: (bs := self basicSize) + 1.
 	1 to: bs do:
 		[:i|
-		copy basicAt: i put: (self basicAt: i) shallowCopy].
+		copy basicAt: i put: (self basicAt: i)].
 	copy basicAt: bs + 1 put: aPropertyOrPragma.
 	1 to: self class instSize do:
 		[:i| copy instVarAt: i put: (self instVarAt: i)].
@@ -142,25 +142,6 @@ AdditionalMethodState >> copyWith: aPropertyOrPragma [ "<Association|Pragma>"
 { #category : 'copying' }
 AdditionalMethodState >> copyWithout: aPropertyOrPragma [ "<Association|Pragma>"
 	"Answer a copy of the receiver which no longer includes aPropertyOrPragma"
-	| bs copy offset |
-	"no need to initialize here; we're copying all inst vars"
-	copy := self class basicNew: (bs := self basicSize) - ((self includes: aPropertyOrPragma)
-															ifTrue: [1]
-															ifFalse: [0]).
-	offset := 0.
-	1 to: bs do:
-		[:i|
-		(self basicAt: i) = aPropertyOrPragma
-			ifTrue: [offset := 1]
-			ifFalse: [copy basicAt: i - offset put: (self basicAt: i) shallowCopy]].
-	1 to: self class instSize do:
-		[:i| copy instVarAt: i put: (self instVarAt: i)].
-	^copy
-]
-
-{ #category : 'copying' }
-AdditionalMethodState >> copyWithoutNoShallowCopy: aPropertyOrPragma [ "<Association|Pragma>"
-	"Answer a copy of the receiver which no longer includes aPropertyOrPragma. Do not copy aPropertyOrPragma. This method is used to update existing state "
 	| bs copy offset |
 	"no need to initialize here; we're copying all inst vars"
 	copy := self class basicNew: (bs := self basicSize) - ((self includes: aPropertyOrPragma)

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -843,7 +843,7 @@ CompiledMethod >> removeProperty: propName [
 	 Do _not_ raise an error if the property is missing."
 	| value |
 	value := self propertyAt: propName ifAbsent: [^nil].
-	self penultimateLiteral: (self penultimateLiteral copyWithoutNoShallowCopy:
+	self penultimateLiteral: (self penultimateLiteral copyWithout:
 									(Association
 										key: propName
 										value: value)).
@@ -859,7 +859,7 @@ CompiledMethod >> removeProperty: propName ifAbsent: aBlock [
 	 Answer the evaluation of aBlock if the property is missing."
 	| value |
 	value := self propertyAt: propName ifAbsent: [^aBlock value].
-	self penultimateLiteral: (self penultimateLiteral copyWithoutNoShallowCopy:
+	self penultimateLiteral: (self penultimateLiteral copyWithout:
 									(Association
 										key: propName
 										value: value)).


### PR DESCRIPTION
This PR makes sure that we never copy the associations and properties when removing an entry from the AdditionalMethodState array.

This is save for the associations as we do not *copy* the method, we just shrink the private AdditionalMethodSate object.