### PR TITLE
Proposal: new message browser layout

### DIFF
--- a/src/Calypso-Browser/ClyBrowserMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserMorph.class.st
@@ -363,7 +363,7 @@ ClyBrowserMorph >> initialize [
 	self changeProportionalLayout.
 	self initializeToolsPanel.
 	self initializeNavigationPanel.
-	self addPaneSplitters
+	self layoutChildren
 ]
 
 { #category : 'initialization' }
@@ -379,7 +379,7 @@ ClyBrowserMorph >> initializeNavigationPanel [
 	eachViewExtent := 1.0 / navigationViews size.
 	lastViewLeft := 0.0.
 	navigationViews do: [ :each | | frame |
-		frame := (lastViewLeft @ 0.0 corner: lastViewLeft + eachViewExtent @ 1.0) asLayoutFrame.
+		frame := ( lastViewLeft @ 0.0 corner: lastViewLeft + eachViewExtent @ 1.0) asLayoutFrame.
 		each == navigationViews last ifFalse: [
 			frame := frame rightOffset: -4 ].
 		navigationPanel
@@ -387,8 +387,7 @@ ClyBrowserMorph >> initializeNavigationPanel [
 			fullFrame: frame.
 		lastViewLeft := lastViewLeft + eachViewExtent ].
 
-	navigationPanel addPaneSplitters.
-	self addMorph: navigationPanel fullFrame: ((0.0 @ 0 corner: 1.0 @ 0.5) asLayoutFrame bottomOffset: toolbar height negated)
+	navigationPanel addPaneSplitters
 ]
 
 { #category : 'initialization' }
@@ -398,20 +397,9 @@ ClyBrowserMorph >> initializeNavigationViews [
 
 { #category : 'initialization' }
 ClyBrowserMorph >> initializeToolsPanel [
+
 	toolbar := ClyToolbarMorph of: self.
-	tabManager := ClyNotebookManager of: self.
-
-	toolPanel := PanelMorph new.
-	toolPanel name: 'tools panel'.
-	toolPanel
-		changeTableLayout;
-		hResizing: #spaceFill;
-		vResizing: #spaceFill;
-		listDirection: #topToBottom.
-	self addMorph: toolPanel fullFrame: ((0.0 @ 0.5 corner: 1.0 @ 1.0) asLayoutFrame topOffset: toolbar height negated).
-
-	toolPanel addMorphBack: toolbar.
-	toolPanel addMorphBack: tabManager tabMorph
+	tabManager := ClyNotebookManager of: self
 ]
 
 { #category : 'testing' }
@@ -433,6 +421,36 @@ ClyBrowserMorph >> itemsChanged [
 ClyBrowserMorph >> kmDispatcher [
 
 	^ CmdKMDispatcher attachedTo: self
+]
+
+{ #category : 'initialization' }
+ClyBrowserMorph >> layoutChildren [
+
+	"Set up the typical calypso browser layout with:
+	  - package | classes | protocols | methods panels
+	  - toolbar
+	  - tool (the code editor and so on)"
+	self
+		addMorph: navigationPanel
+		fullFrame: ((0.0 @ 0 corner: 1.0 @ 0.5) asLayoutFrame bottomOffset:
+				 toolbar height negated).
+
+	toolPanel := PanelMorph new.
+	toolPanel name: 'tools panel'.
+	toolPanel
+		changeTableLayout;
+		hResizing: #spaceFill;
+		vResizing: #spaceFill;
+		listDirection: #topToBottom.
+	self
+		addMorph: toolPanel
+		fullFrame: ((0.0 @ 0.5 corner: 1.0 @ 1.0) asLayoutFrame topOffset:
+				 toolbar height negated).
+
+	toolPanel addMorphBack: toolbar.
+	toolPanel addMorphBack: tabManager tabMorph.
+	
+	self addPaneSplitters
 ]
 
 { #category : 'navigation' }

--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -845,7 +845,7 @@ ClyQueryViewMorph >> targetDropItem: anObject [
 	targetDropItem := anObject
 ]
 
-{ #category : #queries }
+{ #category : 'queries' }
 ClyQueryViewMorph >> transferExpansionStateFrom: oldDataSource [
 
 	| itemsSelector actionSelector newItems |

--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
@@ -225,6 +225,37 @@ ClyQueryBrowserMorph >> itemCount [
 ]
 
 { #category : 'initialization' }
+ClyQueryBrowserMorph >> layoutChildren [
+
+	"Set up the message browser layout with:
+	  - toolbar on top
+	  - list on the left
+	  - tool (the code editor and so on) on the right"
+
+	| contentPanel |
+	self changeTableLayout.
+	self listDirection: #topToBottom.
+
+	self addMorph: toolbar.
+
+	contentPanel := PanelMorph new.
+	contentPanel changeProportionalLayout.
+	contentPanel name: 'tools panel'.
+	contentPanel
+		hResizing: #spaceFill;
+		vResizing: #spaceFill.
+
+	contentPanel
+		addMorph: navigationPanel
+		fullFrame: (0 @ 0.0 corner: 0.5 @ 1) asLayoutFrame.
+	contentPanel
+		addMorph: tabManager tabMorph
+		fullFrame: (0.5 @ 0 corner: 1 @ 1.0) asLayoutFrame.
+	self addMorphBack: contentPanel.
+	contentPanel addPaneSplitters
+]
+
+{ #category : 'initialization' }
 ClyQueryBrowserMorph >> mainNameOf: aBrowserItem [
 	aBrowserItem type = ClyClass ifTrue: [ ^'' ].
 


### PR DESCRIPTION
Screens are wide, not tall.
I often do not have space to browse methods and large lists of methods in the current message browser.
This is aggravated by the critics browser shown in the bottom and the space taken by the tabbing system.

I propose to slightly change the layout by:
 - making the main content left-to-right
 - put the toolbar on the top, as toolbars are

<img width="1624" alt="imagen" src="https://github.com/pharo-project/pharo/assets/708322/18d2b956-0bca-4c42-870a-61526fde20ff">

This is how it looks with critics:

<img width="1624" alt="imagen" src="https://github.com/pharo-project/pharo/assets/708322/0d675f17-764d-4607-a730-87a043248033">

Just a small refactoring and one new method defining the new layout (only for the message browser).
I think this can make the life easier for many people.