### PR TITLE
Do not log recompilation in the source file

### DIFF
--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -108,6 +108,7 @@ Behavior >> recompileBasic: selector from: oldClass [
 				source: (oldClass sourceCodeAt: selector);
 				class: self;
 				permitFaulty: true;
+				logged: false; "No need to log recompilation in the sources."
 				compile.   "Assume OK after proceed from SyntaxError"
 	newMethod sourcePointer: method sourcePointer.
 	


### PR DESCRIPTION
If you update your class, adding a slot for example, the methods of the class are migrated to the new instance through recompilation. This action is currently logged in the source file I have the impression and this seems unecessary to me.

Let's try to disable that to see if it works