### PR TITLE
Fix class template when a tag is selected

### DIFF
--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -95,12 +95,13 @@ ClyTextEditorToolMorph >> buildLeftSideBar [
 
 { #category : 'building' }
 ClyTextEditorToolMorph >> buildTextMorph [
+
 	textModel := RubScrolledTextModel new.
 	textModel interactionModel: self.
 	textMorph := textModel newScrolledText.
 	textMorph
-		width: self width; "build is performed in background when owner is not exist yet. But we need proper width to perform kind of styling/formatting if needed"
-		beWrapped;
+		width: self width;
+		"build is performed in background when owner is not exist yet. But we need proper width to perform kind of styling/formatting if needed"beWrapped;
 		font: StandardFonts codeFont;
 		editingMode: self editingMode.
 	CmdKMDispatcher attachedTo: textMorph textArea withCommandsFrom: self. "It overrides default text morph shortcuts with Commander"

--- a/src/Calypso-SystemTools-Core/ClyClassCreationToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassCreationToolMorph.class.st
@@ -60,7 +60,7 @@ ClyClassCreationToolMorph >> belongsToCurrentBrowserContext [
 { #category : 'template' }
 ClyClassCreationToolMorph >> classTemplate [
 
-	^ ClassDefinitionPrinter fluid compactClassDefinitionTemplateInPackage:  self packageName
+	^ ClassDefinitionPrinter fluid compactClassDefinitionTemplateInPackage:self packageName tag: self tag
 ]
 
 { #category : 'initialization' }
@@ -115,11 +115,9 @@ ClyClassCreationToolMorph >> package: anObject [
 { #category : 'accessing' }
 ClyClassCreationToolMorph >> packageName [
 
-	package ifNil: [ ^'' ].
-
-	tag ifNil: [ ^package name ].
-
-	^package name , '-' , tag
+	^ package
+		  ifNotNil: [ package name ]
+		  ifNil: [ '' ]
 ]
 
 { #category : 'printing' }

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -70,11 +70,10 @@ FluidClassDefinitionPrinterTest >> testChronologyConstants [
 { #category : 'tests - template' }
 FluidClassDefinitionPrinterTest >> testCompactClassTemplate [
 
-	self
-		assert: (FluidClassDefinitionPrinter new compactClassDefinitionTemplateInPackage: 'Kernel')
-		equals:  'Object << #MyClass
+	self assert: (FluidClassDefinitionPrinter new compactClassDefinitionTemplateInPackage: 'Kernel' tag: #Basic) equals: 'Object << #MyClass
 	slots: {};
 	sharedVariables: {};
+	tag: #Basic;
 	package: ''Kernel'''
 ]
 

--- a/src/Kernel/FluidClassDefinitionPrinter.class.st
+++ b/src/Kernel/FluidClassDefinitionPrinter.class.st
@@ -99,22 +99,46 @@ FluidClassDefinitionPrinter >> classVariableDefinitionsOn: aStream [
 ]
 
 { #category : 'template' }
-FluidClassDefinitionPrinter >> compactClassDefinitionTemplateInPackage: aPackageName [
-	^ String streamContents: [ :s |
-			s nextPutAll: 'Object << #MyClass'; crtab.
-			s nextPutAll: 'slots: {};'; crtab.
-			s nextPutAll: 'sharedVariables: {};'; crtab.
-			s nextPutAll: 'package: ''', aPackageName, '''' ]
-]
-
-{ #category : 'template' }
-FluidClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aPackageName [
+FluidClassDefinitionPrinter >> compactClassDefinitionTemplateInPackage: aPackageName tag: aTagName [
 
 	^ String streamContents: [ :s |
 		  s
-			  nextPutAll: 'Trait << #TMyTrait';  crtab;
-			  nextPutAll: 'traits: {};'; crtab ;
-			  nextPutAll: 'slots: {};'; crtab ;
+			  nextPutAll: 'Object << #MyClass';
+			  crtab;
+			  nextPutAll: 'slots: {};';
+			  crtab;
+			  nextPutAll: 'sharedVariables: {};';
+			  crtab.
+		  aTagName ifNotNil: [
+			  s
+				  nextPutAll: 'tag: ';
+				  print: aTagName;
+				  nextPutAll: ';';
+				  crtab ].
+		  s
+			  nextPutAll: 'package: ''';
+			  nextPutAll: aPackageName;
+			  nextPutAll: '''' ]
+]
+
+{ #category : 'template' }
+FluidClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aPackageName tag: aTagName [
+
+	^ String streamContents: [ :s |
+		  s
+			  nextPutAll: 'Trait << #TMyTrait';
+			  crtab;
+			  nextPutAll: 'traits: {};';
+			  crtab;
+			  nextPutAll: 'slots: {};';
+			  crtab.
+		  aTagName ifNotNil: [
+			  s
+				  nextPutAll: 'tag: ';
+				  print: aTagName;
+				  nextPutAll: ';';
+				  crtab ].
+		  s
 			  nextPutAll: 'package: ''';
 			  nextPutAll: aPackageName;
 			  nextPutAll: '''' ]

--- a/src/Kernel/OldPharoClassDefinitionPrinter.class.st
+++ b/src/Kernel/OldPharoClassDefinitionPrinter.class.st
@@ -116,13 +116,6 @@ OldPharoClassDefinitionPrinter >> classVariablesOn: stream [
 ]
 
 { #category : 'template' }
-OldPharoClassDefinitionPrinter >> compactClassDefinitionTemplateInPackage: aString [
-	"there is not compact version..."
-
-	^ self classDefinitionTemplateInPackage: aString
-]
-
-{ #category : 'template' }
 OldPharoClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aString [
 
 	^ self traitDefinitionTemplateInPackage: aString

--- a/src/Traits-Tests/AbstractTraitsOnPreparedModelTest.class.st
+++ b/src/Traits-Tests/AbstractTraitsOnPreparedModelTest.class.st
@@ -151,7 +151,6 @@ AbstractTraitsOnPreparedModelTest >> setUp [
 	"SetUpCount := SetUpCount + 1."
 
 	super setUp.
-	'Setup' traceCr.
 	SystemAnnouncer uniqueInstance suspendAllWhile:
 			[self t1: (self newTrait: #T1
 						traits: { }).

--- a/src/Traits-Tests/TraitFluidClassDefinitionPrinterTest.class.st
+++ b/src/Traits-Tests/TraitFluidClassDefinitionPrinterTest.class.st
@@ -37,7 +37,7 @@ TraitFluidClassDefinitionPrinterTest >> testCompactTraitFullTemplate [
 	self assert: (FluidClassDefinitionPrinter new compactTraitDefinitionTemplateInPackage: 'Traits' tag: #Basic) equals: 'Trait << #TMyTrait
 	traits: {};
 	slots: {};
-	tag: #Basic
+	tag: #Basic;
 	package: ''Traits'''
 ]
 

--- a/src/Traits-Tests/TraitFluidClassDefinitionPrinterTest.class.st
+++ b/src/Traits-Tests/TraitFluidClassDefinitionPrinterTest.class.st
@@ -34,10 +34,10 @@ TraitFluidClassDefinitionPrinterTest >> testClassSideDoesNotShowPackage [
 { #category : 'tests - template' }
 TraitFluidClassDefinitionPrinterTest >> testCompactTraitFullTemplate [
 
-	self
-		assert: (FluidClassDefinitionPrinter new compactTraitDefinitionTemplateInPackage: 'Traits') equals: 'Trait << #TMyTrait
+	self assert: (FluidClassDefinitionPrinter new compactTraitDefinitionTemplateInPackage: 'Traits' tag: #Basic) equals: 'Trait << #TMyTrait
 	traits: {};
 	slots: {};
+	tag: #Basic
 	package: ''Traits'''
 ]
 


### PR DESCRIPTION
The calypso class template was still using the concept of categories and in the past it works because the FluidBuilder was not honoring the #tag: and #package: API. But now it is respecting it so the users should take care to specify correctly the template.

This fix the usage of Calypso when we select a tag

Fixes #15406