### PR TITLE
Clean Epicea Baseline

### DIFF
--- a/src/BaselineOfEpicea/BaselineOfEpicea.class.st
+++ b/src/BaselineOfEpicea/BaselineOfEpicea.class.st
@@ -15,7 +15,7 @@ BaselineOfEpicea >> baseline: spec [
 			package: 'Epicea' with: [ spec requires: 'Ombu' ];
 			package: 'Hiedra';
 			package: 'Hiedra-Examples';
-			package: 'EpiceaBrowsers' with: [ spec requires: 'Hiedra' ].
+			package: 'EpiceaBrowsers' with: [ spec requires: #( 'Epicea' 'Hiedra') ].
 
 		spec
 			package: 'Ombu-Tests' with: [ spec requires: 'Ombu' ];

--- a/src/BaselineOfEpicea/BaselineOfEpicea.class.st
+++ b/src/BaselineOfEpicea/BaselineOfEpicea.class.st
@@ -7,12 +7,23 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfEpicea >> baseline: spec [
+
 	<baseline>
-	spec for: #'common' do: [
-		spec 
+	spec for: #common do: [
+		spec
 			package: 'Ombu';
-			package: 'Epicea';
+			package: 'Epicea' with: [ spec requires: 'Ombu' ];
 			package: 'Hiedra';
 			package: 'Hiedra-Examples';
-			package: 'EpiceaBrowsers'. ]
+			package: 'EpiceaBrowsers' with: [ spec requires: 'Hiedra' ].
+
+		spec
+			package: 'Ombu-Tests' with: [ spec requires: 'Ombu' ];
+			package: 'Epicea-Tests' with: [ spec requires: 'Epicea' ];
+			package: 'Hiedra-Tests' with: [ spec requires: 'Hiedra' ];
+			package: 'EpiceaBrowsers-Tests' with: [ spec requires: 'EpiceaBrowsers' ].
+
+		spec
+			group: #Browsers with: #( #EpiceaBrowsers #'Hiedra-Examples' );
+			group: #Tests with: #( 'Ombu-Tests' 'Epicea-Tests' 'Hiedra-Tests' 'EpiceaBrowsers-Tests' ) ]
 ]

--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -7,9 +7,11 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfGeneralTests >> baseline: spec [
-	<baseline>
 	"Needs to be re-sorted"
-	
+
+	<baseline>
+	| repository |
+	repository := self packageRepositoryURL.
 	spec for: #'common' do: [
 		spec 
 			package: 'Debugging-Utils-Tests';
@@ -28,10 +30,11 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'Debugger-Oups-Tests';		
 			package: 'EmbeddedFreeType-Tests';
 			
-			package: 'Ombu-Tests';
-			package: 'Epicea-Tests';
-			package: 'Hiedra-Tests';
-			package: 'EpiceaBrowsers-Tests';
+
+			baseline: 'Epicea' with: [
+				spec
+					repository: repository;
+					loads: #Tests ];
 			
 			package: 'FileSystem-Tests-Memory';
 			package: 'Fonts-Infrastructure-Tests';

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -36,9 +36,9 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfIDE >> baseline: spec [
+
 	<baseline>
 	| repository |
-
 	repository := self packageRepositoryURL.
 	spec for: #common do: [
 		spec postLoadDoIt: #postload:package:.
@@ -79,11 +79,11 @@ BaselineOfIDE >> baseline: spec [
 			spec
 				repository: repository;
 				loads: #( 'tests' ) ].
-			
+
 		spec baseline: 'Refactoring' with: [
 			spec
 				repository: repository;
-				loads: #( 'Tests') ].
+				loads: #( 'Tests' ) ].
 
 		spec package: 'Math-Operations-Extensions-Tests'.
 		spec package: 'Network-Tests'.
@@ -100,34 +100,44 @@ BaselineOfIDE >> baseline: spec [
 		spec baseline: 'KernelTests' with: [ spec repository: repository ].
 		spec baseline: 'Shout' with: [ spec repository: repository ].
 
-		spec
-			baseline: 'ReflectionMirrors'
-			with: [ spec repository: repository ].
+		spec baseline: 'ReflectionMirrors' with: [ spec repository: repository ].
 		spec baseline: 'FuzzyMatcher' with: [ spec repository: repository ].
 		spec baseline: 'QA' with: [ spec repository: repository ].
 		spec baseline: 'OSWindow' with: [ spec repository: repository ].
 		spec baseline: 'EmergencyDebugger' with: [ spec repository: repository ].
-		spec baseline: 'Epicea' with: [ spec repository: repository ].
+
+		spec baseline: 'Epicea' with: [
+			spec
+				repository: repository;
+				loads: #Browsers ].
+
 		spec baseline: 'Misc' with: [ spec repository: repository ].
 		spec baseline: 'Fuel' with: [
 			spec
 				repository: repository;
 				loads: #( 'Tests' ) ].
 		spec baseline: 'GeneralTests' with: [ spec repository: repository ].
-		spec baseline: 'FreeType' with: [ spec repository: repository; loads: 'tests' ].
-		spec baseline: 'Keymapping' with: [ spec repository: repository; loads: 'tests' ].
+		spec baseline: 'FreeType' with: [
+			spec
+				repository: repository;
+				loads: 'tests' ].
+		spec baseline: 'Keymapping' with: [
+			spec
+				repository: repository;
+				loads: 'tests' ].
 		spec baseline: 'Zodiac' with: [ spec repository: repository ].
 		spec baseline: 'SortFunctions' with: [ spec repository: repository ].
 		spec baseline: 'Equals' with: [ spec repository: repository ].
-		spec baseline: 'NewValueHolder' with: [ spec repository: repository; loads: 'tests' ].
+		spec baseline: 'NewValueHolder' with: [
+			spec
+				repository: repository;
+				loads: 'tests' ].
 		spec package: 'STON-Extensions'.
 
 		spec package: 'BaselineOfPharoBootstrap'.
 		spec package: 'BaselineOfMonticello'.
 		spec package: 'BaselineOfMetacello'.
-		spec
-			baseline: 'ReferenceFinder'
-			with: [ spec repository: repository ].
+		spec baseline: 'ReferenceFinder' with: [ spec repository: repository ].
 		spec baseline: 'ClassParser' with: [ spec repository: repository ].
 		spec baseline: 'Calypso' with: [
 			spec
@@ -135,7 +145,10 @@ BaselineOfIDE >> baseline: spec [
 				loads: #( 'FullEnvironment' 'SystemBrowser' 'Tests' ) ].
 		spec baseline: 'Ring' with: [ spec repository: repository ].
 		spec baseline: 'HeuristicCompletion' with: [ spec repository: repository ].
-		spec baseline: 'DependencyAnalyzer' with: [ spec repository: repository; loads: #('Tool-DependencyAnalyser-UI-Tab') ].
+		spec baseline: 'DependencyAnalyzer' with: [
+			spec
+				repository: repository;
+				loads: #( 'Tool-DependencyAnalyser-UI-Tab' ) ].
 		self specCode: spec.
 		self newTools: spec.
 		self drTests: spec.
@@ -148,9 +161,7 @@ BaselineOfIDE >> baseline: spec [
 		spec baseline: 'ThreadedFFI' with: [ spec repository: repository ].
 		spec baseline: 'ProfilerUI' with: [ spec repository: repository ].
 
-		spec package: 'Kernel-ExtraUtils'
-
-	]
+		spec package: 'Kernel-ExtraUtils' ]
 ]
 
 { #category : 'baselines' }

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -27,6 +27,9 @@ Installs:
 Class {
 	#name : 'BaselineOfIDE',
 	#superclass : 'BaselineOf',
+	#instVars : [
+		'repository'
+	],
 	#classVars : [
 		'Initialized'
 	],
@@ -38,117 +41,71 @@ Class {
 BaselineOfIDE >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURL.
 	spec for: #common do: [
 		spec postLoadDoIt: #postload:package:.
-		spec baseline: 'BasicTools' with: [ spec repository: repository ].
-		spec baseline: 'Athens' with: [ spec repository: repository ].
-		spec baseline: 'Flashback' with: [ spec repository: repository ].
-		spec baseline: 'Shift' with: [
-			spec
-				repository: repository;
-				loads: 'shift-tests' ].
+		spec baseline: 'BasicTools' with: [ spec repository: self repository ].
+		spec baseline: 'Athens' with: [ spec repository: self repository ].
+		spec baseline: 'Flashback' with: [ spec repository: self repository ].
 
-		spec baseline: 'Traits' with: [
-			spec
-				repository: repository;
-				loads: 'traits-tests' ].
-
-		spec baseline: 'Slot' with: [
-			spec
-				repository: repository;
-				loads: 'slot-tests' ].
-
-		spec baseline: 'Clap' with: [
-			spec
-				repository: repository;
-				loads: 'development' ].
-
-		spec baseline: 'SUnit' with: [
-			spec
-				repository: repository;
-				loads: 'Tests' ].
-
-		spec baseline: 'EnlumineurFormatter' with: [
-			spec
-				repository: repository;
-				loads: #( 'Tests' ) ].
-
-		spec baseline: 'Reflectivity' with: [
-			spec
-				repository: repository;
-				loads: #( 'tests' ) ].
-
-		spec baseline: 'Refactoring' with: [
-			spec
-				repository: repository;
-				loads: #( 'Tests' ) ].
+		self
+			load: 'Shift' group: 'shift-tests' spec: spec;
+			load: 'Traits' group: 'traits-tests' spec: spec;
+			load: 'Slot' group: 'slot-tests' spec: spec;
+			load: 'Clap' group: 'development' spec: spec;
+			load: 'SUnit' group: 'Tests' spec: spec;
+			load: 'EnlumineurFormatter' group: 'Tests' spec: spec;
+			load: 'Reflectivity' group: 'tests' spec: spec;
+			load: 'Refactoring' group: 'Tests' spec: spec.
 
 		spec package: 'Math-Operations-Extensions-Tests'.
 		spec package: 'Network-Tests'.
 		spec package: 'Network-Mail-Tests'.
 		spec package: 'Gofer-Tests'.
 		spec package: 'Rubric-SpecFindReplaceDialog'.
-		spec baseline: 'Metacello' with: [
-			spec
-				repository: repository;
-				loads: #( 'Tests' ) ].
+
+
+		self load: 'Metacello' group: 'Tests' spec: spec.
+
 		spec package: 'MonticelloGUI-Tests'.
 		"Later we will load the UI of enlumineur probably here
 		"
-		spec baseline: 'KernelTests' with: [ spec repository: repository ].
-		spec baseline: 'Shout' with: [ spec repository: repository ].
+		spec baseline: 'KernelTests' with: [ spec repository: self repository ].
+		spec baseline: 'Shout' with: [ spec repository: self repository ].
 
-		spec baseline: 'ReflectionMirrors' with: [ spec repository: repository ].
-		spec baseline: 'FuzzyMatcher' with: [ spec repository: repository ].
-		spec baseline: 'QA' with: [ spec repository: repository ].
-		spec baseline: 'OSWindow' with: [ spec repository: repository ].
-		spec baseline: 'EmergencyDebugger' with: [ spec repository: repository ].
+		spec baseline: 'ReflectionMirrors' with: [ spec repository: self repository ].
+		spec baseline: 'FuzzyMatcher' with: [ spec repository: self repository ].
+		spec baseline: 'QA' with: [ spec repository: self repository ].
+		spec baseline: 'OSWindow' with: [ spec repository: self repository ].
+		spec baseline: 'EmergencyDebugger' with: [ spec repository: self repository ].
 
-		spec baseline: 'Epicea' with: [
-			spec
-				repository: repository;
-				loads: #Browsers ].
+		self load: 'Epicea' group: 'Browsers' spec: spec.
 
-		spec baseline: 'Misc' with: [ spec repository: repository ].
-		spec baseline: 'Fuel' with: [
-			spec
-				repository: repository;
-				loads: #( 'Tests' ) ].
-		spec baseline: 'GeneralTests' with: [ spec repository: repository ].
-		spec baseline: 'FreeType' with: [
-			spec
-				repository: repository;
-				loads: 'tests' ].
-		spec baseline: 'Keymapping' with: [
-			spec
-				repository: repository;
-				loads: 'tests' ].
-		spec baseline: 'Zodiac' with: [ spec repository: repository ].
-		spec baseline: 'SortFunctions' with: [ spec repository: repository ].
-		spec baseline: 'Equals' with: [ spec repository: repository ].
-		spec baseline: 'NewValueHolder' with: [
-			spec
-				repository: repository;
-				loads: 'tests' ].
+		spec baseline: 'Misc' with: [ spec repository: self repository ].
+
+		self load: 'Fuel' group: 'Tests' spec: spec.
+
+		spec baseline: 'GeneralTests' with: [ spec repository: self repository ].
+
+		self load: 'FreeType' group: 'tests' spec: spec.
+		self load: 'Keymapping' group: 'tests' spec: spec.
+
+		spec baseline: 'Zodiac' with: [ spec repository: self repository ].
+		spec baseline: 'SortFunctions' with: [ spec repository: self repository ].
+		spec baseline: 'Equals' with: [ spec repository: self repository ].
+
+		self load: 'NewValueHolder' group: 'tests' spec: spec.
 		spec package: 'STON-Extensions'.
 
 		spec package: 'BaselineOfPharoBootstrap'.
 		spec package: 'BaselineOfMonticello'.
 		spec package: 'BaselineOfMetacello'.
-		spec baseline: 'ReferenceFinder' with: [ spec repository: repository ].
-		spec baseline: 'ClassParser' with: [ spec repository: repository ].
-		spec baseline: 'Calypso' with: [
-			spec
-				repository: repository;
-				loads: #( 'FullEnvironment' 'SystemBrowser' 'Tests' ) ].
-		spec baseline: 'Ring' with: [ spec repository: repository ].
-		spec baseline: 'HeuristicCompletion' with: [ spec repository: repository ].
-		spec baseline: 'DependencyAnalyzer' with: [
-			spec
-				repository: repository;
-				loads: #( 'Tool-DependencyAnalyser-UI-Tab' ) ].
+		spec baseline: 'ReferenceFinder' with: [ spec repository: self repository ].
+		spec baseline: 'ClassParser' with: [ spec repository: self repository ].
+
+		self load: 'Calypso' group: #( 'FullEnvironment' 'SystemBrowser' 'Tests' ) spec: spec.
+		spec baseline: 'Ring' with: [ spec repository: self repository ].
+		spec baseline: 'HeuristicCompletion' with: [ spec repository: self repository ].
+		self load: 'DependencyAnalyzer' group: 'Tool-DependencyAnalyser-UI-Tab' spec: spec.
 		self specCode: spec.
 		self newTools: spec.
 		self drTests: spec.
@@ -158,8 +115,8 @@ BaselineOfIDE >> baseline: spec [
 		self welcomeBrowser: spec.
 		self roassal: spec.
 
-		spec baseline: 'ThreadedFFI' with: [ spec repository: repository ].
-		spec baseline: 'ProfilerUI' with: [ spec repository: repository ].
+		spec baseline: 'ThreadedFFI' with: [ spec repository: self repository ].
+		spec baseline: 'ProfilerUI' with: [ spec repository: self repository ].
 
 		spec package: 'Kernel-ExtraUtils' ]
 ]
@@ -183,9 +140,16 @@ BaselineOfIDE >> documentBrowserCore: spec [
 { #category : 'baselines' }
 BaselineOfIDE >> drTests: spec [
 
-	spec 
-		baseline: 'DrTests' 
-		with: [ spec repository: self packageRepositoryURL ]
+	spec baseline: 'DrTests' with: [ spec repository: self repository ]
+]
+
+{ #category : 'baselines' }
+BaselineOfIDE >> load: aProject group: aGroupName spec: spec [
+
+	spec baseline: aProject with: [
+		spec
+			repository: self repository;
+			loads: aGroupName ]
 ]
 
 { #category : 'actions' }
@@ -202,11 +166,11 @@ BaselineOfIDE >> loadExtraTools [
 	"Hack: Document Browser is loaded in 2 steps because of the dependency of some packages to Iceberg.
 	The 2nd load is done through Metacello that adds new project registrations in Iceberg (user, not system).
 	We then remove these last registrations."
-	#('NewTools-DocumentBrowser' 'Iceberg') do: [ :repositoryName | | repository |
-		repository := IceRepository registry 
+	#('NewTools-DocumentBrowser' 'Iceberg') do: [ :repositoryName | | foundRepo |
+		foundRepo := IceRepository registry 
 			detect: [ :repo | repo name = repositoryName ]
 			ifNone: [ self error: repositoryName , ' not found in Iceberg registry!' ].
-		IceRepository unregisterRepository: repository ifAbsent: [ "ignore" ] ].
+		IceRepository unregisterRepository: foundRepo ifAbsent: [ "ignore" ] ].
 ]
 
 { #category : 'actions' }
@@ -406,6 +370,12 @@ BaselineOfIDE >> registerProject: projectName externalProject: externalProject b
 	"Register baselines"
 	({baselineName}, anArray) do: [ :each |
 		Metacello new baseline: each; register ]
+]
+
+{ #category : 'baselines' }
+BaselineOfIDE >> repository [
+
+	^ repository ifNil: [ repository := self packageRepositoryURL ]
 ]
 
 { #category : 'baselines' }


### PR DESCRIPTION
- Add dependencies between packages
- Add tests to the baseline
- Add a Browsers and a Tests group
- Make sure other baseline loads the right group
- Simplify the way to declare projects in BaselineOfIDE

I discovered that tests were not in the baseline while browsing the Epicea project in the projects view of Calypso. This is a nice way to find the problems we have in our projects declarations