### PR TITLE
15299-UFFI-should-release-pointers-allocated-for-packing-for-arity

### DIFF
--- a/src/UnifiedFFI/ExternalAddress.extension.st
+++ b/src/UnifiedFFI/ExternalAddress.extension.st
@@ -273,7 +273,8 @@ ExternalAddress >> packToArity: arity [
 
 	rolledPointer := self.
 	"Start in 2 because first pointer is self"
-	2 to: arity do: [ :index | rolledPointer := rolledPointer pointerAutoRelease ].
+	2 to: arity do: [ :index | 
+		rolledPointer := rolledPointer pointer ].
 	^ rolledPointer
 ]
 
@@ -476,11 +477,14 @@ ExternalAddress >> uint8AtOffset: zeroBasedOffset put: value [
 { #category : '*UnifiedFFI-private' }
 ExternalAddress >> unpackFromArity: arity [
 	"This will 'unpack' a pointer from a certain arity. See #unpackToArity: for a better explanation."
-	| rolledPointer |
+	| rolledPointer previousPointer |
 
 	rolledPointer := self.
 	"Start in 2 because first pointer is self"
-	2 to: arity do: [ :index | rolledPointer := rolledPointer pointerAt: 1 ].
+	2 to: arity do: [ :index | 
+		previousPointer := rolledPointer.
+		rolledPointer := rolledPointer pointerAt: 1.
+		previousPointer free ].
 	^ rolledPointer
 ]
 


### PR DESCRIPTION
UFFI should release pointers allocated for packing for arity instead of using autoRelease.

Using autoRelease is not needed, as we know exactly when to release them and it also puts less pressure in the finalisation scheme. Fix #15299