### PR TITLE
Fix clean blocks with dead context on debugger

### DIFF
--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -469,7 +469,9 @@ EncoderForSistaV1 class >> isCreateBlockAt: pc in: method [
 
 	| byte |
 	byte := self nonExtensionBytecodeAt: pc in: method.
-	^ byte = 250 or: [ (method sourceNodeForPC: pc) isBlock "Clean blocks are created as PushConstant" ]
+	^ byte = 250 or: [
+		  (method sourceNodeForPC: pc) in: [ :node | "Clean blocks are created as PushConstant"
+			  node isBlock and: [ node isClean ] ] ]
 ]
 
 { #category : 'block closure support' }

--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -469,7 +469,7 @@ EncoderForSistaV1 class >> isCreateBlockAt: pc in: method [
 
 	| byte |
 	byte := self nonExtensionBytecodeAt: pc in: method.
-	^ byte = 250
+	^ byte = 250 or: [ (method sourceNodeForPC: pc) isBlock "Clean blocks are created as PushConstant" ]
 ]
 
 { #category : 'block closure support' }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -502,6 +502,21 @@ Context >> cut: aContext [
 	callee privSender: nil
 ]
 
+{ #category : 'accessing' }
+Context >> deadContextForClosure: closure [
+
+	| outerMethod |
+	outerMethod := closure literalAt: closure literals size + 1.
+
+	^ (self class
+		   sender: self
+		   receiver: nil
+		   method: outerMethod
+		   arguments: {  })
+		  pc: nil;
+		  yourself
+]
+
 { #category : 'printing' }
 Context >> debugStack: stackSize on: aStream [
 	"print a condensed version of the stack up to stackSize on aStream"
@@ -925,9 +940,9 @@ Context >> home [
 
 	closureOrNil ifNil: [ ^ self ].
 	"this happens for clean blocks, we try to find the home on the stack"
-	^ closureOrNil outerContext 
-		ifNil: [ self activeHome ]
-		ifNotNil: [:outer | outer home ]
+	^ closureOrNil outerContext
+		  ifNil: [ self activeHome ifNil: [ self deadContextForClosure: self method ] ]
+		  ifNotNil: [ :outer | outer home ]
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -12,9 +12,12 @@ CompiledBlock >> sourceNode [
 
 { #category : '*OpalCompiler-Core' }
 CompiledBlock >> sourceNodeForPC: aPC [
+
 	| blockNode |
 	blockNode := self outerCode sourceNodeForPC: self pcInOuter.
-	^blockNode sourceNodeForPC: aPC
+	"Bug in the cache? The mapping is returning Return node instead of Block"
+	blockNode isReturn ifTrue: [ blockNode := blockNode value ].
+	^ blockNode sourceNodeForPC: aPC
 ]
 
 { #category : '*OpalCompiler-Core' }


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/13779

- A dead context is created for CleanBlocks in case it is not found in the stack
- Then small bugs appear -> check comment in `sourceNodeForPC:`
- I also doubt how `BytecodeEncoder >> isCreateBlockAt:in:` was resolved.

### Related PR: https://github.com/pharo-spec/NewTools/pull/605