### PR TITLE
Fix cyclic dependencies between compiler and ASTs/parser and their tests

### DIFF
--- a/src/AST-Core-Tests/ManifestASTCoreTests.class.st
+++ b/src/AST-Core-Tests/ManifestASTCoreTests.class.st
@@ -9,6 +9,13 @@ Class {
 	#tag : 'Manifest'
 }
 
+{ #category : 'meta-data - dependency analyser' }
+ManifestASTCoreTests class >> manuallyResolvedDependencies [
+
+	<ignoreForCoverage>
+	^ #(#'Collections-Abstract')
+]
+
 { #category : 'code-critics' }
 ManifestASTCoreTests class >> ruleGRTemporaryNeitherReadNorWrittenRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#ASTEvaluationTest #testEvaluateForContext #false)) #'2019-07-05T11:16:20.959329+02:00') )

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -1882,12 +1882,12 @@ RBCodeSnippet class >> badSemantic [
 			         skip: #testEvaluateOnErrorResume). "evaluate cannot distinguishes runtime errors and compiletime errors"
 		        (self new
 			         source:
-				         'OCUndeclaredVariableWarning signal: ''false error''';
+				         'Warning signal: ''false error''';
 			         nodeAt:
-				         '1111111111111111111111111110000000002222222222222';
+				         '11111110000000002222222222222';
 			         styled:
-				         'ggggggggggggggggggggggggggg sssssss ''''''''''''''''''''''''''';
-			         raise: OCUndeclaredVariableWarning). "same, but warning are silently ignored"
+				         'ggggggg sssssss ''''''''''''''''''''''''''';
+			         raise: Warning). "same, but warning are silently ignored"
 		        (self new
 			         source: 'RuntimeSyntaxError signal: ''false error''';
 			         nodeAt: '1111111111111111110000000002222222222222';
@@ -2769,51 +2769,6 @@ RBCodeSnippet class >> styleAll [
 	self allSnippets do: [ :each |
 		bigtext ifNotEmpty: [ bigtext append: String cr ].
 		bigtext append: each styledText ].
-	bigtext inspect
-]
-
-{ #category : 'script' }
-RBCodeSnippet class >> styleWithError: snippets [
-	"Display all snippets in a big styled text with compilation error messages and error nodes.
-	Each compilation error message and each error node is displayed indenpendently."
-
-	<script: 'self styleWithError: self allSnippets'>
-
-	| bigtext |
-	bigtext := Text new.
-	snippets do: [ :each |
-		| text ast |
-		bigtext ifNotEmpty: [ bigtext append: String cr ].
-
-		"Get the original styled text"
-		text := each styledText.
-		bigtext append: text.
-
-		"Try to compile it and collect error messages"
-		each compileOnError: [ :exception |
-				"In case of error, insert error message (like an old-school smalltalk compiler)"
-				text
-					replaceFrom: exception position
-					to: exception position - 1
-					with: (exception messageText asText addAttribute:
-							 (TextBackgroundColor color: Color lightBlue)).
-				bigtext append: String cr.
-				bigtext append: String tab.
-				bigtext append: text.
-				bigtext append: '   '.
-				bigtext append: ('SyntaxErrorNotification' asText makeAllColor: Color gray).
-				].
-
-		"Then the fun part. Add line for each node with error or warning"
-		ast := each doSemanticAnalysis.
-		ast nodesPostorderDo: [ :node |
-			node notices do: [ :notice |
-				text := each textWithNode: node message: notice messageText at: notice position.
-				bigtext append: String cr.
-				bigtext append: String tab.
-				bigtext append: text.
-				bigtext append: (('   {1} ({2})' format: {node class name. notice class name}) asText makeAllColor: Color gray)
-			] ] ].
 	bigtext inspect
 ]
 

--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -94,18 +94,6 @@ RBCodeSnippetTest >> testCodeImporter [
 ]
 
 { #category : 'tests' }
-RBCodeSnippetTest >> testDump [
-
-	| ast dump ast2 dump2 |
-	ast := snippet parse.
-	dump := ast dump.
-	ast2 := OpalCompiler new evaluate: dump.
-	self assert: ast2 equals: ast.
-	dump2 := ast2 dump.
-	self assert: dump2 equals: dump
-]
-
-{ #category : 'tests' }
 RBCodeSnippetTest >> testFormattedCode [
 
 	| ast |

--- a/src/AST-Core-Tests/RBVariableNodeTest.class.st
+++ b/src/AST-Core-Tests/RBVariableNodeTest.class.st
@@ -43,33 +43,6 @@ RBVariableNodeTest >> testIsDefinedByBlock [
 ]
 
 { #category : 'tests' }
-RBVariableNodeTest >> testIsDefinition [
-
-	| ast temps |
-	ast := self class compiler parse: 'myMethod: arg
-  | test testCopied testTempVector|
-  test := 2.
-  test.
-  [ testCopied. testTempVector := 1 ].
-  ^test'.
-	temps := ast allChildren select: [ :each | each isTempVariable ].
-
-	"arguments define variables"
-	self assert: ast arguments first isDefinition.
-	"this is the || definition"
-	self assert: temps first variable class identicalTo: TemporaryVariable.
-	self assert: temps first isDefinition.
-	self assert: temps second variable class identicalTo: CopiedLocalVariable.
-	self assert: temps second isDefinition.
-	self assert: temps third variable class identicalTo: OCVectorTempVariable .
-	self assert: temps third isDefinition.
-	"all the rest are just uses"
-	self deny: temps fourth isDefinition.
-	self deny: (temps at: 5) isDefinition.
-	self deny: (temps at: 6) isDefinition
-]
-
-{ #category : 'tests' }
 RBVariableNodeTest >> testStartForReplacement [
 
 	| source tree dTemporary |

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -462,24 +462,6 @@ RBMethodNode >> matchPragmas: matchNodes against: pragmaNodes inContext: aDictio
 			matchNode match: pragmaNode inContext: aDictionary ] ]
 ]
 
-{ #category : 'accessing - compiled method' }
-RBMethodNode >> method [
-	
-	self deprecated: 'use compiledMethod' transformWith: '`@recv method' -> '`@recv compiledMethod'.
-	^ self compiledMethod
-]
-
-{ #category : 'accessing - compiled method' }
-RBMethodNode >> methodClass [
-
-	^ self scope ifNotNil: [ :s | s targetClass ]
-]
-
-{ #category : 'accessing - compiled method' }
-RBMethodNode >> methodClass: aClass [
-	self semanticScope: (OCMethodSemanticScope targetingClass: aClass)
-]
-
 { #category : 'accessing' }
 RBMethodNode >> methodNode [
 	^self

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -134,6 +134,24 @@ RBMethodNode >> lastPcForNode: aNode [
 ]
 
 { #category : '*OpalCompiler-Core' }
+RBMethodNode >> method [
+	
+	self deprecated: 'use compiledMethod' transformWith: '`@recv method' -> '`@recv compiledMethod'.
+	^ self compiledMethod
+]
+
+{ #category : '*OpalCompiler-Core' }
+RBMethodNode >> methodClass [
+
+	^ self scope ifNotNil: [ :s | s targetClass ]
+]
+
+{ #category : '*OpalCompiler-Core' }
+RBMethodNode >> methodClass: aClass [
+	self semanticScope: (OCMethodSemanticScope targetingClass: aClass)
+]
+
+{ #category : '*OpalCompiler-Core' }
 RBMethodNode >> methodProperties [
 	^self propertyAt: #methodProperties ifAbsent: nil
 ]

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -189,6 +189,18 @@ RBCodeSnippetTest >> testDoSemanticAnalysisOnError [
 ]
 
 { #category : '*OpalCompiler-Tests' }
+RBCodeSnippetTest >> testDump [
+
+	| ast dump ast2 dump2 |
+	ast := snippet parse.
+	dump := ast dump.
+	ast2 := OpalCompiler new evaluate: dump.
+	self assert: ast2 equals: ast.
+	dump2 := ast2 dump.
+	self assert: dump2 equals: dump
+]
+
+{ #category : '*OpalCompiler-Tests' }
 RBCodeSnippetTest >> testExecute: method [
 
 	| runBlock phonyArgs |

--- a/src/OpalCompiler-Tests/RBVariableNodeTest.extension.st
+++ b/src/OpalCompiler-Tests/RBVariableNodeTest.extension.st
@@ -1,0 +1,55 @@
+Extension { #name : 'RBVariableNodeTest' }
+
+{ #category : '*OpalCompiler-Tests' }
+RBVariableNodeTest >> testIsDefinition [
+
+	| ast temps |
+	ast := self class compiler parse: 'myMethod: arg
+  | test testCopied testTempVector|
+  test := 2.
+  test.
+  [ testCopied. testTempVector := 1 ].
+  ^test'.
+	temps := ast allChildren select: [ :each | each isTempVariable ].
+
+	"arguments define variables"
+	self assert: ast arguments first isDefinition.
+	"this is the || definition"
+	self assert: temps first variable class identicalTo: TemporaryVariable.
+	self assert: temps first isDefinition.
+	self assert: temps second variable class identicalTo: CopiedLocalVariable.
+	self assert: temps second isDefinition.
+	self assert: temps third variable class identicalTo: OCVectorTempVariable .
+	self assert: temps third isDefinition.
+	"all the rest are just uses"
+	self deny: temps fourth isDefinition.
+	self deny: (temps at: 5) isDefinition.
+	self deny: (temps at: 6) isDefinition
+]
+
+{ #category : '*OpalCompiler-Tests' }
+RBVariableNodeTest >> testIsDefinitionAfterNameResolution [
+
+	| ast temps |
+	ast := self class compiler parse: 'myMethod: arg
+  | test testCopied testTempVector|
+  test := 2.
+  test.
+  [ testCopied. testTempVector := 1 ].
+  ^test'.
+	temps := ast allChildren select: [ :each | each isTempVariable ].
+
+	"arguments define variables"
+	self assert: ast arguments first isDefinition.
+	"this is the || definition"
+	self assert: temps first variable class identicalTo: TemporaryVariable.
+	self assert: temps first isDefinition.
+	self assert: temps second variable class identicalTo: CopiedLocalVariable.
+	self assert: temps second isDefinition.
+	self assert: temps third variable class identicalTo: OCVectorTempVariable .
+	self assert: temps third isDefinition.
+	"all the rest are just uses"
+	self deny: temps fourth isDefinition.
+	self deny: (temps at: 5) isDefinition.
+	self deny: (temps at: 6) isDefinition
+]


### PR DESCRIPTION
There are cyclic dependencies between 
- AST-Core and OpalCompiler-Core
- AST-Core-Tests and OpalCompiler-Tests

And dependencies from AST-Core-Tests to OpalCompiler-Core.