### PR TITLE
Calypso: Add Undefined project

### DIFF
--- a/src/Calypso-SystemQueries/Project.extension.st
+++ b/src/Calypso-SystemQueries/Project.extension.st
@@ -5,7 +5,8 @@ Project class >> convertToCalypsoBrowserItem: aProject [
 
 	| item |
 	item := ClyBrowserItem named: aProject name with: aProject.
-	aProject hasPackages ifTrue: [ item markWithChildrenOf: self ].
+	"We cannot use `self` because my subclass also need to return Project.."
+	aProject hasPackages ifTrue: [ item markWithChildrenOf: Project ].
 	^ item
 ]
 

--- a/src/Tools/ProjectManager.class.st
+++ b/src/Tools/ProjectManager.class.st
@@ -29,20 +29,24 @@ ProjectManager >> environment: anObject [
 
 { #category : 'testing' }
 ProjectManager >> hasProjects [
+	"Even if we do not have projects we have un undefined project."
 
-	^ self projects isNotEmpty
-]
-
-{ #category : 'testing' }
-ProjectManager >> isNotEmpty [
-
-	^ self projects isNotEmpty
+	^ true
 ]
 
 { #category : 'accessing' }
 ProjectManager >> projects [
+	"Maybe we should cache this and invalidate the cache when a package announcement or class (impacting baselines) is received?"
 
-	^ self environment allClasses
-		  select: [ :class | (class inheritsFrom: BaselineOf) and: [ class isProject ] ]
-		  thenCollect: [ :baseline | Project baseline: baseline ]
+	| projects packages |
+	projects := self environment allClasses
+		            select: [ :class | (class inheritsFrom: BaselineOf) and: [ class isProject ] ]
+		            thenCollect: [ :baseline | Project baseline: baseline ].
+
+	packages := projects flatCollect: [ :project | project packages ].
+
+	(self environment organization packages reject: [ :package | package isUndefined or: [ packages identityIncludes: package ] ]) ifNotEmpty: [ :orphans |
+		projects add: (UndefinedProject packages: orphans) ].
+
+	^ projects
 ]

--- a/src/Tools/UndefinedProject.class.st
+++ b/src/Tools/UndefinedProject.class.st
@@ -1,0 +1,38 @@
+"
+I am a project whose aim is to contain all the packages that are in no project in the environment.
+"
+Class {
+	#name : 'UndefinedProject',
+	#superclass : 'Project',
+	#instVars : [
+		'packages'
+	],
+	#category : 'Tools',
+	#package : 'Tools'
+}
+
+{ #category : 'instance creation' }
+UndefinedProject class >> packages: aCollection [
+
+	^ self new
+		  packages: aCollection;
+		  yourself
+]
+
+{ #category : 'accessing' }
+UndefinedProject >> name [
+
+	^ #'Undefined Project'
+]
+
+{ #category : 'accessing' }
+UndefinedProject >> packages [
+
+	^ packages
+]
+
+{ #category : 'accessing' }
+UndefinedProject >> packages: aCollection [
+
+	packages := aCollection
+]


### PR DESCRIPTION
In case some packages of the image are in no project, I'm adding an undefined project. 

This will allow me to implement a new feature more easily: Select package in projects. Currently in the project view if you select a class of a package that is not part of the opened project (with the spotter for example), it will go back to the packages view. I want to select the first instance of the package in the view but for that I need to be sure all packages are present in the view.

This is a first step