### PR TITLE
Introduce a specific collection for undeclareds

### DIFF
--- a/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompiledMethodIntegrityTest.class.st
@@ -141,7 +141,7 @@ OCCompiledMethodIntegrityTest >> testUndeclaredVariableWhenItIsAlreadyRegistered
 	The bootstrap will be updated at some point. But now this case needs to be supported:
 		- declaring undefined var should update registered variable when its type is not undeclared var"
 	| newCompiledMethod undeclaredBinding |
-	Undeclared add: #undeclaredTestVar -> nil.
+	(UndeclaredVariable named: #undeclaredTestVar) register.
 	newCompiledMethod := OpalCompiler new
 		source:
 			'methodWithUndeclaredVar

--- a/src/Pharo30Bootstrap/PBImageBuilder50.class.st
+++ b/src/Pharo30Bootstrap/PBImageBuilder50.class.st
@@ -210,7 +210,7 @@ PBImageBuilder50 >> createInitialObjects [
 		'DangerousClassNotifier disable'.
 
 	self bootstrapInterpreter evaluateCode:
-		'Undeclared := UndeclaredHolder new.'.
+		'Undeclared := UndeclaredRegistry new.'.
 	self bootstrapInterpreter evaluateCode:
 		'Smalltalk := SmalltalkImage basicNew.'.
 	self bootstrapInterpreter evaluateCode:

--- a/src/Pharo30Bootstrap/PBImageBuilder50.class.st
+++ b/src/Pharo30Bootstrap/PBImageBuilder50.class.st
@@ -210,7 +210,7 @@ PBImageBuilder50 >> createInitialObjects [
 		'DangerousClassNotifier disable'.
 
 	self bootstrapInterpreter evaluateCode:
-		'Undeclared := Dictionary new.'.
+		'Undeclared := UndeclaredHolder new.'.
 	self bootstrapInterpreter evaluateCode:
 		'Smalltalk := SmalltalkImage basicNew.'.
 	self bootstrapInterpreter evaluateCode:

--- a/src/System-Support/UndeclaredHolder.class.st
+++ b/src/System-Support/UndeclaredHolder.class.st
@@ -1,0 +1,19 @@
+"
+I am a dictionary holding UndeclaredVariables in the system. UndeclaredVariables represent the usage of a class that is not (yet) present in the system.
+
+I am named UndeclaredHolder instead of UndeclaredDictionary because one goal is to transform me into a weak collection in the future so that we do not have to explicitly clean up the undeclareds and delegate the work to the GC.
+"
+Class {
+	#name : 'UndeclaredHolder',
+	#superclass : 'IdentityDictionary',
+	#category : 'System-Support-Utilities',
+	#package : 'System-Support',
+	#tag : 'Utilities'
+}
+
+{ #category : 'private' }
+UndeclaredHolder >> atNewIndex: index put: aUndeclaredVariable [
+
+	aUndeclaredVariable isAssociation ifTrue: [ self error: 'Only undeclared variables should be added to the undeclareds and not associations.' ].
+	^ super atNewIndex: index put: aUndeclaredVariable
+]

--- a/src/System-Support/UndeclaredHolder.class.st
+++ b/src/System-Support/UndeclaredHolder.class.st
@@ -10,10 +10,3 @@ Class {
 	#package : 'System-Support',
 	#tag : 'Utilities'
 }
-
-{ #category : 'private' }
-UndeclaredHolder >> atNewIndex: index put: aUndeclaredVariable [
-
-	aUndeclaredVariable isAssociation ifTrue: [ self error: 'Only undeclared variables should be added to the undeclareds and not associations.' ].
-	^ super atNewIndex: index put: aUndeclaredVariable
-]

--- a/src/System-Support/UndeclaredRegistry.class.st
+++ b/src/System-Support/UndeclaredRegistry.class.st
@@ -1,10 +1,10 @@
 "
 I am a dictionary holding UndeclaredVariables in the system. UndeclaredVariables represent the usage of a class that is not (yet) present in the system.
 
-I am named UndeclaredHolder instead of UndeclaredDictionary because one goal is to transform me into a weak collection in the future so that we do not have to explicitly clean up the undeclareds and delegate the work to the GC.
+One goal is to transform me into a weak collection in the future so that we do not have to explicitly clean up the undeclareds and delegate the work to the GC.
 "
 Class {
-	#name : 'UndeclaredHolder',
+	#name : 'UndeclaredRegistry',
 	#superclass : 'IdentityDictionary',
 	#category : 'System-Support-Utilities',
 	#package : 'System-Support',


### PR DESCRIPTION
The goal of this change is to introduce a special collection for Undeclareds. This will allow us to add some constraints to what an undeclared is. For example we can ensure that undeclared contains only UndeclaredVariables and not an association.

This also fix a test that was adding association in the undeclareds

If this works and is integrated maybe @MarcusDenker could improve the class comment with his knowledge?