### PR TITLE
Improve ClassFactoryForTestCase

### DIFF
--- a/src/Deprecated12/ClassFactoryForTestCase.extension.st
+++ b/src/Deprecated12/ClassFactoryForTestCase.extension.st
@@ -1,6 +1,20 @@
 Extension { #name : 'ClassFactoryForTestCase' }
 
 { #category : '*Deprecated12' }
+ClassFactoryForTestCase >> defaultCategory [
+
+	self deprecated: 'Use #packageName and #tagName instead because the concept of categories is been removed from Pharo.'.
+	^ (self packageName , '-' , self tagName) asSymbol
+]
+
+{ #category : '*Deprecated12' }
+ClassFactoryForTestCase >> defaultTagPostfix [
+
+	self deprecated: 'Use #tagName instead.' transformWith: '`@rcv defaultTagPostfix' -> '`@rcv tagName'.
+	^ self tagName
+]
+
+{ #category : '*Deprecated12' }
 ClassFactoryForTestCase >> deleteClass: aClass [
 
 	self deprecated: 'Use #delete: instead. The behavior is the same.' transformWith: '`@rcv deleteClass: `@arg' -> '`@rcv -> delete: `@arg'.
@@ -182,7 +196,7 @@ ClassFactoryForTestCase >> silentlyNewSubclassOf: aClass instanceVariableNames: 
 			  superclass: aClass;
 			  slotsFromString: ivNamesString;
 			  sharedVariablesFromString: classVarsString;
-			  tag: self defaultTagPostfix ]
+			  tag: self tagName ]
 ]
 
 { #category : '*Deprecated12' }

--- a/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyPreviewerTest.class.st
@@ -323,45 +323,45 @@ EpApplyPreviewerTest >> testNonCodeChangeEvent [
 { #category : 'tests' }
 EpApplyPreviewerTest >> testPackageTagAdditionWithPackageTagRemoval [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
 	self setHeadAsInputEntry.
-	self packageOrganizer removeTag: classFactory defaultTagPostfix fromPackage: classFactory packageName.
+	self packageOrganizer removeTag: classFactory tagName fromPackage: classFactory packageName.
 
 	self assertOutputsAnEventWith: [ :output |
 		self assert: output class equals: EpPackageTagAddition.
 		self assert: output packageName equals: classFactory packageName.
-		self assert: output tagName equals: classFactory defaultTagPostfix ]
+		self assert: output tagName equals: classFactory tagName ]
 ]
 
 { #category : 'tests' }
 EpApplyPreviewerTest >> testPackageTagRemovalWithPackageTagAddition [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
-	self packageOrganizer removeTag: classFactory defaultTagPostfix fromPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
+	self packageOrganizer removeTag: classFactory tagName fromPackage: classFactory packageName.
 	self setHeadAsInputEntry.
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
 
 	self assertOutputsAnEventWith: [ :output |
 		self assert: output class equals: EpPackageTagRemoval.
 		self assert: output packageName equals: classFactory packageName.
-		self assert: output tagName equals: classFactory defaultTagPostfix ]
+		self assert: output tagName equals: classFactory tagName ]
 ]
 
 { #category : 'tests' }
 EpApplyPreviewerTest >> testPackageTagRenameWithPreviousRollback [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
 
-	self packageOrganizer renameTag: classFactory defaultTagPostfix to: classFactory defaultTagPostfix , '2' inPackage: classFactory packageName.
+	self packageOrganizer renameTag: classFactory tagName to: classFactory tagName , '2' inPackage: classFactory packageName.
 	self setHeadAsInputEntry.
-	self packageOrganizer renameTag: classFactory defaultTagPostfix , '2' to: classFactory defaultTagPostfix inPackage: classFactory packageName. "Rollback"
+	self packageOrganizer renameTag: classFactory tagName , '2' to: classFactory tagName inPackage: classFactory packageName. "Rollback"
 
 	self assertOutputsAnEventWith: [ :output |
 		self assert: output class equals: EpPackageTagRename.
 		self assert: output packageName equals: classFactory packageName.
-		self assert: output oldTagName equals: classFactory defaultTagPostfix.
-		self assert: output newTagName equals: classFactory defaultTagPostfix , '2' ]
+		self assert: output oldTagName equals: classFactory tagName.
+		self assert: output newTagName equals: classFactory tagName , '2' ]
 ]
 
 { #category : 'tests' }
@@ -521,8 +521,8 @@ EpApplyPreviewerTest >> testRedundantMethodRemovalWithAbsentBehavior [
 { #category : 'tests' }
 EpApplyPreviewerTest >> testRedundantPAckageTagRenameWithAbsentTag [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
-	self packageOrganizer renameTag: classFactory defaultTagPostfix to: classFactory defaultTagPostfix , '2' inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
+	self packageOrganizer renameTag: classFactory tagName to: classFactory tagName , '2' inPackage: classFactory packageName.
 	self setHeadAsInputEntry.
 
 	self assertEmptyPreviewLog
@@ -531,7 +531,7 @@ EpApplyPreviewerTest >> testRedundantPAckageTagRenameWithAbsentTag [
 { #category : 'tests' }
 EpApplyPreviewerTest >> testRedundantPackageTagAddition [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
 	self setHeadAsInputEntry.
 
 	self assertEmptyPreviewLog
@@ -540,8 +540,8 @@ EpApplyPreviewerTest >> testRedundantPackageTagAddition [
 { #category : 'tests' }
 EpApplyPreviewerTest >> testRedundantPackageTagRemoval [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
-	self packageOrganizer removeTag: classFactory defaultTagPostfix fromPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
+	self packageOrganizer removeTag: classFactory tagName fromPackage: classFactory packageName.
 	self setHeadAsInputEntry.
 
 	self assertEmptyPreviewLog

--- a/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpApplyTest.class.st
@@ -333,45 +333,45 @@ EpApplyTest >> testPackageRenameWithExtension [
 { #category : 'tests' }
 EpApplyTest >> testPackageTagAdditionWithPackageTagRemoval [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
 	self setHeadAsInputEntry.
-	self packageOrganizer removeTag: classFactory defaultTagPostfix fromPackage: classFactory packageName.
+	self packageOrganizer removeTag: classFactory tagName fromPackage: classFactory packageName.
 
 	self assert: inputEntry content class equals: EpPackageTagAddition.
-	self deny: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName).
+	self deny: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName).
 	self applyInputEntry.
-	self assert: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName)
+	self assert: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName)
 ]
 
 { #category : 'tests' }
 EpApplyTest >> testPackageTagRemovalWithPackageTagAddition [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
-	self packageOrganizer removeTag: classFactory defaultTagPostfix fromPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
+	self packageOrganizer removeTag: classFactory tagName fromPackage: classFactory packageName.
 	self setHeadAsInputEntry.
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
 
 	self assert: inputEntry content class equals: EpPackageTagRemoval.
-	self assert: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName).
+	self assert: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName).
 	self applyInputEntry.
-	self deny: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName)
+	self deny: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName)
 ]
 
 { #category : 'tests' }
 EpApplyTest >> testPackageTagRename [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
-	self packageOrganizer renameTag: classFactory defaultTagPostfix to: classFactory defaultTagPostfix , '2' inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
+	self packageOrganizer renameTag: classFactory tagName to: classFactory tagName , '2' inPackage: classFactory packageName.
 	self setHeadAsInputEntry.
 
-	self packageOrganizer renameTag: classFactory defaultTagPostfix , '2' to: classFactory defaultTagPostfix inPackage: classFactory packageName. "Rollback"
+	self packageOrganizer renameTag: classFactory tagName , '2' to: classFactory tagName inPackage: classFactory packageName. "Rollback"
 
 	self assert: inputEntry content class equals: EpPackageTagRename.
-	self assert: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName).
-	self deny: (self packageOrganizer hasTag: classFactory defaultTagPostfix , '2' inPackage: classFactory packageName).
+	self assert: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName).
+	self deny: (self packageOrganizer hasTag: classFactory tagName , '2' inPackage: classFactory packageName).
 	self applyInputEntry.
-	self deny: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName).
-	self assert: (self packageOrganizer hasTag: classFactory defaultTagPostfix , '2' inPackage: classFactory packageName)
+	self deny: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName).
+	self assert: (self packageOrganizer hasTag: classFactory tagName , '2' inPackage: classFactory packageName)
 ]
 
 { #category : 'tests' }
@@ -379,20 +379,20 @@ EpApplyTest >> testPackageTagRenameWithClass [
 	"Let's rename a package with a class and see if the class has the right package after."
 
 	| aClass |
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
 
-	aClass := classFactory make: [ :aBuilder | aBuilder tag: classFactory defaultTagPostfix ].
+	aClass := classFactory make: [ :aBuilder | aBuilder tag: classFactory tagName ].
 
-	self packageOrganizer renameTag: classFactory defaultTagPostfix to: classFactory defaultTagPostfix , '2' inPackage: classFactory packageName.
+	self packageOrganizer renameTag: classFactory tagName to: classFactory tagName , '2' inPackage: classFactory packageName.
 	self setHeadAsInputEntry.
-	self packageOrganizer renameTag: classFactory defaultTagPostfix , '2' to: classFactory defaultTagPostfix inPackage: classFactory packageName.
+	self packageOrganizer renameTag: classFactory tagName , '2' to: classFactory tagName inPackage: classFactory packageName.
 
 	self assert: inputEntry content class equals: EpPackageTagRename. "Rollback"
 	self assert: aClass packageName equals: classFactory packageName.
-	self assert: aClass packageTagName equals: classFactory defaultTagPostfix.
+	self assert: aClass packageTagName equals: classFactory tagName.
 	self applyInputEntry.
 	self assert: aClass packageName equals: classFactory packageName.
-	self assert: aClass packageTagName equals: classFactory defaultTagPostfix , '2'
+	self assert: aClass packageTagName equals: classFactory tagName , '2'
 ]
 
 { #category : 'tests' }

--- a/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
+++ b/src/EpiceaBrowsers-Tests/EpRevertTest.class.st
@@ -253,40 +253,40 @@ EpRevertTest >> testMethodRemovalWithMethodAlreadyAdded [
 { #category : 'tests' }
 EpRevertTest >> testPackageTagAdditionWithPackageTagRemoval [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
 	self setHeadAsInputEntry.
 
-	self assert: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName).
+	self assert: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName).
 	self revertInputEntry.
-	self deny: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName)
+	self deny: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName)
 ]
 
 { #category : 'tests' }
 EpRevertTest >> testPackageTagRemovalWithPackageTagAddition [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
-	self packageOrganizer removeTag: classFactory defaultTagPostfix fromPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
+	self packageOrganizer removeTag: classFactory tagName fromPackage: classFactory packageName.
 	self setHeadAsInputEntry.
 
-	self deny: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName).
+	self deny: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName).
 	self revertInputEntry.
-	self assert: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName)
+	self assert: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName)
 ]
 
 { #category : 'tests' }
 EpRevertTest >> testPackageTagRename [
 
-	self packageOrganizer ensureTag: classFactory defaultTagPostfix inPackage: classFactory packageName.
-	self packageOrganizer renameTag: classFactory defaultTagPostfix to: classFactory defaultTagPostfix , '2' inPackage: classFactory packageName.
+	self packageOrganizer ensureTag: classFactory tagName inPackage: classFactory packageName.
+	self packageOrganizer renameTag: classFactory tagName to: classFactory tagName , '2' inPackage: classFactory packageName.
 	self setHeadAsInputEntry.
 
 	self assert: inputEntry content class equals: EpPackageTagRename.
 
-	self deny: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName).
-	self assert: (self packageOrganizer hasTag: classFactory defaultTagPostfix , '2' inPackage: classFactory packageName).
+	self deny: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName).
+	self assert: (self packageOrganizer hasTag: classFactory tagName , '2' inPackage: classFactory packageName).
 	self revertInputEntry.
-	self assert: (self packageOrganizer hasTag: classFactory defaultTagPostfix inPackage: classFactory packageName).
-	self deny: (self packageOrganizer hasTag: classFactory defaultTagPostfix , '2' inPackage: classFactory packageName)
+	self assert: (self packageOrganizer hasTag: classFactory tagName inPackage: classFactory packageName).
+	self deny: (self packageOrganizer hasTag: classFactory tagName , '2' inPackage: classFactory packageName)
 ]
 
 { #category : 'tests' }

--- a/src/Kernel-Tests-WithCompiler/BehaviorWithCompilerTest.class.st
+++ b/src/Kernel-Tests-WithCompiler/BehaviorWithCompilerTest.class.st
@@ -15,7 +15,7 @@ BehaviorWithCompilerTest >> newClass1 [
 	^ self class classInstaller make: [ :aClassBuilder |
 		aClassBuilder
 			name: 'MySuperclass';
-			package: self class category ]
+			package: self class package name ]
 ]
 
 { #category : 'tests' }
@@ -25,7 +25,7 @@ BehaviorWithCompilerTest >> newClass2 [
 		aClassBuilder
 			name: 'MySubclass';
 			superclass: c1;
-			package: self class category ]
+			package: self class package name ]
 ]
 
 { #category : 'running' }

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -98,21 +98,9 @@ ClassFactoryForTestCase >> createdTraits [
 ]
 
 { #category : 'accessing' }
-ClassFactoryForTestCase >> defaultCategory [
-
-	^ (self packageName , '-' , self defaultTagPostfix) asSymbol
-]
-
-{ #category : 'accessing' }
 ClassFactoryForTestCase >> defaultSuperclass [
 
 	^ Object
-]
-
-{ #category : 'accessing' }
-ClassFactoryForTestCase >> defaultTagPostfix [
-
-	^ #Default
 ]
 
 { #category : 'cleaning' }
@@ -299,4 +287,10 @@ ClassFactoryForTestCase >> silentlyNewTrait [
 { #category : 'creating' }
 ClassFactoryForTestCase >> silentlyRename: aClass to: aName [
 	^ self silentlyDo: [ aClass rename: aName asSymbol ]
+]
+
+{ #category : 'accessing' }
+ClassFactoryForTestCase >> tagName [
+
+	^ #Default
 ]

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -51,8 +51,8 @@ ClassFactoryForTestCaseTest >> testClassCreationInDifferentTags [
 	firstThreeClasses := factory createdClasses copy.
 	2 timesRepeat: [ factory make: [ :aBuilder | aBuilder tag: #Two ] ].
 	lastTwoClasses := factory createdClasses copyWithoutAll: firstThreeClasses.
-	self assert: (firstThreeClasses allSatisfy: [ :class | class category = (factory packageName , '-' , #One) asSymbol ]).
-	self assert: (lastTwoClasses allSatisfy: [ :class | class category = (factory packageName , '-' , #Two) asSymbol ])
+	self assert: (firstThreeClasses allSatisfy: [ :class | class package name = factory packageName and: [ class packageTag name = #One ] ]).
+	self assert: (lastTwoClasses allSatisfy: [ :class | class package name = factory packageName and: [ class packageTag name = #Two ] ])
 ]
 
 { #category : 'testing' }
@@ -90,7 +90,8 @@ ClassFactoryForTestCaseTest >> testSingleClassCreation [
 			         sharedVariablesFromString: 'X Y';
 			         tag: factory defaultTagPostfix ].
 	self assert: (self environment allClasses includes: class).
-	self assert: class category equals: factory packageName , '-' , factory defaultTagPostfix.
+	self assert: class package name equals: factory packageName.
+	self assert: class packageTag name equals: factory defaultTagPostfix.
 	self assert: class instVarNames equals: #( a b c ).
 	self assert: class classPool keys asSet equals: #( X Y ) asSet
 ]
@@ -121,6 +122,6 @@ ClassFactoryForTestCaseTest >> testTraitCreationInDifferentCategories [
 				beTrait;
 				tag: #Two ] ].
 	lastTwoTraits := factory createdTraits copyWithoutAll: firstThreeTraits.
-	self assert: (firstThreeTraits allSatisfy: [ :trait | trait category = (factory packageName , '-' , #One) asSymbol ]).
-	self assert: (lastTwoTraits allSatisfy: [ :trait | trait category = (factory packageName , '-' , #Two) asSymbol ])
+	self assert: (firstThreeTraits allSatisfy: [ :trait | trait package name = factory packageName and: [ trait packageTag name = #One ] ]).
+	self assert: (lastTwoTraits allSatisfy: [ :trait | trait package name = factory packageName and: [ trait packageTag name = #Two ] ])
 ]

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -88,10 +88,10 @@ ClassFactoryForTestCaseTest >> testSingleClassCreation [
 			         superclass: Object;
 			         slotsFromString: 'a b c';
 			         sharedVariablesFromString: 'X Y';
-			         tag: factory defaultTagPostfix ].
+			         tag: factory tagName ].
 	self assert: (self environment allClasses includes: class).
 	self assert: class package name equals: factory packageName.
-	self assert: class packageTag name equals: factory defaultTagPostfix.
+	self assert: class packageTag name equals: factory tagName.
 	self assert: class instVarNames equals: #( a b c ).
 	self assert: class classPool keys asSet equals: #( X Y ) asSet
 ]


### PR DESCRIPTION
- Deprecate #defaultCategory 
- Rename #defaultTagPostfix into #tagName (as we have #packageName)
- Remove usage of categories in tests

I also removed two other usage of categories in unrelated tests but the change is really small