### PR TITLE
Guard RubAbstractTextArea>>#recomputeSelection for empty paragraphs

### DIFF
--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -1736,7 +1736,9 @@ RubAbstractTextArea >> recomputeSelection [
 	"The same characters are selected but their coordinates may have changed.
 	Redetermine the selection according to the start and stop block indices;
 	do not highlight."
-
+	
+	"workaround, guard for empty paragraph. https://github.com/pharo-project/pharo/issues/12502"
+	self editingState paragraph lines isEmpty ifTrue: [ ^self ].
 	self markIndex: self markIndex pointIndex: self pointIndex
 ]
 


### PR DESCRIPTION
add a guard for one of the rendering errors we see on the CI (see #12502)