### PR TITLE
MethodAddition: Classify method at installation

### DIFF
--- a/src/Monticello/MethodAddition.class.st
+++ b/src/Monticello/MethodAddition.class.st
@@ -59,14 +59,13 @@ MethodAddition >> createCompiledMethod [
 
 { #category : 'operations' }
 MethodAddition >> installMethod [
-	SystemAnnouncer uniqueInstance
-		suspendAllWhile: [ myClass addSelector: selector withMethod: compiledMethod ]
+
+	SystemAnnouncer uniqueInstance suspendAllWhile: [ myClass addAndClassifySelector: selector withMethod: compiledMethod inProtocol: protocolName ]
 ]
 
 { #category : 'notifying' }
 MethodAddition >> notifyObservers [
 
-	SystemAnnouncer uniqueInstance suspendAllWhile: [ myClass classify: selector under: protocolName ].
 	(priorMethod isNil or: [ priorOrigin ~= compiledMethod origin ])
 		ifTrue: [ SystemAnnouncer uniqueInstance announce: (MethodAdded method: compiledMethod) ]
 		ifFalse: [


### PR DESCRIPTION
MethodAddition has its duplicated way of installing methods in the system. I'm trying to make it as close as possible as the system way on installing methods to avoid inconsistant behaviors. 

Here is a next step: Classify the method at the same time as we install it.

This will help to reduce the difference in behavior because the current implementation does not announce protocol changes. This is because it creates bugs and I found the root of those bugs! The root is that since we install and classify in two steps, the method get first installed in 'as yet unclassified' and then goes to its right protocol. But in case of extension methods, it would consider that the method changed from non extension to extension method and mark the package of the class as dirty because we removed a method from it. So, to avoid that, Monticello prevent RPackageOrganizer from doing the repackaging by silencing the announcement. But I want to get rid of those announcement listening and also the behavior is bad. 

This was really hard to catch