### PR TITLE
Introduce Behavior>>#definedSelectors and #definedMethods and add tests

### DIFF
--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -181,6 +181,20 @@ BehaviorTest >> testIsUsed [
 	self assert: Object class isUsed
 ]
 
+{ #category : 'tests' }
+BehaviorTest >> testLocalMethods [
+
+	self assertCollection: ExampleForTest1 localMethods hasSameElements: {
+			(ExampleForTest1 >> #aSuperclassVariable).
+			(ExampleForTest1 >> #aSuperclassVariable:) }
+]
+
+{ #category : 'tests' }
+BehaviorTest >> testLocalSelectors [
+
+	self assertCollection: ExampleForTest1 localSelectors hasSameElements: #( #aSuperclassVariable #aSuperclassVariable: )
+]
+
 { #category : 'tests - queries' }
 BehaviorTest >> testMethodsAccessingSlot [
 	| numberViaSlot numberViaIVar |

--- a/src/Kernel-Tests/BehaviorTest.class.st
+++ b/src/Kernel-Tests/BehaviorTest.class.st
@@ -103,6 +103,32 @@ BehaviorTest >> testBinding [
 	self assert: Object class binding key isNil
 ]
 
+{ #category : 'tests' }
+BehaviorTest >> testDefinedMethods [
+
+	[
+	ExampleForTest1 compile: 'extensionMethod ' classified: '*AGeneratedPackageForTest'.
+	self assertCollection: ExampleForTest1 localMethods hasSameElements: {
+			(ExampleForTest1 >> #aSuperclassVariable).
+			(ExampleForTest1 >> #aSuperclassVariable:).
+			(ExampleForTest1 >> #extensionMethod) }.
+
+	self assertCollection: ExampleForTest1 definedMethods hasSameElements: {
+			(ExampleForTest1 >> #aSuperclassVariable).
+			(ExampleForTest1 >> #aSuperclassVariable:) } ] ensure: [ self packageOrganizer removePackage: 'AGeneratedPackageForTest' ]
+]
+
+{ #category : 'tests' }
+BehaviorTest >> testDefinedSelectors [
+
+	[
+	ExampleForTest1 compile: 'extensionMethod ' classified: '*AGeneratedPackageForTest'.
+	self assertCollection: ExampleForTest1 localSelectors hasSameElements: #( #aSuperclassVariable #aSuperclassVariable: #extensionMethod ).
+
+	self assertCollection: ExampleForTest1 definedSelectors hasSameElements: #( #aSuperclassVariable #aSuperclassVariable: ) ] ensure: [
+		self packageOrganizer removePackage: 'AGeneratedPackageForTest' ]
+]
+
 { #category : 'tests - queries' }
 BehaviorTest >> testDefinedVariables [
 	self assert: Behavior new definedVariables isEmpty.

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -587,6 +587,22 @@ Behavior >> deepCopy [
 	^ self shallowCopy
 ]
 
+{ #category : 'accessing - method dictionary' }
+Behavior >> definedMethods [
+	"Returns the methods of classes excluding the ones of the traits or extensions"
+
+	^ self localMethods reject: [ :method | method isExtension ]
+]
+
+{ #category : 'accessing - method dictionary' }
+Behavior >> definedSelectors [
+	"Returns the selectors of classes excluding the ones of the traits or extensions"
+
+	^ self localMethods
+		  reject: [ :method | method isExtension ]
+		  thenCollect: [ :method | method selector ]
+]
+
 { #category : 'accessing - instances and variables' }
 Behavior >> definedVariables [
 	"return all the Variables defined"

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1151,6 +1151,19 @@ Behavior >> kindOfSubclass [
 	^ self classLayout kindOfSubclass
 ]
 
+{ #category : 'accessing - method dictionary' }
+Behavior >> localMethods [
+	"returns the methods of classes excluding the ones of the traits that the class uses"
+
+	^ self methods
+]
+
+{ #category : 'accessing - method dictionary' }
+Behavior >> localSelectors [
+	<reflection: 'Class structural inspection - Selectors and methods inspection'>
+	^ self methodDict keys
+]
+
 { #category : 'printing' }
 Behavior >> longPrintOn: aStream [
 	"Append to the argument, aStream, the names and values of all of the receiver's instance variables.  But, not useful for a class with a method dictionary."

--- a/src/RPackage-Core/ClassDescription.extension.st
+++ b/src/RPackage-Core/ClassDescription.extension.st
@@ -1,11 +1,6 @@
 Extension { #name : 'ClassDescription' }
 
 { #category : '*RPackage-Core' }
-ClassDescription >> definedSelectors [
-	^ self package definedSelectorsForClass: self
-]
-
-{ #category : '*RPackage-Core' }
 ClassDescription >> extendingPackages [
 	"the extending packages of a class are the packages that extend it."
 

--- a/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
+++ b/src/RPackage-Tests/RPackageReadOnlyCompleteSetupTest.class.st
@@ -145,17 +145,6 @@ RPackageReadOnlyCompleteSetupTest >> testCompiledMethodPackage [
 ]
 
 { #category : 'tests - situation' }
-RPackageReadOnlyCompleteSetupTest >> testDefinedSelectors [
-
-	self assert: a1 definedSelectors size equals: 2.
-	self assert: (a1 definedSelectors includes: #methodDefinedInP1).
-	self assert: (a1 definedSelectors includes: #anotherMethodDefinedInP1).
-
-	self assert: a2 definedSelectors size equals: 1.
-	self assert: (a2 definedSelectors includes: #methodDefinedInP2)
-]
-
-{ #category : 'tests - situation' }
 RPackageReadOnlyCompleteSetupTest >> testDefinedSelectorsForClass [
 
 	self assert: (p1 definedSelectorsForClass: a1) size equals: 2.

--- a/src/TraitsV2-Tests/TraitTest.class.st
+++ b/src/TraitsV2-Tests/TraitTest.class.st
@@ -98,6 +98,49 @@ TraitTest >> testCompositionCopy [
 				includesAll: { (self t1). (self t2). (self t6) })
 ]
 
+{ #category : 'tests - accessing' }
+TraitTest >> testDefinedMethods [
+
+	[
+	Trait1 compile: 'extensionMethod ' classified: '*AGeneratedPackageForTest'.
+	Trait3 compile: 'extensionMethod ' classified: '*AGeneratedPackageForTest'.
+	MOPTestClassC compile: 'extensionMethod ' classified: '*AGeneratedPackageForTest'.
+	
+	"Test local methods of a trait standalone"
+	self assertCollection: Trait1 localMethods hasSameElements: { (Trait1 >> #c1). (Trait1 >> #c). (Trait1 >> #extensionMethod) }.
+	self assertCollection: Trait1 definedMethods hasSameElements: { (Trait1 >> #c1). (Trait1 >> #c) }.
+	
+	"Test local methods of a trait using a trait"
+	self assertCollection: Trait3 localMethods hasSameElements: { (Trait3 >> #c3). (Trait3 >> #c). (Trait3 >> #extensionMethod) }.
+	self assertCollection: Trait3 definedMethods hasSameElements: { (Trait3 >> #c3). (Trait3 >> #c) }.
+	
+	"Test local methods of a class using a trait"
+	self assertCollection: MOPTestClassC localMethods hasSameElements: { (MOPTestClassC >> #c).  (MOPTestClassC >> #extensionMethod)}.
+	self assertCollection: MOPTestClassC definedMethods hasSameElements: { (MOPTestClassC >> #c) } ] ensure: [ self packageOrganizer removePackage: 'AGeneratedPackageForTest' ]
+	
+]
+
+{ #category : 'tests - accessing' }
+TraitTest >> testDefinedSelectors [
+
+	[
+	Trait1 compile: 'extensionMethod ' classified: '*AGeneratedPackageForTest'.
+	Trait3 compile: 'extensionMethod ' classified: '*AGeneratedPackageForTest'.
+	MOPTestClassC compile: 'extensionMethod ' classified: '*AGeneratedPackageForTest'.
+
+	"Test local selectors of a trait standalone"
+	self assertCollection: Trait1 localSelectors hasSameElements: #( #c1 #c #extensionMethod ).
+	self assertCollection: Trait1 definedSelectors hasSameElements: #( #c1 #c ).
+
+	"Test local selectors of a trait using a trait"
+	self assertCollection: Trait3 localSelectors hasSameElements: #( #c3 #c #extensionMethod ).
+	self assertCollection: Trait3 definedSelectors hasSameElements: #( #c3 #c ).
+
+	"Test local selectors of a class using a trait"
+	self assertCollection: MOPTestClassC localSelectors hasSameElements: #( #c #extensionMethod ).
+	self assertCollection: MOPTestClassC definedSelectors hasSameElements: #( #c ) ] ensure: [ self packageOrganizer removePackage: 'AGeneratedPackageForTest' ]
+]
+
 { #category : 'tests' }
 TraitTest >> testErrorClassCreation [
 
@@ -309,8 +352,8 @@ TraitTest >> testLocalMethods [
 
 { #category : 'tests - accessing' }
 TraitTest >> testLocalSelectors [
-	"Test local selectors of a trait standalone"
 
+	"Test local selectors of a trait standalone"
 	self assertCollection: Trait1 localSelectors hasSameElements: #( #c1 #c ).
 
 	"Test local selectors of a trait using a trait"

--- a/src/TraitsV2-Tests/TraitTest.class.st
+++ b/src/TraitsV2-Tests/TraitTest.class.st
@@ -294,6 +294,32 @@ TraitTest >> testLocalMethodWithSameCodeInTrait [
 										ifNotNil: [ :trait | (trait selectors includes: selector) ifTrue: [ self deny: (trait compiledMethodAt: selector) equals: each >> selector ] ] ] ] ] ]
 ]
 
+{ #category : 'tests - accessing' }
+TraitTest >> testLocalMethods [
+	
+	"Test local methods of a trait standalone"
+	self assertCollection: Trait1 localMethods hasSameElements: { (Trait1 >> #c1). (Trait1 >> #c) }.
+	
+	"Test local methods of a trait using a trait"
+	self assertCollection: Trait3 localMethods hasSameElements: { (Trait3 >> #c3). (Trait3 >> #c) }.
+	
+	"Test local methods of a class using a trait"
+	self assertCollection: MOPTestClassC localMethods hasSameElements: { (MOPTestClassC >> #c) }
+]
+
+{ #category : 'tests - accessing' }
+TraitTest >> testLocalSelectors [
+	"Test local selectors of a trait standalone"
+
+	self assertCollection: Trait1 localSelectors hasSameElements: #( #c1 #c ).
+
+	"Test local selectors of a trait using a trait"
+	self assertCollection: Trait3 localSelectors hasSameElements: #( #c3 #c ).
+
+	"Test local selectors of a class using a trait"
+	self assertCollection: MOPTestClassC localSelectors hasSameElements: #( #c )
+]
+
 { #category : 'tests' }
 TraitTest >> testMarkerMethods [
 	self t1 compile: 'm1 self foo bar'.

--- a/src/TraitsV2/Behavior.extension.st
+++ b/src/TraitsV2/Behavior.extension.st
@@ -46,19 +46,6 @@ Behavior >> localMethodNamed: selector ifAbsent: aBlock [
 ]
 
 { #category : '*TraitsV2' }
-Behavior >> localMethods [
-	"returns the methods of classes excluding the ones of the traits that the class uses"
-
-	^ self methods
-]
-
-{ #category : '*TraitsV2' }
-Behavior >> localSelectors [
-	<reflection: 'Class structural inspection - Selectors and methods inspection'>
-	^ self methodDict keys
-]
-
-{ #category : '*TraitsV2' }
 Behavior >> setTraitComposition: aComposition [
 
 	^ self subclassResponsibility


### PR DESCRIPTION
This PR introduces Behavior>>#definedMethods and #definedSelectors methods to return the list of defined methods and selectors (but I guess you already guessed from the name? :) ) 

A "defined" method is a method of a class that is neither from a trait nor an extension method. 

My goal is to use this to replace the defined selectors cache from RPackage and delegate to the class the behavior directly to have less synchronizations to do.

I also added some tests to #localMethods and #localSelectors and moved those methods from Traits to Kernel on Behavior because it adds no more dependency but can help us writing cleaner code (I've already seen in Kernel some code comparing the origin and the method class of a method to know if they are from traits while we could just ask the local methods directly).