### PR TITLE
Move critics UI methods to critic UI package

### DIFF
--- a/src/Manifest-Core/ClassDescription.extension.st
+++ b/src/Manifest-Core/ClassDescription.extension.st
@@ -8,17 +8,6 @@ ClassDescription >> criticClass [
 ]
 
 { #category : '*Manifest-Core' }
-ClassDescription >> criticNameOn: aStream [
-	"This behavior may be folded later by changing the name of this method or using another one."
-
-	aStream
-		<< self name
-		<< ' ('
-		<< self category
-		<< ')'
-]
-
-{ #category : '*Manifest-Core' }
 ClassDescription >> manifestBuilderForRuleChecker: aRuleChecker [
 	"Return the manifestsince the rulechecker is keeping a cache, we ask it back"
 

--- a/src/Manifest-Core/CompiledMethod.extension.st
+++ b/src/Manifest-Core/CompiledMethod.extension.st
@@ -8,19 +8,6 @@ CompiledMethod >> criticClass [
 ]
 
 { #category : '*Manifest-Core' }
-CompiledMethod >> criticNameOn: aStream [
-	"This behavior may be folded later by changing the name of this method or using another one."
-
-	aStream
-		<< self methodClass name
-		<< '>>#'
-		<< self selector
-		<< ' ('
-		<< self methodClass instanceSide category
-		<< ')'
-]
-
-{ #category : '*Manifest-Core' }
 CompiledMethod >> criticTheNonMetaclassClass [
 	"Return the class of the receiver for the critic browser. This behavior may be folded later by changing the name of this method or using another one."
 

--- a/src/Manifest-Core/RPackage.extension.st
+++ b/src/Manifest-Core/RPackage.extension.st
@@ -1,13 +1,6 @@
 Extension { #name : 'RPackage' }
 
 { #category : '*Manifest-Core' }
-RPackage >> criticNameOn: aStream [
-	"This behavior may be folded later by changing the name of this method or using another one."
-
-	aStream << self packageName
-]
-
-{ #category : '*Manifest-Core' }
 RPackage >> manifestBuilderForRuleChecker: aRuleChecker [
 	"Return the manifestsince the rulechecker is keeping a cache, we ask it back"
 

--- a/src/Renraku/ReSmalllintChecker.class.st
+++ b/src/Renraku/ReSmalllintChecker.class.st
@@ -173,14 +173,13 @@ ReSmalllintChecker >> manifestBuilderOfMethod: aMethod [
 
 { #category : 'accessing' }
 ReSmalllintChecker >> manifestBuilderOfPackage: aPackage [
+
 	| key |
-	key := aPackage packageName.
-	^ manifestClassCache
-		at: key
-		ifAbsentPut: [
-			(self builderManifestClass hasPackageNamed: key)
-				ifTrue: [ self builderManifestClass ofPackageNamed: key ]
-				ifFalse: [ nil ] ]
+	key := aPackage name.
+	^ manifestClassCache at: key ifAbsentPut: [
+		  (self builderManifestClass hasPackageNamed: key)
+			  ifTrue: [ self builderManifestClass ofPackageNamed: key ]
+			  ifFalse: [ nil ] ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
This change moves the display methods of critics from Manifest-Core to the UI packages.

Since the UI packages are not in Pharo we need to wait for PR: https://github.com/pharo-spec/NewTools/pull/606

I'm also fixing a deprecation