### PR TITLE
Deprecated `sender` method of block closures

### DIFF
--- a/src/Deprecated12/BlockClosure.extension.st
+++ b/src/Deprecated12/BlockClosure.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'BlockClosure' }
+
+{ #category : '*Deprecated12' }
+BlockClosure >> sender [
+	<reflection: 'Message sending and code execution - Message send reification'>
+
+	self deprecated:
+		'The sender is the one of the Stack. BlockClosures do not have senders. The new CleanBlocks introduce blocks withput the outerContext. Now, clients should use the outerContext directly and deal with it being possibly nil.'.
+	^ self subclassResponsibility
+]

--- a/src/Deprecated12/CleanBlockClosure.extension.st
+++ b/src/Deprecated12/CleanBlockClosure.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'CleanBlockClosure' }
+
+{ #category : '*Deprecated12' }
+CleanBlockClosure >> sender [
+	<reflection: 'Message sending and code execution - Message send reification'>
+
+	self deprecated:
+		'The sender is the one of the Stack. BlockClosures do not have senders. The new CleanBlocks introduce blocks withput the outerContext. Now, clients should use the outerContext directly and deal with it being possibly nil.'.
+	^ nil
+]

--- a/src/Deprecated12/FullBlockClosure.extension.st
+++ b/src/Deprecated12/FullBlockClosure.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'FullBlockClosure' }
+
+{ #category : '*Deprecated12' }
+FullBlockClosure >> sender [
+	"Answer the context that sent the message that created the receiver."
+	<reflection: 'Message sending and code execution - Message send reification'>
+
+	self deprecated:
+		'The sender is the one of the Stack. BlockClosures do not have senders. The new CleanBlocks introduce blocks withput the outerContext. Now, clients should use the outerContext directly and deal with it being possibly nil.'.
+	^ outerContext sender
+]

--- a/src/Kernel/BlockClosure.class.st
+++ b/src/Kernel/BlockClosure.class.st
@@ -606,12 +606,6 @@ BlockClosure >> repeatWithGCIf: testBlock [
 	^ans
 ]
 
-{ #category : 'accessing' }
-BlockClosure >> sender [	
-	<reflection: 'Message sending and code execution - Message send reification'>
-	^ self subclassResponsibility
-]
-
 { #category : 'evaluating' }
 BlockClosure >> simulateValueWithArguments: anArray caller: aContext [
 	"Simulate the valueWithArguments: primitive. Fail if anArray is not an array of the right arity."

--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -130,13 +130,6 @@ CleanBlockClosure >> refersToLiteral: aLiteral [
 	^self compiledBlock refersToLiteral: aLiteral
 ]
 
-{ #category : 'debugger access' }
-CleanBlockClosure >> sender [
-	" clean blocks do not know the sender"
-	<reflection: 'Message sending and code execution - Message send reification'>
-	^nil
-]
-
 { #category : 'accessing' }
 CleanBlockClosure >> sendsAnySelectorOf: aCollection [
 	^self compiledBlock sendsAnySelectorOf: aCollection

--- a/src/Kernel/FullBlockClosure.class.st
+++ b/src/Kernel/FullBlockClosure.class.st
@@ -28,10 +28,3 @@ FullBlockClosure >> receiver [
 FullBlockClosure >> receiver: anObject [
 	receiver := anObject
 ]
-
-{ #category : 'accessing' }
-FullBlockClosure >> sender [
-	"Answer the context that sent the message that created the receiver."
-	<reflection: 'Message sending and code execution - Message send reification'>
-	^outerContext sender
-]


### PR DESCRIPTION
Fixes  #15062 