### PR TITLE
Release test: Add test that all packages are defined in a baseline

### DIFF
--- a/src/Metacello-Base/BaselineOf.class.st
+++ b/src/Metacello-Base/BaselineOf.class.st
@@ -120,6 +120,15 @@ BaselineOf class >> version [
 	^ self project version
 ]
 
+{ #category : 'accessing' }
+BaselineOf class >> withAllPackageNames [
+	"Return the name of all packages I includes and the name of my package "
+
+	^ self allPackageNames
+		  add: self class package name;
+		  yourself
+]
+
 { #category : 'baselines' }
 BaselineOf >> baseline: spec [
 	<baseline>

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -269,6 +269,16 @@ ReleaseTest >> testNoNullCharacter [
 	self assert: violations isEmpty description: 'Source corrupted: Methods with Null character found'
 ]
 
+{ #category : 'tests' }
+ReleaseTest >> testNoOrphanPackage [
+	"This test ensure that all packages loaded in Pharo are part of a baseline. This will be the most useful when we will be able to execute release tests last in the CI of Pharo. We will be able to detect generated packages that are not removed by the #tearDowns"
+
+	| declaredPackages |
+	declaredPackages := ((self class environment allClasses select: [ :class | class inheritsFrom: BaselineOf ]) flatCollect: [ :baseline |
+		                     baseline withAllPackageNames ]) asSet.
+	self assertEmpty: (self packageOrganizer packages reject: [ :package | package isUndefined or: [ declaredPackages includes: package name ] ])
+]
+
 { #category : 'tests - source' }
 ReleaseTest >> testNoPeriodInMethodSignature [
 	| methods |

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -249,22 +249,22 @@ SystemDependenciesTest >> testExternalBasicToolsDependencies [
 		self metacelloPackageNames,
 		self tonelCorePackageNames,
 		BaselineOfTraits corePackages,
-		{ BaselineOfSUnit name }, BaselineOfSUnit allPackageNames, "ALL"
-		{ BaselineOfDisplay name }, BaselineOfDisplay allPackageNames,
-		{ BaselineOfUnifiedFFI name }, BaselineOfUnifiedFFI allPackageNames,
+		BaselineOfSUnit withAllPackageNames, "ALL"
+		BaselineOfDisplay withAllPackageNames,
+		BaselineOfUnifiedFFI withAllPackageNames,
 		{ BaselineOfFreeType name }, (BaselineOfFreeType deepPackagesOfGroupNamed: #ui),
 		{ BaselineOfKeymapping name }, (BaselineOfKeymapping deepPackagesOfGroupNamed: #ui),
-		{ BaselineOfMorphicCore name }, BaselineOfMorphicCore allPackageNames,
-		{ BaselineOfMorphic name }, BaselineOfMorphic allPackageNames,
-		{ BaselineOfMenuRegistration name }, BaselineOfMenuRegistration allPackageNames,
-		{ BaselineOfUI name }, BaselineOfUI allPackageNames,
-		{ BaselineOfRefactoring name }, BaselineOfRefactoring allPackageNames,
+		BaselineOfMorphicCore withAllPackageNames,
+		BaselineOfMorphic withAllPackageNames,
+		BaselineOfMenuRegistration withAllPackageNames,
+		BaselineOfUI withAllPackageNames,
+		BaselineOfRefactoring withAllPackageNames,
 		{ BaselineOfCommander2 name }, (BaselineOfCommander2 deepPackagesOfGroupNamed: #core),
 		{ BaselineOfCommander2 name }, (BaselineOfCommander2 deepPackagesOfGroupNamed: #ui),
 		{ BaselineOfNewValueHolder name }, (BaselineOfNewValueHolder packagesOfGroupNamed: #core),
 		{ BaselineOfSpecCore name }, (BaselineOfSpecCore deepPackagesOfGroupNamed: #default),
 		{ BaselineOfSpec2 name }, (BaselineOfSpec2 deepPackagesOfGroupNamed: #default),
-		{ BaselineOfBasicTools name }, BaselineOfBasicTools allPackageNames,
+		BaselineOfBasicTools withAllPackageNames,
 		{ BaselineOfNewTools name }, (BaselineOfNewTools deepPackagesOfGroupNamed: 'Methods'),
 		{ BaselineOfFuel name }, (BaselineOfFuel deepPackagesOfGroupNamed: #Tests),
 		BaselineOfThreadedFFI corePackageNames ).
@@ -352,7 +352,7 @@ SystemDependenciesTest >> testExternalIDEDependencies [
 	BaselineOfShout.
 	BaselineOfKernelTests.
 	BaselineOfHeuristicCompletion.
-	 } do: [ :baseline | packages := packages , {baseline name} , baseline allPackageNames ].
+	 } do: [ :baseline | packages := packages , baseline withAllPackageNames ].
 
 	packages := packages ,  { BaselineOfFreeType name }, (self packagesOfGroupNamed: 'ui' on: BaselineOfFreeType ).
 	packages := packages ,  { BaselineOfKeymapping name }, (self packagesOfGroupNamed: 'ui' on: BaselineOfKeymapping ).

--- a/src/Tools/Project.class.st
+++ b/src/Tools/Project.class.st
@@ -58,9 +58,7 @@ Project >> packageManager [
 { #category : 'accessing' }
 Project >> packages [
 
-	^ (self baseline allPackageNames
-		   select: [ :packageName | self packageManager hasPackage: packageName ]
-		   thenCollect: [ :packageName | self packageManager packageNamed: packageName ])
-		  addFirst: self baseline package;
-		  yourself
+	^ self baseline withAllPackageNames
+		  select: [ :packageName | self packageManager hasPackage: packageName ]
+		  thenCollect: [ :packageName | self packageManager packageNamed: packageName ]
 ]


### PR DESCRIPTION
The main goal of this tests is to find generated packages that are not cleanup by tests once release tests will be executed last in the image.

I also added BaselineOf class>>withAllPackageNames because we often need the list of packages including the package of the baseline