### PR TITLE
Packages: Do some cleanings 

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -275,16 +275,25 @@ Class >> category: aString [
 	any previous categorization."
 
 	| newPackage |
-
 	self flag: #package. "Should be deprecated"
 	self category = aString ifTrue: [ ^ self ].
 
 	self basicCategory: aString asSymbol.
 
-	self flag: #package. "#toTagName: should be inlined here."
 	newPackage := self packageOrganizer ensurePackageMatching: self category.
-	newPackage moveClass: self toTag: (newPackage toTagName: self category).
 
+	"The category can be
+- A tag name
+- A package name
+- A package name - a tag name
+
+We are trying to find the right one here."
+	newPackage moveClass: self toTag: ((self category beginsWith: newPackage name asString , '-')
+			 ifTrue: [ (self category allButFirst: newPackage name size + 1) asSymbol ]
+			 ifFalse: [
+				 (self category sameAs: newPackage name)
+					 ifTrue: [ newPackage rootTagName ]
+					 ifFalse: [ self category ] ])
 ]
 
 { #category : 'subclass creation' }

--- a/src/Monticello/MCClassDefinition.class.st
+++ b/src/Monticello/MCClassDefinition.class.st
@@ -283,17 +283,6 @@ MCClassDefinition >> initialize [
 	variables := OrderedCollection new
 ]
 
-{ #category : 'introspection' }
-MCClassDefinition >> instVarNamed: aString put: aValue [
-
-	self flag: #package. "temporary hack until Tonel is fixed"
-	super
-		instVarNamed: (aString = 'category'
-				 ifTrue: [ 'packageName' ]
-				 ifFalse: [ aString ])
-		put: aValue
-]
-
 { #category : 'accessing' }
 MCClassDefinition >> instVarNames [
 	^ self selectVariables: #isInstanceVariable

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -74,9 +74,9 @@ ClassDescription >> packageTag: aTag [
 
 { #category : '*RPackage-Core' }
 ClassDescription >> packageTagName [
-	"Package tags are sub categories of packages to have a better organization of the packages. I return the name of my package tag or nil if the class is uncategorized."
+	"Package tags are sub categories of packages to have a better organization of the packages. I return the name of my package tag.."
 
-	^ self packageTag ifNotNil: [ :tag | tag name ]
+	^ self packageTag name
 ]
 
 { #category : '*RPackage-Core' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -744,9 +744,6 @@ RPackage >> renameTo: aSymbol [
 	self organizer basicUnregisterPackage: self.
 	self name: aSymbol.
 
-	self flag: #package. "For now, the root tag has the name of the package, thus, renaming the package means that we need to rename the root tag. In the future I want to update the root tag name to be fix and not depend on the name of the package. When that happens, we'll be able to remove the next line."
-	self classTagNamed: oldName ifPresent: [ :tag | tag renameTo: newName ].
-
 	self flag: #package. "The next line is necessary until classes know their tag. Then it will not be needed anymore"
 	self classTags do: [ :tag | tag classes do: [ :class | class basicCategory: tag categoryName ] ].
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -814,14 +814,3 @@ RPackage >> tagOf: aClass [
 						   aClass name.
 						   self name }) ]
 ]
-
-{ #category : 'private' }
-RPackage >> toTagName: aSymbol [
-
-	^ (aSymbol beginsWith: self name asString , '-')
-		  ifTrue: [ (aSymbol allButFirst: self name size + 1) asSymbol ]
-		  ifFalse: [
-			  (aSymbol sameAs: self name)
-				  ifTrue: [ self rootTagName ]
-				  ifFalse: [ aSymbol ] ]
-]

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -157,12 +157,9 @@ RPackageTag >> promoteAsPackage [
 	"This method converts this package tag into a package"
 
 	| newPackage |
-	self flag: #package. "We need to create and register in two steps because we cannot have a package X-Y and a package X with a tag Y at the same time because of the system organizer. Once the system organizer is not here anymore, we should just do a `self organizer ensurePackage: self package name , '-' , self name` to avoid to have a manual package creation AND a registration."
-	newPackage := RPackage named: self categoryName organizer: self organizer.
+	newPackage := self organizer ensurePackage: self package name , '-' , self name.
 
-	self classes do: [ :class | newPackage moveClass: class toTag: newPackage rootTag ].
-
-	self organizer addPackage: newPackage
+	self classes do: [ :class | newPackage moveClass: class toTag: newPackage rootTag ]
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -324,8 +324,7 @@ RBNamespace >> createNewClassFor: aBehavior [
 	nonMeta := rbType existingNamed: className model: self.
 	meta := rbMetaType existingNamed: className model: self.
 	nonMeta packageName: aBehavior package name.
-	self flag: #package. "In the future we should have the undefined tag"
-	aBehavior packageTag ifNotNil: [ :tag | tag isRoot ifFalse: [ nonMeta tagName: tag name ] ].
+	aBehavior packageTag isRoot ifFalse: [ nonMeta tagName: aBehavior packageTag name ].
 	^ changedClasses at: className put: (Array with: nonMeta with: meta)
 ]
 

--- a/src/SUnit-Tests/ClassFactoryWithNonDefaultEnvironmentTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryWithNonDefaultEnvironmentTest.class.st
@@ -37,8 +37,6 @@ ClassFactoryWithNonDefaultEnvironmentTest >> testClassCreationInDifferentTags [
 { #category : 'testing' }
 ClassFactoryWithNonDefaultEnvironmentTest >> testMultipleClassCreation [
 
-	self flag: #package. "Broken because of the SystemOrganizer/PackageOrganizer mixup."
-	self skip.
 	super testMultipleClassCreation.
 	factory createdClasses do: [ :aClass | self assertEnvironmentOf: aClass ]
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -344,7 +344,6 @@ ShiftClassBuilder >> fillClassSideFromEnvironment: anEnvironment [
 { #category : 'initialization' }
 ShiftClassBuilder >> fillFor: aClass [
 
-	self flag: #package. "package tag should be improved in the future"
 	self
 		superclass: aClass superclass;
 		name: aClass getName;
@@ -357,7 +356,7 @@ ShiftClassBuilder >> fillFor: aClass [
 		installingEnvironment: aClass environment;
 		oldClass: aClass.
 
-	aClass packageTag ifNotNil: [ :aTag | aTag isRoot ifFalse: [ self tag: aTag name ] ].
+	aClass packageTag isRoot ifFalse: [ self tag: aClass packageTag name ].
 
 	self builderEnhancer fillBuilder: self from: aClass
 ]

--- a/src/SystemCommands-ClassCommands/SycCmAddSubclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmAddSubclassCommand.class.st
@@ -11,11 +11,10 @@ Class {
 { #category : 'executing' }
 SycCmAddSubclassCommand >> executeRefactoring [
 
-	self flag: #package. "Remove ifNotNil: when undefined tag will be here."
 	(RBInsertNewClassRefactoring className: newClassName)
 		superclass: targetClass asString;
 		packageName: targetClass package name;
-		tagName: (targetClass packageTag ifNotNil: [ :tag | tag name ]);
+		tagName: targetClass packageTag name;
 		execute
 ]
 

--- a/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand.class.st
@@ -12,12 +12,11 @@ Class {
 { #category : 'executing' }
 SycCmInsertSubclassCommand >> executeRefactoring [
 
-	self flag: #package. "Remove ifNotNil: when undefined tag will be here."
 	(RBInsertNewClassRefactoring className: newClassName)
 		superclass: targetClass asString;
 		subclasses: targetClass subclasses;
 		packageName: targetClass package name;
-		tagName: (targetClass packageTag ifNotNil: [ :tag | tag name ]);
+		tagName: targetClass packageTag name;
 		execute
 ]
 

--- a/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand.class.st
@@ -12,12 +12,11 @@ Class {
 { #category : 'executing' }
 SycCmInsertSuperclassCommand >> executeRefactoring [
 
-	self flag: #package. "Remove ifNotNil: when undefined tag will be here."
 	(RBInsertNewClassRefactoring className: newClassName)
 		superclass: targetClass superclass asString;
 		subclasses: { targetClass };
 		packageName: targetClass package name;
-		tagName: (targetClass packageTag ifNotNil: [ :tag | tag name ]);
+		tagName: targetClass packageTag name;
 		execute
 ]
 


### PR DESCRIPTION
This change cleans some things in the package management

- Remove some #ifNotNil: that cannot have nil now
- Remove hack in MCClassDefinition that was there for tonel
- Simplify #promoteAsPackage
- Unskip a test that does not fail anymore
- Inline #toTagName in ClassDescription>>category: because this method is bad