### PR TITLE
Refactor AlphaImageMorph to replace ‘cachedForm’ by ‘cachedFormSet’

### DIFF
--- a/src/Graphics-Display Objects/FormSet.class.st
+++ b/src/Graphics-Display Objects/FormSet.class.st
@@ -72,6 +72,12 @@ FormSet >> forms [
 	^ forms
 ]
 
+{ #category : 'accessing' }
+FormSet >> height [
+
+	^ self extent y
+]
+
 { #category : 'file in/out' }
 FormSet >> hibernate [
 
@@ -91,4 +97,10 @@ FormSet >> initializeWithExtent: initialExtent depth: initialDepth forms: initia
 FormSet >> veryDeepCopyWith: deepCopier [
 	"Return self.  I am immutable in the Morphic world.  Do not record me."
 	^ self
+]
+
+{ #category : 'accessing' }
+FormSet >> width [
+
+	^ self extent x
 ]

--- a/src/Graphics-Tests/FormSetTest.class.st
+++ b/src/Graphics-Tests/FormSetTest.class.st
@@ -232,3 +232,57 @@ FormSetTest >> testForms [
 	formSet := FormSet extent: 3@6 depth: 1 forms: { form2. form1 }.
 	self assert: formSet forms equals: { form2. form1 }.
 ]
+
+{ #category : 'tests - accessing' }
+FormSetTest >> testHeight [
+
+	| form1 form2 formSet |
+
+	form1 := Form extent: 1@2 depth: 32.
+	form2 := Form extent: 2@4 depth: 8.
+
+	formSet := FormSet form: form1.
+	self assert: formSet height equals: 2.
+
+	formSet := FormSet form: form2.
+	self assert: formSet height equals: 4.
+
+	formSet := FormSet forms: { form1. form2 }.
+	self assert: formSet height equals: 2.
+
+	formSet := FormSet forms: { form2. form1 }.
+	self assert: formSet height equals: 4.
+
+	formSet := FormSet extent: 1@2 depth: 32 forms: { form1. form2 }.
+	self assert: formSet height equals: 2.
+
+	formSet := FormSet extent: 3@5 depth: 32 forms: { form2. form1 }.
+	self assert: formSet height equals: 5.
+]
+
+{ #category : 'tests - accessing' }
+FormSetTest >> testWidth [
+
+	| form1 form2 formSet |
+
+	form1 := Form extent: 1@2 depth: 32.
+	form2 := Form extent: 2@4 depth: 8.
+
+	formSet := FormSet form: form1.
+	self assert: formSet width equals: 1.
+
+	formSet := FormSet form: form2.
+	self assert: formSet width equals: 2.
+
+	formSet := FormSet forms: { form1. form2 }.
+	self assert: formSet width equals: 1.
+
+	formSet := FormSet forms: { form2. form1 }.
+	self assert: formSet width equals: 2.
+
+	formSet := FormSet extent: 1@2 depth: 32 forms: { form1. form2 }.
+	self assert: formSet width equals: 1.
+
+	formSet := FormSet extent: 3@4 depth: 32 forms: { form2. form1 }.
+	self assert: formSet width equals: 3.
+]

--- a/src/Morphic-Base/AlphaImageMorph.class.st
+++ b/src/Morphic-Base/AlphaImageMorph.class.st
@@ -329,14 +329,20 @@ AlphaImageMorph >> scaledImage [
 	i := self form.
 	i boundingBox area = 0 ifTrue: [^i].
 	(self layout == #scaled and: [self extent ~= i extent]) ifTrue: [
-		^i magnifyBy: (self extent / i extent) smoothing: 2].
+		^self scaledImageBy: (self extent / i extent)].
 	(self layout == #scaledAspect and: [self extent ~= i extent]) ifTrue: [
 		^self width / i width > (self height / i height)
-			ifTrue: [i magnifyBy: (self height / i height) smoothing: 2]
-			ifFalse: [i magnifyBy: (self width / i width) smoothing: 2]].
+			ifTrue: [self scaledImageBy: (self height / i height)]
+			ifFalse: [self scaledImageBy: (self width / i width)]].
 	self scale ~= 1 ifTrue: [
-		^i magnifyBy: self scale smoothing: 2].
+		^self scaledImageBy: self scale].
 	^i
+]
+
+{ #category : 'accessing' }
+AlphaImageMorph >> scaledImageBy: imageScale [
+
+	^ self form magnifyBy: imageScale smoothing: 2
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Base/AlphaImageMorph.class.st
+++ b/src/Morphic-Base/AlphaImageMorph.class.st
@@ -322,27 +322,37 @@ AlphaImageMorph >> scale: aNumber [
 ]
 
 { #category : 'accessing' }
-AlphaImageMorph >> scaledImage [
+AlphaImageMorph >> scaledFormSet [
 	"Answer the image scaled as required."
 
 	|i|
-	i := self form.
-	i boundingBox area = 0 ifTrue: [^i].
+	i := self formSet.
+	(i width = 0 or: [ i height = 0 ]) ifTrue: [^i].
 	(self layout == #scaled and: [self extent ~= i extent]) ifTrue: [
-		^self scaledImageBy: (self extent / i extent)].
+		^self scaledFormSetBy: (self extent / i extent)].
 	(self layout == #scaledAspect and: [self extent ~= i extent]) ifTrue: [
 		^self width / i width > (self height / i height)
-			ifTrue: [self scaledImageBy: (self height / i height)]
-			ifFalse: [self scaledImageBy: (self width / i width)]].
+			ifTrue: [self scaledFormSetBy: (self height / i height)]
+			ifFalse: [self scaledFormSetBy: (self width / i width)]].
 	self scale ~= 1 ifTrue: [
-		^self scaledImageBy: self scale].
+		^self scaledFormSetBy: self scale].
 	^i
 ]
 
 { #category : 'accessing' }
-AlphaImageMorph >> scaledImageBy: imageScale [
+AlphaImageMorph >> scaledFormSetBy: imageScale [
 
-	^ self form magnifyBy: imageScale smoothing: 2
+	| scaledExtent |
+
+	scaledExtent := (formSet extent * imageScale) truncated.
+	^ FormSet extent: scaledExtent depth: formSet depth
+		forms: (formSet forms collect: [ :form | form magnifyBy: (scaledExtent / formSet extent) smoothing: 2 ])
+]
+
+{ #category : 'accessing' }
+AlphaImageMorph >> scaledImage [
+
+	^ self scaledFormSet asForm
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Base/AlphaImageMorph.class.st
+++ b/src/Morphic-Base/AlphaImageMorph.class.st
@@ -159,6 +159,41 @@ AlphaImageMorph >> extent: aPoint [
 ]
 
 { #category : 'accessing' }
+AlphaImageMorph >> formSet: aFormSet [
+
+	self formSet: aFormSet size: aFormSet extent
+]
+
+{ #category : 'accessing' }
+AlphaImageMorph >> formSet: aFormSet size: aPoint [
+	"Set the image to be the form set scaled to the given size and padded if neccesary."
+
+	|f scaledExtent|
+	"Convert color forms etc. to 32 bit before resizing since scaling of ColorForm introduces degraded color resolution.
+	Most noticable with grayscale forms."
+	f := (aFormSet depth < 32 and: [aFormSet depth > 4])
+		ifTrue: [
+			FormSet extent: aFormSet extent depth: 32 forms: (aFormSet forms collect: [ :form |
+				| convertedForm |
+				convertedForm := Form extent: form extent depth: 32.
+				convertedForm fillColor: (Color white alpha: 0.003922).
+				convertedForm getCanvas translucentImage: form at: 0@0.
+				convertedForm fixAlpha.
+				convertedForm ]) ]
+		ifFalse: [aFormSet].
+	aPoint = f extent ifFalse: [
+		scaledExtent := (f extent * (aPoint x / f width min: aPoint y / f height)) truncated.
+		f := FormSet extent: scaledExtent depth: f depth forms: (f forms collect: [ :form |
+			form scaledToSize: scaledExtent * (form extent / f extent) ]) ].
+	self autoSize
+		ifTrue: [super formSet: f]
+		ifFalse: [formSet := f.
+				self changed].
+	self cachedFormSet: nil.
+	self changed: #imageExtent
+]
+
+{ #category : 'accessing' }
 AlphaImageMorph >> getImageSelector [
 
 	^ getImageSelector
@@ -179,24 +214,8 @@ AlphaImageMorph >> image: anImage [
 
 { #category : 'accessing' }
 AlphaImageMorph >> image: aForm size: aPoint [
-	"Set the image to be the form scaled to the given size and padded if neccesary."
 
-	|f|
-	"Convert color forms etc. to 32 bit before resizing since scaling of ColorForm introduces degraded color resolution.
-	Most noticable with grayscale forms."
-	(aForm depth < 32 and: [aForm depth > 4])
-		ifTrue: [f := Form extent: aForm extent depth: 32.
-				f fillColor: (Color white alpha: 0.003922).
-				f getCanvas translucentImage: aForm at: 0@0.
-				f fixAlpha]
-		ifFalse: [f := aForm].
-	f := f scaledToSize: aPoint.
-	self autoSize
-		ifTrue: [super image: f]
-		ifFalse: [formSet := FormSet form: f.
-				self changed].
-	self cachedFormSet: nil.
-	self changed: #imageExtent
+	^ self formSet: (FormSet form: aForm) size: aPoint
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Base/AlphaImageMorph.class.st
+++ b/src/Morphic-Base/AlphaImageMorph.class.st
@@ -9,7 +9,7 @@ Class {
 	#superclass : 'ImageMorph',
 	#instVars : [
 		'alpha',
-		'cachedForm',
+		'cachedFormSet',
 		'layout',
 		'scale',
 		'enabled',
@@ -45,7 +45,7 @@ AlphaImageMorph >> alpha: anObject [
 
 	alpha := anObject.
 	self
-		cachedForm: nil;
+		cachedFormSet: nil;
 		changed;
 		changed: #alpha
 ]
@@ -65,31 +65,35 @@ AlphaImageMorph >> autoSize: anObject [
 ]
 
 { #category : 'accessing' }
-AlphaImageMorph >> cachedForm [
-	"Answer the value of cachedForm"
+AlphaImageMorph >> cachedFormSet [
+	"Answer the value of cachedFormSet"
 
-	|form i effectiveAlpha|
-	cachedForm ifNil: [
-		i := self scaledImage.
+	|forms i effectiveAlpha|
+	cachedFormSet ifNil: [
+		i := self scaledFormSet.
 		effectiveAlpha := self enabled
 			ifTrue: [self alpha]
 			ifFalse: [self alpha / 2].
 		effectiveAlpha = 1.0
-			ifTrue: [self cachedForm: i]
-			ifFalse: [form := Form extent: i extent depth: 32.
+			ifTrue: [self cachedFormSet: i]
+			ifFalse: [
+				forms := i forms collect: [ :scaledForm |
+					| form |
+					form := Form extent: scaledForm extent depth: 32.
 					form fillColor: (Color white alpha: 0.003922).
 					(form getCanvas asAlphaBlendingCanvas: effectiveAlpha)
-						drawImage: i
-					at: 0@0.
-					self cachedForm: form]].
-	^cachedForm
+						drawImage: scaledForm
+						at: 0@0.
+					form ].
+				self cachedFormSet: (FormSet extent: i extent depth: 32 forms: forms)]].
+	^cachedFormSet
 ]
 
 { #category : 'accessing' }
-AlphaImageMorph >> cachedForm: anObject [
-	"Set the value of cachedForm"
+AlphaImageMorph >> cachedFormSet: anObject [
+	"Set the value of cachedFormSet"
 
-	cachedForm := anObject
+	cachedFormSet := anObject
 ]
 
 { #category : 'initialization' }
@@ -112,7 +116,7 @@ AlphaImageMorph >> displayBounds [
 	bounds the image (may be larger/smaller than visible area).
 	Just one rep for the tiled case."
 
-	^self layoutPosition extent: self cachedForm extent
+	^self layoutPosition extent: self cachedFormSet extent
 ]
 
 { #category : 'drawing' }
@@ -121,11 +125,11 @@ AlphaImageMorph >> drawOn: aCanvas [
 	Can't do simple way since BitBlt rules are dodgy!."
 
 	aCanvas fillRectangle: self bounds fillStyle: self fillStyle borderStyle: self borderStyle.
-	(self cachedForm width = 0 or: [self cachedForm height = 0]) ifTrue: [^self].
+	(self cachedFormSet width = 0 or: [self cachedFormSet height = 0]) ifTrue: [^self].
 	self layout == #tiled
-		ifTrue: [aCanvas fillRectangle: self innerBounds fillStyle: (AlphaInfiniteForm with: self cachedForm)]
+		ifTrue: [aCanvas fillRectangle: self innerBounds fillStyle: (AlphaInfiniteForm with: self cachedFormSet asForm)]
 		ifFalse: [aCanvas clipBy: self innerBounds during: [:c |
-					c translucentImage: self cachedForm at: self layoutPosition]]
+					c translucentFormSet: self cachedFormSet at: self layoutPosition]]
 ]
 
 { #category : 'accessing' }
@@ -141,7 +145,7 @@ AlphaImageMorph >> enabled: anObject [
 
 	enabled := anObject.
 	self
-		cachedForm: nil;
+		cachedFormSet: nil;
 		changed
 ]
 
@@ -151,7 +155,7 @@ AlphaImageMorph >> extent: aPoint [
 
 	self basicExtent: aPoint.
 
-	(self layout = #scaled or: [self layout = #scaledAspect]) ifTrue: [self cachedForm: nil]
+	(self layout = #scaled or: [self layout = #scaledAspect]) ifTrue: [self cachedFormSet: nil]
 ]
 
 { #category : 'accessing' }
@@ -191,7 +195,7 @@ AlphaImageMorph >> image: aForm size: aPoint [
 		ifTrue: [super image: f]
 		ifFalse: [formSet := FormSet form: f.
 				self changed].
-	self cachedForm: nil.
+	self cachedFormSet: nil.
 	self changed: #imageExtent
 ]
 
@@ -251,7 +255,7 @@ AlphaImageMorph >> layout: aSymbol [
 	(old := layout) = aSymbol ifTrue: [^self].
 	layout := aSymbol.
 	((old = #scaled or: [old = #scaledAspect]) or: [aSymbol = #scaled or: [aSymbol = #scaledAspect]])
-		ifTrue: [self cachedForm: nil].
+		ifTrue: [self cachedFormSet: nil].
 	self changed
 ]
 
@@ -260,14 +264,14 @@ AlphaImageMorph >> layoutPosition [
 	"Answer the position that the cached form should be drawn
 	based on the layout"
 
-	self layout == #topCenter ifTrue: [^self innerBounds topCenter - (self cachedForm width // 2 @ 0)].
-	self layout == #topRight ifTrue: [^self innerBounds topRight - (self cachedForm width @ 0)].
-	self layout == #rightCenter ifTrue: [^self innerBounds rightCenter - (self cachedForm width @ (self cachedForm height // 2))].
-	self layout == #bottomRight ifTrue: [^self innerBounds bottomRight - self cachedForm extent].
-	self layout == #bottomCenter ifTrue: [^self innerBounds bottomCenter - (self cachedForm width // 2 @ self cachedForm height)].
-	self layout == #bottomLeft ifTrue: [^self innerBounds bottomLeft - (0 @ self cachedForm height)].
-	self layout == #leftCenter ifTrue: [^self innerBounds leftCenter - (0 @ (self cachedForm height // 2))].
-	(self layout == #center or: [self layout == #scaledAspect]) ifTrue: [^self innerBounds center - (self cachedForm extent // 2)].
+	self layout == #topCenter ifTrue: [^self innerBounds topCenter - (self cachedFormSet width // 2 @ 0)].
+	self layout == #topRight ifTrue: [^self innerBounds topRight - (self cachedFormSet width @ 0)].
+	self layout == #rightCenter ifTrue: [^self innerBounds rightCenter - (self cachedFormSet width @ (self cachedFormSet height // 2))].
+	self layout == #bottomRight ifTrue: [^self innerBounds bottomRight - self cachedFormSet extent].
+	self layout == #bottomCenter ifTrue: [^self innerBounds bottomCenter - (self cachedFormSet width // 2 @ self cachedFormSet height)].
+	self layout == #bottomLeft ifTrue: [^self innerBounds bottomLeft - (0 @ self cachedFormSet height)].
+	self layout == #leftCenter ifTrue: [^self innerBounds leftCenter - (0 @ (self cachedFormSet height // 2))].
+	(self layout == #center or: [self layout == #scaledAspect]) ifTrue: [^self innerBounds center - (self cachedFormSet extent // 2)].
 	^self innerBounds topLeft
 ]
 
@@ -316,7 +320,7 @@ AlphaImageMorph >> scale: aNumber [
 	scale = aNumber ifTrue: [^self].
 	scale := aNumber.
 	self
-		cachedForm: nil;
+		cachedFormSet: nil;
 		changed;
 		changed: #scale
 ]

--- a/src/Morphic-Base/FormSet.extension.st
+++ b/src/Morphic-Base/FormSet.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'FormSet' }
+
+{ #category : '*Morphic-Base' }
+FormSet >> asMorph [
+
+	^ ImageMorph withFormSet: self
+]

--- a/src/Morphic-Widgets-PolyTabs/TabSelectorMorph.class.st
+++ b/src/Morphic-Widgets-PolyTabs/TabSelectorMorph.class.st
@@ -261,7 +261,7 @@ TabSelectorMorph >> leftButtonEnabled [
 TabSelectorMorph >> leftButtonLabel [
 	"Answer the label for a button for scrolling left."
 
-	^AlphaImageMorph new image: (
+	^AlphaImageMorph new formSet: (
 		ScrollBarMorph
 			arrowOfDirection: #left
 			size: self controlButtonWidth - (3* self displayScaleFactor)
@@ -423,7 +423,7 @@ TabSelectorMorph >> rightButtonEnabled [
 TabSelectorMorph >> rightButtonLabel [
 	"Answer the label for a button for scrolling right."
 
-	^AlphaImageMorph new image: (
+	^AlphaImageMorph new formSet: (
 		ScrollBarMorph
 			arrowOfDirection: #right
 			size: self controlButtonWidth - (3 * self displayScaleFactor)

--- a/src/Morphic-Widgets-Scrolling/IncrementalSliderMorph.class.st
+++ b/src/Morphic-Widgets-Scrolling/IncrementalSliderMorph.class.st
@@ -202,7 +202,7 @@ IncrementalSliderMorph >> newButtonLabel: direction ofSize: size [
 	"Answer a new label for an inc/dec button."
 
 	^AlphaImageMorph new
-		image: (ScrollBarMorph
+		formSet: (ScrollBarMorph
 				arrowOfDirection: direction
 				size: size
 				color: self paneColor darker)

--- a/src/Morphic-Widgets-Scrolling/ScrollBarMorph.class.st
+++ b/src/Morphic-Widgets-Scrolling/ScrollBarMorph.class.st
@@ -32,7 +32,7 @@ Class {
 { #category : 'images' }
 ScrollBarMorph class >> arrowOfDirection: aSymbol size: finalSizeInteger color: aColor [
 
-	^ (self formSetArrowOfDirection: aSymbol size: finalSizeInteger color: aColor) asForm
+	^ self formSetArrowOfDirection: aSymbol size: finalSizeInteger color: aColor
 ]
 
 { #category : 'images - samples' }

--- a/src/Morphic-Widgets-Scrolling/ScrollBarMorph.class.st
+++ b/src/Morphic-Widgets-Scrolling/ScrollBarMorph.class.st
@@ -31,8 +31,8 @@ Class {
 
 { #category : 'images' }
 ScrollBarMorph class >> arrowOfDirection: aSymbol size: finalSizeInteger color: aColor [
-
-	^ self formSetArrowOfDirection: aSymbol size: finalSizeInteger color: aColor
+	"answer a FormSet with an arrow based on the parameters"
+	^ ArrowImagesCache at: {aSymbol. finalSizeInteger. aColor}
 ]
 
 { #category : 'images - samples' }
@@ -118,12 +118,6 @@ ScrollBarMorph class >> cleanUp [
 	"Re-initialize the image cache"
 
 	self initializeImagesCache
-]
-
-{ #category : 'images' }
-ScrollBarMorph class >> formSetArrowOfDirection: aSymbol size: finalSizeInteger color: aColor [
-	"answer a FormSet with an arrow based on the parameters"
-	^ ArrowImagesCache at: {aSymbol. finalSizeInteger. aColor}
 ]
 
 { #category : 'class initialization' }
@@ -242,7 +236,7 @@ ScrollBarMorph >> doScrollUp [
 ScrollBarMorph >> downImage [
 	"answer a FormSet to be used in the down button"
 	^ self class
-		formSetArrowOfDirection: (bounds isWide
+		arrowOfDirection: (bounds isWide
 				ifTrue: [#right]
 				ifFalse: [#bottom])
 		size: (self buttonExtent x min: self buttonExtent y)
@@ -1021,7 +1015,7 @@ ScrollBarMorph >> totalSliderArea [
 ScrollBarMorph >> upImage [
 	"answer a FormSet to be used in the up button"
 	^ self class
-		formSetArrowOfDirection: (bounds isWide
+		arrowOfDirection: (bounds isWide
 				ifTrue: [#left]
 				ifFalse: [#top])
 		size: (self buttonExtent x min: self buttonExtent y)

--- a/src/Polymorph-Widgets/ExpanderTitleMorph.class.st
+++ b/src/Polymorph-Widgets/ExpanderTitleMorph.class.st
@@ -61,7 +61,7 @@ ExpanderTitleMorph >> defaultBorderStyle [
 ExpanderTitleMorph >> expandLabel [
 	"Answer the label for the expand button."
 
-	^AlphaImageMorph new image: (
+	^AlphaImageMorph new formSet: (
 		ScrollBarMorph
 			arrowOfDirection: (self expanded ifTrue: [#top] ifFalse: [#bottom])
 			size: self buttonWidth - 3

--- a/src/Polymorph-Widgets/OverflowRowMorph.class.st
+++ b/src/Polymorph-Widgets/OverflowRowMorph.class.st
@@ -169,7 +169,7 @@ OverflowRowMorph >> moreButton: anObject [
 OverflowRowMorph >> moreButtonLabel [
 	"Answer the label for the more button."
 
-	^AlphaImageMorph new image: (
+	^AlphaImageMorph new formSet: (
 		ScrollBarMorph
 			arrowOfDirection: #right
 			size: self buttonWidth

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -1702,7 +1702,7 @@ UITheme >> dropListButtonLabelFor: aDropList [
 	"Answer the label for the button of the given drop list."
 
 	^AlphaImageMorph new
-		image: (ScrollBarMorph
+		formSet: (ScrollBarMorph
 			arrowOfDirection: #bottom
 			size: aDropList buttonWidth - 3 scaledByDisplayScaleFactor
 			color: aDropList paneColor darker);


### PR DESCRIPTION
Pull request #14998 refactored the ImageMorph hierarchy instance variables to use FormSet, except for ‘cachedForm’ in AlphaImageMorph. This pull request completes that to replace ‘cachedForm’ by ‘cachedFormSet’ as well. It also changes ScrollBarMorph’s `#arrowOfDirection:size:color:` to answer a FormSet for the arrow at scale 1 and 2, and changes the senders to take that into account.