### PR TITLE
Auto completion should propose globals

### DIFF
--- a/src/HeuristicCompletion-Model/CoGlobalVariableFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoGlobalVariableFetcher.class.st
@@ -13,7 +13,7 @@ Class {
 CoGlobalVariableFetcher >> entriesDo: aBlock [
 
 	self systemNavigation
-		allClassNamesStartingWith: filter completionString
+		allGlobalNamesStartingWith: filter completionString
 		do: [ :e | aBlock value: (NECGlobalEntry contents: e node: astNode) ]
 		caseSensitive: (NECPreferences caseSensitive)
 ]

--- a/src/HeuristicCompletion-Tests/CoMockSystemNavigation.class.st
+++ b/src/HeuristicCompletion-Tests/CoMockSystemNavigation.class.st
@@ -13,16 +13,8 @@ Class {
 	#tag : 'Core'
 }
 
-{ #category : 'accessing' }
-CoMockSystemNavigation >> allClassNamesStartingWith: aString do: aBlock [
-
-	globals do: [ :e |
-		(e beginsWith: aString)
-			ifTrue: [ aBlock value: e ] ]
-]
-
 { #category : 'query' }
-CoMockSystemNavigation >> allClassNamesStartingWith: aString do: aBlock caseSensitive: cs [
+CoMockSystemNavigation >> allGlobalNamesStartingWith: aString do: aBlock caseSensitive: cs [
 
 	globals do: [ :e |
 		(aString isEmpty or: [ e beginsWith: aString caseSensitive: cs ])

--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -75,6 +75,23 @@ SystemNavigationTest >> testAllExistingProtocolsFor [
 ]
 
 { #category : 'tests' }
+SystemNavigationTest >> testAllGlobalNamesStartingWithDoCaseSensitive [
+
+	| result |
+	result := OrderedCollection new.
+	self systemNavigationToTest allGlobalNamesStartingWith: 'Sma' do: [ :name | result add: name ] caseSensitive: true.
+	self assert: (result includes: 'Smalltalk').
+
+	result := OrderedCollection new.
+	self systemNavigationToTest allGlobalNamesStartingWith: 'sma' do: [ :name | result add: name ] caseSensitive: true.
+	self deny: (result includes: 'Smalltalk').
+
+	result := OrderedCollection new.
+	self systemNavigationToTest allGlobalNamesStartingWith: 'sma' do: [ :name | result add: name ] caseSensitive: false.
+	self assert: (result includes: 'Smalltalk')
+]
+
+{ #category : 'tests' }
 SystemNavigationTest >> testAllReferencesToDo [
 	"test trying to not hard code numbers as they will be different"
 	| counterSymbol counterClass |

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -89,6 +89,12 @@ SystemNavigation >> allExistingProtocolsFor: instanceSide [
 			  ifFalse: [ class class protocolNames ] ]
 ]
 
+{ #category : 'query' }
+SystemNavigation >> allGlobalNamesStartingWith: aString do: aBlock caseSensitive: cs [
+
+	self environment keysDo: [ :globalName | (globalName beginsWith: aString caseSensitive: cs) ifTrue: [ aBlock value: globalName ] ]
+]
+
 { #category : 'private' }
 SystemNavigation >> allGlobalRefsOn: aSymbol [
 	"Answer all references to globals"


### PR DESCRIPTION
Since a few years it frustrate me that the auto completion does not propose the globals names. It's bad to use globals but sometimes you don't have the choice, and it can make our like much better while debugging. For example to use the transcript.

Here is a fix so that the CoGlobalVariableFetcher fetch global variables and not just classes