### PR TITLE
Cleanup Message Hierarchy

### DIFF
--- a/src/Kernel/Message.class.st
+++ b/src/Kernel/Message.class.st
@@ -25,21 +25,19 @@ Class {
 Message class >> selector: aSymbol [
 	"Answer an instance of me with unary selector, aSymbol."
 	<reflection: 'Message sending and code execution - Message send reification'>
-	^self new setSelector: aSymbol arguments: (Array new: 0)
+	^self new setSelector: aSymbol arguments: #()
 ]
 
 { #category : 'instance creation' }
 Message class >> selector: aSymbol argument: anObject [
-	"Answer an instance of me whose selector is aSymbol and single
-	argument is anObject."
+	"Answer an instance of me whose selector is aSymbol and single argument is anObject."
 
 	^self new setSelector: aSymbol arguments: { anObject }
 ]
 
 { #category : 'instance creation' }
 Message class >> selector: aSymbol arguments: anArray [
-	"Answer an instance of me with selector, aSymbol, and arguments,
-	anArray."
+	"Answer an instance of me with selector, aSymbol, and arguments, anArray."
 
 	^self new setSelector: aSymbol arguments: anArray
 ]
@@ -103,6 +101,11 @@ Message >> lookupClass [
 Message >> lookupClass: aClass [
 	<reflection: 'Message sending and code execution - Message send reification'>
 	lookupClass := aClass
+]
+
+{ #category : 'accessing' }
+Message >> message [
+	^self
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel/MessageSend.class.st
+++ b/src/Kernel/MessageSend.class.st
@@ -31,7 +31,7 @@ MessageSend class >> receiver: anObject selector: aSymbol [
 
 { #category : 'instance creation' }
 MessageSend class >> receiver: anObject selector: aSymbol argument: aParameter [
-	^ self receiver: anObject selector: aSymbol arguments: (Array with: aParameter)
+	^ self receiver: anObject selector: aSymbol arguments: { aParameter }
 ]
 
 { #category : 'instance creation' }

--- a/src/Kernel/Pragma.class.st
+++ b/src/Kernel/Pragma.class.st
@@ -124,14 +124,6 @@ Pragma class >> pragmaCache [
 	^ pragmaCache ifNil: [ pragmaCache := Dictionary new ]
 ]
 
-{ #category : 'instance creation' }
-Pragma class >> selector: aSymbol arguments: anArray [
-	^ self new
-		selector: aSymbol;
-		arguments: anArray;
-		yourself
-]
-
 { #category : 'comparing' }
 Pragma >> = aPragma [
 
@@ -179,19 +171,6 @@ Pragma >> argumentNamed: aSymbol ifNone: aBlockClosure [
 		(self selector keywords
 			indexOf: aSymbol asMutator
 			ifAbsent: [ ^ aBlockClosure value])
-]
-
-{ #category : 'accessing' }
-Pragma >> arguments [
-	"Answer the arguments of the receiving pragma. For a pragma defined as <key1: val1 key2: val2> this will answer #(val1 val2)."
-	<reflection: 'Class structural inspection - Pragma'>
-	^ arguments
-]
-
-{ #category : 'accessing' }
-Pragma >> arguments: anArray [
-	<reflection: 'Class structural inspection - Pragma'>
-	arguments := anArray
 ]
 
 { #category : 'displaying' }
@@ -269,13 +248,6 @@ Pragma >> methodSelector [
 	^method selector
 ]
 
-{ #category : 'accessing' }
-Pragma >> numArgs [
-	"Answer the number of arguments in the pragma."
-	<reflection: 'Class structural inspection - Pragma'>
-	^ self arguments size
-]
-
 { #category : 'printing' }
 Pragma >> printOn: aStream [
 	aStream nextPut: $<.
@@ -292,20 +264,6 @@ Pragma >> printOn: aStream [
 Pragma >> refersToLiteral: aLiteral [
 	^self selector == aLiteral
 	   or: [arguments hasLiteral: aLiteral]
-]
-
-{ #category : 'accessing' }
-Pragma >> selector [
-	"Answer the selector of the pragma.
-	 For a pragma defined as <key1: val1 key2: val2> this will answer #key1:key2:."
-	<reflection: 'Class structural inspection - Pragma'>
-	^ selector
-]
-
-{ #category : 'accessing' }
-Pragma >> selector: aSymbol [
-	<reflection: 'Class structural inspection - Pragma'>
-	selector := aSymbol
 ]
 
 { #category : 'sending' }


### PR DESCRIPTION
- remove accessors that are now inherited in Pragma
- make sure to use {} and #() for arrays in constructors
- add #message to Message to return self, as all subclasses implement it