### PR TITLE
[WIP] Redo "Revert "Deprecate String>>asDate""

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -436,17 +436,6 @@ StringTest >> testAsCamelCase [
 ]
 
 { #category : 'tests' }
-StringTest >> testAsDate [
-
-	self assert: 'Jan 1 2015' asDate asString equals: '1 January 2015'.
-	self assert: '1/1/2015' asDate asString equals: '1 January 2015'.
-	self assert: '1 1 1' asDate asString equals: '1 January 2001'.
-	self assert: '1 J 1' asDate asString equals: '1 January 2001'.
-	self should: [ '' asDate ] raise: Error.
-	self should: [ '1234' asDate ] raise: Error
-]
-
-{ #category : 'tests' }
 StringTest >> testAsHTMLString [
 
 	self assert: '<a>' asHTMLString equals: '&lt;a&gt;'.

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -636,7 +636,7 @@ String >> asComment [
 { #category : 'converting' }
 String >> asDate [
 	"Many allowed forms, see Date>>#readFrom:"
-
+	self deprecated: 'Use Date>>#readFrom:pattern: specifying a concrete pattern instead.'.
 	^ Date fromString: self
 ]
 

--- a/src/FileSystem-Disk/DiskStore.class.st
+++ b/src/FileSystem-Disk/DiskStore.class.st
@@ -35,7 +35,7 @@ DiskStore class >> checkVMVersion [
 	"Display a warning if the VM is too old"
 	| displayError |
 	displayError := [ ^ self inform: 'Your VM is too old for this image. Please download the latest VM.' ].
-	[(Smalltalk vm interpreterSourceDate >= '2019-01-05' asDate)
+	[(Smalltalk vm interpreterSourceDate >= (Date readFrom: '5-1-2019' pattern: 'd-m-y'))
 		ifFalse: [ displayError value ]
 	] on: Error do: [ :e| displayError value ]
 ]

--- a/src/Kernel-Chronology-Extras/Date.extension.st
+++ b/src/Kernel-Chronology-Extras/Date.extension.st
@@ -74,6 +74,7 @@ Date class >> firstWeekdayOfMonth: month year: year [
 { #category : '*Kernel-Chronology-Extras' }
 Date class >> fromString: aString [
 	"Answer an instance of created from a string with format mm.dd.yyyy or mm-dd-yyyy or mm/dd/yyyy"
+	self deprecated: 'Use Date>>#readFrom:pattern: specifying a concrete pattern instead.'.
 
 	^ self readFrom: aString readStream
 ]
@@ -228,6 +229,10 @@ Date class >> readFrom: aStream [
 		<month> <day> <year>		(April 15, 1982; 4/15/82)
 		<year>-<month>-<day>			(1982-04-15) (ISO8601)"
 	| day month year parsedNumber prefix |
+	
+	self deprecated: 'Use Date>>#readFrom:pattern: specifying a concrete pattern instead.'.
+
+	
 	aStream peek = $-
 		ifTrue: [prefix := -1]
 		ifFalse: [prefix := 1].
@@ -260,7 +265,6 @@ Date class >> readFrom: aStream [
 				ifNil: ["MM-DD-YY or DD-MM-YY"
 					parsedNumber > 12
 						ifTrue: ["DD-MM-YY"
-							Error signal: 'Month out of bounds: ', parsedNumber asString, '.'.
 							day := parsedNumber.
 							month := Month nameOfMonth: (Integer readFrom: aStream) ]
 						ifFalse: ["MM-DD-YY"
@@ -302,7 +306,7 @@ Date >> storeOn: aStream [
 { #category : '*Kernel-Chronology-Extras' }
 Date >> subtractDate: aDate [
 	"Answer the number of days between self and aDate"
-	"((Date year: 2018 month: 9 day: 28) subtractDate: '27 September 2018') >>> 1"
+	"((Date year: 2018 month: 9 day: 28) subtractDate: '2018-09-27') >>> 1"
 
 	^ (self start - aDate asDateAndTime) days
 ]

--- a/src/Kernel-Chronology-Extras/DateAndTime.extension.st
+++ b/src/Kernel-Chronology-Extras/DateAndTime.extension.st
@@ -424,7 +424,9 @@ DateAndTime class >> readFrom: aStream defaultOffset: defaultOffset [
 	"self readFrom: '2013-03-04T23:47:52.876+01:00' readStream"
 
 	| date time offset |
-	date := Date readFrom: aStream.
+	date := (DateParser readingFrom: aStream pattern: 'y-mm-dd')
+		        continueAfterParsing;
+		        parse.
 	[ aStream atEnd or: [ '0123456789Z+-' includes: aStream peek ] ]
 		whileFalse: [ aStream next ].
   	('0123456789' includes: aStream peek)
@@ -465,7 +467,9 @@ DateAndTime class >> readSeparateDateAndTimeFrom: stream [
 
 	| date time |
 	stream skipSeparators.
-	date := Date readFrom: stream.
+	date := (DateParser readingFrom: stream pattern: 'yyyy-mm-dd')
+		        continueAfterParsing;
+		        parse.
 	stream skipSeparators.
 	time := Time readFrom: stream.
 	^ self

--- a/src/Kernel-Chronology-Extras/DateParser.class.st
+++ b/src/Kernel-Chronology-Extras/DateParser.class.st
@@ -28,7 +28,8 @@ Class {
 		'year',
 		'month',
 		'day',
-		'invalidPattern'
+		'invalidPattern',
+		'shouldParseAll'
 	],
 	#category : 'Kernel-Chronology-Extras',
 	#package : 'Kernel-Chronology-Extras'
@@ -41,6 +42,12 @@ DateParser class >> readingFrom: anInputStream pattern: aPattern [
 	self comment"
 
 	^self new initializeReadingFrom: anInputStream pattern: aPattern
+]
+
+{ #category : 'initialization' }
+DateParser >> continueAfterParsing [
+
+	shouldParseAll := false
 ]
 
 { #category : 'private - parsing' }
@@ -70,6 +77,7 @@ DateParser >> initializeParsing [
 { #category : 'initialization' }
 DateParser >> initializeReadingFrom: anInputStream pattern: aPattern [
 
+	shouldParseAll := true.
 	inputStream := anInputStream.
 	pattern := aPattern
 ]
@@ -183,7 +191,8 @@ DateParser >> parseIfError: aBlock [
 	self isInvalidPattern ifTrue: [ aBlock value ].
 	self convertTwoDigitsYear.
 
-	(inputStream atEnd and: [ patternStream atEnd ]) ifFalse: [ DateError signal: 'Input doesn''t match given pattern.' ].
+	(shouldParseAll and: [
+	inputStream atEnd not or: [ patternStream atEnd not ] ]) ifTrue: [ DateError signal: 'Input doesn''t match given pattern.' ].
 
 	^ self createDate
 ]

--- a/src/Kernel-Tests-Extended/DateAndTimeDosEpochTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeDosEpochTest.extension.st
@@ -9,10 +9,10 @@ DateAndTimeDosEpochTest >> testAsMonth [
 
 { #category : '*Kernel-Tests-Extended' }
 DateAndTimeDosEpochTest >> testAsWeek [
-	self assert: aDateAndTime asWeek equals: (Week starting: '12-31-1979' asDate)
+	self assert: aDateAndTime asWeek equals: (Week starting: (Date readFrom: '31-12-1979' pattern: 'd-m-y'))
 ]
 
 { #category : '*Kernel-Tests-Extended' }
 DateAndTimeDosEpochTest >> testAsYear [
-	self assert: aDateAndTime asYear equals: (Year starting: '01-01-1980' asDate)
+	self assert: aDateAndTime asYear equals: (Year starting: (Date readFrom: '1-1-1980' pattern: 'd-m-y'))
 ]

--- a/src/Kernel-Tests-Extended/DateAndTimeEpochTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeEpochTest.extension.st
@@ -9,10 +9,10 @@ DateAndTimeEpochTest >> testAsMonth [
 
 { #category : '*Kernel-Tests-Extended' }
 DateAndTimeEpochTest >> testAsWeek [
-	self assert: aDateAndTime asWeek equals: (Week starting: '12-31-1900' asDate)
+	self assert: aDateAndTime asWeek equals: (Week starting: (Date readFrom: '31-12-1900' pattern: 'd-m-y'))
 ]
 
 { #category : '*Kernel-Tests-Extended' }
 DateAndTimeEpochTest >> testAsYear [
-	self assert: aDateAndTime asYear equals: (Year starting: '01-01-1901' asDate)
+	self assert: aDateAndTime asYear equals: (Year starting: (Date readFrom: '1-1-1901' pattern: 'd-m-y'))
 ]

--- a/src/Kernel-Tests-Extended/DateAndTimeLeapTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeLeapTest.extension.st
@@ -9,7 +9,7 @@ DateAndTimeLeapTest >> testAsMonth [
 
 { #category : '*Kernel-Tests-Extended' }
 DateAndTimeLeapTest >> testAsWeek [
-	self assert: aDateAndTime asWeek equals: ((Week starting: '02-29-2004' asDate) translateTo: 2 hours)
+	self assert: aDateAndTime asWeek equals: ((Week starting: (Date readFrom: '29-2-2004' pattern: 'd-m-y')) translateTo: 2 hours)
 ]
 
 { #category : '*Kernel-Tests-Extended' }
@@ -17,8 +17,8 @@ DateAndTimeLeapTest >> testAsYear [
 	"A year always starts at January 1"
 	self
 		assert: aDateAndTime asYear
-		equals: ((Year starting: '02-29-2004' asDate) translateTo: 2 hours ).
+		equals: ((Year starting: (Date readFrom: '29-2-2004' pattern: 'd-m-y')) translateTo: 2 hours ).
 	self
 		assert: aDateAndTime asYear
-		equals: ((Year starting: '01-01-2004' asDate) translateTo: 2 hours)
+		equals: ((Year starting: (Date readFrom: '29-2-2004' pattern: 'd-m-y')) translateTo: 2 hours)
 ]

--- a/src/Kernel-Tests-Extended/DateAndTimeUnixEpochTest.extension.st
+++ b/src/Kernel-Tests-Extended/DateAndTimeUnixEpochTest.extension.st
@@ -9,10 +9,10 @@ DateAndTimeUnixEpochTest >> testAsMonth [
 
 { #category : '*Kernel-Tests-Extended' }
 DateAndTimeUnixEpochTest >> testAsWeek [
-	self assert: aDateAndTime asWeek equals: (Week starting: '12-31-1969' asDate)
+	self assert: aDateAndTime asWeek equals: (Week starting: (Date readFrom: '31-12-1969' pattern: 'd-m-y'))
 ]
 
 { #category : '*Kernel-Tests-Extended' }
 DateAndTimeUnixEpochTest >> testAsYear [
-	self assert: aDateAndTime asYear equals: (Year starting: '01-01-1970' asDate)
+	self assert: aDateAndTime asYear equals: (Year starting: (Date readFrom: '1-1-1970' pattern: 'd-m-y'))
 ]

--- a/src/Kernel-Tests-Extended/DosTimestampTest.class.st
+++ b/src/Kernel-Tests-Extended/DosTimestampTest.class.st
@@ -14,14 +14,14 @@ DosTimestampTest >> testAsDateAndTime [
 
 	| timestamp |
 	timestamp := DosTimestamp on: 16r40B57856.
-	self assert: timestamp asDateAndTime equals: '21 May 2012 3:02:44 pm' asDateAndTime
+	self assert: timestamp asDateAndTime equals: '2012-05-21T15:02:44' asDateAndTime
 ]
 
 { #category : 'tests' }
 DosTimestampTest >> testFromDateAndTime [
 
 	| timestamp |
-	timestamp := DosTimestamp fromDateAndTime: '21 May 2012 3:02:44 pm' asDateAndTime.
+	timestamp := DosTimestamp fromDateAndTime: '2012-05-21T15:02:44pm' asDateAndTime.
 
 	self assert: timestamp value equals: 16r40B57856
 ]

--- a/src/Kernel-Tests-Extended/MonthTest.class.st
+++ b/src/Kernel-Tests-Extended/MonthTest.class.st
@@ -46,7 +46,7 @@ MonthTest >> tearDown [
 
 { #category : 'tests' }
 MonthTest >> testConverting [
-	self assert: month asDate equals: '1 July 1998' asDate
+	self assert: month asDate equals: (Date readFrom: '1-7-1998' pattern: 'd-m-y')
 ]
 
 { #category : 'tests' }
@@ -54,7 +54,7 @@ MonthTest >> testEnumerating [
 	| weeks |
 	weeks := OrderedCollection new.
 	month weeksDo: [ :w | weeks add: w start ].
-	0 to: 4 do: [ :i | weeks remove: (Week starting: ('29 June 1998' asDate addDays: i * 7)) start ].
+	0 to: 4 do: [ :i | weeks remove: (Week starting: ((Date readFrom: '29-6-1998' pattern: 'd-m-y') addDays: i * 7)) start ].
 	self assertEmpty: weeks
 ]
 
@@ -108,7 +108,7 @@ MonthTest >> testInquiries [
 { #category : 'tests' }
 MonthTest >> testInstanceCreation [
 	| m1 m2 |
-	m1 := Month starting: '4 July 1998' asDate.
+	m1 := Month starting: (Date readFrom: '4-7-1998' pattern: 'd-m-y').
 	m2 := Month year: 1998 month: #July.
 	self
 		assert: month equals: m1;
@@ -133,7 +133,7 @@ MonthTest >> testOffset [
 
 	| dt newMonth |
 
-	dt := DateAndTime fromString: '2018/01/01T00:00:00+10'.
+	dt := DateAndTime fromString: '2018-01-01T00:00:00+10'.
 	newMonth := Month starting: dt duration: 0. "duration is ignored"
 	self assert: newMonth asDateAndTime offset equals: dt offset
 ]

--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -9,7 +9,7 @@ Class {
 	#tag : 'Processes'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 ProcessTest >> setUp [
 	super setUp.
 
@@ -634,7 +634,7 @@ ProcessTest >> testNormalProcessWithArgsCompletionWithLeftEffectiveProcess [
 	effectiveProcess terminate
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testProcessFaithfulTermination [
 	"When terminating a process, unwind blocks should be evaluated as if they were executed by the process being terminated."
 
@@ -648,7 +648,7 @@ ProcessTest >> testProcessFaithfulTermination [
 	self assert: process isTerminated
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testRealActiveProcessFromProcesor [
 
 	| processFromProcessor activeProcess |
@@ -755,7 +755,7 @@ ProcessTest >> testTerminateAnswersSelf [
 	self assert: process isTerminated
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testTerminateInTerminate [
 	"Terminating a terminator process should unwind both the terminator and its terminatee process"
 	
@@ -775,7 +775,7 @@ ProcessTest >> testTerminateInTerminate [
 	self assert: unwound
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testTerminationShouldProceedAllEnsureBlocksIfSomeWasFailed [
 "
 	<expectedFailure>

--- a/src/Kernel-Tests-Extended/WeekTest.class.st
+++ b/src/Kernel-Tests-Extended/WeekTest.class.st
@@ -38,7 +38,7 @@ WeekTest >> setUp [
 	super setUp.
 	restoredStartDay := Week startDay.
 	Week startDay: #Sunday.
-	week := Week starting: '4 July 1998' asDate
+	week := Week starting: (Date readFrom: '4-7-1998' pattern: 'd-m-y')
 ]
 
 { #category : 'running' }
@@ -85,7 +85,7 @@ WeekTest >> testDayNames [
 WeekTest >> testEnumerating [
 	| days |
 	days := OrderedCollection new.
-	0 to: 6 do: [ :i | days add: ('28 June 1998' asDate addDays: i) ].
+	0 to: 6 do: [ :i | days add: ((Date readFrom: '28-6-1998' pattern: 'd-m-y') addDays: i) ].
 
 	week datesDo: [ :d | days remove: d ].
 
@@ -110,8 +110,8 @@ WeekTest >> testIndexOfDay [
 { #category : 'tests' }
 WeekTest >> testInquiries [
 	self
-		assert: week start asDate equals: '28 June 1998' asDate;
-		assert: week end asDate equals: '4 July 1998' asDate;
+		assert: week start asDate equals: (Date readFrom: '28-6-1998' pattern: 'd-m-y');
+		assert: week end asDate equals: (Date readFrom: '4-7-1998' pattern: 'd-m-y');
 		assert: week index equals: 5;
 		assert: week duration equals: 7 days
 ]
@@ -134,7 +134,7 @@ WeekTest >> testOffset [
 
 	| dt newWeek |
 
-	dt := DateAndTime fromString: '2018/01/01T00:00:00+10'.
+	dt := DateAndTime fromString: '2018-01-01T00:00:00+10'.
 	newWeek := Week starting: dt duration: 0. "duration is ignored"
 	self assert: newWeek asDateAndTime offset equals: dt offset
 ]
@@ -142,6 +142,6 @@ WeekTest >> testOffset [
 { #category : 'tests' }
 WeekTest >> testPreviousNext [
 	self
-		assert: week next equals: (Week starting: '6 July 1998' asDate);
-		assert: week previous equals: (Week starting: '22 June 1998' asDate)
+		assert: week next equals: (Week starting: (Date readFrom: '6-7-1998' pattern: 'd-m-y'));
+		assert: week previous equals: (Week starting: (Date readFrom: '22-6-1998' pattern: 'd-m-y'))
 ]

--- a/src/Kernel-Tests-Extended/YearTest.class.st
+++ b/src/Kernel-Tests-Extended/YearTest.class.st
@@ -33,7 +33,7 @@ YearTest >> testOffset [
 
 	| dt newYear |
 
-	dt := DateAndTime fromString: '2018/01/01T00:00:00+10'.
+	dt := DateAndTime fromString: '2018-01-01T00:00:00+10'.
 	newYear := Year starting: dt duration: 0. "duration is ignored"
 	self assert: newYear asDateAndTime offset equals: dt offset
 ]

--- a/src/Kernel-Tests/DateAndTimeDosEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeDosEpochTest.class.st
@@ -35,7 +35,7 @@ DateAndTimeDosEpochTest >> tearDown [
 
 { #category : 'tests' }
 DateAndTimeDosEpochTest >> testAsDate [
-	self assert: aDateAndTime asDate equals: 'January 1, 1980' asDate
+	self assert: aDateAndTime asDate equals: (Date readFrom: '1-1-1980' pattern: 'd-m-y') 
 ]
 
 { #category : 'tests' }
@@ -81,7 +81,7 @@ DateAndTimeDosEpochTest >> testCurrent [
 
 { #category : 'tests' }
 DateAndTimeDosEpochTest >> testDateTime [
-	self assert: aDateAndTime equals: (DateAndTime date: '01-01-1980' asDate time: '00:00:00' asTime)
+	self assert: aDateAndTime equals: (DateAndTime date: (Date readFrom: '1-1-1980' pattern: 'd-m-y') time: '00:00:00' asTime)
 ]
 
 { #category : 'tests' }
@@ -153,10 +153,10 @@ DateAndTimeDosEpochTest >> testFromSeconds [
 
 { #category : 'tests' }
 DateAndTimeDosEpochTest >> testFromString [
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1980-01-01T00:00:00+00:00').
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1980-01-01T00:00:00').
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1980-01-01T00:00').
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1980-01-01T00:00:00+00:00')
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1980-01-01T00:00:00+00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1980-01-01T00:00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1980-01-01T00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1980-01-01T00:00:00+00:00')
 ]
 
 { #category : 'tests' }
@@ -202,7 +202,7 @@ DateAndTimeDosEpochTest >> testMeridianAbbreviation [
 { #category : 'tests' }
 DateAndTimeDosEpochTest >> testMiddleOf [
 	self assert: (aDateAndTime middleOf: '2:00:00:00' asDuration)
-	     equals: (Timespan starting: '12-31-1979' asDate duration: 2 days)
+	     equals: (Timespan starting: (Date readFrom: '31-12-1979' pattern: 'd-m-y') duration: 2 days)
 ]
 
 { #category : 'tests' }

--- a/src/Kernel-Tests/DateAndTimeEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeEpochTest.class.st
@@ -46,7 +46,7 @@ DateAndTimeEpochTest >> tearDown [
 
 { #category : 'tests' }
 DateAndTimeEpochTest >> testAsDate [
-	self assert: aDateAndTime asDate equals: 'January 1, 1901' asDate
+	self assert: aDateAndTime asDate equals: (Date readFrom: '1-1-1901' pattern: 'd-m-y')
 ]
 
 { #category : 'tests' }
@@ -92,7 +92,7 @@ DateAndTimeEpochTest >> testCurrent [
 
 { #category : 'tests' }
 DateAndTimeEpochTest >> testDateTime [
-	self assert: aDateAndTime equals: (DateAndTime date: '01-01-1901' asDate time: '00:00:00' asTime)
+	self assert: aDateAndTime equals: (DateAndTime date: (Date readFrom: '1-1-1901' pattern: 'd-m-y') time: '00:00:00' asTime)
 ]
 
 { #category : 'tests' }
@@ -164,10 +164,10 @@ DateAndTimeEpochTest >> testFromSeconds [
 
 { #category : 'tests' }
 DateAndTimeEpochTest >> testFromString [
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1901-01-01T00:00:00+00:00').
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1901-01-01T00:00:00').
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1901-01-01T00:00').
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1901-01-01T00:00:00+00:00')
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1901-01-01T00:00:00+00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1901-01-01T00:00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1901-01-01T00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1901-01-01T00:00:00+00:00')
 ]
 
 { #category : 'tests' }
@@ -212,7 +212,7 @@ DateAndTimeEpochTest >> testMeridianAbbreviation [
 
 { #category : 'tests' }
 DateAndTimeEpochTest >> testMiddleOf [
-	self assert: (aDateAndTime middleOf: '2:00:00:00' asDuration) equals: (Timespan starting: '12-31-1900' asDate duration: 2 days)
+	self assert: (aDateAndTime middleOf: '2:00:00:00' asDuration) equals: (Timespan starting: (Date readFrom: '31-12-1900' pattern: 'd-m-y') duration: 2 days)
 ]
 
 { #category : 'tests' }

--- a/src/Kernel-Tests/DateAndTimeLeapTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeLeapTest.class.st
@@ -32,7 +32,7 @@ DateAndTimeLeapTest >> setUp [
 
 { #category : 'tests' }
 DateAndTimeLeapTest >> testAsDate [
-	self assert: aDateAndTime asDate equals:  ('February 29, 2004' asDate translateTo: 2 hours)
+	self assert: aDateAndTime asDate equals:  ((Date readFrom: '29-2-2004' pattern: 'd-m-y') translateTo: 2 hours)
 ]
 
 { #category : 'tests' }
@@ -121,7 +121,7 @@ DateAndTimeLeapTest >> testFirstDayOfMonth [
 
 { #category : 'tests' }
 DateAndTimeLeapTest >> testFromString [
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 2004-02-29T13:33:00+02:00')
+	self assert: aDateAndTime equals: (DateAndTime fromString: '2004-02-29T13:33:00+02:00')
 ]
 
 { #category : 'tests' }

--- a/src/Kernel-Tests/DateAndTimeTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeTest.class.st
@@ -43,7 +43,7 @@ DateAndTimeTest >> testArithmeticAcrossDateBoundary [
 DateAndTimeTest >> testAsDos [
 
 	| remoteDatetime |
-	self assert: '21 May 2012 3:02:44 pm' asDateAndTime asDosTimestamp equals: 16r40B57856.
+	self assert: '2012-05-21T15:02:44' asDateAndTime asDosTimestamp equals: 16r40B57856.
 
 	"DOS times are in local time per http://blogs.msdn.com/b/oldnewthing/archive/2003/09/05/54806.aspx"
 	remoteDatetime := DateAndTime current offset: DateAndTime localOffset + 2 hours.
@@ -174,13 +174,13 @@ DateAndTimeTest >> testDayOfWeekWithUTC [
 DateAndTimeTest >> testDosEpoch [
 	self
 		useNonUtcTimeZoneDuring: [ | localEpoch |
-			localEpoch := '1 January 1980 00:00' asDateAndTime.
+			localEpoch := '1980-01-01T00:00' asDateAndTime.
 			self deny: DateAndTime dosEpoch equals: localEpoch ].
 
 	self
 		useTimeZone: 'UTC'
 		during: [ | localEpoch |
-			localEpoch := '1 January 1980 00:00' asDateAndTime.
+			localEpoch := '1980-01-01T00:00' asDateAndTime.
 			self assert: DateAndTime dosEpoch equals: localEpoch ].
 
 	self assert: DateAndTime dosEpoch equals: '1980-01-01T00:00:00+00:00' asDateAndTime
@@ -204,7 +204,7 @@ DateAndTimeTest >> testFromDos [
 
 	| aDateAndTime |
 	aDateAndTime := DateAndTime fromDosTimestamp: 16r40B57856.
-	self assert: aDateAndTime equals:  '21 May 2012 3:02:44 pm' asDateAndTime.
+	self assert: aDateAndTime equals:  '2012-05-21T15:02:44' asDateAndTime.
 
 	"DOS times are in local time per http://blogs.msdn.com/b/oldnewthing/archive/2003/09/05/54806.aspx"
 	self assert: aDateAndTime offset equals: DateAndTime localOffset
@@ -342,11 +342,11 @@ DateAndTimeTest >> testPrintString [
 		offset: (Duration seconds: 5 * 3600).
 	self assert: dt printString equals: '2004-11-02T14:03:05.000012345+05:00'.
 	self assert: '2002-05-16T17:20:45.1+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.1+01:01'.
-	self assert: ' 2002-05-16T17:20:45.02+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.02+01:01'.
+	self assert: '2002-05-16T17:20:45.02+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.02+01:01'.
 	self assert: '2002-05-16T17:20:45.000000009+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.000000009+01:01'.
 	self assert: '2002-05-16T17:20:45+00:00' asDateAndTime printString equals: '2002-05-16T17:20:45+00:00'.
-	self assert: ' 2002-05-16T17:20:45+01:57' asDateAndTime printString equals: '2002-05-16T17:20:45+01:57'.
-	self assert: ' 2002-05-16T17:20:45-02:34' asDateAndTime printString equals: '2002-05-16T17:20:45-02:34'.
+	self assert: '2002-05-16T17:20:45+01:57' asDateAndTime printString equals: '2002-05-16T17:20:45+01:57'.
+	self assert: '2002-05-16T17:20:45-02:34' asDateAndTime printString equals: '2002-05-16T17:20:45-02:34'.
 	self assert: '2002-05-16T17:20:45+00:00' asDateAndTime printString equals: '2002-05-16T17:20:45+00:00'.
 	self assert: '1997-04-26T01:02:03+01:02:3' asDateAndTime printString equals: '1997-04-26T01:02:03+01:02:3'.
 	"When no offset is provided, the local one is used"
@@ -375,8 +375,8 @@ DateAndTimeTest >> testPrintStringSecond [
 	self assert: '2002-05-16T17:20:45.1+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.1+01:01'.
 	self assert: '2002-05-16T17:20:45.02+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.02+01:01'.
 	self assert: '2002-05-16T17:20:45.000000009+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.000000009+01:01'.
-	self assert: ' 2002-05-16T17:20:45+01:57' asDateAndTime printString equals: '2002-05-16T17:20:45+01:57'.
-	self assert: ' 2002-05-16T17:20:45-02:34' asDateAndTime printString equals: '2002-05-16T17:20:45-02:34'.
+	self assert: '2002-05-16T17:20:45+01:57' asDateAndTime printString equals: '2002-05-16T17:20:45+01:57'.
+	self assert: '2002-05-16T17:20:45-02:34' asDateAndTime printString equals: '2002-05-16T17:20:45-02:34'.
 	self assert: '2002-05-16T17:20:45+00:00' asDateAndTime printString equals: '2002-05-16T17:20:45+00:00'.
 	self assert: '1997-04-26T01:02:03+01:02:3' asDateAndTime printString equals: '1997-04-26T01:02:03+01:02:3'
 ]
@@ -391,22 +391,22 @@ DateAndTimeTest >> testReadFrom [
 		assert: '2002-05-16T17:20:45.1+01:01' asDateAndTime printString
 		equals:  '2002-05-16T17:20:45.1+01:01'.
 	self
-		assert:	' 2002-05-16T17:20:45.02+01:01' asDateAndTime printString
+		assert:	'2002-05-16T17:20:45.02+01:01' asDateAndTime printString
 		equals:  '2002-05-16T17:20:45.02+01:01'.
 	self
 		assert:	'2002-05-16T17:20:45.000000009+01:01' asDateAndTime printString
 		equals:   '2002-05-16T17:20:45.000000009+01:01'.
 	self
-		assert: ' 2002-05-16T17:20' asDateAndTime translateToUTC printString
+		assert: '2002-05-16T17:20' asDateAndTime translateToUTC printString
 		equals:  '2002-05-16T17:20:00+00:00'.
 	self
 		assert: '2002-05-16T17:20:45' asDateAndTime translateToUTC printString
 		equals:  '2002-05-16T17:20:45+00:00' .
 	self
-		assert: ' 2002-05-16T17:20:45+01:57' asDateAndTime printString
+		assert: '2002-05-16T17:20:45+01:57' asDateAndTime printString
 		equals:  '2002-05-16T17:20:45+01:57'.
 	self
-		assert: ' 2002-05-16T17:20:45-02:34' asDateAndTime
+		assert: '2002-05-16T17:20:45-02:34' asDateAndTime
 		equals:  '2002-05-16T17:20:45-02:34' asDateAndTime.
 	self
 		assert: '2002-05-16T17:20:45+00:00' asDateAndTime
@@ -473,12 +473,12 @@ DateAndTimeTest >> testReadFromOffset [
 DateAndTimeTest >> testReadFromSecond [
 	self assert: '-1199-01-05T20:33:14.321-05:00' asDateAndTime printString equals: '-1199-01-05T20:33:14.321-05:00'.
 	self assert: '2002-05-16T17:20:45.1+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.1+01:01'.
-	self assert: ' 2002-05-16T17:20:45.02+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.02+01:01'.
+	self assert: '2002-05-16T17:20:45.02+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.02+01:01'.
 	self assert: '2002-05-16T17:20:45.000000009+01:01' asDateAndTime printString equals: '2002-05-16T17:20:45.000000009+01:01'.
-	self assert: ' 2002-05-16T17:20' asDateAndTime translateToUTC printString equals: '2002-05-16T17:20:00+00:00'.
+	self assert: '2002-05-16T17:20' asDateAndTime translateToUTC printString equals: '2002-05-16T17:20:00+00:00'.
 	self assert: '2002-05-16T17:20:45' asDateAndTime translateToUTC printString equals: '2002-05-16T17:20:45+00:00'.
-	self assert: ' 2002-05-16T17:20:45+01:57' asDateAndTime printString equals: '2002-05-16T17:20:45+01:57'.
-	self assert: ' 2002-05-16T17:20:45-02:34' asDateAndTime printString equals: '2002-05-16T17:20:45-02:34'.
+	self assert: '2002-05-16T17:20:45+01:57' asDateAndTime printString equals: '2002-05-16T17:20:45+01:57'.
+	self assert: '2002-05-16T17:20:45-02:34' asDateAndTime printString equals: '2002-05-16T17:20:45-02:34'.
 	self assert: '2002-05-16T17:20:45+00:00' asDateAndTime printString equals: '2002-05-16T17:20:45+00:00'.
 	self assert: '1997-04-26T01:02:03+01:02:3' asDateAndTime printString equals: '1997-04-26T01:02:03+01:02:3'
 ]
@@ -560,7 +560,7 @@ DateAndTimeTest >> testReflexive [
 DateAndTimeTest >> testSecondsAcrossTimeZones [
 
 	| dateTime seconds dateTime2 utc |
-	dateTime := '1/15/2012 0000+00:00' asDateAndTime.
+	dateTime := '2012-01-15T0000+00:00' asDateAndTime.
 	utc := TimeZone abbreviated: 'UTC'.
 
 	self useTimeZone: 'PDT' during: [ :pdt |
@@ -777,7 +777,7 @@ DateAndTimeTest >> testTransitive [
 { #category : 'tests - epoch' }
 DateAndTimeTest >> testUnixEpoch [
 
-	self assert: DateAndTime unixEpoch equals: '1 January 1970 00:00+00:00' asDateAndTime
+	self assert: DateAndTime unixEpoch equals: '1970-01-01T00:00+00:00' asDateAndTime
 ]
 
 { #category : 'tests' }

--- a/src/Kernel-Tests/DateAndTimeUnixEpochTest.class.st
+++ b/src/Kernel-Tests/DateAndTimeUnixEpochTest.class.st
@@ -32,7 +32,7 @@ DateAndTimeUnixEpochTest >> tearDown [
 
 { #category : 'tests' }
 DateAndTimeUnixEpochTest >> testAsDate [
-	self assert: aDateAndTime asDate equals: 'January 1, 1970' asDate
+	self assert: aDateAndTime asDate equals: (Date readFrom: '1-1-1970' pattern: 'd-m-y')
 ]
 
 { #category : 'tests' }
@@ -78,7 +78,7 @@ DateAndTimeUnixEpochTest >> testCurrent [
 
 { #category : 'tests' }
 DateAndTimeUnixEpochTest >> testDateTime [
-	self assert: aDateAndTime equals: (DateAndTime date: '01-01-1970' asDate time: '00:00:00' asTime)
+	self assert: aDateAndTime equals: (DateAndTime date: (Date readFrom: '1-1-1970' pattern: 'd-m-y') time: '00:00:00' asTime)
 ]
 
 { #category : 'tests' }
@@ -150,10 +150,10 @@ DateAndTimeUnixEpochTest >> testFromSeconds [
 
 { #category : 'tests' }
 DateAndTimeUnixEpochTest >> testFromString [
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1970-01-01T00:00:00+00:00').
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1970-01-01T00:00:00').
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1970-01-01T00:00').
-	self assert: aDateAndTime equals: (DateAndTime fromString: ' 1970-01-01T00:00:00+00:00')
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1970-01-01T00:00:00+00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1970-01-01T00:00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1970-01-01T00:00').
+	self assert: aDateAndTime equals: (DateAndTime fromString: '1970-01-01T00:00:00+00:00')
 ]
 
 { #category : 'tests' }
@@ -198,7 +198,7 @@ DateAndTimeUnixEpochTest >> testMeridianAbbreviation [
 
 { #category : 'tests' }
 DateAndTimeUnixEpochTest >> testMiddleOf [
-	self assert: (aDateAndTime middleOf: '2:00:00:00' asDuration) equals: (Timespan starting: '12-31-1969' asDate duration: 2 days)
+	self assert: (aDateAndTime middleOf: '2:00:00:00' asDuration) equals: (Timespan starting: (Date readFrom: '31-12-1969' pattern: 'd-m-y') duration: 2 days)
 ]
 
 { #category : 'tests' }

--- a/src/Kernel-Tests/DateTest.class.st
+++ b/src/Kernel-Tests/DateTest.class.st
@@ -55,7 +55,7 @@ DateTest >> selectorsToBeIgnored [
 DateTest >> setUp [
 	super setUp.
 	june2nd1973 := self dateClass year: 1973 day: 153.
-	january23rd2004 := Date readFrom: '01-23-2004' readStream.
+	january23rd2004 := self dateClass newDay: 23 month: 1 year: 2004.
 	aTime := Time readFrom: '12:34:56 pm' readStream
 ]
 
@@ -75,17 +75,17 @@ DateTest >> testAccessing [
 { #category : 'tests' }
 DateTest >> testAddDays [
 
-	self assert: (january23rd2004 addDays: 0) equals: '2004-01-23' asDate.
-	self assert: (january23rd2004 addDays: 31) equals: '2004-02-23' asDate.
-	self assert: (january23rd2004 addDays: 366) equals: '2005-01-23' asDate
+	self assert: (january23rd2004 addDays: 0) equals: (Date readFrom: '23-1-2004' pattern: 'd-m-y').
+	self assert: (january23rd2004 addDays: 31) equals: (Date readFrom: '23-2-2004' pattern: 'd-m-y').
+	self assert: (january23rd2004 addDays: 366) equals: (Date readFrom: '23-1-2005' pattern: 'd-m-y')
 ]
 
 { #category : 'tests' }
 DateTest >> testAddMonths [
 
-	self assert: (january23rd2004 addMonths: 0) equals: '2004-01-23' asDate.
-	self assert: (january23rd2004 addMonths: 1) equals: '2004-02-23' asDate.
-	self assert: (january23rd2004 addMonths: 12) equals: '2005-01-23' asDate
+	self assert: (january23rd2004 addMonths: 0) equals: (Date readFrom: '23-1-2004' pattern: 'd-m-y').
+	self assert: (january23rd2004 addMonths: 1) equals: (Date readFrom: '23-2-2004' pattern: 'd-m-y').
+	self assert: (january23rd2004 addMonths: 12) equals: (Date readFrom: '23-1-2005' pattern: 'd-m-y')
 ]
 
 { #category : 'tests' }
@@ -117,19 +117,19 @@ DateTest >> testAsSeconds [
 
 	| secondsSinceEpoch dateUTC dateEDT datePST |
 	self useTimeZone: 'UTC' during: [
-		dateUTC := Date readFrom: '01-23-2004' readStream.
+		dateUTC := self dateClass newDay: 23 month: 1 year: 2004.
 		secondsSinceEpoch := (dateUTC start - DateAndTime epoch) asSeconds.
 		self assert: dateUTC asSeconds equals: secondsSinceEpoch.
 		self assert: (Date fromSeconds: dateUTC asSeconds) equals: dateUTC ].
 
 	self useTimeZone: 'EDT' during: [
-		dateEDT := Date readFrom: '01-23-2004' readStream.
+		dateEDT := self dateClass newDay: 23 month: 1 year: 2004.
 		secondsSinceEpoch := (dateEDT start - DateAndTime epoch) asSeconds.
 		self assert: dateEDT asSeconds equals: secondsSinceEpoch.
 		self assert: (Date fromSeconds: dateEDT asSeconds) equals: dateEDT ].
 
 	self useTimeZone: 'PST' during: [
-		datePST := Date readFrom: '01-23-2004' readStream.
+		datePST := self dateClass newDay: 23 month: 1 year: 2004.
 		secondsSinceEpoch := (datePST start - DateAndTime epoch) asSeconds.
 		self assert: datePST asSeconds equals: secondsSinceEpoch.
 		self assert: (Date fromSeconds: datePST asSeconds) equals: datePST ].
@@ -154,7 +154,7 @@ DateTest >> testBasicPrinting [
 DateTest >> testComparing [
 
 	| sameDate laterDate earlierDate |
-	sameDate := june2nd1973 asString asDate.
+	sameDate := june2nd1973 copy.
 	laterDate := june2nd1973 + 1 day.
 	earlierDate := june2nd1973 - 1 day.
 
@@ -215,7 +215,7 @@ DateTest >> testDuration [
 
 { #category : 'tests' }
 DateTest >> testEqual [
-	self assert: january23rd2004 equals: 'January 23, 2004' asDate
+	self assert: january23rd2004 equals: (Date readFrom: '23-1-2004' pattern: 'd-m-y')
 ]
 
 { #category : 'tests' }
@@ -249,7 +249,7 @@ DateTest >> testFromDays [
 	june2nd1973FromDays := self dateClass fromDays: (june2nd1973 - self epoch) asDays.
 	self assert: june2nd1973FromDays equals: (june2nd1973 translateTo: 0).
 
-	march18th1627 := '18 March 1627' asDate.
+	march18th1627 := Date readFrom: '18-3-1627' pattern: 'd-m-y'.
 	march18th1627FromDays := self dateClass fromDays: (march18th1627 - self epoch) asDays.
 	self assert: march18th1627FromDays equals: (march18th1627 translateTo: 0).
 
@@ -428,7 +428,7 @@ DateTest >> testNext [
 
 	| nextDay |
 	nextDay := june2nd1973 next.
-	self assert: nextDay equals: '3 June, 1973' asDate
+	self assert: nextDay equals: (Date readFrom: '3-6-1973' pattern: 'd-m-y')
 ]
 
 { #category : 'tests' }
@@ -436,13 +436,13 @@ DateTest >> testPrevious [
 
 	| previousDay |
 	previousDay := june2nd1973 previous.
-	self assert: previousDay equals: '1 June, 1973' asDate
+	self assert: previousDay equals: (Date readFrom: '1-6-1973' pattern: 'd-m-y')
 ]
 
 { #category : 'tests' }
 DateTest >> testPreviousByName [
 
-	self assert: (january23rd2004 previous: #Friday) equals: '2004-01-16' asDate
+	self assert: (january23rd2004 previous: #Friday) equals: (Date readFrom: '16-1-2004' pattern: 'd-m-y')
 ]
 
 { #category : 'tests' }
@@ -516,22 +516,6 @@ DateTest >> testPrintOnFormat [
 ]
 
 { #category : 'tests' }
-DateTest >> testReadFrom [
-	| s1 s2 s3 s4 s5 |
-	s1 := '2 June 1973' readStream.
-	s2 := '2-JUN-73' readStream.
-	s3 := 'June 2, 1973' readStream.
-	s4 := '6/2/73' readStream.
-	s5 := '2JUN73' readStream.
-
-	self assert: (self dateClass readFrom: s1) equals: june2nd1973.
-	self assert: (self dateClass readFrom: s2) equals: june2nd1973.
-	self assert: (self dateClass readFrom: s3) equals: june2nd1973.
-	self assert: (self dateClass readFrom: s4) equals: june2nd1973.
-	self assert: (self dateClass readFrom: s5) equals: june2nd1973
-]
-
-{ #category : 'tests' }
 DateTest >> testStarting [
 
 	| aDateAndTime anyTime |
@@ -556,8 +540,8 @@ DateTest >> testSubtractDate [
 { #category : 'tests' }
 DateTest >> testSubtractDays [
 
-	self assert: (january23rd2004 subtractDays: 0) equals: '2004-01-23' asDate.
-	self assert: (january23rd2004 subtractDays: 30) equals: '2003-12-24' asDate
+	self assert: (january23rd2004 subtractDays: 0) equals: (Date readFrom: '23-1-2004' pattern: 'd-m-y').
+	self assert: (january23rd2004 subtractDays: 30) equals: (Date readFrom: '24-12-2003' pattern: 'd-m-y')
 ]
 
 { #category : 'tests' }

--- a/src/Kernel-Tests/TimeTest.class.st
+++ b/src/Kernel-Tests/TimeTest.class.st
@@ -184,7 +184,7 @@ TimeTest >> testFromSeconds [
 TimeTest >> testGeneralInquiries [
 	| date aDateAndTime |
 
-	date := '2 June 1973' asDate.
+	date := Date readFrom: '2-6-1973' pattern: 'd-m-y'.
 	time := '4:02:47 am' asTime.
 	aDateAndTime := self timeClass dateAndTimeFromSeconds: (2285280000 + 14567).
 	self

--- a/src/Kernel-Tests/TimespanTest.class.st
+++ b/src/Kernel-Tests/TimespanTest.class.st
@@ -114,8 +114,8 @@ TimespanTest >> testArithmetic [
 
 { #category : 'tests' }
 TimespanTest >> testAsDate [
+
 	self assert: aTimespan asDate equals: jan01 asDate
-	"MessageNotUnderstood: Date class>>starting:"
 ]
 
 { #category : 'tests' }
@@ -394,7 +394,7 @@ TimespanTest >> testMonth [
 
 { #category : 'tests' }
 TimespanTest >> testNew [
-	self assert: Timespan new equals: (Timespan starting: '01-01-1901' asDate)
+	self assert: Timespan new equals: (Timespan starting: (Date readFrom: '1-1-1901' pattern: 'd-m-y'))
 ]
 
 { #category : 'tests' }

--- a/src/Metacello-Reference/MetacelloReferenceConfig.class.st
+++ b/src/Metacello-Reference/MetacelloReferenceConfig.class.st
@@ -24,15 +24,15 @@ MetacelloReferenceConfig >> baseline10: spec [
 		spec blessing: [ spec value: #baseline. ].
 		spec description: [ spec value: 'Descriptive comment'. ].
 		spec author: [ spec value: 'dkh'. ].
-		spec timestamp: [ spec value: '10/7/2009 14:40'. ].
-		spec timestamp: [ spec value: (DateAndTime fromString: '10/7/2009 14:40'). ].
+		spec timestamp: [ spec value: '2009-07-10T14:40'. ].
+		spec timestamp: [ spec value: (DateAndTime fromString: '2009-07-10T14:40'). ].
 		"recommended methods for specifying author, blessing, description, timestamp, preLoadDoIt, postLoadDoit"
 		"#development, #baseline, #release, #beta, etc."
 		spec blessing: #baseline.									
 		spec description: 'Descriptive comment'.
 		spec author: 'dkh'.
-		spec timestamp: (DateAndTime fromString: '10/7/2009 14:40').
-		spec timestamp: '10/7/2009 14:40'.
+		spec timestamp: (DateAndTime fromString: '2009-07-10T14:40').
+		spec timestamp: '12009-07-10T14:40'.
 		spec
 			"Before loading packages or projects in this version, send #preloadForVersion to an instance of this config"
 			preLoadDoIt: #preloadForVersion;

--- a/src/Metacello-TestsReference/MetacelloReferenceTestCase.class.st
+++ b/src/Metacello-TestsReference/MetacelloReferenceTestCase.class.st
@@ -26,7 +26,7 @@ spec description: ''Descriptive comment''.
 spec preLoadDoIt: #''preloadForVersion''.
 spec postLoadDoIt: #''postloadForVersion''.
 spec author: ''dkh''.
-spec timestamp: ''10/7/2009 14:40''.
+spec timestamp: ''12009-07-10T14:40''.
 spec repositories: [
 	spec
 		repository: ''/opt/mc/repository'';

--- a/src/Monticello/MCVersionInfoWriter.class.st
+++ b/src/Monticello/MCVersionInfoWriter.class.st
@@ -24,10 +24,13 @@ MCVersionInfoWriter >> writeVersionInfo: aVersionInfo [
 	(self isWritten: aVersionInfo)
 		ifTrue: [^ stream nextPutAll: '(id '; print: aVersionInfo id asString; nextPut: $) ].
 	stream nextPut: $(.
-	#(name message id date time author) do: [:sel | 
+	#(name message id date time author) do: [:sel | | toWrite |
+		toWrite := (aVersionInfo perform: sel) ifNil: [''].
+		sel = #date
+			ifTrue: [ toWrite := toWrite yyyymmdd ].
 		stream 
 			nextPutAll: sel; space;
-			print: (((aVersionInfo perform: sel) ifNil: ['']) asString encodeWith: #utf8  ) asString; space ].
+			print: (toWrite asString encodeWith: #utf8  ) asString; space ].
 	stream nextPutAll: 'ancestors ('.
 	aVersionInfo ancestors do: [:ea | self writeVersionInfo: ea].
 	stream nextPutAll: ') stepChildren ('.

--- a/src/Ring-Core/RGStampParser.class.st
+++ b/src/Ring-Core/RGStampParser.class.st
@@ -58,15 +58,15 @@ RGStampParser >> basicParseAuthorAliasFrom: aString [
 	unknown := nil.
 	aString isEmptyOrNil
 		ifTrue: [ ^ unknown ].
-	dateStartIndex := (aString indexOf: $/) - 1.	"If there is no / character in the timestamp, no author alias/name exists"
+	dateStartIndex := (aString indexOf: $-) - 1.	"If there is no / character in the timestamp, no author alias/name exists"
 	dateStartIndex = -1
 		ifTrue: [ ^ unknown ].
 	^ [
 	"Go the start of the date string (there can be 1 or 2 digits and a space separator can be missing at the front!!)"
-	(dateStartIndex >= 2 and: [ (aString at: dateStartIndex - 1) isDigit ])
-		ifTrue: [ dateStartIndex := dateStartIndex - 1 ].	"Extract only those tokens that do not possible represent date or time - meaning that authorname may be at the end"
+	[dateStartIndex >= 4 and: [ (aString at: dateStartIndex - 1) isDigit ]]
+		whileTrue: [ dateStartIndex := dateStartIndex - 1 ].	"Extract only those tokens that do not possible represent date or time - meaning that authorname may be at the end"
 	tokens := (aString copyFrom: dateStartIndex to: aString size) substrings
-		reject: [ :token | (token occurrencesOf: $/) = 2 or: [ (token occurrencesOf: $:) = 1 ] ].	"only one token should be left if author name/alias exists"
+		reject: [ :token | (token occurrencesOf: $-) = 2 or: [ (token occurrencesOf: $:) = 1 ] ].	"only one token should be left if author name/alias exists"
 	^ tokens isEmpty
 		ifTrue: [
 			"if dateStartIndex is not 1 then the authorname may be at the beginning"
@@ -107,18 +107,18 @@ RGStampParser >> parseTimestampFrom: aString default: anObject [
 	unknown := anObject.
 	aString isEmptyOrNil
 		ifTrue: [ ^ unknown ].
-	dateStartIndex := (aString indexOf: $/) - 1.	"If there is no / character in the timestamp, we cannot parse a date and return the epoch"
+	dateStartIndex := (aString indexOf: $-) - 1.	"If there is no / character in the timestamp, we cannot parse a date and return the epoch"
 	dateStartIndex = -1
 		ifTrue: [ ^ unknown ].
 	^ [
 	"Go the start of the date string (there can be 1 or 2 digits and a space separator can be missing at the front!!)"
-	(dateStartIndex >= 2 and: [ (aString at: dateStartIndex - 1) isDigit ])
-		ifTrue: [ dateStartIndex := dateStartIndex - 1 ].	"Extract only those tokens that possibly represent date or time"
+	[dateStartIndex >= 4 and: [ (aString at: dateStartIndex - 1) isDigit ]]
+		whileTrue: [ dateStartIndex := dateStartIndex - 1 ].	"Extract only those tokens that possibly represent date or time"
 	tokens := (aString copyFrom: dateStartIndex to: aString size) substrings
-		select: [ :token | (token occurrencesOf: $/) = 2 or: [ (token occurrencesOf: $:) = 1 ] ].	"2 tokens is a datetime"
+		select: [ :token | (token occurrencesOf: $-) = 2 or: [ (token occurrencesOf: $:) = 1 ] ].	"2 tokens is a datetime"
 	tokens size = 2
 		ifTrue: [ (tokens joinUsing: Character space) asDateAndTime ]
-		ifFalse: [ tokens first asDate asDateAndTime ] ]
+		ifFalse: [ tokens first asDateAndTime ] ]
 		on: Exception
 		do: [ :e | unknown ]
 ]

--- a/src/Ring-Definitions-Core/RGElementDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGElementDefinition.class.st
@@ -103,15 +103,15 @@ RGElementDefinition class >> basicParseAuthorAliasFrom: aString [
 	unknown := nil.
 	aString isEmptyOrNil
 		ifTrue: [ ^ unknown ].
-	dateStartIndex := (aString indexOf: $/) - 1.	"If there is no / character in the timestamp, no author alias/name exists"
+	dateStartIndex := (aString indexOf: $-) - 1.	"If there is no / character in the timestamp, no author alias/name exists"
 	dateStartIndex = -1
 		ifTrue: [ ^ unknown ].
 	^ [
-	"Go the start of the date string (there can be 1 or 2 digits and a space separator can be missing at the front!!)"
-	(dateStartIndex >= 2 and: [ (aString at: dateStartIndex - 1) isDigit ])
-		ifTrue: [ dateStartIndex := dateStartIndex - 1 ].	"Extract only those tokens that do not possible represent date or time - meaning that authorname may be at the end"
+	"Go the start of the date string (there can be up to 4 digits and a space separator can be missing at the front!!)"
+	[dateStartIndex >= 4 and: [ (aString at: dateStartIndex - 1) isDigit ]]
+		whileTrue: [ dateStartIndex := dateStartIndex - 1 ].	"Extract only those tokens that do not possible represent date or time - meaning that authorname may be at the end"
 	tokens := (aString copyFrom: dateStartIndex to: aString size) substrings
-		reject: [ :token | (token occurrencesOf: $/) = 2 or: [ (token occurrencesOf: $:) = 1 ] ].	"only one token should be left if author name/alias exists"
+		reject: [ :token | (token occurrencesOf: $-) = 2 or: [ (token occurrencesOf: $:) = 1 ] ].	"only one token should be left if author name/alias exists"
 	^ tokens isEmpty
 		ifTrue: [
 			"if dateStartIndex is not 1 then the authorname may be at the beginning"
@@ -179,18 +179,18 @@ RGElementDefinition class >> parseTimestampFrom: aString default: anObject [
 	unknown := anObject.
 	aString isEmptyOrNil
 		ifTrue: [ ^ unknown ].
-	dateStartIndex := (aString indexOf: $/) - 1.	"If there is no / character in the timestamp, we cannot parse a date and return the epoch"
+	dateStartIndex := (aString indexOf: $-) - 1.	"If there is no / character in the timestamp, we cannot parse a date and return the epoch"
 	dateStartIndex = -1
 		ifTrue: [ ^ unknown ].
 	^ [
 	"Go the start of the date string (there can be 1 or 2 digits and a space separator can be missing at the front!!)"
-	(dateStartIndex >= 2 and: [ (aString at: dateStartIndex - 1) isDigit ])
-		ifTrue: [ dateStartIndex := dateStartIndex - 1 ].	"Extract only those tokens that possibly represent date or time"
+	[dateStartIndex >= 4 and: [ (aString at: dateStartIndex - 1) isDigit ]]
+		whileTrue: [ dateStartIndex := dateStartIndex - 1 ].	"Extract only those tokens that possibly represent date or time"
 	tokens := (aString copyFrom: dateStartIndex to: aString size) substrings
-		select: [ :token | (token occurrencesOf: $/) = 2 or: [ (token occurrencesOf: $:) = 1 ] ].	"2 tokens is a datetime"
+		select: [ :token | (token occurrencesOf: $-) = 2 or: [ (token occurrencesOf: $:) = 1 ] ].	"2 tokens is a datetime"
 	tokens size = 2
 		ifTrue: [ (tokens joinUsing: Character space) asDateAndTime ]
-		ifFalse: [ tokens first asDate asDateAndTime ] ]
+		ifFalse: [ DateAndTime fromString: tokens first ] ]
 		on: Exception
 		do: [ :e | unknown ]
 ]

--- a/src/Ring-Definitions-Tests-Core/RGClassDefinitionTest.class.st
+++ b/src/Ring-Definitions-Tests-Core/RGClassDefinitionTest.class.st
@@ -274,7 +274,7 @@ RGClassDefinitionTest >> testWithComment [
 	newComment := RGCommentDefinition new
 		parent: newClass;
 		content: 'This is a comment for test';
-		stamp: 'VeronicaUquillas 3/22/2011 14:51';
+		stamp: 'VeronicaUquillas 2011-03-22T14:51';
 		yourself.
 	newClass comment: newComment.
 
@@ -283,7 +283,7 @@ RGClassDefinitionTest >> testWithComment [
 	self assert: newClass equals: newComment parent.
 	self assert: newComment content equals: 'This is a comment for test'.
 	self assert: newComment author equals: 'VeronicaUquillas'.
-	self assert: newComment timeStamp equals: '3/22/2011 14:51' asDateAndTime.
+	self assert: newComment timeStamp equals: '2011-03-22T14:51' asDateAndTime.
 
 	newClass comment: nil.
 	self assert: newClass hasComment not.

--- a/src/Ring-Definitions-Tests-Core/RGCommentDefinitionTest.class.st
+++ b/src/Ring-Definitions-Tests-Core/RGCommentDefinitionTest.class.st
@@ -68,7 +68,7 @@ RGCommentDefinitionTest >> testNewComment [
 	| newComment |
 	newComment := RGCommentDefinition new
 		content: 'This is a comment for test';
-		stamp: 'VeronicaUquillas 3/22/2011 14:51';
+		stamp: 'VeronicaUquillas 2011-03-22T14:51';
 		yourself.
 
 	self assert: newComment isComment.
@@ -79,7 +79,7 @@ RGCommentDefinitionTest >> testNewComment [
 	self assert: newComment timeStamp notNil.
 
 	self assert: newComment author equals: 'VeronicaUquillas'.
-	self assert: newComment timeStamp equals: '3/22/2011 14:51' asDateAndTime.
+	self assert: newComment timeStamp equals: '2011-03-22T14:51' asDateAndTime.
 	self assert: newComment parent equals: nil.
 	self assert: newComment environment equals: Smalltalk globals
 ]

--- a/src/Ring-Tests-ChunkImporter/Ring2ChunkImporterTest.class.st
+++ b/src/Ring-Tests-ChunkImporter/Ring2ChunkImporterTest.class.st
@@ -407,7 +407,7 @@ Ring2ChunkImporterTest >> testStandardComment [
 
 	self assert: comment content equals: 'I''m a nice comment!, treat me well :).'.
 	self assert: comment author equals: 'GuillermoPolito'.
-	self assert: comment time equals: ('5/2/2012 13:35' asDateAndTime)
+	self assert: comment time equals: ('2012-05-02T13:35' asDateAndTime)
 ]
 
 { #category : 'tests' }
@@ -440,7 +440,7 @@ Ring2ChunkImporterTest >> testStandardMetaclassMethod [
 
 	importer := RGChunkImporter new.
 
-	code := '!SomeClass class methodsFor: ''some protocol'' stamp: ''GuillermoPolito 5/2/2012 13:35''!someMethod
+	code := '!SomeClass class methodsFor: ''some protocol'' stamp: ''GuillermoPolito 2012-05-02T13:35''!someMethod
 	^true'.
 
 	importer fileInFrom: code readStream.
@@ -455,7 +455,7 @@ Ring2ChunkImporterTest >> testStandardMetaclassMethod [
 	self assert: method name equals: #someMethod.
 	self assert: method protocol equals: 'some protocol'.
 	self assert: method author equals: 'GuillermoPolito'.
-	self assert: method time equals: ('5/2/2012 13:35' asDateAndTime).
+	self assert: method time equals: ('2012-05-02T13:35' asDateAndTime).
 	self assert: method sourceCode equals: 'someMethod
 	^true'
 ]
@@ -518,7 +518,7 @@ Ring2ChunkImporterTest >> testStandardMethod [
 
 	importer := RGChunkImporter new.
 
-	code := '!SomeClass methodsFor: ''some protocol'' stamp: ''GuillermoPolito 5/2/2012 13:35''!someMethod
+	code := '!SomeClass methodsFor: ''some protocol'' stamp: ''GuillermoPolito 2012-05-02T13:35''!someMethod
 	^true'.
 
 	importer fileInFrom: code readStream.
@@ -534,7 +534,7 @@ Ring2ChunkImporterTest >> testStandardMethod [
 	self assert: method name equals: #someMethod.
 	self assert: method protocol equals: 'some protocol'.
 	self assert: method author equals: 'GuillermoPolito'.
-	self assert: method time equals: ('5/2/2012 13:35' asDateAndTime).
+	self assert: method time equals: ('2012-05-02T13:35' asDateAndTime).
 	self assert: method sourceCode equals: 'someMethod
 	^true'
 ]
@@ -547,7 +547,7 @@ Ring2ChunkImporterTest >> testStandardMethodInExistingClass [
 	importer := RGChunkImporter new.
 	class := importer environment ensureClassNamed: #SomeClass.
 
-	code := '!SomeClass methodsFor: ''some protocol'' stamp: ''GuillermoPolito 5/2/2012 13:35''!someMethod
+	code := '!SomeClass methodsFor: ''some protocol'' stamp: ''GuillermoPolito 2012-05-02T13:35''!someMethod
 	^true'.
 
 	importer fileInFrom: code readStream.
@@ -562,7 +562,7 @@ Ring2ChunkImporterTest >> testStandardMethodInExistingClass [
 	self assert: method name equals: #someMethod.
 	self assert: method protocol equals: 'some protocol'.
 	self assert: method author equals: 'GuillermoPolito'.
-	self assert: method time equals: ('5/2/2012 13:35' asDateAndTime).
+	self assert: method time equals: ('2012-05-02T13:35' asDateAndTime).
 	self assert: method sourceCode equals: 'someMethod
 	^true'
 ]
@@ -576,7 +576,7 @@ Ring2ChunkImporterTest >> testStandardMethodInExistingMetaclassTrait [
 
 	trait := importer environment ensureMetaclassTraitNamed: #'SomeTrait classTrait'.
 
-	code := '!SomeTrait classTrait methodsFor: ''some protocol'' stamp: ''GuillermoPolito 5/2/2012 13:35''!someMethod
+	code := '!SomeTrait classTrait methodsFor: ''some protocol'' stamp: ''GuillermoPolito 2012-05-02T13:35''!someMethod
 	^true'.
 
 	importer fileInFrom: code readStream.
@@ -591,7 +591,7 @@ Ring2ChunkImporterTest >> testStandardMethodInExistingMetaclassTrait [
 	self assert: method name equals: #someMethod.
 	self assert: method protocol equals: 'some protocol'.
 	self assert: method author equals: 'GuillermoPolito'.
-	self assert: method time equals: ('5/2/2012 13:35' asDateAndTime).
+	self assert: method time equals: ('2012-05-02T13:35' asDateAndTime).
 	self assert: method sourceCode equals: 'someMethod
 	^true'
 ]
@@ -605,7 +605,7 @@ Ring2ChunkImporterTest >> testStandardMethodInExistingTrait [
 
 	trait := importer environment ensureTraitNamed: #'SomeTrait'.
 
-	code := '!SomeTrait methodsFor: ''some protocol'' stamp: ''GuillermoPolito 5/2/2012 13:35''!someMethod
+	code := '!SomeTrait methodsFor: ''some protocol'' stamp: ''GuillermoPolito 2012-05-02T13:35''!someMethod
 	^true'.
 
 	importer fileInFrom: code readStream.
@@ -620,7 +620,7 @@ Ring2ChunkImporterTest >> testStandardMethodInExistingTrait [
 	self assert: method name equals: #someMethod.
 	self assert: method protocol equals: 'some protocol'.
 	self assert: method author equals: 'GuillermoPolito'.
-	self assert: method time equals: ('5/2/2012 13:35' asDateAndTime).
+	self assert: method time equals: ('2012-05-02T13:35' asDateAndTime).
 	self assert: method sourceCode equals: 'someMethod
 	^true'
 ]
@@ -632,7 +632,7 @@ Ring2ChunkImporterTest >> testStandardMethodInNewMetaclass [
 
 	importer := RGChunkImporter new.
 
-	code := '!SomeClass class methodsFor: ''some protocol'' stamp: ''GuillermoPolito 5/2/2012 13:35''!someMethod
+	code := '!SomeClass class methodsFor: ''some protocol'' stamp: ''GuillermoPolito 2012-05-02T13:35''!someMethod
 	^true'.
 
 	importer fileInFrom: code readStream.
@@ -648,7 +648,7 @@ Ring2ChunkImporterTest >> testStandardMethodInNewMetaclass [
 	self assert: method name equals: #someMethod.
 	self assert: method protocol equals: 'some protocol'.
 	self assert: method author equals: 'GuillermoPolito'.
-	self assert: method time equals: ('5/2/2012 13:35' asDateAndTime).
+	self assert: method time equals: ('2012-05-02T 13:35' asDateAndTime).
 	self assert: method sourceCode equals: 'someMethod
 	^true'
 ]
@@ -801,7 +801,7 @@ Ring2ChunkImporterTest >> testingCommentFor: aClassName [
 
 	comment := 'I''m a nice comment!, treat me well :).'.
 	commentToWrite := 'I''m a nice comment!!, treat me well :).' replaceAll: '!' with: '!!'.
-	^ ('!{1} commentStamp: ''GuillermoPolito 5/2/2012 13:35'' prior: 0!{2}!' format: { aClassName. commentToWrite })
+	^ ('!{1} commentStamp: ''GuillermoPolito 2012-05-02T13:35'' prior: 0!{2}!' format: { aClassName. commentToWrite })
 ]
 
 { #category : 'private - utilities' }

--- a/src/Ring-Tests-Core/RGStampParserTest.class.st
+++ b/src/Ring-Tests-Core/RGStampParserTest.class.st
@@ -9,12 +9,11 @@ Class {
 RGStampParserTest >> testAuthor [
 
 	"TODO: improve"
-	self assert: (RGStampParser parseAuthorAliasFrom: 'StephaneDucasse 11/10/2015 18:13') equals: 'StephaneDucasse'
+	self assert: (RGStampParser parseAuthorAliasFrom: 'StephaneDucasse 2015-10-11T18:13') equals: 'StephaneDucasse'
 ]
 
 { #category : 'tests' }
 RGStampParserTest >> testTime [
 
-	"TODO: improve"
-	self assert: (RGStampParser parseTimestampFrom: '11/10/2015 18:13') equals: '2015-11-10T18:13:00' asDateAndTime
+	self assert: (RGStampParser parseTimestampFrom: '2015-10-11T18:13') equals: '2015-10-11T18:13:00' asDateAndTime
 ]

--- a/src/STON-Core/Date.extension.st
+++ b/src/STON-Core/Date.extension.st
@@ -8,12 +8,14 @@ Date class >> fromSton: stonReader [
 
 	| readStream date |
 	readStream := stonReader parseListSingleton readStream.
-	date := self readFrom: readStream.
-	readStream atEnd
-		ifFalse: [ | offset |
-			offset := DateAndTime readTimezoneOffsetFrom: readStream.
-			offset = date offset
-				ifFalse: [ date start: (date start translateTo: offset) ] ].
+	date := (DateParser readingFrom: readStream pattern: 'yyyy-mm-dd')
+		        continueAfterParsing;
+		        parse.
+	readStream atEnd ifFalse: [
+		| offset |
+		offset := DateAndTime readTimezoneOffsetFrom: readStream.
+		offset = date offset ifFalse: [
+			date start: (date start translateTo: offset) ] ].
 	^ date
 ]
 

--- a/src/System-Installers-Tests/MCMczInstallerTest.class.st
+++ b/src/System-Installers-Tests/MCMczInstallerTest.class.st
@@ -78,6 +78,7 @@ MCMczInstallerTest >> tearDown [
 MCMczInstallerTest >> testInstallFromFile [
 	| stream |
 	stream := self fileStream.
+
 	MCMczWriter fileOut: expected on: stream.
 	stream close.
 

--- a/src/System-Installers/MczInstaller.class.st
+++ b/src/System-Installers/MczInstaller.class.st
@@ -142,7 +142,7 @@ MczInstaller >> contentsForMember: member [
 { #category : 'utilities' }
 MczInstaller >> extractInfoFrom: dict [
 	dict at: #id put: (UUID fromString: (dict at: #id)).
-	dict at: #date ifPresent: [:d | d isEmpty ifFalse: [dict at: #date put: (Date fromString: d)]].
+	dict at: #date ifPresent: [:d | d isEmpty ifFalse: [dict at: #date put: (Date readFrom: d pattern: 'yyyy-mm-dd')]].
 	dict at: #time ifPresent: [:t | t isEmpty ifFalse: [dict at: #time put: (Time readFrom: t readStream)]].
 	dict at: #ancestors ifPresent: [:a | dict at: #ancestors put: (a collect: [:ea | self extractInfoFrom: ea])].
 	^ dict

--- a/src/System-Support/VirtualMachine.class.st
+++ b/src/System-Support/VirtualMachine.class.st
@@ -670,7 +670,7 @@ VirtualMachine >> optionAt: i [
 { #category : 'accessing' }
 VirtualMachine >> optionDash [
 	"VMs release in Mai 2013 use -- instead of - for VM command line options"
-	^ (Smalltalk vm interpreterSourceDate > '2013-05-17' asDate)
+	^ (Smalltalk vm interpreterSourceDate > (Date readFrom: '17-5-2013' pattern: 'd-m-y'))
 		ifTrue: [ '--' ]
 		ifFalse: [ '-' ]
 ]

--- a/src/Tool-Base/TimeStampMethodConverter.class.st
+++ b/src/Tool-Base/TimeStampMethodConverter.class.st
@@ -10,13 +10,17 @@ Class {
 }
 
 { #category : 'private' }
-TimeStampMethodConverter >> formattedModificationTextFor:aUser atStamp:aTimeStampString [
-|stamp|
-stamp:= DateAndTime fromString:aTimeStampString.
-^ String streamContents:[ :s |
-			s << 'Last Modification :' << Character cr.
-			s << Character tab << 'date:' << Character tab << stamp asDate asString << Character space << stamp asTime asString << Character cr.
- 			s << Character tab << 'by:' << Character tab << Character tab << aUser ]
+TimeStampMethodConverter >> formattedModificationTextFor: aUser atStamp: aTimeStampString [
+
+	| stamp |
+	stamp := DateAndTime fromString: aTimeStampString.
+	^ String streamContents: [ :s |
+		  s << 'Last Modification :' << Character cr.
+		  s << Character tab << 'date:' << Character tab
+		  << stamp asDate asString << Character space
+		  << stamp asTime asString << Character cr.
+		  s << Character tab << 'by:' << Character tab << Character tab
+		  << aUser ]
 ]
 
 { #category : 'private' }

--- a/src/UnifiedFFI-Tests/FFIFunctionResolutionTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIFunctionResolutionTest.class.st
@@ -110,7 +110,7 @@ FFIFunctionResolutionTest >> testResolveClassVariableShouldBeInt32Type [
 	context := Context
 		sender: nil
 		receiver: receiver
-		method: String>>#asDate
+		method: String>>#asDuration
 		arguments: #().
 	resolver := FFICallout new
 		sender: context;
@@ -134,7 +134,7 @@ FFIFunctionResolutionTest >> testResolveClassVariableShouldSetClassVariableLoade
 	context := Context
 		sender: nil
 		receiver: receiver
-		method: String>>#asDate
+		method: String>>#asDuration
 		arguments: #().
 	resolver := FFICallout new
 		sender: context;


### PR DESCRIPTION
Redo https://github.com/pharo-project/pharo/pull/15152, originally reverted because there are still broken tests.

Date>>asDate is ambiguous regarding how to interpret the day, month and year fields. Sometimes it interprets them in some order and sometimes in other.

```smalltalk
'1-13-04' asDate => 13 january 2004
```

```smalltalk
'13-1-04' asDate => 13 january 2004
```

Recently an exception was added in one of the cases above, but the ambiguity remains.
We propose with @guillep to deprecate it in favor of `#readFrom:pattern:` with an explicit pattern.

We deprecate methods: 
- String>>asDate,
- Date>>fromString, and 
- Date>>readFrom.
Remove related tests on the deprecated methods.
Use Date>>#readFrom:pattern: specifying a concrete pattern instead + all other.

We also added an option into the pattern parser to continue parsing using the continueAfterParsing method.