### PR TITLE
Packages: Remove #definedSelectors cache

### DIFF
--- a/src/Calypso-SystemQueries/RPackage.extension.st
+++ b/src/Calypso-SystemQueries/RPackage.extension.st
@@ -21,20 +21,13 @@ RPackage class >> defaultSortFunctionForCalypso [
 { #category : '*Calypso-SystemQueries' }
 RPackage >> definesOverridesOf: aMethod [
 
-	(self definesOverridesOf: aMethod in: definedSelectors) ifTrue: [ ^ true ].
-	(self definesOverridesOf: aMethod in: extensionSelectors) ifTrue: [ ^ true ].
-
-	^ false
-]
-
-{ #category : '*Calypso-SystemQueries' }
-RPackage >> definesOverridesOf: aMethod in: classAndSelectors [
-
 	| methodClass selector |
 	methodClass := aMethod origin.
 	selector := aMethod selector.
 
-	classAndSelectors keysAndValuesDo: [ :class :selectors | ((selectors includes: selector) and: [ class inheritsFrom: methodClass ]) ifTrue: [ ^ true ] ].
+	self definedClasses do: [ :class | (class inheritsFrom: methodClass) ifTrue: [ class definedSelectors includes: selector ] ].
+	extensionSelectors keysAndValuesDo: [ :class :selectors | ((selectors includes: selector) and: [ class inheritsFrom: methodClass ]) ifTrue: [ ^ true ] ].
+
 	^ false
 ]
 

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -58,7 +58,6 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'extensionSelectors',
-		'definedSelectors',
 		'name',
 		'classTags',
 		'organizer'
@@ -130,9 +129,7 @@ RPackage >> addMethod: aCompiledMethod [
 	| methodClass |
 	methodClass := aCompiledMethod methodClass.
 	(self includesClass: methodClass)
-		ifTrue: [
-			aCompiledMethod removeProperty: #extensionPackage. "We want to make sure the method is not considered an extension."
-			(definedSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ]
+		ifTrue: [ "We want to make sure the method is not considered an extension." aCompiledMethod removeProperty: #extensionPackage ]
 		ifFalse: [
 			aCompiledMethod propertyAt: #extensionPackage put: self. "We tag the method as an extension method."
 			(extensionSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ].
@@ -208,7 +205,9 @@ RPackage >> definedOrExtendedClasses [
 { #category : 'accessing' }
 RPackage >> definedSelectorsForClass: aClass [
 
-	^ definedSelectors at: aClass ifAbsent: [ #(  ) ]
+	^ (self includesClass: aClass)
+		  ifTrue: [ aClass definedSelectors ]
+		  ifFalse: [ #(  ) ]
 ]
 
 { #category : 'testing' }
@@ -369,6 +368,9 @@ RPackage >> importProtocol: aProtocol forClass: aClass [
 RPackage >> includesClass: aClass [
 	"Returns true if the receiver includes aClass in the classes that are defined within it: only class definition are considered - not class extensions"
 
+	"This check is here for speed reason. We first check that the package of the class is myself, and if it is, we also need to check that I contains the class because if the class is removed it will still know I am its package but I will not contain it anymore."
+	aClass package = self ifFalse: [ ^ false ].
+	
 	^ self classTags anySatisfy: [ :tag | tag includesClass: aClass ]
 ]
 
@@ -424,7 +426,6 @@ RPackage >> includesSelector: aSelector ofClass: aClass [
 RPackage >> initialize [
 
 	super initialize.
-	definedSelectors := IdentityDictionary new.
 	extensionSelectors := IdentityDictionary new.
 	classTags := Set new
 ]
@@ -477,7 +478,10 @@ RPackage >> methods [
 	methods := OrderedCollection new.
 
 	extensionSelectors keysAndValuesDo: [ :class :selectors | methods addAll: (selectors collect: [ :selector | class >> selector ]) ].
-	definedSelectors keysAndValuesDo: [ :class :selectors | methods addAll: (selectors collect: [ :selector | class >> selector ]) ].
+	self definedClasses do: [ :class |
+		methods
+			addAll: class definedMethods;
+			addAll: class classSide definedMethods ].
 
 	^ methods
 ]
@@ -511,7 +515,7 @@ RPackage >> moveClass: aClass toTag: aTag [
 	
 	oldPackage = self ifFalse: [
 		"In case I contain extension methods."
-		self removeAllMethodsFromClass: aClass.
+		self removeAllExtensionMethodsFromClass: aClass.
 		
 		{ aClass. aClass classSide } do: [ :class |
 			(self extensionProtocolsForClass: class) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
@@ -616,23 +620,17 @@ RPackage >> propertyAt: propName put: propValue [
 ]
 
 { #category : 'private - register' }
-RPackage >> removeAllMethodsFromClass: aClass [
+RPackage >> removeAllExtensionMethodsFromClass: aClass [
 	"Remove all the methods (defined and extensions) that are related to the class as parameter. The class should always be instance side."
 
-	definedSelectors removeKey: aClass ifAbsent: [  ].
-	definedSelectors removeKey: aClass classSide ifAbsent: [  ].
 	extensionSelectors removeKey: aClass ifAbsent: [  ].
 	extensionSelectors removeKey: aClass classSide ifAbsent: [  ]
 ]
 
 { #category : 'removing' }
 RPackage >> removeClass: aClass [
-	"I remove the class, methods and potential empty tags from myself."
+	"I remove the class and potential empty tags from myself."
 
-	"First I remove all the methods of the class from myself."
-	self removeAllMethodsFromClass: aClass.
-
-	"Then I unregister it from the tags"
 	self classTags
 		detect: [ :tag | tag includesClass: aClass ]
 		ifFound: [ :tag | tag removeClass: aClass ]
@@ -660,15 +658,11 @@ RPackage >> removeMethod: aCompiledMethod [
 
 	| methodClass |
 	methodClass := aCompiledMethod methodClass.
-	(self includesClass: methodClass)
-		ifTrue: [
-			definedSelectors at: methodClass ifPresent: [ :selectors |
-				selectors remove: aCompiledMethod selector ifAbsent: [  ].
-				selectors ifEmpty: [ definedSelectors removeKey: methodClass ] ] ]
-		ifFalse: [
-			extensionSelectors at: methodClass ifPresent: [ :selectors |
-				selectors remove: aCompiledMethod selector ifAbsent: [  ].
-				selectors ifEmpty: [ extensionSelectors removeKey: methodClass ] ] ].
+	"We need to act only on extension methods because defined methods are not stored anymore"
+	(self includesClass: methodClass) ifFalse: [
+		extensionSelectors at: methodClass ifPresent: [ :selectors |
+			selectors remove: aCompiledMethod selector ifAbsent: [  ].
+			selectors ifEmpty: [ extensionSelectors removeKey: methodClass ] ] ].
 
 	^ aCompiledMethod
 ]
@@ -775,7 +769,10 @@ RPackage >> selectors [
 	| allSelectors |
 	allSelectors := Set new.
 	extensionSelectors valuesDo: [ :selectors | allSelectors addAll: selectors ].
-	definedSelectors valuesDo: [ :selectors | allSelectors addAll: selectors ].
+	self definedClasses do: [ :class |
+		allSelectors
+			addAll: class definedSelectors;
+			addAll: class classSide definedSelectors ].
 	^ allSelectors
 ]
 

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -359,7 +359,7 @@ RPackageOrganizer >> removeClass: class [
 
 	class isClassSide ifTrue: [ self error: 'We should only be able to remove classes and not instances of metaclass.' ].
 	class package removeClass: class.
-	class extendingPackages do: [ :extendedPackage | extendedPackage removeAllMethodsFromClass: class ]
+	class extendingPackages do: [ :extendedPackage | extendedPackage removeAllExtensionMethodsFromClass: class ]
 ]
 
 { #category : 'cleanup' }

--- a/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
+++ b/src/RPackage-Tests/RPackageCompleteSetupButForModificationTest.class.st
@@ -107,17 +107,8 @@ RPackageCompleteSetupButForModificationTest >> testExtensionMethodOfClass [
 { #category : 'test - addition' }
 RPackageCompleteSetupButForModificationTest >> testRemoveMethod [
 
-	p1 removeMethod: a1 >> #methodDefinedInP1.
+	a1 removeSelector: #methodDefinedInP1.
 	self deny: (p1 includesSelector: #methodDefinedInP1 ofClass: a1)
-]
-
-{ #category : 'test - addition' }
-RPackageCompleteSetupButForModificationTest >> testRemoveMethodDoesNotRemoveFromClass [
-	"we remove a method so it is not in the package but also not from the class anymore"
-
-	p1 removeMethod:  a1 >> #methodDefinedInP1.
-	self deny: (p1 includesSelector: #methodDefinedInP1 ofClass: a1).
-	self assert: (a1 selectors includes: #methodDefinedInP1)
 ]
 
 { #category : 'test - addition' }

--- a/src/RPackage-Tests/RPackageIncrementalTest.class.st
+++ b/src/RPackage-Tests/RPackageIncrementalTest.class.st
@@ -68,13 +68,10 @@ RPackageIncrementalTest >> testAddRemoveMethod [
 	p2 := self ensurePackage: self p2Name.
 	p3 := self ensurePackage: self p3Name.
 	a2 := self newClassNamed: #A2InPackageP2 in: p2.
-	a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2'.
 
-	p2 addMethod: a2 >> #methodDefinedInP2.
-	a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1'.
-	p1 addMethod: a2 >> #methodDefinedInP1.
-	a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3'.
-	p3 addMethod: a2 >> #methodDefinedInP3.
+	a2 compile: 'methodDefinedInP2 ^ #methodDefinedInP2'.
+	a2 compile: 'methodDefinedInP1 ^ #methodDefinedInP1' classified: '*' , p1 name.
+	a2 compile: 'methodDefinedInP3 ^ #methodDefinedInP3' classified: '*' , p3 name.
 
 	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
 	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2).
@@ -84,40 +81,11 @@ RPackageIncrementalTest >> testAddRemoveMethod [
 	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClass: a2).
 
 	"removeMethod by default removes from defined methods and not extension"
-	p2 removeMethod: a2 >> #methodDefinedInP2.
+	a2 removeSelector: #methodDefinedInP2.
 	self deny: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
 	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2).
 
-	p1 removeMethod: a2 >> #methodDefinedInP1.
-	self deny: (p1 includesDefinedSelector: #methodDefinedInP3 ofClass: a2).
-	self deny: (p1 includesExtensionSelector: #methodDefinedInP3 ofClass: a2)
-]
-
-{ #category : 'tests - method addition removal' }
-RPackageIncrementalTest >> testAddRemoveSelector [
-
-	| p1 p2 p3 a2 |
-	p1 := self ensurePackage: self p1Name.
-	p2 := self ensurePackage: self p2Name.
-	p3 := self ensurePackage: self p3Name.
-	a2 := self newClassNamed: #A2InPackageP2 in: p2.
-
-	p2 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP2 ^ #methodDefinedInP2').
-	p1 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP1 ^ #methodDefinedInP1').
-	p3 addMethod: a2 >> (a2 compileSilently: 'methodDefinedInP3 ^ #methodDefinedInP3').
-
-	self assert: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP3 ofClass: a2).
-	self assert: (p3 includesExtensionSelector: #methodDefinedInP3 ofClass: a2).
-	self assert: (p1 includesExtensionSelector: #methodDefinedInP1 ofClass: a2).
-	self deny: (p3 includesDefinedSelector: #methodDefinedInP1 ofClass: a2).
-
-	p2 removeMethod: a2 >> #methodDefinedInP2.
-	self deny: (p2 includesDefinedSelector: #methodDefinedInP2 ofClass: a2).
-	self deny: (p2 includesExtensionSelector: #methodDefinedInP2 ofClass: a2).
-
-	p1 removeMethod: a2 >> #methodDefinedInP1.
+	a2 removeSelector: #methodDefinedInP1.
 	self deny: (p1 includesDefinedSelector: #methodDefinedInP3 ofClass: a2).
 	self deny: (p1 includesExtensionSelector: #methodDefinedInP3 ofClass: a2)
 ]

--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -100,6 +100,25 @@ ReflectiveMethodTest >> testLinkCountTwoLinks [
 	self assert: (ReflectivityExamples >> #exampleMethod) reflectiveMethod isNil
 ]
 
+{ #category : 'tests' }
+ReflectiveMethodTest >> testLinkKeepsExtension [
+
+	[
+	| metalink |
+	ReflectivityExamples compile: 'exampleWithExtension' classified: '*GeneratedPackageForTest'.
+
+	self assert: (ReflectivityExamples >> #exampleWithExtension) isExtension.
+
+	metalink := MetaLink new.
+	(ReflectivityExamples >> #exampleWithExtension) ast link: metalink.
+
+	self assert: (ReflectivityExamples >> #exampleWithExtension) isExtension.
+
+	metalink uninstall.
+
+	self assert: (ReflectivityExamples >> #exampleWithExtension) isExtension ] ensure: [ self packageOrganizer removePackage: 'GeneratedPackageForTest' ]
+]
+
 { #category : 'tests - links' }
 ReflectiveMethodTest >> testSetLink [
 	| sendNode link |

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -224,6 +224,10 @@ ReflectiveMethod >> printOn: aStream [
 ReflectiveMethod >> recompileAST [
 
 	compiledMethod := self compileAST.
+	"For now we cannot persiste properties of methods during recompilation, so if we have an extension method, we save here the package in the new method."
+	ast
+		propertyAt: #compiledMethod
+		ifPresent: [ :priorMethod | priorMethod propertyAt: #extensionPackage ifPresent: [ :package | compiledMethod propertyAt: #extensionPackage put: package ] ].
 	ast compiledMethod: compiledMethod.
 	compiledMethod reflectiveMethod: self
 ]


### PR DESCRIPTION
#definedSelectors cache is a dictionary of the classes defined in a package and the method selectors defined in those classes. 

This is used because to know the defined selectors of a class you need to reject the methods from traits and the extension methods and #isExtension was way too slow. 

Recently I did a huge speed up of #isExtension so we are now able to remove this cache and simplify the code! I also did a speed if of #includesClass: 

This PR just deal with the removal of the cache but we will be able to also remove more mecanism after this change. I'm just trying to do it step by step to not break the system. This will also avoid any synchronization missmatch between RPackage and Classes