### PR TITLE
Introduce a method to get the meta model announcer

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -543,6 +543,12 @@ Behavior >> cleanUp: aggressive [
 	^self cleanUp
 ]
 
+{ #category : 'accessing' }
+Behavior >> codeChangeAnnouncer [
+
+	^ self environment codeChangeAnnouncer
+]
+
 { #category : 'accessing - method dictionary' }
 Behavior >> compiledMethodAt: selector [
 	"Answer the compiled method associated with the argument, selector (a
@@ -1336,12 +1342,6 @@ Behavior >> packageOrganizer [
 	^ self environment organization
 ]
 
-{ #category : 'accessing' }
-Behavior >> pharoModelAnnouncer [
-
-	^ self environment pharoModelAnnouncer
-]
-
 { #category : 'copying' }
 Behavior >> postCopy [
 	super postCopy.
@@ -1444,7 +1444,7 @@ Behavior >> removeSelector: aSelector [
 Behavior >> removeSelectorSilently: selector [
 	"Remove selector without sending system change notifications"
 	<reflection: 'Class structural modification - Selector/Method modification'>
-	^ self pharoModelAnnouncer suspendAllWhile: [self removeSelector: selector]
+	^ self codeChangeAnnouncer suspendAllWhile: [self removeSelector: selector]
 ]
 
 { #category : 'cleanup' }

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1336,6 +1336,12 @@ Behavior >> packageOrganizer [
 	^ self environment organization
 ]
 
+{ #category : 'accessing' }
+Behavior >> pharoModelAnnouncer [
+
+	^ self environment pharoModelAnnouncer
+]
+
 { #category : 'copying' }
 Behavior >> postCopy [
 	super postCopy.
@@ -1438,7 +1444,7 @@ Behavior >> removeSelector: aSelector [
 Behavior >> removeSelectorSilently: selector [
 	"Remove selector without sending system change notifications"
 	<reflection: 'Class structural modification - Selector/Method modification'>
-	^ SystemAnnouncer uniqueInstance suspendAllWhile: [self removeSelector: selector]
+	^ self pharoModelAnnouncer suspendAllWhile: [self removeSelector: selector]
 ]
 
 { #category : 'cleanup' }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -119,7 +119,7 @@ Class >> addClassVariable: aClassVariable [
 				, ' is already used as a variable name in class '
 				, subclass name]].
 	self basicDeclareClassVariable: aClassVariable.
-	SystemAnnouncer uniqueInstance
+	self pharoModelAnnouncer 
 			classDefinitionChangedFrom: oldState to: self;
 			classModificationAppliedTo: self
 ]
@@ -443,7 +443,7 @@ Class >> comment: aString stamp: aStamp [
 			self commentSourcePointer: newSourcePointer]
 		onFail: [ "ignore" ].
 
-	SystemAnnouncer uniqueInstance
+	self pharoModelAnnouncer 
 		class: self
 		oldComment: oldComment
 		newComment: aString
@@ -869,7 +869,7 @@ Class >> removeClassVarNamed: aString interactive: interactive [
 	self classPool removeKey: aSymbol.
 	self classPool ifEmpty: [ self classPool: nil ].
 
-	SystemAnnouncer uniqueInstance classModificationAppliedTo: self
+	self pharoModelAnnouncer  classModificationAppliedTo: self
 ]
 
 { #category : 'class variables' }
@@ -905,7 +905,7 @@ Class >> removeFromSystem: logged [
 	We deal also with a special case that is the case a class of the same name than the alias is installed in the image after the alias. In that case we do not remove it. It's the reason we check if the global of the alias is the same as self."
 	self deprecatedAliases do: [ :alias | self environment at: alias ifPresent: [ :class | class = self ifTrue: [ self environment removeKey: alias ] ] ].
 	self obsolete.
-	logged ifTrue: [ SystemAnnouncer announce: (ClassRemoved class: self) ]
+	logged ifTrue: [ self pharoModelAnnouncer  announce: (ClassRemoved class: self) ]
 ]
 
 { #category : 'initialization' }

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -119,7 +119,7 @@ Class >> addClassVariable: aClassVariable [
 				, ' is already used as a variable name in class '
 				, subclass name]].
 	self basicDeclareClassVariable: aClassVariable.
-	self pharoModelAnnouncer 
+	self codeChangeAnnouncer 
 			classDefinitionChangedFrom: oldState to: self;
 			classModificationAppliedTo: self
 ]
@@ -443,7 +443,7 @@ Class >> comment: aString stamp: aStamp [
 			self commentSourcePointer: newSourcePointer]
 		onFail: [ "ignore" ].
 
-	self pharoModelAnnouncer 
+	self codeChangeAnnouncer 
 		class: self
 		oldComment: oldComment
 		newComment: aString
@@ -869,7 +869,7 @@ Class >> removeClassVarNamed: aString interactive: interactive [
 	self classPool removeKey: aSymbol.
 	self classPool ifEmpty: [ self classPool: nil ].
 
-	self pharoModelAnnouncer  classModificationAppliedTo: self
+	self codeChangeAnnouncer  classModificationAppliedTo: self
 ]
 
 { #category : 'class variables' }
@@ -905,7 +905,7 @@ Class >> removeFromSystem: logged [
 	We deal also with a special case that is the case a class of the same name than the alias is installed in the image after the alias. In that case we do not remove it. It's the reason we check if the global of the alias is the same as self."
 	self deprecatedAliases do: [ :alias | self environment at: alias ifPresent: [ :class | class = self ifTrue: [ self environment removeKey: alias ] ] ].
 	self obsolete.
-	logged ifTrue: [ self pharoModelAnnouncer  announce: (ClassRemoved class: self) ]
+	logged ifTrue: [ self codeChangeAnnouncer  announce: (ClassRemoved class: self) ]
 ]
 
 { #category : 'initialization' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -35,7 +35,7 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 		priorOrigin := method origin ].
 
 	oldProtocol := self protocolOfSelector: selector.
-	SystemAnnouncer uniqueInstance prevent: MethodRecategorized during: [ self classify: selector under: protocol ].
+	self pharoModelAnnouncer prevent: MethodRecategorized during: [ self classify: selector under: protocol ].
 	newProtocol := self protocolOfSelector: selector.
 
 	self addSelectorSilently: selector withMethod: compiledMethod.
@@ -45,10 +45,10 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 	(priorMethod isNil or: [ priorOrigin ~= compiledMethod origin ])
 		ifTrue: [
 			compiledMethod shouldBePackaged ifTrue: [ (self packageOrganizer packageForProtocol: newProtocol from: self) addMethod: compiledMethod ].
-			SystemAnnouncer uniqueInstance announce: (MethodAdded method: compiledMethod) ]
+			self pharoModelAnnouncer announce: (MethodAdded method: compiledMethod) ]
 		ifFalse: [ "If protocol changed and someone is from different package, I need to throw a method recategorized"
 			newProtocol = oldProtocol ifFalse: [ self announceRecategorizationOf: compiledMethod oldProtocol: oldProtocol ].
-			SystemAnnouncer uniqueInstance methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol ]
+			self pharoModelAnnouncer methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol ]
 ]
 
 { #category : 'instance variables' }
@@ -74,7 +74,7 @@ ClassDescription >> addProtocol: aProtocol [
 
 	"For now extensions are managed via protocols. If the protocol represent an extension we need to make sure the corresponding package exists."
 	protocol isExtensionProtocol ifTrue: [ self packageOrganizer ensurePackageOfExtensionProtocol: protocol ].
-	SystemAnnouncer announce: (ProtocolAdded in: self protocol: protocol).
+	self pharoModelAnnouncer  announce: (ProtocolAdded in: self protocol: protocol).
 	^ protocol
 ]
 
@@ -156,7 +156,7 @@ ClassDescription >> announceRecategorizationOf: compiledMethod oldProtocol: oldP
 	compiledMethod origin = compiledMethod methodClass ifTrue: [ self packageOrganizer repackageMethod: compiledMethod oldProtocol: oldProtocol newProtocol: compiledMethod protocol ].
 
 	"Announce the recategorization"
-	SystemAnnouncer uniqueInstance methodRecategorized: compiledMethod oldProtocol: oldProtocol
+	self pharoModelAnnouncer methodRecategorized: compiledMethod oldProtocol: oldProtocol
 ]
 
 { #category : 'authors' }
@@ -361,7 +361,7 @@ ClassDescription >> compileSilently: sourceCode classified: protocolName [
 ClassDescription >> compileSilently: sourceCode classified: protocolName notifying: requestor [
 	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list."
 
-	^ SystemAnnouncer uniqueInstance suspendAllWhile: [ self compile: sourceCode classified: protocolName notifying: requestor ]
+	^ self pharoModelAnnouncer suspendAllWhile: [ self compile: sourceCode classified: protocolName notifying: requestor ]
 ]
 
 { #category : 'copying' }
@@ -965,7 +965,7 @@ ClassDescription >> removeProtocolIfEmpty: aProtocol [
 
 	oldProtocolNames := self protocolNames.
 	protocols := protocols copyWithout: protocol.
-	SystemAnnouncer announce: (ProtocolRemoved in: self protocol: protocol)
+	self pharoModelAnnouncer  announce: (ProtocolRemoved in: self protocol: protocol)
 ]
 
 { #category : 'accessing - method dictionary' }
@@ -984,7 +984,7 @@ ClassDescription >> removeSelector: selector [
 
 	super removeSelector: selector.
 
-	SystemAnnouncer uniqueInstance methodRemoved: method protocol: protocol origin: origin
+	self pharoModelAnnouncer  methodRemoved: method protocol: protocol origin: origin
 ]
 
 { #category : 'instance variables' }

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -35,7 +35,7 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 		priorOrigin := method origin ].
 
 	oldProtocol := self protocolOfSelector: selector.
-	self pharoModelAnnouncer prevent: MethodRecategorized during: [ self classify: selector under: protocol ].
+	self codeChangeAnnouncer prevent: MethodRecategorized during: [ self classify: selector under: protocol ].
 	newProtocol := self protocolOfSelector: selector.
 
 	self addSelectorSilently: selector withMethod: compiledMethod.
@@ -45,10 +45,10 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 	(priorMethod isNil or: [ priorOrigin ~= compiledMethod origin ])
 		ifTrue: [
 			compiledMethod shouldBePackaged ifTrue: [ (self packageOrganizer packageForProtocol: newProtocol from: self) addMethod: compiledMethod ].
-			self pharoModelAnnouncer announce: (MethodAdded method: compiledMethod) ]
+			self codeChangeAnnouncer announce: (MethodAdded method: compiledMethod) ]
 		ifFalse: [ "If protocol changed and someone is from different package, I need to throw a method recategorized"
 			newProtocol = oldProtocol ifFalse: [ self announceRecategorizationOf: compiledMethod oldProtocol: oldProtocol ].
-			self pharoModelAnnouncer methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol ]
+			self codeChangeAnnouncer methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol ]
 ]
 
 { #category : 'instance variables' }
@@ -74,7 +74,7 @@ ClassDescription >> addProtocol: aProtocol [
 
 	"For now extensions are managed via protocols. If the protocol represent an extension we need to make sure the corresponding package exists."
 	protocol isExtensionProtocol ifTrue: [ self packageOrganizer ensurePackageOfExtensionProtocol: protocol ].
-	self pharoModelAnnouncer  announce: (ProtocolAdded in: self protocol: protocol).
+	self codeChangeAnnouncer  announce: (ProtocolAdded in: self protocol: protocol).
 	^ protocol
 ]
 
@@ -156,7 +156,7 @@ ClassDescription >> announceRecategorizationOf: compiledMethod oldProtocol: oldP
 	compiledMethod origin = compiledMethod methodClass ifTrue: [ self packageOrganizer repackageMethod: compiledMethod oldProtocol: oldProtocol newProtocol: compiledMethod protocol ].
 
 	"Announce the recategorization"
-	self pharoModelAnnouncer methodRecategorized: compiledMethod oldProtocol: oldProtocol
+	self codeChangeAnnouncer methodRecategorized: compiledMethod oldProtocol: oldProtocol
 ]
 
 { #category : 'authors' }
@@ -361,7 +361,7 @@ ClassDescription >> compileSilently: sourceCode classified: protocolName [
 ClassDescription >> compileSilently: sourceCode classified: protocolName notifying: requestor [
 	"Compile the code and classify the resulting method in the given protocol, leaving no trail in the system log, nor in any change set, nor in the 'recent submissions' list."
 
-	^ self pharoModelAnnouncer suspendAllWhile: [ self compile: sourceCode classified: protocolName notifying: requestor ]
+	^ self codeChangeAnnouncer suspendAllWhile: [ self compile: sourceCode classified: protocolName notifying: requestor ]
 ]
 
 { #category : 'copying' }
@@ -965,7 +965,7 @@ ClassDescription >> removeProtocolIfEmpty: aProtocol [
 
 	oldProtocolNames := self protocolNames.
 	protocols := protocols copyWithout: protocol.
-	self pharoModelAnnouncer  announce: (ProtocolRemoved in: self protocol: protocol)
+	self codeChangeAnnouncer  announce: (ProtocolRemoved in: self protocol: protocol)
 ]
 
 { #category : 'accessing - method dictionary' }
@@ -984,7 +984,7 @@ ClassDescription >> removeSelector: selector [
 
 	super removeSelector: selector.
 
-	self pharoModelAnnouncer  methodRemoved: method protocol: protocol origin: origin
+	self codeChangeAnnouncer  methodRemoved: method protocol: protocol origin: origin
 ]
 
 { #category : 'instance variables' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -261,7 +261,7 @@ RPackage >> ensureTag: aTag [
 	newTag := RPackageTag package: self name: tagName.
 	classTags add: newTag.
 
-	SystemAnnouncer announce: (PackageTagAdded to: newTag).
+	self pharoModelAnnouncer  announce: (PackageTagAdded to: newTag).
 	^ newTag
 ]
 
@@ -522,8 +522,8 @@ RPackage >> moveClass: aClass toTag: aTag [
 
 	"If the tag is undefined, this means we are adding the class. Else we are updating the package or tag."
 	oldTag isUndefined
-		ifTrue: [ SystemAnnouncer uniqueInstance announce: (ClassAdded class: aClass) ]
-		ifFalse: [ SystemAnnouncer uniqueInstance announce: (ClassRepackaged classRepackaged: aClass oldTag: oldTag newTag: newTag) ]
+		ifTrue: [ self pharoModelAnnouncer  announce: (ClassAdded class: aClass) ]
+		ifFalse: [ self pharoModelAnnouncer  announce: (ClassRepackaged classRepackaged: aClass oldTag: oldTag newTag: newTag) ]
 ]
 
 { #category : 'accessing' }
@@ -571,6 +571,12 @@ RPackage >> packageName [
 RPackage >> packages [
 	"Compatibility with monticello and old PackageInfo"
 	^ self classTags
+]
+
+{ #category : 'accessing' }
+RPackage >> pharoModelAnnouncer [
+
+	^ self environment pharoModelAnnouncer
 ]
 
 { #category : 'printing' }
@@ -715,7 +721,7 @@ RPackage >> removeTag: aTag [
 
 	classTags remove: tag ifAbsent: [ ^ self ].
 
-	SystemAnnouncer announce: (PackageTagRemoved to: tag)
+	self pharoModelAnnouncer  announce: (PackageTagRemoved to: tag)
 ]
 
 { #category : 'class tags' }
@@ -745,7 +751,7 @@ RPackage >> renameTo: aSymbol [
 		protocol rename: '*' , newName , (protocol name allButFirst: oldName size + 1) ].
 
 	self organizer basicRegisterPackage: self.
-	SystemAnnouncer uniqueInstance announce: (PackageRenamed to: self oldName: oldName newName: newName)
+	self pharoModelAnnouncer  announce: (PackageRenamed to: self oldName: oldName newName: newName)
 ]
 
 { #category : 'class tags' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -182,6 +182,12 @@ RPackage >> classesTaggedWith: aSymbol [
 ]
 
 { #category : 'accessing' }
+RPackage >> codeChangeAnnouncer [
+
+	^ self environment codeChangeAnnouncer
+]
+
+{ #category : 'accessing' }
 RPackage >> definedClassNames [
 	"Return the class names having methods defined in the receiver."
 
@@ -261,7 +267,7 @@ RPackage >> ensureTag: aTag [
 	newTag := RPackageTag package: self name: tagName.
 	classTags add: newTag.
 
-	self pharoModelAnnouncer  announce: (PackageTagAdded to: newTag).
+	self codeChangeAnnouncer  announce: (PackageTagAdded to: newTag).
 	^ newTag
 ]
 
@@ -522,8 +528,8 @@ RPackage >> moveClass: aClass toTag: aTag [
 
 	"If the tag is undefined, this means we are adding the class. Else we are updating the package or tag."
 	oldTag isUndefined
-		ifTrue: [ self pharoModelAnnouncer  announce: (ClassAdded class: aClass) ]
-		ifFalse: [ self pharoModelAnnouncer  announce: (ClassRepackaged classRepackaged: aClass oldTag: oldTag newTag: newTag) ]
+		ifTrue: [ self codeChangeAnnouncer  announce: (ClassAdded class: aClass) ]
+		ifFalse: [ self codeChangeAnnouncer  announce: (ClassRepackaged classRepackaged: aClass oldTag: oldTag newTag: newTag) ]
 ]
 
 { #category : 'accessing' }
@@ -571,12 +577,6 @@ RPackage >> packageName [
 RPackage >> packages [
 	"Compatibility with monticello and old PackageInfo"
 	^ self classTags
-]
-
-{ #category : 'accessing' }
-RPackage >> pharoModelAnnouncer [
-
-	^ self environment pharoModelAnnouncer
 ]
 
 { #category : 'printing' }
@@ -721,7 +721,7 @@ RPackage >> removeTag: aTag [
 
 	classTags remove: tag ifAbsent: [ ^ self ].
 
-	self pharoModelAnnouncer  announce: (PackageTagRemoved to: tag)
+	self codeChangeAnnouncer  announce: (PackageTagRemoved to: tag)
 ]
 
 { #category : 'class tags' }
@@ -751,7 +751,7 @@ RPackage >> renameTo: aSymbol [
 		protocol rename: '*' , newName , (protocol name allButFirst: oldName size + 1) ].
 
 	self organizer basicRegisterPackage: self.
-	self pharoModelAnnouncer  announce: (PackageRenamed to: self oldName: oldName newName: newName)
+	self codeChangeAnnouncer  announce: (PackageRenamed to: self oldName: oldName newName: newName)
 ]
 
 { #category : 'class tags' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -140,7 +140,7 @@ RPackageOrganizer >> addPackage: aPackage [
 
 	self basicRegisterPackage: package.
 
-	SystemAnnouncer announce: (PackageAdded to: package).
+	self pharoModelAnnouncer  announce: (PackageAdded to: package).
 
 	^ package
 ]
@@ -353,6 +353,12 @@ RPackageOrganizer >> packagesDo: aBlock [
 	self packages do: aBlock
 ]
 
+{ #category : 'accessing' }
+RPackageOrganizer >> pharoModelAnnouncer [
+
+	^ self environment pharoModelAnnouncer
+]
+
 { #category : 'system integration' }
 RPackageOrganizer >> removeClass: class [
 	"Remove the class, the class backpointer, the extensions and the extension backPointer from the receiver and the class involved with the class named: className. className is a class name and should not be a metaclass one. "
@@ -416,7 +422,7 @@ RPackageOrganizer >> repackageMethod: method oldProtocol: oldProtocol newProtoco
 	oldPackage removeMethod: method.
 	newPackage addMethod: method.
 
-	SystemAnnouncer uniqueInstance methodRepackaged: method from: oldPackage to: newPackage
+	self pharoModelAnnouncer  methodRepackaged: method from: oldPackage to: newPackage
 ]
 
 { #category : 'accessing' }
@@ -449,7 +455,7 @@ RPackageOrganizer >> unregisterPackage: aPackage [
 		           ifFalse: [ aPackage ].
 
 	self basicUnregisterPackage: package.
-	SystemAnnouncer announce: (PackageRemoved to: package).
+	self pharoModelAnnouncer  announce: (PackageRemoved to: package).
 
 	^ package
 ]

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -140,7 +140,7 @@ RPackageOrganizer >> addPackage: aPackage [
 
 	self basicRegisterPackage: package.
 
-	self pharoModelAnnouncer  announce: (PackageAdded to: package).
+	self codeChangeAnnouncer  announce: (PackageAdded to: package).
 
 	^ package
 ]
@@ -157,6 +157,12 @@ RPackageOrganizer >> basicUnregisterPackage: aPackage [
 	"Unregister the specified package from the list of registered packages. Raise the PackageRemoved announcement. This is a low level action. It does not unregister the back pointer from classes to packages or any other information managed by the organizer"
 
 	^ packages removeKey: aPackage name ifAbsent: [  ]
+]
+
+{ #category : 'accessing' }
+RPackageOrganizer >> codeChangeAnnouncer [
+
+	^ self environment codeChangeAnnouncer
 ]
 
 { #category : 'registration' }
@@ -353,12 +359,6 @@ RPackageOrganizer >> packagesDo: aBlock [
 	self packages do: aBlock
 ]
 
-{ #category : 'accessing' }
-RPackageOrganizer >> pharoModelAnnouncer [
-
-	^ self environment pharoModelAnnouncer
-]
-
 { #category : 'system integration' }
 RPackageOrganizer >> removeClass: class [
 	"Remove the class, the class backpointer, the extensions and the extension backPointer from the receiver and the class involved with the class named: className. className is a class name and should not be a metaclass one. "
@@ -422,7 +422,7 @@ RPackageOrganizer >> repackageMethod: method oldProtocol: oldProtocol newProtoco
 	oldPackage removeMethod: method.
 	newPackage addMethod: method.
 
-	self pharoModelAnnouncer  methodRepackaged: method from: oldPackage to: newPackage
+	self codeChangeAnnouncer  methodRepackaged: method from: oldPackage to: newPackage
 ]
 
 { #category : 'accessing' }
@@ -455,7 +455,7 @@ RPackageOrganizer >> unregisterPackage: aPackage [
 		           ifFalse: [ aPackage ].
 
 	self basicUnregisterPackage: package.
-	self pharoModelAnnouncer  announce: (PackageRemoved to: package).
+	self codeChangeAnnouncer  announce: (PackageRemoved to: package).
 
 	^ package
 ]

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -133,6 +133,12 @@ RPackageTag >> packageName [
 	^ self package name
 ]
 
+{ #category : 'accessing' }
+RPackageTag >> pharoModelAnnouncer [
+
+	^ self environment pharoModelAnnouncer
+]
+
 { #category : 'printing' }
 RPackageTag >> printOn: aStream [
 	super printOn: aStream.
@@ -191,7 +197,7 @@ RPackageTag >> renameTo: newTagName [
 
 	self basicRenameTo: newTagName.
 
-	SystemAnnouncer announce: (PackageTagRenamed to: self oldName: oldTagName newName: newTagName)
+	self pharoModelAnnouncer  announce: (PackageTagRenamed to: self oldName: oldTagName newName: newTagName)
 ]
 
 { #category : 'accessing' }

--- a/src/RPackage-Core/RPackageTag.class.st
+++ b/src/RPackage-Core/RPackageTag.class.st
@@ -60,6 +60,12 @@ RPackageTag >> classes [
 ]
 
 { #category : 'accessing' }
+RPackageTag >> codeChangeAnnouncer [
+
+	^ self environment codeChangeAnnouncer
+]
+
+{ #category : 'accessing' }
 RPackageTag >> environment [
 
 	^ self package environment
@@ -133,12 +139,6 @@ RPackageTag >> packageName [
 	^ self package name
 ]
 
-{ #category : 'accessing' }
-RPackageTag >> pharoModelAnnouncer [
-
-	^ self environment pharoModelAnnouncer
-]
-
 { #category : 'printing' }
 RPackageTag >> printOn: aStream [
 	super printOn: aStream.
@@ -197,7 +197,7 @@ RPackageTag >> renameTo: newTagName [
 
 	self basicRenameTo: newTagName.
 
-	self pharoModelAnnouncer  announce: (PackageTagRenamed to: self oldName: oldTagName newName: newTagName)
+	self codeChangeAnnouncer  announce: (PackageTagRenamed to: self oldName: oldTagName newName: newTagName)
 ]
 
 { #category : 'accessing' }

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -185,8 +185,8 @@ Breakpoint class >> notifyBreakpointRemoved: aBreakpoint fromNodes: nodes [
 Breakpoint class >> registerInterestToSystemAnnouncement [
 
 	<systemEventRegistration>
-	self pharoModelAnnouncer unsubscribe: self.
-	self pharoModelAnnouncer weak
+	self codeChangeAnnouncer unsubscribe: self.
+	self codeChangeAnnouncer weak
 		when: MethodRemoved send: #handleMethodRemoved: to: self;
 		when: MethodModified send: #handleMethodModified: to: self;
 		when: ClassRemoved send: #handleClassRemoved: to: self

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -183,12 +183,13 @@ Breakpoint class >> notifyBreakpointRemoved: aBreakpoint fromNodes: nodes [
 
 { #category : 'class initialization' }
 Breakpoint class >> registerInterestToSystemAnnouncement [
-	<systemEventRegistration>
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
-	SystemAnnouncer uniqueInstance weak when: MethodRemoved send: #handleMethodRemoved: to: self.
-	SystemAnnouncer uniqueInstance weak when: MethodModified send: #handleMethodModified: to: self.
-	SystemAnnouncer uniqueInstance weak when: ClassRemoved send: #handleClassRemoved: to: self
+	<systemEventRegistration>
+	self pharoModelAnnouncer unsubscribe: self.
+	self pharoModelAnnouncer weak
+		when: MethodRemoved send: #handleMethodRemoved: to: self;
+		when: MethodModified send: #handleMethodModified: to: self;
+		when: ClassRemoved send: #handleClassRemoved: to: self
 ]
 
 { #category : 'cleanup' }

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -187,6 +187,13 @@ SystemDictionary >> classOrTraitNamed: aString [
 ]
 
 { #category : 'accessing' }
+SystemDictionary >> codeChangeAnnouncer [
+	"This should not be hardcoded in the futurebut I should have my own instance."
+
+	^ SystemAnnouncer uniqueInstance
+]
+
+{ #category : 'accessing' }
 SystemDictionary >> environment [
 	"For conversion from SmalltalkImage to SystemDictionary"
 
@@ -328,13 +335,6 @@ SystemDictionary >> organization: anOrganization [
 SystemDictionary >> outerScope [
 
 	^ nil
-]
-
-{ #category : 'accessing' }
-SystemDictionary >> pharoModelAnnouncer [
-	"This should not be hardcoded in the futurebut I should have my own instance."
-
-	^ SystemAnnouncer uniqueInstance
 ]
 
 { #category : 'accessing' }

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -331,6 +331,13 @@ SystemDictionary >> outerScope [
 ]
 
 { #category : 'accessing' }
+SystemDictionary >> pharoModelAnnouncer [
+	"This should not be hardcoded in the futurebut I should have my own instance."
+
+	^ SystemAnnouncer uniqueInstance
+]
+
+{ #category : 'accessing' }
 SystemDictionary >> poolUsers [
 	"Answer a dictionary of pool name -> classes that refer to it.
 	Also includes any globally know dictionaries (such as


### PR DESCRIPTION
This change is the first of a big list of change toward two goals:
- Split system announcer into two parts: One to announce code changes (MethodAdded, ClassAdded, ProtocolAdded, PackageAdded, ...) and tooling changes (breakpoint, ast cache, chunks...)
- Do not have global announcer but environement announcers

I am not sure about the name so if anyone has suggestions go for it! It can be improved later of course. The goal here is just to start reducing the usage of the singleton