### PR TITLE
Remove deprecated calls

### DIFF
--- a/src/Metacello-TestsReference/MetacelloReferenceConfig.class.st
+++ b/src/Metacello-TestsReference/MetacelloReferenceConfig.class.st
@@ -20,12 +20,6 @@ MetacelloReferenceConfig >> baseline10: spec [
 	<version: '1.0-baseline'>
 	
 	spec for: #common do: [
-		"alternate methods for specifying author, blessing, description, timestamp, preLoadDoIt, postLoadDoit (not recommended)"
-		spec blessing: [ spec value: #baseline. ].
-		spec description: [ spec value: 'Descriptive comment'. ].
-		spec author: [ spec value: 'dkh'. ].
-		spec timestamp: [ spec value: '10/7/2009 14:40'. ].
-		spec timestamp: [ spec value: (DateAndTime fromString: '10/7/2009 14:40'). ].
 		"recommended methods for specifying author, blessing, description, timestamp, preLoadDoIt, postLoadDoit"
 		"#development, #baseline, #release, #beta, etc."
 		spec blessing: #baseline.									


### PR DESCRIPTION
I recently deprecated the fact that we could give blocks instead of strings to some properties. They were still called in tests flooding the logs. Here we get rid of this aweful way to deal with those properties