### PR TITLE
Speedup #explicitRequirement

### DIFF
--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -606,6 +606,7 @@ Behavior >> definedSelectors [
 
 	^ self definedMethods collect: [ :method | method selector ]
 ]
+
 { #category : 'accessing - instances and variables' }
 Behavior >> definedVariables [
 	"return all the Variables defined"

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -294,7 +294,7 @@ Context >> activeOuterContext [
 Context >> arguments [
 	"returns the arguments of a message invocation"
 	<reflection: 'Stack Manipulation - Context'>
-	^(1 to: self numArgs) collect: [:i | self tempAt: i]
+	^(1 to: self numArgs) collect: [:i | self basicAt: i]
 ]
 
 { #category : 'closure support' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -891,28 +891,13 @@ Object >> executor [
 { #category : 'error handling' }
 Object >> explicitRequirement [
 	"If one of the superclasses can perform the selector, we execute the method of that class, otherwise, the explicit requirement error is thrown"
+
 	<debuggerCompleteToSender>
-	| originalMethod originalArguments errorBlock originalReceiver callingContext originalSelector |
-	errorBlock := [ ^ self error: 'Explicitly required method' ].
-	callingContext := thisContext sender.
-	originalMethod := callingContext homeMethod.
-	originalMethod isFromTrait
-		ifFalse: [ errorBlock value].
-	originalReceiver := callingContext receiver.
-	originalSelector := originalMethod selector.
-	originalArguments := callingContext arguments.
-	originalReceiver class superclass
-		withAllSuperclassesDo: [ :superClass |
-			superClass
-				compiledMethodAt: originalSelector
-				ifPresent: [ :method |
-					(method isProvided or: [ method isFromTrait not ])
-						ifTrue: [ callingContext
-								return:
-									(method
-										valueWithReceiver: originalReceiver
-										arguments: originalArguments) ] ] ].
-	errorBlock value
+	| sender |
+	sender := thisContext sender.
+	[ sender return: (self perform: sender selector withArguments: sender arguments inSuperclass: sender methodClass superclass) ]
+		on: MessageNotUnderstood
+		do: [ self error: 'Explicitly required method' ]
 ]
 
 { #category : 'finalization' }

--- a/src/Traits-Tests/TraitTestCase.class.st
+++ b/src/Traits-Tests/TraitTestCase.class.st
@@ -99,21 +99,22 @@ TraitTestCase >> testExplicitRequirementInClassAlwaysTakesPrecedence [
 
 	self c10 compile: 'm ^111'.
 	self c11 compile: 'm ^self explicitRequirement'.
-	self should: [ self c11 new m ] raise: Error
+	self assert: self c11 new m equals: 111
 ]
 
 { #category : 'tests' }
 TraitTestCase >> testExplicitRequirementTakesPrecedenceOverTraitImplementation [
-	"If i create an explicit requirement method on a trait, the method has to be explicit requirement "
+
+	"If I create an explicit requirement method on a trait, the method has to be explicit requirement "
 	self t12 compile: 'm ^11'.
 	self t11 compile: 'm ^self explicitRequirement'.
 
 	self should: [ self c11 new m ] raise: Error.
 
-	"If i create an explicit requirement method on a class, and the superclass already have the method (non explicit requirement), the class should raise an exception"
+	"If I create an explicit requirement method on a class, and the superclass already have the method (non explicit requirement), the class execute what is in the superclass"
 	self c10 compile: 'm ^111'.
 	self c11 compile: 'm ^self explicitRequirement'.
-	self should: [ self c11 new m ] raise: Error
+	self assert: self c11 new m equals: 111
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
This is a first iteration for the speedup of #explicitRequirement.

It simplifies the execution of the method to use #perform:withArguments:inSuperclass: which is faster.

It also unify the behavior between traits and classes.

This is a work for #15169 but this is still too slow

Here is an example of the perfs:

```st
actualExampleCode := 'example ^ ''hello'''.

traitExplicit := (Trait << #TExplicit) install.
traitExplicit compile: 'example ^ self explicitRequirement'.
superclassExplicit := (Object << #SuperclassExplicit) install.
superclassExplicit compile: actualExampleCode.
subclassExplicit := ((superclassExplicit << #SubclassExplicit)
	                     traits: traitExplicit;
	                     yourself) install.
instanceExplicit := subclassExplicit new.

traitSuper := (Trait << #TSuper) install.
traitSuper compile: 'example ^ super example'.
superclassSuper := (Object << #SuperclassSuper) install.
superclassSuper compile: actualExampleCode.
subclassSuper := ((superclassSuper << #SubclassSuper)
	                  traits: traitSuper;
	                  yourself) install.
instanceSuper := subclassSuper new.

Smalltalk garbageCollect.
explicitRequirementsTime := [ 1000000 timesRepeat: [ instanceExplicit example ] ] timeToRunWithoutGC.

Smalltalk garbageCollect.
superTime := [ 1000000 timesRepeat: [ instanceSuper example ] ] timeToRunWithoutGC.

{
	('explicitRequirements' -> explicitRequirementsTime).
	('super' -> superTime) }.

"Before: {'explicitRequirements'->414. 'super'->2}"
"After: {'explicitRequirements'->293. 'super'->2}"

"And here another one with a method that does not just return a constant."
actualExampleCode := 'example ^ (self packageOrganizer packageNamed: ''Kernel'')'.
"Beofre: {'explicitRequirements'->723. 'super'->198}"
"After: {'explicitRequirements'->540. 'super'->196}"	
```