### PR TITLE
Do a pass on shift after recent improvements

### DIFF
--- a/src/Shift-ClassBuilder-Tests/ShCreateClassTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShCreateClassTest.class.st
@@ -8,75 +8,71 @@ Class {
 
 { #category : 'tests' }
 ShCreateClassTest >> testClassWithClassSlots [
+
 	builder
 		name: #SHTestClassWithClassSlots;
-		slots: #(anSlot);
-		classSlots: #(aClassSlot).
+		slots: #( anSlot );
+		classSlots: #( aClassSlot ).
 
 	result := builder build.
 
 	self validateResult.
 	self validateSuperclass: Object.
-	self
-		validateSlots:
-			{#anSlot => InstanceVariableSlot}.
+	self validateSlots: { (#anSlot => InstanceVariableSlot) }.
 
-	self
-		validateClassSlots:
-			{#aClassSlot => InstanceVariableSlot.}
-		superclass: Object
+	self validateClassSlots: { (#aClassSlot => InstanceVariableSlot) } superclass: Object
 ]
 
 { #category : 'tests' }
 ShCreateClassTest >> testClassWithInheritedSlots [
+
 	builder
 		name: #SHTestClassWithInheritedSlots;
 		superclassName: #ShCBClassWithInstanceVariables;
-		slots: #(anSlot anotherSlot).
+		slots: #( anSlot anotherSlot ).
 
 	result := builder build.
 
 	self validateResult.
 	self validateSuperclass: ShCBClassWithInstanceVariables.
-	self
-		validateSlots:
-			{#inheritedSlot => InstanceVariableSlot.
-			#anSlot => InstanceVariableSlot.
-			#anotherSlot => InstanceVariableSlot}
+	self validateSlots: {
+			(#inheritedSlot => InstanceVariableSlot).
+			(#anSlot => InstanceVariableSlot).
+			(#anotherSlot => InstanceVariableSlot) }
 ]
 
 { #category : 'tests' }
 ShCreateClassTest >> testClassWithSlots [
+
 	builder
 		name: #SHTestClassWithSlots;
-		slots: #(anSlot anotherSlot).
+		slots: #( anSlot anotherSlot ).
 
 	result := builder build.
 
 	self validateResult.
 	self validateSuperclass: Object.
-	self
-		validateSlots:
-			{(#anSlot => InstanceVariableSlot).
-			(#anotherSlot => InstanceVariableSlot)}
+	self validateSlots: {
+			(#anSlot => InstanceVariableSlot).
+			(#anotherSlot => InstanceVariableSlot) }
 ]
 
 { #category : 'tests' }
 ShCreateClassTest >> testClassWithSuperclassNameAsString [
+
 	builder
 		name: #SHTestClassWithInheritedSlots;
 		superclassName: 'ShCBClassWithInstanceVariables';
-		slots: #(anSlot anotherSlot).
+		slots: #( anSlot anotherSlot ).
 
 	result := builder build.
 
 	self validateResult.
 	self validateSuperclass: ShCBClassWithInstanceVariables.
-	self
-		validateSlots:
-			{#inheritedSlot => InstanceVariableSlot.
-			#anSlot => InstanceVariableSlot.
-			#anotherSlot => InstanceVariableSlot}
+	self validateSlots: {
+			(#inheritedSlot => InstanceVariableSlot).
+			(#anSlot => InstanceVariableSlot).
+			(#anotherSlot => InstanceVariableSlot) }
 ]
 
 { #category : 'tests' }

--- a/src/Shift-ClassBuilder-Tests/ShModifyClassTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShModifyClassTest.class.st
@@ -8,21 +8,23 @@ Class {
 
 { #category : 'tests' }
 ShModifyClassTest >> testEmptyClass [
+
 	builder name: #ShCBEmptyClass.
 	result := builder build.
 
 	self validateResult.
 	self validateSuperclass: Object.
-	self validateMethods: #().
-	self assert: result hasComment.
+	self validateMethods: #(  ).
+	self assert: result hasComment
 ]
 
 { #category : 'tests' }
 ShModifyClassTest >> testEmptyClassWithMethods [
+
 	builder name: #ShCBEmptyClassWithMethods.
 	result := builder build.
 
 	self validateResult.
 	self validateSuperclass: Object.
-	self validateMethods: #(aMethod anotherMethod:)
+	self validateMethods: #( aMethod anotherMethod: )
 ]

--- a/src/Shift-ClassBuilder-Tests/ShiftClassBuilderAbstractTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShiftClassBuilderAbstractTest.class.st
@@ -14,15 +14,6 @@ ShiftClassBuilderAbstractTest >> builder [
 	^ builder
 ]
 
-{ #category : 'private' }
-ShiftClassBuilderAbstractTest >> categoryHack [
-	"Currently there is a bug in Fluid class builder that is that when we define a tag X with a package Y it can generate a package Y-X instead. 
-	This is due to the category mess in RPackage and it will not be fixed until the category mess is cleaned. Until then, to make sure the tests are in a right state, we register the package without the tag before creating the class to ensure the tag is not added as part of the package name.
-	This is ugly but it is currently hard to do better."
-
-	self packageOrganizer ensurePackage: self packageNameForTest
-]
-
 { #category : 'accessing' }
 ShiftClassBuilderAbstractTest >> packageNameForTest [
 

--- a/src/Shift-ClassBuilder-Tests/ShiftClassBuilderTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShiftClassBuilderTest.class.st
@@ -145,7 +145,6 @@ ShiftClassBuilderTest >> testBuilderWithTag [
 ShiftClassBuilderTest >> testChevronIsWorkingOnClassSide [
 
 	| instBuilder newClass clasBuilder |
-	self categoryHack.
 
 	instBuilder := (Object << #Point2)
 		               slots: { #a. #b };
@@ -156,9 +155,6 @@ ShiftClassBuilderTest >> testChevronIsWorkingOnClassSide [
 		               tag: 'boring';
 		               package: self packageNameForTest.
 
-	"Ideally we should not install the class but just build it (sending instBuilder build)
-	the problem is that category and tag are lost by the class builder.
-	Hence we cannot test for real."
 	newClass := instBuilder install.
 
 	clasBuilder := Object class << newClass class traits: { TViewModelMock classTrait }.
@@ -261,37 +257,6 @@ ShiftClassBuilderTest >> testCreateClassWithFullExpandedDefinitionKeepsTheMinimu
 ]
 
 { #category : 'tests - class creation' }
-ShiftClassBuilderTest >> testCreatedClassHasAllElements [
-
-	| instBuilder newClass |
-	self categoryHack.
-
-	instBuilder := (Object << #Point2)
-		               slots: { #a. #b };
-		               layout: WeakLayout;
-		               traits: { TViewModelMock };
-		               sharedVariables: { #AAA };
-		               sharedPools: { #TextConstants };
-		               tag: 'boring';
-		               package: self packageNameForTest.
-
-	"Ideally we should not install the class but just build it (sending instBuilder build)
-	the problem is that category and tag are lost by the class builder.
-	Hence we cannot test for real."
-	newClass := instBuilder install.
-
-	self assert: newClass name equals: #Point2.
-	self assert: newClass slots size equals: 2.
-	self assert: newClass slotNames equals: #( a b ).
-	self assert: newClass classLayout class equals: WeakLayout.
-	self assert: newClass traitComposition equals: { TViewModelMock } asTraitComposition.
-	self assert: newClass class traitComposition equals: { TViewModelMock classSide } asTraitComposition.
-	self assert: newClass classVarNames equals: #( AAA ).
-	self assertCollection: newClass sharedPools hasSameElements: { TextConstants }.
-	self assert: newClass category equals: self packageNameForTest , '-boring'
-]
-
-{ #category : 'tests - class creation' }
 ShiftClassBuilderTest >> testCreatedEmptyClassHasDefaultElements [
 
 	| instBuilder newClass |
@@ -316,8 +281,6 @@ ShiftClassBuilderTest >> testCreatedEmptyClassHasDefaultElements [
 ShiftClassBuilderTest >> testExistingClassWithClassSlot [
 
 	| instBuilder newClass |
-		self categoryHack.
-
 	"We are creating a class with a class slot. This class slot is defined in the class side of the fluid definition.
 	When redefining the instance side, the class slot should not be lost."
 	instBuilder := (Object << #Point2)
@@ -330,9 +293,6 @@ ShiftClassBuilderTest >> testExistingClassWithClassSlot [
 		               tag: 'boring';
 		               package: self packageNameForTest.
 
-	"Ideally we should not install the class but just build it (sending instBuilder build)
-	the problem is that category and tag are lost by the class builder.
-	Hence we cannot test for real."
 	newClass := instBuilder install.
 
 	self assert: newClass class slots first name equals: #AAA.
@@ -344,7 +304,7 @@ ShiftClassBuilderTest >> testExistingClassWithClassSlot [
 		               sharedVariables: { #BBB };
 		               sharedPools: { #TextConstants };
 		               tag: 'boring';
-		               package: self packageNameForTest..
+		               package: self packageNameForTest.
 
 	newClass := instBuilder install.
 
@@ -355,11 +315,8 @@ ShiftClassBuilderTest >> testExistingClassWithClassSlot [
 ShiftClassBuilderTest >> testExistingClassWithClassSlotThenWeRemoveIt [
 
 	| instBuilder newClass classBuilder |
-	self categoryHack.
-
 	"We are creating a class with a class slot. This class slot is defined in the class side of the fluid definition.
 	Then we are removing the classSlot, it should remove it"
-
 	instBuilder := (Object << #Point2)
 		               slots: { #a. #b };
 		               layout: WeakLayout;
@@ -370,9 +327,6 @@ ShiftClassBuilderTest >> testExistingClassWithClassSlotThenWeRemoveIt [
 		               tag: 'boring';
 		               package: self packageNameForTest.
 
-	"Ideally we should not install the class but just build it (sending instBuilder build)
-	the problem is that category and tag are lost by the class builder.
-	Hence we cannot test for real."
 	newClass := instBuilder install.
 
 	self assert: newClass class slots first name equals: #AAA.

--- a/src/Shift-ClassBuilder-Tests/ShiftTraitBuilderTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShiftTraitBuilderTest.class.st
@@ -66,30 +66,6 @@ ShiftTraitBuilderTest >> testCreatingEmptyTraitHasDefaultElements [
 ]
 
 { #category : 'tests - class creation' }
-ShiftTraitBuilderTest >> testCreatingFullTraitHasAllElements [
-
-	| instBuilder newTrait |
-	self categoryHack.
-	instBuilder := (Trait << #TTestTrait)
-		               slots: #( a b c );
-		               traits: { TViewModelMock };
-		               tag: 'lala';
-		               package: self packageNameForTest.
-
-	"Ideally we should not install the class but just build it (sending instBuilder build)
-	the problem is that category and tag are lost by the class builder.
-	Hence we cannot test for real."
-	newTrait := instBuilder install.
-
-	self assert: newTrait name equals: #TTestTrait.
-	self assert: newTrait slotNames equals: #( a b c ).
-	self assert: newTrait traitComposition equals: { TViewModelMock } asTraitComposition.
-	self assert: newTrait class traitComposition equals: { TViewModelMock classSide } asTraitComposition.
-	self assert: newTrait classVarNames equals: #(  ).
-	self assert: newTrait category equals: self packageNameForTest , '-lala'
-]
-
-{ #category : 'tests - class creation' }
 ShiftTraitBuilderTest >> testExistingTraitWithClassSlotsArePreservedIfChangingInstanceSide [
 
 	| instBuilder newTrait |
@@ -137,7 +113,6 @@ ShiftTraitBuilderTest >> testExistingTraitWithSlotsArePreservedIfChangingClassSi
 { #category : 'tests - classBuilder generation' }
 ShiftTraitBuilderTest >> testFillShiftClassBuilder [
 
-	self categoryHack.
 	builder := (Trait << #TPoint2)
 		           slots: { #x. #y };
 		           traits: { TViewModelMock };

--- a/src/Shift-ClassInstaller-Tests/ShAnonymousClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShAnonymousClassInstallerTest.class.st
@@ -10,12 +10,13 @@ ShAnonymousClassInstallerTest >> testSubclasses [
 
 	| aSubClass |
 	aSubClass := Smalltalk anonymousClassInstaller make: [ :builder |
-		             builder superclass: Point.
-		             builder name: #AnotherPoint ].
+		             builder
+			             superclass: Point;
+			             name: #AnotherPoint ].
 
 	self deny: (Point subclasses includes: aSubClass).
 	self assert: aSubClass superclass equals: Point.
 	self deny: (Smalltalk hasClassNamed: #AnotherPoint).
 
-	self assert: (self packageOrganizer packageOfClassNamed: aSubClass name) equals: self packageOrganizer undefinedPackage
+	self assert: (self packageOrganizer packageOfClassNamed: aSubClass name) isUndefined
 ]

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -209,6 +209,54 @@ ShClassInstallerTest >> testClassWithSlotHasInitializeMethodWithInitializeSlots 
 ]
 
 { #category : 'tests' }
+ShClassInstallerTest >> testCreatedClassWithAllElements [
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #SHClass;
+			            superclass: Object;
+			            slots: { #a. #b };
+			            layout: WeakLayout;
+			            traits: { TViewModelMock };
+			            sharedVariables: { #AAA };
+			            sharedPools: { #TextConstants };
+			            tag: 'boring';
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass name equals: #SHClass.
+	self assert: newClass slots size equals: 2.
+	self assert: newClass slotNames equals: #( a b ).
+	self assert: newClass classLayout class equals: WeakLayout.
+	self assert: newClass traitComposition equals: { TViewModelMock } asTraitComposition.
+	self assert: newClass class traitComposition equals: { TViewModelMock classSide } asTraitComposition.
+	self assert: newClass classVarNames equals: #( AAA ).
+	self assertCollection: newClass sharedPools hasSameElements: { TextConstants }.
+	self assert: newClass package name equals: self generatedClassesPackageName.
+	self assert: newClass packageTag name equals: 'boring'
+]
+
+{ #category : 'tests' }
+ShClassInstallerTest >> testCreatingFullTraitHasAllElements [
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            beTrait;
+			            name: #TSHClass;
+			            slots: { #a. #b };
+			            traits: { TViewModelMock };
+			            tag: 'boring';
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass name equals: #TSHClass.
+	self assert: newClass slots size equals: 2.
+	self assert: newClass slotNames equals: #( a b ).
+	self assert: newClass traitComposition equals: { TViewModelMock } asTraitComposition.
+	self assert: newClass class traitComposition equals: { TViewModelMock classSide } asTraitComposition.
+	self assert: newClass package name equals: self generatedClassesPackageName.
+	self assert: newClass packageTag name equals: 'boring'
+]
+
+{ #category : 'tests' }
 ShClassInstallerTest >> testDuplicateClassPreserveClassSlots [
 
 	newClass := ShiftClassInstaller make: [ :builder |
@@ -312,11 +360,8 @@ ShClassInstallerTest >> testInstallInSpecificEnvironment [
 
 	self assert: newClass environment identicalTo: newEnvironment.
 
-	self skip.
-	self flag: #package. "ShiftClassInstaller>>#recategorize:to: is using the old SystemOrganizer system to classify classes, but this does not add the classes to the instance of RPackageOrganizer but to the default package organizer of the image instead. Until we can fix this, we cannot have the next assertions working. They are clearly a bug but it'll be hard to fix this bug in short term........ :("
 	self deny: (self packageOrganizer hasPackage: self generatedClassesPackageName).
-	self assert: (newEnvironment organization hasPackage: self generatedClassesPackageName) ] ensure: [
-		"The tear down will not remove the class in the other environment"
+	self assert: (newEnvironment organization hasPackage: self generatedClassesPackageName) ] ensure: [ "The tear down will not remove the class in the other environment"
 		newEnvironment organization removePackage: self generatedClassesPackageName ]
 ]
 


### PR DESCRIPTION
This change fixes 3 things:
- Some tests on installed classes should be on ShiftClassInstaller tests and not builder (since it's the installer that installs)
- Some tests had a hack because of the categories mess, now we do not need it \0/
- Remove an hack from #testInstallInSpecificEnvironment because now it works better than in the past