### PR TITLE
Calypso: Fix refresh of project view

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -714,15 +714,12 @@ ClyFullBrowserMorph >> showAllMethods [
 
 { #category : 'navigation' }
 ClyFullBrowserMorph >> showInPackageView: aPackage [
-
 	"If true we are in the project view and we need to find the package and expand it"
-	(packageView showsItemsFromQuery: ClyAllProjectsQuery)
-		ifTrue: [
-			packageView dataSource allElements
-				detect: [ :element | (element actualObject isKindOf: Project) and: [ element actualObject packages includes: aPackage ] ]
-				ifFound: [ :element | packageView dataSource expand: element ]
-				ifNone: [ "this should not happen but who knows with calypso.." self switchToPackages ] ]
-		ifFalse: [ self switchToPackages ]
+
+	(packageView showsItemsFromQuery: ClyAllProjectsQuery) ifTrue: [
+		self projectSelection selectItemsWhere: [ :each | (each representsItemOfType: Project) and: [ each actualObject includesPackage: aPackage ] ].
+		self projectSelection items first expand ].
+	self packageSelection selectItemsWith: { aPackage }
 ]
 
 { #category : 'testing' }

--- a/src/Tools/Project.class.st
+++ b/src/Tools/Project.class.st
@@ -21,6 +21,14 @@ Project class >> baseline: aClass [
 		  yourself
 ]
 
+{ #category : 'comparing' }
+Project >> = anObject [
+
+	self == anObject ifTrue: [ ^ true ].
+	self class = anObject class ifFalse: [ ^ false ].
+	^ self baseline = anObject baseline
+]
+
 { #category : 'accessing' }
 Project >> baseline [
 	^ baseline
@@ -35,6 +43,13 @@ Project >> baseline: anObject [
 Project >> hasPackages [
 
 	^ self packages isNotEmpty
+]
+
+{ #category : 'comparing' }
+Project >> hash [
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ baseline hash
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
This change implements #= on Project so that calypso can find the right project during its refresh.

Also incorporate feedback from Denis

In the future I would like to improve the project manager to not recreate the projects all the time but this will be a future step