### PR TITLE
Another pass on #usingMethods for UndeclaredVariable: filter for installed methods

### DIFF
--- a/src/Kernel/UndeclaredVariable.class.st
+++ b/src/Kernel/UndeclaredVariable.class.st
@@ -40,11 +40,6 @@ UndeclaredVariable class >> registeredWithName: aString [
 	^ var
 ]
 
-{ #category : 'registry' }
-UndeclaredVariable >> addUsingMethod: aCompiledMethod [
-	self usingMethods add: aCompiledMethod
-]
-
 { #category : 'queries' }
 UndeclaredVariable >> definingClass [
 	"Nobody defines undeclared variable"
@@ -97,6 +92,18 @@ UndeclaredVariable >> registerFromNode: aNode [
 	self register
 ]
 
+{ #category : 'registry' }
+UndeclaredVariable >> registerMethod: aCompiledMethod [
+	self registeredMethods add: aCompiledMethod
+]
+
+{ #category : 'queries' }
+UndeclaredVariable >> registeredMethods [
+	"We hold weakly on all compiledMethods that use this Undeclared
+	note: they might not be installed, e.g. long running method on the stack or a tool holding on to it"
+	^ self propertyAt: #registeredMethods ifAbsentPut: [ WeakIdentitySet new ]
+]
+
 { #category : 'code generation' }
 UndeclaredVariable >> runtimeUndeclaredRead [
 
@@ -125,5 +132,6 @@ UndeclaredVariable >> unregister [
 
 { #category : 'queries' }
 UndeclaredVariable >> usingMethods [
-	^ self propertyAt: #usingMethods ifAbsentPut: [ WeakIdentitySet new ]
+	"using methods returns just those that are installed in a class"
+	^ self registeredMethods select: [ :method | method isInstalled ]
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -541,7 +541,7 @@ OpalCompiler >> generateMethod [
 	ast compiledMethod: method.
 	ast 
 		propertyAt: #Undeclareds 
-		ifPresent: [:undeclareds | undeclareds do: [ :var | var addUsingMethod: method ]].
+		ifPresent: [:undeclareds | undeclareds do: [ :var | var registerMethod: method ]].
 	method propertyAt: #source put: source.
 	self compilationContext noPattern ifTrue: [
 		method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"

--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -110,7 +110,9 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariable [
 	undeclaredBinding := newCompiledMethod literals detect: [ :each | each name = #undeclaredTestVar ].
 	self assert: undeclaredBinding class equals: UndeclaredVariable.
 	self assert: undeclaredBinding identicalTo: (Undeclared associationAt: #undeclaredTestVar).
-	undeclaredBinding usingMethods includes: newCompiledMethod.
+	self assert: (undeclaredBinding registeredMethods includes: newCompiledMethod).
+	"but as the method is not installed, it is not a usingMethod"
+	self deny: (undeclaredBinding usingMethods includes: newCompiledMethod).
 	undeclaredBinding unregister
 ]
 

--- a/src/Slot-Core/SystemDictionary.extension.st
+++ b/src/Slot-Core/SystemDictionary.extension.st
@@ -13,7 +13,7 @@ SystemDictionary >> declare: key from: aDictionary [
 			[| undeclared |
 			undeclared := aDictionary associationAt: key.
 			"Undeclared variables record using methods in a property, remove. Boostrap might have used Associations"
-			(undeclared class == UndeclaredVariable) ifTrue: [undeclared removeProperty: #usingMethods ifAbsent: [ ]]. 
+			(undeclared class == UndeclaredVariable) ifTrue: [undeclared removeProperty: #registeredMethods ifAbsent: [ ]]. 
 			"and change class to be Global"
 			self add: (undeclared primitiveChangeClassTo: GlobalVariable new).
 			aDictionary removeKey: key]


### PR DESCRIPTION
- we register all methods, that includeds those who are not installed anymore
- thus implement #usingMethods to filter, call the methods stored "registeredMethods"