### PR TITLE
Improve cleanups of tests

### DIFF
--- a/src/AST-Core-Tests/RBCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippetTest.class.st
@@ -54,6 +54,7 @@ RBCodeSnippetTest >> testCodeImporter [
 	| string importer class runBlock |
 	"Code importer meed a plain expression or use a custom format"
 	snippet source isAllSeparators ifTrue: [ ^ self skip ].
+	[
 	string := snippet isScripting
 		          ifFalse: [
 			          class := ChunkImportTestCase new importAClass.
@@ -90,7 +91,7 @@ RBCodeSnippetTest >> testCodeImporter [
 
 	            value ].
 
-	self testExecuteBlock: runBlock
+	self testExecuteBlock: runBlock ] ensure: [ self packageOrganizer removePackage: ChunkImportTestCase new packageNameForTests ]
 ]
 
 { #category : 'tests' }

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -217,11 +217,9 @@ CompiledMethodTest >> nonAbstractMethod [
 	^ 4 + 5
 ]
 
-{ #category : 'private - accessing' }
+{ #category : 'running' }
 CompiledMethodTest >> packageNameForTests [
-	"Answer the category where to classify temporarily created classes"
-
-	^'Dummy-Tests-Class'
+	^ #'Generated-Compiled-Method-Test-Package'
 ]
 
 { #category : 'examples' }
@@ -950,61 +948,62 @@ CompiledMethodTest >> testUndeclaredReparationWithGlobal [
 CompiledMethodTest >> testUndeclaredReparationWithInstanceVariable [
 
 	| method method2 method3 method4 receiver |
-
 	Smalltalk globals at: #TestUndeclaredVariableClass ifPresent: [ :c | c removeFromSystem ].
-	class := (Object << #TestUndeclaredVariableClass package: '') install.
+	class := (Object << #TestUndeclaredVariableClass package: self packageNameForTests) install.
 	self assert: (class instVarIndexFor: #TestUndeclaredVariable) equals: 0.
 	receiver := class new.
 
 	"Note: unlike related tests, we need here a reveiver (see above) and to install the method in the class"
-	method := class compiler permitFaulty: true; install: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
+	method := class compiler
+		          permitFaulty: true;
+		          install: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	self assert: method usesUndeclareds.
 	self should: [ receiver executeMethod: method ] raise: UndeclaredVariableRead.
 
 	"Update the class (same identity, not a new class)"
-	self assert: (Object << #TestUndeclaredVariableClass slots: { #TestUndeclaredVariable}; package: '') install equals: class.
+	self
+		assert: ((Object << #TestUndeclaredVariableClass)
+				 slots: { #TestUndeclaredVariable };
+				 package: self packageNameForTests) install
+		equals: class.
 	self assert: (class instVarIndexFor: #TestUndeclaredVariable) equals: 1.
 	receiver instVarAt: 1 put: 42.
 
 	"Adding ivars DOES not repair the CompiledMethod"
 	self assert: method usesUndeclareds.
 	"But recompile and install a NEW method"
-	self deny: method equals: (method2 := class>>#x). "It is a new method"
+	self deny: method equals: (method2 := class >> #x). "It is a new method"
 	self deny: method2 usesUndeclareds.
 	self assert: (receiver executeMethod: method2) equals: 42.
 
 	"Removal of ivar DOES recompile a new new one"
-	class := (Object << #TestUndeclaredVariableClass package: '') install.
-	self deny: method2 equals: (method3 := class>>#x). "It is a new method"
+	class := (Object << #TestUndeclaredVariableClass package: self packageNameForTests) install.
+	self deny: method2 equals: (method3 := class >> #x). "It is a new method"
 	self assert: method3 usesUndeclareds.
 	self should: [ receiver executeMethod: method3 ] raise: UndeclaredVariableRead.
 
 	"Thus adding back DOES recompile again"
-	class := (Object << #TestUndeclaredVariableClass slots: {#TestUndeclaredVariable}; package: '') install.
+	class := ((Object << #TestUndeclaredVariableClass)
+		          slots: { #TestUndeclaredVariable };
+		          package: self packageNameForTests) install.
 	receiver instVarAt: 1 put: 421.
-	self deny: method3 equals: (method4 := class>>#x). "It is a new method"
+	self deny: method3 equals: (method4 := class >> #x). "It is a new method"
 	self deny: method4 usesUndeclareds.
-	self assert: (receiver executeMethod: method4) equals: 421.
-
-
+	self assert: (receiver executeMethod: method4) equals: 421
 ]
 
 { #category : 'tests - literals' }
 CompiledMethodTest >> testUndeclaredReparationWithShared [
 
 	| method |
-	class := (Object
-		         << #TestUndeclaredVariableClass
-		         package: '') install.
+	class := (Object << #TestUndeclaredVariableClass package: self packageNameForTests) install.
 	method := class compiler
 		          permitFaulty: true;
-		          compile:
-			          'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
+		          compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	"Add and initialize a shared"
-	class := (Object
-		         << #TestUndeclaredVariableClass
-		         sharedVariables:  {#TestUndeclaredVariable};
-		         package: '') install.
+	class := ((Object << #TestUndeclaredVariableClass)
+		          sharedVariables: { #TestUndeclaredVariable };
+		          package: self packageNameForTests) install.
 
 	nil executeMethod: method.
 	nil executeMethod: method
@@ -1014,18 +1013,14 @@ CompiledMethodTest >> testUndeclaredReparationWithShared [
 CompiledMethodTest >> testUndeclaredReparationWithSharedWasCrashingOnOldVM1001 [
 
 	| method |
-	class := (Object
-		         << #TestUndeclaredVariableClass
-		         package: '') install.
+	class := (Object << #TestUndeclaredVariableClass package: self packageNameForTests) install.
 	method := class compiler
 		          permitFaulty: true;
-		          compile:
-			          'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
+		          compile: 'x ^TestUndeclaredVariable ifNil: [ TestUndeclaredVariable ]'.
 	"Add and initialize a shared"
-	class := (Object
-		         << #TestUndeclaredVariableClass
-		         sharedVariables:  {#TestUndeclaredVariable};
-		         package: '') install.
+	class := ((Object << #TestUndeclaredVariableClass)
+		          sharedVariables: { #TestUndeclaredVariable };
+		          package: self packageNameForTests) install.
 
 	nil executeMethod: method.
 	nil executeMethod: method

--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -9,7 +9,7 @@ Class {
 	#tag : 'Processes'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 ProcessTest >> setUp [
 	super setUp.
 
@@ -634,7 +634,7 @@ ProcessTest >> testNormalProcessWithArgsCompletionWithLeftEffectiveProcess [
 	effectiveProcess terminate
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testProcessFaithfulTermination [
 	"When terminating a process, unwind blocks should be evaluated as if they were executed by the process being terminated."
 
@@ -648,7 +648,7 @@ ProcessTest >> testProcessFaithfulTermination [
 	self assert: process isTerminated
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 ProcessTest >> testRealActiveProcessFromProcesor [
 
 	| processFromProcessor activeProcess |
@@ -755,7 +755,7 @@ ProcessTest >> testTerminateAnswersSelf [
 	self assert: process isTerminated
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testTerminateInTerminate [
 	"Terminating a terminator process should unwind both the terminator and its terminatee process"
 	
@@ -775,7 +775,7 @@ ProcessTest >> testTerminateInTerminate [
 	self assert: unwound
 ]
 
-{ #category : #'tests - termination' }
+{ #category : 'tests - termination' }
 ProcessTest >> testTerminationShouldProceedAllEnsureBlocksIfSomeWasFailed [
 "
 	<expectedFailure>

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -537,6 +537,7 @@ RPackage >> name: aSymbol [
 	"Set the name of a package. This method is private and should not be used.
 	If you wish to rename a package, use #renameTo: instead"
 
+	aSymbol isEmptyOrNil ifTrue: [ self error: 'Cannot have empty or nil package name.' ].
 	name := aSymbol asSymbol
 ]
 

--- a/src/Reflectivity-Tests/VariableBreakpointMockClass.class.st
+++ b/src/Reflectivity-Tests/VariableBreakpointMockClass.class.st
@@ -38,7 +38,9 @@ VariableBreakpointMockClass >> methodWithTempsAndArg: arg [
 ]
 
 { #category : 'accessing' }
-VariableBreakpointMockClass >> v1 [ ^v1
+VariableBreakpointMockClass >> v1 [
+
+	^ v1
 ]
 
 { #category : 'accessing' }

--- a/src/Reflectivity-Tests/VariableBreakpointTest.class.st
+++ b/src/Reflectivity-Tests/VariableBreakpointTest.class.st
@@ -58,10 +58,9 @@ VariableBreakpointTest >> argNodes [
 { #category : 'helpers' }
 VariableBreakpointTest >> compileTestClass [
 
-	testClass := (VariableBreakpointMockClass
-		             << #VariableBreakpointTestSubclass
-		             slots:  {#v3}; 
-		             package: 'Reflectivity-Tests-Breakpoints') install.
+	testClass := ((VariableBreakpointMockClass << #VariableBreakpointTestSubclass)
+		              slots: { #v3 };
+		              package: self packageNameForTests) install.
 	testClass compile: 'accessingV1 ^v1'.
 	testClass compile: 'accessingtemp |temp| temp := 0'
 ]
@@ -69,8 +68,7 @@ VariableBreakpointTest >> compileTestClass [
 { #category : 'helpers' }
 VariableBreakpointTest >> compileTestClass2 [
 
-	testSubclass := (testClass
-		                << #VariableBreakpointTestSubclass2 package: 'Reflectivity-Tests-Breakpoints') install.
+	testSubclass := (testClass << #VariableBreakpointTestSubclass2 package: self packageNameForTests) install.
 	testSubclass compile: 'accessingV1 ^v1'
 ]
 
@@ -105,6 +103,12 @@ VariableBreakpointTest >> nodesForV2InVariableBreakpointMockSubclass [
 	^nodes
 ]
 
+{ #category : 'helpers' }
+VariableBreakpointTest >> packageNameForTests [
+
+	^ 'Generated-Reflectivity-Tests-Breakpoints'
+]
+
 { #category : 'running' }
 VariableBreakpointTest >> setUp [
 	super setUp.
@@ -118,12 +122,10 @@ VariableBreakpointTest >> setUp [
 
 { #category : 'running' }
 VariableBreakpointTest >> tearDown [
-	wp
-		ifNotNil: [ wp isInstalled
-				ifTrue: [ wp remove ] ].
+
+	wp ifNotNil: [ wp isInstalled ifTrue: [ wp remove ] ].
 	Breakpoint unregisterObserver: observer.
-	testSubclass ifNotNil:[testSubclass removeFromSystem].
-	testClass ifNotNil:[testClass removeFromSystem].
+	self packageOrganizer removePackage: self packageNameForTests.
 	super tearDown
 ]
 


### PR DESCRIPTION
- CodeSnippetTest was not removing generated package
- Improve code generation and cleaning of ReflectivityTests
- Clean after CompiledMethodTest
- Add error on creation of RPackage with empty name because this causes the system to end up in a weird state (I expect this one to make a test crash but we'll see)