### PR TITLE
Improve the management of TTranscript

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -166,7 +166,7 @@ echo $(date -u) "[Compiler] Installing Traits through Hermes"
 
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save ${TRAITS_IMAGE_NAME}
 ${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes TraitsV2.hermes --save
-${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Kernel-Traits.hermes AST-Core-Traits.hermes Collections-Abstract-Traits.hermes Transcript-Core-Traits.hermes CodeImport-Traits.hermes CodeExport-Traits.hermes TraitsV2-Compatibility.hermes --save
+${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Kernel-Traits.hermes AST-Core-Traits.hermes Collections-Abstract-Traits.hermes CodeImport-Traits.hermes CodeExport-Traits.hermes TraitsV2-Compatibility.hermes --save
 zip "${TRAITS_IMAGE_NAME}.zip" "${TRAITS_IMAGE_NAME}.image"
 
 #Bootstrap Initialization: Class and RPackage initialization

--- a/src/BaselineOfTraits/BaselineOfTraits.class.st
+++ b/src/BaselineOfTraits/BaselineOfTraits.class.st
@@ -45,7 +45,6 @@ BaselineOfTraits >> baseline: spec [
 			package: 'Kernel-Traits' with: [ spec requires: #('TraitsV2') ];
 			package: 'AST-Core-Traits' with: [ spec requires: #('TraitsV2') ];
 			package: 'Collections-Abstract-Traits' with: [ spec requires: #('TraitsV2') ];
-			package: 'Transcript-Core-Traits' with: [ spec requires: #('TraitsV2') ];
 			package: 'CodeImport-Traits' with: [ spec requires: #('TraitsV2') ];
 			package: 'CodeExport-Traits' with: [ spec requires: #('TraitsV2') ];
 			package: 'TraitsV2-Tests' with: [ spec requires: #('TraitsV2') ];
@@ -56,7 +55,6 @@ BaselineOfTraits >> baseline: spec [
 		spec group: 'traits-in-kernel' with: #(
 					'Kernel-Traits'
 					'Collections-Abstract-Traits'
-					'Transcript-Core-Traits'
 					'CodeImport-Traits'
 					'CodeExport-Traits' ).
 

--- a/src/Transcript-Core-Traits/package.st
+++ b/src/Transcript-Core-Traits/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'Transcript-Core-Traits' }

--- a/src/Transcript-Core/TTranscript.trait.st
+++ b/src/Transcript-Core/TTranscript.trait.st
@@ -14,7 +14,8 @@ Historical note: #ensureCr and #reset were removed since they were not used
 Trait {
 	#name : 'TTranscript',
 	#category : 'Transcript-Core-Traits',
-	#package : 'Transcript-Core-Traits'
+	#package : 'Transcript-Core',
+	#tag : 'Traits'
 }
 
 { #category : 'streaming' }

--- a/src/Transcript-Core/ThreadSafeTranscript.class.st
+++ b/src/Transcript-Core/ThreadSafeTranscript.class.st
@@ -21,6 +21,8 @@ The ==stream resetContents== is moved to #step so this occurs directly after ==s
 Class {
 	#name : 'ThreadSafeTranscript',
 	#superclass : 'Model',
+	#traits : 'TTranscript',
+	#classTraits : 'TTranscript classTrait',
 	#instVars : [
 		'stream',
 		'accessSemaphore',
@@ -51,17 +53,6 @@ ThreadSafeTranscript class >> taskbarIconName [
 	"Answer the icon for the receiver in a task bar."
 
 	^#transcript
-]
-
-{ #category : 'streaming' }
-ThreadSafeTranscript >> << anObject [
-	"Write anObject to the receiver, dispatching using #putOn:
-	This is a shortcut for both nextPut: and nextPutAll: since anObject can be both
-	the element type of the receiver as well as a collection of those elements.
-	No further conversions of anObject are applied.
-	Return self to accomodate chaining."
-
- 	anObject putOn: self
 ]
 
 { #category : 'accessing' }
@@ -97,20 +88,6 @@ ThreadSafeTranscript >> contents [
 ]
 
 { #category : 'streaming' }
-ThreadSafeTranscript >> cr [
-	"Output a cr on the receiver, buffered and not yet shown"
-
-	self nextPut: Character cr
-]
-
-{ #category : 'streaming' }
-ThreadSafeTranscript >> crShow: anObject [
-	"Output anObject asString on the receiver preceded by a cr and show the output"
-
-	self critical: [ self cr; show: anObject ]
-]
-
-{ #category : 'streaming' }
 ThreadSafeTranscript >> critical: block [
 	"Execute block making sure only one thread accesses the receiver"
 
@@ -123,16 +100,10 @@ ThreadSafeTranscript >> doItContext [
 ]
 
 { #category : 'streaming' }
-ThreadSafeTranscript >> endEntry [
-"
-	The next #stepGlobal message (usually invoked by Morhic stepping) will raise an #appendEntry update and reset the stream.
-"
-  	self critical: [ deferredEndEntry := true ]
-]
-
-{ #category : 'streaming' }
 ThreadSafeTranscript >> flush [
-	self endEntry
+	"The next #stepGlobal message (usually invoked by Morhic stepping) will raise an #appendEntry update and reset the stream."
+
+	self critical: [ deferredEndEntry := true ]
 ]
 
 { #category : 'ui building' }
@@ -182,13 +153,6 @@ ThreadSafeTranscript >> nextPutAll: value [
 	^ value
 ]
 
-{ #category : 'streaming' }
-ThreadSafeTranscript >> print: anObject [
-	"Output anObject asString on the receiver, buffered, not yet shown"
-
-	self nextPutAll: anObject asString
-]
-
 { #category : 'printing' }
 ThreadSafeTranscript >> printOn: aStream [
 
@@ -204,20 +168,6 @@ ThreadSafeTranscript >> selectedClassOrMetaClass [
 { #category : 'updating' }
 ThreadSafeTranscript >> shoutAboutToStyle: aPluggableShoutMorphOrView [
 	^ false
-]
-
-{ #category : 'streaming' }
-ThreadSafeTranscript >> show: anObject [
-	"Output anObject asString on the receiver and show the output"
-
-	self critical: [ self print: anObject; endEntry ]
-]
-
-{ #category : 'streaming' }
-ThreadSafeTranscript >> space [
-	"Output a space on the receiver, buffered and not yet shown"
-
-	self nextPut: Character space
 ]
 
 { #category : 'updating' }
@@ -250,13 +200,6 @@ ThreadSafeTranscript >> stepGlobal [
 		].
 		self changed: #appendEntry.
 	]
-]
-
-{ #category : 'streaming' }
-ThreadSafeTranscript >> tab [
-	"Output a tab on the receiver, buffered and not yet shown"
-
-	self nextPut: Character tab
 ]
 
 { #category : 'ui building' }


### PR DESCRIPTION
We have in the system Transcript-Core-Traits and it has 2 problems IMO.

The first one is that TTranscript (the only class inside) isn't used.

The second is that it is loaded in the first steps of the bootstrap.

Since Transcript-Core is loaded at a point where we have the traits in the image I propose to move TTranscript to this package (no need to have a package for only one class..) and we should make ThreadSafeTranscript use it

With this Hermes is loading one less package :)