### PR TITLE
Manifest builder should not rely on categories

### DIFF
--- a/src/Deprecated12/TheManifestBuilder.extension.st
+++ b/src/Deprecated12/TheManifestBuilder.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : 'TheManifestBuilder' }
+
+{ #category : '*Deprecated12' }
+TheManifestBuilder class >> ofPackageNamed: aPackageName [
+
+	| builder |
+	self deprecated: 'Call #ofPackage: instead because the only senders of this method is in NewTools and has the package directly.'.
+	builder := self new.
+	self allManifestClasses
+		detect: [ :each | each package name = aPackageName ]
+		ifFound: [ :manifestClass | builder manifestClass: manifestClass ]
+		ifNone: [ builder createManifestNamed: aPackageName ].
+	^ builder
+]

--- a/src/Manifest-Core/TheManifestBuilder.class.st
+++ b/src/Manifest-Core/TheManifestBuilder.class.st
@@ -48,13 +48,6 @@ TheManifestBuilder class >> hasManifestFor: aItem [
 	^  (self new manifestOf: aItem) isNil not
 ]
 
-{ #category : 'instance creation' }
-TheManifestBuilder class >> hasPackageNamed: aPackageName [
-
-	^ self allManifestClasses
-		anySatisfy: [:each | each category = aPackageName  ]
-]
-
 { #category : 'accessing - manifest' }
 TheManifestBuilder class >> manifestClassComment [
 
@@ -93,13 +86,14 @@ TheManifestBuilder class >> of: aItem [
 ]
 
 { #category : 'instance creation' }
-TheManifestBuilder class >> ofPackageNamed: aPackageName [
+TheManifestBuilder class >> ofPackage: aPackage [
+
 	| builder |
 	builder := self new.
 	self allManifestClasses
-		detect: [ :each | each category = aPackageName ]
+		detect: [ :each | each package = aPackage ]
 		ifFound: [ :manifestClass | builder manifestClass: manifestClass ]
-		ifNone: [ builder createManifestNamed: aPackageName ].
+		ifNone: [ builder createManifestNamed: aPackage name ].
 	^ builder
 ]
 

--- a/src/Renraku/ReSmalllintChecker.class.st
+++ b/src/Renraku/ReSmalllintChecker.class.st
@@ -145,21 +145,15 @@ ReSmalllintChecker >> isTruePositive: aCritic forRuleId: ruleId versionId: versi
 ]
 
 { #category : 'accessing' }
-ReSmalllintChecker >> manifestBuilderOf: aPackage [
+ReSmalllintChecker >> manifestBuilderOf: anEntity [
 
-	^ aPackage manifestBuilderForRuleChecker: self
+	^ anEntity manifestBuilderForRuleChecker: self
 ]
 
 { #category : 'accessing' }
 ReSmalllintChecker >> manifestBuilderOfClass: aClass [
-	| key |
-	key := aClass instanceSide category.
-	^ manifestClassCache
-		at: key
-		ifAbsentPut: [
-			(self builderManifestClass hasManifestFor: aClass)
-				ifTrue: [ self builderManifestClass of: aClass ]
-				ifFalse: [ nil ] ]
+
+	^ self manifestBuilderOfPackage: aClass package
 ]
 
 { #category : 'accessing' }
@@ -174,12 +168,10 @@ ReSmalllintChecker >> manifestBuilderOfMethod: aMethod [
 { #category : 'accessing' }
 ReSmalllintChecker >> manifestBuilderOfPackage: aPackage [
 
-	| key |
-	key := aPackage name.
-	^ manifestClassCache at: key ifAbsentPut: [
-		  (self builderManifestClass hasPackageNamed: key)
-			  ifTrue: [ self builderManifestClass ofPackageNamed: key ]
-			  ifFalse: [ nil ] ]
+	^ manifestClassCache at: aPackage name ifAbsentPut: [
+		  self builderManifestClass allManifestClasses
+			  detect: [ :class | class package = aPackage ]
+			  ifNone: [ nil ] ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
I also deprecated a method to use real packages instead