### PR TITLE
Calypso: Improve some namings on package tags

### DIFF
--- a/src/Calypso-Browser-Tests/ClyBrowserContextAbstractTest.class.st
+++ b/src/Calypso-Browser-Tests/ClyBrowserContextAbstractTest.class.st
@@ -53,17 +53,17 @@ ClyBrowserContextAbstractTest >> deleteBrowser [
 
 { #category : 'helpers' }
 ClyBrowserContextAbstractTest >> differentClassGroupContext [
+
 	| items |
-	
 	self deleteBrowser.
 	browser := ClyFullBrowserMorph open.
-	browser selectPackage: (RPackageOrganizer default packageNamed: #Kernel) atClassTag: 'Chronology'.
+	browser selectPackage: (RPackageOrganizer default packageNamed: #Kernel) andTag: 'Chronology'.
 	items := browser classGroupSelection items.
 
 	^ ClyFullBrowserClassGroupContext new
-		tool: browser;
-		selectedItems: items;
-		yourself.
+		  tool: browser;
+		  selectedItems: items;
+		  yourself
 ]
 
 { #category : 'helpers' }
@@ -110,7 +110,7 @@ ClyBrowserContextAbstractTest >> openBrowserWithPackageAndClassGroupOnlySelected
 
 	self deleteBrowser.
 	browser := ClyFullBrowserMorph open.
-	browser selectPackage: (RPackageOrganizer default packageNamed: #Kernel) atClassTag: 'BasicObjects'.
+	browser selectPackage: (RPackageOrganizer default packageNamed: #Kernel) andTag: 'BasicObjects'.
 ]
 
 { #category : 'helpers' }

--- a/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateClassCommand.class.st
+++ b/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateClassCommand.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : 'ClyBrowserCommand',
 	#instVars : [
 		'package',
-		'classTag'
+		'packageTag'
 	],
 	#category : 'Calypso-SystemPlugins-Traits-Browser',
 	#package : 'Calypso-SystemPlugins-Traits-Browser'
@@ -37,7 +37,7 @@ ClyCreateClassCommand >> defaultMenuItemName [
 ClyCreateClassCommand >> execute [
 	| classDefinition p resultTrait |
 	p := package name.
-	classTag ifNotNil: [ p := p , '-' , classTag ].
+	packageTag ifNotNil: [ p := p , '-' , packageTag ].
 	classDefinition := ClassDefinitionPrinter fluid classDefinitionTemplateInPackage: p.
 	classDefinition := UIManager default
 		                   multiLineRequest: 'Define class definition:'
@@ -56,6 +56,6 @@ ClyCreateClassCommand >> prepareFullExecutionInContext: aBrowserContext [
 	super prepareFullExecutionInContext: aBrowserContext.
 
 	package := aBrowserContext lastSelectedPackage.
-	aBrowserContext isClassTagSelected ifTrue: [
-		classTag := aBrowserContext lastSelectedClassTag]
+	aBrowserContext isPackageTagSelected ifTrue: [
+		packageTag := aBrowserContext lastSelectedPackageTag]
 ]

--- a/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTestCaseCommand.class.st
+++ b/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTestCaseCommand.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : 'ClyBrowserCommand',
 	#instVars : [
 		'package',
-		'classTag'
+		'packageTag'
 	],
 	#category : 'Calypso-SystemPlugins-Traits-Browser',
 	#package : 'Calypso-SystemPlugins-Traits-Browser'
@@ -37,7 +37,7 @@ ClyCreateTestCaseCommand >> defaultMenuItemName [
 ClyCreateTestCaseCommand >> execute [
 	| classDefinition p resultClass |
 	p := package name.
-	classTag ifNotNil: [ p := p , '-' , classTag ].
+	packageTag ifNotNil: [ p := p , '-' , packageTag ].
 	classDefinition := ClassDefinitionPrinter fluid testClassDefinitionTemplateInPackage: p.
 	classDefinition := UIManager default
 		                   multiLineRequest: 'Define test class:'
@@ -56,6 +56,6 @@ ClyCreateTestCaseCommand >> prepareFullExecutionInContext: aBrowserContext [
 	super prepareFullExecutionInContext: aBrowserContext.
 
 	package := aBrowserContext lastSelectedPackage.
-	aBrowserContext isClassTagSelected ifTrue: [
-		classTag := aBrowserContext lastSelectedClassTag]
+	aBrowserContext isPackageTagSelected ifTrue: [
+		packageTag := aBrowserContext lastSelectedPackageTag]
 ]

--- a/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTraitCommand.class.st
+++ b/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTraitCommand.class.st
@@ -15,7 +15,7 @@ Class {
 	#superclass : 'ClyBrowserCommand',
 	#instVars : [
 		'package',
-		'classTag'
+		'packageTag'
 	],
 	#category : 'Calypso-SystemPlugins-Traits-Browser',
 	#package : 'Calypso-SystemPlugins-Traits-Browser'
@@ -49,7 +49,7 @@ ClyCreateTraitCommand >> defaultMenuItemName [
 ClyCreateTraitCommand >> execute [
 	| traitDefinition category resultTrait |
 	category := package name.
-	classTag ifNotNil: [ category := category , '-' , classTag ].
+	packageTag ifNotNil: [ category := category , '-' , packageTag ].
 	traitDefinition := ClassDefinitionPrinter fluid traitDefinitionTemplateInPackage: category.
 	traitDefinition := UIManager default
 		                   multiLineRequest: 'Define trait:'
@@ -68,6 +68,6 @@ ClyCreateTraitCommand >> prepareFullExecutionInContext: aBrowserContext [
 	super prepareFullExecutionInContext: aBrowserContext.
 
 	package := aBrowserContext lastSelectedPackage.
-	aBrowserContext isClassTagSelected ifTrue: [
-		classTag := aBrowserContext lastSelectedClassTag]
+	aBrowserContext isPackageTagSelected ifTrue: [
+		packageTag := aBrowserContext lastSelectedPackageTag]
 ]

--- a/src/Calypso-SystemQueries-Tests/ClyAllClassGroupsQueryTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyAllClassGroupsQueryTest.class.st
@@ -8,7 +8,7 @@ Class {
 
 { #category : 'running' }
 ClyAllClassGroupsQueryTest >> createQuery [
-	^ClyAllClassGroupsQuery from: ClyPackageScope of: Object package in: environment
+	^ClyAllPackageTagsQuery from: ClyPackageScope of: Object package in: environment
 ]
 
 { #category : 'running' }

--- a/src/Calypso-SystemQueries-Tests/ClyAllPackageTagsQueryTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyAllPackageTagsQueryTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'ClyAllClassGroupsQueryTest',
+	#name : 'ClyAllPackageTagsQueryTest',
 	#superclass : 'ClyTypedQueryTest',
 	#category : 'Calypso-SystemQueries-Tests-Queries',
 	#package : 'Calypso-SystemQueries-Tests',
@@ -7,19 +7,20 @@ Class {
 }
 
 { #category : 'running' }
-ClyAllClassGroupsQueryTest >> createQuery [
-	^ClyAllPackageTagsQuery from: ClyPackageScope of: Object package in: environment
+ClyAllPackageTagsQueryTest >> createQuery [
+
+	^ ClyAllPackageTagsQuery from: ClyPackageScope of: Object package in: environment
 ]
 
 { #category : 'running' }
-ClyAllClassGroupsQueryTest >> setUp [
+ClyAllPackageTagsQueryTest >> setUp [
 	super setUp.
 
 	environment addPlugin: ClyDefaultSystemEnvironmentPlugin new
 ]
 
 { #category : 'tests' }
-ClyAllClassGroupsQueryTest >> testCheckIfEmpty [
+ClyAllPackageTagsQueryTest >> testCheckIfEmpty [
 	| scope |
 	scope := ClyPackageScope of: ClyClass7WithTag1FromP5Mock package in: environment.
 	query scope: scope.
@@ -31,7 +32,7 @@ ClyAllClassGroupsQueryTest >> testCheckIfEmpty [
 ]
 
 { #category : 'tests' }
-ClyAllClassGroupsQueryTest >> testFromSinglePackage [
+ClyAllPackageTagsQueryTest >> testFromSinglePackage [
 
 	self queryFromScope: ClyPackageScope of: ClyClass7WithTag1FromP5Mock package.
 

--- a/src/Calypso-SystemQueries-Tests/ClyClassGroupProviderTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassGroupProviderTest.class.st
@@ -16,7 +16,7 @@ ClyClassGroupProviderTest >> buildGroupsFor: aPackage [
 	| classScope |
 	classScope := ClyPackageScope of: aPackage in: environment.
 	groupProvider
-		classGroupsIn: classScope
+		packageTagssIn: classScope
 		do: [ :each | builtGroups add: each ]
 ]
 
@@ -25,7 +25,7 @@ ClyClassGroupProviderTest >> buildGroupsForAll: packages [
 	| classScope |
 	classScope := ClyPackageScope ofAll: packages in: environment.
 	groupProvider
-		classGroupsIn: classScope
+		packageTagssIn: classScope
 		do: [ :each | builtGroups add: each ]
 ]
 

--- a/src/Calypso-SystemQueries-Tests/ClyPackageScopeTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyPackageScopeTest.class.st
@@ -27,7 +27,7 @@ ClyPackageScopeTest >> testClassGroupEnumeration [
 	environment addPlugin: ClyDefaultSystemEnvironmentPlugin new.
 	scope := ClyPackageScope of: ClyClass7WithTag1FromP5Mock package in: environment.
 
-	scope classGroupsDo: [ :each | result add: each ].
+	scope packageTagsDo: [ :each | result add: each ].
 
 	self
 		assert: (result collect: #class as: Set)

--- a/src/Calypso-SystemQueries/ClyAllPackageTagsQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyAllPackageTagsQuery.class.st
@@ -34,7 +34,7 @@ ClyAllPackageTagsQuery >> buildResult: aQueryResult [
 	| groups |
 	groups := OrderedCollection new.
 
-	scope classGroupsDo: [ :each | groups add: each].
+	scope packageTagsDo: [ :each | groups add: each].
 
 	aQueryResult fillWith: groups
 ]
@@ -42,7 +42,7 @@ ClyAllPackageTagsQuery >> buildResult: aQueryResult [
 { #category : 'execution' }
 ClyAllPackageTagsQuery >> checkEmptyResult [
 
-	scope classGroupsDo: [ :each | ^false].
+	scope packageTagsDo: [ :each | ^false].
 
 	^true
 ]

--- a/src/Calypso-SystemQueries/ClyAllPackageTagsQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyAllPackageTagsQuery.class.st
@@ -1,22 +1,22 @@
 "
-I am a query of all class groups from given scope.
+I am a query of all package tags from given scope.
 
-Scope should support #classGroupsDo:. 
+Scope should support #packageTagsDo:. 
 Currently it is only ClyPackageScope.
 
 The scope delegates class group building to the environment plugins.
 It asks each plugin to collect class group providers using: 
 
-	plugin collectClassGroupProviders 
+	plugin collectPackageTagsProviders 
 
 And then each provider creates set of class groups using method: 
 
-	groupProvider classGroupsIn: aPackageScope do: aBlockWithGroup
+	groupProvider packageTagsIn: aPackageScope do: aBlockWithGroup
 	
-Look at ClyClassGroupProvider for details
+Look at ClyPackageTagProvider for details
 "
 Class {
-	#name : 'ClyAllClassGroupsQuery',
+	#name : 'ClyAllPackageTagsQuery',
 	#superclass : 'ClyTypedQuery',
 	#category : 'Calypso-SystemQueries-Queries',
 	#package : 'Calypso-SystemQueries',
@@ -24,12 +24,12 @@ Class {
 }
 
 { #category : 'items type' }
-ClyAllClassGroupsQuery class >> resultItemsType [
+ClyAllPackageTagsQuery class >> resultItemsType [
 	^ClyClassGroup
 ]
 
 { #category : 'execution' }
-ClyAllClassGroupsQuery >> buildResult: aQueryResult [
+ClyAllPackageTagsQuery >> buildResult: aQueryResult [
 
 	| groups |
 	groups := OrderedCollection new.
@@ -40,7 +40,7 @@ ClyAllClassGroupsQuery >> buildResult: aQueryResult [
 ]
 
 { #category : 'execution' }
-ClyAllClassGroupsQuery >> checkEmptyResult [
+ClyAllPackageTagsQuery >> checkEmptyResult [
 
 	scope classGroupsDo: [ :each | ^false].
 
@@ -48,18 +48,18 @@ ClyAllClassGroupsQuery >> checkEmptyResult [
 ]
 
 { #category : 'execution' }
-ClyAllClassGroupsQuery >> collectMetadataOf: aQueryResult by: anEnvironmentPlugin [
+ClyAllPackageTagsQuery >> collectMetadataOf: aQueryResult by: anEnvironmentPlugin [
 	anEnvironmentPlugin collectMetadataOfClassGroups: aQueryResult
 ]
 
 { #category : 'printing' }
-ClyAllClassGroupsQuery >> description [
+ClyAllPackageTagsQuery >> description [
 
 	^'all class groups'
 ]
 
 { #category : 'system changes' }
-ClyAllClassGroupsQuery >> isResult: aQueryResult affectedBy: aSystemAnnouncement [
+ClyAllPackageTagsQuery >> isResult: aQueryResult affectedBy: aSystemAnnouncement [
 
 	^scope includesClassGroupsAffectedBy: aSystemAnnouncement
 ]

--- a/src/Calypso-SystemQueries/ClyAllPackageTagsQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyAllPackageTagsQuery.class.st
@@ -49,7 +49,8 @@ ClyAllPackageTagsQuery >> checkEmptyResult [
 
 { #category : 'execution' }
 ClyAllPackageTagsQuery >> collectMetadataOf: aQueryResult by: anEnvironmentPlugin [
-	anEnvironmentPlugin collectMetadataOfClassGroups: aQueryResult
+
+	
 ]
 
 { #category : 'printing' }
@@ -61,5 +62,5 @@ ClyAllPackageTagsQuery >> description [
 { #category : 'system changes' }
 ClyAllPackageTagsQuery >> isResult: aQueryResult affectedBy: aSystemAnnouncement [
 
-	^scope includesClassGroupsAffectedBy: aSystemAnnouncement
+	^scope includesPackageTagsAffectedBy: aSystemAnnouncement
 ]

--- a/src/Calypso-SystemQueries/ClyClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyClassGroup.class.st
@@ -55,7 +55,7 @@ ClyClassGroup class >> decorateBrowserItem: aBrowserItem by: anEnvironmentPlugin
 ]
 
 { #category : 'testing' }
-ClyClassGroup class >> isBasedOnClassTag [
+ClyClassGroup class >> isBasedOnPackageTag [
 	^false
 ]
 

--- a/src/Calypso-SystemQueries/ClyDefaultSystemEnvironmentPlugin.class.st
+++ b/src/Calypso-SystemQueries/ClyDefaultSystemEnvironmentPlugin.class.st
@@ -19,7 +19,7 @@ ClyDefaultSystemEnvironmentPlugin >> checkPackageHasClassGroups: aPackage [
 		pluginsDo: [ :plugin |
 			providers := plugin collectClassGroupProviders.
 			providers
-				do: [ :each | each classGroupsIn: packageScope do: [ :group | ^ true ] ] ].
+				do: [ :each | each packageTagssIn: packageScope do: [ :group | ^ true ] ] ].
 	^ false
 ]
 

--- a/src/Calypso-SystemQueries/ClyDefaultSystemEnvironmentPlugin.class.st
+++ b/src/Calypso-SystemQueries/ClyDefaultSystemEnvironmentPlugin.class.st
@@ -26,8 +26,10 @@ ClyDefaultSystemEnvironmentPlugin >> checkPackageHasClassGroups: aPackage [
 { #category : 'method groups' }
 ClyDefaultSystemEnvironmentPlugin >> collectClassGroupProviders [
 
-	^{ClyExtendedClassGroupProvider. ClyNoTagClassGroupProvider. ClyTaggedClassGroupProvider}
-		collect: [ :each | each new ]
+	^ {
+		  ClyExtendedClassGroupProvider.
+		  ClyNoTagClassGroupProvider.
+		  ClyTaggedClassGroupProvider } collect: [ :each | each new ]
 ]
 
 { #category : 'method groups' }

--- a/src/Calypso-SystemQueries/ClyExtendedClassGroupProvider.class.st
+++ b/src/Calypso-SystemQueries/ClyExtendedClassGroupProvider.class.st
@@ -16,5 +16,6 @@ ClyExtendedClassGroupProvider >> createClassGroupFor: aClassQuery from: aPackage
 
 { #category : 'enumerating' }
 ClyExtendedClassGroupProvider >> createClassQueryFrom: aPackageScope [
-	^ClyAllClassesQuery from: (aPackageScope asScope: ClyPackageExtensionScope)
+
+	^ ClyAllClassesQuery from: (aPackageScope asScope: ClyPackageExtensionScope)
 ]

--- a/src/Calypso-SystemQueries/ClyNoTagClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyNoTagClassGroup.class.st
@@ -18,7 +18,7 @@ Class {
 }
 
 { #category : 'testing' }
-ClyNoTagClassGroup class >> isBasedOnClassTag [
+ClyNoTagClassGroup class >> isBasedOnPackageTag [
 	^true
 ]
 
@@ -28,7 +28,7 @@ ClyNoTagClassGroup class >> priority [
 ]
 
 { #category : 'operations' }
-ClyNoTagClassGroup >> renameClassTagTo: newTag [
+ClyNoTagClassGroup >> renameTagTo: newTag [
 
 	self classes do: [ :class | class packageTag: newTag ]
 ]

--- a/src/Calypso-SystemQueries/ClyNoTagClassGroupProvider.class.st
+++ b/src/Calypso-SystemQueries/ClyNoTagClassGroupProvider.class.st
@@ -18,5 +18,6 @@ ClyNoTagClassGroupProvider >> createClassGroupFor: aClassQuery from: aPackageSco
 
 { #category : 'building groups' }
 ClyNoTagClassGroupProvider >> createClassQueryFrom: aPackageScope [
-	^ClyRestUntaggedClassesQuery from: aPackageScope
+
+	^ ClyRestUntaggedClassesQuery from: aPackageScope
 ]

--- a/src/Calypso-SystemQueries/ClyPackageScope.class.st
+++ b/src/Calypso-SystemQueries/ClyPackageScope.class.st
@@ -39,7 +39,7 @@ ClyPackageScope >> classesDo: aBlock [
 ]
 
 { #category : 'system changes' }
-ClyPackageScope >> includesClassGroupsAffectedBy: aSystemAnnouncement [
+ClyPackageScope >> includesPackageTagsAffectedBy: aSystemAnnouncement [
 
 	| providers |
 	basisObjects do: [ :eachPackage |

--- a/src/Calypso-SystemQueries/ClyPackageScope.class.st
+++ b/src/Calypso-SystemQueries/ClyPackageScope.class.st
@@ -33,14 +33,6 @@ ClyPackageScope >> classGroupProvidersDo: aBlock [
 ]
 
 { #category : 'queries' }
-ClyPackageScope >> classGroupsDo: aBlock [
-
-	self classGroupProvidersDo: [ :groupProvider |
-		groupProvider classGroupsIn: self do: [:group |
-			aBlock value: group] ]
-]
-
-{ #category : 'queries' }
 ClyPackageScope >> classesDo: aBlock [
 	self packagesDo: [ :package |
 		package definedClasses do: aBlock]
@@ -67,6 +59,14 @@ ClyPackageScope >> methodsDo: aBlock [
 
 	self packagesDo: [ :package |
 		package extensionMethods do: aBlock ]
+]
+
+{ #category : 'queries' }
+ClyPackageScope >> packageTagsDo: aBlock [
+
+	self classGroupProvidersDo: [ :groupProvider |
+		groupProvider packageTagssIn: self do: [:group |
+			aBlock value: group] ]
 ]
 
 { #category : 'queries' }

--- a/src/Calypso-SystemQueries/ClyPackageTagProvider.class.st
+++ b/src/Calypso-SystemQueries/ClyPackageTagProvider.class.st
@@ -24,7 +24,7 @@ ClyPackageTagProvider >> packageTagssIn: aPackageScope do: aBlock [
 
 { #category : 'system changes' }
 ClyPackageTagProvider >> providesGroupsAffectedBy: aSystemAnnouncement inScope: aPackageScope [
-	aPackageScope packagesDo: [ :each |
-		(aSystemAnnouncement affectsPackage: each) ifTrue: [^true]].
-	^false
+
+	aPackageScope packagesDo: [ :each | (aSystemAnnouncement affectsPackage: each) ifTrue: [ ^ true ] ].
+	^ false
 ]

--- a/src/Calypso-SystemQueries/ClyPackageTagProvider.class.st
+++ b/src/Calypso-SystemQueries/ClyPackageTagProvider.class.st
@@ -1,16 +1,16 @@
 "
-I am a root of hierarchy of class group providers.
+I am a root of hierarchy of package tag providers.
 My subclasses must build class groups for given package scope.
 
 They should implement following method: 
 
-- classGroupsIn: aPackageScope do: aBlock
+- packageTagsIn: aPackageScope do: aBlock
 
 It should create class group instances and pass them into the block.
 Look at ClyClassGroup comment to see how create groups.
 "
 Class {
-	#name : 'ClyClassGroupProvider',
+	#name : 'ClyPackageTagProvider',
 	#superclass : 'Object',
 	#category : 'Calypso-SystemQueries-Domain',
 	#package : 'Calypso-SystemQueries',
@@ -18,12 +18,12 @@ Class {
 }
 
 { #category : 'building groups' }
-ClyClassGroupProvider >> classGroupsIn: aPackageScope do: aBlock [
+ClyPackageTagProvider >> packageTagssIn: aPackageScope do: aBlock [
 	self subclassResponsibility
 ]
 
 { #category : 'system changes' }
-ClyClassGroupProvider >> providesGroupsAffectedBy: aSystemAnnouncement inScope: aPackageScope [
+ClyPackageTagProvider >> providesGroupsAffectedBy: aSystemAnnouncement inScope: aPackageScope [
 	aPackageScope packagesDo: [ :each |
 		(aSystemAnnouncement affectsPackage: each) ifTrue: [^true]].
 	^false

--- a/src/Calypso-SystemQueries/ClySingleClassGroupProvider.class.st
+++ b/src/Calypso-SystemQueries/ClySingleClassGroupProvider.class.st
@@ -11,21 +11,11 @@ It should creates group instance using given scope. The package scope is given t
 "
 Class {
 	#name : 'ClySingleClassGroupProvider',
-	#superclass : 'ClyClassGroupProvider',
+	#superclass : 'ClyPackageTagProvider',
 	#category : 'Calypso-SystemQueries-Domain',
 	#package : 'Calypso-SystemQueries',
 	#tag : 'Domain'
 }
-
-{ #category : 'building groups' }
-ClySingleClassGroupProvider >> classGroupsIn: aPackageScope do: aBlock [
-
-	| classQuery |
-	classQuery := self createClassQueryFrom: aPackageScope.
-	classQuery hasEmptyResult ifTrue: [ ^self ].
-
-	aBlock value: (self createClassGroupFor: classQuery from: aPackageScope)
-]
 
 { #category : 'building groups' }
 ClySingleClassGroupProvider >> createClassGroupFor: aClassQuery from: aPackageScope [
@@ -35,4 +25,14 @@ ClySingleClassGroupProvider >> createClassGroupFor: aClassQuery from: aPackageSc
 { #category : 'building groups' }
 ClySingleClassGroupProvider >> createClassQueryFrom: aPackageScope [
 	self subclassResponsibility
+]
+
+{ #category : 'building groups' }
+ClySingleClassGroupProvider >> packageTagssIn: aPackageScope do: aBlock [
+
+	| classQuery |
+	classQuery := self createClassQueryFrom: aPackageScope.
+	classQuery hasEmptyResult ifTrue: [ ^self ].
+
+	aBlock value: (self createClassGroupFor: classQuery from: aPackageScope)
 ]

--- a/src/Calypso-SystemQueries/ClySystemEnvironmentPlugin.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironmentPlugin.class.st
@@ -75,10 +75,6 @@ ClySystemEnvironmentPlugin >> collectClassGroupProviders [
 ]
 
 { #category : 'query metadata' }
-ClySystemEnvironmentPlugin >> collectMetadataOfClassGroups: aQueryResult [
-]
-
-{ #category : 'query metadata' }
 ClySystemEnvironmentPlugin >> collectMetadataOfClasses: aQueryResult [
 ]
 

--- a/src/Calypso-SystemQueries/ClyTaggedClassGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedClassGroup.class.st
@@ -24,7 +24,7 @@ Class {
 }
 
 { #category : 'testing' }
-ClyTaggedClassGroup class >> isBasedOnClassTag [
+ClyTaggedClassGroup class >> isBasedOnPackageTag [
 	^true
 ]
 
@@ -48,7 +48,7 @@ ClyTaggedClassGroup >> removeWithClasses [
 ]
 
 { #category : 'operations' }
-ClyTaggedClassGroup >> renameClassTagTo: newTag [
+ClyTaggedClassGroup >> renameTagTo: newTag [
 
 	self classes do: [ :class | class packageTag: newTag ].
 

--- a/src/Calypso-SystemQueries/ClyTaggedClassGroupProvider.class.st
+++ b/src/Calypso-SystemQueries/ClyTaggedClassGroupProvider.class.st
@@ -5,22 +5,21 @@ I collect all class tags from the package scope and create ClyTaggedClassGroup i
 "
 Class {
 	#name : 'ClyTaggedClassGroupProvider',
-	#superclass : 'ClyClassGroupProvider',
+	#superclass : 'ClyPackageTagProvider',
 	#category : 'Calypso-SystemQueries-Domain',
 	#package : 'Calypso-SystemQueries',
 	#tag : 'Domain'
 }
 
 { #category : 'building groups' }
-ClyTaggedClassGroupProvider >> classGroupsIn: aPackageScope do: aBlock [
+ClyTaggedClassGroupProvider >> packageTagssIn: aPackageScope do: aBlock [
+
 	| classGroups group |
 	classGroups := Dictionary new.
-	aPackageScope packagesDo: [ :each |
-		each tagsForClasses do: [ :eachTag |
-			classGroups at: eachTag ifAbsentPut: [
-				group := ClyTaggedClassGroup
-					withClassesFrom: aPackageScope taggedBy: eachTag.
+	aPackageScope packagesDo: [ :package |
+		package tagsForClasses do: [ :tag |
+			classGroups at: tag ifAbsentPut: [
+				group := ClyTaggedClassGroup withClassesFrom: aPackageScope taggedBy: tag.
 				aBlock value: group.
-				group].
-	]]
+				group ] ] ]
 ]

--- a/src/Calypso-SystemQueries/ClyTypedScope.extension.st
+++ b/src/Calypso-SystemQueries/ClyTypedScope.extension.st
@@ -10,12 +10,6 @@ ClyTypedScope >> canDetectAffectOnClassesBy: aSystemAnnouncement [
 ]
 
 { #category : '*Calypso-SystemQueries' }
-ClyTypedScope >> includesClassGroupsAffectedBy: aSystemAnnouncement [
-
-	^false
-]
-
-{ #category : '*Calypso-SystemQueries' }
 ClyTypedScope >> includesClassesAffectedBy: aSystemAnnouncement [
 
 	^basisObjects anySatisfy: [ :each |
@@ -27,6 +21,12 @@ ClyTypedScope >> includesMethodsAffectedBy: aSystemAnnouncement [
 
 	^basisObjects anySatisfy: [ :each |
 		each includesMethodsAffectedBy: aSystemAnnouncement ]
+]
+
+{ #category : '*Calypso-SystemQueries' }
+ClyTypedScope >> includesPackageTagsAffectedBy: aSystemAnnouncement [
+
+	^false
 ]
 
 { #category : '*Calypso-SystemQueries' }

--- a/src/Calypso-SystemQueries/RPackage.extension.st
+++ b/src/Calypso-SystemQueries/RPackage.extension.st
@@ -58,8 +58,8 @@ RPackage class >> itemsSortOrderForCalypso [
 
 { #category : '*Calypso-SystemQueries' }
 RPackage class >> prepareClassGroupQueryFrom: aPackage in: aNavigationEnvironment [
-	^ ClyAllClassGroupsQuery
-		sortedFrom: (ClyPackageScope of: aPackage in: aNavigationEnvironment)
+
+	^ ClyAllPackageTagsQuery sortedFrom: (ClyPackageScope of: aPackage in: aNavigationEnvironment)
 ]
 
 { #category : '*Calypso-SystemQueries' }

--- a/src/Calypso-SystemTools-Core/ClyClassCreationToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassCreationToolMorph.class.st
@@ -14,7 +14,7 @@ Class {
 	#superclass : 'ClyTextEditorToolMorph',
 	#instVars : [
 		'package',
-		'classTag'
+		'tag'
 	],
 	#category : 'Calypso-SystemTools-Core-Editors-Classes',
 	#package : 'Calypso-SystemTools-Core',
@@ -57,16 +57,6 @@ ClyClassCreationToolMorph >> belongsToCurrentBrowserContext [
 	^packageSelection includesActualObject: package
 ]
 
-{ #category : 'accessing' }
-ClyClassCreationToolMorph >> classTag [
-	^ classTag
-]
-
-{ #category : 'accessing' }
-ClyClassCreationToolMorph >> classTag: anObject [
-	classTag := anObject
-]
-
 { #category : 'template' }
 ClyClassCreationToolMorph >> classTemplate [
 
@@ -93,7 +83,7 @@ ClyClassCreationToolMorph >> isSimilarTo: anotherBrowserTool [
 	(super isSimilarTo: anotherBrowserTool) ifFalse: [ ^false ].
 
 	^package = anotherBrowserTool package
-		and: [ classTag = anotherBrowserTool classTag ]
+		and: [ tag = anotherBrowserTool tag ]
 ]
 
 { #category : 'testing' }
@@ -107,9 +97,9 @@ ClyClassCreationToolMorph >> isValidInContext: aClyFullBrowserContext [
 	aClyFullBrowserContext isPackageSelected
 		ifTrue: [ isValid := package = aClyFullBrowserContext lastSelectedPackage ].
 
-	^ isValid and: [ aClyFullBrowserContext isClassTagSelected
-		ifTrue: [ classTag = aClyFullBrowserContext lastSelectedClassTag ]
-		ifFalse: [ classTag isNil ] ]
+	^ isValid and: [ aClyFullBrowserContext isPackageTagSelected
+		ifTrue: [ tag = aClyFullBrowserContext lastSelectedPackageTag ]
+		ifFalse: [ tag isNil ] ]
 ]
 
 { #category : 'accessing' }
@@ -127,16 +117,16 @@ ClyClassCreationToolMorph >> packageName [
 
 	package ifNil: [ ^'' ].
 
-	classTag ifNil: [ ^package name ].
+	tag ifNil: [ ^package name ].
 
-	^package name , '-' , classTag
+	^package name , '-' , tag
 ]
 
 { #category : 'printing' }
 ClyClassCreationToolMorph >> printContext [
 	package ifNil: [^super printContext].
-	classTag ifNil: [ ^package name ].
-	^package name, ' / ' , classTag
+	tag ifNil: [ ^package name ].
+	^package name, ' / ' , tag
 ]
 
 { #category : 'initialization' }
@@ -155,5 +145,15 @@ ClyClassCreationToolMorph >> setUpModelFromContext [
 	super setUpModelFromContext.
 
 	context isPackageSelected ifTrue: [ package := context lastSelectedPackage ].
-	context isClassTagSelected ifTrue: [ classTag := context lastSelectedClassTag]
+	context isPackageTagSelected ifTrue: [ tag := context lastSelectedPackageTag]
+]
+
+{ #category : 'accessing' }
+ClyClassCreationToolMorph >> tag [
+	^ tag
+]
+
+{ #category : 'accessing' }
+ClyClassCreationToolMorph >> tag: anObject [
+	tag := anObject
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserClassGroupContext.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserClassGroupContext.class.st
@@ -22,18 +22,18 @@ ClyFullBrowserClassGroupContext >> isClassGroupSelected [
 ]
 
 { #category : 'testing' }
-ClyFullBrowserClassGroupContext >> isClassTagSelected [
+ClyFullBrowserClassGroupContext >> isPackageSelected [
+	^tool packageSelection isEmpty not
+]
+
+{ #category : 'testing' }
+ClyFullBrowserClassGroupContext >> isPackageTagSelected [
 	| classGroupClass |
 	self isClassGroupSelected ifFalse: [ ^false ].
 
 	classGroupClass := self lastSelectedItem type.
 
-	^classGroupClass isBasedOnClassTag
-]
-
-{ #category : 'testing' }
-ClyFullBrowserClassGroupContext >> isPackageSelected [
-	^tool packageSelection isEmpty not
+	^classGroupClass isBasedOnPackageTag
 ]
 
 { #category : 'selection-class groups' }
@@ -42,9 +42,9 @@ ClyFullBrowserClassGroupContext >> lastSelectedClassGroup [
 ]
 
 { #category : 'selection-class groups' }
-ClyFullBrowserClassGroupContext >> lastSelectedClassTag [
+ClyFullBrowserClassGroupContext >> lastSelectedPackageTag [
 
-	^self lastSelectedObjectIn: self selectedClassTags
+	^self lastSelectedObjectIn: self selectedPackageTags
 ]
 
 { #category : 'selection-class groups' }
@@ -53,9 +53,9 @@ ClyFullBrowserClassGroupContext >> selectedClassGroups [
 ]
 
 { #category : 'selection-class groups' }
-ClyFullBrowserClassGroupContext >> selectedClassTags [
+ClyFullBrowserClassGroupContext >> selectedPackageTags [
 
 	^selectedItems
-		select: [ :each | each type isBasedOnClassTag ]
+		select: [ :each | each type isBasedOnPackageTag ]
 		thenCollect: [ :each | each name ]
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserContext.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserContext.class.st
@@ -25,17 +25,17 @@ ClyFullBrowserContext >> currentMetaLevelOf: aClass [
 	^metaLevelScope metaLevelOf: aClass
 ]
 
-{ #category : 'selection-packages' }
-ClyFullBrowserContext >> isClassTagSelected [
-	| groups |
-	groups := tool classGroupSelection.
-	groups isEmpty ifTrue: [ ^false ].
-	^groups lastSelectedItem type isBasedOnClassTag
-]
-
 { #category : 'selection-method groups' }
 ClyFullBrowserContext >> isMethodGroupSelected [
 	^self selectedMethodGroupItems notEmpty
+]
+
+{ #category : 'selection-packages' }
+ClyFullBrowserContext >> isPackageTagSelected [
+	| groups |
+	groups := tool classGroupSelection.
+	groups isEmpty ifTrue: [ ^false ].
+	^groups lastSelectedItem type isBasedOnPackageTag
 ]
 
 { #category : 'selection-method groups' }
@@ -60,17 +60,15 @@ ClyFullBrowserContext >> isSimilarTo: anotherBrowserContext [
 		and: [ metaLevelScope == anotherBrowserContext metaLevelScope ]
 ]
 
-{ #category : 'selection-packages' }
-ClyFullBrowserContext >> lastSelectedClassTag [
-	| tagItem |
-	tagItem := tool classGroupSelection items
-		detect: [ :each | each type isBasedOnClassTag ].
-	^tagItem name
-]
-
 { #category : 'selection-method groups' }
 ClyFullBrowserContext >> lastSelectedMethodGroup [
 	^self lastSelectedObjectIn: self selectedMethodGroups
+]
+
+{ #category : 'selection-packages' }
+ClyFullBrowserContext >> lastSelectedPackageTag [
+
+	^ (tool classGroupSelection items detect: [ :each | each type isBasedOnPackageTag ]) name
 ]
 
 { #category : 'accessing' }
@@ -127,8 +125,8 @@ ClyFullBrowserContext >> showPackage: aPackage [
 ]
 
 { #category : 'tool controlling' }
-ClyFullBrowserContext >> showPackage: aPackage atClassTag: tagName [
-	tool selectPackage: aPackage atClassTag: tagName
+ClyFullBrowserContext >> showPackage: aPackage tag: tagName [
+	tool selectPackage: aPackage andTag: tagName
 ]
 
 { #category : 'tool controlling' }

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -609,7 +609,7 @@ ClyFullBrowserMorph >> selectClass: aClass [
 
 		aClass packageTag isRoot
 			ifTrue: [ self selectPackage: aClass package ]
-			ifFalse: [ self selectPackage: aClass package atClassTag: aClass packageTagName ].
+			ifFalse: [ self selectPackage: aClass package andTag: aClass packageTagName ].
 
 		self packageSelection isEmpty ifTrue: [ ^ self ].
 
@@ -663,7 +663,7 @@ ClyFullBrowserMorph >> selectPackage: aPackage [
 ]
 
 { #category : 'navigation' }
-ClyFullBrowserMorph >> selectPackage: aPackage atClassTag: tagName [
+ClyFullBrowserMorph >> selectPackage: aPackage andTag: tagName [
 
 	| packageItem targetClassGroup foundPackages |
 
@@ -736,7 +736,7 @@ ClyFullBrowserMorph >> silentlySelectPackageOfSelectedClass [
 	packageView ignoreNavigationDuring: [
 		selectedClass packageTag isRoot
 			ifTrue: [ self selectPackage: selectedClass package ]
-			ifFalse: [ self selectPackage: selectedClass package atClassTag: selectedClass packageTagName ] ]
+			ifFalse: [ self selectPackage: selectedClass package andTag: selectedClass packageTagName ] ]
 ]
 
 { #category : 'navigation' }

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserPackageContext.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserPackageContext.class.st
@@ -22,7 +22,7 @@ ClyFullBrowserPackageContext >> isClassGroupSelected [
 ]
 
 { #category : 'selection-class groups' }
-ClyFullBrowserPackageContext >> isClassTagSelected [
+ClyFullBrowserPackageContext >> isPackageTagSelected [
 	^false
 ]
 

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserProjectContext.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserProjectContext.class.st
@@ -22,6 +22,6 @@ ClyFullBrowserProjectContext >> isClassGroupSelected [
 ]
 
 { #category : 'testing' }
-ClyFullBrowserProjectContext >> isClassTagSelected [
+ClyFullBrowserProjectContext >> isPackageTagSelected [
 	^false
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyRemoveClassGroupCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyRemoveClassGroupCommand.class.st
@@ -19,7 +19,7 @@ Class {
 
 { #category : 'testing' }
 ClyRemoveClassGroupCommand class >> canBeExecutedInContext: aToolContext [
-	^aToolContext isClassTagSelected
+	^aToolContext isPackageTagSelected
 ]
 
 { #category : 'activation' }

--- a/src/Calypso-SystemTools-FullBrowser/ClyRenamePackageTagCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyRenamePackageTagCommand.class.st
@@ -10,12 +10,12 @@ Internal Representation and Key Implementation Points.
 
 "
 Class {
-	#name : 'ClyRenameClassTagCommand',
+	#name : 'ClyRenamePackageTagCommand',
 	#superclass : 'CmdCommand',
 	#instVars : [
 		'package',
-		'classGroup',
-		'newName'
+		'newName',
+		'packageTag'
 	],
 	#category : 'Calypso-SystemTools-FullBrowser-Commands-Class groups',
 	#package : 'Calypso-SystemTools-FullBrowser',
@@ -23,80 +23,70 @@ Class {
 }
 
 { #category : 'testing' }
-ClyRenameClassTagCommand class >> canBeExecutedInContext: aToolContext [
-	^aToolContext isClassTagSelected
+ClyRenamePackageTagCommand class >> canBeExecutedInContext: aToolContext [
+	^aToolContext isPackageTagSelected
 ]
 
 { #category : 'activation' }
-ClyRenameClassTagCommand class >> fullBrowserMenuActivation [
+ClyRenamePackageTagCommand class >> fullBrowserMenuActivation [
 	<classAnnotation>
 
 	^CmdContextMenuActivation byRootGroupItemOrder: 1 for: ClyFullBrowserClassGroupContext
 ]
 
 { #category : 'activation' }
-ClyRenameClassTagCommand class >> fullBrowserShortcutActivation [
+ClyRenamePackageTagCommand class >> fullBrowserShortcutActivation [
 	<classAnnotation>
 
 	^CmdShortcutActivation renamingFor: ClyFullBrowserClassGroupContext
 ]
 
 { #category : 'execution' }
-ClyRenameClassTagCommand >> applyResultInContext: aToolContext [
+ClyRenamePackageTagCommand >> applyResultInContext: aToolContext [
 	super applyResultInContext: aToolContext.
-	aToolContext showPackage: package atClassTag: newName
+	aToolContext showPackage: package tag: newName
 ]
 
 { #category : 'accessing' }
-ClyRenameClassTagCommand >> classGroup [
-	^ classGroup
-]
-
-{ #category : 'accessing' }
-ClyRenameClassTagCommand >> classGroup: anObject [
-	classGroup := anObject
-]
-
-{ #category : 'accessing' }
-ClyRenameClassTagCommand >> defaultMenuItemName [
+ClyRenamePackageTagCommand >> defaultMenuItemName [
 	^'Rename'
 ]
 
 { #category : 'execution' }
-ClyRenameClassTagCommand >> execute [
+ClyRenamePackageTagCommand >> execute [
 
-	classGroup renameClassTagTo: newName
+	packageTag renameTagTo: newName
 ]
 
 { #category : 'accessing' }
-ClyRenameClassTagCommand >> newName [
+ClyRenamePackageTagCommand >> newName [
 	^ newName
 ]
 
 { #category : 'accessing' }
-ClyRenameClassTagCommand >> newName: anObject [
+ClyRenamePackageTagCommand >> newName: anObject [
 	newName := anObject
 ]
 
 { #category : 'accessing' }
-ClyRenameClassTagCommand >> package [
+ClyRenamePackageTagCommand >> package [
 	^ package
 ]
 
 { #category : 'accessing' }
-ClyRenameClassTagCommand >> package: anObject [
+ClyRenamePackageTagCommand >> package: anObject [
 	package := anObject
 ]
 
 { #category : 'execution' }
-ClyRenameClassTagCommand >> prepareFullExecutionInContext: aToolContext [
+ClyRenamePackageTagCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 
 	package := aToolContext lastSelectedPackage.
-	classGroup := aToolContext lastSelectedClassGroup.
+	packageTag := aToolContext lastSelectedClassGroup.
 	newName := UIManager default
 		request: 'New name of the class tag'
-		initialAnswer: classGroup name
+		initialAnswer: packageTag name
 		title: 'Rename a class tag'.
-	newName isEmptyOrNil | (newName = classGroup name) ifTrue: [ CmdCommandAborted signal]
+	newName isEmptyOrNil | (newName = packageTag name) ifTrue: [ CmdCommandAborted signal]
 ]

--- a/src/SystemCommands-PackageCommands/SycAddNewClassTagCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycAddNewClassTagCommand.class.st
@@ -27,7 +27,7 @@ SycAddNewClassTagCommand class >> canBeExecutedInContext: aToolContext [
 { #category : 'execution' }
 SycAddNewClassTagCommand >> applyResultInContext: aToolContext [
 	super applyResultInContext: aToolContext.
-	aToolContext showPackage: package atClassTag: tagName
+	aToolContext showPackage: package tag: tagName
 ]
 
 { #category : 'accessing' }

--- a/src/SystemCommands-PackageCommands/SycDemoteToPackageWithTagCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycDemoteToPackageWithTagCommand.class.st
@@ -16,7 +16,7 @@ SycDemoteToPackageWithTagCommand >> applyResultInContext: aBrowserContext [
 
 	newPackage := (lastPackage name copyUpToLast: $-) asPackage.
 	tag := lastPackage name last: lastPackage name size - newPackage name size - 1.
-	aBrowserContext showPackage: newPackage atClassTag: tag asSymbol
+	aBrowserContext showPackage: newPackage tag: tag asSymbol
 ]
 
 { #category : 'accessing' }

--- a/src/SystemCommands-PackageCommands/SycPromotePackageFromTagCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycPromotePackageFromTagCommand.class.st
@@ -21,7 +21,7 @@ Class {
 
 { #category : 'testing' }
 SycPromotePackageFromTagCommand class >> canBeExecutedInContext: aToolContext [
-	^aToolContext isPackageSelected and: [aToolContext isClassTagSelected]
+	^aToolContext isPackageSelected and: [aToolContext isPackageTagSelected]
 ]
 
 { #category : 'execution' }
@@ -48,5 +48,5 @@ SycPromotePackageFromTagCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 
 	package := aToolContext lastSelectedPackage.
-	classTag := aToolContext lastSelectedClassTag
+	classTag := aToolContext lastSelectedPackageTag
 ]


### PR DESCRIPTION
Calypso has a lot of vocabulary but it happens often that it does not use the same as we are using in the rest of the image. 

This change try to improve the naming related to package tags. We have:
- package tag
- class group
- class tag

I am trying to unify things under 'Package tag'