### PR TITLE
OpalCompiler: Add more robustness to the compiler plugins system

### DIFF
--- a/src/OpalCompiler-Core/OCDynamicASTCompilerPlugin.class.st
+++ b/src/OpalCompiler-Core/OCDynamicASTCompilerPlugin.class.st
@@ -61,7 +61,7 @@ OCDynamicASTCompilerPlugin >> priority: anObject [
 { #category : 'transforming' }
 OCDynamicASTCompilerPlugin >> transform: ast [
 
-	^ transformBlock value: ast copy
+	^ transformBlock value: ast
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Core/OCStaticASTCompilerPlugin.class.st
+++ b/src/OpalCompiler-Core/OCStaticASTCompilerPlugin.class.st
@@ -20,7 +20,8 @@ OCStaticASTCompilerPlugin class >> isAbstract [
 
 { #category : 'private' }
 OCStaticASTCompilerPlugin class >> priority [
-	self subclassResponsibility
+
+	^ 0
 ]
 
 { #category : 'instance creation' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -252,20 +252,22 @@ OpalCompiler >> buildOuterScope [
 
 { #category : 'private' }
 OpalCompiler >> callParsePlugins [
-	| plugins |
 
-	plugins := compilationContext astParseTransformPlugins ifEmpty: [ ^ self ].
-	plugins sort: [ :a :b | a priority > b priority ]. "priority 0 is sorted last"
-	plugins do: [ :each | ast := each transform: ast ]
+	self callPlugins: compilationContext astParseTransformPlugins
 ]
 
 { #category : 'private' }
 OpalCompiler >> callPlugins [
-	| plugins |
 
-	plugins := compilationContext astTransformPlugins ifEmpty: [ ^self ].
-	plugins sort: [ :a :b | a priority > b priority ]. "priority 0 is sorted last"
-	plugins do: [ :each | ast := each transform: ast ]
+	self callPlugins: compilationContext astTransformPlugins
+]
+
+{ #category : 'private' }
+OpalCompiler >> callPlugins: aCollectionOfPlugins [
+
+	aCollectionOfPlugins ifNotEmpty: [ :plugins |
+		plugins sort: [ :a :b | a priority > b priority ]. "priority 0 is sorted last"
+		plugins do: [ :plugin | [ ast := plugin transform: ast copy ] onErrorDo: [ Warning signal: 'Error during the execution of the plugin ' , plugin asString ] ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -267,7 +267,10 @@ OpalCompiler >> callPlugins: aCollectionOfPlugins [
 
 	aCollectionOfPlugins ifNotEmpty: [ :plugins |
 		plugins sort: [ :a :b | a priority > b priority ]. "priority 0 is sorted last"
-		plugins do: [ :plugin | [ ast := plugin transform: ast copy ] onErrorDo: [ Warning signal: 'Error during the execution of the plugin ' , plugin asString ] ] ]
+
+		plugins do: [ :plugin |
+			[ ast := plugin transform: ast copy ] onErrorDo: [ "We should probably raise a warning instead of logging "
+				('Error during the execution of the plugin ' , plugin asString) traceCr ] ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Tests/ASTPluginMeaningOfLife.class.st
+++ b/src/OpalCompiler-Tests/ASTPluginMeaningOfLife.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : 'accessing' }
 ASTPluginMeaningOfLife class >> priority [
-	^ 0
+	^ 0.1
 ]
 
 { #category : 'private - transforming' }


### PR DESCRIPTION
I am trying to simplify the method compilation and installation process in Pharo and I found some hacks I tired to remove.

I currently cannot remove them because of the plugin system of Opal. What happens is that I am loading plugins in Pharo, but they override the #compiler method to add themselves as plugin. Since they are not fully loaded this causes a failure. 

I propose to fix this by catching the error that could happen during a plugin execution and just log that an error happened and ignore the plugin. (We should probably use a warning but that will be a future improvement)