### PR TITLE
Fix random bug in auto completion

### DIFF
--- a/src/HeuristicCompletion-Model/CoGlobalSorterResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoGlobalSorterResultSetBuilder.class.st
@@ -38,11 +38,9 @@ CoGlobalSorterResultSetBuilder >> visitNode: aNode [
 	| fetcher entries sorter |
 	entries := aNode completionEntries: completionContext position.
 	sorter := self sorterClass new context: completionContext.
-	entries := sorter sortCompletionList: entries asOrderedCollection.
+	entries := sorter sortCompletionList: entries.
 
-	fetcher := (CoCollectionFetcher onCollection: entries).
+	fetcher := CoCollectionFetcher onCollection: entries.
 
-	^ self
-		configureFetcher: fetcher
-		forNode: aNode
+	^ self configureFetcher: fetcher forNode: aNode
 ]

--- a/src/HeuristicCompletion-Tests/CoNarrowHistoryFetcherTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoNarrowHistoryFetcherTest.class.st
@@ -44,29 +44,18 @@ CoNarrowHistoryFetcherTest >> testNarrowingAndUnnarrowingReturnsSameResult [
 CoNarrowHistoryFetcherTest >> testNarrowingReturnsSameElementsThatCallingDirectly [
 
 	| originalSearch narrowedResults selectors |
-	
-	"using the array intead of the set leads to the test failing randomly
-	du to duplicate first entry in narrowedResults"
-	selectors := Symbol selectorTable asArray asSet.
+	selectors := Symbol selectorTable asArray.
 
 	"First execution with complete query"
-	fetcher := (CoCollectionFetcher onCollection: selectors)
-		           withNarrowHistory.
-	fetcher := fetcher
-		           narrowFilter: (CoCaseSensitiveBeginsWithFilter filterString: 'asL')
-		           narrowKey: 'as'.
+	fetcher := (CoCollectionFetcher onCollection: selectors) withNarrowHistory.
+	fetcher := fetcher narrowFilter: (CoCaseSensitiveBeginsWithFilter filterString: 'asL') narrowKey: 'as'.
 	originalSearch := fetcher next: 10.
 
 	"Second execution with query using narrowing"
-	fetcher := (CoCollectionFetcher onCollection: selectors)
-		           withNarrowHistory.
-	fetcher := fetcher
-		           narrowFilter: (CoCaseSensitiveBeginsWithFilter filterString: 'as')
-		           narrowKey: 'as'.
+	fetcher := (CoCollectionFetcher onCollection: selectors) withNarrowHistory.
+	fetcher := fetcher narrowFilter: (CoCaseSensitiveBeginsWithFilter filterString: 'as') narrowKey: 'as'.
 	fetcher next: 10.
-	fetcher := fetcher
-		           narrowFilter: (CoCaseSensitiveBeginsWithFilter filterString: 'asL')
-		           narrowKey: 'asL'.
+	fetcher := fetcher narrowFilter: (CoCaseSensitiveBeginsWithFilter filterString: 'asL') narrowKey: 'asL'.
 
 	narrowedResults := fetcher next: 10.
 

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -98,7 +98,8 @@ CompletionContext >> hasMessage [
 
 { #category : 'entries' }
 CompletionContext >> initEntries [
-	^ sorter sortCompletionList: (node completionEntries: position) asOrderedCollection
+
+	^ sorter sortCompletionList: (node completionEntries: position)
 ]
 
 { #category : 'parsing' }

--- a/src/NECompletion/RBMessageNode.extension.st
+++ b/src/NECompletion/RBMessageNode.extension.st
@@ -2,14 +2,15 @@ Extension { #name : 'RBMessageNode' }
 
 { #category : '*NECompletion' }
 RBMessageNode >> completionEntries: offset [
+
 	| selectors |
 	selectors := (receiver hasProperty: #type)
-		ifTrue: [ (receiver propertyAt: #type) allSelectors ]
-		ifFalse: [ Symbol selectorTable ].
+		             ifTrue: [ (receiver propertyAt: #type) allSelectors ]
+		             ifFalse: [ Symbol selectorTable ].
 
-	^selectors
-		select: [ :each | each beginsWith: self selector ]
-		thenCollect: [ :each | NECSelectorEntry contents: each node: self ]
+	^ selectors asOrderedCollection
+		  select: [ :each | each beginsWith: self selector ]
+		  thenCollect: [ :each | NECSelectorEntry contents: each node: self ]
 ]
 
 { #category : '*NECompletion' }


### PR DESCRIPTION
The completion base some entries building on a lookup in the symbols of the system in some places. The current implementation has some bad side effects which are: if a GC happens during the creation of the menus, it is possible that we lose the first entries. (Maybe this is why somtimes we do not get proposed some of the best matches?)

I'm fixing this inconsistency by manipulating only non weak classes

Found with @jordanmontt 