### PR TITLE
Simplify ClassRemoved and MethodRemoved now that packages are preserved

### DIFF
--- a/src/Deprecated12/ClassRemoved.extension.st
+++ b/src/Deprecated12/ClassRemoved.extension.st
@@ -6,3 +6,10 @@ ClassRemoved >> categoryName [
 	self deprecated: 'Use package and tag instead of the category.'.
 	^ self packageTagAffected categoryName
 ]
+
+{ #category : '*Deprecated12' }
+ClassRemoved >> packageTag [
+
+	self deprecated: 'Use #packageTagAffected instead.' transformWith: '`@rcv packageTag' -> '`@rcv packageTagAffected'.
+	^ self packageTagAffected
+]

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -890,7 +890,6 @@ Class >> removeFromSystem: logged [
 	Keep the class name and category for triggering the system change message. If we wait to long, then we get obsolete information which is not what we want.
 	Tell class to deactivate and unload itself-- two separate events in the module system"
 
-	| tag |
 	self release.
 	self unload.
 
@@ -898,15 +897,13 @@ Class >> removeFromSystem: logged [
 
 	"we add the class to Undeclared so that if references still exist, they will  be automatically fixed if this class is loaded again. We do not check if references exist as it is too slow"
 	Undeclared declare: self name asSymbol from: Smalltalk globals.
-	self flag: #package. "For now the class cannot return its package tag after been removed. In the future the class should keep a reference to its package tag so we should not need that."
-	tag := self packageTag.
 	self environment forgetClass: self.
 
 	"In case the class has deprecated aliases we need to remove them from the system dictionary.
 	We deal also with a special case that is the case a class of the same name than the alias is installed in the image after the alias. In that case we do not remove it. It's the reason we check if the global of the alias is the same as self."
 	self deprecatedAliases do: [ :alias | self environment at: alias ifPresent: [ :class | class = self ifTrue: [ self environment removeKey: alias ] ] ].
 	self obsolete.
-	logged ifTrue: [ SystemAnnouncer announce: (ClassRemoved class: self packageTag: tag) ]
+	logged ifTrue: [ SystemAnnouncer announce: (ClassRemoved class: self) ]
 ]
 
 { #category : 'initialization' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -979,18 +979,17 @@ ClassDescription >> removeSelector: selector [
 	dictionary of the receiver, if it is there. Answer nil otherwise."
 
   <reflection: 'Class structural modification - Selector/Method modification'>
-	| method protocol package origin |
+	| method protocol origin |
 	method := self compiledMethodAt: selector ifAbsent: [ ^ nil ].
 	origin := method origin.
 	protocol := self protocolOfSelector: selector.
-	package := method package.
 
 	method removeFromPackage.
 	self removeFromProtocols: selector.
 
 	super removeSelector: selector.
 
-	SystemAnnouncer uniqueInstance methodRemoved: method protocol: protocol origin: origin package: package
+	SystemAnnouncer uniqueInstance methodRemoved: method protocol: protocol origin: origin
 ]
 
 { #category : 'instance variables' }

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -101,8 +101,7 @@ RGEnvironmentAnnouncer >> methodRemoved: aMethod [
 					  at: aMethod methodClass
 					  ifPresent: [ :class | class protocolNamed: aMethod protocol ]
 					  ifAbsent: [ aMethod protocol ])
-			 origin: aMethod parent
-			 package: aMethod package)
+			 origin: aMethod parent)
 ]
 
 { #category : 'accessing' }

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -71,7 +71,7 @@ RGEnvironmentAnnouncer >> behaviorParentRenamed: anRGBehavior from: oldName [
 { #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorRemoved: anRGBehavior [
 
-	self announce: (ClassRemoved class: anRGBehavior packageTag: anRGBehavior packageTag)
+	self announce: (ClassRemoved class: anRGBehavior)
 ]
 
 { #category : 'triggering' }

--- a/src/System-Announcements/ClassRemoved.class.st
+++ b/src/System-Announcements/ClassRemoved.class.st
@@ -6,8 +6,7 @@ Class {
 	#name : 'ClassRemoved',
 	#superclass : 'ClassAnnouncement',
 	#instVars : [
-		'classRemoved',
-		'packageTag'
+		'classRemoved'
 	],
 	#category : 'System-Announcements-System-Classes',
 	#package : 'System-Announcements',
@@ -15,12 +14,10 @@ Class {
 }
 
 { #category : 'instance creation' }
-ClassRemoved class >> class: aClass packageTag: aPackageTag [
+ClassRemoved class >> class: aClass [
 
-	self flag: #package. "For now the class cannot return its package tag after been removed. In the future the class should keep a reference to its package tag so we should not need to know the packageTag, we will be able to ask the class directly."
 	^ self new
 		  classRemoved: aClass;
-		  packageTag: aPackageTag;
 		  yourself
 ]
 
@@ -67,30 +64,5 @@ ClassRemoved >> classRemoved [
 { #category : 'accessing' }
 ClassRemoved >> classRemoved: aClass [
 
-	classRemoved := aClass.
-	packageTag := aClass packageTag
-]
-
-{ #category : 'accessing' }
-ClassRemoved >> packageAffected [
-
-	^ self packageTag package
-]
-
-{ #category : 'accessing' }
-ClassRemoved >> packageTag [
-
-	^ packageTag
-]
-
-{ #category : 'accessing' }
-ClassRemoved >> packageTag: anObject [
-
-	packageTag := anObject
-]
-
-{ #category : 'accessing' }
-ClassRemoved >> packageTagAffected [
-
-	^ self packageTag
+	classRemoved := aClass
 ]

--- a/src/System-Announcements/MethodRemoved.class.st
+++ b/src/System-Announcements/MethodRemoved.class.st
@@ -8,8 +8,7 @@ Class {
 	#superclass : 'MethodAnnouncement',
 	#instVars : [
 		'protocol',
-		'methodOrigin',
-		'methodPackage'
+		'methodOrigin'
 	],
 	#category : 'System-Announcements-System-Methods',
 	#package : 'System-Announcements',
@@ -17,13 +16,12 @@ Class {
 }
 
 { #category : 'instance creation' }
-MethodRemoved class >> methodRemoved: aCompiledMethod protocol: aProtocol origin: aBehavior package: aPackage [
+MethodRemoved class >> methodRemoved: aCompiledMethod protocol: aProtocol origin: aBehavior [
 
 	^ self new
 		  method: aCompiledMethod;
 		  protocol: aProtocol;
 		  methodOrigin: aBehavior;
-		  methodPackage: aPackage;
 		  yourself
 ]
 
@@ -41,18 +39,6 @@ MethodRemoved >> methodOrigin [
 { #category : 'accessing' }
 MethodRemoved >> methodOrigin: anObject [
 	methodOrigin := anObject
-]
-
-{ #category : 'accessing' }
-MethodRemoved >> methodPackage [
-
-	^ methodPackage
-]
-
-{ #category : 'accessing' }
-MethodRemoved >> methodPackage: aPackage [
-
-	methodPackage := aPackage
 ]
 
 { #category : 'accessing' }

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -141,10 +141,10 @@ SystemAnnouncer >> methodRecategorized: method oldProtocol: oldProtocol [
 ]
 
 { #category : 'triggering' }
-SystemAnnouncer >> methodRemoved: aMethod protocol: protocol origin: aBehavior package: aPackage [
+SystemAnnouncer >> methodRemoved: aMethod protocol: protocol origin: aBehavior [
 	"A method with the given selector was removed from the class."
 
-	self announce: (MethodRemoved methodRemoved: aMethod protocol: protocol origin: aBehavior package: aPackage)
+	self announce: (MethodRemoved methodRemoved: aMethod protocol: protocol origin: aBehavior)
 ]
 
 { #category : 'triggering' }


### PR DESCRIPTION
With my recent changes to the system, a class still knows the package it was defined into after been removed. 

This allows us to simplify the removal announcements because we can remove this info that the classes and methods can now give.