### PR TITLE
fix 13709: Code Completion: completion sometimes has its window in a …

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -310,19 +310,19 @@ CompletionEngine >> openMenuForced: forced [
 
 	| theMenu theContext |
 	self stopCompletionDelay.
-
+	
 	theContext := self createContext.
 	(forced or: [ theContext hasEntries ]) ifFalse: [ ^ self ].
 	context := theContext.
 	
 	theMenu := self menuMorphClass
-				engine: self
-				position: (editor selectionPosition: self completionToken).
-
-	theMenu isClosed ifFalse: [ 
-		menuMorph := theMenu.
-		NECPreferences showCompletionDetails ifTrue: [ 
-			theMenu showDetail ] ]
+		           engine: self
+		           position:
+		           (editor selectionPosition: self completionToken).
+		
+	theMenu isClosed ifTrue: [ ^ self ].
+	menuMorph := theMenu.
+	NECPreferences showCompletionDetails ifTrue: [ theMenu showDetail ]
 ]
 
 { #category : 'replacement' }

--- a/src/NECompletion-Morphic/NECMenuMorph.class.st
+++ b/src/NECompletion-Morphic/NECMenuMorph.class.st
@@ -23,7 +23,8 @@ Class {
 		'pageHeight',
 		'detailMorph',
 		'detailPosition',
-		'engine'
+		'engine',
+		'isDetailMorphVisible'
 	],
 	#category : 'NECompletion-Morphic',
 	#package : 'NECompletion-Morphic'
@@ -478,7 +479,8 @@ NECMenuMorph >> home [
 NECMenuMorph >> initialize [
 	super initialize.
 	self color: self class backgroundColor.
-	self borderStyle: (BorderStyle color: Color gray width: 1)
+	self borderStyle: (BorderStyle color: Color gray width: 1).
+	isDetailMorphVisible := false
 ]
 
 { #category : 'actions' }
@@ -655,8 +657,8 @@ NECMenuMorph >> showDetail [
 	detailMorph ifNotNil: [ ^ self browse ].
 	self itemsCount isZero ifTrue: [ ^ self ].
 	detailMorph := NECDetailMorph new.
-	self addMorph: detailMorph.
-	self updateDetail
+	self updateDetail.
+
 ]
 
 { #category : 'testing' }
@@ -666,13 +668,17 @@ NECMenuMorph >> takesKeyboardFocus [
 
 { #category : 'private' }
 NECMenuMorph >> updateDetail [
+
+	detailMorph ifNil: [ ^ self ].
+	detailPosition ifNil: [ ^ self ].	
+		
 	detailMorph
-		ifNil: [^ self].
-	detailPosition ifNil: [^ self].
-	detailMorph
-		entryDescription: (self selectedEntry description);
-		position: detailPosition menuWidth: self width;
-		show
+		entryDescription: self selectedEntry description;
+		position: detailPosition menuWidth: self width.
+
+	isDetailMorphVisible ifTrue: [ ^ self ].
+	self addMorph: detailMorph.
+	isDetailMorphVisible := true
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
…random place

The problem:
- The completion detail morph position is updated depending on the rendering of the selected item in the completion menu.
-  On the first rendering of the completion menu it seems that there is no item selected.
- So the initial position of the completion detail morph is the origin 0@0.

The fix:
- We delegate the opening of the completion detail menu to the NECMenuMorph >> updateDetail instead of NECMenuMorph >> showDetail.
- In NECMenuMorph >> updateDetail we put guard clauses to ensure that the completion detail popup is shown only if a position is defined.

Issue: https://github.com/pharo-project/pharo/issues/13709