### PR TITLE
Remove private system announcer

### DIFF
--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -8,7 +8,6 @@ Class {
 	#superclass : 'Announcer',
 	#instVars : [
 		'suspended',
-		'private',
 		'storedAnnouncements'
 	],
 	#category : 'Ring-Core-Announcements',
@@ -18,13 +17,10 @@ Class {
 
 { #category : 'announce' }
 RGEnvironmentAnnouncer >> announce: anAnnouncement [
+
 	self isSuspended
-		ifFalse: [
-			self private announce: anAnnouncement.
-			super announce: anAnnouncement ]
-		ifTrue:[
-			storedAnnouncements ifNotNil:[ storedAnnouncements add: anAnnouncement ]
-		]
+		ifFalse: [ super announce: anAnnouncement ]
+		ifTrue: [ storedAnnouncements ifNotNil: [ storedAnnouncements add: anAnnouncement ] ]
 ]
 
 { #category : 'triggering' }
@@ -104,11 +100,6 @@ RGEnvironmentAnnouncer >> methodRemoved: aMethod [
 			 origin: aMethod parent)
 ]
 
-{ #category : 'accessing' }
-RGEnvironmentAnnouncer >> private [
-	^private ifNil: [ private := Announcer new ]
-]
-
 { #category : 'announce' }
 RGEnvironmentAnnouncer >> suspendAllWhile: aBlock [
 	| oldSuspended |
@@ -136,10 +127,4 @@ RGEnvironmentAnnouncer >> suspendAllWhileStoring: aBlock [
 			storedAnnouncements := nil.
 		]
 	]
-]
-
-{ #category : 'subscription' }
-RGEnvironmentAnnouncer >> unsubscribe: anObject [
-	self private unsubscribe: anObject.
-	super unsubscribe: anObject
 ]

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -8,7 +8,6 @@ Class {
 	#superclass : 'Announcer',
 	#instVars : [
 		'suspended',
-		'private',
 		'storedAnnouncements'
 	],
 	#classInstVars : [
@@ -59,13 +58,10 @@ SystemAnnouncer class >> unload [
 
 { #category : 'announce' }
 SystemAnnouncer >> announce: anAnnouncement [
+
 	self isSuspended
-		ifFalse: [
-			self private announce: anAnnouncement.
-			super announce: anAnnouncement ]
-		ifTrue:[
-			storedAnnouncements ifNotNil:[ storedAnnouncements add: anAnnouncement ]
-		]
+		ifFalse: [ super announce: anAnnouncement ]
+		ifTrue: [ storedAnnouncements ifNotNil: [ storedAnnouncements add: anAnnouncement ] ]
 ]
 
 { #category : 'triggering' }
@@ -155,11 +151,6 @@ SystemAnnouncer >> methodRepackaged: aMethod from: aPackage to: anotherPackage [
 						newPackage: anotherPackage)
 ]
 
-{ #category : 'accessing' }
-SystemAnnouncer >> private [
-	^private ifNil: [ private := Announcer new ]
-]
-
 { #category : 'triggering' }
 SystemAnnouncer >> snapshotDone: isNewImage [
 
@@ -198,10 +189,4 @@ SystemAnnouncer >> suspendAllWhileStoring: aBlock [
 { #category : 'triggering' }
 SystemAnnouncer >> traitDefinitionChangedFrom: oldTrait to: newTrait [
 	self announce: (ClassModifiedClassDefinition classDefinitionChangedFrom: oldTrait to: newTrait)
-]
-
-{ #category : 'subscription' }
-SystemAnnouncer >> unsubscribe: anObject [
-	self private unsubscribe: anObject.
-	super unsubscribe: anObject
 ]

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -330,16 +330,16 @@ ChangeSet class >> newChanges: aChangeSet withOld: old [
 	SystemAnnouncer uniqueInstance unsubscribe: old.
 	current := aChangeSet.
 
-	SystemAnnouncer uniqueInstance private weak
+	SystemAnnouncer uniqueInstance weak
 		when: ClassRemoved send: #classRemoved: to: aChangeSet;
 		when: ClassAdded send: #classAdded: to: aChangeSet;
 		when: ClassCommented send: #classCommented: to: aChangeSet;
 		when: ClassRenamed send: #classRenamed: to: aChangeSet;
 		when: ProtocolAnnouncement send: #classReorganized: to: aChangeSet;
 		when: ClassRepackaged send: #classRepackaged: to: aChangeSet;
-		when: ClassModifiedClassDefinition send: #classModified: to: aChangeSet.
+		when: ClassModifiedClassDefinition send: #classModified: to: aChangeSet;
 
-	SystemAnnouncer uniqueInstance private weak
+
 		when: MethodAdded send: #methodAdded: to: aChangeSet;
 		when: MethodModified send: #methodModified: to: aChangeSet;
 		when: MethodRemoved send: #methodRemoved: to: aChangeSet;


### PR DESCRIPTION
From what I heard the private system announcer was here because of some cycles in announcements. I think they might be broken now that RPackage is integrated in the MM so maybe we can remove this hack?