### PR TITLE
Edit package of PositionableStream>>#nextWordsInto:

### DIFF
--- a/src/Monticello/PositionableStream.extension.st
+++ b/src/Monticello/PositionableStream.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'PositionableStream' }
 
-{ #category : '*Graphics-Primitives' }
+{ #category : '*Monticello' }
 PositionableStream >> nextWordsInto: aBitmap [
 	"Fill the word based buffer from my collection.
 	Stored on stream as Big Endian. Optimized for speed.


### PR DESCRIPTION
Move it to Monticello because Monticello is the first thing loaded relying on it.

Maybe this could be improved further later but this could improve the bootstrap

I found this in the bootstrap logs:

```
An error happened while reading MCZ. We will fallback to another format. Short error stack: ReadStream(Object)>>doesNotUnderstand: #nextWordsInto:
WideString class>>newFromStream:
MCDataStream>>readWordLike
MCDataStream>>next
MCClassDefinition(Object)>>readDataFrom:size:
MCDataStream>>readInstance
MCDataStream>>next
MCDataStream>>readArray
MCDataStream>>next
MCSnapshot(Object)>>readDataFrom:size:
```