### PR TITLE
Fix trait method recompilation and clean

### DIFF
--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -28,7 +28,7 @@ CompiledMethod >> methodNode [
 
 { #category : '*OpalCompiler-Core' }
 CompiledMethod >> recompile [
-	^ self methodClass recompile: self selector
+	^ self origin recompile: self selector
 ]
 
 { #category : '*OpalCompiler-Core' }

--- a/src/TraitsV2-Tests/T2AbstractTest.class.st
+++ b/src/TraitsV2-Tests/T2AbstractTest.class.st
@@ -37,6 +37,11 @@ T2AbstractTest >> newClass: aName with: slots traits: aComposition [
 ]
 
 { #category : 'instance creation' }
+T2AbstractTest >> newTrait: aName [
+	^ self newTrait: aName with: #()
+]
+
+{ #category : 'instance creation' }
 T2AbstractTest >> newTrait: aName with: slots [
 	^ self newTrait: aName with: slots traits: TEmpty
 ]

--- a/src/TraitsV2-Tests/T2TraitTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitTest.class.st
@@ -239,6 +239,48 @@ T2TraitTest >> testMethodsAddedInMetaclassPresentInSubclassesAfterRemovingSuperc
 ]
 
 { #category : 'tests' }
+T2TraitTest >> testRecompilingTraitClassMethodRecompilesTheMethodInTheUsers [
+
+	| trait class priorTraitMethod priorClassMethod |
+	trait := self newTrait: #TTraitForTest.
+
+	class := self newClass: #ClassUsingTTraitForTest with: #(  ) traits: trait.
+
+	trait class compile: 'test
+    ^ #test'.
+
+
+	priorTraitMethod := trait class >> #test.
+	priorClassMethod := class class >> #test.
+
+	priorTraitMethod recompile.
+
+	self deny: trait class >> #test identicalTo: priorTraitMethod.
+	self deny: class class >> #test identicalTo: priorClassMethod
+]
+
+{ #category : 'tests' }
+T2TraitTest >> testRecompilingTraitMethodRecompilesTheMethodInTheUsers [
+
+	| trait class priorTraitMethod priorClassMethod |
+	trait := self newTrait: #TTraitForTest.
+
+	class := self newClass: #ClassUsingTTraitForTest with: #(  ) traits: trait.
+	
+	trait compile: 'test
+    ^ #test'.
+
+
+	priorTraitMethod := trait >> #test.
+	priorClassMethod := class >> #test.
+
+	priorTraitMethod recompile.
+
+	self deny: trait >> #test identicalTo: priorTraitMethod.
+	self deny: class >> #test identicalTo: priorClassMethod
+]
+
+{ #category : 'tests' }
 T2TraitTest >> testRedefiningAClassAsTraitShouldRaiseError [
 
 	self newClass: #C1.

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -21,18 +21,6 @@ Class {
 	#tag : 'Base'
 }
 
-{ #category : 'accessing - method dictionary' }
-TraitedClass class >> addAndClassifySelector: selector withMethod: compiledMethod inProtocol: aProtocol [
-	<reflection: 'Class structural modification - Selector/Method modification'>
-
-	super
-		addAndClassifySelector: selector
-		withMethod: compiledMethod
-		inProtocol: aProtocol.
-
-	self propagateChangeOf: selector
-]
-
 { #category : 'users' }
 TraitedClass class >> addUser: aClass [
 
@@ -53,17 +41,6 @@ TraitedClass class >> classTrait [
 TraitedClass class >> isTrait [
 	<reflection: 'Class structural inspection - Traits'>
 	^ true
-]
-
-{ #category : 'changes' }
-TraitedClass class >> propagateChangeOf: aSelector [
-	| change |
-
-	change := TraitChange new
-		updatedSelectors: {aSelector};
-		yourself.
-
-	self basicUsers do: [ :e | change applyOn: e ]
 ]
 
 { #category : 'users' }
@@ -240,15 +217,9 @@ TraitedClass >> recategorizeSelector: selector from: oldProtocol to: newProtocol
 
 { #category : 'recompilation' }
 TraitedClass >> recompile: selector from: oldClass [
-	"Compile the method associated with selector in the receiver's method dictionary."
 
-	| method newMethod |
-	method := oldClass compiledMethodAt: selector.
-	newMethod := self recompileBasic: selector from: oldClass.
-
-	method properties at: #traitSource ifPresent: [ :aSource | newMethod propertyAt: #traitSource put: aSource ].
-
-	self addSelectorSilently: selector withMethod: newMethod
+	super recompile: selector from: oldClass.
+	TraitChange addSelector: selector on: self
 ]
 
 { #category : 'trait-composition' }

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -279,13 +279,8 @@ TraitedMetaclass >> recategorizeSelector: selector from: oldProtocol to: newProt
 TraitedMetaclass >> recompile: selector from: oldClass [
 	"Compile the method associated with selector in the receiver's method dictionary."
 
-	| method newMethod |
-	method := oldClass compiledMethodAt: selector.
-	newMethod := self recompileBasic: selector from: oldClass.
-
-	method properties at: #traitSource ifPresent: [ :aSource | newMethod propertyAt: #traitSource put: aSource ].
-
-	self addSelectorSilently: selector withMethod: newMethod
+	super recompile: selector from: oldClass.
+	TraitChange addSelector: selector on: self
 ]
 
 { #category : 'traits' }


### PR DESCRIPTION
The main goal of this PR is to fix the fact that recompiling a method from a trait does not update the method in the users to install the recompiled method. 

I also found some things that seems inconsistant and tried to clean them. All the traits tests are passing so I guess this is good?

Changes:
- CompiledMethod>>#recompile now ask to the origin to recompile the method and not the method class
- Recompiling on TraitedClass and TraitedMetaclass ask the TraitChange class to add the updated method to the users method dictionary
- Unify the recompilation code between TraitedMetaclass and TraitedClass. Here I am not sure about what I did! Maybe we should keep the code on the #traitSource property but add it also to TraitedClass?
- Remove TraitedClass class>>#addAndClassifySelector:withMethod:inProtocol: because I have the impression that the version on TraitedMetaclass is already managing this

Maybe @tesonep wants to check

I also added some tests

Fixes #15202