### PR TITLE
Make ClySystemEnvironments responsible for managing environment elements in ClyScopes

### DIFF
--- a/src/Calypso-SystemQueries/ClyClassHierarchyScope.class.st
+++ b/src/Calypso-SystemQueries/ClyClassHierarchyScope.class.st
@@ -162,7 +162,7 @@ ClyClassHierarchyScope >> metaLevelsOf: aClass do: aBlock [
 ClyClassHierarchyScope >> methodsDo: aBlock [
 
 	self classesDo: [ :eachClass |
-		eachClass methods do: aBlock ]
+		(environment system methodsInClass: eachClass) do: aBlock ]
 ]
 
 { #category : 'converting' }

--- a/src/Calypso-SystemQueries/ClyClassSideScope.class.st
+++ b/src/Calypso-SystemQueries/ClyClassSideScope.class.st
@@ -24,5 +24,6 @@ ClyClassSideScope >> methodsDo: aBlock [
 
 	self classesDo: [ :eachClass |
 		self metaLevelsOf: eachClass do: [ :concreteMetaLevelClass |
-			concreteMetaLevelClass visibleMethods do: aBlock ] ]
+			(environment system visibleMethodsInMetaclass:
+				 concreteMetaLevelClass) do: aBlock ] ]
 ]

--- a/src/Calypso-SystemQueries/ClyLocalClassScope.class.st
+++ b/src/Calypso-SystemQueries/ClyLocalClassScope.class.st
@@ -108,7 +108,7 @@ ClyLocalClassScope >> methodsDo: aBlock [
 
 	self classesDo: [ :eachClass |
 		self metaLevelsOf: eachClass do: [ :concreteMetaLevelClass |
-			concreteMetaLevelClass methods do: aBlock ] ]
+			(environment system methodsInClass: concreteMetaLevelClass) do: aBlock ] ]
 ]
 
 { #category : 'converting' }

--- a/src/Calypso-SystemQueries/ClyPackageExtensionScope.class.st
+++ b/src/Calypso-SystemQueries/ClyPackageExtensionScope.class.st
@@ -13,7 +13,7 @@ Class {
 { #category : 'queries' }
 ClyPackageExtensionScope >> classesDo: aBlock [
 	self packagesDo: [ :package |
-		package extendedClasses
+		(environment system extendedClassesInPackage: package) 
 			collect: [ :each | each instanceSide ]
 			thenDo: aBlock]
 ]
@@ -22,7 +22,7 @@ ClyPackageExtensionScope >> classesDo: aBlock [
 ClyPackageExtensionScope >> methodsDo: aBlock [
 
 	self packagesDo: [ :package |
-		package extensionMethods do: aBlock ]
+		(environment system extensionMethodsInPackage: package) do: aBlock ]
 ]
 
 { #category : 'queries' }

--- a/src/Calypso-SystemQueries/ClyPackageScope.class.st
+++ b/src/Calypso-SystemQueries/ClyPackageScope.class.st
@@ -34,8 +34,9 @@ ClyPackageScope >> classGroupProvidersDo: aBlock [
 
 { #category : 'queries' }
 ClyPackageScope >> classesDo: aBlock [
+
 	self packagesDo: [ :package |
-		package definedClasses do: aBlock]
+		(environment system definedClassesInPackage: package) do: aBlock ]
 ]
 
 { #category : 'system changes' }
@@ -54,11 +55,11 @@ ClyPackageScope >> includesPackageTagsAffectedBy: aSystemAnnouncement [
 { #category : 'queries' }
 ClyPackageScope >> methodsDo: aBlock [
 	self classesDo: [:class |
-		class localMethods do: aBlock.
-		class classSide localMethods do: aBlock].
+		(environment system localMethodsInClass: class) do: aBlock.
+		(environment system localMethodsInClass: class classSide) do: aBlock].
 
 	self packagesDo: [ :package |
-		package extensionMethods do: aBlock ]
+		(environment system extensionMethodsInPackage: package) do: aBlock ]
 ]
 
 { #category : 'queries' }

--- a/src/Calypso-SystemQueries/ClyProjectScope.class.st
+++ b/src/Calypso-SystemQueries/ClyProjectScope.class.st
@@ -22,7 +22,8 @@ ClyProjectScope class >> defaultName [
 { #category : 'queries' }
 ClyProjectScope >> classesDo: aBlock [
 
-	self packagesDo: [ :package | package classes do: aBlock ]
+	self packagesDo: [ :package |
+		(environment system classesInPackage: package) do: aBlock ]
 ]
 
 { #category : 'testing' }
@@ -49,13 +50,15 @@ ClyProjectScope >> includesPackagesAffectedBy: aSystemAnnouncement [
 { #category : 'queries' }
 ClyProjectScope >> methodsDo: aBlock [
 
-	self packagesDo: [ :package | package methods do: aBlock ]
+	self packagesDo: [ :package |
+		(environment system methodsInPackage: package) do: aBlock ]
 ]
 
 { #category : 'queries' }
 ClyProjectScope >> packagesDo: aBlock [
+
 	self projectsDo: [ :project |
-		project packages do: aBlock ]
+		(environment system packagesInProject: project) do: aBlock ]
 ]
 
 { #category : 'queries' }

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -121,6 +121,12 @@ ClySystemEnvironment >> classes [
 	^ globals allClassesAndTraits
 ]
 
+{ #category : 'class management' }
+ClySystemEnvironment >> classesInPackage: aPackage [
+	
+	^ aPackage classes
+]
+
 { #category : 'compiling' }
 ClySystemEnvironment >> compileANewClassFrom: newClassDefinitionString notifying: aController startingFrom: oldClass [
 	"The receiver's textual content is a request to define a new class or trait. The
@@ -173,6 +179,12 @@ ClySystemEnvironment >> defaultClassCompiler [
 	^ self class compiler
 ]
 
+{ #category : 'class management' }
+ClySystemEnvironment >> definedClassesInPackage: aRBPackage [
+
+ 	^ aRBPackage definedClasses
+]
+
 { #category : 'package management' }
 ClySystemEnvironment >> ensurePackage: packageName [
 
@@ -182,6 +194,18 @@ ClySystemEnvironment >> ensurePackage: packageName [
 { #category : 'accessing' }
 ClySystemEnvironment >> environment [
 	^ RBBrowserEnvironment new
+]
+
+{ #category : 'class management' }
+ClySystemEnvironment >> extendedClassesInPackage: aPackage [
+	
+	^ aPackage extendedClasses
+]
+
+{ #category : 'method management' }
+ClySystemEnvironment >> extensionMethodsInPackage: aRBPackage [
+
+ 	^ aRBPackage extensionMethods
 ]
 
 { #category : 'class management' }
@@ -218,6 +242,22 @@ ClySystemEnvironment >> isOverridingExistingClassWhenDefiningClassNamed: newClas
 	^ (oldClass isNil or: [ oldClass instanceSide name asString ~= newClassName ]) and: [ self includesClassNamed: newClassName asSymbol ]
 ]
 
+{ #category : 'method management' }
+ClySystemEnvironment >> localMethodsInClass: aClass [
+	^ aClass localMethods
+]
+
+{ #category : 'method management' }
+ClySystemEnvironment >> methodsInClass: aClass [
+
+	^ aClass methods
+]
+
+{ #category : 'method management' }
+ClySystemEnvironment >> methodsInPackage: aPackage [
+	^ aPackage methods
+]
+
 { #category : 'accessing' }
 ClySystemEnvironment >> name [
 	^ name ifNil: [ super printString ]
@@ -246,6 +286,11 @@ ClySystemEnvironment >> packageOrganizer: anObject [
 { #category : 'accessing' }
 ClySystemEnvironment >> packages [
 	^ packageOrganizer packages
+]
+
+{ #category : 'package management' }
+ClySystemEnvironment >> packagesInProject: aProject [
+	^ aProject packages
 ]
 
 { #category : 'printing' }
@@ -286,6 +331,12 @@ ClySystemEnvironment >> subscribe: anObject for: anAnnouncementClass [
 { #category : 'subscription' }
 ClySystemEnvironment >> unsubscribe: anObject [
 	changesAnnouncer unsubscribe: anObject
+]
+
+{ #category : 'method management' }
+ClySystemEnvironment >> visibleMethodsInMetaclass: aMetaclass [
+
+	^ aMetaclass visibleMethods
 ]
 
 { #category : 'subscription' }


### PR DESCRIPTION
ClyScopes have an environment but currently they don't use it to get packages, classes, and methods from the environment. Instead, they ask directly to the elements for their related elements, for example, they ask a RPackages for their classes.
 
This PR proposes a refactor to make ClyScopes ask for environment elements to its own environment. 

This change will make it possible to browse RBEnvironment elements in calypso (This feature is implemented in this [NewTools PR](https://github.com/pharo-spec/NewTools/pull/585))