### PR TITLE
Calypso: Fix regression in taskbar label

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -870,6 +870,12 @@ ClyFullBrowserMorph >> switchToVariables [
 	]
 ]
 
+{ #category : 'taskbar-required' }
+ClyFullBrowserMorph >> taskbarLabel [
+
+	^ self newWindowTitle copyAfter: $:
+]
+
 { #category : 'private' }
 ClyFullBrowserMorph >> updateDefaultPackageFilter [
 


### PR DESCRIPTION
Recently I updated the title of Calypso windows to print the type of the selected itme but this made it harder to sort our windows in the taskbar morph. This change removes the selected type from the taskbar label