### PR TITLE
Improve logs while running tests

### DIFF
--- a/src/JenkinsTools-Core/HDReport.class.st
+++ b/src/JenkinsTools-Core/HDReport.class.st
@@ -22,14 +22,15 @@ HDReport class >> runPackage: aString [
 HDReport class >> runPackages: aCollectionOfStrings [
 
 	^ aCollectionOfStrings collect: [ :packageName |
-		  | time |
+		  | time result |
 		  time := DateAndTime now.
 		  Transcript << 'Beginning to run tests of ' << packageName << OSPlatform current lineEnding.
 		  "We flush so that if a crash happens during the tests, we print in which package is the naughty test in the logs."
 		  Transcript flush.
-		  self runPackage: packageName.
+		  result := self runPackage: packageName.
 		  Transcript << 'Finished to run tests of ' << packageName << ' in ' << (DateAndTime now - time) humanReadablePrintString << OSPlatform current lineEnding.
-		  Transcript flush ]
+		  Transcript flush.
+		  result ]
 ]
 
 { #category : 'private' }

--- a/src/JenkinsTools-Core/HDReport.class.st
+++ b/src/JenkinsTools-Core/HDReport.class.st
@@ -22,8 +22,14 @@ HDReport class >> runPackage: aString [
 HDReport class >> runPackages: aCollectionOfStrings [
 
 	^ aCollectionOfStrings collect: [ :packageName |
-		  Stdio stdout << 'Running tests of ' << packageName << OSPlatform current lineEnding.
-		  self runPackage: packageName ]
+		  | time |
+		  time := DateAndTime now.
+		  Transcript << 'Beginning to run tests of ' << packageName << OSPlatform current lineEnding.
+		  "We flush so that if a crash happens during the tests, we print in which package is the naughty test in the logs."
+		  Transcript flush.
+		  self runPackage: packageName.
+		  Transcript << 'Finished to run tests of ' << packageName << ' in ' << (DateAndTime now - time) humanReadablePrintString << OSPlatform current lineEnding.
+		  Transcript flush ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
The goal of the change is to improve logs while running tests.

It prints when it starts, when it ends and how long it took.

Also it now uses the Transcript instead of Stdout to be sure the logs are in the right order (because transcript is buffered). Also I flush often because if a test crashes the image while the buffer of the transcript is not flushed. we cannot know when the problem occured.