### PR TITLE
Calypso: Fix taskbar label

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -873,7 +873,7 @@ ClyFullBrowserMorph >> switchToVariables [
 { #category : 'taskbar-required' }
 ClyFullBrowserMorph >> taskbarLabel [
 
-	^ self newWindowTitle copyAfter: $:
+	^ self newWindowTitle copyAfter: Character space
 ]
 
 { #category : 'private' }

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -873,7 +873,9 @@ ClyFullBrowserMorph >> switchToVariables [
 { #category : 'taskbar-required' }
 ClyFullBrowserMorph >> taskbarLabel [
 
-	^ self newWindowTitle copyAfter: Character space
+	| title |
+	title := self newWindowTitle.
+	^ title allButFirst: (title findString: ': ')
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
After #15220, the taskbar label still had an extraneous leading whitespace.
<img width="200" alt="image" src="https://github.com/pharo-project/pharo/assets/78592838/88808dbb-2017-4a99-8b88-b2252a4be960">
<img width="200" alt="image" src="https://github.com/pharo-project/pharo/assets/78592838/cb07a2b9-e05d-4fc7-ba78-8d0efd48fc41">
