### PR TITLE
DependencyAnalyzer: Remove usage of RPackageSet

### DIFF
--- a/src/Tool-DependencyAnalyser-Tests/DAMessageSendAnalyzerTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAMessageSendAnalyzerTest.class.st
@@ -16,26 +16,6 @@ DAMessageSendAnalyzerTest >> setUp [
 ]
 
 { #category : 'tests' }
-DAMessageSendAnalyzerTest >> testRPackage [
-
-	self assert: (analyzer rPackage isKindOf: RPackage).
-	analyzer := DAMessageSendAnalyzer on: 'Unloaded-Dummy-Package'.
-	self
-		assert: (analyzer rPackage isKindOf: RPackage)
-		description: 'It test that rPackage still answer a RPackage even when the analyzer was instantiated with an unexisting or unloaded package'.
-	self assert: analyzer rPackage definedClasses isEmpty.
-
-]
-
-{ #category : 'tests' }
-DAMessageSendAnalyzerTest >> testRPackageIsAnsweredWithLoadedPackage [
-
-	self
-		assertCollection: analyzer rPackage definedClasses
-		hasSameElements: { DASomeClass }
-]
-
-{ #category : 'tests' }
 DAMessageSendAnalyzerTest >> testShouldFindDependencyWhenUnimplementedCalls [
 	self
 		assert: analyzer missingMethods size
@@ -51,4 +31,21 @@ DAMessageSendAnalyzerTest >> testShouldGetPotentialMatchForUnimplementedCalls [
 	self
 		assert: (analyzer missingMethodsWithPotentialMatchAfterManuallyResolvedDependenciesAddition values collect: #size)
 		equals: #(0 2 10)
+]
+
+{ #category : 'tests' }
+DAMessageSendAnalyzerTest >> testSystemPackage [
+
+	self assert: analyzer systemPackage class equals: RPackage.
+	analyzer := DAMessageSendAnalyzer on: 'Unloaded-Dummy-Package'.
+	self
+		assert: analyzer systemPackage class = RPackage
+		description: 'It test that rPackage still answer a RPackage even when the analyzer was instantiated with an unexisting or unloaded package'.
+	self assertEmpty: analyzer systemPackage definedClasses
+]
+
+{ #category : 'tests' }
+DAMessageSendAnalyzerTest >> testSystemPackageIsAnsweredWithLoadedPackage [
+
+	self assertCollection: analyzer systemPackage definedClasses hasSameElements: { DASomeClass }
 ]

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageCycleDetectorTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageCycleDetectorTest.class.st
@@ -44,13 +44,14 @@ DAPackageCycleDetectorTest >> queue [
 
 { #category : 'running' }
 DAPackageCycleDetectorTest >> setUp [
+
 	super setUp.
 	aPackageCycleDetection := DAPackageCycleDetector new.
-	packageA := DAPackage on: (RPackageSet named: 'A').
-	packageB := DAPackage on: (RPackageSet named: 'B').
-	packageC := DAPackage on: (RPackageSet named: 'C').
-	packageD := DAPackage on: (RPackageSet named: 'D').
-	packageE := DAPackage on: (RPackageSet named: 'E').
+	packageA := DAPackage onPackageNamed: 'A'.
+	packageB := DAPackage onPackageNamed: 'B'.
+	packageC := DAPackage onPackageNamed: 'C'.
+	packageD := DAPackage onPackageNamed: 'D'.
+	packageE := DAPackage onPackageNamed: 'E'.
 	cycleA := DAPackageCycle new.
 	cycleB := DAPackageCycle new.
 	cycleC := DAPackageCycle new

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageCycleTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageCycleTest.class.st
@@ -14,11 +14,12 @@ Class {
 
 { #category : 'running' }
 DAPackageCycleTest >> setUp [
+
 	super setUp.
 	aPDPackageCycle := DAPackageCycle new.
-	packageA := DAPackage on: (RPackageSet named:'A').
-	packageB := DAPackage on: (RPackageSet named:'B').
-	packageC := DAPackage on: (RPackageSet named:'C')
+	packageA := DAPackage onPackageNamed: 'A'.
+	packageB := DAPackage onPackageNamed: 'B'.
+	packageC := DAPackage onPackageNamed: 'C'
 ]
 
 { #category : 'tests' }
@@ -47,17 +48,20 @@ DAPackageCycleTest >> testIsInCycle [
 
 { #category : 'running' }
 DAPackageCycleTest >> testRemoveOutgoingDependencies [
+
 	| firstPackage secondPackage outgoingPackage otherOutgoingPackage |
-	firstPackage := DAPackage on: (RPackageSet named: 'A').
-	secondPackage := DAPackage on: (RPackageSet named: 'B').
-	outgoingPackage := DAPackage on: (RPackageSet named: 'C').
-	otherOutgoingPackage := DAPackage on: (RPackageSet named: 'D').
+	firstPackage := DAPackage onPackageNamed: 'A'.
+	secondPackage := DAPackage onPackageNamed: 'B'.
+	outgoingPackage := DAPackage onPackageNamed: 'C'.
+	otherOutgoingPackage := DAPackage onPackageNamed: 'D'.
 	firstPackage add: (DACompositeDependency from: firstPackage to: secondPackage).
 	firstPackage add: (DACompositeDependency from: firstPackage to: outgoingPackage).
 	firstPackage add: (DACompositeDependency from: firstPackage to: otherOutgoingPackage).
 	secondPackage add: (DACompositeDependency from: secondPackage to: firstPackage).
 	secondPackage add: (DACompositeDependency from: secondPackage to: outgoingPackage).
-	aPDPackageCycle addPackage: firstPackage; addPackage: secondPackage.
+	aPDPackageCycle
+		addPackage: firstPackage;
+		addPackage: secondPackage.
 	aPDPackageCycle removeOutgoingDependencies.
 	"at this point, package A and B does not have dependency with C and D, because C is not in the cycle"
 	"self halt."
@@ -80,8 +84,9 @@ DAPackageCycleTest >> testReversedCycle [
 
 { #category : 'tests' }
 DAPackageCycleTest >> testSizeOfCycles [
+
 	self assert: aPDPackageCycle size equals: 0.
-	aPDPackageCycle addPackage: (DAPackage on: (RPackageSet named: 'Kernel')).
-	aPDPackageCycle addPackage: (DAPackage on: (RPackageSet named: 'Collections-Abstract')).
+	aPDPackageCycle addPackage: (DAPackage onPackageNamed: 'Kernel').
+	aPDPackageCycle addPackage: (DAPackage onPackageNamed: 'Collections-Abstract').
 	self assert: aPDPackageCycle size equals: 2
 ]

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageDependencyTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageDependencyTest.class.st
@@ -32,14 +32,15 @@ DAPackageDependencyTest >> referenceDependency: aClass [
 
 { #category : 'running' }
 DAPackageDependencyTest >> setUp [
+
 	| source target |
 	super setUp.
-	source := DAPackage on: (RPackageSet named:'Kernel').
-	target := DAPackage on: (RPackageSet named:'Collections-Abstract').
-	aPackageDependency := DAPackageDependency from:source to:target.
-	anInternalPackageDependency := DAPackageDependency from:source to:source.
-	packageA := DAPackage on: (RPackageSet named:'A').
-	packageB := DAPackage on: (RPackageSet named:'B')
+	source := DAPackage onPackageNamed: 'Kernel'.
+	target := DAPackage onPackageNamed: 'Collections-Abstract'.
+	aPackageDependency := DAPackageDependency from: source to: target.
+	anInternalPackageDependency := DAPackageDependency from: source to: source.
+	packageA := DAPackage onPackageNamed: 'A'.
+	packageB := DAPackage onPackageNamed: 'B'
 ]
 
 { #category : 'tests' }

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageDependencyWrapperTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageDependencyWrapperTest.class.st
@@ -12,8 +12,9 @@ Class {
 
 { #category : 'running' }
 DAPackageDependencyWrapperTest >> setUp [
+
 	super setUp.
-	packageA := DAPackage on: (RPackageSet named:'A')
+	packageA := DAPackage onPackageNamed: 'A'
 ]
 
 { #category : 'tests' }

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphDiffTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphDiffTest.class.st
@@ -15,21 +15,22 @@ Class {
 
 { #category : 'running' }
 DAPackageRelationGraphDiffTest >> setUp [
+
 	| packageCollectionsAbstract packageCollectionsString |
 	super setUp.
-	packageA := DAPackage on: (RPackageSet named: 'A').
-	packageB := DAPackage on: (RPackageSet named: 'B').
-	packageCollectionsAbstract := DAPackage on: (RPackageSet named: 'Collections-Abstract').
-	packageCollectionsString := DAPackage on: (RPackageSet named: 'Collections-Strings').
-	oldRelationGraph := DAPackageRelationGraph onPackages: (Array with: packageCollectionsAbstract with: packageCollectionsString ).
-	newRelationGraph := DAPackageRelationGraph
-		onPackages: (Array with: (DAPackage on: (RPackageSet named: 'Collections-Abstract')) with: (DAPackage on: (RPackageSet named: 'Collections-Strings'))).
+	packageA := DAPackage onPackageNamed: 'A'.
+	packageB := DAPackage onPackageNamed: 'B'.
+	packageCollectionsAbstract := DAPackage onPackageNamed: 'Collections-Abstract'.
+	packageCollectionsString := DAPackage onPackageNamed: 'Collections-Strings'.
+	oldRelationGraph := DAPackageRelationGraph onPackages: (Array with: packageCollectionsAbstract with: packageCollectionsString).
+	newRelationGraph := DAPackageRelationGraph onPackages:
+		                    (Array with: (DAPackage onPackageNamed: 'Collections-Abstract') with: (DAPackage onPackageNamed: 'Collections-Strings')).
 	oldRelationGraph build.
 	newRelationGraph build.
 
 	packageRelationGraphDiff := DAPackageRelationGraphDiff new
-		oldRelationGraph: oldRelationGraph;
-		newRelationGraph: newRelationGraph
+		                            oldRelationGraph: oldRelationGraph;
+		                            newRelationGraph: newRelationGraph
 ]
 
 { #category : 'running' }
@@ -136,9 +137,10 @@ DAPackageRelationGraphDiffTest >> testRemovedDependentPackagesIncludesFrom [
 
 { #category : 'running' }
 DAPackageRelationGraphDiffTest >> testRemovedPackagesIncludes [
-	newRelationGraph clearPackages .
+
+	newRelationGraph clearPackages.
 	packageRelationGraphDiff makePackagesDiff.
 
-	self assert: (packageRelationGraphDiff removedPackagesIncludes: (DAPackage on: (RPackageSet named: 'Collections-Abstract'))).
-	self assert: (packageRelationGraphDiff removedPackagesIncludes: (DAPackage on: (RPackageSet named: 'Collections-Strings')))
+	self assert: (packageRelationGraphDiff removedPackagesIncludes: (DAPackage onPackageNamed: 'Collections-Abstract')).
+	self assert: (packageRelationGraphDiff removedPackagesIncludes: (DAPackage onPackageNamed: 'Collections-Strings'))
 ]

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageRelationGraphTest.class.st
@@ -28,20 +28,21 @@ DAPackageRelationGraphTest >> packageDependencyFrom: aPackage to: anOtherPackage
 
 { #category : 'running' }
 DAPackageRelationGraphTest >> setUp [
+
 	super setUp.
 	aPackageRelationGraph := DAPackageRelationGraph new.
-	packageCollectionAbstract := DAPackage on: (RPackageSet named: 'Collections-Abstract').
-	packageStrings := DAPackage on:(RPackageSet named: 'Collections-Strings').
-	packageKernel := DAPackage on:(RPackageSet named: 'Kernel').
-	packageMorphicBase := DAPackage on: (RPackageSet named: 'Morphic-Base').
-	packageTextCore := DAPackage on: (RPackageSet named: 'Text-Core').
-	packageRegexCore := DAPackage on:(RPackageSet named: 'Regex-Core').
-	packageCollectionsSequenceable := DAPackage on: (RPackageSet named: 'Collections-Sequenceable').
-	packagePackageDependencies := DAPackage on: (RPackageSet named:  #'Tool-DependencyAnalyser').
-	packageA := DAPackage on: (RPackageSet named: 'A').
-	packageB := DAPackage on: (RPackageSet named: 'B').
-	packageC := DAPackage on: (RPackageSet named: 'C').
-	packageD := DAPackage on: (RPackageSet named: 'D')
+	packageCollectionAbstract := DAPackage onPackageNamed: 'Collections-Abstract'.
+	packageStrings := DAPackage onPackageNamed: 'Collections-Strings'.
+	packageKernel := DAPackage onPackageNamed: 'Kernel'.
+	packageMorphicBase := DAPackage onPackageNamed: 'Morphic-Base'.
+	packageTextCore := DAPackage onPackageNamed: 'Text-Core'.
+	packageRegexCore := DAPackage onPackageNamed: 'Regex-Core'.
+	packageCollectionsSequenceable := DAPackage onPackageNamed: 'Collections-Sequenceable'.
+	packagePackageDependencies := DAPackage onPackageNamed: #'Tool-DependencyAnalyser'.
+	packageA := DAPackage onPackageNamed: 'A'.
+	packageB := DAPackage onPackageNamed: 'B'.
+	packageC := DAPackage onPackageNamed: 'C'.
+	packageD := DAPackage onPackageNamed: 'D'
 ]
 
 { #category : 'tests' }
@@ -133,10 +134,10 @@ DAPackageRelationGraphTest >> testCanGetDaPackageFromAGivenClass [
 
 { #category : 'tests' }
 DAPackageRelationGraphTest >> testClearAllDependencies [
+
 	| aRelationGraph packagesFromGraph |
-	aRelationGraph := DAPackageRelationGraph
-		onPackages:
-			(#('Collections-Abstract' 'Collections-Sequenceable') collect: [ :each | DAPackage on: (RPackageSet named: each) ]).
+	aRelationGraph := DAPackageRelationGraph onPackages:
+		                  (#( 'Collections-Abstract' 'Collections-Sequenceable' ) collect: [ :each | DAPackage onPackageNamed: each ]).
 	aRelationGraph
 		build;
 		clearAllDependencies.

--- a/src/Tool-DependencyAnalyser-Tests/DAPackageTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DAPackageTest.class.st
@@ -15,13 +15,14 @@ Class {
 
 { #category : 'running' }
 DAPackageTest >> setUp [
+
 	super setUp.
-	aPackage := DAPackage on: (RPackageSet named: 'Collections-Abstract').
-	aSecondPackage := DAPackage on: (RPackageSet named: 'Collections-Arithmetic').
-	packageA := DAPackage on: (RPackageSet named: 'A').
-	packageB := DAPackage on: (RPackageSet named: 'B').
-	packageC := DAPackage on: (RPackageSet named: 'C').
-	aPackage add: (DAInheritanceDependency from:aPackage to:aSecondPackage)
+	aPackage := DAPackage onPackageNamed: 'Collections-Abstract'.
+	aSecondPackage := DAPackage onPackageNamed: 'Collections-Arithmetic'.
+	packageA := DAPackage onPackageNamed: 'A'.
+	packageB := DAPackage onPackageNamed: 'B'.
+	packageC := DAPackage onPackageNamed: 'C'.
+	aPackage add: (DAInheritanceDependency from: aPackage to: aSecondPackage)
 ]
 
 { #category : 'tests' }

--- a/src/Tool-DependencyAnalyser-Tests/DATarjanAlgorithmTest.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/DATarjanAlgorithmTest.class.st
@@ -20,17 +20,18 @@ Class {
 
 { #category : 'running' }
 DATarjanAlgorithmTest >> setUp [
+
 	super setUp.
 	tarjanPackage := AITarjan new.
 	anArray := Array new: 8.
-	packageA := DAPackage on: (RPackageSet named: 'A').
-	packageB := DAPackage on: (RPackageSet named: 'B').
-	packageC := DAPackage on: (RPackageSet named: 'C').
-	packageD := DAPackage on: (RPackageSet named: 'D').
-	packageE := DAPackage on: (RPackageSet named: 'E').
-	packageF := DAPackage on: (RPackageSet named: 'F').
-	packageG := DAPackage on: (RPackageSet named: 'G').
-	packageH := DAPackage on: (RPackageSet named: 'H').
+	packageA := DAPackage onPackageNamed: 'A'.
+	packageB := DAPackage onPackageNamed: 'B'.
+	packageC := DAPackage onPackageNamed: 'C'.
+	packageD := DAPackage onPackageNamed: 'D'.
+	packageE := DAPackage onPackageNamed: 'E'.
+	packageF := DAPackage onPackageNamed: 'F'.
+	packageG := DAPackage onPackageNamed: 'G'.
+	packageH := DAPackage onPackageNamed: 'H'.
 	anArray at: 1 put: packageA.
 	anArray at: 2 put: packageB.
 	anArray at: 3 put: packageC.
@@ -38,7 +39,7 @@ DATarjanAlgorithmTest >> setUp [
 	anArray at: 5 put: packageE.
 	anArray at: 6 put: packageF.
 	anArray at: 7 put: packageG.
-	anArray at: 8 put:packageH
+	anArray at: 8 put: packageH
 ]
 
 { #category : 'utilities' }
@@ -54,7 +55,7 @@ DATarjanAlgorithmTest >> testNoOutgoingDependenciesAfterTarjan [
 	aCollection := OrderedCollection withAll: (self packageOrganizer packages
 			                select: [ :package | '*Collections*' match: package name asString ]
 			                thenCollect: [ :package | package name ]).
-	aRelation := DAPackageRelationGraph onPackages: (aCollection collect: [ :each | DAPackage on: (RPackageSet named: each) ]).
+	aRelation := DAPackageRelationGraph onPackages: (aCollection collect: [ :each | DAPackage onPackageNamed: each ]).
 	aRelation
 		computeStaticDependencies;
 		removeInternalDependencies;

--- a/src/Tool-DependencyAnalyser-Tests/ManifestToolDependencyAnalyserTests.class.st
+++ b/src/Tool-DependencyAnalyser-Tests/ManifestToolDependencyAnalyserTests.class.st
@@ -1,0 +1,10 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestToolDependencyAnalyserTests',
+	#superclass : 'PackageManifest',
+	#category : 'Tool-DependencyAnalyser-Tests-Manifest',
+	#package : 'Tool-DependencyAnalyser-Tests',
+	#tag : 'Manifest'
+}

--- a/src/Tool-DependencyAnalyser-UI-Tab/DABrowserToolMorph.class.st
+++ b/src/Tool-DependencyAnalyser-UI-Tab/DABrowserToolMorph.class.st
@@ -67,10 +67,10 @@ DABrowserToolMorph >> isSimilarTo: anotherBrowserTool [
 
 { #category : 'testing' }
 DABrowserToolMorph >> isValidInContext: aClyFullBrowserContext [
-	self context class = aClyFullBrowserContext class
-		ifFalse: [ ^ false ].
 
-	^ self analyzedPackage rPackageSet packageName = aClyFullBrowserContext lastSelectedClassGroup name
+	self context class = aClyFullBrowserContext class ifFalse: [ ^ false ].
+
+	^ self analyzedPackage packageName = aClyFullBrowserContext lastSelectedClassGroup name
 ]
 
 { #category : 'initialization' }

--- a/src/Tool-DependencyAnalyser-UI/DAAbstractPackageNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAAbstractPackageNode.class.st
@@ -22,7 +22,12 @@ DAAbstractPackageNode >> packageName [
 
 { #category : 'browse-nautilus' }
 DAAbstractPackageNode >> selectInBrowser [
-	"rPackage is always a RPackageSet"
 
-	self selectPackage: self rPackage packages last
+	self selectPackage: self systemPackage
+]
+
+{ #category : 'accessing' }
+DAAbstractPackageNode >> systemPackage [
+
+	^ self subclassResponsibility
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAAbstractPackageNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAAbstractPackageNode.class.st
@@ -29,5 +29,5 @@ DAAbstractPackageNode >> selectInBrowser [
 { #category : 'accessing' }
 DAAbstractPackageNode >> systemPackage [
 
-	^ self subclassResponsibility
+	^ self content systemPackage
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
@@ -97,5 +97,5 @@ DAAddPackagePresenter >> selectedItemsFromPackageList [
 { #category : 'accessing' }
 DAAddPackagePresenter >> systemPackages [
 
-	^ (self packageOrganizer packages collect: [ :package | package packageName asString ]) asSortedCollection
+	^ (self packageOrganizer packages collect: [ :package | package name asString ]) asSortedCollection
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAAddPackagePresenter.class.st
@@ -23,19 +23,17 @@ DAAddPackagePresenter class >> title [
 
 { #category : 'protocol' }
 DAAddPackagePresenter >> actionOnAddPackage [
+
 	| relationGraph packagesToAdd |
-	buttonAddPackage
-		action: [
-			self selectedItemsFromPackageList
-				ifNotEmpty: [
-					relationGraph := self dependenciesPresenter relationGraph.
-					packagesToAdd := self selectedItemsFromPackageList
-						collect: [ :packageName | (DAPackage on: (RPackageSet named: packageName)) beSeen ].
-					relationGraph addPackages: packagesToAdd.
-					self dependenciesPresenter
-						refresh;
-						resetDefaultSettings.
-					self delete ] ]
+	buttonAddPackage action: [
+		self selectedItemsFromPackageList ifNotEmpty: [
+			relationGraph := self dependenciesPresenter relationGraph.
+			packagesToAdd := self selectedItemsFromPackageList collect: [ :packageName | (DAPackage onPackageNamed: packageName) beSeen ].
+			relationGraph addPackages: packagesToAdd.
+			self dependenciesPresenter
+				refresh;
+				resetDefaultSettings.
+			self delete ] ]
 ]
 
 { #category : 'actions' }

--- a/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
@@ -46,13 +46,6 @@ DADependencyTreePresenter class >> defaultLayout [
 		yourself
 ]
 
-{ #category : 'instance creation' }
-DADependencyTreePresenter class >> onPackages: aCollection [
-	^ self new
-		initializeWithRPackageSet: aCollection;
-		yourself
-]
-
 { #category : 'examples' }
 DADependencyTreePresenter class >> onPackagesMatch: match [
 
@@ -63,7 +56,10 @@ DADependencyTreePresenter class >> onPackagesMatch: match [
 
 { #category : 'instance creation' }
 DADependencyTreePresenter class >> onPackagesNamed: aCollection [
-	^ self onPackages: (aCollection collect: [ :each | RPackageSet named: each ])
+
+	^ self new
+		  initializeWith: aCollection;
+		  yourself
 ]
 
 { #category : 'specs' }
@@ -265,8 +261,9 @@ DADependencyTreePresenter >> initializePresenters [
 ]
 
 { #category : 'accessing' }
-DADependencyTreePresenter >> initializeWithRPackageSet: aCollection [
-	self relationGraph: (DAPackageRelationGraph onPackages: (aCollection collect: [ :each | DAPackage on: each ]))
+DADependencyTreePresenter >> initializeWith: packageNames [
+
+	self relationGraph: (DAPackageRelationGraph onPackages: (packageNames collect: [ :packageName | DAPackage onPackageNamed: packageName ]))
 ]
 
 { #category : 'private' }
@@ -294,7 +291,8 @@ DADependencyTreePresenter >> packagesEntryCompletion [
 
 { #category : 'accessing' }
 DADependencyTreePresenter >> pdPackagesFrom: selectedItems [
-	^ selectedItems collect: [ :item | DAPackage on: (RPackageSet named: item content packageName asString) ]
+
+	^ selectedItems collect: [ :item | DAPackage onPackageNamed: item content packageName asString ]
 ]
 
 { #category : 'actions' }

--- a/src/Tool-DependencyAnalyser-UI/DADependentPackageNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependentPackageNode.class.st
@@ -53,5 +53,5 @@ DADependentPackageNode >> label [
 { #category : 'accessing' }
 DADependentPackageNode >> systemPackage [
 
-	^ self content target rPackageSet packages first
+	^ self content target systemPackage
 ]

--- a/src/Tool-DependencyAnalyser-UI/DADependentPackageNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependentPackageNode.class.st
@@ -47,10 +47,11 @@ DADependentPackageNode >> isPackageNode [
 
 { #category : 'displaying' }
 DADependentPackageNode >> label [
-	^ self rPackage packageName
+	^ self systemPackage name
 ]
 
 { #category : 'accessing' }
-DADependentPackageNode >> rPackage [
-	^ self content target rPackageSet
+DADependentPackageNode >> systemPackage [
+
+	^ self content target rPackageSet packages first
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAMissingMethodNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAMissingMethodNode.class.st
@@ -38,13 +38,14 @@ DAMissingMethodNode >> messageSendAnalysis [
 
 { #category : 'api' }
 DAMissingMethodNode >> messageSendNodes [
-	^ self messageSendAnalysis rPackage methods
-		select: [ :method | method sendsSelector: self content ]
-		thenCollect: [ :method |
-			DAMessageSendNode new
-				content: method;
-				parentNode: self;
-				yourself ]
+
+	^ self messageSendAnalysis systemPackage methods
+		  select: [ :method | method sendsSelector: self content ]
+		  thenCollect: [ :method |
+			  DAMessageSendNode new
+				  content: method;
+				  parentNode: self;
+				  yourself ]
 ]
 
 { #category : 'api' }
@@ -56,11 +57,6 @@ DAMissingMethodNode >> methodImplementationNodes [
 			parentNode: self;
 			yourself ])
 		sorted: [ :a :b | a content package name < b content package name ]
-]
-
-{ #category : 'private' }
-DAMissingMethodNode >> packageMethods [
-	^ self messageSendAnalysis rPackage methods
 ]
 
 { #category : 'browse-nautilus' }

--- a/src/Tool-DependencyAnalyser-UI/DANode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DANode.class.st
@@ -108,7 +108,8 @@ DANode >> label [
 
 { #category : 'accessing' }
 DANode >> packageUnderAnalysis [
-	^ self rootNode daPackage rPackageSet packages first
+
+	^ self rootNode daPackage systemPackage
 ]
 
 { #category : 'accessing' }

--- a/src/Tool-DependencyAnalyser-UI/DAPackageUnderAnalysisNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageUnderAnalysisNode.class.st
@@ -87,12 +87,6 @@ DAPackageUnderAnalysisNode >> printOn: aStream [
 	aStream nextPut: $)
 ]
 
-{ #category : 'browse-nautilus' }
-DAPackageUnderAnalysisNode >> systemPackage [
-
-	^ self content systemPackage
-]
-
 { #category : 'dependencies' }
 DAPackageUnderAnalysisNode >> wrappedPackageDependencies [
 	^ (self packageDependencies

--- a/src/Tool-DependencyAnalyser-UI/DAPackageUnderAnalysisNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageUnderAnalysisNode.class.st
@@ -88,8 +88,9 @@ DAPackageUnderAnalysisNode >> printOn: aStream [
 ]
 
 { #category : 'browse-nautilus' }
-DAPackageUnderAnalysisNode >> selectInBrowser [
-	self selectPackage: self content rPackage
+DAPackageUnderAnalysisNode >> systemPackage [
+
+	^ self content systemPackage
 ]
 
 { #category : 'dependencies' }

--- a/src/Tool-DependencyAnalyser-UI/DAReverseDependentPackageNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAReverseDependentPackageNode.class.st
@@ -36,6 +36,6 @@ DAReverseDependentPackageNode >> icon [
 ]
 
 { #category : 'accessing' }
-DAReverseDependentPackageNode >> rPackage [
-	^ self content rPackageSet
+DAReverseDependentPackageNode >> systemPackage [
+	^ self content rPackageSet packages first
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAReverseDependentPackageNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAReverseDependentPackageNode.class.st
@@ -34,9 +34,3 @@ DAReverseDependentPackageNode >> hasChildren [
 DAReverseDependentPackageNode >> icon [
 	^ self iconNamed: #back
 ]
-
-{ #category : 'accessing' }
-DAReverseDependentPackageNode >> systemPackage [
-
-	^ self content systemPackage
-]

--- a/src/Tool-DependencyAnalyser-UI/DAReverseDependentPackageNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAReverseDependentPackageNode.class.st
@@ -37,5 +37,6 @@ DAReverseDependentPackageNode >> icon [
 
 { #category : 'accessing' }
 DAReverseDependentPackageNode >> systemPackage [
-	^ self content rPackageSet packages first
+
+	^ self content systemPackage
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAReversePackageNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAReversePackageNode.class.st
@@ -31,6 +31,7 @@ DAReversePackageNode >> icon [
 ]
 
 { #category : 'accessing' }
-DAReversePackageNode >> rPackage [
-	^ self content rPackageSet
+DAReversePackageNode >> systemPackage [
+
+	^ self content rPackageSet packages first
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAReversePackageNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAReversePackageNode.class.st
@@ -33,5 +33,5 @@ DAReversePackageNode >> icon [
 { #category : 'accessing' }
 DAReversePackageNode >> systemPackage [
 
-	^ self content rPackageSet packages first
+	^self content systemPackage
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAReversePackageNode.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAReversePackageNode.class.st
@@ -29,9 +29,3 @@ DAReversePackageNode >> hasChildren [
 DAReversePackageNode >> icon [
 	^ self iconNamed: #package
 ]
-
-{ #category : 'accessing' }
-DAReversePackageNode >> systemPackage [
-
-	^self content systemPackage
-]

--- a/src/Tool-DependencyAnalyser/DADependentPackageWrapper.class.st
+++ b/src/Tool-DependencyAnalyser/DADependentPackageWrapper.class.st
@@ -80,11 +80,6 @@ DADependentPackageWrapper >> printOn: aStream [
 ]
 
 { #category : 'accessing' }
-DADependentPackageWrapper >> rPackageSet [
-	^ pdPackage rPackageSet
-]
-
-{ #category : 'accessing' }
 DADependentPackageWrapper >> relationGraph [
 	^ relationGraph
 ]
@@ -92,6 +87,11 @@ DADependentPackageWrapper >> relationGraph [
 { #category : 'accessing' }
 DADependentPackageWrapper >> relationGraph: anObject [
 	relationGraph := anObject
+]
+
+{ #category : 'accessing' }
+DADependentPackageWrapper >> systemPackage [
+	^ pdPackage systemPackage
 ]
 
 { #category : 'accessing' }

--- a/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
+++ b/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
@@ -145,9 +145,7 @@ DAMessageSendAnalyzer >> sentMessages [
 DAMessageSendAnalyzer >> systemPackage [
 	"Answer a <Package> matching the receiver's package name. If we are browsing an unloaded package, then answer a virtual RPackage so the message send analyzer could preserve its behavior with loaded packages in #manuallyResolvedDependencies"
 
-	^ packageAnalysis rPackageSet packages
-		  ifNotEmpty: [ :rPackages | rPackages detect: [ :each | each name = self packageName ] ]
-		  ifEmpty: [ RPackage named: 'Virtual' , self packageName ]
+	^ packageAnalysis systemPackage ifNil: [ RPackage named: 'Virtual' , self packageName ]
 ]
 
 { #category : 'computing' }

--- a/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
+++ b/src/Tool-DependencyAnalyser/DAMessageSendAnalyzer.class.st
@@ -63,7 +63,8 @@ DAMessageSendAnalyzer >> initializeWith: aDAPackage [
 
 { #category : 'accessing' }
 DAMessageSendAnalyzer >> manuallyResolvedDependencies [
-	^ self rPackage manuallyResolvedDependencies
+
+	^ self systemPackage manuallyResolvedDependencies
 ]
 
 { #category : 'computing' }
@@ -134,20 +135,19 @@ DAMessageSendAnalyzer >> possibleDeadCode [
 		select: #isEmpty
 ]
 
+{ #category : 'computing' }
+DAMessageSendAnalyzer >> sentMessages [
+
+	^self systemPackage methods flatCollect: #messages as: Set
+]
+
 { #category : 'accessing' }
-DAMessageSendAnalyzer >> rPackage [
-	"Answer a <RPackage> matching the receiver's package name. If we are browsing an unloaded package, then answer a virtual RPackage so the message send analyzer could preserve its behavior with loaded packages in #manuallyResolvedDependencies"
+DAMessageSendAnalyzer >> systemPackage [
+	"Answer a <Package> matching the receiver's package name. If we are browsing an unloaded package, then answer a virtual RPackage so the message send analyzer could preserve its behavior with loaded packages in #manuallyResolvedDependencies"
 
 	^ packageAnalysis rPackageSet packages
 		  ifNotEmpty: [ :rPackages | rPackages detect: [ :each | each name = self packageName ] ]
 		  ifEmpty: [ RPackage named: 'Virtual' , self packageName ]
-]
-
-{ #category : 'computing' }
-DAMessageSendAnalyzer >> sentMessages [
-	^ self rPackage methods
-		flatCollect: #messages
-		as: Set
 ]
 
 { #category : 'computing' }

--- a/src/Tool-DependencyAnalyser/DAMessageSendDependency.class.st
+++ b/src/Tool-DependencyAnalyser/DAMessageSendDependency.class.st
@@ -24,7 +24,8 @@ DAMessageSendDependency >> isMessageSendDependency [
 
 { #category : 'accessing' }
 DAMessageSendDependency >> users [
-	^  (source rPackage methods
-		select: [ :method | method messages includesAny: implementedMethods ]
-		thenCollect: [ :method | method -> (method messages intersection: implementedMethods) ])
+
+	^ source systemPackage methods
+		  select: [ :method | method messages includesAny: implementedMethods ]
+		  thenCollect: [ :method | method -> (method messages intersection: implementedMethods) ]
 ]

--- a/src/Tool-DependencyAnalyser/DAPackage.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackage.class.st
@@ -5,7 +5,7 @@ Instance variables :
 
 - dependencies : a collection of `DAPackageDependency` (actually the nodes of a graph dependency, from a source DAPackage to a target DAPackage)
 - included : says if the DAPackage is included or not, at the beginning, in the set of packages.
-- rpackage : the instance of asRPackageSet 	
+- systemPackage : the instance of asRPackageSet 	
 - inStack : useful for tarjan algorithm and cycle algorithm. It avoids stack access
 - tarjanIndex and tarjanLowLink : integer for the tarjan algorithm.
 - bfsParent : see cycle algorithm
@@ -244,12 +244,8 @@ DAPackage >> printOn: aStream [
 ]
 
 { #category : 'accessing' }
-DAPackage >> rPackage [
-	^ self rPackageSet packages first
-]
-
-{ #category : 'accessing' }
 DAPackage >> rPackageSet [
+
 	^ rPackageSet
 ]
 
@@ -272,6 +268,12 @@ DAPackage >> remove: aDependency [
 { #category : 'dependencies' }
 DAPackage >> removeAllInternal [
 	dependencies := dependencies reject: [ :each | each isInternal ]
+]
+
+{ #category : 'accessing' }
+DAPackage >> systemPackage [
+
+	^ self rPackageSet packages first
 ]
 
 { #category : 'tarjan' }

--- a/src/Tool-DependencyAnalyser/DAPackage.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackage.class.st
@@ -5,7 +5,7 @@ Instance variables :
 
 - dependencies : a collection of `DAPackageDependency` (actually the nodes of a graph dependency, from a source DAPackage to a target DAPackage)
 - included : says if the DAPackage is included or not, at the beginning, in the set of packages.
-- systemPackage : the instance of asRPackageSet 	
+- systemPackage : the instance of the package in the system if it is loaded 	
 - inStack : useful for tarjan algorithm and cycle algorithm. It avoids stack access
 - tarjanIndex and tarjanLowLink : integer for the tarjan algorithm.
 - bfsParent : see cycle algorithm
@@ -22,7 +22,8 @@ Class {
 		'tarjanLowLink',
 		'bfsParent',
 		'seen',
-		'rPackageSet'
+		'systemPackage',
+		'packageName'
 	],
 	#category : 'Tool-DependencyAnalyser-Core',
 	#package : 'Tool-DependencyAnalyser',
@@ -35,13 +36,13 @@ DAPackage class >> new [
 ]
 
 { #category : 'instance creation' }
-DAPackage class >> on: aRPackageSet [
-	^ self basicNew initializeWithPackage: aRPackageSet; yourself
-]
-
-{ #category : 'instance creation' }
 DAPackage class >> onPackageNamed: aString [
-	^ self on: (RPackageSet named: aString)
+	"In the future we should manage different environment and not go into the global one."
+
+	^ self basicNew
+		  initializeWithPackage: (self packageOrganizer packageNamed: aString ifAbsent: [ nil ]);
+		  packageName: aString;
+		  yourself
 ]
 
 { #category : 'comparing' }
@@ -199,10 +200,11 @@ DAPackage >> included: anObject [
 ]
 
 { #category : 'initialization' }
-DAPackage >> initializeWithPackage: aRPackageSet [
+DAPackage >> initializeWithPackage: aPackage [
+
 	self initialize.
 	self clearDependencies.
-	rPackageSet := aRPackageSet.
+	systemPackage := aPackage.
 	included := false.
 	inStack := false.
 	seen := false.
@@ -233,7 +235,13 @@ DAPackage >> isTarjanUndefined [
 
 { #category : 'accessing' }
 DAPackage >> packageName [
-	^ self rPackageSet packageName
+
+	^ packageName
+]
+
+{ #category : 'accessing' }
+DAPackage >> packageName: anObject [
+	packageName := anObject
 ]
 
 { #category : 'printing' }
@@ -241,17 +249,6 @@ DAPackage >> printOn: aStream [
 	aStream
 		nextPutAll: 'Dependencies on: ';
 		nextPutAll: self packageName
-]
-
-{ #category : 'accessing' }
-DAPackage >> rPackageSet [
-
-	^ rPackageSet
-]
-
-{ #category : 'accessing' }
-DAPackage >> rPackageSet: anObject [
-	rPackageSet := anObject
 ]
 
 { #category : 'accessing' }
@@ -273,7 +270,7 @@ DAPackage >> removeAllInternal [
 { #category : 'accessing' }
 DAPackage >> systemPackage [
 
-	^ self rPackageSet packages first
+	^ systemPackage
 ]
 
 { #category : 'tarjan' }

--- a/src/Tool-DependencyAnalyser/DAPackageCycleDetector.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageCycleDetector.class.st
@@ -38,15 +38,11 @@ DAPackageCycleDetector class >> new [
 ]
 
 { #category : 'instance creation' }
-DAPackageCycleDetector class >> onPackages: aCollection [
-	^ self basicNew
-		initializeWithRPackageSet: aCollection;
-		yourself
-]
-
-{ #category : 'instance creation' }
 DAPackageCycleDetector class >> onPackagesNamed: aCollection [
-	^ self onPackages: (aCollection collect: [ :each | RPackageSet named: each ])
+
+	^ self basicNew
+		  initializeWith: aCollection;
+		  yourself
 ]
 
 { #category : 'instance creation' }
@@ -165,8 +161,9 @@ DAPackageCycleDetector >> initializeVisitedNodes [
 ]
 
 { #category : 'initialization' }
-DAPackageCycleDetector >> initializeWithRPackageSet: aCollection [
-	relationGraph := DAPackageRelationGraph onPackages: (aCollection collect: [ :each | DAPackage on: each ]).
+DAPackageCycleDetector >> initializeWith: packageNames [
+
+	relationGraph := DAPackageRelationGraph onPackages: (packageNames collect: [ :packageName | DAPackage onPackageNamed: packageName ]).
 	cycles := OrderedCollection new.
 	self relationGraph build.
 	sccs := self runTarjan

--- a/src/Tool-DependencyAnalyser/DAPackageDependencyWrapper.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageDependencyWrapper.class.st
@@ -49,6 +49,7 @@ DAPackageDependencyWrapper >> printOn: aStream [
 ]
 
 { #category : 'accessing' }
-DAPackageDependencyWrapper >> rPackageSet [
-	^ daPackage rPackageSet
+DAPackageDependencyWrapper >> systemPackage [
+
+	^ daPackage systemPackage
 ]

--- a/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
+++ b/src/Tool-DependencyAnalyser/DAPackageRelationGraph.class.st
@@ -38,18 +38,17 @@ DAPackageRelationGraph class >> onPackagesNamed: packageNames [
 ]
 
 { #category : 'adding' }
-DAPackageRelationGraph >> addExtensionDependencies: aPDPackage [
-	aPDPackage rPackageSet extensionMethods
-		do: [ :method | | packageOfExtendedClass |
+DAPackageRelationGraph >> addExtensionDependencies: aDAPackage [
+
+	aDAPackage systemPackage ifNotNil: [ :package |
+		package extensionMethods do: [ :method |
+			| packageOfExtendedClass |
 			packageOfExtendedClass := self packageForBehavior: method methodClass.
 			self addPackage: packageOfExtendedClass.
-			aPDPackage
-				add:
-					((DAExtensionDependency from: aPDPackage to: packageOfExtendedClass)
-						theClass: method methodClass;
-						selector: method selector asSymbol;
-						method: method).
-			 ]
+			aDAPackage add: ((DAExtensionDependency from: aDAPackage to: packageOfExtendedClass)
+					 theClass: method methodClass;
+					 selector: method selector asSymbol;
+					 method: method) ] ]
 ]
 
 { #category : 'adding' }
@@ -188,11 +187,6 @@ DAPackageRelationGraph >> build [
 		combineDependencies
 ]
 
-{ #category : 'adding' }
-DAPackageRelationGraph >> classesFor: aPackage [
-	^ aPackage rPackageSet classes
-]
-
 { #category : 'actions' }
 DAPackageRelationGraph >> clearAllDependencies [
 	packages do: [ :package | package clearDependencies ]
@@ -248,7 +242,8 @@ DAPackageRelationGraph >> computeStaticDependencies: aPackage [
 
 { #category : 'accessing' }
 DAPackageRelationGraph >> daPackageWith: packageName [
-	^ DAPackage on: (RPackageSet named: packageName)
+
+	^ DAPackage onPackageNamed: packageName
 ]
 
 { #category : 'accessing' }
@@ -310,7 +305,10 @@ DAPackageRelationGraph >> isReference: aLiteral [
 
 { #category : 'adding' }
 DAPackageRelationGraph >> methodsFor: aPackage [
-	^ aPackage rPackageSet methods
+
+	^ aPackage systemPackage
+		  ifNil: [ #(  ) ]
+		  ifNotNil: [ :package | package methods ]
 ]
 
 { #category : 'accessing' }
@@ -328,7 +326,8 @@ DAPackageRelationGraph >> outgoing [
 
 { #category : 'enumerating' }
 DAPackageRelationGraph >> package: aPackage classesDo: aBlock [
-	aPackage rPackageSet classes do: aBlock
+
+	aPackage systemPackage ifNotNil: [ :package | package classes do: aBlock ]
 ]
 
 { #category : 'accessing' }
@@ -348,13 +347,14 @@ DAPackageRelationGraph >> packageForBehavior: aClass [
 		at: aClass
 		ifAbsentPut: [
 			self packages
-				detect: [ :each | each rPackageSet includesClass: aClass ]
+				detect: [ :each | each systemPackage includesClass: aClass ]
 				ifNone: [ self systemPackageContaining: aClass ] ]
 ]
 
 { #category : 'accessing' }
 DAPackageRelationGraph >> packageForClass: aClass [
-	^ packages detect: [ :package | package rPackageSet includesClass: aClass ]
+
+	^ packages detect: [ :package | package systemPackage includesClass: aClass ]
 ]
 
 { #category : 'accessing' }
@@ -488,7 +488,7 @@ DAPackageRelationGraph >> systemPackageContaining: aClass [
 
 	^ aClass package name
 		  ifNil: [ self error: 'Package for ' , aClass name , ' not found.' ]
-		  ifNotNil: [ :packageName | DAPackage on: (RPackageSet named: packageName asString) ]
+		  ifNotNil: [ :packageName | DAPackage onPackageNamed: packageName asString ]
 ]
 
 { #category : 'computing' }


### PR DESCRIPTION
This change updates the dependency analyzer so that DAPackage is now based on a system package and not a RPackageSet since RPackageSet will get deprecated