### PR TITLE
Cleanup: #recompile and CompilerPlugin tests

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -306,10 +306,6 @@ BaselineOfIDE >> postload: loader package: packageSpec [
 	RubTextFieldArea defaultFindReplaceServiceClass: SpRubFindReplaceService.
 	RubEditingArea defaultFindReplaceServiceClass: SpRubFindReplaceService.
 
-	ASTTransformExamplePluginActive recompile.
-	PharoCommandLineHandler recompile.
-	SmalltalkImage recompile.
-
 	RubCharacterScanner initialize.
 
 	RubAbstractTextArea highlightMessageSend: true.

--- a/src/OpalCompiler-Tests/OCStaticASTCompilerPluginTest.class.st
+++ b/src/OpalCompiler-Tests/OCStaticASTCompilerPluginTest.class.st
@@ -9,9 +9,9 @@ Class {
 { #category : 'tests' }
 OCStaticASTCompilerPluginTest >> testClassWithPluginEnabled [
 
-	self
-		assert: ASTTransformExamplePluginActive new example42
-		equals: 'meaning of life'
+ 	"It is possible that the method was loaded before the plugin was active. We recompile to be sure the plugin was active."
+ 	ASTTransformExamplePluginActive recompile.
+ 	self assert: ASTTransformExamplePluginActive new example42 equals: 'meaning of life'
 ]
 
 { #category : 'tests' }

--- a/src/OpalCompiler-Tests/OCTargetCompilerSample.class.st
+++ b/src/OpalCompiler-Tests/OCTargetCompilerSample.class.st
@@ -7,6 +7,11 @@ Class {
 }
 
 { #category : 'accessing' }
+OCTargetCompilerSample class >> classSideCompilerClass [
+	^ OCTargetCompiler
+]
+
+{ #category : 'accessing' }
 OCTargetCompilerSample class >> compilerClass [
 	^ OCTargetCompiler
 ]

--- a/src/OpalCompiler-Tests/OCTargetCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCTargetCompilerTest.class.st
@@ -6,16 +6,12 @@ Class {
 	#tag : 'Semantic'
 }
 
-{ #category : 'testing' }
-OCTargetCompilerTest >> expectedFailures [
-	^ #(testModifiedReturnFromClass testRecompiledReturnFromClass)
-]
-
 { #category : 'tests' }
 OCTargetCompilerTest >> testModifiedReturn [
 	" I test that the compilerClass method works for instance-side "
-	" if something has failed to recompile using compilerClass, then you may need to go to OCTargetCompilerSample and force recompile of the method returnExpected (by e.g. adding/deleting a space and saving) "
-	self skipOnPharoCITestingEnvironment.
+	
+ 	"It is possible that the method was loaded before the plugin was active. We recompile to be sure the plugin was active."
+	OCTargetCompilerSample recompile.
 	self assert: OCTargetCompilerSample new returnExpected equals: #expectedReturn
 ]
 
@@ -24,13 +20,14 @@ OCTargetCompilerTest >> testModifiedReturnFromClass [
 	" I test that the compilerClass method works for class-side "
 	" it ***doesn't*** at the moment!!!! "
 	" if something has failed to recompile using compilerClass, then you may need to go to OCTargetCompilerSample class and force recompile of the method returnExpected (by e.g. adding/deleting a space and saving) "
+	<expectedFailure>
 	self assert: OCTargetCompilerSample returnExpected equals: #expectedReturn
 ]
 
 { #category : 'tests' }
 OCTargetCompilerTest >> testRecompiledReturn [
-	" I test that the compilerClass method works for instance-side when we trigger method recompilation by adding/removing a slot for the class "
-	" it ***doesn't*** at the moment!!!! "
+	" I test that the compilerClass method works for instance-side when we trigger method recompilation by adding/removing a slot for the class"
+	
 	self
 		assert: ([
 				OCTargetCompilerSample addSlot: #xyzzy. " forces recompile of methods "
@@ -45,6 +42,7 @@ OCTargetCompilerTest >> testRecompiledReturn [
 OCTargetCompilerTest >> testRecompiledReturnFromClass [
 	" I test that the compilerClass method works for class-side when we trigger method recompilation by adding/removing a slot for the metaclass "
 	" it ***doesn't*** at the moment!!!! "
+	<expectedFailure>
 	self
 		assert: ([
 				OCTargetCompilerSample class addSlot: #xyzzy. " forces recompile of methods "

--- a/src/OpalCompiler-Tests/OCTargetCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCTargetCompilerTest.class.st
@@ -18,9 +18,7 @@ OCTargetCompilerTest >> testModifiedReturn [
 { #category : 'tests' }
 OCTargetCompilerTest >> testModifiedReturnFromClass [
 	" I test that the compilerClass method works for class-side "
-	" it ***doesn't*** at the moment!!!! "
-	" if something has failed to recompile using compilerClass, then you may need to go to OCTargetCompilerSample class and force recompile of the method returnExpected (by e.g. adding/deleting a space and saving) "
-	<expectedFailure>
+
 	self assert: OCTargetCompilerSample returnExpected equals: #expectedReturn
 ]
 
@@ -41,8 +39,6 @@ OCTargetCompilerTest >> testRecompiledReturn [
 { #category : 'tests' }
 OCTargetCompilerTest >> testRecompiledReturnFromClass [
 	" I test that the compilerClass method works for class-side when we trigger method recompilation by adding/removing a slot for the metaclass "
-	" it ***doesn't*** at the moment!!!! "
-	<expectedFailure>
 	self
 		assert: ([
 				OCTargetCompilerSample class addSlot: #xyzzy. " forces recompile of methods "


### PR DESCRIPTION
- remove #recompile from Baseline of IDE
- make sure compiler plugin tests recompile the example class, as it might be loadded before the plugin

(from #15028, but better to do that independely of the other change)

- add recompile to other plugin test
- fix tests marked as expected failures by using #classSideCompilerClass