### PR TITLE
Monticello: Improve MCZ management

### DIFF
--- a/src/Monticello-BackwardCompatibility/MCDataStream.extension.st
+++ b/src/Monticello-BackwardCompatibility/MCDataStream.extension.st
@@ -144,18 +144,6 @@ MCDataStream >> readWordArray [
 ]
 
 { #category : '*Monticello-BackwardCompatibility' }
-MCDataStream >> readWordLike [
-	| refPosn aSymbol newClass anObject |
-	"Can be used by any class that is bits and not bytes (WordArray, Bitmap, SoundBuffer, etc)."
-	refPosn := self getCurrentReference.
-	aSymbol := self next.
-	newClass := Smalltalk globals at: aSymbol asSymbol.
-	anObject := newClass newFromStream: byteStream.	"Size is number of long words."
-	self setCurrentReference: refPosn.	"before returning to next"
-	^ anObject
-]
-
-{ #category : '*Monticello-BackwardCompatibility' }
 MCDataStream >> writeBitmap: aBitmap [
 	"PRIVATE -- Write the contents of a Bitmap."
 

--- a/src/Monticello/MCDataStream.class.st
+++ b/src/Monticello/MCDataStream.class.st
@@ -541,6 +541,18 @@ MCDataStream >> readTrue [
     ^ true
 ]
 
+{ #category : 'write and read' }
+MCDataStream >> readWordLike [
+	| refPosn aSymbol newClass anObject |
+	"Can be used by any class that is bits and not bytes (WordArray, Bitmap, SoundBuffer, etc)."
+	refPosn := self getCurrentReference.
+	aSymbol := self next.
+	newClass := Smalltalk globals at: aSymbol asSymbol.
+	anObject := newClass newFromStream: byteStream.	"Size is number of long words."
+	self setCurrentReference: refPosn.	"before returning to next"
+	^ anObject
+]
+
 { #category : 'initialization' }
 MCDataStream >> reset [
     "Reset the stream."

--- a/src/Monticello/MCMczReader.class.st
+++ b/src/Monticello/MCMczReader.class.st
@@ -154,7 +154,8 @@ MCMczReader >> loadDefinitions [
 		self adaptDefinitions.
 		^ definitions ]
 			on: Error
-			do: [ :fallThrough |  ] ].
+			do: [ :fallThrough |
+				('An error happened while reading MCZ. We will fallback to another format. Short error stack: ' , fallThrough signalerContext shortStack) traceCr ] ].
 	"otherwise"
 	(self zip membersMatching: 'snapshot/*') do: [ :m | self extractDefinitionsFrom: m ]
 ]

--- a/src/Transcript-NonInteractive/Object.extension.st
+++ b/src/Transcript-NonInteractive/Object.extension.st
@@ -1,11 +1,11 @@
 Extension { #name : 'Object' }
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> crTrace [
 	self crTrace: self
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> crTrace: aString [
 	"Log the argument. Use self crTrace: instead of Transcript cr; show: "
 
@@ -13,39 +13,39 @@ Object >> crTrace: aString [
 	self trace: aString
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> logEntry [
 	self traceCr: 'Entered ' , thisContext sender printString
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> logExecution [
 	self traceCr: 'Executing ' , thisContext sender printString
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> logExit [
 	self traceCr: 'Exited ' , thisContext sender printString
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> trace [
 	self trace: self
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> trace: anObject [
 	"Log the argument. Use self trace: instead of Transcript show: "
 
 	Transcript show: anObject asString
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> traceCr [
 	self traceCr: self
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> traceCr: anObject [
 	"Log the argument. Use self traceCr: 'something' instead of Transcript show: 'something'  ; cr "
 
@@ -53,7 +53,7 @@ Object >> traceCr: anObject [
 	Transcript cr
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> traceCrTab: anObject [
 	"Log the argument. Use self traceCr: 'something' instead of Transcript show: 'something'  ; cr "
 


### PR DESCRIPTION
This improves two small things:
- MCDataStream had #readWordLike as backward compatible method but it is still used (for example the bootstrap code sometimes fallback to another importer than MCZ importer because mcz got exported with this selector defined or reading)
- When we cannot read a MCZ, log the failure and give the short stack so that we can find in CIs why we have troubles