### PR TITLE
Clean AthensFontDescription>>#asString

### DIFF
--- a/src/Athens-Cairo/AthensFontDescription.class.st
+++ b/src/Athens-Cairo/AthensFontDescription.class.st
@@ -37,22 +37,15 @@ AthensFontDescription class >> example [
 { #category : 'accessing' }
 AthensFontDescription >> asString [
 	"[FAMILY-LIST] [STYLE-OPTIONS] [SIZE]"
-	| str |
-	str := '' writeStream.
-	str nextPutAll:  family; space.
-	"
-2)STYLE_OPTIONS is a whitespace separated list of words where each WORD describes one of style, variant, weight, stretch, or gravity. If STYLE-OPTIONS is missing, then all style options will be set to the default values
-"
-	#(slant. variant. weight. stretch. gravity) do:[:each|
-		|val|
-		val := options at: each ifAbsent: nil.
-		val notNil ifTrue:[str nextPutAll: val ; space ]].
 
-	self fontSize notNil ifTrue:[
-		str
-			space;
-			nextPutAll: self fontSize asString ].
-	^ str contents
+	^ String streamContents: [ :str |
+		  str nextPutAll: family; space.
+
+		  "2)STYLE_OPTIONS is a whitespace separated list of words where each WORD describes one of style, variant, weight, stretch, or gravity. If STYLE-OPTIONS is missing, then all style options will be set to the default values"
+		  #( slant variant weight stretch gravity ) do: [ :style |
+			  options at: style ifPresent: [ :val | str nextPutAll: val; space ] ].
+
+		  self fontSize ifNotNil: [ :fontSize | str space; nextPutAll: fontSize asString ] ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
AthensFontDescription>>#asString contains a literal array but is separating the elements with dots which is what is needed for dynamic array. 

This cleans this and improves the code