### PR TITLE
Packages: Cleanup after recent changes

### DIFF
--- a/src/InitializePackagesCommandLineHandler/RPackageOrganizer.extension.st
+++ b/src/InitializePackagesCommandLineHandler/RPackageOrganizer.extension.st
@@ -9,25 +9,5 @@ RPackageOrganizer >> basicBootstrapInitialize [
 	"This is a hack because of a weird behavior produced by the bootstrap were the package or tags end up containing classes that are not the same instances than we have in the system dictionary..To be investigated..."
 	self packages do: [ :package |
 		package classTags do: [ :tag |
-			tag instVarNamed: #classes put: (tag classes collect: [ :class | allBehaviors detect: [ :aClass | aClass name = class name ] ]) ] ].
-
-	self flag: #todo. "This next step should not be needed when we will not use announcements to manage method addition"
-	allBehaviors
-		do: [ :behavior |
-			{
-				behavior.
-				behavior classSide } do: [ :aBehavior |
-				aBehavior protocols
-					reject: [ :protocol | protocol isExtensionProtocol ]
-					thenDo: [ :protocol | aBehavior package importProtocol: protocol forClass: aBehavior ] ] ]
-		displayingProgress: 'Importing methods'.
-
-	allBehaviors
-		do: [ :behavior |
-			{
-				behavior.
-				behavior classSide } do: [ :aBehavior |
-				aBehavior extensionProtocols do: [ :protocol |
-					(self ensurePackageMatching: protocol name allButFirst trimBoth) importProtocol: protocol forClass: aBehavior ] ] ]
-		displayingProgress: 'Importing extensions'
+			tag instVarNamed: #classes put: (tag classes collect: [ :class | allBehaviors detect: [ :aClass | aClass name = class name ] ]) ] ]
 ]

--- a/src/Kernel/ClassDescription.class.st
+++ b/src/Kernel/ClassDescription.class.st
@@ -153,7 +153,7 @@ ClassDescription >> allUnreferencedInstanceVariables [
 ClassDescription >> announceRecategorizationOf: compiledMethod oldProtocol: oldProtocol [
 
 	"Repackage the method if it is not from a trait"
-	compiledMethod origin = compiledMethod methodClass ifTrue: [ self packageOrganizer repackageMethod: compiledMethod oldProtocol: oldProtocol newProtocol: compiledMethod protocol ].
+	compiledMethod isFromTrait ifFalse: [ self packageOrganizer repackageMethod: compiledMethod oldProtocol: oldProtocol newProtocol: compiledMethod protocol ].
 
 	"Announce the recategorization"
 	self codeChangeAnnouncer methodRecategorized: compiledMethod oldProtocol: oldProtocol

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -919,8 +919,7 @@ CompiledMethod >> setSourcePointer: srcPointer [
 CompiledMethod >> shouldBePackaged [
 	"This method is a hack.. Ideally this code should be inlined in ClassDescription>>#addAndClassifySelector:withMethod:inProtocol: but ObjectsAsMethodsExample needs this in order to work. I don't like this. If someone has a better idea on how to not packages this kind of ObjectAsMethod go ahead please!"
 
-	"This means I'm not from a Trait."
-	^ self origin = self methodClass
+	^ true
 ]
 
 { #category : 'accessing' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -123,18 +123,19 @@ RPackage >> addClass: aClass [
 ]
 
 { #category : 'add method - compiled method' }
-RPackage >> addMethod: aCompiledMethod [
-	"Add the method to the receiver as a defined method if the class is  defined in it, else as an extension."
+RPackage >> addMethod: aMethod [
+	"Ensure the method is in this package. If it is in a class I'm defining, I'll not keep a reference to it but just ensure it is not considered as an extension. If it is in a foreign class, it means it is an extension and I'll remember that."
 
-	| methodClass |
-	methodClass := aCompiledMethod methodClass.
-	(self includesClass: methodClass)
-		ifTrue: [ "We want to make sure the method is not considered an extension." aCompiledMethod removeProperty: #extensionPackage ]
+	"In case this method was an extension from another package we want to make sure we remove it from there."
+	aMethod extensionPackage ifNotNil: [ :extensionPackage | extensionPackage removeMethod: aMethod ].
+
+	(self includesClass: aMethod methodClass)
+		ifTrue: [ aMethod removeProperty: #extensionPackage ]
 		ifFalse: [
-			aCompiledMethod propertyAt: #extensionPackage put: self. "We tag the method as an extension method."
-			(extensionSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ].
+			aMethod propertyAt: #extensionPackage put: self.
+			(extensionSelectors at: aMethod methodClass ifAbsentPut: [ IdentitySet new ]) add: aMethod selector ].
 
-	^ aCompiledMethod
+	^ aMethod
 ]
 
 { #category : 'class tags' }
@@ -238,9 +239,7 @@ RPackage >> demoteToTagInPackage [
 	tag := newPackage ensureTag: (self name withoutPrefix: newPackage name , '-').
 
 	self definedClasses do: [ :class | newPackage moveClass: class toTag: tag ].
-	self extensionMethods do: [ :method |
-		newPackage addMethod: method.
-		self removeMethod: method ].
+	self extensionMethods do: [ :method | newPackage addMethod: method ].
 
 	self removeFromSystem.
 
@@ -662,20 +661,13 @@ RPackage >> removeFromSystem [
 RPackage >> removeMethod: aCompiledMethod [
 	"Remove the method to the receiver as a defined method."
 
-	| methodClass |
-	methodClass := aCompiledMethod methodClass.
-	"We need to act only on extension methods because defined methods are not stored anymore"
-	(self includesClass: methodClass) ifFalse: [
-		extensionSelectors at: methodClass ifPresent: [ :selectors |
-			selectors remove: aCompiledMethod selector ifAbsent: [  ].
-			selectors ifEmpty: [ extensionSelectors removeKey: methodClass ] ] ].
+	(self includesClass: aCompiledMethod methodClass) ifFalse: [
+		extensionSelectors at: aCompiledMethod methodClass ifPresent: [ :selectors |
+			selectors remove: aCompiledMethod selector ifAbsent: [ ^ aCompiledMethod ].
+			"Cleanup the class from the dictionary if there is no extension anymore."
+			selectors ifEmpty: [ extensionSelectors removeKey: aCompiledMethod methodClass ] ] ].
 
 	^ aCompiledMethod
-]
-
-{ #category : 'add method - compiled method' }
-RPackage >> removeMethods: aCollection [
-	aCollection do: [ :each | self removeMethod: each ]
 ]
 
 { #category : 'properties' }

--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -126,6 +126,9 @@ RPackage >> addClass: aClass [
 RPackage >> addMethod: aMethod [
 	"Ensure the method is in this package. If it is in a class I'm defining, I'll not keep a reference to it but just ensure it is not considered as an extension. If it is in a foreign class, it means it is an extension and I'll remember that."
 
+	"I do not save methods from traits."
+	aMethod isFromTrait ifTrue: [ ^ self ].
+
 	"In case this method was an extension from another package we want to make sure we remove it from there."
 	aMethod extensionPackage ifNotNil: [ :extensionPackage | extensionPackage removeMethod: aMethod ].
 
@@ -360,15 +363,6 @@ RPackage >> hierarchyRoots [
 		select: [ :each | (each superclass isNil or: [ each superclass package ~~ self ]) and: [ each hasSubclasses ] ]
 ]
 
-{ #category : 'private' }
-RPackage >> importProtocol: aProtocol forClass: aClass [
-	"import all the local methods of a protocol as defined in the receiver."
-
-	(aClass methodsInProtocol: aProtocol)
-		reject: [ :method | method isFromTrait ]
-		thenDo: [ :method | self addMethod: method ]
-]
-
 { #category : 'testing' }
 RPackage >> includesClass: aClass [
 	"Returns true if the receiver includes aClass in the classes that are defined within it: only class definition are considered - not class extensions"
@@ -514,25 +508,26 @@ RPackage >> moveClass: aClass toTag: aTag [
 
 	"It is possible that we are just updating the tag and not the package.
 	If we update the package we should remove the class from the old one and update the methods"
-	oldPackage = self ifTrue: [ oldTag removeClass: aClass ] ifFalse: [ oldPackage removeClass: aClass ].
+	oldPackage = self
+		ifTrue: [ oldTag removeClass: aClass ]
+		ifFalse: [ oldPackage removeClass: aClass ].
 
 	newTag privateAddClass: aClass instanceSide.
-	
-	oldPackage = self ifFalse: [
-		"In case I contain extension methods."
+
+	oldPackage = self ifFalse: [ "In case I contain extension methods."
 		self removeAllExtensionMethodsFromClass: aClass.
-		
+
 		{ aClass. aClass classSide } do: [ :class |
 			(self extensionProtocolsForClass: class) do: [ :protocol | class renameProtocol: protocol as: Protocol unclassified ].
 
 			class protocols
 				reject: [ :protocol | protocol isExtensionProtocol ]
-				thenDo: [ :protocol | self importProtocol: protocol forClass: class ] ] ].
+				thenDo: [ :protocol |(class methodsInProtocol: protocol) do: [ :method | self addMethod: method ] ] ] ].
 
 	"If the tag is undefined, this means we are adding the class. Else we are updating the package or tag."
 	oldTag isUndefined
-		ifTrue: [ self codeChangeAnnouncer  announce: (ClassAdded class: aClass) ]
-		ifFalse: [ self codeChangeAnnouncer  announce: (ClassRepackaged classRepackaged: aClass oldTag: oldTag newTag: newTag) ]
+		ifTrue: [ self codeChangeAnnouncer announce: (ClassAdded class: aClass) ]
+		ifFalse: [ self codeChangeAnnouncer announce: (ClassRepackaged classRepackaged: aClass oldTag: oldTag newTag: newTag) ]
 ]
 
 { #category : 'accessing' }

--- a/src/RPackage-Core/RPackageOrganizer.class.st
+++ b/src/RPackage-Core/RPackageOrganizer.class.st
@@ -415,14 +415,13 @@ RPackageOrganizer >> repackageMethod: method oldProtocol: oldProtocol newProtoco
 
 	| oldPackage newPackage |
 	newPackage := self packageForProtocol: newProtocol from: method methodClass.
-	oldPackage := self packageForProtocol: oldProtocol from: method methodClass.
+	oldPackage := method package.
 
 	oldPackage = newPackage ifTrue: [ ^ self ].
 
-	oldPackage removeMethod: method.
 	newPackage addMethod: method.
 
-	self codeChangeAnnouncer  methodRepackaged: method from: oldPackage to: newPackage
+	self codeChangeAnnouncer methodRepackaged: method from: oldPackage to: newPackage
 ]
 
 { #category : 'accessing' }

--- a/src/RPackage-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
+++ b/src/RPackage-Tests/RPackageExtensionMethodsSynchronisationTest.class.st
@@ -155,20 +155,20 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensionsOnClassAndBack [
 	"Move a class in package XXXXX (with extensions from YYYY) to package YYYYY."
 
-	| class xPackage secondPackage |
+	| class xPackage yPackage |
 	xPackage := self ensureXPackage.
-	secondPackage := self ensureYPackage.
+	yPackage := self ensureYPackage.
 	class := self newClassNamed: 'NewClass' in: xPackage.
-	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*' , secondPackage name.
+	self createMethodNamed: 'stubMethod' inClass: class inCategory: '*' , yPackage name.
 
-	secondPackage addClass: class.
+	yPackage addClass: class.
 
 	"Everything should now be in second package (and not listed as an extension, but instead as 'as yet unclassified')."
 
 	self deny: (class >> #stubMethod) isClassified.
-	self assert: (secondPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class).
-	self assert: (class >> #stubMethod) package equals: secondPackage.
+	self assert: (yPackage includesDefinedSelector: #stubMethod ofClass: class).
+	self deny: (yPackage includesExtensionSelector: #stubMethod ofClass: class).
+	self assert: (class >> #stubMethod) package equals: yPackage.
 
 	"Moving back, we should not see the extension reappear."
 
@@ -176,7 +176,7 @@ RPackageExtensionMethodsSynchronisationTest >> testMoveClassInPackageWithExtensi
 
 	self deny: (class >> #stubMethod) isClassified.
 	self assert: (xPackage includesDefinedSelector: #stubMethod ofClass: class).
-	self deny: (secondPackage includesExtensionSelector: #stubMethod ofClass: class)
+	self deny: (yPackage includesExtensionSelector: #stubMethod ofClass: class)
 ]
 
 { #category : 'tests - operations on methods' }


### PR DESCRIPTION
This PR has for goal to cleanup a little after the recent changes.

Let's see if we still need some of the bootstrap hacks.

I also simplified some code by removing methods from old package in #addMethod: and asking the current package of a method directly instead of going through the protocol in a place