### PR TITLE
Extend ThemeIcons to load the icons for all scales in the icon pack

### DIFF
--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -25,7 +25,7 @@ Class {
 	#instVars : [
 		'name',
 		'url',
-		'icons',
+		'iconsPerScale',
 		'scale',
 		'reportNotFound'
 	],
@@ -327,7 +327,14 @@ ThemeIcons >> iconNamed: aSymbol ifNone: aBlock [
 
 { #category : 'accessing' }
 ThemeIcons >> icons [
-	^ icons ifNil: [ icons := Dictionary new: 0 ]
+
+	^ self iconsPerScale at: scale ifAbsentPut: [ IdentityDictionary new ]
+]
+
+{ #category : 'accessing' }
+ThemeIcons >> iconsPerScale [
+
+	^ iconsPerScale ifNil: [ iconsPerScale := Dictionary new ]
 ]
 
 { #category : 'testing' }
@@ -343,20 +350,24 @@ ThemeIcons >> loadIconsFromUrl [
 
 { #category : 'loading' }
 ThemeIcons >> loadIconsFromUrlUsingScale: newScale [
-	| newIcons zipArchive |
+	| newIconsPerScale zipArchive |
 
-	newIcons := IdentityDictionary new.
+	newIconsPerScale := Dictionary new.
 	zipArchive := self downloadFromUrl.
 
-	(((FileSystem zip: zipArchive) open workingDirectory allChildrenMatching: '*scale' , newScale asFloat asString) anyOne
-	allChildrenMatching: '*.png')
-		reject: [ :each | each base beginsWith: '.' ]
-		thenDo: [ :each |
-			[ newIcons
-				at: each base asSymbol
-				put: (self readPNGFrom: each) ]
-			on: Error do: [ :e | self crTrace: each fullName, ' not a PNG, skipping.'  ]].
-	icons := newIcons.
+	((FileSystem zip: zipArchive) open workingDirectory allChildrenMatching: 'png-scale*') do: [ :directory |
+		| newIcons |
+		newIconsPerScale
+			at: (Float readFrom: (directory basename copyFrom: 10 to: directory basename size))
+			put: (newIcons := IdentityDictionary new).
+		(directory allChildrenMatching: '*.png')
+			reject: [ :each | each base beginsWith: '.' ]
+			thenDo: [ :each |
+				[ newIcons
+					at: each base asSymbol
+					put: (self readPNGFrom: each) ]
+				on: Error do: [ :e | self crTrace: ('{1} not a PNG, skipping.' format: { each fullName }) ] ] ].
+	iconsPerScale := newIconsPerScale.
 	scale := newScale
 ]
 


### PR DESCRIPTION
In pull request #13767, ThemeIcons was extended to allow one to specify which scale to load from the icon pack. This pull request expands on that so that the icons for the other scales are loaded as well. The other scales are not used yet though, that’s left to ‘future work’.

Loading these changes in an existing Pharo image will cause icons to become blank. That can be fixed by doing `ThemeIcons reset`.

The following pull request needs to be merged before this one: https://github.com/pharo-spec/NewTools/pull/609