### PR TITLE
Opal: Add concept of prior methods 

### DIFF
--- a/src/Flashback-Decompiler/FBDDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBDDecompiler.class.st
@@ -585,7 +585,6 @@ FBDDecompiler >> recompile: selector from: oldClass [
 	| newMethod |
 	newMethod := oldClass compiler
 		             source: (self decompile: oldClass >> selector) formattedCode;
-		             class: oldClass;
 		             failBlock: [ ^ self ];
 		             compile. "Assume OK after proceed from SyntaxError"
 	selector == newMethod selector ifFalse: [ self error: 'selector changed!' ].

--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -345,6 +345,23 @@ CompiledMethodTest >> testComparison [
 			self deny: each equals: method2 ]
 ]
 
+{ #category : 'tests - abstract' }
+CompiledMethodTest >> testCompilingExistingMethodDoesNotRemoveExtensions [
+	"Regression test for a case where recompiling a method removed the fact that it was an extension."
+
+	[
+	| method |
+	self class compile: 'isExtensionTestMethod ^ 1' classified: '*Kernel-Tests-Generated-Package'.
+	method := self class >> #isExtensionTestMethod.
+	self assert: method isExtension.
+
+	self class compile: 'isExtensionTestMethod ^ 2'.
+
+	self assert: method isExtension ] ensure: [
+		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
+		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
+]
+
 { #category : 'tests' }
 CompiledMethodTest >> testCopy [
 	<pragma: #pragma>

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -88,11 +88,6 @@ ClassDescription >> addSelector: selector withMethod: compiledMethod [
 ClassDescription >> addSelectorSilently: selector withMethod: compiledMethod [
 
 	<reflection: 'Class structural modification - Selector/Method modification'>
-	self
-		compiledMethodAt: selector
-		ifPresent: [ :priorMethod | "For now we cannot persiste properties of methods during recompilation, so if we have an extension method, we save here the package in the new method."
-			priorMethod propertyAt: #extensionPackage ifPresent: [ :package | compiledMethod propertyAt: #extensionPackage put: package ] ].
-
 	super addSelectorSilently: selector withMethod: compiledMethod.
 	self instanceSide noteAddedSelector: selector meta: self isMeta
 ]

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -110,9 +110,6 @@ Behavior >> recompileBasic: selector from: oldClass [
 				permitFaulty: true;
 				compile.   "Assume OK after proceed from SyntaxError"
 	newMethod sourcePointer: method sourcePointer.
-	
-	"For now we cannot persiste properties of methods during recompilation, so if we have an extension method, we save here the package in the new method."
-	method propertyAt: #extensionPackage ifPresent: [ :package | newMethod propertyAt: #extensionPackage put: package ].
 
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
 	^ newMethod

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -39,7 +39,8 @@ Class {
 		'logged',
 		'changeStamp',
 		'protocol',
-		'requestor'
+		'requestor',
+		'priorMethod'
 	],
 	#classInstVars : [
 		'overlayEnvironment'
@@ -213,6 +214,7 @@ OpalCompiler >> ast: anObject [
 
 	ast := anObject.
 	source := ast source.
+	ast compiledMethod ifNotNil: [ :method | self priorMethod: method ].
 
 	"If a compilation context exists in the AST, we use this one.
 	Otherwise, we assign our"
@@ -539,12 +541,15 @@ OpalCompiler >> generateMethod [
 	method := ir compiledMethod.
 
 	ast compiledMethod: method.
-	ast 
-		propertyAt: #Undeclareds 
-		ifPresent: [:undeclareds | undeclareds do: [ :var | var registerMethod: method ]].
+	ast propertyAt: #Undeclareds ifPresent: [ :undeclareds | undeclareds do: [ :var | var registerMethod: method ] ].
 	method propertyAt: #source put: source.
-	self compilationContext noPattern ifTrue: [
-		method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"
+	self compilationContext noPattern ifTrue: [ method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"
+
+	"If the prior method was not set explicitly, we set it because we will need it if we are not in the first compilation"
+	self priorMethod ifNil: [ self methodClass ifNotNil: [ :class | self priorMethod: (class compiledMethodAt: method selector ifAbsent: [ nil ]) ] ].
+
+	"In case we are not compiling the method for the first time, we want to ensure that some properties are kept."
+	self priorMethod ifNotNil: [ priorMethod propertyAt: #extensionPackage ifPresent: [ :package | method propertyAt: #extensionPackage put: package ] ].
 	^ method
 ]
 
@@ -552,26 +557,25 @@ OpalCompiler >> generateMethod [
 OpalCompiler >> install [
 	"Compile and install a method in a class"
 
-	| class method logSource priorMethod |
-	class := self semanticScope targetClass.
+	| class method logSource |
+	class := self methodClass.
 	self assert: class isNotNil.
 
 	method := self compile ifNil: [ ^ nil ].
-	priorMethod := class compiledMethodAt: method selector ifAbsent: [  ].
 
 	changeStamp ifNil: [ changeStamp := Author changeStamp ].
 	logSource := self logged ifNil: [ true ].
+	protocol := protocol ifNil: [ self priorMethod ifNotNil: [ self priorMethod protocol ] ].
 
 	class addAndClassifySelector: method selector withMethod: method inProtocol: protocol.
 
-	logSource ifTrue: [
-		"For the log we do not use `protocol` because in case it is nil, we keep the current classification or we classify under uncategorize in the method is not present in a protocol yet. So we ask to the method its protocol after classifying it."
+	logSource ifTrue: [ "For the log we do not use `protocol` because in case it is nil, we keep the current classification or we classify under uncategorize in the method is not present in a protocol yet. So we ask to the method its protocol after classifying it."
 		method
 			putSource: source
 			class: class
 			protocol: method protocol
 			withStamp: changeStamp
-			priorMethod: priorMethod ].
+			priorMethod: self priorMethod ].
 
 	class instanceSide noteCompilationOf: method meta: class isClassSide.
 
@@ -616,6 +620,12 @@ OpalCompiler >> logged [
 { #category : 'accessing' }
 OpalCompiler >> logged: aBoolean [
 	logged := aBoolean
+]
+
+{ #category : 'accessing' }
+OpalCompiler >> methodClass [
+
+	^ self semanticScope targetClass
 ]
 
 { #category : 'testing' }
@@ -731,6 +741,19 @@ OpalCompiler >> permitUndeclared [
 OpalCompiler >> permitUndeclared: aBoolean [
 
 	permitUndeclared := aBoolean
+]
+
+{ #category : 'accessing' }
+OpalCompiler >> priorMethod [
+
+	^ priorMethod
+]
+
+{ #category : 'accessing' }
+OpalCompiler >> priorMethod: aCompiledMethod [
+	"Setting the prior method all Opal to conserve some informations from a previous method to the new compiled method easily. For example it can keep some properties or the protocol."
+
+	priorMethod := aCompiledMethod
 ]
 
 { #category : 'accessing' }

--- a/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
+++ b/src/Reflectivity-Tests/ReflectiveMethodTest.class.st
@@ -100,6 +100,25 @@ ReflectiveMethodTest >> testLinkCountTwoLinks [
 	self assert: (ReflectivityExamples >> #exampleMethod) reflectiveMethod isNil
 ]
 
+{ #category : 'tests' }
+ReflectiveMethodTest >> testLinkKeepsExtension [
+
+	[
+	| metalink |
+	ReflectivityExamples compile: 'exampleWithExtension' classified: '*GeneratedPackageForTest'.
+
+	self assert: (ReflectivityExamples >> #exampleWithExtension) isExtension.
+
+	metalink := MetaLink new.
+	(ReflectivityExamples >> #exampleWithExtension) ast link: metalink.
+
+	self assert: (ReflectivityExamples >> #exampleWithExtension) isExtension.
+
+	metalink uninstall.
+
+	self assert: (ReflectivityExamples >> #exampleWithExtension) isExtension ] ensure: [ self packageOrganizer removePackage: 'GeneratedPackageForTest' ]
+]
+
 { #category : 'tests - links' }
 ReflectiveMethodTest >> testSetLink [
 	| sendNode link |

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -224,6 +224,10 @@ ReflectiveMethod >> printOn: aStream [
 ReflectiveMethod >> recompileAST [
 
 	compiledMethod := self compileAST.
+	"For now we cannot persiste properties of methods during recompilation, so if we have an extension method, we save here the package in the new method."
+	ast
+		propertyAt: #compiledMethod
+		ifPresent: [ :priorMethod | priorMethod propertyAt: #extensionPackage ifPresent: [ :package | compiledMethod propertyAt: #extensionPackage put: package ] ].
 	ast compiledMethod: compiledMethod.
 	compiledMethod reflectiveMethod: self
 ]

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -224,10 +224,6 @@ ReflectiveMethod >> printOn: aStream [
 ReflectiveMethod >> recompileAST [
 
 	compiledMethod := self compileAST.
-	"For now we cannot persiste properties of methods during recompilation, so if we have an extension method, we save here the package in the new method."
-	ast
-		propertyAt: #compiledMethod
-		ifPresent: [ :priorMethod | priorMethod propertyAt: #extensionPackage ifPresent: [ :package | compiledMethod propertyAt: #extensionPackage put: package ] ].
 	ast compiledMethod: compiledMethod.
 	compiledMethod reflectiveMethod: self
 ]


### PR DESCRIPTION
This change adds to Opal the concept of prior method. This allows us to persist in a cleaner way the persistance of the extension package! No need to do it in multiple places in the system anymore.

This is a step toward another goal that is to be able to persist more properties. If this works, then I'll use this mechanism to also persiste the #traitSource property because adding a meta link to a method from a trait is removing this property and then the method loses this info