### PR TITLE
Refactor ThemeIcons to have methods that answer a FormSet instead of a Form

### DIFF
--- a/src/Calypso-Browser/ClyMainItemCellMorph.class.st
+++ b/src/Calypso-Browser/ClyMainItemCellMorph.class.st
@@ -86,7 +86,7 @@ ClyMainItemCellMorph >> addBarForLabelIndentation [
 ClyMainItemCellMorph >> addExtraIcon: iconName [
 
 	| icon |
-	icon := self iconNamed: iconName.
+	icon := self iconFormSetNamed: iconName.
 	^self addExtraTool: icon asMorph
 ]
 
@@ -179,7 +179,7 @@ ClyMainItemCellMorph >> currentExpansionButton [
 ClyMainItemCellMorph >> definitionIcon: iconName [
 
 	| icon |
-	icon := self iconNamed: iconName.
+	icon := self iconFormSetNamed: iconName.
 	^self definitionMorph: icon asMorph
 ]
 

--- a/src/Calypso-SystemTools-Core/ClyClassIconTableDecorator.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassIconTableDecorator.class.st
@@ -18,7 +18,7 @@ ClyClassIconTableDecorator class >> decorateMainTableCell: anItemCellMorph of: a
 	| icon |
 	super decorateMainTableCell: anItemCellMorph of: aDataSourceItem.
 
-   icon := self iconNamed: (Object environment
+   icon := self iconFormSetNamed: (Object environment
 		at: aDataSourceItem name asSymbol
 		ifPresent: [ :aClass | aClass systemIconName ]
 		ifAbsent: [ Object systemIconName ]).

--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -718,12 +718,12 @@ HaloMorph >> createHandleAt: aPoint color: aColor iconName: iconName [
 			handle borderWidth: 0 ].
 	handle wantsYellowButtonMenu: false.
 	iconName
-		ifNotNil: [ ( self iconNamed: iconName )
-				ifNotNil: [ :form |
+		ifNotNil: [ ( self iconFormSetNamed: iconName )
+				ifNotNil: [ :formSet |
 					| image |
 
 					image := ImageMorph new.
-					image form: form.
+					image formSet: formSet.
 					image color: aColor contrastingBlackAndWhiteColor.
 					image lock.
 					handle addMorphCentered: image

--- a/src/Polymorph-Widgets/AboutDialogWindow.class.st
+++ b/src/Polymorph-Widgets/AboutDialogWindow.class.st
@@ -29,7 +29,7 @@ AboutDialogWindow class >> openForPharo [
 			width := width
 				max: (self theme textFont widthOfStringOrText: l) ].
 	dialog := self new entryText: text.
-	dialog iconMorph image: (self iconNamed: #pharo).
+	dialog iconMorph formSet: (self iconFormSetNamed: #pharo).
 	dialog title: 'About Pharo'.
 	dialog open.
 	dialog textMorph

--- a/src/Polymorph-Widgets/Object.extension.st
+++ b/src/Polymorph-Widgets/Object.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : 'Object' }
 
 { #category : '*Polymorph-Widgets' }
+Object >> iconFormSetNamed: aSymbol [
+
+	^ Smalltalk ui icons iconFormSetNamed: aSymbol
+]
+
+{ #category : '*Polymorph-Widgets' }
 Object >> iconNamed: aSymbol [
 
 	^ Smalltalk ui icons iconNamed: aSymbol

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -210,6 +210,13 @@ ThemeIcons >> allIconNames [
 	^ self icons keys
 ]
 
+{ #category : 'private' }
+ThemeIcons >> basicIconNamed: aSymbol [
+
+	^ self icons at: aSymbol ifPresent: [ :icon |
+		icon scaledToSize: icon extent * (self currentWorld displayScaleFactor / self scale) ]
+]
+
 { #category : 'accessing' }
 ThemeIcons >> beCurrent [
 	self class current: self
@@ -293,16 +300,15 @@ ThemeIcons >> iconNamed: aSymbol [
 { #category : 'accessing' }
 ThemeIcons >> iconNamed: aSymbol ifNone: aBlock [
 
-	self icons at: aSymbol asSymbol ifPresent: [ :icon | ^ icon scaledToSize: icon extent * (self currentWorld displayScaleFactor / self scale) ].
+	(self basicIconNamed: aSymbol asSymbol) ifNotNil: [ :icon | ^ icon ].
 	"Trying the old way"
 
 	
 	((aSymbol endsWith: 'Icon') or: [ (aSymbol endsWith: 'Form') ]) ifTrue: [
-		self icons
-			at: (aSymbol allButLast: 4) asSymbol
-			ifPresent: [ :icon | 
+		(self basicIconNamed: (aSymbol allButLast: 4) asSymbol)
+			ifNotNil: [ :icon | 
 				('Using old icon name, please rename ', aSymbol printString) traceCr.
-				^ icon scaledToSize: icon extent * (self currentWorld displayScaleFactor / self scale) ]
+				^ icon ]
 	].
 
 	^ aBlock value

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -211,10 +211,11 @@ ThemeIcons >> allIconNames [
 ]
 
 { #category : 'private' }
-ThemeIcons >> basicIconNamed: aSymbol [
+ThemeIcons >> basicIconFormSetNamed: aSymbol [
 
 	^ self icons at: aSymbol ifPresent: [ :icon |
-		icon scaledToSize: icon extent * (self currentWorld displayScaleFactor / self scale) ]
+		FormSet form:
+			(icon scaledToSize: icon extent * (self currentWorld displayScaleFactor / self scale)) ]
 ]
 
 { #category : 'accessing' }
@@ -235,7 +236,13 @@ ThemeIcons >> beReportNotFound [
 { #category : 'accessing' }
 ThemeIcons >> blankIcon [
 
-	^ self iconNamed: #blank
+	^ self blankIconFormSet asForm
+]
+
+{ #category : 'accessing' }
+ThemeIcons >> blankIconFormSet [
+
+	^ self iconFormSetNamed: #blank
 ]
 
 { #category : 'private' }
@@ -286,32 +293,45 @@ ThemeIcons >> hash [
 ]
 
 { #category : 'accessing' }
-ThemeIcons >> iconNamed: aSymbol [
+ThemeIcons >> iconFormSetNamed: aSymbol [
+
 	^ (self
-		iconNamed: aSymbol
+		iconFormSetNamed: aSymbol
 		ifNone: [
 			self isReportingNotFound
 				ifTrue: [
 					self crTrace: (aSymbol, ' icon not found!').
-					self notFoundIcon ]
-				ifFalse: [ self blankIcon ]])
+					self notFoundIconFormSet ]
+				ifFalse: [ self blankIconFormSet ]])
 ]
 
 { #category : 'accessing' }
-ThemeIcons >> iconNamed: aSymbol ifNone: aBlock [
+ThemeIcons >> iconFormSetNamed: aSymbol ifNone: aBlock [
 
-	(self basicIconNamed: aSymbol asSymbol) ifNotNil: [ :icon | ^ icon ].
+	(self basicIconFormSetNamed: aSymbol asSymbol) ifNotNil: [ :icon | ^ icon ].
 	"Trying the old way"
 
 	
 	((aSymbol endsWith: 'Icon') or: [ (aSymbol endsWith: 'Form') ]) ifTrue: [
-		(self basicIconNamed: (aSymbol allButLast: 4) asSymbol)
+		(self basicIconFormSetNamed: (aSymbol allButLast: 4) asSymbol)
 			ifNotNil: [ :icon | 
 				('Using old icon name, please rename ', aSymbol printString) traceCr.
 				^ icon ]
 	].
 
 	^ aBlock value
+]
+
+{ #category : 'accessing' }
+ThemeIcons >> iconNamed: aSymbol [
+
+	^ (self iconFormSetNamed: aSymbol) asForm
+]
+
+{ #category : 'accessing' }
+ThemeIcons >> iconNamed: aSymbol ifNone: aBlock [
+
+	^ (self iconFormSetNamed: aSymbol ifNone: [ ^ aBlock value ]) asForm
 ]
 
 { #category : 'accessing' }
@@ -375,7 +395,13 @@ ThemeIcons >> name: aName [
 { #category : 'accessing' }
 ThemeIcons >> notFoundIcon [
 
-	^ self iconNamed: #notFound ifNone: [ Form extent: 0@0 ]
+	^ self notFoundIconFormSet asForm
+]
+
+{ #category : 'accessing' }
+ThemeIcons >> notFoundIconFormSet [
+
+	^ self iconFormSetNamed: #notFound ifNone: [ FormSet form: (Form extent: 0@0) ]
 ]
 
 { #category : 'printing' }

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -221,9 +221,12 @@ ThemeIcons >> basicIconFormSetNamed: aSymbol [
 		ifAbsentPut: [ IdentityDictionary new ])
 			at: aSymbol ifAbsentPut: [
 				self icons at: aSymbol
-					ifPresent: [ :icon |
-						FormSet form:
-							(icon scaledToSize: icon extent * (displayScaleFactor / self scale)) ]
+					ifPresent: [ :form |
+						| allForms scaledForm |
+						allForms := OrderedCollection new.
+						iconsPerScale do: [ :icons | icons at: aSymbol ifPresent: [ :otherForm | allForms add: otherForm ] ].
+						allForms add: (scaledForm := form scaledToSize: form extent * (displayScaleFactor / self scale)).
+						FormSet extent: scaledForm extent depth: scaledForm depth forms: (Array withAll: allForms) ]
 					ifAbsent: [ ^ nil ] ]
 ]
 

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -27,6 +27,7 @@ Class {
 		'url',
 		'iconsPerScale',
 		'scale',
+		'formSetsCache',
 		'reportNotFound'
 	],
 	#classVars : [
@@ -213,9 +214,17 @@ ThemeIcons >> allIconNames [
 { #category : 'private' }
 ThemeIcons >> basicIconFormSetNamed: aSymbol [
 
-	^ self icons at: aSymbol ifPresent: [ :icon |
-		FormSet form:
-			(icon scaledToSize: icon extent * (self currentWorld displayScaleFactor / self scale)) ]
+	| displayScaleFactor |
+
+	^ ((formSetsCache ifNil: [ formSetsCache := Dictionary new ])
+		at: (displayScaleFactor := self currentWorld displayScaleFactor)
+		ifAbsentPut: [ IdentityDictionary new ])
+			at: aSymbol ifAbsentPut: [
+				self icons at: aSymbol
+					ifPresent: [ :icon |
+						FormSet form:
+							(icon scaledToSize: icon extent * (displayScaleFactor / self scale)) ]
+					ifAbsent: [ ^ nil ] ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This pull request refactors ThemeIcons to have methods that answer a FormSet instead of a Form (FormSet was introduced in pull request #14998), and changes a few sends of `#iconNamed:` to use `#iconFormSetNamed:` instead.