### PR TITLE
Monticello: Fix problem in package loading logic

### DIFF
--- a/src/Hermes/HEInstaller.class.st
+++ b/src/Hermes/HEInstaller.class.st
@@ -181,10 +181,8 @@ HEInstaller >> installMethods: exportedClass into: aClass [
 
 { #category : 'installing package' }
 HEInstaller >> installPackage: aHEPackage [
-	| storedAnnouncements |
-	
-	storedAnnouncements := SystemAnnouncer uniqueInstance suspendAllWhileStoring: [ self doInstallPackage: aHEPackage ].	
-	storedAnnouncements do: [ :e | SystemAnnouncer uniqueInstance announce: e ].
+
+	SystemAnnouncer uniqueInstance delayAnnouncementsAfter: [ self doInstallPackage: aHEPackage ]
 ]
 
 { #category : 'messages' }

--- a/src/Monticello/MCDefinition.class.st
+++ b/src/Monticello/MCDefinition.class.st
@@ -27,11 +27,6 @@ MCDefinition >> actualClass [
 	^nil
 ]
 
-{ #category : 'installing' }
-MCDefinition >> addMethodAdditionTo: aCollection [
-	self load
-]
-
 { #category : 'accessing' }
 MCDefinition >> className [
 	"Answer the class name here or nil if not applicable."

--- a/src/Monticello/MCMethodDefinition.class.st
+++ b/src/Monticello/MCMethodDefinition.class.st
@@ -124,13 +124,13 @@ MCMethodDefinition >> actualClass [
 ]
 
 { #category : 'installing' }
-MCMethodDefinition >> addMethodAdditionTo: aCollection [
+MCMethodDefinition >> asMethodAddition [
 
-	aCollection add: (MethodAddition new
-			 compile: source
-			 classified: category
-			 withStamp: timeStamp
-			 inClass: self actualClass)
+	^ MethodAddition new
+		  compile: source
+		  classified: category
+		  withStamp: timeStamp
+		  inClass: self actualClass
 ]
 
 { #category : 'accessing - backward' }

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -22,8 +22,7 @@ Class {
 		'additions',
 		'removals',
 		'errorDefinitions',
-		'provisions',
-		'methodAdditions'
+		'provisions'
 	],
 	#category : 'Monticello-Loading',
 	#package : 'Monticello',
@@ -85,6 +84,9 @@ MCPackageLoader >> basicLoadDefinitions [
 	superclass definitions before methods for subclasses but I need this NOW, and adding
 	an extra pass ensures that methods are compiled against their new class definitions."
 
+	| methodAdditions |
+	methodAdditions := OrderedCollection new.
+
 	additions do: [ :aDefinition | self loadClassDefinition: aDefinition ] displayingProgress: 'Loading classes...'.
 
 	errorDefinitions ifNotEmpty: [
@@ -106,21 +108,34 @@ MCPackageLoader >> basicLoadDefinitions [
 
 { #category : 'private' }
 MCPackageLoader >> dependencyWarning [
+
 	| packageName |
-	
-	packageName := (additions, methodAdditions) 
-		detect:  [ :each | each respondsTo: #category ]
-		ifFound: [ :aDefinition | aDefinition category ] 
-		ifNone: [ 'UNKNOWN' ].
-	
-	^ String streamContents: [ :stream|
-		stream 
-			nextPutAll: 'Package '; 
-			nextPutAll: packageName; 
-			nextPutAll: ' depends on the following classes:'; cr.
-		requirements do: [ :each | stream space; space; nextPutAll: each; cr].
-		stream nextPutAll: 'You must resolve these dependencies before you will be able to load these definitions: '; cr.
-		unloadableDefinitions do: [:ea | stream space; space; nextPutAll: ea summary; cr]] 
+	packageName := additions
+		               detect: [ :aDefinition | aDefinition isClassDefinition ]
+		               ifFound: [ :aDefinition | aDefinition packageName ]
+		               ifNone: [ 'UNKNOWN' ].
+
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: 'Package ';
+			  nextPutAll: packageName;
+			  nextPutAll: ' depends on the following classes:';
+			  cr.
+		  requirements do: [ :each |
+			  stream
+				  space;
+				  space;
+				  nextPutAll: each;
+				  cr ].
+		  stream
+			  nextPutAll: 'You must resolve these dependencies before you will be able to load these definitions: ';
+			  cr.
+		  unloadableDefinitions do: [ :ea |
+			  stream
+				  space;
+				  space;
+				  nextPutAll: ea summary;
+				  cr ] ]
 ]
 
 { #category : 'private' }
@@ -133,12 +148,11 @@ MCPackageLoader >> errorDefinitionWarning [
 
 { #category : 'initialization' }
 MCPackageLoader >> initialize [
+
 	super initialize.
 	additions := OrderedCollection new.
 	removals := OrderedCollection new.
-	obsoletions := Dictionary new.
-	methodAdditions := OrderedCollection new. 
-
+	obsoletions := Dictionary new
 ]
 
 { #category : 'public' }

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -55,14 +55,15 @@ MCPackageLoader >> addDefinition: aDefinition [
 
 { #category : 'private' }
 MCPackageLoader >> analyze [
+
 	| sorter |
 	sorter := self sorterForItems: additions.
 	additions := sorter orderedItems.
 	requirements := sorter externalRequirements.
 	unloadableDefinitions := sorter itemsWithMissingRequirements asSortedCollection.
-	
+
 	sorter := self sorterForItems: removals.
-	removals := sorter orderedItems reversed.
+	removals := sorter orderedItems reversed
 ]
 
 { #category : 'private' }
@@ -73,42 +74,19 @@ MCPackageLoader >> basicLoad [
 
 { #category : 'private' }
 MCPackageLoader >> basicLoadDefinitions [
-	"FIXME. Do a separate pass on loading class definitions as the very first thing.
-	This is a workaround for a problem with the so-called 'atomic' loading (you wish!)
-	which isn't atomic at all but mixes compilation of methods with reshapes of classes.
 
-	Since the method is not installed until later, any class reshape in the middle *will*
-	affect methods in subclasses that have been compiled before. There is probably
-	a better way of dealing with this by ensuring that the sort order of the definition lists
-	superclass definitions before methods for subclasses but I need this NOW, and adding
-	an extra pass ensures that methods are compiled against their new class definitions."
+	| methodAdditions |
+	self loadClassDefinitions.
 
-	| methodAdditions classAdditions errorDefinitions |
-	errorDefinitions := OrderedCollection new.
-	methodAdditions := OrderedCollection new.
+	methodAdditions := additions
+		                   select: [ :aDefinition | aDefinition isMethodDefinition ]
+		                   thenCollect: [ :aDefinition | aDefinition asMethodAddition ].
 
-	classAdditions := additions select: [ :aDefinition | aDefinition isClassDefinition ].
-	classAdditions
-		do: [ :aDefinition |
-			[ aDefinition load ]
-				on: Error
-				do: [ errorDefinitions add: aDefinition ] ]
-		displayingProgress: 'Loading classes...'.
-
-	errorDefinitions ifNotEmpty: [
-		self warnAboutErrors: errorDefinitions.
-		errorDefinitions do: [ :aClassDefinition | aClassDefinition load ] displayingProgress: 'Reloading erroneous definitions...' ].
-
-	additions
-		select: [ :aDefinition | aDefinition isMethodDefinition ]
-		thenDo: [ :aDefinition | methodAdditions add: aDefinition asMethodAddition ].
+	"We want to announce the addition of the methods only once all methods are loaded because the system might react to the annoucements and execute code requirement other methods from the classes we are loading."
+	SystemAnnouncer uniqueInstance delayAnnouncementsAfter: [ methodAdditions do: [ :each | each installMethod ] ].
 
 	removals do: [ :each | each unload ] displayingProgress: 'Cleaning up...'.
 
-	"Since the system is reacting to method addition, we want to announce the addition of methods only once we loaded all the methods.
-	This can be useful for example if a method defines a world menu entry (that is executed when the MethodAdded announcement is raised) and this entry relies on other methods of the class. We want all methods to be loaded before executing it."
-	(SystemAnnouncer uniqueInstance suspendAllWhileStoring: [ methodAdditions do: [ :each | each installMethod ] ]) do: [ :announcement |
-		SystemAnnouncer uniqueInstance announce: announcement ].
 	additions do: [ :each | each postloadOver: (self obsoletionFor: each) ] displayingProgress: 'Initializing...'
 ]
 
@@ -166,6 +144,41 @@ MCPackageLoader >> load [
 
 	self validate.
 	self useNewChangeSetDuring: [ self basicLoad ]
+]
+
+{ #category : 'private' }
+MCPackageLoader >> loadClassDefinitions [
+	"Here we are loading the class definitions.
+	
+	When loading a class it is possible that it fails. The reason is that a class can use a trait from this package, but the dependency sorter of Monticello does not sort those traits before the classes using it.
+	In that case we are implementing a retry mechanisme."
+
+	| errorDefinitions |
+	errorDefinitions := OrderedCollection new.
+
+	"We first load the class definitions and store the potential errors"
+	(additions select: [ :aDefinition | aDefinition isClassDefinition ])
+		do: [ :aDefinition |
+			[ aDefinition load ]
+				on: Error
+				do: [ errorDefinitions add: aDefinition ] ]
+		displayingProgress: 'Loading classes...'.
+
+	"Until we succed to fix errors, we try to install them"
+	[
+	| previousErrors |
+	previousErrors := errorDefinitions copy.
+	previousErrors
+		do: [ :aClassDefinition |
+			errorDefinitions remove: aClassDefinition.
+			[ aClassDefinition load ]
+				on: Error
+				do: [ errorDefinitions add: aClassDefinition ] ]
+		displayingProgress: 'Reloading erroneous definitions...'.
+	previousErrors size = errorDefinitions size ] whileFalse.
+
+	"Finally we warn about the errors we could not fix."
+	errorDefinitions ifNotEmpty: [ self warnAboutErrors: errorDefinitions ]
 ]
 
 { #category : 'public' }

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -85,14 +85,15 @@ MCPackageLoader >> basicLoadDefinitions [
 	superclass definitions before methods for subclasses but I need this NOW, and adding
 	an extra pass ensures that methods are compiled against their new class definitions."
 
-	additions do: [ :each | self loadClassDefinition: each ] displayingProgress: 'Loading classes...'.
+	additions do: [ :aDefinition | self loadClassDefinition: aDefinition ] displayingProgress: 'Loading classes...'.
 
-	self shouldWarnAboutErrors ifTrue: [ self warnAboutErrors ].
-	errorDefinitions do: [ :each | each addMethodAdditionTo: methodAdditions ] displayingProgress: 'Reloading erroneous definitions...'.
+	errorDefinitions ifNotEmpty: [
+		self warnAboutErrors.
+		errorDefinitions do: [ :aClassDefinition | aClassDefinition load ] displayingProgress: 'Reloading erroneous definitions...' ].
 
 	additions
 		select: [ :aDefinition | aDefinition isMethodDefinition ]
-		thenDo: [ :aDefinition | aDefinition addMethodAdditionTo: methodAdditions ].
+		thenDo: [ :aDefinition | methodAdditions add: aDefinition asMethodAddition ].
 
 	removals do: [ :each | each unload ] displayingProgress: 'Cleaning up...'.
 
@@ -206,11 +207,6 @@ MCPackageLoader >> provisions [
 MCPackageLoader >> removeDefinition: aDefinition [
 
 	removals add: aDefinition
-]
-
-{ #category : 'private' }
-MCPackageLoader >> shouldWarnAboutErrors [
-	^ errorDefinitions isEmpty not and: [false "should make this a setting ?"]
 ]
 
 { #category : 'private' }

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -21,7 +21,6 @@ Class {
 		'obsoletions',
 		'additions',
 		'removals',
-		'errorDefinitions',
 		'provisions'
 	],
 	#category : 'Monticello-Loading',
@@ -68,8 +67,8 @@ MCPackageLoader >> analyze [
 
 { #category : 'private' }
 MCPackageLoader >> basicLoad [
-    errorDefinitions := OrderedCollection new.
-    SourceFiles deferFlushDuring: [self basicLoadDefinitions].
+
+	SourceFiles deferFlushDuring: [ self basicLoadDefinitions ]
 ]
 
 { #category : 'private' }
@@ -84,13 +83,20 @@ MCPackageLoader >> basicLoadDefinitions [
 	superclass definitions before methods for subclasses but I need this NOW, and adding
 	an extra pass ensures that methods are compiled against their new class definitions."
 
-	| methodAdditions |
+	| methodAdditions classAdditions errorDefinitions |
+	errorDefinitions := OrderedCollection new.
 	methodAdditions := OrderedCollection new.
 
-	additions do: [ :aDefinition | self loadClassDefinition: aDefinition ] displayingProgress: 'Loading classes...'.
+	classAdditions := additions select: [ :aDefinition | aDefinition isClassDefinition ].
+	classAdditions
+		do: [ :aDefinition |
+			[ aDefinition load ]
+				on: Error
+				do: [ errorDefinitions add: aDefinition ] ]
+		displayingProgress: 'Loading classes...'.
 
 	errorDefinitions ifNotEmpty: [
-		self warnAboutErrors.
+		self warnAboutErrors: errorDefinitions.
 		errorDefinitions do: [ :aClassDefinition | aClassDefinition load ] displayingProgress: 'Reloading erroneous definitions...' ].
 
 	additions
@@ -138,14 +144,6 @@ MCPackageLoader >> dependencyWarning [
 				  cr ] ]
 ]
 
-{ #category : 'private' }
-MCPackageLoader >> errorDefinitionWarning [
-	^ String streamContents:
-		[:s |
-		s nextPutAll: 'The following definitions had errors while loading.  Press Proceed to try to load them again (they may work on a second pass):'; cr.
-		errorDefinitions do: [:ea | s space; space; nextPutAll: ea summary; cr]] 
-]
-
 { #category : 'initialization' }
 MCPackageLoader >> initialize [
 
@@ -168,15 +166,6 @@ MCPackageLoader >> load [
 
 	self validate.
 	self useNewChangeSetDuring: [ self basicLoad ]
-]
-
-{ #category : 'private' }
-MCPackageLoader >> loadClassDefinition: aDefinition [
-
-	[ aDefinition isClassDefinition 
-		ifTrue: [ aDefinition load ]
-	] on: Error do: [ 
-		errorDefinitions add: aDefinition ].
 ]
 
 { #category : 'public' }
@@ -280,7 +269,16 @@ MCPackageLoader >> warnAboutDependencies [
 ]
 
 { #category : 'private' }
-MCPackageLoader >> warnAboutErrors [
-	self notify: self errorDefinitionWarning.
+MCPackageLoader >> warnAboutErrors: errorDefinitions [
 
+	self notify: (String streamContents: [ :s |
+			 s
+				 nextPutAll: 'The following definitions had errors while loading.  Press Proceed to try to load them again (they may work on a second pass):';
+				 cr.
+			 errorDefinitions do: [ :ea |
+				 s
+					 space;
+					 space;
+					 nextPutAll: ea summary;
+					 cr ] ])
 ]

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -103,6 +103,14 @@ SystemAnnouncer >> classRenamed: aClass from: oldClassName to: newClassName [
 	self announce: (ClassRenamed class: aClass oldName: oldClassName newName: newClassName)
 ]
 
+{ #category : 'announce' }
+SystemAnnouncer >> delayAnnouncementsAfter: aBlock [
+	"I will execute a block and store all the announcements I am making during the execution of this block.
+	Once the execution is done, I will announce everything at once."
+
+	(self suspendAllWhileStoring: aBlock) do: [ :announcement | self announce: announcement ]
+]
+
 { #category : 'triggering' }
 SystemAnnouncer >> evaluated: textOrStream [
 	^ self evaluated: textOrStream context: nil


### PR DESCRIPTION
The MCPackageLoader is complexe and has a flawed logic.

During its execution it will try to load all classes but might fail to load classes with traits from the same package. So it retries once. But this could lead to problems if a class uses a trait that is using a trait and we are unlucky.

This PR fixes this problem.

Also I cleaned the code because some things were really bad like implementing #addMethodAdditionTo: on MethodDefinition to add a method addition to a collection and also on MCDefinition to launch the #load method.

I also fixed some warnings that could appear in the logs but had no reason to be logged since it was a flaw of Monticello loading (it was always notifying of the classes it could not load. Now it notifies only about the classes it cannot load even after the retry)

Fixes #15201