### PR TITLE
Packages: Fix missing extensions after class recompiling

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -293,6 +293,24 @@ CompiledMethodTest >> testAccessesSlot [
 	self assert: ((Point>>#setX:setY:) accessesSlot: (Point slotNamed: #y))
 ]
 
+{ #category : 'tests - compiling' }
+CompiledMethodTest >> testAddingSlotDoesNotRemoveExtension [
+	"Regression test for a case where recompiling a method removed the fact that it was an extension."
+
+	[
+	class := self class classInstaller make: [ :aBuilder |
+		         aBuilder
+			         name: #TUTU;
+			         slots: { #test };
+			         package: self packageNameForTests ].
+	class compile: 'isExtensionTestMethod ^ test' classified: '*Kernel-Tests-Generated-Package'.
+	self assert: (class >> #isExtensionTestMethod) isExtension.
+
+	class addInstVarNamed: 'test2'.
+
+	self assert: (class >> #isExtensionTestMethod) isExtension ] ensure: [ self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package' ]
+]
+
 { #category : 'tests - converting' }
 CompiledMethodTest >> testAsString [
 
@@ -345,7 +363,7 @@ CompiledMethodTest >> testComparison [
 			self deny: each equals: method2 ]
 ]
 
-{ #category : 'tests - abstract' }
+{ #category : 'tests - compiling' }
 CompiledMethodTest >> testCompilingExistingMethodDoesNotRemoveExtensions [
 	"Regression test for a case where recompiling a method removed the fact that it was an extension."
 
@@ -457,7 +475,7 @@ CompiledMethodTest >> testHasPragma [
 	self deny: methodWithOutPragma hasPragma
 ]
 
-{ #category : 'tests - abstract' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testIsAbstract [
 
 	self assert: (self class >> #abstractMethod) isAbstract.
@@ -481,7 +499,7 @@ CompiledMethodTest >> testIsDeprecated [
 			ifFalse: [ self deny: (self class >> each) isDeprecated ] ]
 ]
 
-{ #category : 'tests - abstract' }
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testIsExtension [
 
 	[
@@ -854,7 +872,7 @@ CompiledMethodTest >> testReadsSlot [
 	self deny: ((Point>>#setX:setY:) readsSlot: (Point slotNamed: #y))
 ]
 
-{ #category : 'tests - abstract' }
+{ #category : 'tests - compiling' }
 CompiledMethodTest >> testRecompilingDoesNotRemoveExtensions [
 	"Regression test for a case where recompiling a method removed the fact that it was an extension."
 

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -110,6 +110,11 @@ Behavior >> recompileBasic: selector from: oldClass [
 				permitFaulty: true;
 				compile.   "Assume OK after proceed from SyntaxError"
 	newMethod sourcePointer: method sourcePointer.
+	
+	"In case we are not compiling the method for the first time, we want to ensure that some properties are kept.
+	Opal should do the work but since we give the new class to opal it cannot find the old properties."
+	method propertyAt: #extensionPackage ifPresent: [ :package | newMethod propertyAt: #extensionPackage put: package ].
+
 
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
 	^ newMethod


### PR DESCRIPTION
This fixes a bug introduced with the new way to manage extensions.

When recompiling a class with an extension method accessing a slot, we were losing the extension. I added a regression test.