### PR TITLE
Some cleanup of CodeExport

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -166,7 +166,7 @@ echo $(date -u) "[Compiler] Installing Traits through Hermes"
 
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save ${TRAITS_IMAGE_NAME}
 ${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Traits.hermes --save
-${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Kernel-Traits.hermes Collections-Abstract-Traits.hermes CodeImport-Traits.hermes CodeExport-Traits.hermes --save
+${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Kernel-Traits.hermes Collections-Abstract-Traits.hermes CodeImport-Traits.hermes --save
 zip "${TRAITS_IMAGE_NAME}.zip" "${TRAITS_IMAGE_NAME}.image"
 
 #Bootstrap Initialization: Class and RPackage initialization

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -149,7 +149,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" initializePackages --proto
 
 # Installing compiler through Hermes 
 echo $(date -u) "[Compiler] Installing compiler through Hermes"
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes OpalCompiler-Core.hermes CodeExport.hermes CodeImport.hermes CodeImportCommandLineHandlers.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes OpalCompiler-Core.hermes CodeImport.hermes CodeImportCommandLineHandlers.hermes --save --no-fail-on-undeclared
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "OpalCompiler register. CompilationContext initialize. OCASTTranslator initialize."
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/01-init.st --no-source --save --quit
 

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -68,6 +68,7 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'NECompletion-Preferences'.
 		spec package: 'Metacello-FileTree'.
 		spec package: 'Metacello-Cypress'.
+		spec package: 'CodeExport'..
 		spec package: 'MonticelloGUI'.
 		spec package: 'Monticello-GUI-Diff' with: [ spec requires: #( 'Tool-Diff' 'MonticelloGUI' ) ].
 		spec package: 'System-Changes-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -68,7 +68,7 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'NECompletion-Preferences'.
 		spec package: 'Metacello-FileTree'.
 		spec package: 'Metacello-Cypress'.
-		spec package: 'CodeExport'..
+		spec package: 'CodeExport'.
 		spec package: 'MonticelloGUI'.
 		spec package: 'Monticello-GUI-Diff' with: [ spec requires: #( 'Tool-Diff' 'MonticelloGUI' ) ].
 		spec package: 'System-Changes-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -68,7 +68,7 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'NECompletion-Preferences'.
 		spec package: 'Metacello-FileTree'.
 		spec package: 'Metacello-Cypress'.
-		spec package: 'CodeExport'.
+		spec package: 'CodeExport'..
 		spec package: 'MonticelloGUI'.
 		spec package: 'Monticello-GUI-Diff' with: [ spec requires: #( 'Tool-Diff' 'MonticelloGUI' ) ].
 		spec package: 'System-Changes-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -129,7 +129,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		
 		spec package: 'FFI-Kernel'.
 				
-		spec package: 'CodeExport'.
 		spec package: 'CodeImport'.
 		
 		spec package: 'CodeImportCommandLineHandlers'.
@@ -206,7 +205,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'AST-Core'.
 			'Collections-Arithmetic'.
 			'Collections-Atomic'.
-			'CodeExport'.
 			'CodeImport'.
 			'CodeImportCommandLineHandlers'.
 			'Jobs'.

--- a/src/BaselineOfTraits/BaselineOfTraits.class.st
+++ b/src/BaselineOfTraits/BaselineOfTraits.class.st
@@ -39,12 +39,11 @@ BaselineOfTraits >> baseline: spec [
 			package: 'Kernel-Traits' with: [ spec requires: #( 'Traits' ) ];
 			package: 'Collections-Abstract-Traits' with: [ spec requires: #( 'Traits' ) ];
 			package: 'CodeImport-Traits' with: [ spec requires: #( 'Traits' ) ];
-			package: 'CodeExport-Traits' with: [ spec requires: #( 'Traits' ) ];
 			package: 'Traits-Tests' with: [ spec requires: #( 'Traits' ) ].
 
 		spec group: 'core' with: #( 'Traits' ).
 
-		spec group: 'core-traits' with: #( 'Kernel-Traits' 'Collections-Abstract-Traits' 'CodeImport-Traits' 'CodeExport-Traits' ).
+		spec group: 'core-traits' with: #( 'Kernel-Traits' 'Collections-Abstract-Traits' 'CodeImport-Traits' ).
 
 		spec group: 'default' with: #( 'core-traits' ).
 		spec group: 'traits-tests' with: #( 'default' 'Traits-Tests' ) ]

--- a/src/CodeExport/ChangeSet.extension.st
+++ b/src/CodeExport/ChangeSet.extension.st
@@ -1,0 +1,182 @@
+Extension { #name : 'ChangeSet' }
+
+{ #category : '*CodeExport' }
+ChangeSet >> fileOut [
+	"File out the receiver, to a file whose name is a function of the
+	change-set name and a unique numeric tag."
+
+	| fileReference dir |
+	dir := self class promptForDefaultChangeSetDirectoryIfNecessary.
+	fileReference := ( dir / self name , 'cs') nextVersion.
+	self fileOutBody: fileReference
+]
+
+{ #category : '*CodeExport' }
+ChangeSet >> fileOutBody: fileReference [
+
+	UIManager default
+		showWaitCursorWhile:
+			[
+			| internalStream |
+			internalStream := (String new: 10000) writeStream.
+			internalStream
+				header;
+				timeStamp.
+			self fileOutPreambleOn: internalStream.
+			self fileOutOn: internalStream.
+			self fileOutPostscriptOn: internalStream.
+
+			CodeExporter
+				writeSourceCodeFrom: internalStream
+				toFileReference: fileReference ]
+]
+
+{ #category : '*CodeExport' }
+ChangeSet >> fileOutChangesFor: class on: stream [
+	"Write out all the method changes for this class."
+
+	| changes |
+	changes := Set new.
+	(self methodChangesAtClass: class name)
+		associationsDo: [ :mAssoc |
+			(mAssoc value = #remove or: [ mAssoc value = #addedThenRemoved ])
+				ifFalse: [ changes add: mAssoc key ] ].
+	changes isEmpty
+		ifTrue: [ ^ self ].
+	class fileOutChangedMessages: changes on: stream.
+	stream cr
+]
+
+{ #category : '*CodeExport' }
+ChangeSet >> fileOutClassDefinition: class on: stream [
+	"Write out class definition for the given class on the given stream, if the class definition was added or changed."
+
+	(self atClass: class includes: #rename)
+		ifTrue: [
+			stream
+				nextChunkPut: 'Smalltalk renameClassNamed: #' , (self oldNameFor: class) , ' as: #' , class name;
+				cr ].
+	(self atClass: class includes: #change)
+		ifTrue: [
+			"fat definition only needed for changes"
+			stream
+				nextChunkPut: class definitionString;
+				cr.
+			DeepCopier new checkClass: class	"If veryDeepCopy weakly copies some inst
+			vars in this class, warn author when new ones are added." ]
+		ifFalse: [
+			(self atClass: class includes: #add)
+				ifTrue: [
+					"use current definition for add"
+					stream
+						nextChunkPut: class definition;
+						cr.
+					DeepCopier new checkClass: class	"If veryDeepCopy weakly copies some inst
+				vars in this class, warn author when new ones are added." ] ].
+	(self atClass: class includes: #comment)
+		ifFalse: [ ^ self ].
+	class instanceSide putCommentOnFile: stream.
+	stream cr
+]
+
+{ #category : '*CodeExport' }
+ChangeSet >> fileOutOn: stream [
+	"Write out all the changes the receiver knows about"
+
+	| classList traits classes traitList list |
+	self isEmpty ifTrue: [self inform: 'Warning: no changes to file out'].
+
+	traits := self changedClasses select: [:each | each isTrait].
+	classes := self changedClasses select: [:each | each isBehavior & each isTrait not].
+	traitList := self class traitsOrder: traits asOrderedCollection.
+	classList := self class classesOrder: classes asOrderedCollection.
+	list := OrderedCollection new
+		addAll: traitList;
+		addAll: classList;
+		yourself.
+
+	"First put out rename, max classDef and comment changes."
+	list do: [:aClass | self fileOutClassDefinition: aClass on: stream].
+
+	"Then put out all the method changes"
+	list do: [:aClass | self fileOutChangesFor: aClass on: stream].
+
+	"Finally put out removals, final class defs and reorganization if any"
+	list reverseDo: [:aClass | self fileOutPSFor: aClass on: stream].
+
+	self classRemoves asSortedCollection do:
+		[:aClassName | stream nextChunkPut: 'Smalltalk removeClassNamed: #', aClassName; cr]
+]
+
+{ #category : '*CodeExport' }
+ChangeSet >> fileOutPSFor: class on: stream [
+	"Write out removals and initialization for this class."
+
+	| dict classRecord currentDef |
+	classRecord := changeRecords at: class name ifAbsent: [ ^ self ].
+	dict := classRecord methodChangeTypes.
+	dict keysSortedSafely
+		do: [ :key |
+			| changeType |
+			changeType := dict at: key.
+			(#(#remove #addedThenRemoved) includes: changeType)
+				ifTrue: [
+					stream
+						nextChunkPut: class name , ' removeSelector: ' , key storeString;
+						cr ]
+				ifFalse: [
+					(key = #initialize and: [ class isMeta ])
+						ifTrue: [
+							stream
+								nextChunkPut: class soleInstance name , ' initialize';
+								cr ] ] ].
+	((classRecord includesChangeType: #change) and: [ (currentDef := class definitionString) ~= class definitionString ])
+		ifTrue: [
+			stream
+				nextChunkPut: currentDef;
+				cr ].
+	(classRecord includesChangeType: #reorganize)
+		ifFalse: [ ^ self ].
+	class fileOutProtocolsOn: stream.
+	stream cr
+]
+
+{ #category : '*CodeExport' }
+ChangeSet >> fileOutPostscriptOn: stream [
+	"If the receiver has a postscript, put it out onto the stream.  "
+
+	| aString |
+	aString := self postscriptString.
+	(aString isNotNil and: [ aString notEmpty ])
+		ifFalse: [ ^ self ].
+	stream nextChunkPut: aString.	"surroundedBySingleQuotes"
+	stream
+		cr;
+		cr
+]
+
+{ #category : '*CodeExport' }
+ChangeSet >> fileOutPreambleOn: stream [
+	"If the receiver has a preamble, put it out onto the stream.  "
+
+	| aString |
+	aString := self preambleString.
+	(aString isNotNil and: [ aString notEmpty ])
+		ifFalse: [ ^ self ].
+	stream nextChunkPut: aString.	"surroundedBySingleQuotes"
+	stream
+		cr;
+		cr
+]
+
+{ #category : '*CodeExport' }
+ChangeSet class >> promptForDefaultChangeSetDirectoryIfNecessary [
+	<script>
+
+	| path |
+	path := UIManager default
+		chooseDirectory: 'Please select where you want to save your cs'
+		from: FileSystem workingDirectory.
+	self defaultChangeSetDirectoryName: path asFileReference.
+	^ path asFileReference
+]

--- a/src/CodeExport/ClassDescription.extension.st
+++ b/src/CodeExport/ClassDescription.extension.st
@@ -115,32 +115,6 @@ ClassDescription >> printMethodChunk: selector on: outStream [
 ]
 
 { #category : '*CodeExport' }
-ClassDescription >> printProtocolChunk: protocol on: aFileStream withStamp: changeStamp priorMethod: priorMethod [
-	"Print a method preamble.  This must have a protocol name.
-	It may have an author/date stamp, and it may have a prior source link.
-	If it has a prior source link, it MUST have a stamp, even if it is empty."
-
-	"The current design is that changeStamps and prior source links are preserved in the changes file.  All fileOuts include changeStamps.  Condensing sources, however, eliminates all stamps (and links, natch)."
-
-	aFileStream
-		cr;
-		nextPut: $!.
-	aFileStream nextChunkPut: (String streamContents: [ :strm |
-			 strm
-				 nextPutAll: self name;
-				 nextPutAll: ' methodsFor: ';
-				 print: protocol name asString.
-			 (changeStamp isNotNil and: [ changeStamp size > 0 or: [ priorMethod isNotNil ] ]) ifTrue: [
-				 strm
-					 nextPutAll: ' stamp: ';
-					 print: changeStamp ].
-			 priorMethod ifNotNil: [
-				 strm
-					 nextPutAll: ' prior: ';
-					 print: priorMethod sourcePointer ] ])
-]
-
-{ #category : '*CodeExport' }
 ClassDescription >> putCommentOnFile: aFileStream [ 
 	"Store the comment about the class onto file, aFileStream."
 

--- a/src/CodeExport/TraitedClass.extension.st
+++ b/src/CodeExport/TraitedClass.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'TraitedClass' }
 
-{ #category : '*CodeExport-Traits' }
+{ #category : '*CodeExport' }
 TraitedClass >> fileOutLocalMethodsInProtocol: protocol on: aFileStream [
 
 	aFileStream cr.

--- a/src/CodeExport/TraitedMetaclass.extension.st
+++ b/src/CodeExport/TraitedMetaclass.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'TraitedMetaclass' }
 
-{ #category : '*CodeExport-Traits' }
+{ #category : '*CodeExport' }
 TraitedMetaclass >> fileOutLocalMethodsInProtocol: protocol on: aFileStream [
 
 	aFileStream cr.

--- a/src/CodeExport/WriteStream.extension.st
+++ b/src/CodeExport/WriteStream.extension.st
@@ -1,23 +1,6 @@
 Extension { #name : 'WriteStream' }
 
 { #category : '*CodeExport' }
-WriteStream >> nextChunkPut: aString [
-	"Append the argument, aString, to the receiver, doubling embedded ! terminators and adding a extra one"
-
-	| string start bangIndex |
-	string := aString asString.
-	start := 1.
-	[ (bangIndex := string indexOf: $! startingAt: start) = 0 ]
-		whileFalse: [
-			self next: bangIndex - start + 1 putAll: string startingAt: start.
-			self nextPut: $!. "double it"
-			start := bangIndex + 1 ].
-	self next: string size - start + 1 putAll: string startingAt: start.
-	self nextPut: $!. "one extra"
-	self flush
-]
-
-{ #category : '*CodeExport' }
 WriteStream >> timeStamp [
 	"Append the current time to the receiver as a String."
 	self nextChunkPut:	"double string quotes and !s"

--- a/src/OpalCompiler-Core/ManifestOpalCompilerCore.class.st
+++ b/src/OpalCompiler-Core/ManifestOpalCompilerCore.class.st
@@ -13,7 +13,7 @@ ManifestOpalCompilerCore class >> ignoredDependencies [
 
 { #category : 'meta-data - dependency analyser' }
 ManifestOpalCompilerCore class >> manuallyResolvedDependencies [
-	^ #(#'Morphic-Base' #'System-Settings-Core' #CodeExport #'System-Announcements' #'System-Sources')
+	^ #(#'Morphic-Base' #'System-Settings-Core' #'System-Announcements' #'System-Sources')
 ]
 
 { #category : 'code-critics' }

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -380,18 +380,6 @@ ChangeSet class >> promoteToTop: aChangeSet [
 	AllChangeSets add: aChangeSet
 ]
 
-{ #category : 'defaults' }
-ChangeSet class >> promptForDefaultChangeSetDirectoryIfNecessary [
-	<script>
-
-	| path |
-	path := UIManager default
-		chooseDirectory: 'Please select where you want to save your cs'
-		from: FileSystem workingDirectory.
-	self defaultChangeSetDirectoryName: path asFileReference.
-	^ path asFileReference
-]
-
 { #category : 'system-events' }
 ChangeSet class >> registerInterestToSystemAnnouncer [
 	<systemEventRegistration>
@@ -659,19 +647,6 @@ ChangeSet >> changedMessageList [
 	^ messageList asArray sort
 ]
 
-{ #category : 'file in/out' }
-ChangeSet >> checkForSlips [
-	"Return a collection of method refs with possible debugging code in them."
-
-	| slips |
-	slips := OrderedCollection new.
-	self changedClasses do: [ :aClass |
-		(self methodChangesAtClass: aClass name) associationsDo: [ :mAssoc |
-			(#( remove addedThenRemoved ) includes: mAssoc value) ifFalse: [
-				aClass compiledMethodAt: mAssoc key ifPresent: [ :method | (self hasReportableSlip: method) ifTrue: [ slips add: aClass >> mAssoc key ] ] ] ] ].
-	^ slips
-]
-
 { #category : 'change logging' }
 ChangeSet >> classAdded: anEvent [
 
@@ -820,175 +795,6 @@ ChangeSet >> expungeEmptyClassChangeEntries [
 		classRecord hasNoChanges ]
 ]
 
-{ #category : 'file in/out' }
-ChangeSet >> fileOut [
-	"File out the receiver, to a file whose name is a function of the
-	change-set name and a unique numeric tag."
-
-	| fileReference dir |
-	dir := self class promptForDefaultChangeSetDirectoryIfNecessary.
-	fileReference := ( dir / self name , 'cs') nextVersion.
-	self fileOutBody: fileReference
-]
-
-{ #category : 'file in/out' }
-ChangeSet >> fileOutBody: fileReference [
-
-	UIManager default
-		showWaitCursorWhile:
-			[
-			| internalStream |
-			internalStream := (String new: 10000) writeStream.
-			internalStream
-				header;
-				timeStamp.
-			self fileOutPreambleOn: internalStream.
-			self fileOutOn: internalStream.
-			self fileOutPostscriptOn: internalStream.
-
-			CodeExporter
-				writeSourceCodeFrom: internalStream
-				toFileReference: fileReference ]
-]
-
-{ #category : 'file in/out' }
-ChangeSet >> fileOutChangesFor: class on: stream [
-	"Write out all the method changes for this class."
-
-	| changes |
-	changes := Set new.
-	(self methodChangesAtClass: class name)
-		associationsDo: [ :mAssoc |
-			(mAssoc value = #remove or: [ mAssoc value = #addedThenRemoved ])
-				ifFalse: [ changes add: mAssoc key ] ].
-	changes isEmpty
-		ifTrue: [ ^ self ].
-	class fileOutChangedMessages: changes on: stream.
-	stream cr
-]
-
-{ #category : 'private' }
-ChangeSet >> fileOutClassDefinition: class on: stream [
-	"Write out class definition for the given class on the given stream, if the class definition was added or changed."
-
-	(self atClass: class includes: #rename)
-		ifTrue: [
-			stream
-				nextChunkPut: 'Smalltalk renameClassNamed: #' , (self oldNameFor: class) , ' as: #' , class name;
-				cr ].
-	(self atClass: class includes: #change)
-		ifTrue: [
-			"fat definition only needed for changes"
-			stream
-				nextChunkPut: class definitionString;
-				cr.
-			DeepCopier new checkClass: class	"If veryDeepCopy weakly copies some inst
-			vars in this class, warn author when new ones are added." ]
-		ifFalse: [
-			(self atClass: class includes: #add)
-				ifTrue: [
-					"use current definition for add"
-					stream
-						nextChunkPut: class definition;
-						cr.
-					DeepCopier new checkClass: class	"If veryDeepCopy weakly copies some inst
-				vars in this class, warn author when new ones are added." ] ].
-	(self atClass: class includes: #comment)
-		ifFalse: [ ^ self ].
-	class instanceSide putCommentOnFile: stream.
-	stream cr
-]
-
-{ #category : 'file in/out' }
-ChangeSet >> fileOutOn: stream [
-	"Write out all the changes the receiver knows about"
-
-	| classList traits classes traitList list |
-	self isEmpty ifTrue: [self inform: 'Warning: no changes to file out'].
-
-	traits := self changedClasses select: [:each | each isTrait].
-	classes := self changedClasses select: [:each | each isBehavior & each isTrait not].
-	traitList := self class traitsOrder: traits asOrderedCollection.
-	classList := self class classesOrder: classes asOrderedCollection.
-	list := OrderedCollection new
-		addAll: traitList;
-		addAll: classList;
-		yourself.
-
-	"First put out rename, max classDef and comment changes."
-	list do: [:aClass | self fileOutClassDefinition: aClass on: stream].
-
-	"Then put out all the method changes"
-	list do: [:aClass | self fileOutChangesFor: aClass on: stream].
-
-	"Finally put out removals, final class defs and reorganization if any"
-	list reverseDo: [:aClass | self fileOutPSFor: aClass on: stream].
-
-	self classRemoves asSortedCollection do:
-		[:aClassName | stream nextChunkPut: 'Smalltalk removeClassNamed: #', aClassName; cr]
-]
-
-{ #category : 'file in/out' }
-ChangeSet >> fileOutPSFor: class on: stream [
-	"Write out removals and initialization for this class."
-
-	| dict classRecord currentDef |
-	classRecord := changeRecords at: class name ifAbsent: [ ^ self ].
-	dict := classRecord methodChangeTypes.
-	dict keysSortedSafely
-		do: [ :key |
-			| changeType |
-			changeType := dict at: key.
-			(#(#remove #addedThenRemoved) includes: changeType)
-				ifTrue: [
-					stream
-						nextChunkPut: class name , ' removeSelector: ' , key storeString;
-						cr ]
-				ifFalse: [
-					(key = #initialize and: [ class isMeta ])
-						ifTrue: [
-							stream
-								nextChunkPut: class soleInstance name , ' initialize';
-								cr ] ] ].
-	((classRecord includesChangeType: #change) and: [ (currentDef := class definitionString) ~= class definitionString ])
-		ifTrue: [
-			stream
-				nextChunkPut: currentDef;
-				cr ].
-	(classRecord includesChangeType: #reorganize)
-		ifFalse: [ ^ self ].
-	class fileOutProtocolsOn: stream.
-	stream cr
-]
-
-{ #category : 'file in/out' }
-ChangeSet >> fileOutPostscriptOn: stream [
-	"If the receiver has a postscript, put it out onto the stream.  "
-
-	| aString |
-	aString := self postscriptString.
-	(aString isNotNil and: [ aString notEmpty ])
-		ifFalse: [ ^ self ].
-	stream nextChunkPut: aString.	"surroundedBySingleQuotes"
-	stream
-		cr;
-		cr
-]
-
-{ #category : 'file in/out' }
-ChangeSet >> fileOutPreambleOn: stream [
-	"If the receiver has a preamble, put it out onto the stream.  "
-
-	| aString |
-	aString := self preambleString.
-	(aString isNotNil and: [ aString notEmpty ])
-		ifFalse: [ ^ self ].
-	stream nextChunkPut: aString.	"surroundedBySingleQuotes"
-	stream
-		cr;
-		cr
-]
-
 { #category : 'moving changes' }
 ChangeSet >> forgetAllChangesFoundIn: otherChangeSet [
 	"Remove from the receiver all method changes found in aChangeSet. The intention is facilitate the process of factoring a large set of changes into disjoint change sets.  To use:  in a change sorter, copy over all the changes you want into some new change set, then use the subtract-other-side feature to subtract those changes from the larger change set, and continue in this manner."
@@ -1005,13 +811,6 @@ ChangeSet >> forgetChangesForClass: className in: otherChangeSet [
 
 	(self changeRecorderFor: className) forgetChangesIn:
 		(otherChangeSet changeRecorderFor: className)
-]
-
-{ #category : 'method changes' }
-ChangeSet >> hasAnyChangeForSelector: aSelector [
-	"Answer whether the receiver has any change under the given selector, whether it be add, change, or remove, for any class"
-
-	^ changeRecords anySatisfy: [ :aRecord | aRecord changedSelectors includes: aSelector ]
 ]
 
 { #category : 'accessing' }

--- a/src/System-Sources/ClassDescription.extension.st
+++ b/src/System-Sources/ClassDescription.extension.st
@@ -1,0 +1,27 @@
+Extension { #name : 'ClassDescription' }
+
+{ #category : '*System-Sources' }
+ClassDescription >> printProtocolChunk: protocol on: aFileStream withStamp: changeStamp priorMethod: priorMethod [
+	"Print a method preamble.  This must have a protocol name.
+	It may have an author/date stamp, and it may have a prior source link.
+	If it has a prior source link, it MUST have a stamp, even if it is empty."
+
+	"The current design is that changeStamps and prior source links are preserved in the changes file.  All fileOuts include changeStamps.  Condensing sources, however, eliminates all stamps (and links, natch)."
+
+	aFileStream
+		cr;
+		nextPut: $!.
+	aFileStream nextChunkPut: (String streamContents: [ :strm |
+			 strm
+				 nextPutAll: self name;
+				 nextPutAll: ' methodsFor: ';
+				 print: protocol name asString.
+			 (changeStamp isNotNil and: [ changeStamp size > 0 or: [ priorMethod isNotNil ] ]) ifTrue: [
+				 strm
+					 nextPutAll: ' stamp: ';
+					 print: changeStamp ].
+			 priorMethod ifNotNil: [
+				 strm
+					 nextPutAll: ' prior: ';
+					 print: priorMethod sourcePointer ] ])
+]

--- a/src/System-Sources/ManifestSystemSources.class.st
+++ b/src/System-Sources/ManifestSystemSources.class.st
@@ -11,5 +11,7 @@ Class {
 
 { #category : 'meta-data - dependency analyser' }
 ManifestSystemSources class >> manuallyResolvedDependencies [
-	^ #(#'Announcements-Core' #'Collections-Abstract')
+
+	<ignoreForCoverage>
+	^ #(#'Announcements-Core' #'System-Support')
 ]

--- a/src/System-Sources/WriteStream.extension.st
+++ b/src/System-Sources/WriteStream.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : 'WriteStream' }
+
+{ #category : '*System-Sources' }
+WriteStream >> nextChunkPut: aString [
+	"Append the argument, aString, to the receiver, doubling embedded ! terminators and adding a extra one"
+
+	| string start bangIndex |
+	string := aString asString.
+	start := 1.
+	[ (bangIndex := string indexOf: $! startingAt: start) = 0 ]
+		whileFalse: [
+			self next: bangIndex - start + 1 putAll: string startingAt: start.
+			self nextPut: $!. "double it"
+			start := bangIndex + 1 ].
+	self next: string size - start + 1 putAll: string startingAt: start.
+	self nextPut: $!. "one extra"
+	self flush
+]


### PR DESCRIPTION
- Opal should not depend on CodeExport
- Move export code of ChangeSet to CodeExport
- Move loading of CodeExport to BaselineOfBasicTool instead of the bootstrap (Was loaded by Hermes before)
- Merge CodeExport-Traits into CodeExport because it is now loaded after traits

I think the coolest part is to have two less packages loaded by Hermes :)