### PR TITLE
ExternalAddress: Avoid temporary instance of ByteArray

### DIFF
--- a/src/FFI-Kernel/ExternalAddress.class.st
+++ b/src/FFI-Kernel/ExternalAddress.class.st
@@ -194,15 +194,18 @@ ExternalAddress >> fromCString [
 ]
 
 { #category : 'converting' }
-ExternalAddress >> fromInteger: address [
-	"Make me point at address."
+ExternalAddress >> fromInteger: anInteger [
+	"Update me with the received address, which is an integer.
+	Warning: The implementation assumes the platform is little-endian."
 
 	| tmp |
-	tmp := address.
+	tmp := anInteger.
+	"Set each byte except last"
 	1 to: self size - 1 do: [ :i |
 		self basicAt: i put: (tmp bitAnd: 16rff).
 		tmp := tmp bitShift: -8 ].
-	self basicAt: self size put: (tmp bitAnd: 16rff)
+	"Last byte doesn't need any additional bit operation"
+	self basicAt: self size put: tmp
 ]
 
 { #category : 'accessing' }

--- a/src/FFI-Kernel/ExternalAddress.class.st
+++ b/src/FFI-Kernel/ExternalAddress.class.st
@@ -195,22 +195,14 @@ ExternalAddress >> fromCString [
 
 { #category : 'converting' }
 ExternalAddress >> fromInteger: address [
-	"set my handle to point at address."
-	"Do we really need this? bf 2/21/2001 23:48"
+	"Make me point at address."
 
-	| sz pointer |
-	sz := self size.
-	pointer := ByteArray new: sz.
-	pointer integerAt: 1 put: address size: sz signed: false.
-	self basicAt: 1 put: (pointer byteAt: 1);
-		basicAt: 2 put: (pointer byteAt: 2);
-		basicAt: 3 put: (pointer byteAt: 3);
-		basicAt: 4 put: (pointer byteAt: 4).
-	sz = 8 ifTrue:
-		[self basicAt: 5 put: (pointer byteAt: 5);
-			basicAt: 6 put: (pointer byteAt: 6);
-			basicAt: 7 put: (pointer byteAt: 7);
-			basicAt: 8 put: (pointer byteAt: 8)]
+	| tmp |
+	tmp := address.
+	1 to: self size - 1 do: [ :i |
+		self basicAt: i put: (tmp bitAnd: 16rff).
+		tmp := tmp bitShift: -8 ].
+	self basicAt: self size put: (tmp bitAnd: 16rff)
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This change showed 2x speedup on my MacbookPro 2018.

Revealed by illimani-memory-profiler on Bloc benchmarks. See: https://github.com/pharo-graphics/Bloc/issues/322

@tesonep do you agree?