### PR TITLE
RBPragmaNode/Pragma: add #sourceNode, reduce #asPragma

### DIFF
--- a/src/AST-Core/RBPragmaNode.class.st
+++ b/src/AST-Core/RBPragmaNode.class.st
@@ -19,7 +19,8 @@ Class {
 		'keywordsPositions',
 		'arguments',
 		'left',
-		'right'
+		'right',
+		'pragma'
 	],
 	#category : 'AST-Core-Nodes',
 	#package : 'AST-Core',
@@ -201,6 +202,18 @@ RBPragmaNode >> numArgs [
 RBPragmaNode >> postCopy [
 	super postCopy.
 	self arguments: (self arguments collect: [ :each | each copy ])
+]
+
+{ #category : 'accessing' }
+RBPragmaNode >> pragma [
+
+	^ pragma
+]
+
+{ #category : 'accessing' }
+RBPragmaNode >> pragma: anObject [
+
+	pragma := anObject
 ]
 
 { #category : 'replacing' }

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -315,6 +315,13 @@ Pragma >> sendTo: anObject [
 	^ anObject perform: self selector withArguments: self arguments
 ]
 
+{ #category : 'accessing' }
+Pragma >> sourceNode [
+	| index |
+	index := method pragmas identityIndexOf: self.
+	^ method ast pragmas at: index
+]
+
 { #category : 'processing' }
 Pragma >> withArgumentsDo: aBlock [
 	"Pass the arguments of the receiving pragma into aBlock and answer the result."

--- a/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTSemanticAnalyzer.class.st
@@ -260,8 +260,9 @@ OCASTSemanticAnalyzer >> visitPragmaNode: aPragmaNode [
 
 	| varNode |
 	super visitPragmaNode: aPragmaNode.
+	aPragmaNode pragma: aPragmaNode asPragma.
 	aPragmaNode selector = #compilerOptions: ifTrue: [
-		aPragmaNode asPragma sendTo:
+		aPragmaNode pragma sendTo:
 			self compilationContext ].
 
 	"if the pragma is a primitive that defines an error variable, we need to declare a temp

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -730,7 +730,7 @@ OCASTTranslator >> visitPragmaNode: aPragmaNode [
 
 	| var |
 	aPragmaNode isParseError ifTrue: [ ^self ].
-	methodBuilder addPragma: aPragmaNode asPragma.
+	methodBuilder addPragma: aPragmaNode pragma.
 
 	"if the pragma is a primitive that defines an error variable, we need to store error value
 	which is on the stack"

--- a/src/OpalCompiler-Tests/OCPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/OCPragmaTest.class.st
@@ -14,6 +14,13 @@ OCPragmaTest >> methodDoublePragma [
 ]
 
 { #category : 'method - tested' }
+OCPragmaTest >> methodDoublePragmaIdentical [
+		^'methodDoublePragma
+			<hello>
+			<hello>'
+]
+
+{ #category : 'method - tested' }
 OCPragmaTest >> methodNoPragma [
 	^'methodNoPragma: aNum
 		^aNum'
@@ -155,4 +162,19 @@ OCPragmaTest >> testSinglePragma [
 	| aCompiledMethod |
 	aCompiledMethod := OpalCompiler new compile: self methodSinglePragma.
 	self assert: aCompiledMethod pragmas first selector equals: #hello:
+]
+
+{ #category : 'tests' }
+OCPragmaTest >> testSourceNode [
+	| aCompiledMethod node1 node2|
+	aCompiledMethod := OpalCompiler new compile: self methodDoublePragmaIdentical.
+	
+	node1 := aCompiledMethod pragmas first sourceNode.
+	node2 := aCompiledMethod pragmas second sourceNode.
+	
+	self assert: node1 isPragma.
+	self assert: node1 selector equals: aCompiledMethod pragmas first selector.
+	self assert: node2 isPragma.
+	self assert: node2 selector equals: aCompiledMethod pragmas second selector.
+	self deny: node1 == node2
 ]

--- a/src/OpalCompiler-Tests/OCPragmaTest.class.st
+++ b/src/OpalCompiler-Tests/OCPragmaTest.class.st
@@ -171,10 +171,10 @@ OCPragmaTest >> testSourceNode [
 	
 	node1 := aCompiledMethod pragmas first sourceNode.
 	node2 := aCompiledMethod pragmas second sourceNode.
-	
+
 	self assert: node1 isPragma.
 	self assert: node1 selector equals: aCompiledMethod pragmas first selector.
 	self assert: node2 isPragma.
 	self assert: node2 selector equals: aCompiledMethod pragmas second selector.
-	self deny: node1 == node2
+	self deny: node1 identicalTo: node2
 ]

--- a/src/Reflectivity/RBMethodNode.extension.st
+++ b/src/Reflectivity/RBMethodNode.extension.st
@@ -28,9 +28,9 @@ RBMethodNode >> metaLinkOptionsFromClassAndMethod [
 						ifAbsent: [ #() ]) ].
 	"set meta link options defined per method"
 	(self pragmas
-		select: [ :pragma | pragma selector == #metaLinkOptions: ])
+		select: [ :pragmaNode | pragmaNode selector == #metaLinkOptions: ])
 		do:
-			[ :pragma | (pragma asPragma selector: #parseOptions:) sendTo: options ].
+			[ :pragmaNode | (pragmaNode pragma copy selector: #parseOptions:) sendTo: options ].
 	^ options
 ]
 


### PR DESCRIPTION
This PR changes the compiler to create the Pragma instance during name analysis and add it to the RBPragmaNode.

This allows is to have just one place where Pragmas are created (there is just one sender of #asPragma after this PR is merged)

add a #sourceNode method and test so we can add a nice inspector for Pragma highlighting it in the source