### PR TITLE
Simplify recompilation

### DIFF
--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -106,16 +106,12 @@ Behavior >> recompileBasic: selector from: oldClass [
 	method := oldClass compiledMethodAt: selector.
 	newMethod := oldClass compiler
 				source: (oldClass sourceCodeAt: selector);
+				priorMethod: method;
 				class: self;
 				permitFaulty: true;
 				logged: false; "No need to log recompilation in the sources."
 				compile.   "Assume OK after proceed from SyntaxError"
 	newMethod sourcePointer: method sourcePointer.
-	
-	"In case we are not compiling the method for the first time, we want to ensure that some properties are kept.
-	Opal should do the work but since we give the new class to opal it cannot find the old properties."
-	method propertyAt: #extensionPackage ifPresent: [ :package | newMethod propertyAt: #extensionPackage put: package ].
-
 
 	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
 	^ newMethod


### PR DESCRIPTION
Now that we do not log the recompiled methods we can simplify the recompilation process