### PR TITLE
Reduce usage of category for protocol

### DIFF
--- a/src/CodeImport/ChunkFileFormatParser.class.st
+++ b/src/CodeImport/ChunkFileFormatParser.class.st
@@ -183,7 +183,8 @@ ChunkFileFormatParser >> parseCommentDeclaration: commentPreamble [
 
 { #category : 'parsing' }
 ChunkFileFormatParser >> parseMethodDeclarations: methodsPreamble [
-	| behaviorName isMeta category stamp methodSource |
+
+	| behaviorName isMeta protocol stamp methodSource |
 	"The method preable is an array with the following structure:
 	If instance side method:
 
@@ -199,31 +200,24 @@ ChunkFileFormatParser >> parseMethodDeclarations: methodsPreamble [
 
 	"
 	behaviorName := methodsPreamble first.
-	isMeta := methodsPreamble second = self classSelector
-		or: [ methodsPreamble second = self classTraitSelector ].
-	category := isMeta
-		ifTrue: [ methodsPreamble at: 4 ]
-		ifFalse: [ methodsPreamble at: 3 ].
+	isMeta := methodsPreamble second = self classSelector or: [ methodsPreamble second = self classTraitSelector ].
+	protocol := isMeta
+		            ifTrue: [ methodsPreamble at: 4 ]
+		            ifFalse: [ methodsPreamble at: 3 ].
 	stamp := ''.
-	methodsPreamble size > 4
-		ifTrue:
-			[
-			stamp := isMeta
-				ifTrue: [ methodsPreamble at: 6 ]
-				ifFalse: [ methodsPreamble at: 5 ] ].
+	methodsPreamble size > 4 ifTrue: [
+		stamp := isMeta
+			         ifTrue: [ methodsPreamble at: 6 ]
+			         ifFalse: [ methodsPreamble at: 5 ] ].
 	[
 	methodSource := readStream next.
-	methodSource notEmpty ]
-		whileTrue:
-			[
-			self
-				addDeclaration:
-					(self methodChunkClass
-						contents: methodSource
-						behaviorName: behaviorName asSymbol
-						isMeta: isMeta
-						category: category
-						stamp: stamp) ]
+	methodSource isNotEmpty ] whileTrue: [
+		self addDeclaration: (self methodChunkClass
+				 contents: methodSource
+				 behaviorName: behaviorName asSymbol
+				 isMeta: isMeta
+				 protocol: protocol
+				 stamp: stamp) ]
 ]
 
 { #category : 'parsing' }

--- a/src/CodeImport/MethodChunk.class.st
+++ b/src/CodeImport/MethodChunk.class.st
@@ -7,8 +7,8 @@ Class {
 	#name : 'MethodChunk',
 	#superclass : 'BehaviorOwnedChunk',
 	#instVars : [
-		'categoryName',
-		'stamp'
+		'stamp',
+		'protocol'
 	],
 	#category : 'CodeImport-Chunks',
 	#package : 'CodeImport',
@@ -16,12 +16,12 @@ Class {
 }
 
 { #category : 'instance creation' }
-MethodChunk class >> contents: someContents behaviorName: behaviorName isMeta: isMeta category: categoryName stamp: stamp [
+MethodChunk class >> contents: someContents behaviorName: behaviorName isMeta: isMeta protocol: protocol stamp: stamp [
 	^self new
 			contents: someContents;
 			behaviorName: behaviorName;
 			isMeta: isMeta;
-			category: categoryName;
+			protocol: protocol;
 			stamp: stamp;
 			yourself
 ]
@@ -30,16 +30,6 @@ MethodChunk class >> contents: someContents behaviorName: behaviorName isMeta: i
 MethodChunk >> accept: aVisitor [
 
 	^ aVisitor visitMethodChunk: self
-]
-
-{ #category : 'accessing' }
-MethodChunk >> category [
-	^ categoryName
-]
-
-{ #category : 'accessing' }
-MethodChunk >> category: aCategoryName [
-	categoryName := aCategoryName
 ]
 
 { #category : 'accessing' }
@@ -69,7 +59,7 @@ MethodChunk >> importFor: requestor logSource: logSource [
 
 	^ (self targetClass compiler
 		   permitUndeclared: true;
-		   protocol: categoryName;
+		   protocol: protocol;
 		   changeStamp: stamp;
 		   logged: logSource;
 		   install: contents) selector
@@ -85,6 +75,16 @@ MethodChunk >> isMethodDeclaration [
 MethodChunk >> methodSelector [
 
 	^ RBParser parseMethodPattern: self contents
+]
+
+{ #category : 'accessing' }
+MethodChunk >> protocol [
+	^ protocol
+]
+
+{ #category : 'accessing' }
+MethodChunk >> protocol: aString [
+	protocol := aString
 ]
 
 { #category : 'accessing' }

--- a/src/Deprecated12/MethodChunk.extension.st
+++ b/src/Deprecated12/MethodChunk.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : 'MethodChunk' }
+
+{ #category : '*Deprecated12' }
+MethodChunk >> category [
+
+	self deprecated: 'Use #protocol instead' transformWith: '`@rcv category' -> '`@rcv protocol'.
+	^ protocol
+]
+
+{ #category : '*Deprecated12' }
+MethodChunk >> category: aProtocol [
+
+	self deprecated: 'Use #protocol: instead' transformWith: '`@rcv category: `@arg' -> '`@rcv protocol: `@arg'.
+	^ protocol := aProtocol
+]

--- a/src/Monticello/CompiledMethod.extension.st
+++ b/src/Monticello/CompiledMethod.extension.st
@@ -40,6 +40,6 @@ CompiledMethod >> sameAsMCDefinition: anMCMethodDefinition [
 		  anMCMethodDefinition className = self className and: [ 
 			  anMCMethodDefinition classIsMeta = self isClassSide 
 				  and: [ 
-					  anMCMethodDefinition category = self protocolName and: [ 
+					  anMCMethodDefinition protocol = self protocolName and: [ 
 						  anMCMethodDefinition source = self sourceCode ] ] ] ]
 ]

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -104,7 +104,7 @@ MCMethodDefinition class >> shutDown [
 { #category : 'comparing' }
 MCMethodDefinition >> = aDefinition [
 	^ super = aDefinition
-		and: [ aDefinition category = self category
+		and: [ aDefinition protocol = self protocol
 		and: [ aDefinition source withInternalLineEndings = self source withInternalLineEndings ] ]
 ]
 
@@ -303,7 +303,7 @@ MCMethodDefinition >> printAnnotations: requests on: aStream [
 	
 	requests do: [ :aRequest |
 		aRequest == #timeStamp ifTrue: [ aStream nextPutAll: self timeStamp ].
-		aRequest == #messageCategory ifTrue: [ aStream nextPutAll: self category ].
+		aRequest == #messageCategory ifTrue: [ aStream nextPutAll: self protocol ].
 		aRequest == #requirements ifTrue: [
 			self requirements do: [ :req |
 				aStream nextPutAll: req ] separatedBy: [ aStream space ]].

--- a/src/Monticello/MCStWriter.class.st
+++ b/src/Monticello/MCStWriter.class.st
@@ -194,7 +194,7 @@ MCStWriter >> writeMethodPreamble: definition [
 			[ str nextPutAll: ' class' ].
 		str
 			nextPutAll: ' methodsFor: ';
-			nextPutAll: definition category asString printString;
+			nextPutAll: definition protocol asString printString;
 			nextPutAll: ' stamp: ';
 			nextPutAll: definition timeStamp asString printString
 		]

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressWriter.class.st
@@ -293,10 +293,11 @@ MCFileTreeStCypressWriter >> writeExtensionClassDefinition: definition to: class
 
 { #category : 'writing' }
 MCFileTreeStCypressWriter >> writeMethodDefinition: definition [
-    fileStream
-        nextPutAll: definition category;
-        lf;
-        nextPutAll: definition source withUnixLineEndings
+
+	fileStream
+		nextPutAll: definition protocol;
+		lf;
+		nextPutAll: definition source withUnixLineEndings
 ]
 
 { #category : 'writing' }

--- a/src/MonticelloGUI/MCSnapshotBrowser.class.st
+++ b/src/MonticelloGUI/MCSnapshotBrowser.class.st
@@ -222,9 +222,8 @@ MCSnapshotBrowser >> methodSelection: aNumber [
 
 { #category : 'accessing' }
 MCSnapshotBrowser >> methodsForSelectedClass [
-	^ items select: [:ea | (ea className = classSelection) 
-							and: [ea isMethodDefinition
-									and: [ea classIsMeta = self switchIsClass]]].
+
+	^ items select: [ :ea | ea className = classSelection and: [ ea isMethodDefinition and: [ ea classIsMeta = self switchIsClass ] ] ]
 ]
 
 { #category : 'accessing' }
@@ -242,7 +241,7 @@ MCSnapshotBrowser >> methodsForSelectedProtocol [
 	protocolSelection ifNil: [^ Array new].
 	methods := self methodsForSelectedClass asOrderedCollection.
 	(protocolSelection = '-- all --') 
-		ifFalse: [methods removeAllSuchThat: [:ea | ea category ~= protocolSelection]].
+		ifFalse: [methods removeAllSuchThat: [:ea | ea protocol ~= protocolSelection]].
 	^ methods 
 	
 								

--- a/src/Ring-ChunkImporter/RGChunkImporter.class.st
+++ b/src/Ring-ChunkImporter/RGChunkImporter.class.st
@@ -505,9 +505,8 @@ RGChunkImporter >> visitMethodChunk: aChunk [
 	theClass := self classNamed: aChunk behaviorName.
 	aChunk isMeta ifTrue: [ theClass := theClass classSide makeResolved ].
 
-	theMethod := theClass ensureLocalMethodNamed:
-		             aChunk methodSelector asSymbol.
-	theProtocol := theClass ensureProtocolNamed: aChunk category asSymbol.
+	theMethod := theClass ensureLocalMethodNamed: aChunk methodSelector asSymbol.
+	theProtocol := theClass ensureProtocolNamed: aChunk protocol asSymbol.
 	theMethod protocol: theProtocol.
 	theMethod sourceCode: aChunk contents.
 	theMethod author: (RGStampParser authorForStamp: aChunk stamp).

--- a/src/Ring-Definitions-Monticello/RGMethodDefinition.extension.st
+++ b/src/Ring-Definitions-Monticello/RGMethodDefinition.extension.st
@@ -2,15 +2,8 @@ Extension { #name : 'RGMethodDefinition' }
 
 { #category : '*Ring-Definitions-Monticello' }
 RGMethodDefinition >> sameAsMCDefinition: anMCMethodDefinition [
-	^ anMCMethodDefinition selector = self selector
-		and:
-			[
-			anMCMethodDefinition className = self className
-				and:
-					[
-					anMCMethodDefinition classIsMeta = self isMeta
-						and:
-							[
-							anMCMethodDefinition category = self protocol
-								and: [ anMCMethodDefinition source = self sourceCode ] ] ] ]
+
+	^ anMCMethodDefinition selector = self selector and: [
+		  anMCMethodDefinition className = self className and: [
+			  anMCMethodDefinition classIsMeta = self isMeta and: [ anMCMethodDefinition protocol = self protocol and: [ anMCMethodDefinition source = self sourceCode ] ] ] ]
 ]

--- a/src/Ring-Definitions-Tests-Monticello/RGMonticelloTest.class.st
+++ b/src/Ring-Definitions-Tests-Monticello/RGMonticelloTest.class.st
@@ -11,6 +11,7 @@ Class {
 
 { #category : 'testing' }
 RGMonticelloTest >> testAsMCMethodDefinition [
+
 	| ringMethod mcMethod |
 	ringMethod := (OrderedCollection >> #size) asActiveRingDefinition.
 	mcMethod := ringMethod asMCMethodDefinition.
@@ -19,7 +20,7 @@ RGMonticelloTest >> testAsMCMethodDefinition [
 	self assert: mcMethod className equals: #OrderedCollection.
 	self deny: mcMethod classIsMeta.
 	self assert: mcMethod selector equals: #size.
-	self assert: mcMethod category equals: #accessing.
+	self assert: mcMethod protocol equals: #accessing.
 	self assert: mcMethod source equals: (OrderedCollection >> #size) sourceCode
 ]
 

--- a/src/Ring-Monticello/MCMethodDefinition.extension.st
+++ b/src/Ring-Monticello/MCMethodDefinition.extension.st
@@ -41,7 +41,7 @@ MCMethodDefinition >> ensureRingDefinitionIn: anRGEnvironment [
 		def author: (self authorForStamp: self timeStamp).
 		def time: (self timeForStamp: self timeStamp).
 
-		protocol := parent ensureProtocolNamed: self category asSymbol.
+		protocol := parent ensureProtocolNamed: self protocol asSymbol.
 		parent addProtocol: protocol.
 		def protocol: protocol.
 		def

--- a/src/Ring-OldChunkImporter/RingChunkImporter.class.st
+++ b/src/Ring-OldChunkImporter/RingChunkImporter.class.st
@@ -236,18 +236,16 @@ RingChunkImporter >> visitDoItChunk: aChunk [
 RingChunkImporter >> visitMethodChunk: aChunk [
 
 	| theClass theMethod |
-	theClass:= self classNamed: aChunk behaviorName.
-	theMethod := (RGMethodDefinition
-						class: theClass
-						selector: aChunk methodSelector)
-							protocol: aChunk category;
-							sourceCode: aChunk contents;
-							stamp: aChunk stamp.
+	theClass := self classNamed: aChunk behaviorName.
+	theMethod := (RGMethodDefinition class: theClass selector: aChunk methodSelector)
+		             protocol: aChunk protocol;
+		             sourceCode: aChunk contents;
+		             stamp: aChunk stamp.
 	aChunk isMeta
 		ifTrue: [
 			theMethod isMeta: true.
-			theClass classSide addMethod: theMethod. ]
-		ifFalse:[ theClass addMethod: theMethod ]
+			theClass classSide addMethod: theMethod ]
+		ifFalse: [ theClass addMethod: theMethod ]
 ]
 
 { #category : 'visitor' }

--- a/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
+++ b/src/TraitsV2-Tests/TraitPureBehaviorTest.class.st
@@ -173,7 +173,7 @@ TraitPureBehaviorTest >> testOwnMethodsTakePrecedenceOverTraitsMethods [
 	add subtrait t1 which implements m11 as well."
 
 	| trait |
-	trait := self createTraitNamed: #T uses: {}.
+	trait := self createTraitNamed: #T uses: {  }.
 	trait compile: 'm11 ^999'.
 	self assert: trait methodDict size equals: 1.
 	self assert: (trait methodDict at: #m11) sourceCode equals: 'm11 ^999'.
@@ -182,11 +182,11 @@ TraitPureBehaviorTest >> testOwnMethodsTakePrecedenceOverTraitsMethods [
 		aBuilder
 			name: #T;
 			traitComposition: self t1;
-			package: self class category;
+			package: self class package name;
 			beTrait ].
 
 	self assert: trait methodDict size equals: 3.
-	self assert: (trait selectors asSet includesAll: #(#m11 #m12 #m13)).
+	self assert: (trait selectors asSet includesAll: #( #m11 #m12 #m13 )).
 	self assert: (trait methodDict at: #m11) sourceCode equals: 'm11 ^999'.
 	self assert: (trait methodDict at: #m12) sourceCode equals: 'm12 ^12'
 ]


### PR DESCRIPTION
This change rename some "categories" into "protocols". Mostly renaming things in MethodChunk and some users in MethodDefinition