### PR TITLE
do not hardcode global environment in #removeFromSystem: 

### DIFF
--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -908,7 +908,7 @@ Class >> removeFromSystem: logged [
 	self superclass ifNotNil: [ "If we have no superclass there's nothing to be remembered" self superclass addObsoleteSubclass: self ].
 
 	"we add the class to Undeclared so that if references still exist, they will  be automatically fixed if this class is loaded again. We do not check if references exist as it is too slow"
-	Undeclared declare: self name asSymbol from: Smalltalk globals.
+	Undeclared declare: self name asSymbol from: self environment.
 	self environment forgetClass: self.
 
 	"In case the class has deprecated aliases we need to remove them from the system dictionary.


### PR DESCRIPTION
#removeFromSystem: was hard coding Smalltalk globals, but the class knows it's environment