### PR TITLE
Allow to create anonymous classes in a specific environment

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -758,11 +758,20 @@ Class >> needsSlotClassDefinition [
 
 { #category : 'subclass creation' }
 Class >> newAnonymousSubclass [
+
+	<reflection: 'Class structural modification - Anonymous class creation'>
+	^ self newAnonymousSubclassInEnvironment: self environment
+]
+
+{ #category : 'subclass creation' }
+Class >> newAnonymousSubclassInEnvironment: anEnvironment [
+
 	<reflection: 'Class structural modification - Anonymous class creation'>
 	^ Smalltalk anonymousClassInstaller make: [ :builder |
-		builder
-			superclass: self ;
-			layoutClass: self classLayout class ]
+		  builder
+			  installingEnvironment: anEnvironment;
+			  superclass: self;
+			  layoutClass: self classLayout class ]
 ]
 
 { #category : 'subclass creation' }

--- a/src/RPackage-Tests/RPackageTest.class.st
+++ b/src/RPackage-Tests/RPackageTest.class.st
@@ -128,7 +128,7 @@ RPackageTest >> testAnonymousClassAndSelector [
 	"Make sure we don't have a registration or a package for the method."
 
 	| ghost method |
-	ghost := Object newAnonymousSubclass.
+	ghost := Object newAnonymousSubclassInEnvironment: testEnvironment.
 	method := ghost compiler compile: 'rpackagetest'.
 	ghost addSelector: #rpackagetest withMethod: method.
 	self deny: (self organizer undefinedPackage includesDefinedSelector: #rpackagetest ofClass: ghost).

--- a/src/Shift-ClassInstaller-Tests/ShAnonymousClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShAnonymousClassInstallerTest.class.st
@@ -20,3 +20,14 @@ ShAnonymousClassInstallerTest >> testSubclasses [
 
 	self assert: (self packageOrganizer packageOfClassNamed: aSubClass name) isUndefined
 ]
+
+{ #category : 'tests' }
+ShAnonymousClassInstallerTest >> testSubclassesInEnvironment [
+
+	| newEnvironment aSubClass |
+	newEnvironment := self class environment class new.
+
+	aSubClass := Object newAnonymousSubclassInEnvironment: newEnvironment.
+
+	self assert: aSubClass environment identicalTo: newEnvironment
+]


### PR DESCRIPTION
Creating an anonymous class currently installs it in the global environment. It would be better to be able to install it in any environment. Also, when we do not specify an environment, we should install it in the environment of the class receiving the message and not the global one.

I also fixed a test to use this new way of creating an anonymous class and not pollute the global system