### PR TITLE
Deprecate ClassRenamed>>category

### DIFF
--- a/src/Deprecated12/ClassRenamed.extension.st
+++ b/src/Deprecated12/ClassRenamed.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'ClassRenamed' }
+
+{ #category : '*Deprecated12' }
+ClassRenamed >> category [
+	self deprecated: 'The usage of categories is been removed in favor of using the packages and tags API.'.
+	^ self classRenamed category
+]

--- a/src/System-Announcements/ClassRenamed.class.st
+++ b/src/System-Announcements/ClassRenamed.class.st
@@ -68,12 +68,6 @@ ClassRenamed >> affectsVariablesOf: aClass [
 ]
 
 { #category : 'accessing' }
-ClassRenamed >> category [
-
-	^ self classRenamed category
-]
-
-{ #category : 'accessing' }
 ClassRenamed >> classAffected [
 	^self classRenamed
 ]


### PR DESCRIPTION
I think this method is not used anymore but it is quite hard to find with all the senders we still have, so I'm doing this in a standalone PR