### PR TITLE
Remove some classes generated by tests

### DIFF
--- a/src/ClassParser-Tests/ASTClassBuilderTest.class.st
+++ b/src/ClassParser-Tests/ASTClassBuilderTest.class.st
@@ -108,8 +108,8 @@ ASTClassBuilderTest >> testCreateNormalClassSuperClass [
 	| class |
 	class := self buildClassFromDefinition: 'Xcrd << #TestSubClass' allowUndefined: true.
 
-	self assert: class superclass equals: (self class environment classNamed: 'Xcrd') ] ensure: [
-		self class environment at: 'Xcrd' ifPresent: [ :aClass | aClass removeFromSystem ] ]
+	self assert: class superclass equals: (self class environment classNamed: #Xcrd) ] ensure: [
+		self class environment at: #Xcrd ifPresent: [ :aClass | aClass removeFromSystem ] ]
 ]
 
 { #category : 'tests' }

--- a/src/TraitsV2-Tests/T2TraitSlotScopeTest.class.st
+++ b/src/TraitsV2-Tests/T2TraitSlotScopeTest.class.st
@@ -206,7 +206,8 @@ T2TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedPoo
 	x1 := self class classInstaller make: [ :aClassBuilder |
 		      aClassBuilder
 			      name: #X1;
-			      superclass: SharedPool ].
+			      superclass: SharedPool;
+			      package: self packageNameForTests ].
 
 
 	c1 := self class classInstaller make: [ :aClassBuilder |


### PR DESCRIPTION
testCreateNormalClassSuperClass was using a string instead of a symbol in its #ensure: which failed

testSubClassWithTraitsAfterModificationOfParentSharedPools was not packaging its X1 class and we cleanup by removing the generated package