### PR TITLE
Fix depth conversion in #image:size: on AlphaImageMorph to use the original Form’s extent

### DIFF
--- a/src/Morphic-Base/AlphaImageMorph.class.st
+++ b/src/Morphic-Base/AlphaImageMorph.class.st
@@ -181,7 +181,7 @@ AlphaImageMorph >> image: aForm size: aPoint [
 	"Convert color forms etc. to 32 bit before resizing since scaling of ColorForm introduces degraded color resolution.
 	Most noticable with grayscale forms."
 	(aForm depth < 32 and: [aForm depth > 4])
-		ifTrue: [f := Form extent: aPoint depth: 32.
+		ifTrue: [f := Form extent: aForm extent depth: 32.
 				f fillColor: (Color white alpha: 0.003922).
 				f getCanvas translucentImage: aForm at: 0@0.
 				f fixAlpha]


### PR DESCRIPTION
This pull request fixes the depth conversion step in `#image:size:` on AlphaImageMorph to use the original Form’s extent, instead of the ‘size’ argument, as the extent for the converted Form.

Example:

```smalltalk
#(32 16) withIndexCollect: [ :depth :index |
	| form morph |
	(form := Form extent: 10@20 depth: depth)
		fillColor: Color red.
	(morph := AlphaImageMorph new)
		image: form size: 30@40;
		borderStyle: (SimpleBorderStyle width: 1 color: Color black).
	PNGReadWriter putForm: morph asForm
		onFileNamed: FileLocator imageDirectory / (index asString , '.png').
	morph ]
```

The result without this fix:

| 1.png | 2.png |
| - | - |
| ![1](https://github.com/pharo-project/pharo/assets/1611248/f3139ab5-9ffd-45ca-a290-bb04a2b2a24e) | ![2](https://github.com/pharo-project/pharo/assets/1611248/341dcbc5-34e0-4ddf-91ab-a20b8d327ca9) |

The result with this fix:

| 1.png | 2.png |
| - | - |
| ![1](https://github.com/pharo-project/pharo/assets/1611248/8bc4507f-80a1-4543-a086-ea0476030414) | ![2](https://github.com/pharo-project/pharo/assets/1611248/f3925d91-66e4-4db0-b2b4-daafd9e33d33) |