### PR TITLE
Traits: Fix bug in dictionary rebuild

### DIFF
--- a/src/Traits-Tests/TraitWithConflictsTest.class.st
+++ b/src/Traits-Tests/TraitWithConflictsTest.class.st
@@ -102,3 +102,23 @@ TraitWithConflictsTest >> testSameSourceButDifferentMethodsAreConflict [
 
 	self should: [ c1 new m1 ] raise: Error
 ]
+
+{ #category : 'tests' }
+TraitWithConflictsTest >> testTraitCompositionSelectorsDoesNotHaveDuplicates [
+
+	<ignoreNotImplementedSelectors: #( m1 )>
+	| t1 t2 c1 t3 t4 t5 t6 |
+	t1 := self newTrait: #T1.
+	t2 := self newTrait: #T2 traits: { t1 }.
+	t3 := self newTrait: #T3 traits: { t1 }.
+	t4 := self newTrait: #T4 traits: { (t2 + t3) }.
+	t5 := self newTrait: #T5 traits: { t3 }.
+	t6 := self newTrait: #T6 traits: { (t5 + t4) }.
+
+	t1 compile: 'm1 ^42'.
+
+	c1 := self newClass: #C1 with: #( aSlot ) traits: t6 + t1.
+
+	{  t2 . t3 . t4 . t5 . t6 . c1 } do: [ :behavior | self assert: behavior traitComposition selectors equals: { #m1 } ].
+	self assertEmpty: t1 traitComposition selectors
+]

--- a/src/Traits/TaCompositionElement.class.st
+++ b/src/Traits/TaCompositionElement.class.st
@@ -152,7 +152,8 @@ TaCompositionElement >> selectors [
 	" I get all the selectors of the methods in this talent, if there is a #initializeTalent selector I rename it to #initializeTalent_NameOfTalent"
 
 	| originals |
-	originals := self methods collect: [ :method | method selector ].
+	"We do not rely on the methods of the innerclass because while removing a trait we might return the removed methods during the removal and I need to work properly during the method dictionary rebuild"
+	originals := innerClass localSelectors , innerClass traitComposition selectors.
 	^ (originals includes: #initializeTalent)
 		  ifTrue: [ (originals reject: [ :e | e = #initializeTalent ]) copyWith: self initializeSelectorForMe ]
 		  ifFalse: [ originals ]

--- a/src/Traits/TaSequence.class.st
+++ b/src/Traits/TaSequence.class.st
@@ -245,7 +245,8 @@ TaSequence >> selectorForConflict: selector [
 
 { #category : 'accessing' }
 TaSequence >> selectors [
-	^ members flatCollect: #selectors
+	"We should really introduce a #removeDuplicates or #withoutDuplicates on Array..."
+	^ (members flatCollect: [ :member | member selectors ] as: Set) asArray
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Ok so this one was not an easy one and took me quite a while to hunt.

When we remove a trait from the system, it removes itself from its users. When this happens, the method dictionary of the behavior is rebuilt and we had a bug there! The bug was that TaCompositeElement>>#selector was returning the selectors of the methods of the element. But since we were in the middle of the method dictionary rebuild, we did not remove the copied methods from the removed trait yet! (Or maybe we got lucky on the rebuild order and it worked! This is the origin of the bug randomness). 

I updated the method to collect the selectors of the trait composition instead. Since the trait composition is right, the list of selectors will be updated even before we rebuild the method dictionary.

I also fixed another bug were diamonds in trait composition could return multiple times the selectors. 

Fixes #15282

Side note: Why did it start to fail now? Because before we were removing the classes in the reverse order of their compilation by a piece of code that was done by hand. Now we delegate this to the system by removing the packages containing the generated code. This means that the order is not the creation order. And depending on this, it could fail or not. But with this fix, we fix it for all trait removals and we do bypass this bug by taking care of the order ourself in the tests