### PR TITLE
Improve tests logs

### DIFF
--- a/src/JenkinsTools-Core/HDReport.class.st
+++ b/src/JenkinsTools-Core/HDReport.class.st
@@ -21,16 +21,7 @@ HDReport class >> runPackage: aString [
 { #category : 'running' }
 HDReport class >> runPackages: aCollectionOfStrings [
 
-	^ aCollectionOfStrings collect: [ :packageName |
-		  | time result |
-		  time := DateAndTime now.
-		  Transcript << 'Beginning to run tests of ' << packageName << OSPlatform current lineEnding.
-		  "We flush so that if a crash happens during the tests, we print in which package is the naughty test in the logs."
-		  Transcript flush.
-		  result := self runPackage: packageName.
-		  Transcript << 'Finished to run tests of ' << packageName << ' in ' << (DateAndTime now - time) humanReadablePrintString << OSPlatform current lineEnding.
-		  Transcript flush.
-		  result ]
+	^ aCollectionOfStrings collect: [ :packageName | self runPackage: packageName ]
 ]
 
 { #category : 'private' }

--- a/src/JenkinsTools-Core/HDTestReport.class.st
+++ b/src/JenkinsTools-Core/HDTestReport.class.st
@@ -35,18 +35,25 @@ HDTestReport class >> currentStageName: aStageName [
 ]
 
 { #category : 'running' }
-HDTestReport class >> runClasses: aCollectionOfClasses named: aString [
-	| suite classes |
-	suite := TestSuite named: aString.
-	classes := (aCollectionOfClasses
-		select: [ :each | (each includesBehavior: TestCase) and: [ each isAbstract not ] ])
-			asSortedCollection: [ :a :b | a name <= b name ].
-	classes isEmpty
-		ifTrue: [ ^ nil ].
-		
-	classes
-		do: [ :each | suite addTests: each buildSuite tests ].
-	^ self runSuite: suite
+HDTestReport class >> runClasses: aCollectionOfClasses named: packageName [
+
+	| suite classes time result |
+	suite := TestSuite named: packageName.
+	classes := (aCollectionOfClasses select: [ :class | class isTestCase and: [ class isAbstract not ] ]) asSortedCollection: [ :a :b | a name <= b name ].
+
+	classes ifEmpty: [ ^ nil ].
+
+	classes do: [ :class | suite addTests: class buildSuite tests ].
+
+	time := DateAndTime now.
+	Transcript << 'Beginning to run tests of ' << packageName << OSPlatform current lineEnding.
+	"We flush so that if a crash happens during the tests, we print in which package is the naughty test in the logs."
+	Transcript flush.
+	result := self runSuite: suite.
+	Transcript << 'Finished to run tests of ' << packageName << ' in ' << (DateAndTime now - time) humanReadablePrintString << OSPlatform current lineEnding.
+	Transcript flush.
+
+	^ result
 ]
 
 { #category : 'running' }
@@ -57,8 +64,8 @@ HDTestReport class >> runPackage: aString [
 
 { #category : 'running' }
 HDTestReport class >> runSuite: aTestSuite [
-	^ self new
-		runSuite: aTestSuite
+
+	^ self new runSuite: aTestSuite
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
New step at improving tests logs. 

Instead of printing logs for each package, now we print only for packages containing tests. 

BTW HDTestReport seems to duplicate the whole test running logic. This does not seems really nice