### PR TITLE
Stay in calypso project view when selecting a class

### DIFF
--- a/src/Calypso-SystemQueries/Project.extension.st
+++ b/src/Calypso-SystemQueries/Project.extension.st
@@ -5,7 +5,8 @@ Project class >> convertToCalypsoBrowserItem: aProject [
 
 	| item |
 	item := ClyBrowserItem named: aProject name with: aProject.
-	aProject hasPackages ifTrue: [ item markWithChildrenOf: self ].
+	"We cannot use `self` because my subclass also need to return Project.."
+	aProject hasPackages ifTrue: [ item markWithChildrenOf: Project ].
 	^ item
 ]
 

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -657,27 +657,25 @@ ClyFullBrowserMorph >> selectPackage: aPackage [
 
 	self changeStateBy: [
 		packageView selection selectItemsWith: { aPackage }.
-		packageView selection isEmpty ifTrue: [ self switchToPackages ].
-		packageView selection selectItemsWith: { aPackage }.
-	]
+		packageView selection isEmpty ifTrue: [
+			self showInPackageView: aPackage.
+			packageView selection selectItemsWith: { aPackage } ] ]
 ]
 
 { #category : 'navigation' }
 ClyFullBrowserMorph >> selectPackage: aPackage andTag: tagName [
 
 	| packageItem targetClassGroup foundPackages |
-
 	self changeStateBy: [
-		foundPackages := packageView findItemsWith: {aPackage}.
+		foundPackages := packageView findItemsWith: { aPackage }.
 		foundPackages ifEmpty: [
-			self switchToPackages.
-			foundPackages := packageView findItemsWith: {aPackage} ].
+			self showInPackageView: aPackage.
+			foundPackages := packageView findItemsWith: { aPackage } ].
 		packageItem := foundPackages first.
 		packageItem expand.
-		targetClassGroup := packageItem childrenItems detect: [:each | each name = tagName ].
+		targetClassGroup := packageItem childrenItems detect: [ :each | each name = tagName ].
 
-		packageView selection selectItems: { targetClassGroup }
-	]
+		packageView selection selectItems: { targetClassGroup } ]
 ]
 
 { #category : 'navigation' }
@@ -712,6 +710,19 @@ ClyFullBrowserMorph >> showAllMethods [
 
 	methodQuery := ClyAllMethodsQuery sortedFrom: self classScopeForMethods.
 	methodView showQuery: methodQuery
+]
+
+{ #category : 'navigation' }
+ClyFullBrowserMorph >> showInPackageView: aPackage [
+
+	"If true we are in the project view and we need to find the package and expand it"
+	(packageView showsItemsFromQuery: ClyAllProjectsQuery)
+		ifTrue: [
+			packageView dataSource allElements
+				detect: [ :element | (element actualObject isKindOf: Project) and: [ element actualObject packages includes: aPackage ] ]
+				ifFound: [ :element | packageView dataSource expand: element ]
+				ifNone: [ "this should not happen but who knows with calypso.." self switchToPackages ] ]
+		ifFalse: [ self switchToPackages ]
 ]
 
 { #category : 'testing' }

--- a/src/Tools/ProjectManager.class.st
+++ b/src/Tools/ProjectManager.class.st
@@ -29,20 +29,24 @@ ProjectManager >> environment: anObject [
 
 { #category : 'testing' }
 ProjectManager >> hasProjects [
+	"Even if we do not have projects we have un undefined project."
 
-	^ self projects isNotEmpty
-]
-
-{ #category : 'testing' }
-ProjectManager >> isNotEmpty [
-
-	^ self projects isNotEmpty
+	^ true
 ]
 
 { #category : 'accessing' }
 ProjectManager >> projects [
+	"Maybe we should cache this and invalidate the cache when a package announcement or class (impacting baselines) is received?"
 
-	^ self environment allClasses
-		  select: [ :class | (class inheritsFrom: BaselineOf) and: [ class isProject ] ]
-		  thenCollect: [ :baseline | Project baseline: baseline ]
+	| projects packages |
+	projects := self environment allClasses
+		            select: [ :class | (class inheritsFrom: BaselineOf) and: [ class isProject ] ]
+		            thenCollect: [ :baseline | Project baseline: baseline ].
+
+	packages := projects flatCollect: [ :project | project packages ].
+
+	(self environment organization packages reject: [ :package | package isUndefined or: [ packages identityIncludes: package ] ]) ifNotEmpty: [ :orphans |
+		projects add: (UndefinedProject packages: orphans) ].
+
+	^ projects
 ]

--- a/src/Tools/UndefinedProject.class.st
+++ b/src/Tools/UndefinedProject.class.st
@@ -1,0 +1,38 @@
+"
+I am a project whose aim is to contain all the packages that are in no project in the environment.
+"
+Class {
+	#name : 'UndefinedProject',
+	#superclass : 'Project',
+	#instVars : [
+		'packages'
+	],
+	#category : 'Tools',
+	#package : 'Tools'
+}
+
+{ #category : 'instance creation' }
+UndefinedProject class >> packages: aCollection [
+
+	^ self new
+		  packages: aCollection;
+		  yourself
+]
+
+{ #category : 'accessing' }
+UndefinedProject >> name [
+
+	^ #'Undefined Project'
+]
+
+{ #category : 'accessing' }
+UndefinedProject >> packages [
+
+	^ packages
+]
+
+{ #category : 'accessing' }
+UndefinedProject >> packages: aCollection [
+
+	packages := aCollection
+]


### PR DESCRIPTION
This is a big step to have the project view working. When we select a class whose package is not shown in the first pane, before we switched to package view. Now we stay in project view and we expand the item containing the package.

Depends on #15246