### PR TITLE
Deprecate TRBProgramNodeVisitor

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -166,7 +166,7 @@ echo $(date -u) "[Compiler] Installing Traits through Hermes"
 
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save ${TRAITS_IMAGE_NAME}
 ${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes TraitsV2.hermes --save
-${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Kernel-Traits.hermes AST-Core-Traits.hermes Collections-Abstract-Traits.hermes CodeImport-Traits.hermes CodeExport-Traits.hermes TraitsV2-Compatibility.hermes --save
+${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Kernel-Traits.hermes Collections-Abstract-Traits.hermes CodeImport-Traits.hermes CodeExport-Traits.hermes TraitsV2-Compatibility.hermes --save
 zip "${TRAITS_IMAGE_NAME}.zip" "${TRAITS_IMAGE_NAME}.image"
 
 #Bootstrap Initialization: Class and RPackage initialization

--- a/src/AST-Core-Traits/package.st
+++ b/src/AST-Core-Traits/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'AST-Core-Traits' }

--- a/src/BaselineOfShout/BaselineOfShout.class.st
+++ b/src/BaselineOfShout/BaselineOfShout.class.st
@@ -7,22 +7,16 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfShout >> baseline: spec [
+
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURL.
-	spec for: #'common' do: [
-		
-		spec baseline: 'Traits' with: [ 
-			spec
-				loads: #( 'traits-ast' );
-				repository: repository ].
-					
-		spec 
+
+	spec for: #common do: [
+		spec
 			package: 'Shout';
 			package: 'Rubric-Styling';
-			package: 'Shout-Tests'.
-		spec 
-			group: 'Core' with: #('Shout' 'Rubric-Styling');
-			group: 'Tests' with: #('Shout-Tests');
-			group: 'default' with: #('Core' 'Tests') ]
+			package: 'Shout-Tests';
+
+			group: 'Core' with: #( 'Shout' 'Rubric-Styling' );
+			group: 'Tests' with: #( 'Shout-Tests' );
+			group: 'default' with: #( 'Core' 'Tests' ) ]
 ]

--- a/src/BaselineOfTraits/BaselineOfTraits.class.st
+++ b/src/BaselineOfTraits/BaselineOfTraits.class.st
@@ -43,7 +43,6 @@ BaselineOfTraits >> baseline: spec [
 			package: 'TraitsV2';
 			
 			package: 'Kernel-Traits' with: [ spec requires: #('TraitsV2') ];
-			package: 'AST-Core-Traits' with: [ spec requires: #('TraitsV2') ];
 			package: 'Collections-Abstract-Traits' with: [ spec requires: #('TraitsV2') ];
 			package: 'CodeImport-Traits' with: [ spec requires: #('TraitsV2') ];
 			package: 'CodeExport-Traits' with: [ spec requires: #('TraitsV2') ];
@@ -57,9 +56,6 @@ BaselineOfTraits >> baseline: spec [
 					'Collections-Abstract-Traits'
 					'CodeImport-Traits'
 					'CodeExport-Traits' ).
-
-		spec group: 'traits-ast' with: #(
-					'AST-Core-Traits' ).
 					
 		spec group: 'compatibility' with: #('TraitsV2-Compatibility').
 		

--- a/src/Deprecated12/TRBProgramNodeVisitor.trait.st
+++ b/src/Deprecated12/TRBProgramNodeVisitor.trait.st
@@ -3,9 +3,16 @@ A TRBProgramNodeVisitor is a simple Trait that define visitor methods.
 "
 Trait {
 	#name : 'TRBProgramNodeVisitor',
-	#category : 'AST-Core-Traits',
-	#package : 'AST-Core-Traits'
+	#category : 'Deprecated12',
+	#package : 'Deprecated12'
 }
+
+{ #category : 'testing' }
+TRBProgramNodeVisitor classSide >> isDeprecated [
+	"You should subclass RBProgramNodeVisitor"
+
+	^ true
+]
 
 { #category : 'visiting' }
 TRBProgramNodeVisitor >> visitAnnotationMarkNode: aRBAnnotationMarkNode [


### PR DESCRIPTION
This Trait is not used in Pharo and it seems overkilled to keep it. We discussed at some point with Stephane and Marcus and decided that it should be deprecated.