### PR TITLE
Calypso: Simplify ClyExtendingPackagesQuery adn clean package API

### DIFF
--- a/src/Calypso-Ring/RGMethod.extension.st
+++ b/src/Calypso-Ring/RGMethod.extension.st
@@ -37,12 +37,6 @@ RGMethod >> implementors [
 ]
 
 { #category : '*Calypso-Ring' }
-RGMethod >> isDefinedInPackage: aPackage [
-
-	^ self package = aPackage
-]
-
-{ #category : '*Calypso-Ring' }
 RGMethod >> isInstalled [
 	^ true
 ]

--- a/src/Calypso-SystemQueries/ClyExtendingPackagesQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyExtendingPackagesQuery.class.st
@@ -19,13 +19,11 @@ Class {
 
 { #category : 'execution' }
 ClyExtendingPackagesQuery >> buildResult: aQueryResult [
-	| packages classPackage |
+
+	| packages |
 	packages := IdentitySet new.
 
-	scope methodsDo: [ :eachMethod |
-		classPackage := eachMethod origin package.
-		(eachMethod isDefinedInPackage: classPackage) ifFalse: [
-			eachMethod package ifNotNil: [ :p | packages add: p]]].
+	scope methodsDo: [ :method | method isExtension ifTrue: [ packages add: method package ] ].
 
 	aQueryResult fillWith: packages
 ]
@@ -33,13 +31,9 @@ ClyExtendingPackagesQuery >> buildResult: aQueryResult [
 { #category : 'execution' }
 ClyExtendingPackagesQuery >> checkEmptyResult [
 
-	| classPackage |
-	scope methodsDo: [ :eachMethod |
-		classPackage := eachMethod origin package.
-		(eachMethod isDefinedInPackage: classPackage) ifFalse: [
-			eachMethod package ifNotNil: [ :p | ^false]]].
+	scope methodsDo: [ :method | method isExtension ifTrue: [ ^ false ] ].
 
-	^true
+	^ true
 ]
 
 { #category : 'printing' }

--- a/src/Deprecated12/ClassDescription.extension.st
+++ b/src/Deprecated12/ClassDescription.extension.st
@@ -171,6 +171,15 @@ ClassDescription >> copyCategory: protocolName from: aClass classified: newProto
 ]
 
 { #category : '*Deprecated12' }
+ClassDescription >> isDefinedInPackage: aPackage [
+
+	self
+		deprecated: 'This method will be removed because it is really specific and easy to inline. Use `receiver package = argument` instead.'
+		transformWith: '`@rcv isDefinedInPackage: `@package' -> '`@rcv package = `@package'.
+	^ self package = aPackage
+]
+
+{ #category : '*Deprecated12' }
 ClassDescription >> listAtCategoryNamed: aName [
 
 	self deprecated: 'Use #selectorsInProtocol: instead.' transformWith: '`@rcv listAtCategoryNamed: `@arg' -> '`@rcv selectorsInProtocol: `@arg'.

--- a/src/Deprecated12/CompiledMethod.extension.st
+++ b/src/Deprecated12/CompiledMethod.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : 'CompiledMethod' }
 
 { #category : '*Deprecated12' }
+CompiledMethod >> isDefinedInPackage: aPackage [
+
+	self
+		deprecated: 'This method will be removed because it is really specific and easy to inline. Use `receiver package = argument` instead.'
+		transformWith: '`@rcv isDefinedInPackage: `@package' -> '`@rcv package = `@package'.
+	^ self package = aPackage
+]
+
+{ #category : '*Deprecated12' }
 CompiledMethod >> isTaggedWith: aSymbol [
 
 	self deprecated: 'You should compare the protocol instead of using this method.' transformWith: '`@rcv isTaggedWith: `@arg' -> '`@rcv protocolName == `@arg'.

--- a/src/Deprecated12/RGBehavior.extension.st
+++ b/src/Deprecated12/RGBehavior.extension.st
@@ -7,3 +7,12 @@ RGBehavior >> addMethodTag: aSymbol [
 
 	self addProtocol: aSymbol
 ]
+
+{ #category : '*Deprecated12' }
+RGBehavior >> isDefinedInPackage: aPackage [
+
+	self
+		deprecated: 'This method will be removed because it is really specific and easy to inline. Use `receiver package = argument` instead.'
+		transformWith: '`@rcv isDefinedInPackage: `@package' -> '`@rcv package = `@package'.
+	^ self package = aPackage
+]

--- a/src/Deprecated12/RGMethod.extension.st
+++ b/src/Deprecated12/RGMethod.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'RGMethod' }
+
+{ #category : '*Deprecated12' }
+RGMethod >> isDefinedInPackage: aPackage [
+
+	self
+		deprecated: 'This method will be removed because it is really specific and easy to inline. Use `receiver package = argument` instead.'
+		transformWith: '`@rcv isDefinedInPackage: `@package' -> '`@rcv package = `@package'.
+	^ self package = aPackage
+]

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -18,13 +18,6 @@ ClassDescription >> extensionSelectors [
 ]
 
 { #category : '*RPackage-Core' }
-ClassDescription >> isDefinedInPackage: aPackage [
-	"returns true if aPackage contains the definitino of this class"
-
-	^ aPackage includesClass: self
-]
-
-{ #category : '*RPackage-Core' }
 ClassDescription >> isExtended [
 
 	^ self extendingPackages isEmpty

--- a/src/RPackage-Core/CompiledMethod.extension.st
+++ b/src/RPackage-Core/CompiledMethod.extension.st
@@ -12,8 +12,12 @@ CompiledMethod >> isExtension [
 ]
 
 { #category : '*RPackage-Core' }
-CompiledMethod >> isExtensionInPackage: anRPackage [
-	^ anRPackage includesExtensionSelector: self selector ofClass: self methodClass
+CompiledMethod >> isExtensionInPackage: aPackage [
+
+	self
+		deprecated: 'This method will be removed from future version of Pharo because it is too specific (I doubt anybody uses this) and easy to inline.'
+		transformWith: '`@rcv isExtensionInPackage: `@package' -> '`@rcv isExtension and: [ `@rcv package = `@package ]'.
+	^ self isExtension and: [ self package = aPackage ]
 ]
 
 { #category : '*RPackage-Core' }

--- a/src/RPackage-Core/CompiledMethod.extension.st
+++ b/src/RPackage-Core/CompiledMethod.extension.st
@@ -1,11 +1,6 @@
 Extension { #name : 'CompiledMethod' }
 
 { #category : '*RPackage-Core' }
-CompiledMethod >> isDefinedInPackage: anRPackage [
-	^ anRPackage includesDefinedSelector: self selector ofClass: self methodClass
-]
-
-{ #category : '*RPackage-Core' }
 CompiledMethod >> isExtension [
 	"I return true if a method is an extension method. Which means that the methods is not packaged in the package of the class containing the method, but in another package."
 

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -138,13 +138,6 @@ RPackageReadOnlyCompleteSetupTest >> testClassIsExtendedInPackage [
 ]
 
 { #category : 'tests - compiled method' }
-RPackageReadOnlyCompleteSetupTest >> testCompiledMethodIsDefinedInPackage [
-
-	self assert: (a1 >> #methodDefinedInP1 isDefinedInPackage: p1).
-	self deny: (a2 >> #methodDefinedInP1 isDefinedInPackage: p1)
-]
-
-{ #category : 'tests - compiled method' }
 RPackageReadOnlyCompleteSetupTest >> testCompiledMethodIsExtensionInPackage [
 
 	self deny: (a1 >> #methodDefinedInP1 isExtensionInPackage: p1).

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -138,13 +138,6 @@ RPackageReadOnlyCompleteSetupTest >> testClassIsExtendedInPackage [
 ]
 
 { #category : 'tests - compiled method' }
-RPackageReadOnlyCompleteSetupTest >> testCompiledMethodIsExtensionInPackage [
-
-	self deny: (a1 >> #methodDefinedInP1 isExtensionInPackage: p1).
-	self assert: (a2 >> #methodDefinedInP1 isExtensionInPackage: p1)
-]
-
-{ #category : 'tests - compiled method' }
 RPackageReadOnlyCompleteSetupTest >> testCompiledMethodPackage [
 
 	self assert: (a1 >> #methodDefinedInP1) package equals: p1.

--- a/src/Ring-RuntimeSupport/RGBehavior.extension.st
+++ b/src/Ring-RuntimeSupport/RGBehavior.extension.st
@@ -102,12 +102,6 @@ RGBehavior >> isClassSide [
 ]
 
 { #category : '*Ring-RuntimeSupport' }
-RGBehavior >> isDefinedInPackage: aPackage [
-
-	^ self package = aPackage
-]
-
-{ #category : '*Ring-RuntimeSupport' }
 RGBehavior >> isInstanceSide [
 	^self isClassSide not
 ]


### PR DESCRIPTION
This change mainly simplifies the code of ClyExtendingPackagesQuery to make it easier to understand and faster (At least it will be faster when #15212 will be integrated).

I also deprecated #isDefinedInPackage: because it the bahavuior was unclear and it is easy to do without this method polluting the API (and it is not used).

Thie behavior was unclear because in some part of the systemit returned true if the entity was in the package as parameter while in other part it returned true if the entity was in the package AND was not an extension (extensions could never return true)