### PR TITLE
Move traceCr & co to non interactive transcript

### DIFF
--- a/src/Transcript-NonInteractive/Object.extension.st
+++ b/src/Transcript-NonInteractive/Object.extension.st
@@ -1,11 +1,11 @@
 Extension { #name : 'Object' }
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> crTrace [
 	self crTrace: self
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> crTrace: aString [
 	"Log the argument. Use self crTrace: instead of Transcript cr; show: "
 
@@ -13,39 +13,39 @@ Object >> crTrace: aString [
 	self trace: aString
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> logEntry [
 	self traceCr: 'Entered ' , thisContext sender printString
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> logExecution [
 	self traceCr: 'Executing ' , thisContext sender printString
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> logExit [
 	self traceCr: 'Exited ' , thisContext sender printString
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> trace [
 	self trace: self
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> trace: anObject [
 	"Log the argument. Use self trace: instead of Transcript show: "
 
 	Transcript show: anObject asString
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> traceCr [
 	self traceCr: self
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> traceCr: anObject [
 	"Log the argument. Use self traceCr: 'something' instead of Transcript show: 'something'  ; cr "
 
@@ -53,7 +53,7 @@ Object >> traceCr: anObject [
 	Transcript cr
 ]
 
-{ #category : '*Transcript-Core' }
+{ #category : '*Transcript-NonInteractive' }
 Object >> traceCrTab: anObject [
 	"Log the argument. Use self traceCr: 'something' instead of Transcript show: 'something'  ; cr "
 


### PR DESCRIPTION
We have Trancript-Core (which is a bad name IMO. It should be Transcript-Interactive) and Transcript-NonInteractive. The second one is loaded in the bootstrap while the second one is loaded with Morphic. 

The first one is adding #traceCr and co to Object but that makes it unavailable in the bootstrap. I propose to move them to non interactive transcript so that we can log things on the stdout ealier with it.