### PR TITLE
Pusing down dependencies of Collection-Abstract

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -324,203 +324,11 @@ Collection >> anySatisfy: aBlock [
 ]
 
 { #category : 'converting' }
-Collection >> asArray [
-
-	"Answer an Array whose elements are the elements of the receiver.
-	Implementation note: Cannot use ''Array withAll: self'' as that only
-	works for SequenceableCollections which support the replacement
-	primitive."
-
-	"'ab' asArray >>> {$a. $b}"
-	"(1 to: 5 by: 3) asArray >>> {1. 4}"
-
-	"#(1 2) asArray == #(1 2) >>> true"
-
-	"'' asArray >>> #()"
-	"(10 to: 5) asArray >>> #()"
-
-	| newArray index |
-	newArray := Array new: self size.
-	index := 0.
-	self do: [ :each | newArray at: (index := index + 1) put: each ].
-	^ newArray
-]
-
-{ #category : 'converting' }
-Collection >> asBag [
-
-	"Answer a Bag whose elements are the elements of the receiver."
-
-	"{1. 2} asBag =    {2. 1} asBag >>> true"
-	"{1. 2} asBag = {1. 2. 2} asBag >>> false"
-	"{1. 2} asBag = {1. 2. 3} asBag >>> false"
-	"#() asBag = Bag new >>> true"
-
-	^ Bag withAll: self
-]
-
-{ #category : 'converting' }
-Collection >> asByteArray [
-	"Answer a ByteArray whose elements are the elements of the receiver.
-	Implementation note: Cannot use ''ByteArray withAll: self'' as that only
-	works for SequenceableCollections which support the replacement
-	primitive."
-
-	"{1. 2} asByteArray >>> #[1 2]"
-	"#[1 2] asByteArray == #[1 2] >>> true"
-	"'foo' asByteArray >>> #[102 111 111]"
-	"#() asByteArray >>> #[]"
-
-	| array index |
-	array := ByteArray new: self size.
-	index := 0.
-	self do: [:each | array at: (index := index + 1) put: each].
-	^ array
-]
-
-{ #category : 'converting' }
 Collection >> asCharacterSet [
 	"Answer a CharacterSet whose elements are the unique elements of the receiver.
 	The reciever should only contain characters."
 
 	^ CharacterSet newFrom: self
-]
-
-{ #category : 'printing' }
-Collection >> asCommaString [
-
-	"Return collection printed as 'a, b, c' "
-
-	"#('a' 'b' 'c') asCommaString >>> 'a, b, c'"
-	"#('a') asCommaString >>> 'a'"
-	"#() asCommaString >>> ''"
-	"'foo' asCommaString >>> 'f, o, o'"
-	"(10 to: 25 by: 5) asCommaString >>> '10, 15, 20, 25'"
-
-	^ String streamContents: [ :s | self asStringOn: s delimiter: ', ' ]
-]
-
-{ #category : 'printing' }
-Collection >> asCommaStringAnd [
-
-	"Return collection printed as 'a, b and c' "
-
-	"#( 'a' 'b' 'c') asCommaStringAnd >>> 'a, b and c'"
-	"#('a') asCommaStringAnd >>> 'a'"
-	"#() asCommaStringAnd >>> ''"
-	"'foo' asCommaStringAnd >>> 'f, o and o'"
-	"(10 to: 25 by: 5) asCommaStringAnd >>> '10, 15, 20 and 25'"
-
-	^String streamContents: [:s | self asStringOn: s delimiter: ', ' last: ' and ']
-]
-
-{ #category : 'converting' }
-Collection >> asDictionary [
-
-	"Answers a Dictionary based on collection of Associations."
-
-	"{'one' -> 1. 'two' ->2} asDictionary >>> (Dictionary with: 'one' -> 1 with: 'two' ->2)"
-	"{'two' ->2. 'one' -> 1} asDictionary >>> (Dictionary with: 'one' -> 1 with: 'two' ->2)"
-	"#() asDictionary >>> Dictionary new"
-
-	^ self as: Dictionary
-]
-
-{ #category : 'converting' }
-Collection >> asIdentitySet [
-
-	"Return a new IdentitySet based on self."
-
-	"{ 2. 1+1 } asIdentitySet size >>> 1"
-	"{ 'foo'. ('fo','o') } asIdentitySet size >>> 2"
-
-	^(IdentitySet new: self size) addAll: self; yourself
-]
-
-{ #category : 'converting' }
-Collection >> asMultilineString [
-
-	^ String streamContents: [ :stream |
-		  self
-			  do: [ :each | stream nextPutAll: each asString ]
-			  separatedBy: [ stream nextPut: Character cr ] ]
-]
-
-{ #category : 'converting' }
-Collection >> asNewArray [
-
-	"Like asArray: but return a copy if self is already an Array.
-	This ensures that the result is always a new Array"
-
-	"'foo' asNewArray >>> 'foo' asArray"
-	"|a| a := #(1 2 3). a asNewArray == a >>> false"
-
-	^ self asArray
-]
-
-{ #category : 'converting' }
-Collection >> asOrderedCollection [
-
-	"Answer an OrderedCollection whose elements are the elements of the
-	receiver. The order in which elements are added depends on the order
-	in which the receiver enumerates its elements. In the case of unordered
-	collections, the ordering is not necessarily the same for multiple
-	requests for the conversion."
-
-	"(10 to: 25 by: 5) asOrderedCollection >>> #(10 15 20 25) asOrderedCollection"
-
-	"'foo' asOrderedCollection = #($f $o $o) asOrderedCollection >>> true"
-	"'foo' asOrderedCollection = #($o $o $f) asOrderedCollection >>> false"
-
-	^ self as: OrderedCollection
-]
-
-{ #category : 'converting' }
-Collection >> asOrderedDictionary [
-
-	"Answers a Dictionary based on collection of Associations."
-
-	"{'one' -> 1. 'two' ->2} asOrderedDictionary keys first >>> 'one'"
-
-	^ self as: OrderedDictionary
-]
-
-{ #category : 'converting' }
-Collection >> asSet [
-	"Answer a Set whose elements are the unique elements of the receiver."
-
-	"{1. 2} asSet =    {2. 1} asSet >>> true"
-	"{1. 2} asSet = {1. 2. 2} asSet >>> true"
-	"{1. 2} asSet = {1. 2. 3} asSet >>> false"
-	"{} asSet = Set new >>> true"
-
-	^ Set withAll: self
-]
-
-{ #category : 'converting' }
-Collection >> asSortedCollection [
-
-	"Answer a SortedCollection whose elements are the elements of the receiver. The sort order is the default less than or equal. Note that you should use #sorted if you don't really need a SortedCollection, but a sorted collection."
-
-	"'bar' asSortedCollection asArray >>> {$a. $b. $r}."
-
-	"('bar' asSortedCollection add: $c; yourself) asArray >>> {$a. $b. $c. $r}."
-
-	^ self as: SortedCollection
-]
-
-{ #category : 'converting' }
-Collection >> asSortedCollection: aSortBlock [
-
-	"Answer a SortedCollection whose elements are the elements of the receiver. The sort order is defined by the argument, aSortBlock. Note that it is better to use #sorted if you don't really need a SortedCollection, but a sorted collection!!"
-
-	"('bar' asSortedCollection: [:x :y| x>y ]) asArray >>> {$r. $b. $a}."
-
-	| aSortedCollection |
-	aSortedCollection := SortedCollection new: self size.
-	aSortedCollection sortBlock: aSortBlock.
-	aSortedCollection addAll: self.
-	^ aSortedCollection
 ]
 
 { #category : 'printing' }
@@ -1068,49 +876,11 @@ Collection >> flatCollect: aBlock [
 ]
 
 { #category : 'enumerating' }
-Collection >> flatCollect: aBlock as: aCollectionClass [
-	"Evaluate aBlock for each of the receiver's elements and answer the
-	list of all resulting values flatten one level. Assumes that aBlock returns some kind
-	of collection for each element. Equivalent to the lisp's mapcan"
-
-	"(#(1 2 3) flatCollect: [:each | { each. each+1 } ] as: Set) >>> #(1 2 3 4) asSet"
-	"(#(65 66 67) flatCollect: [:each | { each asCharacter. each asCharacter asLowercase } ] as: String) >>> 'AaBbCc'"
-
-	| col |
-	col := OrderedCollection new: self size.
-	self do: [ :each | col addAll: (aBlock value: each) ].
-	^ aCollectionClass withAll: col
-]
-
-{ #category : 'enumerating' }
-Collection >> flatCollectAsSet: aBlock [
-	"Evaluate aBlock for each of the receiver's elements and answer the
-	list of all resulting values flatten one level. Assumes that aBlock returns some kind
-	of collection for each element. Equivalent to the lisp's mapcan"
-
-	"( #(1 2 3) flatCollectAsSet: [:each | { each. each+1 } ] ) >>> #(1 2 3 4) asSet"
-
-	^ self flatCollect: aBlock as: Set
-]
-
-{ #category : 'enumerating' }
 Collection >> flattenOn: aStream [
 
 	"See Collection>>flattened that uses this method"
 
 	self do: [ :each | each flattenOn: aStream ]
-]
-
-{ #category : 'enumerating' }
-Collection >> flattened [
-
-	"Flattens a collection of collections (no matter how many levels of collections exist). Strings are considered atoms and, as such, won't be flattened"
-
-	"( #(1 #(2 3) #(4 #(5))) flattened ) >>> #(1 2 3 4 5)"
-
-	"( #('string1' #('string2' 'string3')) flattened ) >>> #('string1' 'string2' 'string3')"
-
-	^ Array streamContents: [ :stream | self flattenOn: stream ]
 ]
 
 { #category : 'enumerating' }
@@ -1127,23 +897,6 @@ Collection >> gather: aBlock [
 	"This method is kept for compatibility reasons, use flatCollect: instead."
 
 	^ self flatCollect: aBlock
-]
-
-{ #category : 'enumerating' }
-Collection >> groupedBy: aBlock [
-	"Answer a dictionary whose keys are the result of evaluating aBlock for all my elements, and the value for each key is the selection of my elements that evaluated to that key. Uses species."
-
-	"(#(1 2 3 4 5) groupedBy: [ :v | v odd ]) asString
-		>>> 'an OrderedDictionary(true->#(1 3 5) false->#(2 4))'"
-
-	| groups |
-	groups := OrderedDictionary new.
-	self do: [ :each |
-		(groups at: (aBlock value: each) ifAbsentPut: [ OrderedCollection new ]) add: each ].
-	self species ~~ OrderedCollection ifTrue: [
-		groups associationsDo: [ :association |
-			association value: (self species withAll: association value) ]].
-	^ groups
 ]
 
 { #category : 'enumerating' }
@@ -1694,32 +1447,6 @@ Collection >> size [
 	tally := 0.
 	self do: [:each | tally := tally + 1].
 	^ tally
-]
-
-{ #category : 'sorting' }
-Collection >> sorted [
-	"Return a new sequenceable collection which contains the same elements as self but its
-elements are sorted"
-
-	"#(3 1 4 2) sorted >>> #(1 2 3 4)"
-	"'hello' sorted >>> 'ehllo'"
-	"(10 to: 1 by: -2) sorted >>> (2 to: 10 by: 2)"
-
-	^self asArray sorted
-]
-
-{ #category : 'sorting' }
-Collection >> sorted: aSortBlockOrNil [
-	"Return a new sequenceable collection which contains the same elements as self but its
-elements are sorted by aSortBlockOrNil. The block should take two arguments and return true if
-the first element should preceed the second one. If aSortBlock is nil then <= is used for
-comparison."
-
-	"(#(3 1 4 2) sorted: [:a :b| a>=b]) >>> #(4 3 2 1)"
-	"('hello' sorted: [:a :b| a>=b]) >>> 'ollhe'"
-	"((1 to: 10 by: 2) sorted: [:a :b| a>=b]) >>> #(9 7 5 3 1)"
-
-	^self asArray sort: aSortBlockOrNil
 ]
 
 { #category : 'printing' }

--- a/src/Collections-Abstract/Object.extension.st
+++ b/src/Collections-Abstract/Object.extension.st
@@ -7,31 +7,9 @@ Object >> appendTo: aCollection [
 ]
 
 { #category : '*Collections-Abstract-splitjoin' }
-Object >> join: aSequenceableCollection [
-	"Append the elements of the argument, aSequenceableCollection, separating them by the receiver."
-	"(Character space join: #('Pharo' 'is' 'cool')) >>> 'Pharo is cool'"
-
-	^ (Array with: self) join: aSequenceableCollection
-]
-
-{ #category : '*Collections-Abstract-splitjoin' }
 Object >> joinTo: stream [
 	"double dispatch for join:"
 	^ stream nextPut: self
-]
-
-{ #category : '*Collections-Abstract-splitjoin' }
-Object >> split: aSequenceableCollection [
-	"Split the argument using the receiver as a separator."
-	"optimized version for single delimiters"
-	"($/ split: '/foo/bar')>>>#('' 'foo' 'bar') asOrderedCollection"
-	"([:c| c isSeparator] split: 'aa bb cc dd')>>> #('aa' 'bb' 'cc' 'dd') asOrderedCollection"
-
-	| result |
-	result := OrderedCollection new: aSequenceableCollection size //2.
-	self split: aSequenceableCollection do: [ :item |
-		result add: item ].
-	^ result
 ]
 
 { #category : '*Collections-Abstract-splitjoin' }

--- a/src/Collections-Native/Collection.extension.st
+++ b/src/Collections-Native/Collection.extension.st
@@ -1,0 +1,20 @@
+Extension { #name : 'Collection' }
+
+{ #category : '*Collections-Native' }
+Collection >> asByteArray [
+	"Answer a ByteArray whose elements are the elements of the receiver.
+	Implementation note: Cannot use ''ByteArray withAll: self'' as that only
+	works for SequenceableCollections which support the replacement
+	primitive."
+
+	"{1. 2} asByteArray >>> #[1 2]"
+	"#[1 2] asByteArray == #[1 2] >>> true"
+	"'foo' asByteArray >>> #[102 111 111]"
+	"#() asByteArray >>> #[]"
+
+	| array index |
+	array := ByteArray new: self size.
+	index := 0.
+	self do: [:each | array at: (index := index + 1) put: each].
+	^ array
+]

--- a/src/Collections-Sequenceable/ArrayedCollection.class.st
+++ b/src/Collections-Sequenceable/ArrayedCollection.class.st
@@ -4,9 +4,8 @@ I am an abstract collection of elements with a fixed range of integers (from 1 t
 Class {
 	#name : 'ArrayedCollection',
 	#superclass : 'SequenceableCollection',
-	#category : 'Collections-Abstract-Base',
-	#package : 'Collections-Abstract',
-	#tag : 'Base'
+	#category : 'Collections-Sequenceable',
+	#package : 'Collections-Sequenceable'
 }
 
 { #category : 'testing' }

--- a/src/Collections-Sequenceable/Collection.extension.st
+++ b/src/Collections-Sequenceable/Collection.extension.st
@@ -1,0 +1,159 @@
+Extension { #name : 'Collection' }
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> asArray [
+
+	"Answer an Array whose elements are the elements of the receiver.
+	Implementation note: Cannot use ''Array withAll: self'' as that only
+	works for SequenceableCollections which support the replacement
+	primitive."
+
+	"'ab' asArray >>> {$a. $b}"
+	"(1 to: 5 by: 3) asArray >>> {1. 4}"
+
+	"#(1 2) asArray == #(1 2) >>> true"
+
+	"'' asArray >>> #()"
+	"(10 to: 5) asArray >>> #()"
+
+	| newArray index |
+	newArray := Array new: self size.
+	index := 0.
+	self do: [ :each | newArray at: (index := index + 1) put: each ].
+	^ newArray
+]
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> asNewArray [
+
+	"Like asArray: but return a copy if self is already an Array.
+	This ensures that the result is always a new Array"
+
+	"'foo' asNewArray >>> 'foo' asArray"
+	"|a| a := #(1 2 3). a asNewArray == a >>> false"
+
+	^ self asArray
+]
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> asOrderedCollection [
+
+	"Answer an OrderedCollection whose elements are the elements of the
+	receiver. The order in which elements are added depends on the order
+	in which the receiver enumerates its elements. In the case of unordered
+	collections, the ordering is not necessarily the same for multiple
+	requests for the conversion."
+
+	"(10 to: 25 by: 5) asOrderedCollection >>> #(10 15 20 25) asOrderedCollection"
+
+	"'foo' asOrderedCollection = #($f $o $o) asOrderedCollection >>> true"
+	"'foo' asOrderedCollection = #($o $o $f) asOrderedCollection >>> false"
+
+	^ self as: OrderedCollection
+]
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> asOrderedDictionary [
+
+	"Answers a Dictionary based on collection of Associations."
+
+	"{'one' -> 1. 'two' ->2} asOrderedDictionary keys first >>> 'one'"
+
+	^ self as: OrderedDictionary
+]
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> asSortedCollection [
+
+	"Answer a SortedCollection whose elements are the elements of the receiver. The sort order is the default less than or equal. Note that you should use #sorted if you don't really need a SortedCollection, but a sorted collection."
+
+	"'bar' asSortedCollection asArray >>> {$a. $b. $r}."
+
+	"('bar' asSortedCollection add: $c; yourself) asArray >>> {$a. $b. $c. $r}."
+
+	^ self as: SortedCollection
+]
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> asSortedCollection: aSortBlock [
+
+	"Answer a SortedCollection whose elements are the elements of the receiver. The sort order is defined by the argument, aSortBlock. Note that it is better to use #sorted if you don't really need a SortedCollection, but a sorted collection!!"
+
+	"('bar' asSortedCollection: [:x :y| x>y ]) asArray >>> {$r. $b. $a}."
+
+	| aSortedCollection |
+	aSortedCollection := SortedCollection new: self size.
+	aSortedCollection sortBlock: aSortBlock.
+	aSortedCollection addAll: self.
+	^ aSortedCollection
+]
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> flatCollect: aBlock as: aCollectionClass [
+	"Evaluate aBlock for each of the receiver's elements and answer the
+	list of all resulting values flatten one level. Assumes that aBlock returns some kind
+	of collection for each element. Equivalent to the lisp's mapcan"
+
+	"(#(1 2 3) flatCollect: [:each | { each. each+1 } ] as: Set) >>> #(1 2 3 4) asSet"
+	"(#(65 66 67) flatCollect: [:each | { each asCharacter. each asCharacter asLowercase } ] as: String) >>> 'AaBbCc'"
+
+	| col |
+	col := OrderedCollection new: self size.
+	self do: [ :each | col addAll: (aBlock value: each) ].
+	^ aCollectionClass withAll: col
+]
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> flattened [
+
+	"Flattens a collection of collections (no matter how many levels of collections exist). Strings are considered atoms and, as such, won't be flattened"
+
+	"( #(1 #(2 3) #(4 #(5))) flattened ) >>> #(1 2 3 4 5)"
+
+	"( #('string1' #('string2' 'string3')) flattened ) >>> #('string1' 'string2' 'string3')"
+
+	^ Array streamContents: [ :stream | self flattenOn: stream ]
+]
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> groupedBy: aBlock [
+	"Answer a dictionary whose keys are the result of evaluating aBlock for all my elements, and the value for each key is the selection of my elements that evaluated to that key. Uses species."
+
+	"(#(1 2 3 4 5) groupedBy: [ :v | v odd ]) asString
+		>>> 'an OrderedDictionary(true->#(1 3 5) false->#(2 4))'"
+
+	| groups |
+	groups := OrderedDictionary new.
+	self do: [ :each |
+		(groups at: (aBlock value: each) ifAbsentPut: [ OrderedCollection new ]) add: each ].
+	self species ~~ OrderedCollection ifTrue: [
+		groups associationsDo: [ :association |
+			association value: (self species withAll: association value) ]].
+	^ groups
+]
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> sorted [
+	"Return a new sequenceable collection which contains the same elements as self but its
+elements are sorted"
+
+	"#(3 1 4 2) sorted >>> #(1 2 3 4)"
+	"'hello' sorted >>> 'ehllo'"
+	"(10 to: 1 by: -2) sorted >>> (2 to: 10 by: 2)"
+
+	^self asArray sorted
+]
+
+{ #category : '*Collections-Sequenceable' }
+Collection >> sorted: aSortBlockOrNil [
+	"Return a new sequenceable collection which contains the same elements as self but its
+elements are sorted by aSortBlockOrNil. The block should take two arguments and return true if
+the first element should preceed the second one. If aSortBlock is nil then <= is used for
+comparison."
+
+	"(#(3 1 4 2) sorted: [:a :b| a>=b]) >>> #(4 3 2 1)"
+	"('hello' sorted: [:a :b| a>=b]) >>> 'ollhe'"
+	"((1 to: 10 by: 2) sorted: [:a :b| a>=b]) >>> #(9 7 5 3 1)"
+
+	^self asArray sort: aSortBlockOrNil
+]

--- a/src/Collections-Sequenceable/Object.extension.st
+++ b/src/Collections-Sequenceable/Object.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : 'Object' }
+
+{ #category : '*Collections-Sequenceable' }
+Object >> join: aSequenceableCollection [
+	"Append the elements of the argument, aSequenceableCollection, separating them by the receiver."
+	"(Character space join: #('Pharo' 'is' 'cool')) >>> 'Pharo is cool'"
+
+	^ (Array with: self) join: aSequenceableCollection
+]
+
+{ #category : '*Collections-Sequenceable' }
+Object >> split: aSequenceableCollection [
+	"Split the argument using the receiver as a separator."
+	"optimized version for single delimiters"
+	"($/ split: '/foo/bar')>>>#('' 'foo' 'bar') asOrderedCollection"
+	"([:c| c isSeparator] split: 'aa bb cc dd')>>> #('aa' 'bb' 'cc' 'dd') asOrderedCollection"
+
+	| result |
+	result := OrderedCollection new: aSequenceableCollection size //2.
+	self split: aSequenceableCollection do: [ :item |
+		result add: item ].
+	^ result
+]

--- a/src/Collections-Sequenceable/SequenceableCollection.class.st
+++ b/src/Collections-Sequenceable/SequenceableCollection.class.st
@@ -4,9 +4,8 @@ I am an abstract superclass for collections that have a well-defined order assoc
 Class {
 	#name : 'SequenceableCollection',
 	#superclass : 'Collection',
-	#category : 'Collections-Abstract-Base',
-	#package : 'Collections-Abstract',
-	#tag : 'Base'
+	#category : 'Collections-Sequenceable',
+	#package : 'Collections-Sequenceable'
 }
 
 { #category : 'testing' }

--- a/src/Collections-Strings/CharacterSet.class.st
+++ b/src/Collections-Strings/CharacterSet.class.st
@@ -16,9 +16,8 @@ Class {
 	#classVars : [
 		'CrLf'
 	],
-	#category : 'Collections-Support-CharacterSets',
-	#package : 'Collections-Support',
-	#tag : 'CharacterSets'
+	#category : 'Collections-Strings',
+	#package : 'Collections-Strings'
 }
 
 { #category : 'instance creation' }

--- a/src/Collections-Strings/CharacterSetComplement.class.st
+++ b/src/Collections-Strings/CharacterSetComplement.class.st
@@ -14,9 +14,8 @@ Class {
 		'absent',
 		'byteArrayMapCache'
 	],
-	#category : 'Collections-Support-CharacterSets',
-	#package : 'Collections-Support',
-	#tag : 'CharacterSets'
+	#category : 'Collections-Strings',
+	#package : 'Collections-Strings'
 }
 
 { #category : 'instance creation' }

--- a/src/Collections-Strings/Collection.extension.st
+++ b/src/Collections-Strings/Collection.extension.st
@@ -1,0 +1,38 @@
+Extension { #name : 'Collection' }
+
+{ #category : '*Collections-Strings' }
+Collection >> asCommaString [
+
+	"Return collection printed as 'a, b, c' "
+
+	"#('a' 'b' 'c') asCommaString >>> 'a, b, c'"
+	"#('a') asCommaString >>> 'a'"
+	"#() asCommaString >>> ''"
+	"'foo' asCommaString >>> 'f, o, o'"
+	"(10 to: 25 by: 5) asCommaString >>> '10, 15, 20, 25'"
+
+	^ String streamContents: [ :s | self asStringOn: s delimiter: ', ' ]
+]
+
+{ #category : '*Collections-Strings' }
+Collection >> asCommaStringAnd [
+
+	"Return collection printed as 'a, b and c' "
+
+	"#( 'a' 'b' 'c') asCommaStringAnd >>> 'a, b and c'"
+	"#('a') asCommaStringAnd >>> 'a'"
+	"#() asCommaStringAnd >>> ''"
+	"'foo' asCommaStringAnd >>> 'f, o and o'"
+	"(10 to: 25 by: 5) asCommaStringAnd >>> '10, 15, 20 and 25'"
+
+	^String streamContents: [:s | self asStringOn: s delimiter: ', ' last: ' and ']
+]
+
+{ #category : '*Collections-Strings' }
+Collection >> asMultilineString [
+
+	^ String streamContents: [ :stream |
+		  self
+			  do: [ :each | stream nextPutAll: each asString ]
+			  separatedBy: [ stream nextPut: Character cr ] ]
+]

--- a/src/Collections-Strings/WideCharacterSet.class.st
+++ b/src/Collections-Strings/WideCharacterSet.class.st
@@ -23,9 +23,8 @@ Class {
 		'map',
 		'byteArrayMap'
 	],
-	#category : 'Collections-Support-CharacterSets',
-	#package : 'Collections-Support',
-	#tag : 'CharacterSets'
+	#category : 'Collections-Strings',
+	#package : 'Collections-Strings'
 }
 
 { #category : 'instance creation' }

--- a/src/Collections-Unordered/Collection.extension.st
+++ b/src/Collections-Unordered/Collection.extension.st
@@ -1,0 +1,60 @@
+Extension { #name : 'Collection' }
+
+{ #category : '*Collections-Unordered' }
+Collection >> asBag [
+
+	"Answer a Bag whose elements are the elements of the receiver."
+
+	"{1. 2} asBag =    {2. 1} asBag >>> true"
+	"{1. 2} asBag = {1. 2. 2} asBag >>> false"
+	"{1. 2} asBag = {1. 2. 3} asBag >>> false"
+	"#() asBag = Bag new >>> true"
+
+	^ Bag withAll: self
+]
+
+{ #category : '*Collections-Unordered' }
+Collection >> asDictionary [
+
+	"Answers a Dictionary based on collection of Associations."
+
+	"{'one' -> 1. 'two' ->2} asDictionary >>> (Dictionary with: 'one' -> 1 with: 'two' ->2)"
+	"{'two' ->2. 'one' -> 1} asDictionary >>> (Dictionary with: 'one' -> 1 with: 'two' ->2)"
+	"#() asDictionary >>> Dictionary new"
+
+	^ self as: Dictionary
+]
+
+{ #category : '*Collections-Unordered' }
+Collection >> asIdentitySet [
+
+	"Return a new IdentitySet based on self."
+
+	"{ 2. 1+1 } asIdentitySet size >>> 1"
+	"{ 'foo'. ('fo','o') } asIdentitySet size >>> 2"
+
+	^(IdentitySet new: self size) addAll: self; yourself
+]
+
+{ #category : '*Collections-Unordered' }
+Collection >> asSet [
+	"Answer a Set whose elements are the unique elements of the receiver."
+
+	"{1. 2} asSet =    {2. 1} asSet >>> true"
+	"{1. 2} asSet = {1. 2. 2} asSet >>> true"
+	"{1. 2} asSet = {1. 2. 3} asSet >>> false"
+	"{} asSet = Set new >>> true"
+
+	^ Set withAll: self
+]
+
+{ #category : '*Collections-Unordered' }
+Collection >> flatCollectAsSet: aBlock [
+	"Evaluate aBlock for each of the receiver's elements and answer the
+	list of all resulting values flatten one level. Assumes that aBlock returns some kind
+	of collection for each element. Equivalent to the lisp's mapcan"
+
+	"( #(1 2 3) flatCollectAsSet: [:each | { each. each+1 } ] ) >>> #(1 2 3 4) asSet"
+
+	^ self flatCollect: aBlock as: Set
+]

--- a/src/Collections-Unordered/HashedCollection.class.st
+++ b/src/Collections-Unordered/HashedCollection.class.st
@@ -24,9 +24,8 @@ Class {
 		'tally',
 		'array'
 	],
-	#category : 'Collections-Abstract-Base',
-	#package : 'Collections-Abstract',
-	#tag : 'Base'
+	#category : 'Collections-Unordered',
+	#package : 'Collections-Unordered'
 }
 
 { #category : 'cleanup' }

--- a/src/Tool-DependencyAnalyser-Tests/DAMessageSendAnalyzerTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAMessageSendAnalyzerTest.class.st
@@ -47,8 +47,8 @@ DAMessageSendAnalyzerTest >> testShouldGetPotentialMatchForUnimplementedCalls [
 
 	self
 		assert: (analyzer missingMethodsWithPotentialMatch values collect: [:each | each size])
-		equals: #(0 2 11).
+		equals: #(0 2 10).
 	self
 		assert: (analyzer missingMethodsWithPotentialMatchAfterManuallyResolvedDependenciesAddition values collect: #size)
-		equals: #(0 2 11)
+		equals: #(0 2 10)
 ]


### PR DESCRIPTION
There are circular dependencies between `Collections-Abstract` and other collection packages.
This PR pushes classes and extension methods to their own packages to minimize these dependencies and allow separate loading without cyclic issues.