### PR TITLE
Use a test resource for SystemDependenciesTest

### DIFF
--- a/src/System-DependenciesTests/SystemDependenciesReportResource.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesReportResource.class.st
@@ -1,0 +1,34 @@
+"
+I am a resource holding a dependency analysis of the system.
+
+I can be used by test about system dependencies to not rebuild it at each test.
+"
+Class {
+	#name : 'SystemDependenciesReportResource',
+	#superclass : 'TestResource',
+	#instVars : [
+		'dependenciesReport'
+	],
+	#category : 'System-DependenciesTests',
+	#package : 'System-DependenciesTests'
+}
+
+{ #category : 'accessing' }
+SystemDependenciesReportResource >> dependenciesReport [
+
+	^ dependenciesReport ifNil: [ self rebuildDependenciesReport ]
+]
+
+{ #category : 'accessing' }
+SystemDependenciesReportResource >> rebuildDependenciesReport [
+
+	^ dependenciesReport := DADependencyChecker new computeImageDependencies
+]
+
+{ #category : 'running' }
+SystemDependenciesReportResource >> tearDown [
+
+	dependenciesReport := nil.
+
+	super tearDown
+]

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -7,9 +7,6 @@ It is not a standard unit test because to compute dependencies takes a lot of ti
 Class {
 	#name : 'SystemDependenciesTest',
 	#superclass : 'TestCase',
-	#classInstVars : [
-		'dependenciesReport'
-	],
 	#category : 'System-DependenciesTests',
 	#package : 'System-DependenciesTests'
 }
@@ -17,34 +14,19 @@ Class {
 { #category : 'accessing' }
 SystemDependenciesTest class >> defaultTimeLimit [
 
-	^ 1 minute
+	^ 30 seconds
 ]
 
 { #category : 'accessing' }
-SystemDependenciesTest class >> dependenciesReport [
+SystemDependenciesTest class >> resources [
 
-	^ dependenciesReport ifNil: [ self rebuildDependenciesReport ]
-]
-
-{ #category : 'accessing' }
-SystemDependenciesTest class >> rebuildDependenciesReport [
-
-	dependenciesReport := DADependencyChecker new computeImageDependencies.
-	^ dependenciesReport
-]
-
-{ #category : 'accessing' }
-SystemDependenciesTest class >> resetDependenciesReport [
-	<script>
-	"self resetDependenciesReport"
-
-	dependenciesReport := nil
+	^ super resources copyWith: SystemDependenciesReportResource
 ]
 
 { #category : 'accessing' }
 SystemDependenciesTest >> dependenciesReport [
 
-	^ self class dependenciesReport
+	^ SystemDependenciesReportResource current dependenciesReport
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
SystemDepenendeciesTest is using a cache to not recreate the dependency report at each test. But the problem is that when you work in your image, the dependencies get outdated fast.

I propose to replace it by a TestResource to recreate the report each time we launch the test suite.