### PR TITLE
Bootstrap: Remove hack for defined methods

### DIFF
--- a/src/InitializePackagesCommandLineHandler/PackageOrganizer.extension.st
+++ b/src/InitializePackagesCommandLineHandler/PackageOrganizer.extension.st
@@ -17,16 +17,6 @@ PackageOrganizer >> basicBootstrapInitialize [
 			{
 				behavior.
 				behavior classSide } do: [ :aBehavior |
-				aBehavior protocols
-					reject: [ :protocol | protocol isExtensionProtocol ]
-					thenDo: [ :protocol | aBehavior package importProtocol: protocol forClass: aBehavior ] ] ]
-		displayingProgress: 'Importing methods'.
-
-	allBehaviors
-		do: [ :behavior |
-			{
-				behavior.
-				behavior classSide } do: [ :aBehavior |
 				aBehavior extensionProtocols do: [ :protocol |
 					(self ensurePackageMatching: protocol name allButFirst trimBoth) importProtocol: protocol forClass: aBehavior ] ] ]
 		displayingProgress: 'Importing extensions'


### PR DESCRIPTION
Defined methods are not cached anymore in RPackage so it should be safe to remove the hack that ensure that defined methods are in their package