### PR TITLE
OSSDL2Driver loop: Avoid creating a new Delay every 5ms

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -207,16 +207,15 @@ OSSDL2Driver >> eventLoopProcessWithVMWindow [
 
 { #category : 'events-processing' }
 OSSDL2Driver >> eventLoopProcessWithoutPlugin [
-	| event session |
+
+	| event delay |
 	event := SDL_Event new.
-	session := Smalltalk session.
+	delay := Delay forMilliseconds: 5.
 
-	[ session == Smalltalk session]
-	whileTrue: [
+	[ event isNull ] whileFalse: [
 		[ (SDL2 pollEvent: event) > 0 ]
-		whileTrue: [ self processEvent: event ].
-
-		(Delay forMilliseconds: 5) wait ]
+			whileTrue: [ self processEvent: event ].
+		delay wait ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
Revealed by illimani-memory-profiler on Bloc benchmarks. See: https://github.com/pharo-graphics/Bloc/issues/323