### PR TITLE
Calypso: Fix display of extended classes in project view

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserMorph.class.st
@@ -384,10 +384,12 @@ ClyFullBrowserMorph >> isClassSelected: aClass [
 { #category : 'testing' }
 ClyFullBrowserMorph >> isPackagePartOfSelection: aPackage [
 
-	(self isPackageSelected: aPackage) ifTrue: [ ^true ].
+	(packageView selection isBasedOnItemType: Project) ifTrue: [
+		self projectSelection actualObjects
+			detect: [ :project | project includesPackage: aPackage ]
+			ifFound: [ ^ true ] ].
 
-	^self projectSelection actualObjects
-		anySatisfy: [ :project | project includesPackage: aPackage ]
+	^ self isPackageSelected: aPackage
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
When selecting a package in a project view, if the package extend a class from the same project the display is wrong. This fixes the problem

Before: 

![image](https://github.com/pharo-project/pharo/assets/9519971/85a7d909-a591-459e-ac02-2ffcee53f8cc)

After:

![image](https://github.com/pharo-project/pharo/assets/9519971/65de7eb4-f50d-489d-aec6-157a40744858)
