### PR TITLE
Traits: Speedup #isFromTrait

### DIFF
--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -462,10 +462,9 @@ CompiledMethod >> isFaulty [
 { #category : 'testing' }
 CompiledMethod >> isFromTrait [
 	"Return true for methods that have been included from Traits"
+
 	<reflection: 'Class structural inspection - Selectors and methods inspection'>
-	| origin |
-	origin := self origin.
-	^ origin isTrait and: [ origin ~= self methodClass ]
+	^ self hasProperty: #traitSource
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
Methods from traits have the #traitSource property and it is faster to check for a property than to get the origin and method class of a method and compare them.

With this change, the method is around 6 times faster

```st
methods := CompiledMethod allInstances.

[ methods do: #isFromTrait ] bench

"Before: 296 iterations in 5 seconds 3 milliseconds. 59.165 per second"

"After: 1,709 iterations in 5 seconds 4 milliseconds. 341.527 per second"
```