### PR TITLE
Opal: Make plugins no-op to not crash during the loading

### DIFF
--- a/src/OpalCompiler-Core/OCASTCompilerPlugin.class.st
+++ b/src/OpalCompiler-Core/OCASTCompilerPlugin.class.st
@@ -17,6 +17,11 @@ IR
 These plugins are called <<HERE>>, that is, after semantic analysis before generating the IR.
 They are sorted by #priority and handed the AST without making a copy (as plugins might just analyse the AST). If you modify the AST, you have to make a copy before!
 
+## Note on plugin installation
+
+Plugins can usually be used by classes by overriding #compiler method and adding the plugin there. But this can lead to problems if you use a plugin that is defined in the same package than the user during the loading of the package in Pharo.
+This is due to the fact that the plugin can be used before its methods are installed. Simple plugins will not have this problem because I work as a no-op. But if a plugin overrides #transform: and call other methods then it could happen. In that case, make sure to have the users of the pluggin in another package and to get your package dependencies right!
+
 
 "
 Class {
@@ -48,6 +53,7 @@ OCASTCompilerPlugin >> priority [
 
 { #category : 'transforming' }
 OCASTCompilerPlugin >> transform: ast [
+	"No op"
 
-	self subclassResponsibility
+	^ ast
 ]

--- a/src/OpalCompiler-Core/OCStaticASTCompilerPlugin.class.st
+++ b/src/OpalCompiler-Core/OCStaticASTCompilerPlugin.class.st
@@ -20,7 +20,8 @@ OCStaticASTCompilerPlugin class >> isAbstract [
 
 { #category : 'private' }
 OCStaticASTCompilerPlugin class >> priority [
-	self subclassResponsibility
+
+	^ 0
 ]
 
 { #category : 'instance creation' }
@@ -51,9 +52,11 @@ OCStaticASTCompilerPlugin >> priority [
 { #category : 'private - transforming' }
 OCStaticASTCompilerPlugin >> transform [
 	"Subclasses override this method to actually provide the AST transformation.
-	 IMPORTANT: If you modify the AST, make sure to copy it before using #copyAST!"
+	 IMPORTANT: If you modify the AST, make sure to copy it before using #copyAST!
+	
+	I act as a no-op to prevent loading errors. Image ClassA overrides #compiler to use PluginA from the same package. During the loading maybe the #transfrom method is not present yet and will break the loading if we use a subclass responsibility."
 
-	self subclassResponsibility
+	
 ]
 
 { #category : 'transforming' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -256,7 +256,7 @@ OpalCompiler >> callParsePlugins [
 
 	plugins := compilationContext astParseTransformPlugins ifEmpty: [ ^ self ].
 	plugins sort: [ :a :b | a priority > b priority ]. "priority 0 is sorted last"
-	plugins do: [ :each | ast := each transform: ast ]
+	plugins do: [ :each | ast := each transform: ast "In case I fail during the loading of code, check OCASTComplierPlugin class comment."]
 ]
 
 { #category : 'private' }
@@ -265,7 +265,7 @@ OpalCompiler >> callPlugins [
 
 	plugins := compilationContext astTransformPlugins ifEmpty: [ ^self ].
 	plugins sort: [ :a :b | a priority > b priority ]. "priority 0 is sorted last"
-	plugins do: [ :each | ast := each transform: ast ]
+	plugins do: [ :each | ast := each transform: ast "In case I fail during the loading of code, check OCASTComplierPlugin class comment."]
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Tests/ASTPluginMeaningOfLife.class.st
+++ b/src/OpalCompiler-Tests/ASTPluginMeaningOfLife.class.st
@@ -11,11 +11,6 @@ Class {
 	#tag : 'Plugins'
 }
 
-{ #category : 'accessing' }
-ASTPluginMeaningOfLife class >> priority [
-	^ 0
-]
-
 { #category : 'private - transforming' }
 ASTPluginMeaningOfLife >> transform [
 


### PR DESCRIPTION
It is possible that installing a package with an opal plugin and a class using it in the same package crashes because all methods of the plugin are not loaded. 

This change make Opal pluggin superclass a no-op to avoid crashes on simple cases and add a warning in the class comment to warn about this.