### PR TITLE
Clean traits tests

### DIFF
--- a/src/TraitsV2-Tests/T2AbstractTest.class.st
+++ b/src/TraitsV2-Tests/T2AbstractTest.class.st
@@ -4,9 +4,6 @@ Abstract Test of all the TraitsV2 tests
 Class {
 	#name : 'T2AbstractTest',
 	#superclass : 'TestCase',
-	#instVars : [
-		'createdClasses'
-	],
 	#category : 'TraitsV2-Tests',
 	#package : 'TraitsV2-Tests'
 }
@@ -19,124 +16,53 @@ T2AbstractTest class >> isAbstract [
 
 { #category : 'instance creation' }
 T2AbstractTest >> newClass: aName [
-	^self newClass: aName with: #() trait: TEmpty
+	^self newClass: aName with: #() traits: TEmpty
 ]
 
 { #category : 'instance creation' }
-T2AbstractTest >> newClass: aName superclass: aSuperclass with: slots trait: aComposition [
+T2AbstractTest >> newClass: aName superclass: aSuperclass with: slots traits: aComposition [
 
-	^ self newClass: aName superclass: aSuperclass with: slots uses: aComposition category: 'TraitsV2-Tests-TestClasses'
+	^ self class classInstaller make: [ :aClassBuilder |
+		  aClassBuilder
+			  name: aName;
+			  superclass: aSuperclass;
+			  slots: slots;
+			  traitComposition: aComposition;
+			  package: self packageNameForTests ]
 ]
 
 { #category : 'instance creation' }
-T2AbstractTest >> newClass: aName superclass: aSuperclass with: slots trait: aComposition category: category [
-
-	| class |
-
-	class := self class classInstaller make: [ :aClassBuilder |
-		aClassBuilder
-			name: aName;
-			superclass: aSuperclass;
-			slots: slots;
-			traitComposition: aComposition;
-			package: category ].
-
-	createdClasses add:class.
-
-	^class
-]
-
-{ #category : 'instance creation' }
-T2AbstractTest >> newClass: aName superclass: aSuperclass with: slots uses: aComposition [
-
-	^ self newClass: aName superclass: aSuperclass with: slots uses: aComposition category: 'TraitsV2-Tests-TestClasses'
-]
-
-{ #category : 'instance creation' }
-T2AbstractTest >> newClass: aName superclass: aSuperclass with: slots uses: aComposition category: category [
-
-	| class |
-
-	class := self class classInstaller make: [ :aClassBuilder |
-		aClassBuilder
-			name: aName;
-			superclass: aSuperclass;
-			slots: slots;
-			traitComposition: aComposition;
-			package: category ].
-
-	createdClasses add:class.
-
-	^class
-]
-
-{ #category : 'instance creation' }
-T2AbstractTest >> newClass: aName with: slots trait: aComposition [
-	^ self newClass: aName superclass: Object with: slots trait: aComposition
-]
-
-{ #category : 'instance creation' }
-T2AbstractTest >> newClass: aName with: slots uses: aComposition [
-	^ self newClass: aName superclass: Object with: slots uses: aComposition
+T2AbstractTest >> newClass: aName with: slots traits: aComposition [
+	^ self newClass: aName superclass: Object with: slots traits: aComposition
 ]
 
 { #category : 'instance creation' }
 T2AbstractTest >> newTrait: aName with: slots [
-	^ self newTrait: aName with: slots trait: TEmpty
+	^ self newTrait: aName with: slots traits: TEmpty
 ]
 
 { #category : 'instance creation' }
-T2AbstractTest >> newTrait: aName with: slots trait: aComposition [
-	^ self newTrait: aName with: slots trait: aComposition category: 'TraitsV2-Tests-TestClasses'
+T2AbstractTest >> newTrait: aName with: slots traits: aComposition [
+
+	^ self class classInstaller make: [ :aBuilder |
+		  aBuilder
+			  name: aName;
+			  traitComposition: aComposition;
+			  slots: slots;
+			  package: self packageNameForTests;
+			  beTrait ]
 ]
 
-{ #category : 'instance creation' }
-T2AbstractTest >> newTrait: aName with: slots trait: aComposition category: category [
-	| class |
-	class := self class classInstaller make: [ :aBuilder |
-		aBuilder
-			name: aName;
-			traitComposition: aComposition;
-			slots: slots;
-			package: category;
-			beTrait ].
+{ #category : 'setup' }
+T2AbstractTest >> packageNameForTests [
 
-	createdClasses add:class.
-
-	^class
-]
-
-{ #category : 'instance creation' }
-T2AbstractTest >> newTrait: aName with: slots uses: aComposition [
-	^ self newTrait: aName with: slots trait: aComposition category: 'TraitsV2-Tests-TestClasses'
-]
-
-{ #category : 'instance creation' }
-T2AbstractTest >> newTrait: aName with: slots uses: aComposition category: category [
-	| class |
-	class := self class classInstaller make: [ :aBuilder |
-		aBuilder
-			name: aName;
-			traitComposition: aComposition;
-			slots: slots;
-			package: category;
-			beTrait ].
-
-	createdClasses add:class.
-
-	^class
-]
-
-{ #category : 'running' }
-T2AbstractTest >> setUp [
-	super setUp.
-	createdClasses := OrderedCollection new
+	^ #'Generated-Trait-Test-Package'
 ]
 
 { #category : 'running' }
 T2AbstractTest >> tearDown [
-	createdClasses reverseDo: #removeFromSystem.
-	createdClasses := nil.
+
+	self packageOrganizer removePackage: self packageNameForTests.
 
 	super tearDown
 ]

--- a/src/TraitsV2-Tests/T2ObsoleteClassTest.class.st
+++ b/src/TraitsV2-Tests/T2ObsoleteClassTest.class.st
@@ -10,55 +10,55 @@ Class {
 
 { #category : 'tests' }
 T2ObsoleteClassTest >> testObsoleteClassIsRemovedFromUsers [
-	| t1 t2 c1 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
 
-	c1 := self newClass: #C1 with: #()  uses:  t1 + t2.
+	| t1 t2 c1 |
+	t1 := self newTrait: #T1 with: #(  ) traits: {  }.
+	t2 := self newTrait: #T2 with: #(  ) traits: {  }.
+
+	c1 := self newClass: #C1 with: #(  ) traits: t1 + t2.
 
 	self assert: (t1 users includes: c1).
 	self assert: (t2 users includes: c1).
 
 	c1 removeFromSystem.
-	createdClasses remove: c1.
 
 	self deny: (t1 users includes: c1).
-	self deny: (t2 users includes: c1).
+	self deny: (t2 users includes: c1)
 ]
 
 { #category : 'tests' }
 T2ObsoleteClassTest >> testObsoleteClassIsRemovedFromUsersClassSide [
-	| t1 t2 c1 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
 
-	c1 := self newClass: #C1 with: #()  uses: {}.
+	| t1 t2 c1 |
+	t1 := self newTrait: #T1 with: #(  ) traits: {  }.
+	t2 := self newTrait: #T2 with: #(  ) traits: {  }.
+
+	c1 := self newClass: #C1 with: #(  ) traits: {  }.
 	c1 class setTraitComposition: t1 + t2.
 
 	self assert: (t1 users includes: c1 class).
 	self assert: (t2 users includes: c1 class).
 
 	c1 removeFromSystem.
-	createdClasses remove: c1.
 
 	self deny: (t1 users includes: c1 class).
-	self deny: (t2 users includes: c1 class).
+	self deny: (t2 users includes: c1 class)
 ]
 
 { #category : 'tests' }
 T2ObsoleteClassTest >> testObsoleteTraitIsRemovedFromUsers [
-	| t1 t2 t3 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
 
-	t3 := self newTrait: #T3 with: #()  uses:  t1 + t2.
+	| t1 t2 t3 |
+	t1 := self newTrait: #T1 with: #(  ) traits: {  }.
+	t2 := self newTrait: #T2 with: #(  ) traits: {  }.
+
+	t3 := self newTrait: #T3 with: #(  ) traits: t1 + t2.
 
 	self assert: (t1 users includes: t3).
 	self assert: (t2 users includes: t3).
 
 	t3 removeFromSystem.
-	createdClasses remove: t3.
 
 	self deny: (t1 users includes: t3).
-	self deny: (t2 users includes: t3).
+	self deny: (t2 users includes: t3)
 ]

--- a/src/TraitsV2-Tests/T2OverloadingOfMethodsInTraitedClassTest.class.st
+++ b/src/TraitsV2-Tests/T2OverloadingOfMethodsInTraitedClassTest.class.st
@@ -49,7 +49,7 @@ T2OverloadingOfMethodsInTraitedClassTest >> testDirectTraitSubclassing [
 		<ignoreNotImplementedSelectors: #(isTrueForUsersOfTheTraitForT2OverloadingOfMethodsInTraitedClassTest)>
 	| t1 c1 |
 	t1 := self createT1.
-	c1 := self newClass: #C1 with: '' asSlotCollection uses: t1.
+	c1 := self newClass: #C1 with: '' asSlotCollection traits: t1.
 	self
 		assert:
 			c1 isTrueForUsersOfTheTraitForT2OverloadingOfMethodsInTraitedClassTest
@@ -64,13 +64,13 @@ T2OverloadingOfMethodsInTraitedClassTest >> testIndirectTraitSubclassing [
 	superclass := self
 		newClass: #C2Superclass
 		with: '' asSlotCollection
-		uses: t2.
+		traits: t2.
 
 	subclass := self
 		newClass: #C1Subclass
 		superclass: superclass
 		with: '' asSlotCollection
-		uses: t1.
+		traits: t1.
 	self
 		deny:
 			superclass

--- a/src/TraitsV2-Tests/T2PrecedenceCompositionTest.class.st
+++ b/src/TraitsV2-Tests/T2PrecedenceCompositionTest.class.st
@@ -10,10 +10,10 @@ T2PrecedenceCompositionTest >> testClassCompositionOnPrecedenceKeepsPreference [
 
 	| t1 t2 original copy |
 
-	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 := self newTrait: #T1 with: #() traits: #().
 	t1 classTrait uses: {} slots: #().
 
-	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 := self newTrait: #T2 with: #() traits: #().
 	t2 classTrait uses: {} slots: #().
 
 	t1 compile: 'm1 ^ 42'.
@@ -32,10 +32,10 @@ T2PrecedenceCompositionTest >> testCopyingAPrecedenceKeepsPreference [
 
 	| t1 t2 original copy |
 
-	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 := self newTrait: #T1 with: #() traits: #().
 	t1 classTrait uses: {} slots: #().
 
-	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 := self newTrait: #T2 with: #() traits: #().
 	t2 classTrait uses: {} slots: #().
 
 	t1 compile: 'm1 ^ 42'.
@@ -49,58 +49,54 @@ T2PrecedenceCompositionTest >> testCopyingAPrecedenceKeepsPreference [
 
 { #category : 'tests' }
 T2PrecedenceCompositionTest >> testPrecedencesAreGeneratedInClassDefinition [
+
 	| t1 t2 t3 c1 |
-	t1 := self newTrait: #T1 with: #() uses: #().
-	t1 classTrait uses: {} slots: #().
+	t1 := self newTrait: #T1 with: #(  ) traits: #(  ).
+	t1 classTrait uses: {  } slots: #(  ).
 
-	t2 := self newTrait: #T2 with: #() uses: #().
-	t2 classTrait uses: {} slots: #().
+	t2 := self newTrait: #T2 with: #(  ) traits: #(  ).
+	t2 classTrait uses: {  } slots: #(  ).
 
-	t3 := self newTrait: #T3 with: #() uses: #().
-	t3 classTrait uses: {} slots: #().
+	t3 := self newTrait: #T3 with: #(  ) traits: #(  ).
+	t3 classTrait uses: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 	t3 compile: 'm2 ^ 11'.
 
-	c1 := self newClass: #C1 with: #() uses: (t2 + t1 + t3 withPrecedenceOf: t2).
+	c1 := self newClass: #C1 with: #(  ) traits: (t2 + t1 + t3 withPrecedenceOf: t2).
 
-	self
-		assert: (ClassDefinitionPrinter oldPharo for: c1) definitionString
-		equals:
-
-			'Object subclass: #C1
+	self assert: (ClassDefinitionPrinter oldPharo for: c1) definitionString equals: 'Object subclass: #C1
 	uses: (T2 + T1 + T3 withPrecedenceOf: T2)
 	instanceVariableNames: ''''
 	classVariableNames: ''''
-	package: ''TraitsV2-Tests-TestClasses'''
+	package: ''' , self packageNameForTests , ''''
 ]
 
 { #category : 'tests' }
 T2PrecedenceCompositionTest >> testPrecedencesAreGeneratedInClassDefinitionWithAlias [
+
 	| t1 t2 t3 c1 |
-	t1 := self newTrait: #T1 with: #() uses: #().
-	t1 classTrait uses: {} slots: #().
+	t1 := self newTrait: #T1 with: #(  ) traits: #(  ).
+	t1 classTrait uses: {  } slots: #(  ).
 
-	t2 := self newTrait: #T2 with: #() uses: #().
-	t2 classTrait uses: {} slots: #().
+	t2 := self newTrait: #T2 with: #(  ) traits: #(  ).
+	t2 classTrait uses: {  } slots: #(  ).
 
-	t3 := self newTrait: #T3 with: #() uses: #().
-	t3 classTrait uses: {} slots: #().
+	t3 := self newTrait: #T3 with: #(  ) traits: #(  ).
+	t3 classTrait uses: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 	t3 compile: 'm2 ^ 11'.
 
-	c1 := self newClass: #C1 with: #() uses: (t2 + (t1 -- #aSlot) + t3 withPrecedenceOf: t2).
+	c1 := self newClass: #C1 with: #(  ) traits: (t2 + (t1 -- #aSlot) + t3 withPrecedenceOf: t2).
 
-	self
-		assert: (ClassDefinitionPrinter oldPharo for: c1) definitionString
-		equals: 'Object subclass: #C1
+	self assert: (ClassDefinitionPrinter oldPharo for: c1) definitionString equals: 'Object subclass: #C1
 	uses: (T2 + (T1 -- #aSlot) + T3 withPrecedenceOf: T2)
 	instanceVariableNames: ''''
 	classVariableNames: ''''
-	package: ''TraitsV2-Tests-TestClasses'''
+	package: ''' , self packageNameForTests , ''''
 ]
 
 { #category : 'tests' }
@@ -108,13 +104,13 @@ T2PrecedenceCompositionTest >> testPrecedencesCanBeCombined [
 
 	| t1 t2 t3 c1 |
 	<ignoreNotImplementedSelectors: #(m1 m2)>
-	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 := self newTrait: #T1 with: #() traits: #().
 	t1 classTrait uses: {} slots: #().
 
-	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 := self newTrait: #T2 with: #() traits: #().
 	t2 classTrait uses: {} slots: #().
 
-	t3 := self newTrait: #T3 with: #() uses: #().
+	t3 := self newTrait: #T3 with: #() traits: #().
 	t3 classTrait uses: {} slots: #().
 
 	t1 compile: 'm1 ^ 42'.
@@ -122,7 +118,7 @@ T2PrecedenceCompositionTest >> testPrecedencesCanBeCombined [
 
 	t3 compile: 'm2 ^ 11'.
 
-	c1 := self newClass: #C1 with: #() uses: (((t2 + t1) withPrecedenceOf: t2) + t3).
+	c1 := self newClass: #C1 with: #() traits: (((t2 + t1) withPrecedenceOf: t2) + t3).
 
 	self assert: (c1 new m1) equals: 33.
 	self assert: (c1 new m2) equals: 11
@@ -133,16 +129,16 @@ T2PrecedenceCompositionTest >> testWithPrecedenceIsNonAConflict [
 
 	| t1 t2 c1 |
 
-	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 := self newTrait: #T1 with: #() traits: #().
 	t1 classTrait uses: {} slots: #().
 
-	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 := self newTrait: #T2 with: #() traits: #().
 	t2 classTrait uses: {} slots: #().
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 
-	c1 := self newClass: #C1 with: #() uses: ((t1 + t2) withPrecedenceOf: t2).
+	c1 := self newClass: #C1 with: #() traits: ((t1 + t2) withPrecedenceOf: t2).
 
 	self deny: (c1 >> #m1) isConflict
 ]
@@ -152,16 +148,16 @@ T2PrecedenceCompositionTest >> testWithPrecedenceUsesThePreferedOne [
 	<ignoreNotImplementedSelectors: #(m1)>
 	| t1 t2 c1 |
 
-	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 := self newTrait: #T1 with: #() traits: #().
 	t1 classTrait uses: {} slots: #().
 
-	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 := self newTrait: #T2 with: #() traits: #().
 	t2 classTrait uses: {} slots: #().
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 
-	c1 := self newClass: #C1 with: #() uses: ((t1 + t2) withPrecedenceOf: t2).
+	c1 := self newClass: #C1 with: #() traits: ((t1 + t2) withPrecedenceOf: t2).
 
 	self assert: (c1 new m1) equals: 33
 ]
@@ -171,16 +167,16 @@ T2PrecedenceCompositionTest >> testWithPrecedenceUsesThePreferedOneWithoutCaring
 	<ignoreNotImplementedSelectors: #(m1)>
 	| t1 t2 c1 |
 
-	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 := self newTrait: #T1 with: #() traits: #().
 	t1 classTrait uses: {} slots: #().
 
-	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 := self newTrait: #T2 with: #() traits: #().
 	t2 classTrait uses: {} slots: #().
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 
-	c1 := self newClass: #C1 with: #() uses: ((t2 + t1) withPrecedenceOf: t2).
+	c1 := self newClass: #C1 with: #() traits: ((t2 + t1) withPrecedenceOf: t2).
 
 	self assert: (c1 new m1) equals: 33
 ]
@@ -190,16 +186,16 @@ T2PrecedenceCompositionTest >> testWithoutPrecedenceIsAConflict [
 
 	| t1 t2 c1 |
 
-	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 := self newTrait: #T1 with: #() traits: #().
 	t1 classTrait uses: {} slots: #().
 
-	t2 := self newTrait: #T2 with: #() uses: #().
+	t2 := self newTrait: #T2 with: #() traits: #().
 	t2 classTrait uses: {} slots: #().
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 
-	c1 := self newClass: #C1 with: #() uses: t1 + t2.
+	c1 := self newClass: #C1 with: #() traits: t1 + t2.
 
 	self assert: (c1 >> #m1) isConflict
 ]

--- a/src/TraitsV2-Tests/T2SubclassingTraitedClassTest.class.st
+++ b/src/TraitsV2-Tests/T2SubclassingTraitedClassTest.class.st
@@ -7,40 +7,50 @@ Class {
 
 { #category : 'tests' }
 T2SubclassingTraitedClassTest >> testCreatingMethodInSubclass [
-	| t1 c1 c2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	c1 := self newClass: #C1 with: #()  uses: t1.
 
-	c2 := self newClass: #C2 superclass: c1 with: #() uses: {}.
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1 with: #(  ) traits: {  }.
+	c1 := self newClass: #C1 with: #(  ) traits: t1.
+
+	c2 := self
+		      newClass: #C2
+		      superclass: c1
+		      with: #(  )
+		      traits: {  }.
 
 	c2 compile: 'asd'.
 
-	self shouldnt: [c2 >> #asd] raise: Error.
-	self assert: (c2 >> #asd) package name equals: 'TraitsV2-Tests-TestClasses'.
+	self shouldnt: [ c2 >> #asd ] raise: Error.
+	self assert: (c2 >> #asd) package name equals: self packageNameForTests.
 	self assert: (c2 >> #asd) package equals: c2 package
 ]
 
 { #category : 'tests' }
 T2SubclassingTraitedClassTest >> testCreatingMethodInSubclass2 [
-	| t1 c1 c2 |
-	c1 := self newClass: #C1 with: #() uses: {}.
-	c2 := self newClass: #C2 superclass: c1 with: #() uses: {}.
 
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	c1 := self newClass: #C1 with: #() uses: t1.
+	| t1 c1 c2 |
+	c1 := self newClass: #C1 with: #(  ) traits: {  }.
+	c2 := self
+		      newClass: #C2
+		      superclass: c1
+		      with: #(  )
+		      traits: {  }.
+
+	t1 := self newTrait: #T1 with: #(  ) traits: {  }.
+	c1 := self newClass: #C1 with: #(  ) traits: t1.
 
 	c2 compile: 'asd'.
 
-	self shouldnt: [c2 >> #asd] raise: Error.
-	self assert: (c2 >> #asd) package name equals: 'TraitsV2-Tests-TestClasses'.
+	self shouldnt: [ c2 >> #asd ] raise: Error.
+	self assert: (c2 >> #asd) package name equals: self packageNameForTests.
 	self assert: (c2 >> #asd) package equals: c2 package
 ]
 
 { #category : 'tests' }
 T2SubclassingTraitedClassTest >> testCreatingMethodInTraitClassSide [
 	| t1 c1 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 	t1 class compile: 'someObject ^#executingOverridenMethod'.
-	c1 := self newClass: #C1 with: #() uses: t1.
+	c1 := self newClass: #C1 with: #() traits: t1.
 	self assert: c1 someObject equals: #executingOverridenMethod
 ]

--- a/src/TraitsV2-Tests/T2TraitAnnouncementsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitAnnouncementsTest.class.st
@@ -18,33 +18,34 @@ T2TraitAnnouncementsTest >> testRPackageIsUpdatedInClassSide [
 
 	| c1 t1 |
 
-	t1 := self newTrait: #T1 with: #() trait: TEmpty category: self packageName.
+	t1 := self newTrait: #T1 with: #() traits: TEmpty.
 	t1 class compile: 'msg ^ 1'.
 
-	c1 := self newClass: #C1 superclass: Object with: #() trait: t1 category: self packageName.
+	c1 := self newClass: #C1 superclass: Object with: #() traits: t1.
 	c1 class compile: 'msg ^ 12'.
 
-	self assert: self packageName asPackage methods size equals: 2.
+	self assert: self packageNameForTests asPackage methods size equals: 2.
 	(c1 class >> #msg) removeFromSystem.
-	self assert: self packageName asPackage methods size equals: 1
+	self assert: self packageNameForTests asPackage methods size equals: 1
 ]
 
 { #category : 'tests' }
 T2TraitAnnouncementsTest >> testRPackageIsUpdatedInInstanceSide [
 
-	[
 	| c1 t1 |
-
-	t1 := self newTrait: #T1 with: #() uses: #() category: self packageName.
+	t1 := self newTrait: #T1 with: #(  ) traits: #(  ).
 	t1 compile: 'msg ^ 1'.
 
-	c1 := self newClass: #C1 superclass: Object with: #() uses: t1 category: self packageName.
+	c1 := self
+		      newClass: #C1
+		      superclass: Object
+		      with: #(  )
+		      traits: t1.
 	c1 compile: 'msg ^ 12'.
 
 	self assert: (c1 >> #msg) origin equals: c1.
 
-	self assert: self packageName asPackage methods size equals: 2.
+	self assert: self packageNameForTests asPackage methods size equals: 2.
 	(c1 >> #msg) removeFromSystem.
-	self assert: self packageName asPackage methods size equals: 1 ] ensure: [ 
-		(self packageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ] ]
+	self assert: self packageNameForTests asPackage methods size equals: 1
 ]

--- a/src/TraitsV2-Tests/T2TraitChangesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitChangesTest.class.st
@@ -9,17 +9,16 @@ Class {
 T2TraitChangesTest >> testGeneratingTheSameTraitDoesNotProduceChanges [
 
 	| t1 builder |
-
-	t1 := self newTrait: #T1 with: {}.
+	t1 := self newTrait: #T1 with: {  }.
 
 	builder := ShiftClassBuilder new
-		name: #T1;
-		package: 'TraitsV2-Tests-TestClasses';
-		traitComposition: TEmpty;
-		tryToFillOldClass;
-		detectBuilderEnhancer;
-		beTrait.
-		
+		           name: #T1;
+		           package: self packageNameForTests;
+		           traitComposition: TEmpty;
+		           tryToFillOldClass;
+		           detectBuilderEnhancer;
+		           beTrait.
+
 	builder builderEnhancer validateRedefinition: builder oldClass.
 
 	builder validateSuperclass.
@@ -36,7 +35,7 @@ T2TraitChangesTest >> testUpdatingTheSameTraitDoesNotProduceChanges [
 
 	builder := ShiftClassBuilder new
 		           name: #T1;
-		           package: 'TraitsV2-Tests-TestClasses';
+		           package: self packageNameForTests;
 		           traitComposition: TEmpty;
 		           beTrait;
 		           yourself.
@@ -61,7 +60,7 @@ T2TraitChangesTest >> testconfigureBuilderWithNameTraitCompositionInstanceVariab
 		           name: #T1;
 		           beTrait;
 		           slotsFromString: 'a b';
-		           package: 'TraitsV2-Tests-TestClasses'.
+		           package: self packageNameForTests.
 
 	self assert: builder slots size equals: 2.
 	self assert: builder slots first name equals: 'a'.

--- a/src/TraitsV2-Tests/T2TraitInTraitClassTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitInTraitClassTest.class.st
@@ -10,7 +10,7 @@ T2TraitInTraitClassTest >> testAddingSlotToClassSide [
 
 	| t1 |
 
-	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 := self newTrait: #T1 with: #() traits: #().
 	t1 classTrait uses: {} slots: #(aSlot).
 
 	self assert: t1 classTrait slots size equals: 1.
@@ -22,7 +22,7 @@ T2TraitInTraitClassTest >> testAddingSpecialSlotToClassSide [
 
 	| t1 |
 
-	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 := self newTrait: #T1 with: #() traits: #().
 	t1 classTrait uses: {} slots: {#aSlot => WeakSlot}.
 
 	self assert: t1 classTrait slots size equals: 1.

--- a/src/TraitsV2-Tests/T2TraitMCDefinitionsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitMCDefinitionsTest.class.st
@@ -10,27 +10,40 @@ Class {
 
 { #category : 'tests' }
 T2TraitMCDefinitionsTest >> testDefinitionHasCorrectString [
+
 	| t2 definition t1 definitionString |
-	t1 := self newTrait: #T1 with: {#x => PropertySlot. #y => PropertySlot }.
-	t2 := self newTrait: #T2 with: {#a => PropertySlot. #b => PropertySlot } uses: t1.
+	t1 := self newTrait: #T1 with: {
+			      (#x => PropertySlot).
+			      (#y => PropertySlot) }.
+	t2 := self
+		      newTrait: #T2
+		      with: {
+				      (#a => PropertySlot).
+				      (#b => PropertySlot) }
+		      traits: t1.
 
 	definition := t2 asClassDefinition.
 	definitionString := String streamContents: [ :s | definition printDefinitionOn: s ].
 
- 	self assert: (definitionString reject: [ :each | each isSeparator]) equals: 'Traitnamed:#T2uses:T1instanceVariableNames:''#a=>PropertySlot#b=>PropertySlot''package:''TraitsV2-Tests-TestClasses'''
+	self
+		assert: (definitionString reject: [ :each | each isSeparator ])
+		equals: 'Traitnamed:#T2uses:T1instanceVariableNames:''#a=>PropertySlot#b=>PropertySlot''package:''' , self packageNameForTests , ''''
 	"We cannot use the class printer because this is a mix between instancevariableNames and complex slot."
 ]
 
 { #category : 'tests' }
 T2TraitMCDefinitionsTest >> testDefinitionHasCorrectStringWithoutSlots [
+
 	| t2 definition t1 definitionString |
-	t1 := self newTrait: #T1 with: {}.
-	t2 := self newTrait: #T2 with: {#a. #b } uses: t1.
+	t1 := self newTrait: #T1 with: {  }.
+	t2 := self newTrait: #T2 with: { #a. #b } traits: t1.
 
 	definition := t2 asClassDefinition.
 	definitionString := String streamContents: [ :s | definition printDefinitionOn: s ].
 
-	self assert: (definitionString reject: [ :each | each isSeparator ]) equals: 'Traitnamed:#T2uses:T1instanceVariableNames:''ab''package:''TraitsV2-Tests-TestClasses'''
+	self
+		assert: (definitionString reject: [ :each | each isSeparator ])
+		equals: 'Traitnamed:#T2uses:T1instanceVariableNames:''ab''package:''' , self packageNameForTests , ''''
 
 
 	"We cannot use ((ClassDefinitionPrinter oldPharo for: t2) definitionString reject: [ :each | each isSeparator ])
@@ -42,7 +55,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfClassSideTrait [
 
 	| t1 definition |
 
-	t1 := self newTrait: #T1 with: #() uses: #().
+	t1 := self newTrait: #T1 with: #() traits: #().
 	t1 classTrait uses: {} slots: #(aSlot).
 
 	definition := t1 asClassDefinition.
@@ -54,7 +67,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfClassSideTrait [
 T2TraitMCDefinitionsTest >> testDefinitionOfClassSideTraitHasCorrectString [
 
 	| t1 definition |
-	t1 := self newTrait: #T1 with: #() trait: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 	t1 classTrait trait: { } slots: #(aSlot).
 
 	definition := t1 asClassDefinition.
@@ -70,7 +83,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfClassSideTraitWithSpecialSlotHasCorr
 
 	| t1 definition |
 
-	t1 := self newTrait: #T1 with: #() trait: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 	t1 classTrait trait: { } slots: {#aSlot => WeakSlot.}.
 
 	definition := t1 asClassDefinition.
@@ -81,7 +94,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfClassSideTraitWithSpecialSlotHasCorr
 { #category : 'tests' }
 T2TraitMCDefinitionsTest >> testDefinitionOfNormalClass [
 	| c1 definition |
-	c1 := self newClass: #C1 with: #(a b c) uses: {}.
+	c1 := self newClass: #C1 with: #(a b c) traits: {}.
 	definition := c1 asClassDefinition.
 
 	self assert: definition instanceVariablesString equals: 'a b c'.
@@ -93,7 +106,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfNormalClass [
 { #category : 'tests' }
 T2TraitMCDefinitionsTest >> testDefinitionOfNormalClassWithSlots [
 	| c1 definition |
-	c1 := self newClass: #C1 with: { #a => PropertySlot. #b => PropertySlot } uses: {}.
+	c1 := self newClass: #C1 with: { #a => PropertySlot. #b => PropertySlot } traits: {}.
 	definition := c1 asClassDefinition.
 
 	self assert: definition instanceVariablesString equals: '#a => PropertySlot #b => PropertySlot'.
@@ -105,7 +118,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfNormalClassWithSlots [
 { #category : 'tests' }
 T2TraitMCDefinitionsTest >> testDefinitionOfTrait [
 	| t1 definition |
-	t1 := self newTrait: #T1 with: #(a b c) uses: {}.
+	t1 := self newTrait: #T1 with: #(a b c) traits: {}.
 	definition := t1 asClassDefinition.
 
 	self assert: definition instanceVariablesString equals: 'a b c'.
@@ -118,7 +131,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfTrait [
 T2TraitMCDefinitionsTest >> testDefinitionOfTraitUsingTrait [
 	| t2 definition t1 |
 	t1 := self newTrait: #T1 with: #(x y z).
-	t2 := self newTrait: #T2 with: #(a b c) uses: t1.
+	t2 := self newTrait: #T2 with: #(a b c) traits: t1.
 	definition := t2 asClassDefinition.
 
 	self assert: definition instanceVariablesString equals: 'a b c'.
@@ -131,7 +144,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfTraitUsingTrait [
 T2TraitMCDefinitionsTest >> testDefinitionOfTraitUsingTraitWithSlots [
 	| t2 definition t1 |
 	t1 := self newTrait: #T1 with: {#x => PropertySlot. #y => PropertySlot }.
-	t2 := self newTrait: #T2 with: {#a => PropertySlot. #b => PropertySlot } uses: t1.
+	t2 := self newTrait: #T2 with: {#a => PropertySlot. #b => PropertySlot } traits: t1.
 
 	definition := t2 asClassDefinition.
 
@@ -144,7 +157,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfTraitUsingTraitWithSlots [
 { #category : 'tests' }
 T2TraitMCDefinitionsTest >> testDefinitionOfTraitWithSlots [
 	| t1  definition |
-	t1 := self newClass: #C1 with: { #a => PropertySlot. #b => PropertySlot } uses: {}.
+	t1 := self newClass: #C1 with: { #a => PropertySlot. #b => PropertySlot } traits: {}.
 
 	definition := t1 asClassDefinition.
 
@@ -157,7 +170,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfTraitWithSlots [
 T2TraitMCDefinitionsTest >> testDefinitionOfTraitedClass [
 	| c1 definition t1 |
 	t1 := self newTrait: #T1 with: #(x y z).
-	c1 := self newClass: #C1 with: #(a b c) uses: t1.
+	c1 := self newClass: #C1 with: #(a b c) traits: t1.
 	definition := c1 asClassDefinition.
 
 	self assert: definition instanceVariablesString equals: 'a b c'.
@@ -170,7 +183,7 @@ T2TraitMCDefinitionsTest >> testDefinitionOfTraitedClass [
 T2TraitMCDefinitionsTest >> testDefinitionOfTraitedClassWithSlots [
 	| c1 definition t1 |
 	t1 := self newTrait: #T1 with: {#x => PropertySlot. #y => PropertySlot }.
-	c1 := self newClass: #C1 with: {#a => PropertySlot. #b => PropertySlot } uses: t1.
+	c1 := self newClass: #C1 with: {#a => PropertySlot. #b => PropertySlot } traits: t1.
 
 	definition := c1 asClassDefinition.
 
@@ -183,10 +196,10 @@ T2TraitMCDefinitionsTest >> testDefinitionOfTraitedClassWithSlots [
 { #category : 'tests' }
 T2TraitMCDefinitionsTest >> testEqualityOfTraitDefinition [
 	| t1 definition1 definition2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 	definition1 := t1 asClassDefinition.
 
-	t1 := self newTrait: #T1 with: #(a b c) uses: {}.
+	t1 := self newTrait: #T1 with: #(a b c) traits: {}.
 	definition2 := t1 asClassDefinition.
 
 	self deny: definition1 equals: definition2
@@ -195,12 +208,12 @@ T2TraitMCDefinitionsTest >> testEqualityOfTraitDefinition [
 { #category : 'tests' }
 T2TraitMCDefinitionsTest >> testEqualityOfTraitDefinitionInUses [
 	| t1 t2 definition1 definition2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
 	definition1 := t2 asClassDefinition.
 
-	t2 := self newTrait: #T2 with: #() uses: {t1}.
+	t2 := self newTrait: #T2 with: #() traits: {t1}.
 	definition2 := t2 asClassDefinition.
 
 	self deny: definition1 equals: definition2
@@ -209,10 +222,10 @@ T2TraitMCDefinitionsTest >> testEqualityOfTraitDefinitionInUses [
 { #category : 'tests' }
 T2TraitMCDefinitionsTest >> testEqualityOfTraitDefinitionWithDifferentSlotTypes [
 	| t1 definition1 definition2 |
-	t1 := self newTrait: #T1 with: #(a) uses: {}.
+	t1 := self newTrait: #T1 with: #(a) traits: {}.
 	definition1 := t1 asClassDefinition.
 
-	t1 := self newTrait: #T1 with: {(#a => PropertySlot)} uses: {}.
+	t1 := self newTrait: #T1 with: {(#a => PropertySlot)} traits: {}.
 	definition2 := t1 asClassDefinition.
 
 	self deny: definition1 equals: definition2

--- a/src/TraitsV2-Tests/T2TraitPropagatingSlotChangesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitPropagatingSlotChangesTest.class.st
@@ -11,14 +11,14 @@ Class {
 { #category : 'tests' }
 T2TraitPropagatingSlotChangesTest >> testAddingSlotToTrait [
 	| t1 c1 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	c1 := self newClass: #C1 with: #() uses: t1.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	c1 := self newClass: #C1 with: #() traits: t1.
 
 	self assert: c1 classLayout slotScope parentScope identicalTo: c1 superclass classLayout slotScope.
 	self assert: c1 class classLayout slotScope parentScope identicalTo: c1 class superclass classLayout slotScope.
 	self assertCollection: c1 slots equals: #().
 
-	t1 := self newTrait: #T1 with: #(aSlot) uses: {}.
+	t1 := self newTrait: #T1 with: #(aSlot) traits: {}.
 
 	self assert: c1 classLayout slotScope parentScope identicalTo: c1 superclass classLayout slotScope.
 	self assert: c1 class classLayout slotScope parentScope identicalTo: c1 class superclass classLayout slotScope.
@@ -28,14 +28,14 @@ T2TraitPropagatingSlotChangesTest >> testAddingSlotToTrait [
 { #category : 'tests' }
 T2TraitPropagatingSlotChangesTest >> testRemovingSlotToTrait [
 	| t1 c1 |
-	t1 := self newTrait: #T1 with: #(aSlot) uses: {}.
-	c1 := self newClass: #C1 with: #() uses: t1.
+	t1 := self newTrait: #T1 with: #(aSlot) traits: {}.
+	c1 := self newClass: #C1 with: #() traits: t1.
 
 	self assert: c1 classLayout slotScope parentScope identicalTo: c1 superclass classLayout slotScope.
 	self assert: c1 class classLayout slotScope parentScope identicalTo: c1 class superclass classLayout slotScope.
 	self assertCollection: (c1 allSlots collect: [:each | each name]) hasSameElements: #(aSlot).
 
-	t1 := self newTrait: #T1 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 
 	self assert: c1 classLayout slotScope parentScope identicalTo: c1 superclass classLayout slotScope.
 	self assert: c1 class classLayout slotScope parentScope identicalTo: c1 class superclass classLayout slotScope.

--- a/src/TraitsV2-Tests/T2TraitSlotScopeTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitSlotScopeTest.class.st
@@ -11,10 +11,10 @@ Class {
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testClassWithComplexTraits [
 	| t1 t2 c1 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1 + t2.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1 + t2.
 
 	self assert: c1 classLayout slotScope parentScope identicalTo: c1 superclass classLayout slotScope.
 	self assert: c1 class classLayout slotScope parentScope identicalTo: c1 class superclass classLayout slotScope
@@ -23,8 +23,8 @@ T2TraitSlotScopeTest >> testClassWithComplexTraits [
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testClassWithTraits [
 	| t1 c1 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1.
 
 	self assert: c1 classLayout slotScope parentScope identicalTo: c1 superclass classLayout slotScope.
 	self assert: c1 class classLayout slotScope parentScope identicalTo: c1 class superclass classLayout slotScope
@@ -33,19 +33,19 @@ T2TraitSlotScopeTest >> testClassWithTraits [
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testSubClassAndAddComplexTraitAfter [
 	| t1 c1 c2 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: {}.
+	c1 := self newClass: #C1 with: #(aSlot) traits: {}.
 	c2 := self
 		newClass: #C2
 		superclass: c1
 		with: #(otherSlot)
-		uses: {}.
+		traits: {}.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 
-	c2 := self newClass: #C2 with: #(aSlot otherSlot) uses: t1 + t2.
+	c2 := self newClass: #C2 with: #(aSlot otherSlot) traits: t1 + t2.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope
@@ -54,15 +54,15 @@ T2TraitSlotScopeTest >> testSubClassAndAddComplexTraitAfter [
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testSubClassAndAddTraitAfter [
 	| t1 c1 c2 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: {}.
+	c1 := self newClass: #C1 with: #(aSlot) traits: {}.
 	c2 := self
 		newClass: #C2
 		superclass: c1
 		with: #(otherSlot)
-		uses: {}.
+		traits: {}.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 
@@ -73,15 +73,15 @@ T2TraitSlotScopeTest >> testSubClassAndAddTraitAfter [
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testSubClassWithComplexTraits [
 	| t1 c1 c2 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1 + t2.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1 + t2.
 	c2 := self
 		newClass: #C2
 		superclass: c1
 		with: #(otherSlot)
-		uses: {}.
+		traits: {}.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope
@@ -90,15 +90,15 @@ T2TraitSlotScopeTest >> testSubClassWithComplexTraits [
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testSubClassWithComplexTraitsAfterModification [
 	| t1 c1 c2 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1 + t2.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1 + t2.
 	c2 := self
 		newClass: #C2
 		superclass: c1
 		with: #(otherSlot)
-		uses: {}.
+		traits: {}.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 
@@ -106,7 +106,7 @@ T2TraitSlotScopeTest >> testSubClassWithComplexTraitsAfterModification [
 		newClass: #C2
 		superclass: c1
 		with: #(otherSlot another)
-		uses: {}.
+		traits: {}.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope
@@ -115,16 +115,16 @@ T2TraitSlotScopeTest >> testSubClassWithComplexTraitsAfterModification [
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testSubClassWithComplexTraitsAfterModificationOfParent [
 	| t1 c1 c2 t2 t3 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
-	t3 := self newTrait: #T3 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
+	t3 := self newTrait: #T3 with: #() traits: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1 + t3.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1 + t3.
 	c2 := self
 		newClass: #C2
 		superclass: c1
 		with: #(otherSlot)
-		uses: t2.
+		traits: t2.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope
@@ -133,15 +133,15 @@ T2TraitSlotScopeTest >> testSubClassWithComplexTraitsAfterModificationOfParent [
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testSubClassWithTraits [
 	| t1 c1 c2 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1.
 	c2 := self
 		newClass: #C2
 		superclass: c1
 		with: #(otherSlot)
-		uses: t2.
+		traits: t2.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope
@@ -150,15 +150,15 @@ T2TraitSlotScopeTest >> testSubClassWithTraits [
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModification [
 	| t1 c1 c2 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1.
 	c2 := self
 		newClass: #C2
 		superclass: c1
 		with: #(otherSlot)
-		uses: t2.
+		traits: t2.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 
@@ -166,7 +166,7 @@ T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModification [
 		newClass: #C2
 		superclass: c1
 		with: #(otherSlot another)
-		uses: t2.
+		traits: t2.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope
@@ -175,15 +175,15 @@ T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModification [
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParent [
 	| t1 c1 c2 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1.
 	c2 := self
 		newClass: #C2
 		superclass: c1
 		with: #(otherSlot)
-		uses: t2.
+		traits: t2.
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope
@@ -191,29 +191,30 @@ T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParent [
 
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedPools [
-	| t1 c1 c2 t2 x1 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1.
+	| t1 c1 c2 t2 x1 |
+	t1 := self newTrait: #T1 with: #(  ) traits: {  }.
+	t2 := self newTrait: #T2 with: #(  ) traits: {  }.
+
+	c1 := self newClass: #C1 with: #( aSlot ) traits: t1.
 	c2 := self
-		newClass: #C2
-		superclass: c1
-		with: #(otherSlot)
-		uses: t2.
+		      newClass: #C2
+		      superclass: c1
+		      with: #( otherSlot )
+		      traits: t2.
 
 	x1 := self class classInstaller make: [ :aClassBuilder |
-		aClassBuilder
-			name: #X1;
-			superclass: SharedPool ].
+		      aClassBuilder
+			      name: #X1;
+			      superclass: SharedPool ].
 
 
 	c1 := self class classInstaller make: [ :aClassBuilder |
-		aClassBuilder
-			name: #C1;
-			traitComposition: t1;
-			sharedPools: 'X1';
-			package: 'TraitsV2-Tests-TestClasses' ].
+		      aClassBuilder
+			      name: #C1;
+			      traitComposition: t1;
+			      sharedPools: 'X1';
+			      package: self packageNameForTests ].
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope
@@ -221,26 +222,26 @@ T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedPoo
 
 { #category : 'tests' }
 T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedvariables [
-	| t1 c1 c2 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1.
+	| t1 c1 c2 t2 |
+	t1 := self newTrait: #T1 with: #(  ) traits: {  }.
+	t2 := self newTrait: #T2 with: #(  ) traits: {  }.
+
+	c1 := self newClass: #C1 with: #( aSlot ) traits: t1.
 	c2 := self
-		newClass: #C2
-		superclass: c1
-		with: #(otherSlot)
-		uses: t2.
+		      newClass: #C2
+		      superclass: c1
+		      with: #( otherSlot )
+		      traits: t2.
 
 	c1 := self class classInstaller make: [ :builder |
-		  builder
-			  name: #C1;
-			  superclass: Object;
-			  slots: #(aSlot);
-			  sharedVariables: #(ClassVar);
-			  traitComposition: t1;
-			  package: 'TraitsV2-Tests-TestClasses' ].
-	createdClasses add: c1.
+		      builder
+			      name: #C1;
+			      superclass: Object;
+			      slots: #( aSlot );
+			      sharedVariables: #( ClassVar );
+			      traitComposition: t1;
+			      package: self packageNameForTests ].
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
 	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope

--- a/src/TraitsV2-Tests/T2TraitTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitTest.class.st
@@ -77,7 +77,7 @@ T2TraitTest >> testClassHavingAnInstanceVariableUsersDifferenThanUsers [
 
 	t1 := self newTrait: #T1 with: #(users).
 
-	aClass := self newClass: #C1 superclass: Object with: #() uses: {}.
+	aClass := self newClass: #C1 superclass: Object with: #() traits: {}.
 	aClass class setTraitComposition: { t1 }.
 
 	self assert: (aClass class allSlots anySatisfy: [:e | e name = #users]).
@@ -90,7 +90,7 @@ T2TraitTest >> testClassTraitThatHasAPragmaHasCorrectTraitSourceAfterRecompile [
 
 	t3 := self createT3.
 
-	aClass := self newClass: #C1 superclass: Object with: #() uses: {t3}.
+	aClass := self newClass: #C1 superclass: Object with: #() traits: {t3}.
 
 	self assert: (aClass class >> #aClassMethod) traitSource equals: t3 class asTraitComposition.
 
@@ -111,12 +111,12 @@ T2TraitTest >> testClassTraits [
 
 	t2 classTrait compile: 'otherSelector2 ^ 42'.
 
-	aClass := self newClass: #C1 superclass: Object with: #() uses: {}.
+	aClass := self newClass: #C1 superclass: Object with: #() traits: {}.
 	aClass class setTraitComposition: t1 classSide - { #aSelector }.
 
 	self assert: aClass otherSelector equals: 42.
 
-	aClass := self newClass: #C1 superclass: Object with: #() uses: {}.
+	aClass := self newClass: #C1 superclass: Object with: #() traits: {}.
 	aClass class setTraitComposition: t1 classSide + t2 classSide.
 
 	self assert: aClass otherSelector equals: 42.
@@ -124,7 +124,7 @@ T2TraitTest >> testClassTraits [
 	self assert: aClass aSelector equals: 21.
 
 
-	aClass := self newClass: #C1 superclass: Object with: #() uses: {}.
+	aClass := self newClass: #C1 superclass: Object with: #() traits: {}.
 	aClass class setTraitComposition: t1 classSide @ {#anAlias -> #aSelector}.
 
 	self assert: aClass anAlias equals: 21.
@@ -135,8 +135,8 @@ T2TraitTest >> testClassTraits [
 T2TraitTest >> testClassUsesTrait [
 	| t1 superclass subclass |
 	t1 := self newTrait: #T1 with: {}.
-	superclass := self newClass: #Superclass with:#() uses: t1.
-	subclass := self newClass: #Subclass superclass: superclass with: #() uses: {}.
+	superclass := self newClass: #Superclass with:#() traits: t1.
+	subclass := self newClass: #Subclass superclass: superclass with: #() traits: {}.
 
 	self assert: (superclass usesTrait: t1).
 	self assert: (superclass usesTraitLocally: t1).
@@ -150,7 +150,7 @@ T2TraitTest >> testClassUsingTraitsDoesNotHaveUsers [
 
 	t1 := self newTrait: #T1 with: #().
 
-	aClass := self newClass: #C1 superclass: Object with: #() uses: {t1}.
+	aClass := self newClass: #C1 superclass: Object with: #() traits: {t1}.
 
 	self assert: (aClass class allSlots noneSatisfy: [:e | e name = #users])
 ]
@@ -159,7 +159,7 @@ T2TraitTest >> testClassUsingTraitsDoesNotHaveUsers [
 T2TraitTest >> testEmptyCompositionManagesTEmpty [
 
 	| t1 |
-	t1 := self newTrait: #T1 with: {} trait: TEmpty.
+	t1 := self newTrait: #T1 with: {} traits: TEmpty.
 
 	self assert: t1 hasEmptyComposition
 ]
@@ -171,9 +171,9 @@ T2TraitTest >> testIndirectSequence [
 
 	t1 := self createT1.
 	t2 := self createT2.
-	t3 := self newTrait: #T3 with: #() uses: t1 + t2.
+	t3 := self newTrait: #T3 with: #() traits: t1 + t2.
 
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t3.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t3.
 
 	obj := c1 new.
 	obj setValues.
@@ -190,7 +190,7 @@ T2TraitTest >> testMethodsAddedInMetaclass [
 	| t1 c1 |
 
 	t1 := self createT1.
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t1.
 
 	self assertCollection: c1 class selectors sorted equals: TraitedClass selectors sorted
 ]
@@ -200,8 +200,8 @@ T2TraitTest >> testMethodsAddedInMetaclassNotPresentInSubclasses [
 	| t1 c1 c2 |
 
 	t1 := self createT1.
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
-	c2 := self newClass: #C2 superclass: c1 with: #() uses: {}.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t1.
+	c2 := self newClass: #C2 superclass: c1 with: #() traits: {}.
 
 	self assertCollection: c2 class selectors sorted equals: #()
 ]
@@ -213,11 +213,11 @@ T2TraitTest >> testMethodsAddedInMetaclassPresentInSubclassesAfterChangingSuperc
 	t1 := self createT1.
 	t2 := self createT2.
 
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
-	c2 := self newClass: #C2 superclass: c1 with: #() uses: {t2}.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t1.
+	c2 := self newClass: #C2 superclass: c1 with: #() traits: {t2}.
 
 	self assertCollection: c2 class selectors sorted equals: #().
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: {}.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: {}.
 
 	self assertCollection: c2 class selectors sorted equals: TraitedClass selectors sorted
 ]
@@ -229,8 +229,8 @@ T2TraitTest >> testMethodsAddedInMetaclassPresentInSubclassesAfterRemovingSuperc
 	t1 := self createT1.
 	t2 := self createT2.
 
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
-	c2 := self newClass: #C2 superclass: c1 with: #() uses: {t2}.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t1.
+	c2 := self newClass: #C2 superclass: c1 with: #() traits: {t2}.
 
 	self assertCollection: c2 class selectors sorted equals: #().
 	c1 removeFromSystem.
@@ -258,11 +258,11 @@ T2TraitTest >> testRemovingTraitsRemoveTraitedClassMethods [
 
 	t1 := self createT1.
 	t2 := self createT2.
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1 + t2.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t1 + t2.
 
 	self assert: (c1 class includesSelector: #traits).
 
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: {}.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: {}.
 
 	self deny: (c1 class includesSelector: #traits)
 ]
@@ -273,13 +273,13 @@ T2TraitTest >> testRemovingTraitsRemoveTraitedClassMethodsWithSubclasses [
 
 	t1 := self createT1.
 	t2 := self createT2.
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
-	c2 := self newClass: #C2 superclass: c1 with: '' asSlotCollection uses: t2.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t1.
+	c2 := self newClass: #C2 superclass: c1 with: '' asSlotCollection traits: t2.
 
 	self assert: (c1 class includesSelector: #traits).
 	self deny: (c2 class includesSelector: #traits).
 
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: {}.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: {}.
 
 	self deny: (c1 class includesSelector: #traits).
 	self assert: (c2 class includesSelector: #traits)
@@ -291,8 +291,8 @@ T2TraitTest >> testRemovingTraitsUpdatesCategories [
 	| t1 t2 c1 |
 	t1 := self createT1.
 	t2 := self createT2.
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1 + t2.
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: {  }.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t1 + t2.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: {  }.
 
 	c1 selectors do: [ :selector | self assert: (c1 includesSelector: selector) ].
 	c1 class selectors do: [ :selector | self assert: (c1 class includesSelector: selector) ]
@@ -306,7 +306,7 @@ T2TraitTest >> testSelectorsWithExplicitOrigin [
 	t1 := self newTrait: #T1 with: #().
 	t1 compile: 'instanceSideMethod'.
 	t1 class compile: 'classSideMethod'.
-	c1 := self newClass: #C1 with: #() uses: t1.
+	c1 := self newClass: #C1 with: #() traits: t1.
 	self assertCollection: c1 selectorsWithExplicitOrigin hasSameElements: #(instanceSideMethod).
 	self assertCollection: c1 class selectorsWithExplicitOrigin hasSameElements: #(classSideMethod)
 ]
@@ -329,7 +329,7 @@ T2TraitTest >> testSequence [
 
 	t1 := self createT1.
 	t2 := self createT2.
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1 + t2.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t1 + t2.
 
 	obj := c1 new.
 	obj setValues.
@@ -347,7 +347,7 @@ T2TraitTest >> testSettingAClassInAClassTraitCompositionShouldRaiseAnError [
 
 	| t1 c1 |
 	t1 :=  self newTrait: #T1 with: 'a' asSlotCollection.
-	c1 := self newClass: #C1 with: '' asSlotCollection uses: #().
+	c1 := self newClass: #C1 with: '' asSlotCollection traits: #().
 
 	self should: [ t1 traitComposition: c1 ] raise: Error.
 	self should: [ t1 classTrait traitComposition: c1 ] raise: Error.
@@ -357,8 +357,8 @@ T2TraitTest >> testSettingAClassInAClassTraitCompositionShouldRaiseAnError [
 T2TraitTest >> testSlotsAreNotDuplicated [
 	| t1 t2 c1 |
 	t1 :=  self newTrait: #T1 with: 'a' asSlotCollection.
-	t2 :=  self newTrait: #T2 with: '' asSlotCollection uses: t1.
-	c1 := self newClass: #C1 with: '' asSlotCollection uses: t1 + t2.
+	t2 :=  self newTrait: #T2 with: '' asSlotCollection traits: t1.
+	c1 := self newClass: #C1 with: '' asSlotCollection traits: t1 + t2.
 
 	self assert: c1 traitComposition slots size equals: c1 traitComposition slots asSet size.
 	self assert: c1 traitComposition slots size equals: 1
@@ -369,7 +369,7 @@ T2TraitTest >> testSubclasses [
 	| t1 t2 |
 
 	t1 := self createT1.
-	t2 := self newTrait: #T2 with: #(aa bb) uses: t1.
+	t2 := self newTrait: #T2 with: #(aa bb) traits: t1.
 
 	self deny: t1 hasSubclasses.
 	self deny: t2 hasSubclasses.
@@ -387,7 +387,7 @@ T2TraitTest >> testTraitHaveUsersInstanceVariable [
 
 	t1 := self newTrait: #T1 with: #(users).
 
-	aClass := self newClass: #C1 superclass: Object with: #() uses: {t1}.
+	aClass := self newClass: #C1 superclass: Object with: #() traits: {t1}.
 
 	self assert: (aClass allSlots anySatisfy: [:e | e name = #users]).
 	self assert: (aClass slotNamed: #users) definingClass equals: t1
@@ -399,7 +399,7 @@ T2TraitTest >> testTraitThatHasAPragmaHasCorrectTraitSourceAfterRecompile [
 
 	t3 := self createT3.
 
-	aClass := self newClass: #C1 superclass: Object with: #() uses: {t3}.
+	aClass := self newClass: #C1 superclass: Object with: #() traits: {t3}.
 
 	self assert: (aClass >> #aMethod) traitSource equals: t3 asTraitComposition.
 

--- a/src/TraitsV2-Tests/T2TraitWithAliasTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithAliasTest.class.st
@@ -13,7 +13,7 @@ T2TraitWithAliasTest >> testChangingAnAliasedMethodIsIncludedInClass [
 	t1 := self newTrait: #T1 with: #().
 	t1 compile: 'm1 ^ 1'.
 
-	c1 := self newClass: #C1 with: #() uses: t1 @ { #m2 -> #m1 }.
+	c1 := self newClass: #C1 with: #() traits: t1 @ { #m2 -> #m1 }.
 
 	self assert: (c1 includesSelector: #m1).
 	self assert: (c1 includesSelector: #m2)
@@ -27,7 +27,7 @@ T2TraitWithAliasTest >> testChangingAnAliasedMethodIsUpdated [
 	t1 := self newTrait: #T1 with: #().
 	t1 compile: 'm1 ^ 1'.
 
-	c1 := self newClass: #C1 with: #() uses: t1 @ { #m2 -> #m1 }.
+	c1 := self newClass: #C1 with: #() traits: t1 @ { #m2 -> #m1 }.
 	obj := c1 new.
 
 	self assert: obj m1 equals: 1.
@@ -47,7 +47,7 @@ T2TraitWithAliasTest >> testChangingDeleteSlot [
 	t1 := self newTrait: #T1 with: #(ivar).
 	t1 compile: 'ivar ^ ivar'.
 
-	c1 := self newClass: #C1 with: #() uses: t1 -- {#ivar}.
+	c1 := self newClass: #C1 with: #() traits: t1 -- {#ivar}.
 
 	"we got the method #ivar from the Trait"
 	self assert: (c1 includesSelector: #ivar).
@@ -66,7 +66,7 @@ T2TraitWithAliasTest >> testChangingDeleteSlot2Slots [
 	t1 compile: 'ivar2 ^ ivar2'.
 	t1 compile: 'ivar1 ^ ivar1'.
 
-	c1 := self newClass: #C1 with: #() uses: t1 -- {  #ivar1 . #ivar2 }.
+	c1 := self newClass: #C1 with: #() traits: t1 -- {  #ivar1 . #ivar2 }.
 
 	"we got the methods from the Trait"
 	self assert: (c1 includesSelector: #ivar1).
@@ -86,7 +86,7 @@ T2TraitWithAliasTest >> testChangingDeleteSlotAddVar [
 	t1 := self newTrait: #T1 with: #(ivar).
 	t1 compile: 'ivar ^ ivar'.
 
-	c1 := self newClass: #C1 with: #(ivar) uses: t1 -- {#ivar}.
+	c1 := self newClass: #C1 with: #(ivar) traits: t1 -- {#ivar}.
 
 	"we got the method #ivar from the Trait"
 	self assert: (c1 includesSelector: #ivar).
@@ -104,7 +104,7 @@ T2TraitWithAliasTest >> testChangingDeleteSlotAndAlias [
 	t1 := self newTrait: #T1 with: #(name).
 	t2 := self newTrait: #T2 with: #(personName).
 
-	c1 := self newClass: #C1 with: #() uses: (t1 -- #name) + (t2 @@ {#personName-> #name}).
+	c1 := self newClass: #C1 with: #() traits: (t1 -- #name) + (t2 @@ {#personName-> #name}).
 
 	"In the class we have just name"
 	self assert: c1 slotNames equals: #(name).
@@ -121,7 +121,7 @@ T2TraitWithAliasTest >> testChangingRenamedSlot [
 	t1 := self newTrait: #T1 with: #(ivar).
 	t1 compile: 'ivar ^ ivar'.
 
-	c1 := self newClass: #C1 with: #() uses: t1 @@ { #ivar -> #ivar2 }.
+	c1 := self newClass: #C1 with: #() traits: t1 @@ { #ivar -> #ivar2 }.
 
 	"we got the method #ivar from the Trait"
 	self assert: (c1 includesSelector: #ivar).
@@ -145,7 +145,7 @@ T2TraitWithAliasTest >> testChangingRenamedSlot2Slots [
 	t1 compile: 'ivar2 ^ ivar2'.
 	t1 compile: 'ivar1 ^ ivar1'.
 
-	c1 := self newClass: #C1 with: #() uses: t1 @@ {  #ivar1 -> #rvar1 . #ivar2 -> #rvar2 }.
+	c1 := self newClass: #C1 with: #() traits: t1 @@ {  #ivar1 -> #rvar1 . #ivar2 -> #rvar2 }.
 
 	"we got the methods from the Trait"
 	self assert: (c1 includesSelector: #ivar1).

--- a/src/TraitsV2-Tests/T2TraitWithComplexSlotsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithComplexSlotsTest.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : 'instance creation' }
 T2TraitWithComplexSlotsTest >> createSlotClass [
-	slotClass := self newClass: #TestSlot superclass: IndexedSlot with: #(associatedSlotName) uses: #().
+	slotClass := self newClass: #TestSlot superclass: IndexedSlot with: #(associatedSlotName) traits: #().
 	slotClass class compile: 'associatedSlotName: aName
 		^ self new
 			associatedSlotName: aName;
@@ -33,7 +33,7 @@ T2TraitWithComplexSlotsTest >> testNormalClassWithComplexSlot [
 	| c1 obj |
 	<ignoreNotImplementedSelectors: #(associatedSlotName:)>
 	self createSlotClass.
-	c1 := self newClass: #C1 with: { #aSlot. #otherSlot => (slotClass associatedSlotName: #aSlot) } uses: #().
+	c1 := self newClass: #C1 with: { #aSlot. #otherSlot => (slotClass associatedSlotName: #aSlot) } traits: #().
 	c1 compile: 'initialize
 		aSlot := 0'.
 	c1 compile: 'doSomething
@@ -51,7 +51,7 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlot [
 	<ignoreNotImplementedSelectors: #(associatedSlotName:)>
 	self createSlotClass.
 	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }.
-	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1}.
+	c1 := self newClass: #C1 with: { #aSlot. } traits: {t1}.
 
 	c1 compile: 'initialize
 		aSlot := 0'.
@@ -69,7 +69,7 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotAddClassSlot [
 	| t1 c1 |
 	self createSlotClass.
 	t1 := self newTrait: #T1 with: { #ivar }.
-	c1 := self newClass: #C1 with: { #aSlot } uses: { t1 }.
+	c1 := self newClass: #C1 with: { #aSlot } traits: { t1 }.
 	self assert: (c1 traitComposition includesTrait: t1).
 	c1 addClassSlot:  #ivar2 => InstanceVariableSlot.
 	self assert: c1 instVarNames equals: #( aSlot ivar ).
@@ -82,7 +82,7 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotAddSlot [
 	| t1 c1 |
 	self createSlotClass.
 	t1 := self newTrait: #T1 with: { #ivar }.
-	c1 := self newClass: #C1 with: { #aSlot } uses: { t1 }.
+	c1 := self newClass: #C1 with: { #aSlot } traits: { t1 }.
 	self assert: (c1 traitComposition includesTrait: t1).
 	c1 addSlot: #ivar2 => InstanceVariableSlot.
 	self assert: c1 instVarNames equals: #( aSlot ivar2 ivar ).
@@ -95,7 +95,7 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotAfter [
 	<ignoreNotImplementedSelectors: #(associatedSlotName:)>
 	self createSlotClass.
 	t1 := self newTrait: #T1 with: {}.
-	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1}.
+	c1 := self newClass: #C1 with: { #aSlot. } traits: {t1}.
 
 	c1 compile: 'initialize
 		aSlot := 0'.
@@ -117,8 +117,8 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotInSuperclass [
 	<ignoreNotImplementedSelectors: #(associatedSlotName:)>
 	self createSlotClass.
 	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }.
-	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1}.
-	c2 := self newClass: #C2 superclass: c1 with: #() uses: #().
+	c1 := self newClass: #C1 with: { #aSlot. } traits: {t1}.
+	c2 := self newClass: #C2 superclass: c1 with: #() traits: #().
 
 	c1 compile: 'initialize
 		aSlot := 0'.
@@ -137,7 +137,7 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotUpdatedAfter [
 	<ignoreNotImplementedSelectors: #(associatedSlotName:)>
 	self createSlotClass.
 	t1 := self newTrait: #T1 with: {}.
-	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1}.
+	c1 := self newClass: #C1 with: { #aSlot. } traits: {t1}.
 
 	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }.
 
@@ -159,7 +159,7 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotUsedInOtherSlot [
 	self createSlotClass.
 	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }.
 	t2 := self newTrait: #T2 with: { #otherSlot }.
-	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1. t2 asTraitComposition -- #otherSlot}.
+	c1 := self newClass: #C1 with: { #aSlot. } traits: {t1. t2 asTraitComposition -- #otherSlot}.
 
 	c1 compile: 'initialize
 		aSlot := 0'.
@@ -180,7 +180,7 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotUsedInOtherSlotInSupercla
 	self createSlotClass.
 	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }.
 	t2 := self newTrait: #T2 with: { #otherSlot }.
-	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1. t2 asTraitComposition -- #otherSlot}.
+	c1 := self newClass: #C1 with: { #aSlot. } traits: {t1. t2 asTraitComposition -- #otherSlot}.
 
 	c1 compile: 'initialize
 		aSlot := 0'.
@@ -188,7 +188,7 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotUsedInOtherSlotInSupercla
 	t2 compile: 'doSomething
 		otherSlot := ''a'''.
 
-	c2 := self newClass: #C2 superclass: c1 with: #() uses: #().
+	c2 := self newClass: #C2 superclass: c1 with: #() traits: #().
 
 	obj := c2 new.
 	self assert: (obj instVarNamed: #aSlot) equals: 0.
@@ -203,7 +203,7 @@ T2TraitWithComplexSlotsTest >> testTraitWithComplexSlotUsedInOtherSlotWithoutTra
 	self createSlotClass.
 	t1 := self newTrait: #T1 with: { #otherSlot => (slotClass associatedSlotName: #aSlot) }.
 	t2 := self newTrait: #T2 with: { #otherSlot }.
-	c1 := self newClass: #C1 with: { #aSlot. } uses: {t1. t2 -- #otherSlot}.
+	c1 := self newClass: #C1 with: { #aSlot. } traits: {t1. t2 -- #otherSlot}.
 
 	c1 compile: 'initialize
 		aSlot := 0'.

--- a/src/TraitsV2-Tests/T2TraitWithConflictsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithConflictsTest.class.st
@@ -12,12 +12,12 @@ Class {
 T2TraitWithConflictsTest >> testAddingSameDependencyIsNotConflict [
 	| t1 t2 c1 |
 	<ignoreNotImplementedSelectors: #(m1)>
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {t1}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {t1}.
 
 	t1 compile: 'm1 ^42'.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t2 + t1.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t2 + t1.
 
 	self assert:c1 new m1 equals: 42
 ]
@@ -26,16 +26,16 @@ T2TraitWithConflictsTest >> testAddingSameDependencyIsNotConflict [
 T2TraitWithConflictsTest >> testComplexDependencyIsNotConflict [
 	| t1 t2 c1 t3 t4 t5 t6|
 	<ignoreNotImplementedSelectors: #(m1)>
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {t1}.
-	t3 := self newTrait: #T3 with: #() uses: {t1}.
-	t4 := self newTrait: #T4 with: #() uses: {t2 + t3}.
-	t5 := self newTrait: #T5 with: #() uses: {t3}.
-	t6 := self newTrait: #T6 with: #() uses: {t5 + t4}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {t1}.
+	t3 := self newTrait: #T3 with: #() traits: {t1}.
+	t4 := self newTrait: #T4 with: #() traits: {t2 + t3}.
+	t5 := self newTrait: #T5 with: #() traits: {t3}.
+	t6 := self newTrait: #T6 with: #() traits: {t5 + t4}.
 
 	t1 compile: 'm1 ^42'.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t6 + t1.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t6 + t1.
 
 	self assert:c1 new m1 equals: 42
 ]
@@ -44,13 +44,13 @@ T2TraitWithConflictsTest >> testComplexDependencyIsNotConflict [
 T2TraitWithConflictsTest >> testDiamonProblemIsNotConflict [
 	| t1 t2 c1 t3 |
 
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {t1}.
-	t3 := self newTrait: #T3 with: #() uses: {t1}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {t1}.
+	t3 := self newTrait: #T3 with: #() traits: {t1}.
 
 	t1 compile: 'm1 ^42'.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t2 + t3.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t2 + t3.
 
 	self assert: (c1 new perform: #m1) equals: 42
 ]
@@ -59,13 +59,13 @@ T2TraitWithConflictsTest >> testDiamonProblemIsNotConflict [
 T2TraitWithConflictsTest >> testDifferentMethodsAreConflict [
 	| t1 t2 c1 |
 	<ignoreNotImplementedSelectors: #(m1)>
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
 	t1 compile: 'm1 ^42'.
 	t2 compile: 'm1 ^43'.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1 + t2.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1 + t2.
 
 	self should: [ c1 new m1 ] raise: Error
 ]
@@ -73,13 +73,13 @@ T2TraitWithConflictsTest >> testDifferentMethodsAreConflict [
 { #category : 'tests' }
 T2TraitWithConflictsTest >> testNonConflictingTraitsAreNotConflict [
 	| t1 t2 c1 |
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
 	t1 compile: 'm1 ^42'.
 	t2 compile: 'm2 ^43'.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1 + t2.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1 + t2.
 
 	self assert: (c1 new perform: #m1) equals: 42.
 	self assert: (c1 new perform: #m2) equals: 43
@@ -89,13 +89,13 @@ T2TraitWithConflictsTest >> testNonConflictingTraitsAreNotConflict [
 T2TraitWithConflictsTest >> testSameSourceButDifferentMethodsAreConflict [
 	| t1 t2 c1 |
 	<ignoreNotImplementedSelectors: #(m1)>
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: {}.
 
 	t1 compile: 'm1 ^42'.
 	t2 compile: 'm1 ^42'.
 
-	c1 := self newClass: #C1 with: #(aSlot) uses: t1 + t2.
+	c1 := self newClass: #C1 with: #(aSlot) traits: t1 + t2.
 
 	self should: [c1 new m1] raise: Error
 ]

--- a/src/TraitsV2-Tests/T2TraitWithMethodsInProtocolsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithMethodsInProtocolsTest.class.st
@@ -2,31 +2,31 @@
 Unit test for categorization of traits
 "
 Class {
-	#name : 'T2TraitWithCategoriesTest',
+	#name : 'T2TraitWithMethodsInProtocolsTest',
 	#superclass : 'T2AbstractTest',
 	#category : 'TraitsV2-Tests',
 	#package : 'TraitsV2-Tests'
 }
 
 { #category : 'tests' }
-T2TraitWithCategoriesTest >> testPackageOfMethodFromTraits [
+T2TraitWithMethodsInProtocolsTest >> testPackageOfMethodFromTraits [
 	| t1 t2 |
 
-	t1 := self newTrait: #T1 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 	t1 compile: 'm1 ^42.' classified: 'aProtocol'.
 
-	t2 := self newTrait: #T2 with: #() uses: t1.
+	t2 := self newTrait: #T2 with: #() traits: t1.
 
 	self assert: (t1 >> #m1) protocolName equals: 'aProtocol'.
 	self assert: (t2 >> #m1) protocolName equals: 'aProtocol'
 ]
 
 { #category : 'tests' }
-T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsAfterCreation [
+T2TraitWithMethodsInProtocolsTest >> testPackageOfMethodFromTraitsAfterCreation [
 	| t1 t2 |
 
-	t1 := self newTrait: #T1 with: #() uses: {}.
-	t2 := self newTrait: #T2 with: #() uses: t1.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: t1.
 	t1 compile: 'm1 ^42.' classified: 'aProtocol'.
 
 	self assert: (t1 >> #m1) protocolName equals: 'aProtocol'.
@@ -34,13 +34,13 @@ T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsAfterCreation [
 ]
 
 { #category : 'tests' }
-T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsChanged [
+T2TraitWithMethodsInProtocolsTest >> testPackageOfMethodFromTraitsChanged [
 	| t1 t2 |
 
-	t1 := self newTrait: #T1 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 	t1 compile: 'm1 ^42.' classified: 'aProtocol'.
 
-	t2 := self newTrait: #T2 with: #() uses: t1.
+	t2 := self newTrait: #T2 with: #() traits: t1.
 
 	t1 compile: 'm1 ^42.' classified: 'anotherProtocol'.
 
@@ -49,13 +49,13 @@ T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsChanged [
 ]
 
 { #category : 'tests' }
-T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsChangedWithoutCompile [
+T2TraitWithMethodsInProtocolsTest >> testPackageOfMethodFromTraitsChangedWithoutCompile [
 	| trait1 trait2 |
 
-	trait1 := self newTrait: #T1 with: #() uses: {}.
+	trait1 := self newTrait: #T1 with: #() traits: {}.
 	trait1 compile: 'm1 ^42.' classified: 'aProtocol'.
 
-	trait2 := self newTrait: #T2 with: #() uses: trait1.
+	trait2 := self newTrait: #T2 with: #() traits: trait1.
 
 	trait1 classify: #m1 under: 'anotherProtocol'.
 
@@ -64,13 +64,13 @@ T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsChangedWithoutCompile 
 ]
 
 { #category : 'tests' }
-T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsOverriden [
+T2TraitWithMethodsInProtocolsTest >> testPackageOfMethodFromTraitsOverriden [
 	| t1 t2 |
 
-	t1 := self newTrait: #T1 with: #() uses: {}.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 	t1 compile: 'm1 ^42.' classified: 'aProtocol'.
 
-	t2 := self newTrait: #T2 with: #() uses: t1.
+	t2 := self newTrait: #T2 with: #() traits: t1.
 	t2 compile: 'm1 ^42.' classified: 'anotherProtocol'.
 
 	self assert: (t1 >> #m1) protocolName equals: 'aProtocol'.
@@ -78,14 +78,14 @@ T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsOverriden [
 ]
 
 { #category : 'tests' }
-T2TraitWithCategoriesTest >> testPackageOfMethodFromTraitsRenamedCategory [
+T2TraitWithMethodsInProtocolsTest >> testPackageOfMethodFromTraitsRenamedCategory [
 
 	| t1 t2 |
-	t1 := self newTrait: #T1 with: #(  ) uses: {  }.
+	t1 := self newTrait: #T1 with: #(  ) traits: {  }.
 	t1 compile: 'm1 ^42.' classified: 'aProtocol'.
 	t1 compile: 'm2 ^42.' classified: 'aProtocol'.
 
-	t2 := self newTrait: #T2 with: #(  ) uses: t1.
+	t2 := self newTrait: #T2 with: #(  ) traits: t1.
 
 	t1 renameProtocol: 'aProtocol' as: 'anotherProtocol'.
 

--- a/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithPackagesTest.class.st
@@ -8,33 +8,40 @@ Class {
 	#package : 'TraitsV2-Tests'
 }
 
-{ #category : 'tests' }
-T2TraitWithPackagesTest >> packageName [
-	^ 'TestPackage'
+{ #category : 'instance creation' }
+T2TraitWithPackagesTest >> newTrait: aName with: slots traits: aComposition package: package [
+
+	^ self class classInstaller make: [ :aBuilder |
+		  aBuilder
+			  name: aName;
+			  traitComposition: aComposition;
+			  slots: slots;
+			  package: package;
+			  beTrait ]
 ]
 
 { #category : 'tests' }
-T2TraitWithPackagesTest >> packageName2 [
-	^ 'TestPackage2'
+T2TraitWithPackagesTest >> packageNameForTests2 [
+
+	^ self packageNameForTests , '2'
 ]
 
 { #category : 'tests' }
 T2TraitWithPackagesTest >> packageUnderTest [
 
-	^ self packageOrganizer packageNamed: self packageName
+	^ self packageOrganizer packageNamed: self packageNameForTests
 ]
 
 { #category : 'tests' }
 T2TraitWithPackagesTest >> packageUnderTest2 [
 
-	^ self packageOrganizer packageNamed: self packageName2
+	^ self packageOrganizer packageNamed: self packageNameForTests2
 ]
 
 { #category : 'running' }
 T2TraitWithPackagesTest >> tearDown [
 
-	(self packageName asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
-	(self packageName2 asPackageIfAbsent: [ nil ]) ifNotNil: [ :package | package removeFromSystem ].
+	self packageOrganizer removePackage: self packageNameForTests2.
 
 	super tearDown
 ]
@@ -42,11 +49,11 @@ T2TraitWithPackagesTest >> tearDown [
 { #category : 'tests' }
 T2TraitWithPackagesTest >> testPackageOfMethodFromTraits [
 	| t1 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {} category: self packageName.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 
 	t1 compile: 'm1 ^42.'.
 
-	t2 := self newTrait: #T2 with: #() uses: t1 category: self packageName2.
+	t2 := self newTrait: #T2 with: #() traits: t1 package: self packageNameForTests2.
 
 	self assert: (t1 >> #m1) package equals: self packageUnderTest.
 	self assert: (t2 >> #m1) package equals: self packageUnderTest
@@ -55,8 +62,8 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraits [
 { #category : 'tests' }
 T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsAfterCreation [
 	| t1 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {} category: self packageName.
-	t2 := self newTrait: #T2 with: #() uses: t1 category: self packageName2.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: t1 package: self packageNameForTests2.
 
 	t1 compile: 'm1 ^42.'.
 
@@ -67,8 +74,8 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsAfterCreation [
 { #category : 'tests' }
 T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsAfterCreationOverriden [
 	| t1 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {} category: self packageName.
-	t2 := self newTrait: #T2 with: #() uses: t1 category: self packageName2.
+	t1 := self newTrait: #T1 with: #() traits: {}.
+	t2 := self newTrait: #T2 with: #() traits: t1 package: self packageNameForTests2.
 
 	t1 compile: 'm1 ^42.'.
 
@@ -84,11 +91,11 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsAfterCreationOverriden [
 { #category : 'tests' }
 T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsOverriden [
 	| t1 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {} category: self packageName.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 
 	t1 compile: 'm1 ^42.'.
 
-	t2 := self newTrait: #T2 with: #() uses: t1 category: self packageName2.
+	t2 := self newTrait: #T2 with: #() traits: t1 package: self packageNameForTests2.
 
 	self assert: (t1 >> #m1) package equals: self packageUnderTest.
 	self assert: (t2 >> #m1) package equals: self packageUnderTest.
@@ -102,11 +109,11 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsOverriden [
 { #category : 'tests' }
 T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsOverridenAndRemoved [
 	| t1 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {} category: self packageName.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 
 	t1 compile: 'm1 ^42.'.
 
-	t2 := self newTrait: #T2 with: #() uses: t1 category: self packageName2.
+	t2 := self newTrait: #T2 with: #() traits: t1 package: self packageNameForTests2.
 
 	self assert: (t1 >> #m1) package equals: self packageUnderTest.
 	self assert: (t2 >> #m1) package equals: self packageUnderTest.
@@ -125,11 +132,11 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsOverridenAndRemoved [
 { #category : 'tests' }
 T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsOverridenModifiedKeepPackage [
 	| t1 t2 |
-	t1 := self newTrait: #T1 with: #() uses: {} category: self packageName.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 
 	t1 compile: 'm1 ^42.'.
 
-	t2 := self newTrait: #T2 with: #() uses: t1 category: self packageName2.
+	t2 := self newTrait: #T2 with: #() traits: t1 package: self packageNameForTests2.
 
 	self assert: (t1 >> #m1) package equals: self packageUnderTest.
 	self assert: (t2 >> #m1) package equals: self packageUnderTest.
@@ -152,16 +159,15 @@ T2TraitWithPackagesTest >> testPackageOfMethodFromTraitsRemoved [
 	t1 := self
 		      newTrait: #T1
 		      with: #(  )
-		      uses: {  }
-		      category: self packageName.
+		      traits: {  }.
 
 	t1 compile: 'm1 ^42.'.
 
 	t2 := self
 		      newTrait: #T2
 		      with: #(  )
-		      uses: t1
-		      category: self packageName2.
+		      traits: t1
+		      package: self packageNameForTests2.
 
 	self assert: (t1 >> #m1) package equals: self packageUnderTest.
 	self assert: (t2 >> #m1) package equals: self packageUnderTest.
@@ -185,13 +191,12 @@ T2TraitWithPackagesTest >> testPackageOfRemovedTrait [
 	t1 := self
 		      newTrait: #T1
 		      with: #(  )
-		      uses: {  }
-		      category: self packageName.
+		      traits: {  }.
 	t2 := self
 		      newTrait: #T2
 		      with: #(  )
-		      uses: t1
-		      category: self packageName2.
+		      traits: t1
+		      package: self packageNameForTests2.
 
 	self assert: t1 package equals: self packageUnderTest.
 	self assert: t2 package equals: self packageUnderTest2.
@@ -213,7 +218,7 @@ T2TraitWithPackagesTest >> testPackageOfRemovedTrait [
 { #category : 'tests' }
 T2TraitWithPackagesTest >> testTraitMethodPackage [
 	| t1 testPackage |
-	t1 := self newTrait: #T1 with: #() uses: {} category: self packageName.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 	testPackage := self packageUnderTest.
 
 	t1 compile: 'm1 ^42.'.
@@ -224,7 +229,7 @@ T2TraitWithPackagesTest >> testTraitMethodPackage [
 { #category : 'tests' }
 T2TraitWithPackagesTest >> testTraitPackage [
 	| t1 testPackage |
-	t1 := self newTrait: #T1 with: #() uses: {} category: self packageName.
+	t1 := self newTrait: #T1 with: #() traits: {}.
 	testPackage := self packageUnderTest.
 
 	self assert: t1 package equals: testPackage

--- a/src/TraitsV2-Tests/T2TraitWithSlotsTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitWithSlotsTest.class.st
@@ -32,13 +32,13 @@ T2TraitWithSlotsTest >> testAddingStatefulTraitToClassAddsInstanceVariable [
 
 	| t1 c1 obj |
 	t1 := self newTrait: #T1 with: #(aSlot).
-	c1 := self newClass: #C1 superclass: Object with: #(anotherSlot) uses: {}.
+	c1 := self newClass: #C1 superclass: Object with: #(anotherSlot) traits: {}.
 
 	obj := c1 new.
 
 	self should: [ obj instVarAt: 2 ] raise: PrimitiveFailed.
 
-	c1 := self newClass: #C1 superclass: Object with: #(anotherSlot) uses: {t1}.
+	c1 := self newClass: #C1 superclass: Object with: #(anotherSlot) traits: {t1}.
 
 	self assert: (obj instVarAt: 2) isNil.
 ]
@@ -49,7 +49,7 @@ T2TraitWithSlotsTest >> testClassUsingStatefulTraits [
 	| t1 c1 |
 
 	t1 := self newTrait: #T1 with: #(aSlot).
-	c1 := self newClass: #C1 superclass: Object with: #() uses: { t1 }.
+	c1 := self newClass: #C1 superclass: Object with: #() traits: { t1 }.
 
 	self assertCollection: c1 slots hasSameElements: { c1 slotNamed: #aSlot }
 ]
@@ -60,7 +60,7 @@ T2TraitWithSlotsTest >> testClassUsingStatefulTraitsAndLocalSlots [
 	| t1 c1 |
 
 	t1 := self newTrait: #T1 with: #(aSlot).
-	c1 := self newClass: #C1 superclass: Object with: #(anotherSlot) uses: { t1 }.
+	c1 := self newClass: #C1 superclass: Object with: #(anotherSlot) traits: { t1 }.
 
 	self assertCollection: c1 slots hasSameElements: { c1 slotNamed: #aSlot. c1 slotNamed: #anotherSlot }
 ]
@@ -71,7 +71,7 @@ T2TraitWithSlotsTest >> testDefiningClass [
 	| t1 c1 |
 
 	t1 := self createT1.
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t1.
 
 	self assert: (t1 slotNamed: #a) definingClass equals: t1.
 	self assert: (t1 slotNamed: #b) definingClass equals: t1.
@@ -88,14 +88,14 @@ T2TraitWithSlotsTest >> testDefiningClass [
 T2TraitWithSlotsTest >> testDiamonProblemIsNotConflict [
 	| t1 t2 c1 t3 t4 |
 
-	t1 := self newTrait: #T1 with: #(anSlot) uses: {}.
-	t2 := self newTrait: #T2 with: #(s2) uses: {t1}.
-	t3 := self newTrait: #T3 with: #(s3) uses: {t1}.
-	t4 := self newTrait: #T4 with: #(s4) uses: {t1}.
+	t1 := self newTrait: #T1 with: #(anSlot) traits: {}.
+	t2 := self newTrait: #T2 with: #(s2) traits: {t1}.
+	t3 := self newTrait: #T3 with: #(s3) traits: {t1}.
+	t4 := self newTrait: #T4 with: #(s4) traits: {t1}.
 
 	t1 compile: 'm1 ^ anSlot:=42'.
 
-	c1 := self newClass: #C1 with: #(aSlot s2) uses: t2 + t3.
+	c1 := self newClass: #C1 with: #(aSlot s2) traits: t2 + t3.
 	c1 traitComposition: c1 traitComposition + t4.
 
 	self assert: (c1 new perform: #m1) equals: 42
@@ -105,12 +105,12 @@ T2TraitWithSlotsTest >> testDiamonProblemIsNotConflict [
 T2TraitWithSlotsTest >> testHavingASlotAlreadyInTheHierarchy [
 	| t1 t2 c1 |
 
-	t1 := self newTrait: #T1 with: #(anSlot) uses: {}.
-	t2 := self newTrait: #T2 with: #(s2) uses: {t1}.
+	t1 := self newTrait: #T1 with: #(anSlot) traits: {}.
+	t2 := self newTrait: #T2 with: #(s2) traits: {t1}.
 
 	t1 compile: 'm1 ^ anSlot:=42'.
 
-	c1 := self newClass: #C1 with: #(aSlot s2) uses: t2 + t1.
+	c1 := self newClass: #C1 with: #(aSlot s2) traits: t2 + t1.
 
 	self assert: (c1 new perform: #m1) equals: 42
 ]
@@ -121,7 +121,7 @@ T2TraitWithSlotsTest >> testOwningClass [
 	| t1 c1 |
 
 	t1 := self createT1.
-	c1 := self newClass: #C1 with: 'g h' asSlotCollection uses: t1.
+	c1 := self newClass: #C1 with: 'g h' asSlotCollection traits: t1.
 
 	self assert: (t1 slotNamed: #a) owningClass equals: t1.
 	self assert: (t1 slotNamed: #b) owningClass equals: t1.
@@ -142,15 +142,15 @@ T2TraitWithSlotsTest >> testRedefiningSuperclass [
 	t1 := self newTrait: #T1 with: #(a b).
 	t2 := self newTrait: #T2 with: #(g h).
 
-	c1 := self newClass: #C1 with: #(c d) uses: t1.
-	c2 := self newClass: #C2 superclass: c1 with: #(e) uses: t2.
+	c1 := self newClass: #C1 with: #(c d) traits: t1.
+	c2 := self newClass: #C2 superclass: c1 with: #(e) traits: t2.
 
 	self assert: (c2 localSlots collect: [:each | each name]) equals: #(e).
 	self assert: (c1 localSlots collect: [:each | each name]) equals: #(c d).
 	self assertCollection: (c2 allSlots collect: [:each | each name]) hasSameElements: #(c d a b e g h).
 	self assertCollection: (c1 allSlots collect: [:each | each name]) hasSameElements: #(c d a b).
 
-	c1 := self newClass: #C1 with: #(c d) uses: t1.
+	c1 := self newClass: #C1 with: #(c d) traits: t1.
 
 	self assert: (c2 localSlots collect: [:each | each name]) equals: #(e).
 	self assert: (c1 localSlots collect: [:each | each name]) equals: #(c d).

--- a/src/TraitsV2-Tests/T2UsingTraitsWithSlotsTest.class.st
+++ b/src/TraitsV2-Tests/T2UsingTraitsWithSlotsTest.class.st
@@ -10,7 +10,7 @@ T2UsingTraitsWithSlotsTest >> testRedefinitionKeepsSlots [
 	| t1 c1 |
 	t1 := self newTrait: #T1 with: #(a b c).
 	t1 classTrait slots: #(aSlot).
-	c1 := self newClass: #C1 with: {} uses: {t1}.
+	c1 := self newClass: #C1 with: {} traits: {t1}.
 
 	self assertEmpty: c1 localSlots.
 	self assertEmpty: c1 class localSlots.

--- a/src/TraitsV2-Tests/TraitTest.class.st
+++ b/src/TraitsV2-Tests/TraitTest.class.st
@@ -16,16 +16,29 @@ TraitTest >> createClassUsing: aTrait [
 
 { #category : 'utilities' }
 TraitTest >> createTrait [
-	| trait |
 
+	| trait |
 	trait := self class classInstaller make: [ :aBuilder |
-		aBuilder
-			name: #ATraitForTests;
-			package: 'AAA';
-			beTrait ].
+		         aBuilder
+			         name: #ATraitForTests;
+			         package: self packageNameForTests;
+			         beTrait ].
 
 	trait compile: 'm1 ^1' classified: 'test'.
 	^ trait
+]
+
+{ #category : 'helpers' }
+TraitTest >> packageNameForTests [
+
+	^ #'Generated-Trait-Test-Package'
+]
+
+{ #category : 'running' }
+TraitTest >> tearDown [
+
+	self packageOrganizer removePackage: self packageNameForTests.
+	super tearDown
 ]
 
 { #category : 'tests' }
@@ -87,47 +100,42 @@ TraitTest >> testCompositionCopy [
 
 { #category : 'tests' }
 TraitTest >> testErrorClassCreation [
-    | tmpCategory trait aSubclass aClass |
 
-    tmpCategory := 'TemporaryGeneratedClasses'.
-
-	 trait := self class classInstaller make: [ :aBuilder |
-		aBuilder
-			name: #TMyTrait;
-			package: tmpCategory;
-			beTrait ].
+	| trait aSubclass aClass |
+	trait := self class classInstaller make: [ :aBuilder |
+		         aBuilder
+			         name: #TMyTrait;
+			         package: self packageNameForTests;
+			         beTrait ].
 
 
-    [
-		aClass := self class classInstaller make: [ :aClassBuilder |
-			aClassBuilder
-				name: #AClass;
-				superclass: nil;
-				package: tmpCategory ].
+	[
+	aClass := self class classInstaller make: [ :aClassBuilder |
+		          aClassBuilder
+			          name: #AClass;
+			          superclass: nil;
+			          package: self packageNameForTests ].
 
 	"----------------"
-		aSubclass := self class classInstaller make: [ :aClassBuilder |
-			aClassBuilder
-				name: #AClass2;
-				traitComposition: trait;
-				superclass: aClass;
-				package: tmpCategory ].
+	aSubclass := self class classInstaller make: [ :aClassBuilder |
+		             aClassBuilder
+			             name: #AClass2;
+			             traitComposition: trait;
+			             superclass: aClass;
+			             package: self packageNameForTests ].
 
 	"----------------"
 
-    "Change the superclass of AClass"
-		aClass := self class classInstaller make: [ :aClassBuilder |
-			aClassBuilder
-				name: #AClass;
-				superclass: Object;
-				package: tmpCategory ].
+	"Change the superclass of AClass"
+	aClass := self class classInstaller make: [ :aClassBuilder |
+		          aClassBuilder
+			          name: #AClass;
+			          superclass: Object;
+			          package: self packageNameForTests ].
 
-    self assert: trait traitUsers asArray equals: {aSubclass}.
-    self assert: aSubclass traits asArray equals: {trait}.
-
-    ] ensure: [
-        #(AClass AClass2 TMyTrait) do: [ :aClassName |
-            testingEnvironment at: aClassName ifPresent: [ :v | v removeFromSystem ]]]
+	self assert: trait traitUsers asArray equals: { aSubclass }.
+	self assert: aSubclass traits asArray equals: { trait } ] ensure: [
+		#( AClass AClass2 TMyTrait ) do: [ :aClassName | testingEnvironment at: aClassName ifPresent: [ :v | v removeFromSystem ] ] ]
 ]
 
 { #category : 'tests' }
@@ -248,14 +256,13 @@ TraitTest >> testExplicitRequirementWithSuperclassImplementatiosAlwaysReturnsThe
 
 { #category : 'tests' }
 TraitTest >> testForbidInstantiation [
-	| tmpCategory trait |
-	tmpCategory := 'TemporaryGeneratedClasses'.
 
+	| trait |
 	trait := self class classInstaller make: [ :aBuilder |
-		aBuilder
-			name: #TMyTrait;
-			package: tmpCategory;
-			beTrait ].
+		         aBuilder
+			         name: #TMyTrait;
+			         package: self packageNameForTests;
+			         beTrait ].
 
 	self should: [ trait basicNew ] raise: Error
 ]


### PR DESCRIPTION
Traits tests seems to leave the system in a bad state now that the categories are not used to install a class anymore. This is probably due to that fact that the class builder was not using the right package/tag before.

So here is a cleaning. On top of fixing the problem I also simplified the cleaning code and the API to create classes and traits. I used the vocabulary that we are using in ShiftClassBuilder now. I also renamed a class to remove the "category" vocabulary that is been removed from the image slowly.