### PR TITLE
Remove #acceptsLoggingOfCompilation

### DIFF
--- a/src/Graphics-Fonts/FontSet.class.st
+++ b/src/Graphics-Fonts/FontSet.class.st
@@ -22,14 +22,6 @@ Class {
 	#package : 'Graphics-Fonts'
 }
 
-{ #category : 'compiling' }
-FontSet class >> acceptsLoggingOfCompilation [
-	"Dont log sources for my subclasses, so as not to waste time
-	and space storing printString versions of the string literals."
-
-	^ self == FontSet
-]
-
 { #category : 'private' }
 FontSet class >> fontCategory [
 	^ 'Graphics-Fonts' asSymbol

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -25,14 +25,6 @@ ClassDescription class >> isAbstract [
 	^ self == ClassDescription
 ]
 
-{ #category : 'compiling' }
-ClassDescription >> acceptsLoggingOfCompilation [
-	"Answer whether the receiver's method submisions and class defintions should be logged to the changes file and to the current change set.  The metaclass follows the rule of the class itself
-	Weird name is so that it will come lexically before #compile, so that a clean build can make it through."
-
-	^ true
-]
-
 { #category : 'accessing - method dictionary' }
 ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: protocol [
 
@@ -308,7 +300,7 @@ ClassDescription >> compile: sourceCode classified: protocol withStamp: changeSt
 		  classified: protocol
 		  withStamp: changeStamp
 		  notifying: requestor
-		  logSource: self acceptsLoggingOfCompilation
+		  logSource: true
 ]
 
 { #category : 'compiling' }

--- a/src/Kernel/Metaclass.class.st
+++ b/src/Kernel/Metaclass.class.st
@@ -19,13 +19,6 @@ Class {
 	#tag : 'Classes'
 }
 
-{ #category : 'compiling' }
-Metaclass >> acceptsLoggingOfCompilation [
-	"Answer whether the receiver's method submisions and class defintions should be logged to the changes file and to the current change set.  The metaclass follows the rule of the class itself."
-
-	^ self instanceSide acceptsLoggingOfCompilation
-]
-
 { #category : 'instance variables' }
 Metaclass >> addInstVarNamed: aString [
 	"Add the argument, aString, as one of the receiver's instance variables."

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -560,7 +560,7 @@ OpalCompiler >> install [
 	priorMethod := class compiledMethodAt: method selector ifAbsent: [  ].
 
 	changeStamp ifNil: [ changeStamp := Author changeStamp ].
-	logSource := self logged ifNil: [ class acceptsLoggingOfCompilation ].
+	logSource := self logged ifNil: [ true ].
 
 	class addAndClassifySelector: method selector withMethod: method inProtocol: protocol.
 

--- a/src/System-Sources/ChangesLog.class.st
+++ b/src/System-Sources/ChangesLog.class.st
@@ -83,16 +83,14 @@ ChangesLog >> logChange: aStringOrText [
 
 { #category : 'event-listening' }
 ChangesLog >> logClassRemoved: announcement [
-	announcement classRemoved acceptsLoggingOfCompilation ifTrue: [
-		self logChange: 'Smalltalk globals removeClassNamed: #', announcement classRemoved name
-	]
+
+	self logChange: 'Smalltalk globals removeClassNamed: #' , announcement classRemoved name
 ]
 
 { #category : 'event-listening' }
 ChangesLog >> logClassRenamed: announcement [
-	announcement classRenamed acceptsLoggingOfCompilation ifTrue: [
-		self logChange: '(Smalltalk globals at: #', announcement oldName, ') rename: #', announcement newName.
-	]
+
+	self logChange: '(Smalltalk globals at: #' , announcement oldName , ') rename: #' , announcement newName
 ]
 
 { #category : 'event-listening' }
@@ -102,10 +100,8 @@ ChangesLog >> logExpressionEvaluated: announcement [
 
 { #category : 'event-listening' }
 ChangesLog >> logMethodRemoved: announcement [
-	announcement methodClass acceptsLoggingOfCompilation ifTrue: [
-		self logChange:
-			announcement methodClass name, ' removeSelector: #', announcement selector
-	]
+
+	self logChange: announcement methodClass name , ' removeSelector: #' , announcement selector
 ]
 
 { #category : 'logging' }


### PR DESCRIPTION
This method is a hook that is never used in the image. If someone wants to not log, Opal offers an API for that and if a class want to avoid logging, it can override #compiler on the class side to set the logging to false. It will have the same effect

Fixes #15171