### PR TITLE
Calypso: Project view should activate class creation tool

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/ClyClassCreationToolMorph.extension.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyClassCreationToolMorph.extension.st
@@ -13,3 +13,10 @@ ClyClassCreationToolMorph class >> fullBrowserPackageActivation [
 
 	^ClyTabActivationStrategyAnnotation for: ClyFullBrowserPackageContext
 ]
+
+{ #category : '*Calypso-SystemTools-FullBrowser' }
+ClyClassCreationToolMorph class >> fullBrowserProjectActivation [
+	<classAnnotation>
+
+	^ClyTabActivationStrategyAnnotation for: ClyFullBrowserProjectContext
+]


### PR DESCRIPTION
So that we can create a class when in project view with a project selected  (or not)