### PR TITLE
Introduce and use CategoryConverter

### DIFF
--- a/src/CodeImport/OldClassDefinitionBuilder.class.st
+++ b/src/CodeImport/OldClassDefinitionBuilder.class.st
@@ -166,7 +166,7 @@ OldClassDefinitionBuilder >> build [
 	(#( CompiledBlock CompiledCode CompiledMethod ) includes: subclassName) ifTrue: [ layoutClass := CompiledMethodLayout ].
 
 	^ self class classInstaller make: [ :aBuilder |
-		  | superclass realPackageName |
+		  | superclass converter |
 		  superclass := self class environment at: superclassName asSymbol.
 
 		  aBuilder
@@ -176,14 +176,10 @@ OldClassDefinitionBuilder >> build [
 			  layoutClass: layoutClass.
 		  instanceVariableNames ifNotNil: [ aBuilder slotsFromString: instanceVariableNames ].
 		  classVariableNames ifNotNil: [ aBuilder sharedVariablesFromString: classVariableNames ].
-
-		  packageName ifNotNil: [ "Since before the category included the package name and the tags name, we are trying to find the right one here."
-			  realPackageName := (superclass environment organization packageMatchingExtensionName: packageName)
-				                     ifNil: [ packageName ]
-				                     ifNotNil: [ :package | package name ].
-			  aBuilder package: realPackageName ].
-
-		  realPackageName = packageName ifFalse: [ aBuilder tag: (packageName withoutPrefix: realPackageName , '-') ].
+		
+		  converter := CategoryConverter category: packageName environment: superclass environment.
+		  aBuilder package: converter packageName.
+		  aBuilder tag: converter tagName.
 
 		  poolDictionariesNames ifNotNil: [ aBuilder sharedPools: poolDictionariesNames ].
 		  isTrait ifTrue: [ aBuilder beTrait ].

--- a/src/Monticello-BackwardCompatibility/MCSystemCategoryParser.class.st
+++ b/src/Monticello-BackwardCompatibility/MCSystemCategoryParser.class.st
@@ -16,23 +16,14 @@ MCSystemCategoryParser class >> pattern [
 { #category : 'actions' }
 MCSystemCategoryParser >> addDefinitionsTo: aCollection [
 
-	| definition category |
+	| definition converter |
 	definition := aCollection
 		              detect: [ :ea | ea isOrganizationDefinition ]
 		              ifNone: [ aCollection add: MCOrganizationDefinition new ].
 
-	category := self category.
-
-	"Let's find the package and the tag from the category."
-	definition packageName ifNil: [
-		definition packageName: ((self packageOrganizer packageMatchingExtensionName: category)
-				 ifNil: [ category ]
-				 ifNotNil: [ :package | package name ]) ].
-
-	category = definition packageName ifFalse: [
-		definition tagNames: (definition tagNames copyWith: ((category beginsWith: definition packageName , '-')
-					  ifTrue: [ category withoutPrefix: definition packageName , '-' ]
-					  ifFalse: [ category ])) ]
+	converter := CategoryConverter category: self category.
+	definition packageName ifNil: [ definition packageName: converter packageName ].
+	converter tagName ifNotNil: [ :tagName | definition tagNames: (definition tagNames copyWith: tagName) ]
 ]
 
 { #category : 'accessing' }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -600,7 +600,7 @@ MCClassDefinition >> tagName: aString [
 
 	tagName := aString = RPackage rootTagName
 		           ifTrue: [ nil ]
-		           ifFalse: [ aString asSymbol ]
+		           ifFalse: [ aString ifNotNil: [ aString asSymbol ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -44,7 +44,7 @@ MCStReader >> categoryFromDoIt: aString [
 { #category : 'reading' }
 MCStReader >> classDefinitionFrom: aRingClass [
 
-	| tokens traitCompositionString lastIndex classTraitCompositionString |
+	| tokens traitCompositionString lastIndex classTraitCompositionString converter |
 	tokens := aRingClass definitionSource parseLiterals.
 	traitCompositionString := (aRingClass definitionSource readStream
 		                           match: 'uses:';
@@ -55,11 +55,13 @@ MCStReader >> classDefinitionFrom: aRingClass [
 	traitCompositionString ifEmpty: [ traitCompositionString := '{}' ].
 	classTraitCompositionString ifEmpty: [ classTraitCompositionString := '{}' ].
 	lastIndex := tokens size.
+	converter := CategoryConverter category: (tokens at: lastIndex).
 	^ (MCClassDefinition named: (tokens at: 3))
 		  superclassName: (tokens at: 1);
 		  traitComposition: traitCompositionString;
 		  classTraitComposition: classTraitCompositionString;
-		  packageName: (tokens at: lastIndex);
+		  packageName: converter packageName;
+		  tagName: converter tagName;
 		  instVarNames: ((tokens at: lastIndex - 6) findTokens: ' ');
 		  classVarNames: ((tokens at: lastIndex - 4) findTokens: ' ');
 		  poolDictionaryNames: ((tokens at: lastIndex - 2) findTokens: ' ');

--- a/src/Monticello/MCTraitParser.class.st
+++ b/src/Monticello/MCTraitParser.class.st
@@ -17,25 +17,36 @@ MCTraitParser class >> pattern [
 { #category : 'actions' }
 MCTraitParser >> addDefinitionsTo: aCollection [
 
-	| node compositionIndex categoryIndex slotsIndex traitName traitCompositionString slotsArray argumentNode categoryString definition |
+	| node compositionIndex categoryIndex slotsIndex traitCompositionString slotsArray argumentNode categoryString converter |
 	node := RBParser parseExpression: source.
 
-	node selector caseOf: { 
-		[#named:] -> [ 
-			compositionIndex := nil. slotsIndex := nil. categoryIndex := nil ].
-		[#named:uses:] -> [ 
-			compositionIndex := 2. slotsIndex := nil. categoryIndex := nil ].
-		[#named:uses:category:] -> [ 
-			compositionIndex := 2. slotsIndex := nil. categoryIndex := 3 ].
-		[#named:uses:package:] -> [ 
-			compositionIndex := 2. slotsIndex := nil. categoryIndex := 3 ].
-		[#named:uses:slots:category:] -> [ 
-			compositionIndex := 2. slotsIndex := 3. categoryIndex := 4 ].
-		[#named:uses:slots:package:] -> [ 
-			compositionIndex := 2. slotsIndex := 3. categoryIndex := 4 ]
-	} otherwise: [ self error: 'Unknown trait building selector' ].
-
-	traitName := node arguments first value.
+	node selector
+		caseOf: {
+				([ #named: ] -> [
+				 compositionIndex := nil.
+				 slotsIndex := nil.
+				 categoryIndex := nil ]).
+				([ #named:uses: ] -> [
+				 compositionIndex := 2.
+				 slotsIndex := nil.
+				 categoryIndex := nil ]).
+				([ #named:uses:category: ] -> [
+				 compositionIndex := 2.
+				 slotsIndex := nil.
+				 categoryIndex := 3 ]).
+				([ #named:uses:package: ] -> [
+				 compositionIndex := 2.
+				 slotsIndex := nil.
+				 categoryIndex := 3 ]).
+				([ #named:uses:slots:category: ] -> [
+				 compositionIndex := 2.
+				 slotsIndex := 3.
+				 categoryIndex := 4 ]).
+				([ #named:uses:slots:package: ] -> [
+				 compositionIndex := 2.
+				 slotsIndex := 3.
+				 categoryIndex := 4 ]) }
+		otherwise: [ self error: 'Unknown trait building selector' ].
 
 	traitCompositionString := compositionIndex
 		                          ifNotNil: [
@@ -49,17 +60,16 @@ MCTraitParser >> addDefinitionsTo: aCollection [
 			              argumentNode statements collect: [ :each | each source copyFrom: each sourceInterval first to: each sourceInterval last ] ]
 		              ifNil: [ Array new ].
 
-	categoryString := categoryIndex
-		                  ifNotNil: [
-			                  argumentNode := node arguments at: categoryIndex.
-			                  argumentNode source copyFrom: argumentNode sourceInterval first to: argumentNode sourceInterval last ]
-		                  ifNil: [ 'Unclassified' ].
+	categoryString := categoryIndex ifNotNil: [
+		                  argumentNode := node arguments at: categoryIndex.
+		                  argumentNode source copyFrom: argumentNode sourceInterval first to: argumentNode sourceInterval last ].
 
-	definition := (MCTraitDefinition named: traitName)
-		              traitComposition: traitCompositionString;
-		              packageName: categoryString;
-		              instVarNames: slotsArray;
-		              yourself.
+	converter := CategoryConverter category: categoryString.
 
-	aCollection add: definition
+	aCollection add: ((MCTraitDefinition named: node arguments first value)
+			 traitComposition: traitCompositionString;
+			 packageName: converter packageName;
+			 tagName: converter tagName;
+			 instVarNames: slotsArray;
+			 yourself)
 ]

--- a/src/Shift-ClassBuilder/CategoryConverter.class.st
+++ b/src/Shift-ClassBuilder/CategoryConverter.class.st
@@ -1,0 +1,67 @@
+"
+I am a class used to manage some compatibility with the concept of old class categories. 
+
+The categories were a mix of package names and package tag names but this had the drawback that it was not possible to know for sure what was what.
+
+Since multiple places relied on categories, I am here to emulate the old behavior.
+"
+Class {
+	#name : 'CategoryConverter',
+	#superclass : 'Object',
+	#instVars : [
+		'packageName',
+		'tagName',
+		'environment'
+	],
+	#category : 'Shift-ClassBuilder',
+	#package : 'Shift-ClassBuilder'
+}
+
+{ #category : 'class initialization' }
+CategoryConverter class >> category: aString [
+
+	^ self new processCategory: aString
+]
+
+{ #category : 'class initialization' }
+CategoryConverter class >> category: aString environment: anEnvironment [
+
+	^ self new
+		  environment: anEnvironment;
+		  processCategory: aString
+]
+
+{ #category : 'accessing' }
+CategoryConverter >> environment [
+
+	^ environment ifNil: [ self class environment ]
+]
+
+{ #category : 'accessing' }
+CategoryConverter >> environment: anObject [
+
+	environment := anObject
+]
+
+{ #category : 'accessing' }
+CategoryConverter >> packageName [
+
+	^ packageName
+]
+
+{ #category : 'processing' }
+CategoryConverter >> processCategory: aString [
+	"We are looking for the packages that matches the best the category and we consider the tag is what is left."
+
+	(self environment organization packageMatchingExtensionName: aString)
+		ifNil: [ packageName := aString ]
+		ifNotNil: [ :package |
+			packageName := package name.
+			aString = packageName ifFalse: [ tagName := aString withoutPrefix: packageName , '-' ] ]
+]
+
+{ #category : 'accessing' }
+CategoryConverter >> tagName [
+
+	^ tagName
+]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -168,18 +168,11 @@ ShiftClassBuilder >> category [
 { #category : 'deprecated' }
 ShiftClassBuilder >> category: aString [
 
+	| converter |
 	self flag: #package. "To deprecate once it is not use in the bootstrap anymore."
-	(self installingEnvironment organization packageMatchingExtensionName: aString)
-		ifNil: [
-			(aString includes: $-)
-				ifTrue: [
-					self
-						package: (aString copyUpToLast: $-);
-						tag: (aString copyAfterLast: $-) ]
-				ifFalse: [ self package: aString ] ]
-		ifNotNil: [ :aPackage |
-			self package: aPackage name.
-			aString = aPackage name ifFalse: [ self tag: (aString withoutPrefix: aPackage name , '-') ] ]
+	converter := CategoryConverter category: aString environment: self installingEnvironment.
+	self package: converter packageName.
+	self tag: converter tagName
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
With the removal of the categories we need to handle the code that was using categories in the past. I already handled it in multiple places but this was duplicating the behavior and I found even more places.

In the end I'm proposing to introduce a CetagoryConverter class to centralize this behavior and make all other places rely on it. I also updated MCStReader and MCTraitParser to handle better the categories