### PR TITLE
updates the #manuallyResolvedDependencies 

### DIFF
--- a/src/Collections-Streams/ManifestCollectionsStreams.class.st
+++ b/src/Collections-Streams/ManifestCollectionsStreams.class.st
@@ -14,12 +14,6 @@ ManifestCollectionsStreams class >> dependencies [
 	^ #(#'Collections-Strings' #'Collections-Support' #'Collections-Sequenceable' #Kernel #'Collections-Native')
 ]
 
-{ #category : 'meta-data - dependency analyser' }
-ManifestCollectionsStreams class >> manuallyResolvedDependencies [
-
-	^ #( #'Collections-Abstract' )
-]
-
 { #category : 'meta-data' }
 ManifestCollectionsStreams class >> packageName [
 	^ #'Collections-Streams'

--- a/src/Collections-Weak/ManifestCollectionsWeak.class.st
+++ b/src/Collections-Weak/ManifestCollectionsWeak.class.st
@@ -16,7 +16,7 @@ ManifestCollectionsWeak class >> dependencies [
 
 { #category : 'meta-data - dependency analyser' }
 ManifestCollectionsWeak class >> manuallyResolvedDependencies [
-	^ #(#'System-Support' #'Collections-Streams')
+	^ #('Collections-Streams')
 ]
 
 { #category : 'meta-data' }


### PR DESCRIPTION
When running the tests Tool-DependencyAnalyser-Tests we get some Warnings in the CI log.

this PR updates the #manuallyResolvedDependencies to fix that