### PR TITLE
Do not announce method recategorization when removing a selector from a protocol

### DIFF
--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -415,7 +415,7 @@ EpMonitor >> methodRecategorized: aMethodRecategorized [
 		             protocol: aMethodRecategorized oldProtocol name;
 		             yourself.
 	newMethod := aMethodRecategorized methodRecategorized asEpiceaRingDefinition
-		             protocol: (aMethodRecategorized newProtocol ifNotNil: [ :protocol | protocol name ]);
+		             protocol: aMethodRecategorized newProtocol name;
 		             yourself.
 
 	self addEvent: (EpMethodModification oldMethod: oldMethod newMethod: newMethod)

--- a/src/Epicea/TestCase.extension.st
+++ b/src/Epicea/TestCase.extension.st
@@ -1,14 +1,14 @@
 Extension { #name : 'TestCase' }
 
 { #category : '*Epicea' }
+TestCase >> shouldLogWithEpicea [
+
+	^ self class shouldLogWithEpicea
+]
+
+{ #category : '*Epicea' }
 TestCase class >> shouldLogWithEpicea [
 	"When running a test, we disable the loggings of Epicea to run the tests silently. In case a TestCase explicitly wants to Epicea logs, then I can be overriden to return true and enable the logs."
 
 	^ false
-]
-
-{ #category : '*Epicea' }
-TestCase >> shouldLogWithEpicea [
-
-	^ self class shouldLogWithEpicea
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -893,8 +893,7 @@ ClassDescription >> removeFromProtocols: aSelector [
 
 	(self protocolOfSelector: aSelector) ifNotNil: [ :protocol |
 		protocol removeMethodSelector: aSelector.
-		self removeProtocolIfEmpty: protocol.
-		self notifyOfRecategorizedSelector: aSelector from: protocol to: nil ]
+		self removeProtocolIfEmpty: protocol ]
 ]
 
 { #category : 'instance variables' }
@@ -955,8 +954,7 @@ ClassDescription >> removeSelector: selector [
 	package := method package.
 
 	method removeFromPackage.
-	"When we remove a method we do not want to announce a recategorization."
-	SystemAnnouncer uniqueInstance prevent: MethodRecategorized during: [ self removeFromProtocols: selector ].
+	self removeFromProtocols: selector.
 
 	super removeSelector: selector.
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -495,28 +495,25 @@ RPackageOrganizer >> systemMethodAddedActionFrom: ann [
 { #category : 'system integration' }
 RPackageOrganizer >> systemMethodRecategorizedActionFrom: ann [
 
-	| method |
+	| method oldPackage newPackage |
 	method := ann method.
 
 	method origin = ann methodClass ifFalse: [ ^ self ]. "Methods from traits are not treated"
 
 	ann methodClass package isUndefined ifTrue: [ ^ self ]. "Classes that are not packages are not treated"
 
-	"If the new protocol is nil it means we are removing the method and this will be managed by the method removal"
-	ann newProtocol ifNotNil: [ :newProtocol |
-		| oldPackage newPackage |
-		newPackage := newProtocol isExtensionProtocol
-			              ifTrue: [ self ensurePackageOfExtensionProtocol: newProtocol ]
-			              ifFalse: [ method methodClass package ].
+	newPackage := ann newProtocol isExtensionProtocol
+		              ifTrue: [ self ensurePackageOfExtensionProtocol: ann newProtocol ]
+		              ifFalse: [ method methodClass package ].
 
-		oldPackage := (self packageForProtocol: ann oldProtocol) ifNil: [ method methodClass package ].
+	oldPackage := (self packageForProtocol: ann oldProtocol) ifNil: [ method methodClass package ].
 
-		oldPackage = newPackage ifTrue: [ ^ self ].
+	oldPackage = newPackage ifTrue: [ ^ self ].
 
-		oldPackage removeMethod: method.
-		newPackage addMethod: method.
+	oldPackage removeMethod: method.
+	newPackage addMethod: method.
 
-		SystemAnnouncer uniqueInstance methodRepackaged: method from: oldPackage to: newPackage ]
+	SystemAnnouncer uniqueInstance methodRepackaged: method from: oldPackage to: newPackage
 ]
 
 { #category : 'system integration' }


### PR DESCRIPTION
Removal of selector from a protocol is used in 3 cases:
- We have protocols including non existing selectors and we are cleaning
- We are removing a method
- We are rebuilding a method dictionary

IMO we should not announce a method recategorized in those cases because either it's cleaning or removal anc we already announce method removal