### PR TITLE
Replacing the use of species new with copyEmpty.

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -609,7 +609,7 @@ Collection >> collect: aBlock [
 	"(#() collect: [:x | x+1]) >>> #()"
 
 	| newCollection |
-	newCollection := self species new.
+	newCollection := self copyEmpty.
 	self do: [:each | newCollection add: (aBlock value: each)].
 	^ newCollection
 ]

--- a/src/Collections-Sequenceable/OrderedCollection.class.st
+++ b/src/Collections-Sequenceable/OrderedCollection.class.st
@@ -836,7 +836,7 @@ OrderedCollection >> reversed [
 	"Answer a copy of the receiver with element order reversed.  "
 	"#(2 3 4 'fred') asOrderedCollection reversed >>> #('fred' 4 3 2) asOrderedCollection"
 	| newCol |
-	newCol := self species new.
+	newCol := self copyEmpty.
 	self reverseDo:
 		[:elem | newCol addLast: elem].
 	^ newCol

--- a/src/Collections-Sequenceable/OrderedDictionary.class.st
+++ b/src/Collections-Sequenceable/OrderedDictionary.class.st
@@ -200,7 +200,7 @@ OrderedDictionary >> at: firstKey at: secondKey ifAbsentPut: aZeroArgBlock [
 	"Return the object stored in the second dictionary at secondKey. The second dictionary is accessed via the key firstKey. If firstKey is not defined, set a new dictionary for the second key and set the value of aZeroArgBlock execution. If firstKey is defined and not second key set the value of aZeroArgBlock execution. See NestedDictionaryTest for examples."
 
 	| subDictionary |
-	subDictionary := self at: firstKey ifAbsentPut: [ self species new ].
+	subDictionary := self at: firstKey ifAbsentPut: [ self copyEmpty ].
 	^ subDictionary at: secondKey ifAbsentPut: aZeroArgBlock
 ]
 
@@ -209,7 +209,7 @@ OrderedDictionary >> at: firstKey at: secondKey put: aValue [
 	"Set a value at secondKey in the dictionary returned by firstKey."
 
 	| subDictionary |
-	subDictionary := self at: firstKey ifAbsentPut: [ self species new ].
+	subDictionary := self at: firstKey ifAbsentPut: [ self copyEmpty ].
 	^ subDictionary at: secondKey put: aValue
 ]
 

--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -326,7 +326,7 @@ Dictionary >> associationsSelect: aBlock [
 	to true."
 
 	| newCollection |
-	newCollection := self species new.
+	newCollection := self copyEmpty.
 	self associationsDo:
 		[:each |
 		(aBlock value: each) ifTrue: [newCollection add: each]].
@@ -368,7 +368,7 @@ Dictionary >> at: firstKey at: secondKey ifAbsentPut: aZeroArgBlock [
 	"Return the object stored in the second dictionary at secondKey. The second dictionary is accessed via the key firstKey. If firstKey is not defined, set a new dictionary for the second key and set the value of aZeroArgBlock execution. If firstKey is defined and not second key set the value of aZeroArgBlock execution. See NestedDictionaryTest for examples."
 
 	| subDictionary |
-	subDictionary := self at: firstKey ifAbsentPut: [ self species new ].
+	subDictionary := self at: firstKey ifAbsentPut: [ self copyEmpty ].
 	^ subDictionary at: secondKey ifAbsentPut: aZeroArgBlock
 ]
 
@@ -377,7 +377,7 @@ Dictionary >> at: firstKey at: secondKey put: aValue [
 	"Set a value at secondKey in the dictionary returned by firstKey."
 
 	| subDictionary |
-	subDictionary := self at: firstKey ifAbsentPut: [ self species new ].
+	subDictionary := self at: firstKey ifAbsentPut: [ self copyEmpty ].
 	^ subDictionary at: secondKey put: aValue
 ]
 
@@ -489,7 +489,7 @@ Dictionary >> collect: aBlock [
 	resulting values into a collection that is like me. Answer with the new
 	collection."
 	| newCollection |
-	newCollection := self species new.
+	newCollection := self copyEmpty.
 	self associationsDo:[:each |
 		newCollection at: each key put: (aBlock value: each value).
 	].

--- a/src/Collections-Unordered/KeyedTree.class.st
+++ b/src/Collections-Unordered/KeyedTree.class.st
@@ -64,7 +64,7 @@ KeyedTree >> atPath: anArray ifAbsentPut: aBlock [
 		ifTrue: [^self].
 	element := self.
 	anArray allButLastDo: [:key |
-		element := element at: key ifAbsentPut: [self species new]].
+		element := element at: key ifAbsentPut: [ self copyEmpty ]].
 	^element at: anArray last ifAbsentPut: aBlock
 ]
 
@@ -77,7 +77,7 @@ KeyedTree >> atPath: anArray put: aBlock [
 		ifTrue: [^self].
 	element := self.
 	anArray allButLastDo: [:key |
-		element := element at: key ifAbsentPut: [self species new]].
+		element := element at: key ifAbsentPut: [self copyEmpty]].
 	^element at: anArray last put: aBlock
 ]
 
@@ -111,7 +111,7 @@ KeyedTree >> merge: aKeyedTree [
 			| subtree |
 			(v isKindOf: KeyedTree)
 				ifTrue: [
-					subtree := self at: k ifAbsentPut: [ v species new ].
+					subtree := self at: k ifAbsentPut: [ v copyEmpty ].
 					(subtree isKindOf: KeyedTree)
 						ifFalse: [ subtree := self at: k put: v species new ].
 					subtree merge: v ]

--- a/src/Collections-Unordered/SmallDictionary.class.st
+++ b/src/Collections-Unordered/SmallDictionary.class.st
@@ -211,7 +211,7 @@ SmallDictionary >> associationsSelect: aBlock [
 	to true."
 
 	| newCollection |
-	newCollection := self species new.
+	newCollection := self copyEmpty.
 	self associationsDo:
 		[:each |
 		(aBlock value: each) ifTrue: [newCollection add: each]].
@@ -254,7 +254,7 @@ SmallDictionary >> at: firstKey at: secondKey ifAbsentPut: aZeroArgBlock [
 	"Return the object stored in the second dictionary at secondKey. The second dictionary is accessed via the key firstKey. If firstKey is not defined, set a new dictionary for the second key and set the value of aZeroArgBlock execution. If firstKey is defined and not second key set the value of aZeroArgBlock execution. See NestedDictionaryTest for examples."
 
 	| subDictionary |
-	subDictionary := self at: firstKey ifAbsentPut: [ self species new ].
+	subDictionary := self at: firstKey ifAbsentPut: [ self copyEmpty ].
 	^ subDictionary at: secondKey ifAbsentPut: aZeroArgBlock
 ]
 
@@ -263,7 +263,7 @@ SmallDictionary >> at: firstKey at: secondKey put: aValue [
 	"Set a value at secondKey in the dictionary returned by firstKey."
 
 	| subDictionary |
-	subDictionary := self at: firstKey ifAbsentPut: [ self species new ].
+	subDictionary := self at: firstKey ifAbsentPut: [ self copyEmpty ].
 	^ subDictionary at: secondKey put: aValue
 ]
 
@@ -390,7 +390,7 @@ SmallDictionary >> collect: aBlock [
 	resulting values into a collection that is like me. Answer with the new
 	collection."
 	| newCollection |
-	newCollection := self species new.
+	newCollection := self copyEmpty.
 	self associationsDo:[:each |
 		newCollection at: each key put: (aBlock value: each value).
 	].


### PR DESCRIPTION
Replaces `self species new` with `self copyEmpty` because `copyEmpty` already deals with `species new`. And, it is better to use `copyEmpty` because there are some cases in which you can loose behavior with `self species new`. For example look `SortedCollection>>#copyEmpty`.