### PR TITLE
Introduce #codeSupportAnnouncer

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -36,7 +36,7 @@ Class {
 { #category : 'private - announcements' }
 ASTCache class >> announceCacheReset [
 
-	SystemAnnouncer announce: ASTCacheReset new
+	self codeSupportAnnouncer announce: ASTCacheReset new
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -549,6 +549,12 @@ Behavior >> codeChangeAnnouncer [
 	^ self environment codeChangeAnnouncer
 ]
 
+{ #category : 'accessing' }
+Behavior >> codeSupportAnnouncer [
+
+	^ self environment codeSupportAnnouncer
+]
+
 { #category : 'accessing - method dictionary' }
 Behavior >> compiledMethodAt: selector [
 	"Answer the compiled method associated with the argument, selector (a

--- a/src/Reflectivity-Tests/Breakpoint.extension.st
+++ b/src/Reflectivity-Tests/Breakpoint.extension.st
@@ -5,7 +5,7 @@ Breakpoint class >> registerObserver: anObject [
 	"Do not use this method, it is there for compatibility with old users.
 	Instead, register your object yourself to 'SystemAnnouncer uniqueInstance' like below, but only for the announcements you need"
 
-	SystemAnnouncer uniqueInstance
+	self codeSupportAnnouncer
 		when: BreakpointAdded send: #update: to: anObject;
 		when: BreakpointHit send: #update: to: anObject;
 		when: BreakpointRemoved send: #update: to: anObject
@@ -14,7 +14,7 @@ Breakpoint class >> registerObserver: anObject [
 { #category : '*Reflectivity-Tests' }
 Breakpoint class >> unregisterObserver: anObject [
 	"Do not use this method, it is there for compatibility with old users.
-	Instead, unsubscribe yourself from 'SystemAnnouncer uniqueInstance' directly (like shown below)"
+	Instead, unsubscribe yourself from the announcer directly (like shown below)"
 
-	SystemAnnouncer uniqueInstance unsubscribe: anObject
+	self codeSupportAnnouncer unsubscribe: anObject
 ]

--- a/src/Reflectivity/Breakpoint.class.st
+++ b/src/Reflectivity/Breakpoint.class.st
@@ -154,31 +154,19 @@ Breakpoint class >> isInstalledIn: aMethod [
 { #category : 'notifications' }
 Breakpoint class >> notifyBreakpointAdded: aBreakpoint [
 
-	| announcement |
-	announcement := BreakpointAdded
-		on: aBreakpoint
-		nodes: aBreakpoint link nodes.
-	SystemAnnouncer announce: announcement
+	self codeSupportAnnouncer announce: (BreakpointAdded on: aBreakpoint nodes: aBreakpoint link nodes)
 ]
 
 { #category : 'notifications' }
 Breakpoint class >> notifyBreakpointHit: aBreakpoint inContext: aContext node: node [
 
-	| announcement |
-	announcement := BreakpointHit
-		on: aBreakpoint
-		nodes: {node}.
-	SystemAnnouncer announce: announcement
+	self codeSupportAnnouncer announce: (BreakpointHit on: aBreakpoint nodes: { node })
 ]
 
 { #category : 'notifications' }
 Breakpoint class >> notifyBreakpointRemoved: aBreakpoint fromNodes: nodes [
 
-	| announcement |
-	announcement := BreakpointRemoved
-		on: aBreakpoint
-		nodes: nodes.
-	SystemAnnouncer announce: announcement
+	self codeSupportAnnouncer announce: (BreakpointRemoved on: aBreakpoint nodes: nodes)
 ]
 
 { #category : 'class initialization' }

--- a/src/Reflectivity/MetaLink.class.st
+++ b/src/Reflectivity/MetaLink.class.st
@@ -96,17 +96,20 @@ MetaLink >> allReifications [
 
 { #category : 'installing' }
 MetaLink >> announceChange [
-	self optionAnnounce ifTrue: [SystemAnnouncer announce: (MetalinkChanged new link: self)]
+
+	self optionAnnounce ifTrue: [ self codeSupportAnnouncer announce: (MetalinkChanged new link: self) ]
 ]
 
 { #category : 'installing' }
 MetaLink >> announceInstall: node [
-	self optionAnnounce ifTrue: [SystemAnnouncer announce: (MetalinkChanged linkAdded: self toNode: node)]
+
+	self optionAnnounce ifTrue: [ self codeSupportAnnouncer announce: (MetalinkChanged linkAdded: self toNode: node) ]
 ]
 
 { #category : 'installing' }
 MetaLink >> announceRemove: node [
-	self optionAnnounce ifTrue: [SystemAnnouncer announce: (MetalinkChanged linkRemoved: self fromNode: node)]
+
+	self optionAnnounce ifTrue: [ self codeSupportAnnouncer announce: (MetalinkChanged linkRemoved: self fromNode: node) ]
 ]
 
 { #category : 'accessing' }
@@ -134,6 +137,12 @@ MetaLink >> checkForCompatibilityWith: aNode [
 		supported add: plugin key]].
 	self allReifications do: [ :each | (supported includes: each) ifFalse: [^false  ]  ].
 	^true
+]
+
+{ #category : 'accessing' }
+MetaLink >> codeSupportAnnouncer [
+
+	^ self class codeSupportAnnouncer
 ]
 
 { #category : 'accessing' }

--- a/src/Reflectivity/MetaLinkInstaller.class.st
+++ b/src/Reflectivity/MetaLinkInstaller.class.st
@@ -136,14 +136,16 @@ MetaLinkInstaller >> findSubNode: node in: methodNode [
 
 { #category : 'initialization' }
 MetaLinkInstaller >> initialize [
+
 	anonSubclassesBuilder := MetaLinkAnonymousClassBuilder new.
 	linksRegistry := MetaLinkRegistry new.
 	linkToNodesMapper := MetaLinkNodesMapper new.
 	superJumpLinks := OrderedCollection new.
 
-	SystemAnnouncer uniqueInstance weak when: MethodModified send: #methodChanged: to: self.
-	SystemAnnouncer uniqueInstance weak when: MethodRemoved send: #methodRemoved: to: self.
-	SystemAnnouncer uniqueInstance weak when: MethodAdded send: #methodAdded: to: self
+	self class codeSupportAnnouncer weak
+		when: MethodModified send: #methodChanged: to: self;
+		when: MethodRemoved send: #methodRemoved: to: self;
+		when: MethodAdded send: #methodAdded: to: self
 ]
 
 { #category : 'installation' }
@@ -432,5 +434,6 @@ MetaLinkInstaller >> uninstallSuperJumpLinks [
 
 { #category : 'initialization' }
 MetaLinkInstaller >> unsubscribeFromAnnouncers [
-	SystemAnnouncer uniqueInstance unsubscribe: self
+
+	self class codeSupportAnnouncer unsubscribe: self
 ]

--- a/src/Reflectivity/VariableBreakpoint.class.st
+++ b/src/Reflectivity/VariableBreakpoint.class.st
@@ -43,12 +43,10 @@ VariableBreakpoint class >> newForClass: aClass [
 
 { #category : 'notifications' }
 VariableBreakpoint class >> notifyBreakpointHit: aBreakpoint inContext: aContext node: node [
-	| announcement |
-	announcement := BreakpointHit
-		on: aBreakpoint
-		nodes: {node}.
-	announcement valueOrNil: (node variableValueInContext: aContext).
-	SystemAnnouncer announce: announcement
+
+	self codeSupportAnnouncer announce: ((BreakpointHit on: aBreakpoint nodes: { node })
+			 valueOrNil: (node variableValueInContext: aContext);
+			 yourself)
 ]
 
 { #category : 'API' }

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -188,6 +188,17 @@ SystemDictionary >> classOrTraitNamed: aString [
 
 { #category : 'accessing' }
 SystemDictionary >> codeChangeAnnouncer [
+	"A code change announcer is an announcer to register to Class, Method, Package and Protocol announcement."
+
+	"This should not be hardcoded in the futurebut I should have my own instance."
+
+	^ SystemAnnouncer uniqueInstance
+]
+
+{ #category : 'accessing' }
+SystemDictionary >> codeSupportAnnouncer [
+	"A code support announcer is an announcer used for tooling support such as the breakpoints or AST cache."
+
 	"This should not be hardcoded in the futurebut I should have my own instance."
 
 	^ SystemAnnouncer uniqueInstance


### PR DESCRIPTION
In the efoort of working on announcement, after adding a #codeChangeAnnouncer on the environment, I'm adding a codeSupportAnnouncer on environemnt.

This one will be used to manage announcements around the tooling support and not the model changes.

I'm starting to use it with Breakpoints and Reflectivity.

For now it just forward to system announcer but in the future they will be their own instance of Announcer.