### PR TITLE
Fix bug in recompilation of trait methods

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -293,7 +293,7 @@ CompiledMethodTest >> testAccessesSlot [
 	self assert: ((Point>>#setX:setY:) accessesSlot: (Point slotNamed: #y))
 ]
 
-{ #category : 'tests - compiling' }
+{ #category : 'tests - compilation' }
 CompiledMethodTest >> testAddingSlotDoesNotRemoveExtension [
 	"Regression test for a case where recompiling a method removed the fact that it was an extension."
 
@@ -303,12 +303,12 @@ CompiledMethodTest >> testAddingSlotDoesNotRemoveExtension [
 			         name: #TUTU;
 			         slots: { #test };
 			         package: self packageNameForTests ].
-	class compile: 'isExtensionTestMethod ^ test' classified: '*Kernel-Tests-Generated-Package'.
+	class compile: 'isExtensionTestMethod ^ test' classified: '*GeneratedPackageForTest'.
 	self assert: (class >> #isExtensionTestMethod) isExtension.
 
 	class addInstVarNamed: 'test2'.
 
-	self assert: (class >> #isExtensionTestMethod) isExtension ] ensure: [ self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package' ]
+	self assert: (class >> #isExtensionTestMethod) isExtension ] ensure: [ self packageOrganizer removePackage: 'GeneratedPackageForTest' ]
 ]
 
 { #category : 'tests - converting' }
@@ -363,20 +363,20 @@ CompiledMethodTest >> testComparison [
 			self deny: each equals: method2 ]
 ]
 
-{ #category : 'tests - compiling' }
+{ #category : 'tests - compilation' }
 CompiledMethodTest >> testCompilingExistingMethodDoesNotRemoveExtensions [
 	"Regression test for a case where recompiling a method removed the fact that it was an extension."
 
 	[
 	| method |
-	self class compile: 'isExtensionTestMethod ^ 1' classified: '*Kernel-Tests-Generated-Package'.
+	self class compile: 'isExtensionTestMethod ^ 1' classified: '*GeneratedPackageForTest'.
 	method := self class >> #isExtensionTestMethod.
 	self assert: method isExtension.
 
 	self class compile: 'isExtensionTestMethod ^ 2'.
 
 	self assert: method isExtension ] ensure: [
-		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
+		self packageOrganizer removePackage: 'GeneratedPackageForTest'.
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
 ]
 
@@ -872,20 +872,20 @@ CompiledMethodTest >> testReadsSlot [
 	self deny: ((Point>>#setX:setY:) readsSlot: (Point slotNamed: #y))
 ]
 
-{ #category : 'tests - compiling' }
+{ #category : 'tests - compilation' }
 CompiledMethodTest >> testRecompilingDoesNotRemoveExtensions [
 	"Regression test for a case where recompiling a method removed the fact that it was an extension."
 
 	[
 	| method |
-	self class compile: 'isExtensionTestMethod ^ 1' classified: '*Kernel-Tests-Generated-Package'.
+	self class compile: 'isExtensionTestMethod ^ 1' classified: '*GeneratedPackageForTest'.
 	method := self class >> #isExtensionTestMethod.
 	self assert: method isExtension.
 
 	method recompile.
 
 	self assert: method isExtension ] ensure: [
-		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
+		self packageOrganizer removePackage: 'GeneratedPackageForTest'.
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
 ]
 

--- a/src/Kernel/CompiledMethod.class.st
+++ b/src/Kernel/CompiledMethod.class.st
@@ -588,6 +588,18 @@ CompiledMethod >> methodClass: aClass [
 		ifTrue: [ self literalAt: self numLiterals put: aClass binding ]
 ]
 
+{ #category : 'private' }
+CompiledMethod >> migratePersistingPropertiesIn: aNewCompileMethod [
+	"While creating a new version of a method, we might want to persist some properties. I am here for this. I migrate the properties to persist from myself, the old version of the method, to the new version."
+
+	| properties |
+	(properties := self penultimateLiteral) isMethodProperties ifFalse: [ ^ self "There is no property so nothing to migrate." ].
+
+	"For now the properties are hard coded. Later they should be configurable in the additional state"
+	#( #extensionPackage #traitSource ) do: [ :propertyName |
+		properties at: propertyName ifPresent: [ :value | aNewCompileMethod propertyAt: propertyName put: value ] ]
+]
+
 { #category : 'accessing' }
 CompiledMethod >> name [
 	^ self printString

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -546,7 +546,9 @@ OpalCompiler >> generateMethod [
 	self compilationContext noPattern ifTrue: [ method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"
 
 	"If the prior method was not set explicitly, we set it because we will need it if we are not in the first compilation"
-	self priorMethod ifNil: [ self methodClass ifNotNil: [ :class | self priorMethod: (class compiledMethodAt: method selector ifAbsent: [ nil ]) ] ].
+	self priorMethod ifNil: [
+		self methodClass ifNotNil: [ :class | "In case the method comes from a trait, we ignore it because it means we are overriding the trait method in the class"
+			class compiledMethodAt: method selector ifPresent: [ :aMethod | aMethod isFromTrait ifFalse: [ self priorMethod: aMethod ] ] ] ].
 
 	"In case we are not compiling the method for the first time, we want to ensure that some properties are kept."
 	self priorMethod ifNotNil: [ priorMethod migratePersistingPropertiesIn: method ].

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -549,7 +549,7 @@ OpalCompiler >> generateMethod [
 	self priorMethod ifNil: [ self methodClass ifNotNil: [ :class | self priorMethod: (class compiledMethodAt: method selector ifAbsent: [ nil ]) ] ].
 
 	"In case we are not compiling the method for the first time, we want to ensure that some properties are kept."
-	self priorMethod ifNotNil: [ priorMethod propertyAt: #extensionPackage ifPresent: [ :package | method propertyAt: #extensionPackage put: package ] ].
+	self priorMethod ifNotNil: [ priorMethod migratePersistingPropertiesIn: method ].
 	^ method
 ]
 

--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -683,6 +683,52 @@ TraitTest >> testTraitRemoval [
 ]
 
 { #category : 'tests' }
+TraitTest >> testTraitSource [
+
+	self assert: (MOPTestClassC >> #c) traitSource isNil.
+	self assert: (MOPTestClassC >> #c2) traitSource equals: Trait2 asTraitComposition
+]
+
+{ #category : 'tests' }
+TraitTest >> testTraitSourceIsPersistedWithRecompilation [
+
+	[
+	Trait2 compile: 'traitMethod ^ 1' classified: '*GeneratedPackageForTest'.
+
+	self assert: (Trait2 >> #traitMethod) traitSource isNil.
+	self assert: (MOPTestClassC >> #traitMethod) traitSource equals: Trait2 asTraitComposition.
+
+	(Trait2 >> #traitMethod) recompile.
+
+	self assert: (Trait2 >> #traitMethod) traitSource isNil.
+	self assert: (MOPTestClassC >> #traitMethod) traitSource equals: Trait2 asTraitComposition ] ensure: [
+		self packageOrganizer removePackage: 'GeneratedPackageForTest' ]
+]
+
+{ #category : 'tests' }
+TraitTest >> testTraitSourceIsPersistedWithRemovalOfMetalinks [
+
+	[
+	| metalink |
+	Trait2 compile: 'traitMethod ^ 1' classified: '*GeneratedPackageForTest'.
+
+	self assert: (Trait2 >> #traitMethod) traitSource isNil.
+	self assert: (MOPTestClassC >> #traitMethod) traitSource equals: Trait2 asTraitComposition.
+
+	metalink := MetaLink new.
+	(MOPTestClassC >> #traitMethod) ast link: metalink.
+
+	self assert: (Trait2 >> #traitMethod) traitSource isNil.
+	self assert: (MOPTestClassC >> #traitMethod) traitSource equals: Trait2 asTraitComposition.
+
+	metalink uninstall.
+
+	self assert: (Trait2 >> #traitMethod) traitSource isNil.
+	self assert: (MOPTestClassC >> #traitMethod) traitSource equals: Trait2 asTraitComposition ] ensure: [
+		self packageOrganizer removePackage: 'GeneratedPackageForTest' ]
+]
+
+{ #category : 'tests' }
 TraitTest >> testTraitThatHasAPragmaHasCorrectTraitSourceAfterRecompile [
 	| t3 aClass |
 


### PR DESCRIPTION
Methods copied from traits have a #traitSource property. This property can be lost on recompilation. 

This change adds tests and fixes this. For now the properties to persist are hard coded. In a next iteration I'll make this configurable (in fact I already have a PR to try and do that but it is not working yet)