### PR TITLE
Metacello: Clean the way to create a class

### DIFF
--- a/src/Metacello-Core/MetacelloPlatform.class.st
+++ b/src/Metacello-Core/MetacelloPlatform.class.st
@@ -56,25 +56,6 @@ MetacelloPlatform >> collection: aCollection do: aBlock displaying: aString [
 	aCollection do: aBlock displayingProgress: aString
 ]
 
-{ #category : 'reflection' }
-MetacelloPlatform >> copyClass: oldClass as: newName inCategory: newCategoryName [
-
-	| copysName class newDefinition |
-	copysName := newName asSymbol.
-	copysName = oldClass name ifTrue: [ ^ oldClass ].
-	(Smalltalk globals includesKey: copysName) ifTrue: [ ^ self error: copysName , ' already exists' ].
-	newDefinition := oldClass definition copyReplaceAll: '#' , oldClass name asString with: '#' , copysName asString printString.
-	newDefinition := newDefinition copyReplaceAll: 'category: ' , oldClass category asString printString with: 'category: ' , newCategoryName printString.
-	class := self class compiler
-		         logged: true;
-		         evaluate: newDefinition.
-	class class instanceVariableNames: oldClass class instanceVariablesString.
-	class copyAllMethodsFrom: oldClass.
-	class class copyAllMethodsFrom: oldClass class.
-	class category: newCategoryName.
-	^ class
-]
-
 { #category : 'repository creation' }
 MetacelloPlatform >> createRepository: aRepositorySpec [
 

--- a/src/Metacello-Core/MetacelloScriptEngine.class.st
+++ b/src/Metacello-Core/MetacelloScriptEngine.class.st
@@ -39,11 +39,11 @@ MetacelloScriptEngine class >> baselineNameFrom: baseName [
 
 { #category : 'utilities' }
 MetacelloScriptEngine class >> configurationNameFrom: baseName [
-    "Return the fully-qualified configuration class name."
+	"Return the fully-qualified configuration class name."
 
-    ^ (baseName indexOfSubCollection: 'ConfigurationOf') > 0
-        ifTrue: [ baseName ]
-        ifFalse: [ 'ConfigurationOf' , baseName ]
+	^ ((baseName beginsWith: 'ConfigurationOf')
+		   ifTrue: [ baseName ]
+		   ifFalse: [ 'ConfigurationOf' , baseName ]) asSymbol
 ]
 
 { #category : 'defaults' }

--- a/src/Metacello-ToolBox/MetacelloToolBox.class.st
+++ b/src/Metacello-ToolBox/MetacelloToolBox.class.st
@@ -1546,13 +1546,7 @@ MetacelloToolBox >> configurationNameFrom: baseName [
 { #category : 'api-configuration' }
 MetacelloToolBox >> configurationNamed: baseName [
 
-	| configurationName |
-	"Check if the class does not exist"
-	configurationName := self configurationNameFrom: baseName.
-	(Smalltalk includesKey: configurationName asSymbol) ifFalse: [
-		MetacelloPlatform current copyClass: MetacelloConfigTemplate as: configurationName asSymbol inCategory: configurationName asString. "Create the package that has the same name"
-		self packageOrganizer ensurePackage: configurationName ].
-	project := (self class environment at: configurationName asSymbol) project
+	project := self createConfiguration: baseName
 ]
 
 { #category : 'accessing' }
@@ -1562,6 +1556,20 @@ MetacelloToolBox >> constructor [
 	constructor := MetacelloToolBoxConstructor new.
 	constructor configuration: project configuration class new.
 	^constructor
+]
+
+{ #category : 'private' }
+MetacelloToolBox >> copyClass: oldClass as: newName inPackage: packageName [
+
+	newName = oldClass name ifTrue: [ ^ oldClass ].
+
+	(Smalltalk globals includesKey: newName) ifTrue: [ ^ self error: newName , ' already exists' ].
+
+	^ self class classInstaller make: [ :builder |
+		  builder
+			  fillFor: oldClass;
+			  name: newName;
+			  package: packageName ]
 ]
 
 { #category : 'api-configuration' }
@@ -1577,14 +1585,8 @@ MetacelloToolBox >> createBaselineOfMethod: selector inCategory: category [
 MetacelloToolBox >> createConfiguration: baseName [
 
 	| configurationName |
-	"Check if the class does not exist"
-	configurationName := (baseName beginsWith: 'ConfigurationOf')
-		                     ifTrue: [ baseName ]
-		                     ifFalse: [ 'ConfigurationOf' , baseName ].
-	(Smalltalk includesKey: configurationName asSymbol) ifFalse: [
-		MetacelloPlatform current copyClass: MetacelloConfigTemplate as: configurationName asSymbol inCategory: configurationName asString. "Create the package that has the same name"
-		self packageOrganizer ensurePackage: configurationName ].
-	^ (self class environment at: configurationName asSymbol) project
+	configurationName := self configurationNameFrom: baseName.
+	^ (Smalltalk at: configurationName ifAbsent: [ self copyClass: MetacelloConfigTemplate as: configurationName inPackage: configurationName ]) project
 ]
 
 { #category : 'spec creation' }


### PR DESCRIPTION
This change simplifies the code generating classes.

Advantages:
- No use of categories
- Use shift class builder instead of definition string manipulation
- Simpler code (less code, code more readable)
- Less code in MetacelloPlatform