### PR TITLE
Cleanup: usage of #notNil in UnifiedFFI

### DIFF
--- a/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
@@ -191,9 +191,9 @@ FFICalloutAPITest >> testCallWithObjectCreation [
 
 	[
 		self shouldnt: [ object := FFICalloutObjectForTest primCreate: 1 ] raise: Error.
-		self assert: object notNil.
+		self assert: object isNotNil.
 		self assert: object class equals: FFICalloutObjectForTest.
-		self assert: object handle notNil.
+		self assert: object handle isNotNil.
 		self deny: object handle isNull ]
 	ensure: [
 		object ifNotNil: [ object free ] ]

--- a/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTest.class.st
@@ -38,7 +38,7 @@ FFICalloutMethodBuilderTest >> testAllAtomicTypesCall [
 				methodClass: Object;
 				yourself )].
 
-	self assert: result notNil.
+	self assert: result isNotNil.
 	self assert: result isCompiledMethod.
 	self assert: result primitive equals: 0.
 
@@ -75,7 +75,7 @@ FFICalloutMethodBuilderTest >> testCallCreateObject [
 				methodClass: FFICalloutObjectForTest;
 				yourself )].
 
-	self assert: result notNil.
+	self assert: result isNotNil.
 	self assert: result isCompiledMethod.
 	self assert: result primitive equals: 0.
 	self assert: result literals second functionName equals: 'method1'.
@@ -97,7 +97,7 @@ FFICalloutMethodBuilderTest >> testCallReturningEnumeration [
 				methodClass: FFICalloutObjectForTest;
 				yourself )].
 
-	self assert: result notNil.
+	self assert: result isNotNil.
 	self assert: result isCompiledMethod.
 	self assert: result primitive equals: 0.
 
@@ -120,7 +120,7 @@ FFICalloutMethodBuilderTest >> testCallSimple [
 				methodClass: Object;
 				yourself )].
 
-	self assert: result notNil.
+	self assert: result isNotNil.
 	self assert: result isCompiledMethod.
 	self assert: result primitive equals: 0.
 	tfFunction := result literals second.
@@ -143,7 +143,7 @@ FFICalloutMethodBuilderTest >> testCallWithConstant [
 				methodClass: Object;
 				yourself )].
 
-	self assert: result notNil.
+	self assert: result isNotNil.
 	self assert: result isCompiledMethod.
 	self assert: result primitive equals: 0.
 
@@ -168,7 +168,7 @@ FFICalloutMethodBuilderTest >> testCallWithObject [
 				methodClass: FFICalloutObjectForTest;
 				yourself )].
 
-	self assert: result notNil.
+	self assert: result isNotNil.
 	self assert: result isCompiledMethod.
 	self assert: result primitive equals: 0.
 	tfFunction := result literals second.
@@ -191,7 +191,7 @@ FFICalloutMethodBuilderTest >> testCallWithPointer [
 				methodClass: Object;
 				yourself )].
 
-	self assert: result notNil.
+	self assert: result isNotNil.
 	self assert: result isCompiledMethod.
 	self assert: result primitive equals: 0.
 
@@ -215,7 +215,7 @@ FFICalloutMethodBuilderTest >> testCallWithPointerPointer [
 				methodClass: Object;
 				yourself )].
 
-	self assert: result notNil.
+	self assert: result isNotNil.
 	self assert: result isCompiledMethod.
 	self assert: result primitive equals: 0.
 
@@ -240,7 +240,7 @@ FFICalloutMethodBuilderTest >> testCallWithSelf [
 				methodClass: FFICalloutObjectForTest;
 				yourself )].
 
-	self assert: result notNil.
+	self assert: result isNotNil.
 	self assert: result isCompiledMethod.
 	self assert: result primitive equals: 0.
 

--- a/src/UnifiedFFI-Tests/FFICompilerPluginTest.class.st
+++ b/src/UnifiedFFI-Tests/FFICompilerPluginTest.class.st
@@ -79,6 +79,6 @@ FFICompilerPluginTest >> testMethodCall [
 FFICompilerPluginTest >> testThatFFIAdditionalStateIsFilledCorrectlyWith2Parameters [
 	| ffiCallMethod |
 	ffiCallMethod := self class >> #ffiCopyString:to:.
-	self assert: ffiCallMethod properties notNil.
+	self assert: ffiCallMethod properties isNotNil.
 	self assert: (ffiCallMethod propertyAt: #argumentNames) equals: #(#aString #dest)
 ]

--- a/src/UnifiedFFI-Tests/FFIExternalStructureFieldParserTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalStructureFieldParserTest.class.st
@@ -31,7 +31,7 @@ FFIExternalStructureFieldParserTest >> testParseFieldsStructure [
 		parseFields: FFITestStructure fields
 		structure: FFITestStructure.
 
-	self assert: fieldSpec notNil.
+	self assert: fieldSpec isNotNil.
 	self assert: fieldSpec fieldNames equals: #(byte short long float double int64 ulong size_t).
 	self assert: (fieldSpec typeFor: #byte) class equals: FFIUInt8.
 	self assert: (fieldSpec typeFor: #short) class equals: FFIInt16.

--- a/src/UnifiedFFI/ExternalAddress.extension.st
+++ b/src/UnifiedFFI/ExternalAddress.extension.st
@@ -163,7 +163,7 @@ ExternalAddress class >> fromString: aString [
 	| result |
 
 	result := self allocate: aString size + 1.
-	(self assert: result notNil).
+	(self assert: result isNotNil).
 	result writeString: aString.
 	result unsignedByteAt: aString size + 1 put: 0.
 	^ result

--- a/src/UnifiedFFI/FFICallout.class.st
+++ b/src/UnifiedFFI/FFICallout.class.st
@@ -111,7 +111,7 @@ FFICallout >> aliasForType: aTypeName [
 	| alias |
 
 	alias := aTypeName.
-	(requestor notNil and: [ requestor respondsTo: #externalTypeAlias: ])
+	(requestor isNotNil and: [ requestor respondsTo: #externalTypeAlias: ])
 		ifTrue: [
 			alias := requestor externalTypeAlias: aTypeName.
 			alias ifNil: [ alias := aTypeName ] ].

--- a/src/UnifiedFFI/FFIFunctionParser.class.st
+++ b/src/UnifiedFFI/FFIFunctionParser.class.st
@@ -261,10 +261,10 @@ FFIFunctionParser >> parseWord [
 	^ String streamContents: [:st | | ch |
 		"first char must be letter or underscore"
 		ch := stream peek.
-		(ch notNil and: [ ch isLetter or: [ '_$' includes: ch ]]) ifFalse: [ ^ nil ].
+		(ch isNotNil and: [ ch isLetter or: [ '_$' includes: ch ]]) ifFalse: [ ^ nil ].
 		[
 			ch := stream peek.
-			ch notNil
+			ch isNotNil
 				and: [
 					ch isLetter
 					or: [ ('_$' includes: ch)


### PR DESCRIPTION
Fix #15255