### PR TITLE
Fixes #15437 less debugger open for nothing.

### DIFF
--- a/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
+++ b/src/OpalCompiler-Core/OCDoItSemanticScope.class.st
@@ -25,7 +25,9 @@ OCDoItSemanticScope class >> isAbstract [
 { #category : 'code evaluation' }
 OCDoItSemanticScope >> evaluateDoIt: doItMethod [
 
-	^self receiver withArgs: #() executeMethod: doItMethod
+	^ [ self receiver withArgs: #() executeMethod: doItMethod] 
+			on: UndeclaredVariableRead
+		 	do: [ self receiver ]
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION

{ #category : 'code evaluation' }
OCDoItSemanticScope >> evaluateDoIt: doItMethod [

	^self receiver withArgs: #() executeMethod: doItMethod
	^ [ self receiver withArgs: #() executeMethod: doItMethod] 
			on: UndeclaredVariableRead
		 	do: [ self receiver ]