### PR TITLE
Prevent undeclared to be associations

### DIFF
--- a/src/System-Support/UndeclaredRegistry.class.st
+++ b/src/System-Support/UndeclaredRegistry.class.st
@@ -10,3 +10,11 @@ Class {
 	#package : 'System-Support',
 	#tag : 'Utilities'
 }
+
+{ #category : 'private' }
+UndeclaredRegistry >> atNewIndex: index put: anUndeclaredVariable [
+
+	anUndeclaredVariable isAssociation ifTrue: [
+		self error: 'Only global variables should be added to the SystemDictionary and not associations. Undeclared: ' , anUndeclaredVariable name ].
+	^ super atNewIndex: index put: anUndeclaredVariable
+]


### PR DESCRIPTION
Undeclared should only contain UndeclaredVariables but currently it seems that some places (the bootstrap?) are still using association. Here I am trying to force the usage of the variable to find the missbehaving places