### PR TITLE
Fix scaling of #blankIcon and #notFoundIcon on ThemeIcons

### DIFF
--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -1031,7 +1031,7 @@ MenuMorph >> layoutItems [
 		item icon ifNotNil: [maxIconWidth := maxIconWidth max: item icon width].
 		item hasSubMenu ifTrue: [item subMenu layoutItems]].
 	maxIconWidth isZero
-		ifFalse: [self addBlankIconsIfNecessary: (Smalltalk ui icons blankIconOfWidth: maxIconWidth)]
+		ifFalse: [self addBlankIconsIfNecessary: (Form extent: maxIconWidth @ 1 depth: 8)]
 ]
 
 { #category : 'events' }

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -227,7 +227,8 @@ ThemeIcons >> beReportNotFound [
 
 { #category : 'accessing' }
 ThemeIcons >> blankIcon [
-	^ self blankIconOfWidth: 16
+
+	^ self iconNamed: #blank
 ]
 
 { #category : 'utilities' }
@@ -304,7 +305,7 @@ ThemeIcons >> iconNamed: aSymbol [
 				ifTrue: [
 					self crTrace: (aSymbol, ' icon not found!').
 					self notFoundIcon scaledByDisplayScaleFactor ]
-				ifFalse: [ self blankIcon scaledByDisplayScaleFactor ]])
+				ifFalse: [ self blankIcon ]])
 ]
 
 { #category : 'accessing' }

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -231,24 +231,6 @@ ThemeIcons >> blankIcon [
 	^ self iconNamed: #blank
 ]
 
-{ #category : 'utilities' }
-ThemeIcons >> blankIconOfWidth: aNumber [
-
-	"We hard-code the most used cases to avoid symbol creation"
-
-	aNumber == 16 ifTrue: [ ^ self icons
-		at: #blank16
-		ifAbsentPut: [Form extent: 16 @ 1 depth: 8] ].
-
-	aNumber == 10 ifTrue: [ ^ self icons
-		at: #blank10
-		ifAbsentPut: [Form extent: 10 @ 1 depth: 8] ].
-
-	^ self icons
-		at: ('blank-' , aNumber asString) asSymbol
-		ifAbsentPut: [Form extent: aNumber @ 1 depth: 8]
-]
-
 { #category : 'private' }
 ThemeIcons >> defaultUrl [
 	^ self class baseUrl / (self name, '.zip')

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -286,7 +286,7 @@ ThemeIcons >> iconNamed: aSymbol [
 			self isReportingNotFound
 				ifTrue: [
 					self crTrace: (aSymbol, ' icon not found!').
-					self notFoundIcon scaledByDisplayScaleFactor ]
+					self notFoundIcon ]
 				ifFalse: [ self blankIcon ]])
 ]
 
@@ -350,6 +350,8 @@ ThemeIcons >> loadIconsFromUrlUsingScale: newScale [
 					at: each base asSymbol
 					put: (self readPNGFrom: each) ]
 				on: Error do: [ :e | self crTrace: ('{1} not a PNG, skipping.' format: { each fullName }) ] ] ].
+	newIconsPerScale keysAndValuesDo: [ :iconsScale :icons |
+		icons at: #notFound ifAbsentPut: [ Color red iconOrThumbnailOfSize: 16 * iconsScale ] ].
 	iconsPerScale := newIconsPerScale.
 	scale := newScale
 ]
@@ -366,9 +368,8 @@ ThemeIcons >> name: aName [
 
 { #category : 'accessing' }
 ThemeIcons >> notFoundIcon [
-	^ self icons
-		at: #notFoundIcon
-		ifAbsentPut: [ Color red iconOrThumbnailOfSize: 16 ]
+
+	^ self iconNamed: #notFound ifNone: [ Form extent: 0@0 ]
 ]
 
 { #category : 'printing' }


### PR DESCRIPTION
This pull request changes `#blankIcon` and `#notFoundIcon` on ThemeIcons to be implemented using `#iconNamed:` and `#iconNamed:ifNone:` so that those icons are consistent with the others with respect to scaling. The method `#blankIconOfWidth:` is removed, so the Form objects used in `MenuMorph>>#layoutItems` are no longer cached but I don’t think that matters much. The creation of the icon named `#notFound` is moved to the `#loadIconsFromUrlUsingScale:` method; it could, for consistency, also be moved into the icon pack (`#notFoundIcon` takes into account it could be missing by using a Form with extent `0@0` as the ultimate fallback).