### PR TITLE
Monticello: Simplify class announcement listening

### DIFF
--- a/src/Manifest-Core/ClassDescription.extension.st
+++ b/src/Manifest-Core/ClassDescription.extension.st
@@ -17,5 +17,5 @@ ClassDescription >> manifestBuilderForRuleChecker: aRuleChecker [
 { #category : '*Manifest-Core' }
 ClassDescription >> mcWorkingCopy [
 
-	MCWorkingCopy workingCopiesForClass: self do: [ :package | ^ package ]
+	^ self package mcWorkingCopy
 ]

--- a/src/Manifest-Core/CompiledMethod.extension.st
+++ b/src/Manifest-Core/CompiledMethod.extension.st
@@ -24,5 +24,5 @@ CompiledMethod >> manifestBuilderForRuleChecker: aRuleChecker [
 { #category : '*Manifest-Core' }
 CompiledMethod >> mcWorkingCopy [
 
-	MCWorkingCopy workingCopiesForPackage: self package do: [ :package | ^ package ]
+	^ self package mcWorkingCopy
 ]

--- a/src/Metacello-Core/MetacelloProject.class.st
+++ b/src/Metacello-Core/MetacelloProject.class.st
@@ -213,7 +213,7 @@ MetacelloProject >> fetchProject: aLoaderPolicy [
 	(mcLoader := self loader) ifNil: [ mcLoader := self project loaderClass on: nil ].
 	mcLoader loaderPolicy: aLoaderPolicy.
 	mcLoader doingLoads: [
-		MCWorkingCopy workingCopiesForClass: self configuration class do: [ :workingCopy |
+		self configuration class mcWorkingCopy ifNotNil: [ :workingCopy |
 			| pkg |
 			pkg := self packageSpec.
 			workingCopy repositoryGroup repositories do: [ :repo | pkg repositories repository: (repo asRepositorySpecFor: self) ].
@@ -411,23 +411,21 @@ MetacelloProject >> projectForScriptEngine: aMetacelloScriptEngine unconditional
 
 { #category : 'development support' }
 MetacelloProject >> projectPackage [
-  MCWorkingCopy
-    workingCopiesForClass: self configuration class
-    do: [ :workingCopy | 
-      | pkgSpec repo |
-      pkgSpec := self packageSpec
-        name: workingCopy packageName;
-        yourself.
-      workingCopy ancestors notEmpty
-        ifTrue: [ pkgSpec file: workingCopy ancestors first name ].
-      repo := workingCopy repositoryGroup repositories
-        detect: [ :each | each ~~ MCCacheRepository default ]
-        ifNone: [ 
-          MetacelloNotification signal: ('Using cache repository for ' , self label , ' project package').
-          MCCacheRepository default ].
-      pkgSpec repository: (repo asRepositorySpecFor: self).
-      ^ pkgSpec ].
-  ^ nil
+
+	self configuration class mcWorkingCopy ifNotNil: [ :workingCopy |
+		| pkgSpec repo |
+		pkgSpec := self packageSpec
+			           name: workingCopy packageName;
+			           yourself.
+		workingCopy ancestors notEmpty ifTrue: [ pkgSpec file: workingCopy ancestors first name ].
+		repo := workingCopy repositoryGroup repositories
+			        detect: [ :each | each ~~ MCCacheRepository default ]
+			        ifNone: [
+				        MetacelloNotification signal: 'Using cache repository for ' , self label , ' project package'.
+				        MCCacheRepository default ].
+		pkgSpec repository: (repo asRepositorySpecFor: self).
+		^ pkgSpec ].
+	^ nil
 ]
 
 { #category : 'private' }

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -82,34 +82,7 @@ MCWorkingCopy class >> announcer: anAnnouncer [
 { #category : 'system changes' }
 MCWorkingCopy class >> classModified: anEvent [
 
-	self workingCopiesForClass: anEvent classAffected do: [ :wc | wc modified: true ]
-]
-
-{ #category : 'system changes' }
-MCWorkingCopy class >> classMoved: anEvent [
-
-	self workingCopiesForPackage: anEvent oldPackage do: [ :mgr | mgr modified: true ].
-	self workingCopiesForPackage: anEvent newPackage do: [ :mgr | mgr modified: true ]
-]
-
-{ #category : 'system changes' }
-MCWorkingCopy class >> classRemoved: anEvent [
-	"Informs the registry who use to keep this class that its changed. Unlike #classModified:, class is not anymore in RPackages so it will not be found, that's why we look for system category instead if class is included or not"
-
-	anEvent packageAffected mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ].
-
-	anEvent classAffected protocols , anEvent classAffected classSide protocols
-		select: [ :protocol | protocol isExtensionProtocol ]
-		thenDo: [ :extensionProtocol |
-			(self packageOrganizer packageMatchingExtensionName: extensionProtocol name allButFirst) ifNotNil: [ :package |
-				package mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ] ] ]
-]
-
-{ #category : 'system changes' }
-MCWorkingCopy class >> classRenamed: anEvent [
-
-	self classModified: anEvent.
-	anEvent classAffected extendingPackages do: [ :pkg | self workingCopiesForPackage: pkg do: [ :workingCopy | workingCopy modified: true ] ]
+	anEvent packagesAffected do: [ :package | package mcWorkingCopy ifNotNil: [ :copy | copy modified: true ] ]
 ]
 
 { #category : 'accessing' }
@@ -178,22 +151,23 @@ MCWorkingCopy class >> initialize [
 { #category : 'system changes' }
 MCWorkingCopy class >> methodModified: anEvent [
 	"trait methods aren't handled here"
+
 	anEvent isProvidedByATrait ifTrue: [ ^ self ].
 
-	^ self workingCopiesForPackage: anEvent methodPackage do: [ :wc | wc modified: true ]
+	^ anEvent methodPackage mcWorkingCopy ifNotNil: [ :wc | wc modified: true ]
 ]
 
 { #category : 'system changes' }
 MCWorkingCopy class >> methodMoved: anEvent [
 
-	self workingCopiesForPackage: anEvent oldPackage do: [ :workingCopy | workingCopy modified: true ].
-	self workingCopiesForPackage: anEvent newPackage do: [ :workingCopy | workingCopy modified: true ]
+	anEvent oldPackage mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ].
+	anEvent newPackage mcWorkingCopy ifNotNil: [ :workingCopy | workingCopy modified: true ]
 ]
 
 { #category : 'system changes' }
 MCWorkingCopy class >> methodRemoved: anEvent [
 
-	self workingCopiesForPackage: anEvent methodPackage do: [ :wc | wc modified: true ]
+	anEvent methodPackage mcWorkingCopy ifNotNil: [ :wc | wc modified: true ]
 ]
 
 { #category : 'system changes' }
@@ -239,10 +213,7 @@ MCWorkingCopy class >> registerInterestOnSystemChanges [
 		when: PackageAdded send: #packageAdded: to: self;
 		when: PackageRenamed send: #packageRenamed: to: self;
 		when: PackageRemoved send: #packageRemoved: to: self;
-		when: ClassAdded , ClassModifiedClassDefinition , ClassCommented , ClassParentRenamed send: #classModified: to: self;
-		when: ClassRenamed send: #classRenamed: to: self;
-		when: ClassRepackaged send: #classMoved: to: self;
-		when: ClassRemoved send: #classRemoved: to: self;
+		when: ClassAdded , ClassModifiedClassDefinition , ClassCommented , ClassParentRenamed , ClassRenamed , ClassRepackaged , ClassRemoved send: #classModified: to: self;
 		when: MethodAdded , MethodModified , MethodRecategorized send: #methodModified: to: self;
 		when: MethodRepackaged send: #methodMoved: to: self;
 		when: MethodRemoved send: #methodRemoved: to: self
@@ -270,21 +241,6 @@ MCWorkingCopy class >> registry [
 MCWorkingCopy class >> unregisterForNotifications [
 
 	SystemAnnouncer uniqueInstance unsubscribe: self
-]
-
-{ #category : 'system changes' }
-MCWorkingCopy class >> workingCopiesForClass: aClass do: aBlock [
-
-	^ self workingCopiesForPackage: aClass package do: aBlock
-]
-
-{ #category : 'system changes' }
-MCWorkingCopy class >> workingCopiesForPackage: aPackage do: aBlock [
-
-	| packageName |
-	packageName := aPackage name.
-
-	self registry select: [ :workingCopy | workingCopy packageName = packageName ] thenDo: aBlock
 ]
 
 { #category : 'operations' }

--- a/src/System-Announcements/ClassRepackaged.class.st
+++ b/src/System-Announcements/ClassRepackaged.class.st
@@ -125,7 +125,5 @@ ClassRepackaged >> packagedChanged [
 { #category : 'accessing' }
 ClassRepackaged >> packagesAffected [
 
-	^ {
-		  self oldPackage.
-		  self newPackage }
+	^ { self oldPackage. self newPackage }
 ]


### PR DESCRIPTION
Subpart of: https://github.com/pharo-project/pharo/pull/15403

Since I don't know why the build fail, here is a subset of the changes. It contains two things:
- Use a more effective way to access the working copy of packages, classes and methods
- Merge the behavior of all class announcement listening into one