### PR TITLE
Fix moving classes in tags

### DIFF
--- a/src/Calypso-SystemQueries/ClyClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyClassGroup.class.st
@@ -102,7 +102,6 @@ ClyClassGroup >> = anObject [
 ClyClassGroup >> addClass: aClass [
 
 	| newPackages |
-	super addClass: aClass.
 	newPackages := OrderedCollection new.
 	classQuery scope packagesDo: [ :package | package = aClass package ifFalse: [ newPackages add: package ] ].
 	newPackages size > 1 ifTrue: [ self error: 'You should select single package for import!' ].


### PR DESCRIPTION
During a previous refactoring it seems that a super call was left in code and this super is not needed