### PR TITLE
Add binary selector alias for #newFromArray: for Collection

### DIFF
--- a/src/Collections-Abstract-Tests/TCreationWithTest.trait.st
+++ b/src/Collections-Abstract-Tests/TCreationWithTest.trait.st
@@ -30,6 +30,18 @@ TCreationWithTest >> test0FixtureCreationWithTest [
 ]
 
 { #category : 'tests - creation' }
+TCreationWithTest >> testLessThanMinus [
+
+	| aCol collection |
+	collection := self collectionMoreThan5Elements asArray.
+	aCol := self collectionClass <- collection.
+
+	collection do: [ :each | self assert: (aCol occurrencesOf: each ) equals: ( collection occurrencesOf: each ) ].
+
+	self assert: aCol size equals: collection size
+]
+
+{ #category : 'tests - creation' }
 TCreationWithTest >> testNewFromArray [
 
 	| aCol collection |
@@ -47,18 +59,6 @@ TCreationWithTest >> testOfSize [
 	| aCol |
 	aCol := self collectionClass ofSize: 3.
 	self assert: aCol size equals: 3
-]
-
-{ #category : 'tests - creation' }
-TCreationWithTest >> testPercentSignGreaterThan [
-
-	| aCol collection |
-	collection := self collectionMoreThan5Elements asArray.
-	aCol := self collectionClass %> collection.
-
-	collection do: [ :each | self assert: (aCol occurrencesOf: each ) equals: ( collection occurrencesOf: each ) ].
-
-	self assert: aCol size equals: collection size
 ]
 
 { #category : 'tests - creation' }

--- a/src/Collections-Abstract-Tests/TCreationWithTest.trait.st
+++ b/src/Collections-Abstract-Tests/TCreationWithTest.trait.st
@@ -30,6 +30,18 @@ TCreationWithTest >> test0FixtureCreationWithTest [
 ]
 
 { #category : 'tests - creation' }
+TCreationWithTest >> testNewFromArray [
+
+	| aCol collection |
+	collection := self collectionMoreThan5Elements asArray.
+	aCol := self collectionClass newFromArray: collection.
+
+	collection do: [ :each | self assert: (aCol occurrencesOf: each ) equals: ( collection occurrencesOf: each ) ].
+
+	self assert: aCol size equals: collection size
+]
+
+{ #category : 'tests - creation' }
 TCreationWithTest >> testOfSize [
 
 	| aCol |

--- a/src/Collections-Abstract-Tests/TCreationWithTest.trait.st
+++ b/src/Collections-Abstract-Tests/TCreationWithTest.trait.st
@@ -50,6 +50,18 @@ TCreationWithTest >> testOfSize [
 ]
 
 { #category : 'tests - creation' }
+TCreationWithTest >> testPercentSignGreaterThan [
+
+	| aCol collection |
+	collection := self collectionMoreThan5Elements asArray.
+	aCol := self collectionClass %> collection.
+
+	collection do: [ :each | self assert: (aCol occurrencesOf: each ) equals: ( collection occurrencesOf: each ) ].
+
+	self assert: aCol size equals: collection size
+]
+
+{ #category : 'tests - creation' }
 TCreationWithTest >> testWith [
 
 	| aCol anElement |

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -14,7 +14,7 @@ Class {
 }
 
 { #category : 'instance creation' }
-Collection class >> %> anArray [
+Collection class >> <- anArray [
 
 	^ self newFromArray: anArray
 ]

--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -14,6 +14,12 @@ Class {
 }
 
 { #category : 'instance creation' }
+Collection class >> %> anArray [
+
+	^ self newFromArray: anArray
+]
+
+{ #category : 'instance creation' }
 Collection class >> empty [
 	^ self new
 ]

--- a/src/Collections-Sequenceable-Tests/IntervalTest.class.st
+++ b/src/Collections-Sequenceable-Tests/IntervalTest.class.st
@@ -4,8 +4,8 @@ SUnit tests for intervals
 Class {
 	#name : 'IntervalTest',
 	#superclass : 'CollectionRootTest',
-	#traits : 'TSortTest - {#testSort. #testSortUsingSortBlock} + TCloneTest + TIncludesWithIdentityCheckTest + TSequencedElementAccessTest + TIterateSequencedReadableTest + TSequencedConcatenationTest + TSubCollectionAccess + TAsStringCommaAndDelimiterSequenceableTest + TIndexAccess + TPrintOnSequencedTest + TConvertTest + (TCopySequenceableWithReplacement - {#testCopyReplaceAllWithManyOccurrence. #collectionWith2TimeSubcollection}) + TCopySequenceableWithOrWithoutSpecificElements + (TCopySequenceableSameContents - {#testShuffled}) + (TCopyPartOfSequenceable - {#testCopyEmptyMethod}) + TCopyTest + TBeginsEndsWith + TConvertAsSortedTest + TSequencedStructuralEqualityTest + TOccurrencesTest + TSequenceableTruncatedToSize',
-	#classTraits : 'TSortTest classTrait + TCloneTest classTrait + TIncludesWithIdentityCheckTest classTrait + TSequencedElementAccessTest classTrait + TIterateSequencedReadableTest classTrait + TSequencedConcatenationTest classTrait + TSubCollectionAccess classTrait + TAsStringCommaAndDelimiterSequenceableTest classTrait + TIndexAccess classTrait + TPrintOnSequencedTest classTrait + TConvertTest classTrait + TCopySequenceableWithReplacement classTrait + TCopySequenceableWithOrWithoutSpecificElements classTrait + TCopySequenceableSameContents classTrait + TCopyPartOfSequenceable classTrait + TCopyTest classTrait + TBeginsEndsWith classTrait + TConvertAsSortedTest classTrait + TSequencedStructuralEqualityTest classTrait + TOccurrencesTest classTrait + TSequenceableTruncatedToSize classTrait',
+	#traits : 'TSortTest - {#testSort. #testSortUsingSortBlock} + TCloneTest + TIncludesWithIdentityCheckTest + TSequencedElementAccessTest + TIterateSequencedReadableTest + TSequencedConcatenationTest + TSubCollectionAccess + TAsStringCommaAndDelimiterSequenceableTest + TIndexAccess + TPrintOnSequencedTest + TConvertTest + (TCopySequenceableWithReplacement - {#testCopyReplaceAllWithManyOccurrence. #collectionWith2TimeSubcollection}) + TCopySequenceableWithOrWithoutSpecificElements + (TCopySequenceableSameContents - {#testShuffled}) + (TCopyPartOfSequenceable - {#testCopyEmptyMethod}) + TCopyTest + TBeginsEndsWith + TConvertAsSortedTest + TSequencedStructuralEqualityTest + TOccurrencesTest + TSequenceableTruncatedToSize + (TCreationWithTest - {#testOfSize. #testWithAll. #testWith. #testWithWith. #testWithWithWith. #testWithWithWithWith. #testWithWithWithWithWith})',
+	#classTraits : 'TSortTest classTrait + TCloneTest classTrait + TIncludesWithIdentityCheckTest classTrait + TSequencedElementAccessTest classTrait + TIterateSequencedReadableTest classTrait + TSequencedConcatenationTest classTrait + TSubCollectionAccess classTrait + TAsStringCommaAndDelimiterSequenceableTest classTrait + TIndexAccess classTrait + TPrintOnSequencedTest classTrait + TConvertTest classTrait + TCopySequenceableWithReplacement classTrait + TCopySequenceableWithOrWithoutSpecificElements classTrait + TCopySequenceableSameContents classTrait + TCopyPartOfSequenceable classTrait + TCopyTest classTrait + TBeginsEndsWith classTrait + TConvertAsSortedTest classTrait + TSequencedStructuralEqualityTest classTrait + TOccurrencesTest classTrait + TSequenceableTruncatedToSize classTrait + TCreationWithTest classTrait',
 	#instVars : [
 		'empty',
 		'nonEmpty',
@@ -66,6 +66,13 @@ IntervalTest >> collectionInForIncluding [
 IntervalTest >> collectionMoreThan1NoDuplicates [
 	" return a collection of size 5 without equal elements"
 	^ nonEmpty
+]
+
+{ #category : 'requirements' }
+IntervalTest >> collectionMoreThan5Elements [
+" return a collection including at least 5 elements"
+
+	^ collectionWith5Elements
 ]
 
 { #category : 'requirements' }

--- a/src/Collections-Support-Tests/RunArrayTest.class.st
+++ b/src/Collections-Support-Tests/RunArrayTest.class.st
@@ -4,14 +4,28 @@ SUnit tests for class RunArray
 Class {
 	#name : 'RunArrayTest',
 	#superclass : 'TestCase',
-	#traits : 'TSequenceableTruncatedToSize',
-	#classTraits : 'TSequenceableTruncatedToSize classTrait',
+	#traits : 'TSequenceableTruncatedToSize + (TCreationWithTest - {#testWithAll})',
+	#classTraits : 'TSequenceableTruncatedToSize classTrait + TCreationWithTest classTrait',
 	#instVars : [
 		'collectionWith5Elements'
 	],
 	#category : 'Collections-Support-Tests',
 	#package : 'Collections-Support-Tests'
 }
+
+{ #category : 'requirements' }
+RunArrayTest >> collectionClass [
+	"Return the class to be used to create instances of the class tested"
+
+	^ RunArray
+]
+
+{ #category : 'requirements' }
+RunArrayTest >> collectionMoreThan5Elements [
+" return a collection including at least 5 elements"
+
+	^ collectionWith5Elements
+]
 
 { #category : 'requirements' }
 RunArrayTest >> collectionWith5Elements [

--- a/src/Collections-Support-Tests/RunArrayTest.class.st
+++ b/src/Collections-Support-Tests/RunArrayTest.class.st
@@ -143,18 +143,13 @@ RunArrayTest >> testNew [
 ]
 
 { #category : 'tests - instance creation' }
-RunArrayTest >> testNewFromArray [
+RunArrayTest >> testNewFrom [
 
 	| array |
 	array := RunArray newFrom: #($a $b $b $b $b $c $c $a).
 	self assert: array size equals: 8.
-	self assert: array asArray equals: #($a $b $b $b $b $c $c $a)
-]
+	self assert: array asArray equals: #($a $b $b $b $b $c $c $a).
 
-{ #category : 'tests - instance creation' }
-RunArrayTest >> testNewFromString [
-
-	| array |
 	array := RunArray newFrom: 'abbbbcca'.
 	self assert: array size equals: 8.
 	self assert: array asArray equals: #($a $b $b $b $b $c $c $a)

--- a/src/Collections-Unordered-Tests/DictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/DictionaryTest.class.st
@@ -619,6 +619,16 @@ DictionaryTest >> testKeyForIdentity [
 ]
 
 { #category : 'tests - new' }
+DictionaryTest >> testLessThanMinus [
+
+	| assocs |
+	self assert: (self classToBeTested <- {}) equals: self emptyDict.
+
+	assocs := self nonEmptyDict associations collect: [ :each | each copy ].
+	self assert: (self classToBeTested <- assocs) equals: self nonEmptyDict
+]
+
+{ #category : 'tests - new' }
 DictionaryTest >> testNew [
 	| d |
 	d := self classToBeTested new: 10.
@@ -739,16 +749,6 @@ DictionaryTest >> testOtherDictionaryEquality [
 			self nonEmptyDict keysAndValuesDo: [ :key :value | nonEmptyDict2 at: key put: value ].
 			self deny: self nonEmptyDict equals: nonEmptyDict2.
 			self deny: nonEmptyDict2 equals: self nonEmptyDict ]
-]
-
-{ #category : 'tests - new' }
-DictionaryTest >> testPercentSignGreaterThan [
-
-	| assocs |
-	self assert: (self classToBeTested %> {}) equals: self emptyDict.
-
-	assocs := self nonEmptyDict associations collect: [ :each | each copy ].
-	self assert: (self classToBeTested %> assocs) equals: self nonEmptyDict
 ]
 
 { #category : 'tests' }

--- a/src/Collections-Unordered-Tests/DictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/DictionaryTest.class.st
@@ -640,6 +640,16 @@ DictionaryTest >> testNewFrom [
 ]
 
 { #category : 'tests - new' }
+DictionaryTest >> testNewFromArray [
+
+	| assocs |
+	self assert: (self classToBeTested newFromArray: {}) equals: self emptyDict.
+
+	assocs := self nonEmptyDict associations collect: [ :each | each copy ].
+	self assert: (self classToBeTested newFromArray: assocs) equals: self nonEmptyDict
+]
+
+{ #category : 'tests - new' }
 DictionaryTest >> testNewFromKeysAndValues [
 
 	| keys values newDict |

--- a/src/Collections-Unordered-Tests/DictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/DictionaryTest.class.st
@@ -741,6 +741,16 @@ DictionaryTest >> testOtherDictionaryEquality [
 			self deny: nonEmptyDict2 equals: self nonEmptyDict ]
 ]
 
+{ #category : 'tests - new' }
+DictionaryTest >> testPercentSignGreaterThan [
+
+	| assocs |
+	self assert: (self classToBeTested %> {}) equals: self emptyDict.
+
+	assocs := self nonEmptyDict associations collect: [ :each | each copy ].
+	self assert: (self classToBeTested %> assocs) equals: self nonEmptyDict
+]
+
 { #category : 'tests' }
 DictionaryTest >> testRemoveAll [
 	"Allows one to remove all elements of a collection"


### PR DESCRIPTION
This pull request adds a binary selector as an alias for `#newFromArray:` on Collection’s class as suggested in [pull request #22 in the Pharo Enhancement Proposals repository](https://github.com/pharo-project/pheps/pull/22). I used `#%>` as suggested in a [comment by @Ducasse](https://github.com/pharo-project/pheps/pull/22#issuecomment-1802010966). Other options I considered were `#<-` and `#<=`, which look like leftwards pointing arrows, to reflect that in `Set<-{1. 2}` the elements on the right are put into a collection of the class on the left. I implemented the alias only on Collection’s class, even though `#newFromArray:` is also implemented on Object’s class, as a [comment in pull request #11716](https://github.com/pharo-project/pharo/pull/11716#discussion_r979675710) explains the latter only exists for backwards compatibility.