### PR TITLE
Push the bahevior of SystemAnnouncer into Announcer

### DIFF
--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -1,6 +1,11 @@
 "
-The implementation uses a threadsafe subscription registry, in the sense that registering, unregistering, and announcing from an announcer at the same time in different threads should never cause failures.
+I am the main implementation of the Announcement Design Pattern, equivalent to the Observer Design Pattern in other languages.
 
+This design pattern allows the creation of a subscription mechanism to notify subscribing objects about event happening to the system and allows them to react to it.
+
+Users can create subclasses of Announcement, then objects can register to an announcer declaring that they want to react of the announcer is announcing this specific announcement. When the announcer will annouce it, it will notify all listeners of the announcement.
+
+The implementation uses a threadsafe subscription registry, in the sense that registering, unregistering, and announcing from an announcer at the same time in different threads should never cause failures.
 
 The method #prevent:during: allows one to prevent the firing of some announcements during the execution of a block wile letting the other announcements go throuht.
 "
@@ -21,19 +26,30 @@ Class {
 { #category : 'announce' }
 Announcer >> announce: anAnnouncement [
 
-	| announcement |
-	announcement := anAnnouncement asAnnouncement.
+	^ self isSuspended
+		  ifFalse: [
+			  | announcement |
+			  announcement := anAnnouncement asAnnouncement.
 
-	"If the user required to prevent the current announcement, we stop here."
-	(self preventedAnnouncements handlesAnnouncement: announcement) ifTrue: [ ^ self ].
+			  "If the user required to prevent the current announcement, we stop here."
+			  (self preventedAnnouncements handlesAnnouncement: announcement) ifTrue: [ ^ self ].
 
-	registry ifNotNil: [ registry deliver: announcement ].
-	^ announcement
+			  registry ifNotNil: [ registry deliver: announcement ].
+			  announcement ]
+		  ifTrue: [ storedAnnouncements ifNotNil: [ storedAnnouncements add: anAnnouncement ] ]
 ]
 
 { #category : 'private' }
 Announcer >> basicSubscribe: subscription [
 	^ registry add: subscription
+]
+
+{ #category : 'announce' }
+Announcer >> delayAnnouncementsAfter: aBlock [
+	"I will execute a block and store all the announcements I am making during the execution of this block.
+	Once the execution is done, I will announce everything at once."
+
+	(self suspendAllWhileStoring: aBlock) do: [ :announcement | self announce: announcement ]
 ]
 
 { #category : 'testing' }
@@ -54,6 +70,11 @@ Announcer >> hasSubscriber: anObject [
 Announcer >> initialize [
 	super initialize.
 	registry := SubscriptionRegistry new
+]
+
+{ #category : 'testing' }
+Announcer >> isSuspended [
+	^suspended ifNil: [ suspended := false ]
 ]
 
 { #category : 'statistics' }
@@ -101,6 +122,35 @@ Announcer >> subscriptions [
 Announcer >> subscriptionsForClass: subscriberClass [
 	"Return the list of subscription for a given class"
 	^ self subscriptions subscriptionsForClass: subscriberClass
+]
+
+{ #category : 'announce' }
+Announcer >> suspendAllWhile: aBlock [
+	| oldSuspended |
+	oldSuspended := self isSuspended.
+	suspended := true.
+	^aBlock ensure: [ suspended := oldSuspended ]
+]
+
+{ #category : 'announce' }
+Announcer >> suspendAllWhileStoring: aBlock [
+	| reentring |
+	" Suspend all the announcements, storing them in an OrderedCollection, then returns this collection"
+
+	reentring := storedAnnouncements isNotNil.
+
+	reentring ifFalse:[
+		storedAnnouncements := OrderedCollection new.
+	].
+
+	[
+		self suspendAllWhile: aBlock.
+		^ storedAnnouncements.
+	] ensure:[
+		reentring ifFalse:[
+			storedAnnouncements := nil.
+		]
+	]
 ]
 
 { #category : 'subscription' }

--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -9,7 +9,9 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'registry',
-		'preventedAnnouncements'
+		'preventedAnnouncements',
+		'suspended',
+		'storedAnnouncements'
 	],
 	#category : 'Announcements-Core-Base',
 	#package : 'Announcements-Core',

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -11,14 +11,6 @@ Class {
 	#tag : 'Announcements'
 }
 
-{ #category : 'announce' }
-RGEnvironmentAnnouncer >> announce: anAnnouncement [
-
-	self isSuspended
-		ifFalse: [ super announce: anAnnouncement ]
-		ifTrue: [ storedAnnouncements ifNotNil: [ storedAnnouncements add: anAnnouncement ] ]
-]
-
 { #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorAdded: anRGBehavior [
 
@@ -72,11 +64,6 @@ RGEnvironmentAnnouncer >> behaviorRenamed: anRGBehavior from: oldName [
 	self announce: (ClassRenamed class: anRGBehavior oldName: oldName newName: anRGBehavior name)
 ]
 
-{ #category : 'testing' }
-RGEnvironmentAnnouncer >> isSuspended [
-	^suspended ifNil: [ suspended := false ]
-]
-
 { #category : 'triggering' }
 RGEnvironmentAnnouncer >> methodAdded: aMethod [
 
@@ -88,33 +75,4 @@ RGEnvironmentAnnouncer >> methodRemoved: aMethod [
 	"For the protocol we should just send #protocol to the method when #protocol will return a protocol and not a symbol."
 
 	self announce: (MethodRemoved methodRemoved: aMethod origin: aMethod parent)
-]
-
-{ #category : 'announce' }
-RGEnvironmentAnnouncer >> suspendAllWhile: aBlock [
-	| oldSuspended |
-	oldSuspended := self isSuspended.
-	suspended := true.
-	^aBlock ensure: [ suspended := oldSuspended ]
-]
-
-{ #category : 'announce' }
-RGEnvironmentAnnouncer >> suspendAllWhileStoring: aBlock [
-	| reentring |
-	" Suspend all the announcements, storing them in an OrderedCollection, then returns this collection"
-
-	reentring := storedAnnouncements isNotNil.
-
-	reentring ifFalse:[
-		storedAnnouncements := OrderedCollection new.
-	].
-
-	[
-		self suspendAllWhile: aBlock.
-		^ storedAnnouncements.
-	] ensure:[
-		reentring ifFalse:[
-			storedAnnouncements := nil.
-		]
-	]
 ]

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -6,10 +6,6 @@ BEWARE: You should not need to subclass me. Think about just using me to send yo
 Class {
 	#name : 'RGEnvironmentAnnouncer',
 	#superclass : 'Announcer',
-	#instVars : [
-		'suspended',
-		'storedAnnouncements'
-	],
 	#category : 'Ring-Core-Announcements',
 	#package : 'Ring-Core',
 	#tag : 'Announcements'

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -52,14 +52,6 @@ SystemAnnouncer class >> unload [
 	self uniqueInstance unsubscribe: self
 ]
 
-{ #category : 'announce' }
-SystemAnnouncer >> announce: anAnnouncement [
-
-	self isSuspended
-		ifFalse: [ super announce: anAnnouncement ]
-		ifTrue: [ storedAnnouncements ifNotNil: [ storedAnnouncements add: anAnnouncement ] ]
-]
-
 { #category : 'triggering' }
 SystemAnnouncer >> class: aClass oldComment: oldComment newComment: newComment oldStamp: oldStamp newStamp: newStamp [
 	"A class was commented in the system."
@@ -95,14 +87,6 @@ SystemAnnouncer >> classRenamed: aClass from: oldClassName to: newClassName [
 	self announce: (ClassRenamed class: aClass oldName: oldClassName newName: newClassName)
 ]
 
-{ #category : 'announce' }
-SystemAnnouncer >> delayAnnouncementsAfter: aBlock [
-	"I will execute a block and store all the announcements I am making during the execution of this block.
-	Once the execution is done, I will announce everything at once."
-
-	(self suspendAllWhileStoring: aBlock) do: [ :announcement | self announce: announcement ]
-]
-
 { #category : 'triggering' }
 SystemAnnouncer >> evaluated: textOrStream [
 	^ self evaluated: textOrStream context: nil
@@ -113,11 +97,6 @@ SystemAnnouncer >> evaluated: expression context: aContext [
 	self announce: (ExpressionEvaluated
 				expression: expression
 				context: aContext)
-]
-
-{ #category : 'testing' }
-SystemAnnouncer >> isSuspended [
-	^suspended ifNil: [ suspended := false ]
 ]
 
 { #category : 'triggering' }
@@ -151,38 +130,4 @@ SystemAnnouncer >> methodRepackaged: aMethod from: aPackage to: anotherPackage [
 SystemAnnouncer >> snapshotDone: isNewImage [
 
 	self announce: (SnapshotDone isNewImage: isNewImage)
-]
-
-{ #category : 'announce' }
-SystemAnnouncer >> suspendAllWhile: aBlock [
-	| oldSuspended |
-	oldSuspended := self isSuspended.
-	suspended := true.
-	^aBlock ensure: [ suspended := oldSuspended ]
-]
-
-{ #category : 'announce' }
-SystemAnnouncer >> suspendAllWhileStoring: aBlock [
-	| reentring |
-	" Suspend all the announcements, storing them in an OrderedCollection, then returns this collection"
-
-	reentring := storedAnnouncements isNotNil.
-
-	reentring ifFalse:[
-		storedAnnouncements := OrderedCollection new.
-	].
-
-	[
-		self suspendAllWhile: aBlock.
-		^ storedAnnouncements.
-	] ensure:[
-		reentring ifFalse:[
-			storedAnnouncements := nil.
-		]
-	]
-]
-
-{ #category : 'triggering' }
-SystemAnnouncer >> traitDefinitionChangedFrom: oldTrait to: newTrait [
-	self announce: (ClassModifiedClassDefinition classDefinitionChangedFrom: oldTrait to: newTrait)
 ]

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -6,10 +6,6 @@ BEWARE: You should not need to subclass me. Think about just using me to send yo
 Class {
 	#name : 'SystemAnnouncer',
 	#superclass : 'Announcer',
-	#instVars : [
-		'suspended',
-		'storedAnnouncements'
-	],
 	#classInstVars : [
 		'announcer'
 	],


### PR DESCRIPTION
SystemAnnouncer is adding some behavior compared to Announcer. Since I would like to get rid of this singleton class, I propose to push up this behavior. It can be interesting for any announcer. 

This contains mostly the possibility to suspend announcements during a block.

I also improved the class comment of Announcer.