### PR TITLE
Inlining `select:thenCollect:` and `reject:thenCollect:` to not do two iterations on the same collection

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -1659,7 +1659,11 @@ Collection >> select: selectBlock thenCollect: collectBlock [
 	"(#(1 2 3 4 5) select: #even thenCollect: #negated) >>> #(-2 -4)"
 	"('Hello, World!' select: #isLetter thenCollect: #uppercase) >>> 'HELLOWORLD'"
 
-	^ (self select: selectBlock) collect: collectBlock
+	| selectedItems |
+	selectedItems := self copyEmpty.
+	self do: [ :e |
+		(selectBlock value: e) ifTrue: [ selectedItems add: (collectBlock value: e) ] ].
+	^ selectedItems
 ]
 
 { #category : 'enumerating' }

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -1546,11 +1546,11 @@ Collection >> reject: rejectBlock thenCollect: collectBlock [
 
 	"(#(1 2 3 4 5) reject: #even thenCollect: [:x|x*10]) >>> #(10 30 50)"
 
-	| rejectedItems |
-	rejectedItems := self copyEmpty.
+	| newCollection |
+	newCollection := self copyEmpty.
 	self do: [ :e | (rejectBlock value: e) ifFalse: [ 
-			rejectedItems add: (collectBlock value: e) ] ].
-	^ rejectedItems
+			newCollection add: (collectBlock value: e) ] ].
+	^ newCollection
 ]
 
 { #category : 'enumerating' }

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -1542,11 +1542,15 @@ Collection >> reject: aBlock [
 
 { #category : 'enumerating' }
 Collection >> reject: rejectBlock thenCollect: collectBlock [
-	"Utility method to improve readability."
+	"Optimized implementation"
 
 	"(#(1 2 3 4 5) reject: #even thenCollect: [:x|x*10]) >>> #(10 30 50)"
 
-	^ (self reject: rejectBlock) collect: collectBlock
+	| rejectedItems |
+	rejectedItems := self copyEmpty.
+	self do: [ :e | (rejectBlock value: e) ifFalse: [ 
+			rejectedItems add: (collectBlock value: e) ] ].
+	^ rejectedItems
 ]
 
 { #category : 'enumerating' }
@@ -1654,15 +1658,15 @@ Collection >> select: aBlock [
 
 { #category : 'enumerating' }
 Collection >> select: selectBlock thenCollect: collectBlock [
-	"Utility method to improve readability."
+	"Optimized implementation"
 
 	"(#(1 2 3 4 5) select: #even thenCollect: #negated) >>> #(-2 -4)"
 	"('Hello, World!' select: #isLetter thenCollect: #uppercase) >>> 'HELLOWORLD'"
 
 	| selectedItems |
 	selectedItems := self copyEmpty.
-	self do: [ :e |
-		(selectBlock value: e) ifTrue: [ selectedItems add: (collectBlock value: e) ] ].
+	self do: [ :e | (selectBlock value: e) ifTrue: [ 
+			selectedItems add: (collectBlock value: e) ] ].
 	^ selectedItems
 ]
 

--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -831,6 +831,23 @@ Dictionary >> rehash [
 	array := newSelf array
 ]
 
+{ #category : 'enumerating' }
+Dictionary >> reject: rejectBlock thenCollect: collectBlock [
+	"Optimized version of Collection>>#reject:thenCollect:"
+
+	| newDictionary |
+	tally = 0 ifTrue: [ ^ self copyEmpty ].
+	newDictionary := self copyEmpty.
+
+	1 to: array size do: [ :index |
+		| assoc |
+		assoc := array at: index.
+		assoc ifNotNil: [
+			(rejectBlock value: assoc value) ifFalse: [
+				newDictionary at: assoc key put: (collectBlock value: assoc value) ] ] ].
+	^ newDictionary
+]
+
 { #category : 'removing' }
 Dictionary >> remove: anObject [
 
@@ -916,13 +933,19 @@ Dictionary >> select: aBlock [
 
 { #category : 'enumerating' }
 Dictionary >> select: selectBlock thenCollect: collectBlock [
+	"Optimized version of Collection>>#select:thenCollect:"
 
-	| newCollection |
-	newCollection := self copyEmpty.
-	self associationsDo: [ :each |
-		(selectBlock value: each value) ifTrue: [
-			newCollection at: each key put: (collectBlock value: each value) ] ].
-	^ newCollection
+	| newDictionary |
+	tally = 0 ifTrue: [ ^ self copyEmpty ].
+	newDictionary := self copyEmpty.
+
+	1 to: array size do: [ :index |
+		| assoc |
+		assoc := array at: index.
+		assoc ifNotNil: [
+			(selectBlock value: assoc value) ifTrue: [
+				newDictionary at: assoc key put: (collectBlock value: assoc value) ] ] ].
+	^ newDictionary
 ]
 
 { #category : 'printing' }

--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -914,6 +914,17 @@ Dictionary >> select: aBlock [
 	^ newCollection
 ]
 
+{ #category : 'enumerating' }
+Dictionary >> select: selectBlock thenCollect: collectBlock [
+
+	| newCollection |
+	newCollection := self copyEmpty.
+	self associationsDo: [ :each |
+		(selectBlock value: each value) ifTrue: [
+			newCollection at: each key put: (collectBlock value: each value) ] ].
+	^ newCollection
+]
+
 { #category : 'printing' }
 Dictionary >> storeOn: aStream [
 	| noneYet |

--- a/src/Collections-Unordered/Set.class.st
+++ b/src/Collections-Unordered/Set.class.st
@@ -144,12 +144,6 @@ Set >> collect: aBlock [
 	^ newSet
 ]
 
-{ #category : 'copying' }
-Set >> copyEmpty [
-
-	^ self species new: self size
-]
-
 { #category : 'removing' }
 Set >> copyWithout: oldElement [
 	"Answer a copy of the receiver that does not contain any

--- a/src/Collections-Unordered/Set.class.st
+++ b/src/Collections-Unordered/Set.class.st
@@ -144,6 +144,12 @@ Set >> collect: aBlock [
 	^ newSet
 ]
 
+{ #category : 'copying' }
+Set >> copyEmpty [
+
+	^ self species new: self size
+]
+
 { #category : 'removing' }
 Set >> copyWithout: oldElement [
 	"Answer a copy of the receiver that does not contain any

--- a/src/Collections-Unordered/SmallDictionary.class.st
+++ b/src/Collections-Unordered/SmallDictionary.class.st
@@ -744,6 +744,17 @@ SmallDictionary >> select: aBlock [
 	^newCollection
 ]
 
+{ #category : 'enumerating' }
+SmallDictionary >> select: selectBlock thenCollect: collectBlock [
+
+	| newCollection |
+	newCollection := self copyEmpty.
+	self associationsDo: [ :each |
+		(selectBlock value: each value) ifTrue: [
+			newCollection at: each key put: (collectBlock value: each value) ] ].
+	^ newCollection
+]
+
 { #category : 'private' }
 SmallDictionary >> setClass [
 	^ Set

--- a/src/Collections-Unordered/SmallDictionary.class.st
+++ b/src/Collections-Unordered/SmallDictionary.class.st
@@ -683,6 +683,18 @@ SmallDictionary >> privateAt: key put: value [
 	^values at: size put: value
 ]
 
+{ #category : 'enumerating' }
+SmallDictionary >> reject: rejectBlock thenCollect: collectBlock [
+	"Optimized implementation"
+
+	| newSmallDictionary |
+	newSmallDictionary := self copyEmpty.
+	1 to: size do: [:index | 
+		(rejectBlock value: (keys at: index)) ifFalse: [
+			newSmallDictionary at: (keys at: index) put: (collectBlock value: (values at: index)) ] ].
+	^ newSmallDictionary
+]
+
 { #category : 'removing' }
 SmallDictionary >> remove:anAssociation [
 
@@ -747,12 +759,12 @@ SmallDictionary >> select: aBlock [
 { #category : 'enumerating' }
 SmallDictionary >> select: selectBlock thenCollect: collectBlock [
 
-	| newCollection |
-	newCollection := self copyEmpty.
-	self associationsDo: [ :each |
-		(selectBlock value: each value) ifTrue: [
-			newCollection at: each key put: (collectBlock value: each value) ] ].
-	^ newCollection
+	| newSmallDictionary |
+	newSmallDictionary := self copyEmpty.
+	1 to: size do: [:index | 
+		(selectBlock value: (keys at: index)) ifTrue: [
+			newSmallDictionary at: (keys at: index) put: (collectBlock value: (values at: index)) ] ].
+	^ newSmallDictionary
 ]
 
 { #category : 'private' }

--- a/src/Collections-Weak-Tests/WeakSetTest.class.st
+++ b/src/Collections-Weak-Tests/WeakSetTest.class.st
@@ -309,6 +309,6 @@ WeakSetTest >> testSelectThenCollectPrint [
 	actualSet := self classToBeTested withAll: allElements.
 	actualSet := actualSet select: selectionBlock thenCollect: collectionBlock.
 
-	actualSet do: [ :e | self assert: (e enclosedElement beginsWith: #print) ].
+	actualSet do: [ :e | self assert: (selectionBlock value: e enclosedElement) ].
 	self assert: actualSet size equals: 4
 ]

--- a/src/Collections-Weak-Tests/WeakSetTest.class.st
+++ b/src/Collections-Weak-Tests/WeakSetTest.class.st
@@ -4,21 +4,51 @@ A trait for test purposes
 Class {
 	#name : 'WeakSetTest',
 	#superclass : 'TestCase',
+	#traits : 'TIterateTest',
+	#classTraits : 'TIterateTest classTrait',
+	#instVars : [
+		'weakSetWith3Elements',
+		'empty'
+	],
 	#category : 'Collections-Weak-Tests-Base',
 	#package : 'Collections-Weak-Tests',
 	#tag : 'Base'
 }
 
-{ #category : 'building suites' }
+{ #category : 'testing' }
 WeakSetTest class >> shouldInheritSelectors [
 
-^true
+	^ true
 ]
 
 { #category : 'requirements' }
 WeakSetTest >> classToBeTested [
 
 	^ WeakSet
+]
+
+{ #category : 'requirements' }
+WeakSetTest >> collectionWithoutNilElements [
+" return a collection that doesn't includes a nil element  and that doesn't includes equal elements'"
+	^ weakSetWith3Elements
+]
+
+{ #category : 'requirements' }
+WeakSetTest >> empty [
+
+	^ empty
+]
+
+{ #category : 'running' }
+WeakSetTest >> setUp [
+	super setUp.
+
+	empty := self classToBeTested  new.
+	weakSetWith3Elements := self classToBeTested new
+		add: 1;
+		add: -2;
+		add: 3;
+		yourself
 ]
 
 { #category : 'tests' }
@@ -265,4 +295,20 @@ WeakSetTest >> testIncludesNil [
 	ws add: 1/3.
 	Smalltalk garbageCollect.
 	self deny: (ws includes: nil)
+]
+
+{ #category : 'tests - iterating' }
+WeakSetTest >> testSelectThenCollectPrint [
+
+	| actualSet selectionBlock collectionBlock allElements |
+	selectionBlock := [ :e | e beginsWith: #print ].
+	collectionBlock := [ :e | CollectionElement with: e ].
+	allElements := { #printS. #print. #printG. #qwerty. #prontS. #printShowingDecimalPlaces:.
+	               #prrint }.
+
+	actualSet := self classToBeTested withAll: allElements.
+	actualSet := actualSet select: selectionBlock thenCollect: collectionBlock.
+
+	actualSet do: [ :e | self assert: (e enclosedElement beginsWith: #print) ].
+	self assert: actualSet size equals: 4
 ]


### PR DESCRIPTION
Fixes #15142