### PR TITLE
Fix flacky testSubClassWithTraitsAfterModificationOfParentSharedPools

### DIFF
--- a/src/Traits-Tests/TraitSlotScopeTest.class.st
+++ b/src/Traits-Tests/TraitSlotScopeTest.class.st
@@ -193,6 +193,7 @@ TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParent [
 TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedPools [
 
 	| t1 c1 c2 t2 x1 |
+	[
 	t1 := self newTrait: #T1.
 	t2 := self newTrait: #T2.
 
@@ -218,7 +219,8 @@ TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedPools
 			      package: self packageNameForTests ].
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.
-	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope
+	self assert: c2 class classLayout slotScope parentScope identicalTo: c2 class superclass classLayout slotScope ] ensure: [
+		c1 ifNotNil: [ "For now if we remove a used shared variables it causes troubles. So as a temporary workaround we remove the class first." c1 removeFromSystem ] ]
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
TraitSlotScopeTest>>#testSubClassWithTraitsAfterModificationOfParentSharedPools is flacky because it creates a class using a trait and a shared pool from the same packages.

Depending on the order of removal, things can get nasty. This happens when the shared pool get removed first then the trait then the class.

The trait removal triggers a recompilation of the class without the trait. But the sharedpool is still considered in the class even if it got removed. This causes a crash.

I added a workaround to remove the class first but this is just hidding the problem (because I don't have the time for a better fix right now and also I need to discuss with the team to know what to do in this case).

Should we remove the shared pool from its users when we remove it lile we do with traits? Should we order thing when we remove them? Should the trait declare they are removed from their users when we remove them from the system while they still have users? I don't know what to do for now on those subjects