### PR TITLE
Fix DateParser comment

### DIFF
--- a/src/Kernel-Chronology-Extras/DateParser.class.st
+++ b/src/Kernel-Chronology-Extras/DateParser.class.st
@@ -9,8 +9,8 @@ Read a Date from the stream based on the pattern which can include the tokens:
 		d = A day with 1 or 2 digits
 		dd = A day with 2 digits
 		
-	...and any other Strings inbetween. Representing $y, $m and $d is done using
-	\y, \m and \d and slash itself with \\. Simple example patterns:
+	...and any other String inbetween. Representing \$y, \$m and \$d is done using
+	\\y, \\m and \\d, and the slash itself with \\\\. Simple example patterns:
 
 		'yyyy-mm-dd'
 		'yyyymmdd'


### PR DESCRIPTION
Looked like:
<img width="598" alt="image" src="https://github.com/pharo-project/pharo/assets/78592838/77382b3d-dad0-49f0-b632-ac2002e1b739">

Now fixed:
![image](https://github.com/pharo-project/pharo/assets/78592838/20e07621-6c33-4c1c-8aa0-3477a53e6b06)
