### PR TITLE
Reflectivity: fix extension method recompilation

### DIFF
--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -100,6 +100,25 @@ ReflectiveMethodTest >> testLinkCountTwoLinks [
 	self assert: (ReflectivityExamples >> #exampleMethod) reflectiveMethod isNil
 ]
 
+{ #category : 'tests' }
+ReflectiveMethodTest >> testLinkKeepsExtension [
+
+	[
+	| metalink |
+	ReflectivityExamples compile: 'exampleWithExtension' classified: '*GeneratedPackageForTest'.
+
+	self assert: (ReflectivityExamples >> #exampleWithExtension) isExtension.
+
+	metalink := MetaLink new.
+	(ReflectivityExamples >> #exampleWithExtension) ast link: metalink.
+
+	self assert: (ReflectivityExamples >> #exampleWithExtension) isExtension.
+
+	metalink uninstall.
+
+	self assert: (ReflectivityExamples >> #exampleWithExtension) isExtension ] ensure: [ self packageOrganizer removePackage: 'GeneratedPackageForTest' ]
+]
+
 { #category : 'tests - links' }
 ReflectiveMethodTest >> testSetLink [
 	| sendNode link |

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -224,6 +224,10 @@ ReflectiveMethod >> printOn: aStream [
 ReflectiveMethod >> recompileAST [
 
 	compiledMethod := self compileAST.
+	"For now we cannot persiste properties of methods during recompilation, so if we have an extension method, we save here the package in the new method."
+	ast
+		propertyAt: #compiledMethod
+		ifPresent: [ :priorMethod | priorMethod propertyAt: #extensionPackage ifPresent: [ :package | compiledMethod propertyAt: #extensionPackage put: package ] ].
 	ast compiledMethod: compiledMethod.
 	compiledMethod reflectiveMethod: self
 ]


### PR DESCRIPTION
ReflectiveMethod can recompile the AST and during this the method properties are lost. Which means we are losing the extension packages. 

I added here a quick fix with a test.

But I think we need something better here. First, can't we share a part of the recompilation process in all the places that recompile methods so that we can persist at least some properties in one point? Also, maybe we could have a mecanism to tag some properties so that we conserve them between recompilation? Maybe we could have a collection of properties to persist on the class side of AdditionalState and when we recompile we transfer those?

To discuss with @MarcusDenker 