### PR TITLE
[P11] Update document browser to 1.0.1 to 1.0.2, which depends on iceberg 2.2.2

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -43,7 +43,7 @@ BaselineOfPharo class >> documentBrowser [
 		newName: 'DocumentBrowser' 
 		owner: 'pharo-spec' 
 		project: 'NewTools-DocumentBrowser' 
-		version: 'v1.0.1'
+		version: 'v1.0.2'
 ]
 
 { #category : #'repository urls' }


### PR DESCRIPTION
Fix #13726 for P11