### PR TITLE
Metacello: fix block evaluation

### DIFF
--- a/src/Metacello-Core/MetacelloProjectRegistration.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistration.class.st
@@ -283,7 +283,7 @@ MetacelloProjectRegistration >> configurationProjectSpec: anObject [
 { #category : 'accessing' }
 MetacelloProjectRegistration >> configurationProjectSpecIfAbsent: absentBlock [
 
-	^ configurationProjectSpec ifNil: [ absentBlock ]
+	^ configurationProjectSpec ifNil: [ absentBlock value ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
In my recent changes of Metacello I introduced a stupid mistake of forgetting to evaluate a block