### PR TITLE
Rpackage: Extension methods should know their package

### DIFF
--- a/src/JenkinsTools-Core/HDReport.class.st
+++ b/src/JenkinsTools-Core/HDReport.class.st
@@ -22,14 +22,15 @@ HDReport class >> runPackage: aString [
 HDReport class >> runPackages: aCollectionOfStrings [
 
 	^ aCollectionOfStrings collect: [ :packageName |
-		  | time |
+		  | time result |
 		  time := DateAndTime now.
 		  Transcript << 'Beginning to run tests of ' << packageName << OSPlatform current lineEnding.
 		  "We flush so that if a crash happens during the tests, we print in which package is the naughty test in the logs."
 		  Transcript flush.
-		  self runPackage: packageName.
+		  result := self runPackage: packageName.
 		  Transcript << 'Finished to run tests of ' << packageName << ' in ' << (DateAndTime now - time) humanReadablePrintString << OSPlatform current lineEnding.
-		  Transcript flush ]
+		  Transcript flush.
+		  result ]
 ]
 
 { #category : 'private' }

--- a/src/JenkinsTools-Core/HDReport.class.st
+++ b/src/JenkinsTools-Core/HDReport.class.st
@@ -22,8 +22,14 @@ HDReport class >> runPackage: aString [
 HDReport class >> runPackages: aCollectionOfStrings [
 
 	^ aCollectionOfStrings collect: [ :packageName |
-		  Stdio stdout << 'Running tests of ' << packageName << OSPlatform current lineEnding.
-		  self runPackage: packageName ]
+		  | time |
+		  time := DateAndTime now.
+		  Transcript << 'Beginning to run tests of ' << packageName << OSPlatform current lineEnding.
+		  "We flush so that if a crash happens during the tests, we print in which package is the naughty test in the logs."
+		  Transcript flush.
+		  self runPackage: packageName.
+		  Transcript << 'Finished to run tests of ' << packageName << ' in ' << (DateAndTime now - time) humanReadablePrintString << OSPlatform current lineEnding.
+		  Transcript flush ]
 ]
 
 { #category : 'private' }

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -839,6 +839,23 @@ CompiledMethodTest >> testReadsSlot [
 	self deny: ((Point>>#setX:setY:) readsSlot: (Point slotNamed: #y))
 ]
 
+{ #category : 'tests - abstract' }
+CompiledMethodTest >> testRecompilingDoesNotRemoveExtensions [
+	"Regression test for a case where recompiling a method removed the fact that it was an extension."
+
+	[
+	| method |
+	self class compile: 'isExtensionTestMethod ^ 1' classified: '*Kernel-Tests-Generated-Package'.
+	method := self class >> #isExtensionTestMethod.
+	self assert: method isExtension.
+
+	method recompile.
+
+	self assert: method isExtension ] ensure: [
+		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
+		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
+]
+
 { #category : 'tests - accessing' }
 CompiledMethodTest >> testSelector [
 

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -479,7 +479,8 @@ CompiledMethodTest >> testIsExtension [
 	self assert: method isExtension.
 
 	self class removeSelector: #isExtensionTestMethod.
-	self deny: method isExtension ] ensure: [
+	"Now we keep the infos about extension methods even after removing them"
+	self assert: method isExtension ] ensure: [
 		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
 ]

--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -62,7 +62,7 @@ ProcessTest >> testChangingOtherPriorityAffectsScheduling [
 	self assert: val equals: #( 1 2 )
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testChangingOtherPriorityLowerDuringSemaphoreWait [
 
 	| semaphore hasBlockRun backgroundProcess |
@@ -83,7 +83,7 @@ ProcessTest >> testChangingOtherPriorityLowerDuringSemaphoreWait [
 	self assert: hasBlockRun. "Preempted as normal"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testChangingOtherPriorityPreemptsCurrentProcess [
 
 	| hasBlockRun backgroundProcess |
@@ -95,7 +95,7 @@ ProcessTest >> testChangingOtherPriorityPreemptsCurrentProcess [
 	self assert: hasBlockRun "We have been preempted."
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testChangingOtherPriorityRaiseDuringSemaphoreWait [
 
 	| semaphore hasBlockRun backgroundProcess |
@@ -114,7 +114,7 @@ ProcessTest >> testChangingOtherPriorityRaiseDuringSemaphoreWait [
 	self assert: hasBlockRun
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testChangingPriorityRespectsTheProcessPreemptionSettings [
 	"test whether #priority: preempts active process to allow higher priority processes run;
 	#priority behavior reflects the processPreemptionYields setting - for false the active

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -34,9 +34,6 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 		priorMethod := method.
 		priorOrigin := method origin ].
 
-	"For now we cannot persiste properties of methods during recompilation, so if we have an extension method, we save here the package in the new method."
-	priorMethod ifNotNil: [ priorMethod propertyAt: #extensionPackage ifPresent: [ :package | compiledMethod propertyAt: #extensionPackage put: package ] ].
-
 	oldProtocol := self protocolOfSelector: selector.
 	SystemAnnouncer uniqueInstance prevent: MethodRecategorized during: [ self classify: selector under: protocol ].
 	newProtocol := self protocolOfSelector: selector.
@@ -89,7 +86,13 @@ ClassDescription >> addSelector: selector withMethod: compiledMethod [
 
 { #category : 'accessing - method dictionary' }
 ClassDescription >> addSelectorSilently: selector withMethod: compiledMethod [
+
 	<reflection: 'Class structural modification - Selector/Method modification'>
+	self
+		compiledMethodAt: selector
+		ifPresent: [ :priorMethod | "For now we cannot persiste properties of methods during recompilation, so if we have an extension method, we save here the package in the new method."
+			priorMethod propertyAt: #extensionPackage ifPresent: [ :package | compiledMethod propertyAt: #extensionPackage put: package ] ].
+
 	super addSelectorSilently: selector withMethod: compiledMethod.
 	self instanceSide noteAddedSelector: selector meta: self isMeta
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -34,6 +34,9 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 		priorMethod := method.
 		priorOrigin := method origin ].
 
+	"For now we cannot persiste properties of methods during recompilation, so if we have an extension method, we save here the package in the new method."
+	priorMethod ifNotNil: [ priorMethod propertyAt: #extensionPackage ifPresent: [ :package | compiledMethod propertyAt: #extensionPackage put: package ] ].
+
 	oldProtocol := self protocolOfSelector: selector.
 	SystemAnnouncer uniqueInstance prevent: MethodRecategorized during: [ self classify: selector under: protocol ].
 	newProtocol := self protocolOfSelector: selector.

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -110,6 +110,10 @@ Behavior >> recompileBasic: selector from: oldClass [
 				permitFaulty: true;
 				compile.   "Assume OK after proceed from SyntaxError"
 	newMethod sourcePointer: method sourcePointer.
+	
+	"For now we cannot persiste properties of methods during recompilation, so if we have an extension method, we save here the package in the new method."
+	method propertyAt: #extensionPackage ifPresent: [ :package | newMethod propertyAt: #extensionPackage put: package ].
+
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
 	^ newMethod
 ]

--- a/src/OpalCompiler-Tests/OCCalledMethodProxy.class.st
+++ b/src/OpalCompiler-Tests/OCCalledMethodProxy.class.st
@@ -55,6 +55,13 @@ OCCalledMethodProxy >> originalMethod: anObject [
 	originalMethod := anObject
 ]
 
+{ #category : 'accessing' }
+OCCalledMethodProxy >> propertyAt: aSymbol ifPresent: aBlock [
+	"Do nothing there"
+
+	
+]
+
 { #category : 'evaluation' }
 OCCalledMethodProxy >> run: aSelector with: arguments in: aReceiver [
 

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -9,7 +9,9 @@ ClassDescription >> definedSelectors [
 ClassDescription >> extendingPackages [
 	"the extending packages of a class are the packages that extend it."
 
-	^ self packageOrganizer extendingPackagesOf: self
+	^ (self localMethods , self classSide localMethods
+		   select: #isExtension
+		   thenCollect: #extensionPackage) asIdentitySet
 ]
 
 { #category : '*RPackage-Core' }

--- a/src/RPackage-Core/CompiledCode.extension.st
+++ b/src/RPackage-Core/CompiledCode.extension.st
@@ -2,16 +2,10 @@ Extension { #name : 'CompiledCode' }
 
 { #category : '*RPackage-Core' }
 CompiledCode >> extensionPackage [
-	"Private method - Do not use it if you don't know what to do.
+	"Private method - Do not use it if you don't know what to do. 
 	In case I am in an extension, I return the package containing me. Else return nil."
 
-	| originSelector class |
-	originSelector := self originMethod selector.
-	class := self origin.
-
-	^ class extendingPackages
-		  detect: [ :extendedPackage | extendedPackage includesExtensionSelector: originSelector ofClass: class ]
-		  ifNone: [ nil ]
+	^ self originMethod propertyAt: #extensionPackage ifAbsent: [ nil ]
 ]
 
 { #category : '*RPackage-Core' }

--- a/src/RPackage-Core/CompiledMethod.extension.st
+++ b/src/RPackage-Core/CompiledMethod.extension.st
@@ -13,7 +13,7 @@ CompiledMethod >> isExtension [
 
 	"(self >> #traitSource) isExtension >>> true"
 
-	^ self extensionPackage isNotNil
+	^ self hasProperty: #extensionPackage
 ]
 
 { #category : '*RPackage-Core' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -135,9 +135,7 @@ RPackage >> addMethod: aCompiledMethod [
 			(definedSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ]
 		ifFalse: [
 			aCompiledMethod propertyAt: #extensionPackage put: self. "We tag the method as an extension method."
-			(extensionSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector.
-			"we added a method extension so the receiver is an extending package of the class"
-			self organizer registerExtendingPackage: self forClass: methodClass ].
+			(extensionSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ].
 
 	^ aCompiledMethod
 ]
@@ -623,9 +621,7 @@ RPackage >> removeAllMethodsFromClass: aClass [
 	definedSelectors removeKey: aClass ifAbsent: [  ].
 	definedSelectors removeKey: aClass classSide ifAbsent: [  ].
 	extensionSelectors removeKey: aClass ifAbsent: [  ].
-	extensionSelectors removeKey: aClass classSide ifAbsent: [  ].
-
-	self organizer unregisterExtendingPackage: self forClass: aClass
+	extensionSelectors removeKey: aClass classSide ifAbsent: [  ]
 ]
 
 { #category : 'removing' }
@@ -672,10 +668,6 @@ RPackage >> removeMethod: aCompiledMethod [
 			extensionSelectors at: methodClass ifPresent: [ :selectors |
 				selectors remove: aCompiledMethod selector ifAbsent: [  ].
 				selectors ifEmpty: [ extensionSelectors removeKey: methodClass ] ] ].
-
-	((extensionSelectors at: methodClass instanceSide ifAbsent: [ #(  ) ]) isEmpty and: [
-		 (extensionSelectors at: methodClass classSide ifAbsent: [ #(  ) ]) isEmpty ]) ifTrue: [
-		self organizer unregisterExtendingPackage: self forClass: methodClass ].
 
 	^ aCompiledMethod
 ]

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -130,8 +130,11 @@ RPackage >> addMethod: aCompiledMethod [
 	| methodClass |
 	methodClass := aCompiledMethod methodClass.
 	(self includesClass: methodClass)
-		ifTrue: [ (definedSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ]
+		ifTrue: [
+			aCompiledMethod removeProperty: #extensionPackage. "We want to make sure the method is not considered an extension."
+			(definedSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ]
 		ifFalse: [
+			aCompiledMethod propertyAt: #extensionPackage put: self. "We tag the method as an extension method."
 			(extensionSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector.
 			"we added a method extension so the receiver is an extending package of the class"
 			self organizer registerExtendingPackage: self forClass: methodClass ].

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -106,7 +106,6 @@ Class {
 	#instVars : [
 		'classPackageMapping',
 		'packages',
-		'classExtendingPackagesMapping',
 		'environment'
 	],
 	#category : 'RPackage-Core-Base',
@@ -146,7 +145,6 @@ RPackageOrganizer >> addPackage: aPackage [
 		ifTrue: [ package := RPackage named: aPackage organizer: self ]
 		ifFalse: [
 			aPackage organizer: self.
-			aPackage extendedClasses do: [ :extendedClass | self registerExtendingPackage: aPackage forClass: extendedClass ].
 			aPackage definedClasses do: [ :definedClass | self registerPackage: aPackage forClass: definedClass ].
 			package := aPackage ].
 
@@ -216,13 +214,6 @@ RPackageOrganizer >> environment: aSystemDictionary [
 	 environment := aSystemDictionary
 ]
 
-{ #category : 'package - access from class' }
-RPackageOrganizer >> extendingPackagesOf: aClass [
-	"Returns the packages extending the class aClass"
-
-	^ classExtendingPackagesMapping at: aClass instanceSide ifAbsent: [ #(  ) ]
-]
-
 { #category : 'testing' }
 RPackageOrganizer >> hasPackage: aPackage [
 	"Takes a package or a package name as parameter and return true if I include this package."
@@ -249,7 +240,6 @@ RPackageOrganizer >> initialize [
 
 	packages := IdentityDictionary new.
 	classPackageMapping := IdentityDictionary new.
-	classExtendingPackagesMapping := IdentityDictionary new.
 	self ensurePackage: UndefinedPackage new
 ]
 
@@ -362,12 +352,6 @@ RPackageOrganizer >> packagesDo: aBlock [
 ]
 
 { #category : 'private - registration' }
-RPackageOrganizer >> registerExtendingPackage: aPackage forClass: aClass [
-
-	(classExtendingPackagesMapping at: aClass instanceSide ifAbsentPut: [ IdentitySet new ]) add: aPackage
-]
-
-{ #category : 'private - registration' }
 RPackageOrganizer >> registerPackage: aPackage forClass: aClass [
 
 	(aPackage includesClass: aClass) ifFalse: [ self error: aPackage name , ' does not includes the class ' , aClass name ].
@@ -379,8 +363,8 @@ RPackageOrganizer >> removeClass: class [
 	"Remove the class, the class backpointer, the extensions and the extension backPointer from the receiver and the class involved with the class named: className. className is a class name and should not be a metaclass one. "
 
 	class isClassSide ifTrue: [ self error: 'We should only be able to remove classes and not instances of metaclass.' ].
-	(self packageOf: class) removeClass: class.
-	(self extendingPackagesOf: class) do: [ :extendedPackage | extendedPackage removeAllMethodsFromClass: class ]
+	class package removeClass: class.
+	class extendingPackages do: [ :extendedPackage | extendedPackage removeAllMethodsFromClass: class ]
 ]
 
 { #category : 'cleanup' }
@@ -458,12 +442,6 @@ RPackageOrganizer >> undefinedPackage [
 	^ self packages detect: [ :package | package isUndefined ]
 ]
 
-{ #category : 'private - registration' }
-RPackageOrganizer >> unregisterExtendingPackage: aPackage forClass: aClass [
-
-	classExtendingPackagesMapping at: aClass instanceSide ifPresent: [ :extendingPackages | extendingPackages remove: aPackage ifAbsent: [  ] ]
-]
-
 { #category : 'private' }
 RPackageOrganizer >> unregisterPackage: aPackage [
 	"I am a private method to unregister a package from myself without removing its contents fro the image."
@@ -476,7 +454,6 @@ RPackageOrganizer >> unregisterPackage: aPackage [
 		           ifFalse: [ aPackage ].
 
 	self basicUnregisterPackage: package.
-	package extendedClasses do: [ :extendedClass | self unregisterExtendingPackage: package forClass: extendedClass ].
 	package definedClasses do: [ :definedClass | self unregisterPackage: package forClass: definedClass ].
 	SystemAnnouncer announce: (PackageRemoved to: package).
 

--- a/src/RPackage-Tests/RPackageClassesSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageClassesSynchronisationTest.class.st
@@ -191,7 +191,7 @@ RPackageClassesSynchronisationTest >> testRenameClassUpdateOrganizerClassExtendi
 
 	class rename: 'RPackageNewStubClass'.
 
-	self assert: ((self organizer extendingPackagesOf: class) includes: yPackage)
+	self assert: (class extendingPackages includes: yPackage)
 ]
 
 { #category : 'tests - operations on classes' }

--- a/src/RPackage-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
@@ -194,8 +194,8 @@ RPackageExtensionMethodsSynchronisationTest >> testRemoveAllExtensionMethodsFrom
 	class removeSelector: #stubMethod.
 	class classSide removeSelector: #stubMethod2.
 	"there should be no differences made between class and metaClass:"
-	self deny: ((self organizer extendingPackagesOf: class) includes: yPackage).
-	self deny: ((self organizer extendingPackagesOf: class classSide) includes: yPackage)
+	self deny: (class extendingPackages includes: yPackage).
+	self deny: (class classSide extendingPackages includes: yPackage)
 ]
 
 { #category : 'tests - operations on methods' }

--- a/src/RPackage-Tests/RPackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/RPackageOrganizerTest.class.st
@@ -302,18 +302,6 @@ RPackageOrganizerTest >> testRegisteredPackages [
 		self assert: (self organizer packages includes: package) ]
 ]
 
-{ #category : 'tests - extending' }
-RPackageOrganizerTest >> testRegistrationExtendingPackages [
-
-	| p |
-	self newClassNamed: 'QuadrangleForTesting' in: self class package.
-	self assertEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
-	p := self ensurePackage: 'P1'.
-	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
-	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
-	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #P1
-]
-
 { #category : 'tests' }
 RPackageOrganizerTest >> testRemoveClassUsingEnvironment [
 
@@ -457,17 +445,4 @@ RPackageOrganizerTest >> testUnregister [
 		self deny: (self organizer packageNames includes: package name) ].
 
 	self assert: self organizer packageNames size equals: 1
-]
-
-{ #category : 'tests - extending' }
-RPackageOrganizerTest >> testUnregistrationExtendingPackages [
-
-	| p |
-	self newClassNamed: 'QuadrangleForTesting' in: self class package.
-	p := self ensurePackage: 'P1'.
-	self organizer registerExtendingPackage: p forClass: self quadrangleClass.
-	self denyEmpty: (self organizer extendingPackagesOf: self quadrangleClass).
-	self assert: (self organizer extendingPackagesOf: self quadrangleClass) anyOne name equals: #P1.
-	self organizer unregisterExtendingPackage: p forClass: self quadrangleClass.
-	self assertEmpty: (self organizer extendingPackagesOf: self quadrangleClass)
 ]

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -439,6 +439,7 @@ ShClassInstallerTest >> testRecompilingAClassKeepExtensionMethodsAsExtension [
 	| extensionMethod |
 	newClass := self newClass: #ShCITestClass slots: {  }.
 
+	[
 	extensionMethod := newClass compiler
 		                   protocol: '*' , self generatedClassesPackageName , '2';
 		                   install: 'billy ^ #Billy'.
@@ -449,7 +450,8 @@ ShClassInstallerTest >> testRecompilingAClassKeepExtensionMethodsAsExtension [
 	newClass := self newClass: #ShCITestClass slots: { #addedSlot }.
 
 	self assert: extensionMethod isExtension.
-	self assert: extensionMethod package name equals: self generatedClassesPackageName , '2'
+	self assert: extensionMethod package name equals: self generatedClassesPackageName , '2' ] ensure: [
+		self packageOrganizer removePackage: self generatedClassesPackageName , '2' ]
 ]
 
 { #category : 'tests' }

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -433,6 +433,26 @@ ShClassInstallerTest >> testModifyingSuperclassInOtherOrder [
 ]
 
 { #category : 'tests' }
+ShClassInstallerTest >> testRecompilingAClassKeepExtensionMethodsAsExtension [
+	"This is a regression test were recompiling a class was considering that all extension method became defined methods."
+
+	| extensionMethod |
+	newClass := self newClass: #ShCITestClass slots: {  }.
+
+	extensionMethod := newClass compiler
+		                   protocol: '*' , self generatedClassesPackageName , '2';
+		                   install: 'billy ^ #Billy'.
+
+	self assert: extensionMethod isExtension.
+	self assert: extensionMethod package name equals: self generatedClassesPackageName , '2'.
+
+	newClass := self newClass: #ShCITestClass slots: { #addedSlot }.
+
+	self assert: extensionMethod isExtension.
+	self assert: extensionMethod package name equals: self generatedClassesPackageName , '2'
+]
+
+{ #category : 'tests' }
 ShClassInstallerTest >> testTryingToModifyReadOnlyInstances [
 
 	| obj obj2 |


### PR DESCRIPTION
Now extension methods know directly their package which will speed up a lot of things. (See bellow for some examples) Those speed up will allow me to remove multiple caches in RPackage and simplify a lot the code of RPackage! 

Another change this will enable is for the methods to be able to return their package even after they are removed from the system. The next step to enable this is for the class to still know their package after removal (for non extension methods). This is planed for the next few weeks! This will also simplify and speedup more things in the future!

I'm kinda excited by all the speedup and simplifications this will allow me to do and the code to do that is not that complex.

Benches:

```st
allMethods := CompiledMethod allInstances.

[ allMethods collect: #isExtension] timeToRun. 

Before: "0:00:00:00.358"

After: "0:00:00:00.005" 

[ allMethods collect: #package ] timeToRun. 

Before: "0:00:00:00.455"

After: "0:00:00:00.195"  
```

I might add more things to this PR to start removing the caches

Edit: I added the removal of a cache. Here are the benches:

```st
allClasses := Smalltalk allClassesAndTraits.

[ allClasses collect: #extendingPackages ] timeToRun.

Before: "0:00:00:00.009"

After: "0:00:00:00.038"
```

This is slower but I think it is worth it because of the reduction of the complexity of the code and also this code is not called a lot compared to #package or #isExtension

