### PR TITLE
Undeclared: keep weak reference to all methods using the Undeclared Variable

### DIFF
--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -8,6 +8,9 @@ In future I can profice logging and user warning when evaluated code accesses un
 Class {
 	#name : 'UndeclaredVariable',
 	#superclass : 'LiteralVariable',
+	#instVars : [
+		'usingMethods'
+	],
 	#category : 'Kernel-Variables',
 	#package : 'Kernel',
 	#tag : 'Variables'
@@ -38,6 +41,11 @@ UndeclaredVariable class >> registeredWithName: aString [
 	var := self possiblyRegisteredWithName: aString.
 	(var isUndeclaredVariable and: [ var isRegistered not ]) ifTrue: [ var register ].
 	^ var
+]
+
+{ #category : 'registry' }
+UndeclaredVariable >> addUsingMethod: aCompiledMethod [
+	self usingMethods add: aCompiledMethod
 ]
 
 { #category : 'queries' }
@@ -83,6 +91,15 @@ UndeclaredVariable >> register [
 	Undeclared add: self
 ]
 
+{ #category : 'registry' }
+UndeclaredVariable >> registerFromNode: aNode [
+	| methodNode |
+	methodNode := aNode methodNode.
+	methodNode propertyAt: #Undeclareds ifAbsentPut: [WeakSet new].
+	(methodNode propertyAt: #Undeclareds) add: self.
+	self register
+]
+
 { #category : 'code generation' }
 UndeclaredVariable >> runtimeUndeclaredRead [
 
@@ -107,4 +124,10 @@ UndeclaredVariable >> runtimeUndeclaredWrite: anObject [
 { #category : 'registry' }
 UndeclaredVariable >> unregister [
 	Undeclared removeKey: name ifAbsent: [ ]
+]
+
+{ #category : 'queries' }
+UndeclaredVariable >> usingMethods [
+	^usingMethods 
+		ifNil: [ usingMethods := WeakIdentitySet new ]
 ]

--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -8,9 +8,6 @@ In future I can profice logging and user warning when evaluated code accesses un
 Class {
 	#name : 'UndeclaredVariable',
 	#superclass : 'LiteralVariable',
-	#instVars : [
-		'usingMethods'
-	],
 	#category : 'Kernel-Variables',
 	#package : 'Kernel',
 	#tag : 'Variables'
@@ -128,6 +125,5 @@ UndeclaredVariable >> unregister [
 
 { #category : 'queries' }
 UndeclaredVariable >> usingMethods [
-	^usingMethods 
-		ifNil: [ usingMethods := WeakIdentitySet new ]
+	^ self propertyAt: #usingMethods ifAbsentPut: [ WeakIdentitySet new ]
 ]

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -528,7 +528,7 @@ OCASTTranslator >> visitAssignmentNode: anAssignmentNode [
 	var isInvalidVariable ifTrue: [ ^ self emitRuntimeError: anAssignmentNode ].
 
 	"Because we are producing a CompiledMethod, register undeclared variables to `Undeclared`"
-	var isUndeclaredVariable ifTrue: [ var register ].
+	var isUndeclaredVariable ifTrue: [ var registerFromNode: anAssignmentNode ].
 
 	var emitStore: methodBuilder
 ]
@@ -765,7 +765,7 @@ OCASTTranslator >> visitVariableNode: aVariableNode [
 
 	"Because we are producing a CompiledMethod, register undeclared variables to `Undeclared`"
 	aVariableNode variable isUndeclaredVariable ifTrue: [
-		aVariableNode variable register ].
+		aVariableNode variable registerFromNode: aVariableNode  ].
 
 	aVariableNode variable emitValue: methodBuilder
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -538,7 +538,10 @@ OpalCompiler >> generateMethod [
 	ir := self generateIR.
 	method := ir compiledMethod.
 
-	ast compiledMethod: method.	
+	ast compiledMethod: method.
+	ast 
+		propertyAt: #Undeclareds 
+		ifPresent: [:undeclareds | undeclareds do: [ :var | var addUsingMethod: method ]].
 	method propertyAt: #source put: source.
 	self compilationContext noPattern ifTrue: [
 		method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"

--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -110,6 +110,7 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariable [
 	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].
 	self assert: undeclaredBinding class equals: UndeclaredVariable.
 	self assert: undeclaredBinding identicalTo: (Undeclared associationAt: #undeclaredTestVar).
+	undeclaredBinding usingMethods includes: newCompiledMethod.
 	undeclaredBinding unregister
 ]
 

--- a/src/Slot-Core/SystemDictionary.extension.st
+++ b/src/Slot-Core/SystemDictionary.extension.st
@@ -12,8 +12,8 @@ SystemDictionary >> declare: key from: aDictionary [
 		ifTrue:
 			[| undeclared |
 			undeclared := aDictionary associationAt: key.
-			"Undeclared variables record using methods in a property, remove"
-			undeclared removeProperty: #usingMethods ifAbsent: [ ]. 
+			"Undeclared variables record using methods in a property, remove. Boostrap might have used Associations"
+			(undeclared class == UndeclaredVariable) ifTrue: [undeclared removeProperty: #usingMethods ifAbsent: [ ]]. 
 			"and change class to be Global"
 			self add: (undeclared primitiveChangeClassTo: GlobalVariable new).
 			aDictionary removeKey: key]

--- a/src/Slot-Core/SystemDictionary.extension.st
+++ b/src/Slot-Core/SystemDictionary.extension.st
@@ -10,7 +10,12 @@ SystemDictionary >> declare: key from: aDictionary [
 	(self includesKey: key) ifTrue: [^ self].
 	(aDictionary includesKey: key)
 		ifTrue:
-			[self add: ((aDictionary associationAt: key) primitiveChangeClassTo: GlobalVariable new).
+			[| undeclared |
+			undeclared := aDictionary associationAt: key.
+			"Undeclared variables record using methods in a property, remove"
+			undeclared removeProperty: #usingMethods ifAbsent: [ ]. 
+			"and change class to be Global"
+			self add: (undeclared primitiveChangeClassTo: GlobalVariable new).
 			aDictionary removeKey: key]
 		ifFalse:
 			[self add: (GlobalVariable key: key)]


### PR DESCRIPTION
When we compile an undeclared, record the compiled methods in the UndeclaredVariabke instance.

This will allow us to fix these methods without having to search all methods.