### PR TITLE
Fix ‘span’ in BalloonEngine not being wider than the ‘destForm’

### DIFF
--- a/src/FormCanvas-Core/BalloonEngine.class.st
+++ b/src/FormCanvas-Core/BalloonEngine.class.st
@@ -260,7 +260,7 @@ BalloonEngine >> bitBlt: aBitBlt [
 	bitBlt ifNil: [^self].
 	width := bitBlt destForm width.
 	width <= 0 ifTrue: [ width := self class defaultBitmapWidth ].
-	span := Bitmap new: width.
+	span := Bitmap new: width + 1.
 	self class primitiveSetBitBltPlugin: bitBlt getPluginName.
 	self clipRect: bitBlt clipRect.
 	bitBlt

--- a/src/FormCanvas-Tests/BalloonEngineTest.class.st
+++ b/src/FormCanvas-Tests/BalloonEngineTest.class.st
@@ -21,6 +21,6 @@ BalloonEngineTest >> testSpan [
 	engine := BalloonEngine new.
 
 	Display width > 0
-		ifTrue: [ self assert: engine span size equals: Display width ]
-		ifFalse: [ self assert: engine span size equals: BalloonEngine defaultBitmapWidth ]
+		ifTrue: [ self assert: engine span size equals: Display width + 1 ]
+		ifFalse: [ self assert: engine span size equals: BalloonEngine defaultBitmapWidth + 1 ]
 ]


### PR DESCRIPTION
This pull request corrects pull request #14926: setting the ‘span’ to have exactly the width of the ‘destForm’ caused a new bug. See the example below. Presumably there is an off-by-one error in the primitives. This pull request takes that into account by increasing the width by one.

Example:

```smalltalk
(form := Form extent: 10@30 depth: 32) fillColor: Color red.
form getCanvas drawPolygon: form boundingBox corners fillStyle: (SolidFillStyle color: Color gray).
PNGReadWriter putForm: form onFileNamed: FileLocator imageDirectory / 'Result.png'
```

The result without this fix, note the red line on the right:

![](https://github.com/pharo-project/pharo/assets/1611248/fdb63432-0b3a-4cd8-9634-2a0f96c57d19)

The result with this fix:

![](https://github.com/pharo-project/pharo/assets/1611248/746b3dd0-8359-4298-bad8-7cf8571d20fc)
