### PR TITLE
15191-Undeclared-cleanOutUndeclared-should-not-iterate-over-all-methods 

### DIFF
--- a/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
@@ -706,22 +706,6 @@ OrderedDictionaryTest >> testCopyEmpty [
 ]
 
 { #category : 'tests' }
-OrderedDictionaryTest >> testDeclareFrom [
-	| dictionary otherDictionary |
-	dictionary := self emptyDictionary.
-	otherDictionary := self dictionaryWithOrderedAssociations.
-	self orderedKeys do: [ :each | self assert: (dictionary declare: each from: otherDictionary) identicalTo: dictionary ].
-	self assertIsDictionary: dictionary withOrderedAssociations: self orderedAssociations.
-	self assertEmpty: otherDictionary.
-
-	self orderedKeys
-		do: [ :each |
-			otherDictionary add: each -> self newValue.
-			self assert: (dictionary declare: each from: otherDictionary) identicalTo: dictionary ].
-	self assertIsDictionary: dictionary withOrderedAssociations: self orderedAssociations
-]
-
-{ #category : 'tests' }
 OrderedDictionaryTest >> testDictionary [
 	| dictionary |
 	dictionary := self emptyDictionary.

--- a/src/Collections-Sequenceable/OrderedDictionary.class.st
+++ b/src/Collections-Sequenceable/OrderedDictionary.class.st
@@ -299,18 +299,6 @@ OrderedDictionary >> collect: aBlock [
 			each key -> (aBlock value: each value)])
 ]
 
-{ #category : 'adding' }
-OrderedDictionary >> declare: aKey from: aDictionary [
-	(self includesKey: aKey)
-		ifTrue: [^ self].
-
-	(aDictionary includesKey: aKey)
-		ifTrue: [
-			self add: (aDictionary associationAt: aKey).
-			aDictionary removeKey: aKey]
-		ifFalse: [self add: aKey -> nil]
-]
-
 { #category : 'private' }
 OrderedDictionary >> dictionary [
 	^ dictionary

--- a/src/Collections-Unordered-Tests/TDictionaryAddingTest.trait.st
+++ b/src/Collections-Unordered-Tests/TDictionaryAddingTest.trait.st
@@ -80,24 +80,3 @@ TDictionaryAddingTest >> testAddWithKeyNotIn [
 	self assert: (dictionary at: association key) equals: association value.
 	self assert: dictionary size equals: oldSize + 1
 ]
-
-{ #category : 'tests - adding' }
-TDictionaryAddingTest >> testDeclareFrom [
-	| newDict v dictionary keyIn associationKeyNotIn |
-	dictionary := self nonEmptyDict.
-	keyIn := dictionary keys anyOne.
-	associationKeyNotIn := self associationWithKeyNotInToAdd.
-	newDict := self collectionClass new
-		add: associationKeyNotIn;
-		yourself.
-
-	"if the key already exist, nothing changes"
-	v := dictionary at: keyIn.
-	dictionary declare: keyIn from: newDict.
-	self assert: (dictionary at: keyIn) equals: v.
-
-	"if the key does not exist, then it gets removed from newDict and is added to the receiver"
-	self nonEmptyDict declare: associationKeyNotIn key from: newDict.
-	self assert: (dictionary at: associationKeyNotIn key) equals: associationKeyNotIn value.
-	self assert: newDict size equals: 0
-]

--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -496,21 +496,6 @@ Dictionary >> collect: aBlock [
 	^newCollection
 ]
 
-{ #category : 'adding' }
-Dictionary >> declare: key from: aDictionary [
-	"Add key to the receiver. If key already exists, do nothing. If aDictionary
-	includes key, then remove it from aDictionary and use its association as
-	the element of the receiver."
-
-	(self includesKey: key) ifTrue: [^ self].
-	(aDictionary includesKey: key)
-		ifTrue:
-			[self add: (aDictionary associationAt: key).
-			aDictionary removeKey: key]
-		ifFalse:
-			[self add: key -> nil]
-]
-
 { #category : 'enumerating' }
 Dictionary >> difference: aCollection [
 	"Answer the set theoretic difference of two collections. This is a specialized version for Dictionaries keeping the keys of the objects. At a slightly higher price of an additional Set to track duplicates."

--- a/src/Collections-Unordered/SmallDictionary.class.st
+++ b/src/Collections-Unordered/SmallDictionary.class.st
@@ -397,21 +397,6 @@ SmallDictionary >> collect: aBlock [
 	^newCollection
 ]
 
-{ #category : 'adding' }
-SmallDictionary >> declare: key from: aDictionary [
-	"Add key to the receiver. If key already exists, do nothing. If aDictionary
-	includes key, then remove it from aDictionary and use its association as
-	the element of the receiver."
-
-	(self includesKey: key) ifTrue: [^ self].
-	(aDictionary includesKey: key)
-		ifTrue:
-			[self add: (aDictionary associationAt: key).
-			aDictionary removeKey: key]
-		ifFalse:
-			[self add: key -> nil]
-]
-
 { #category : 'enumerating' }
 SmallDictionary >> difference: aCollection [
 	"Answer the set theoretic difference of two collections. This is a specialized version for Dictionaries keeping the keys of the objects. At a slightly higher price of an additional Set to track duplicates."

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -891,18 +891,17 @@ Class >> removeFromSystem: logged [
 	Keep the class name and category for triggering the system change message. If we wait to long, then we get obsolete information which is not what we want.
 	Tell class to deactivate and unload itself-- two separate events in the module system"
 
-	| tag variable |
-
+	| tag |
 	self release.
 	self unload.
 
 	self superclass ifNotNil: [ "If we have no superclass there's nothing to be remembered" self superclass addObsoleteSubclass: self ].
 
 	"we add the class to Undeclared so that if references still exist, they will  be automatically fixed if this class is loaded again. We do not check if references exist as it is too slow"
-	variable := self environment associationAt: self name asSymbol.
+	self environment associationAt: self name asSymbol ifPresent: [ :variable |
 	"we remove it later using #forgetClass:"
 	variable primitiveChangeClassTo: UndeclaredVariable new.
-	variable register.
+	variable register].
 	self flag: #package. "For now the class cannot return its package tag after been removed. In the future the class should keep a reference to its package tag so we should not need that."
 	tag := self packageTag.
 	self environment forgetClass: self.

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -883,7 +883,7 @@ Class >> removeFromSystem: logged [
 	self superclass ifNotNil: [ "If we have no superclass there's nothing to be remembered" self superclass addObsoleteSubclass: self ].
 
 	"we add the class to Undeclared so that if references still exist, they will  be automatically fixed if this class is loaded again. We do not check if references exist as it is too slow"
-	Undeclared declare: self name asSymbol from: Smalltalk globals.
+	(UndeclaredVariable named: self name) register.
 	self flag: #package. "For now the class cannot return its package tag after been removed. In the future the class should keep a reference to its package tag so we should not need that."
 	packageTag := self packageTag.
 	self environment forgetClass: self.

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -846,11 +846,12 @@ Class >> removeClassVarNamed: aString interactive: interactive [
 		(self confirm: (aString , ' is still used in code of class ' , varUserClass name , '.\Is it okay to move it to Undeclared?') withCRs) ifFalse: [ ^ self ] ].
 
 	varUserClass
-		ifNotNil: [
+		ifNotNil: [ | variable |
 			NewUndeclaredWarning signal: aString in: self name.
-			Undeclared declare: aSymbol from: self classPool ]
-		ifNil: [ self classPool removeKey: aSymbol ].
-
+			variable := (self classPool associationAt: aSymbol).
+			variable primitiveChangeClassTo: UndeclaredVariable new.
+			variable register ].
+	self classPool removeKey: aSymbol.
 	self classPool ifEmpty: [ self classPool: nil ].
 
 	SystemAnnouncer uniqueInstance classModificationAppliedTo: self
@@ -876,14 +877,17 @@ Class >> removeFromSystem: logged [
 	Keep the class name and category for triggering the system change message. If we wait to long, then we get obsolete information which is not what we want.
 	Tell class to deactivate and unload itself-- two separate events in the module system"
 
-	| packageTag |
+	| packageTag variable |
 	self release.
 	self unload.
 
 	self superclass ifNotNil: [ "If we have no superclass there's nothing to be remembered" self superclass addObsoleteSubclass: self ].
 
 	"we add the class to Undeclared so that if references still exist, they will  be automatically fixed if this class is loaded again. We do not check if references exist as it is too slow"
-	(UndeclaredVariable named: self name) register.
+	variable := self environment associationAt: self name asSymbol.
+	"we remove it later using #forgetClass:"
+	variable primitiveChangeClassTo: UndeclaredVariable new.
+	variable register.
 	self flag: #package. "For now the class cannot return its package tag after been removed. In the future the class should keep a reference to its package tag so we should not need that."
 	packageTag := self packageTag.
 	self environment forgetClass: self.

--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -141,7 +141,7 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariableWhenItIsAlreadyRegistered
 	The bootstrap will be updated at some point. But now this case needs to be supported:
 		- declaring undefined var should update registered variable when its type is not undeclared var"
 	| newCompiledMethod undeclaredBinding |
-	Undeclared add: #undeclaredTestVar -> nil.
+	Undeclared add: (UndeclaredVariable named: #undeclaredTestVar).
 	newCompiledMethod := OpalCompiler new
 		source:
 			'methodWithUndeclaredVar

--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -141,7 +141,7 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariableWhenItIsAlreadyRegistered
 	The bootstrap will be updated at some point. But now this case needs to be supported:
 		- declaring undefined var should update registered variable when its type is not undeclared var"
 	| newCompiledMethod undeclaredBinding |
-	Undeclared add: (UndeclaredVariable named: #undeclaredTestVar).
+	(UndeclaredVariable named: #undeclaredTestVar) register.
 	newCompiledMethod := OpalCompiler new
 		source:
 			'methodWithUndeclaredVar

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -339,7 +339,7 @@ SmalltalkImage >> cleanOutUndeclared [
 	"remove all Undeclareds that are not used in installed methods"
 	Undeclared associations 
 		select: [ :var | var usingMethods isEmpty ]
-		thenDo: [ :var | Undeclared removeKey: var name ]
+		thenDo: [ :var | var unregister ]
 ]
 
 { #category : 'cleanup' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -336,18 +336,10 @@ SmalltalkImage >> classOrTraitNamed: aString [
 
 { #category : 'housekeeping' }
 SmalltalkImage >> cleanOutUndeclared [
-	| unreferenced |
-	unreferenced := Undeclared keys asSet.
-	self systemNavigation allBehaviorsDo: [ :class |
-		class methodsDo: [ :method |
-			method withAllNestedLiteralsDo: [ :lit |
-				(lit isKindOf: UndeclaredVariable) ifTrue: [
-					unreferenced
-						remove: lit key
-						ifAbsent: [ "Sanity check--a binding with more than one reference may already be gone from the unreferenced set, but should be present in Undeclared itself"
-							self at: lit key ] ] ] ] ].
-
-	unreferenced do: [ :key | Undeclared removeKey: key ]
+	"remove all Undeclareds that are not used in installed methods"
+	Undeclared associations 
+		select: [ :var | var usingMethods isEmpty ]
+		thenDo: [ :var | Undeclared removeKey: var name ]
 ]
 
 { #category : 'cleanup' }

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -107,11 +107,25 @@ SystemDictionary >> at: aKey put: anObject [
 	"Override from Dictionary to check Undeclared and fix up
 	references to undeclared variables."
 
+	| index assoc |
+
 	aKey isSymbol ifFalse: [ self error: 'Only symbols are accepted as keys in SystemDictionary' ].
-	(self includesKey: aKey) ifFalse: [
-		self declare: aKey from: Undeclared.
-		self flushClassNameCache ].
-	super at: aKey put: anObject.
+	((self includesKey: aKey) not and: [ Undeclared includesKey: aKey ]) ifTrue: [
+			| undeclared |
+			undeclared := Undeclared associationAt: aKey.
+			"Undeclared variables record using methods in a property, remove. Boostrap might have used Associations"
+			(undeclared class == UndeclaredVariable) ifTrue: [undeclared removeProperty: #registeredMethods ifAbsent: [ ]]. 
+			"and change class to be Global" 
+			self add: (undeclared primitiveChangeClassTo: GlobalVariable new).
+			Undeclared removeKey: aKey.
+			self flushClassNameCache ].
+
+	"code of super at:put:, not using Associations but GlobalVariable"
+	index := self findElementOrNil: aKey.
+	assoc := array at: index.
+	assoc
+		ifNil: [self atNewIndex: index put: (GlobalVariable key: aKey value: anObject)]
+		ifNotNil: [assoc value: anObject].
 	^ anObject
 ]
 
@@ -167,27 +181,6 @@ SystemDictionary >> classOrTraitNamed: aString [
 			  meta
 				  ifFalse: [ global ]
 				  ifTrue: [ global classSide ] ] ]
-]
-
-{ #category : 'adding' }
-SystemDictionary >> declare: key from: aDictionary [
-	"Add key to the receiver. If key already exists, do nothing. If aDictionary
-	includes key, then remove it from aDictionary and use its association as
-	the element of the receiver."
-	"overridden here to add a Global, not just an association"
-
-	(self includesKey: key) ifTrue: [^ self].
-	(aDictionary includesKey: key)
-		ifTrue:
-			[| undeclared |
-			undeclared := aDictionary associationAt: key.
-			"Undeclared variables record using methods in a property, remove. Boostrap might have used Associations"
-			(undeclared class == UndeclaredVariable) ifTrue: [undeclared removeProperty: #registeredMethods ifAbsent: [ ]]. 
-			"and change class to be Global"
-			self add: (undeclared primitiveChangeClassTo: GlobalVariable new).
-			aDictionary removeKey: key]
-		ifFalse:
-			[self add: (GlobalVariable key: key)]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This PR now does:

- Inline and remove the private method #declare:from: from Dictionaries
- This allows to make sure that when we move variables to and from Undeclared, we correctly change the class (this code is not nice, we need to improve the Undeclared fixing in a second step)
- fix tests to not put a Association into the Undeclared Dict
- fix SystemDictionary>>#at:put: to no use Associations when using #at:put: 

And the original starting point:
- do not iterate all methods for #cleanOutUndeclared, but use the recorded #usingMethods


fixes #15191
fixes #11903 