### PR TITLE
Fix inconsistent behavior after BlockCannotReturn exception; fixes issue #15433

### DIFF
--- a/src/Kernel-Tests-Extended/ProcessTest.class.st
+++ b/src/Kernel-Tests-Extended/ProcessTest.class.st
@@ -671,6 +671,26 @@ ProcessTest >> testRealActiveProcessFromProcesorShouldIgnoreInstalledEffectivePr
 	self assert: processFromProcessor identicalTo: activeProcess
 ]
 
+{ #category : 'tests - termination' }
+ProcessTest >> testResumeAfterBCR [
+
+	| expr executedReturnTwo error sync |
+	expr := true.
+	executedReturnTwo := false.
+	error := false.
+	sync := Semaphore new.
+	[[sync signal.
+	      [expr ifTrue: [^1].
+	       executedReturnTwo := true. ^2]
+	        on: BlockCannotReturn
+	        do: #resume]
+			on: Error
+			do: [error := true]] fork.
+	sync wait.
+	self deny: executedReturnTwo.
+	self assert: error
+]
+
 { #category : 'tests' }
 ProcessTest >> testSchedulingHigherPriorityServedFirst [
     "The first process to run will pass straight through the gate

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -428,9 +428,7 @@ Context >> cannotReturn: result [
 	closureOrNil ifNotNil: [ 
 		BlockCannotReturn result: result from: self home.
 		^self push: pc; pc: nil ].
-	UIManager default
-		requestDebuggerOpeningNamed: 'computation has been terminated'
-		inContext: thisContext
+	self error: 'computation has been terminated'
 ]
 
 { #category : 'private' }

--- a/src/Kernel/Context.class.st
+++ b/src/Kernel/Context.class.st
@@ -416,9 +416,18 @@ Context >> canHandleSignal: exception [
 
 { #category : 'private - exceptions' }
 Context >> cannotReturn: result [
+	"NB: Nil the receiver's pc to make sure it can't resume.
+	Backup the pc before nilling for the sake of debugging.
+	Example: 
+	Without nilling the pc the following example would crash the VM after resumption:
+	[[^ 1] on: BlockCannotReturn do: #resume ] fork
+	and the following example would run and happily execute an illegal return after resumption:
+	[[true ifTrue: [^ 1]] on: BlockCannotReturn do: #resume ] fork
+	"
 
-	closureOrNil ifNotNil: [
-		^ BlockCannotReturn result: result from: self home ].
+	closureOrNil ifNotNil: [ 
+		BlockCannotReturn result: result from: self home.
+		^self push: pc; pc: nil ].
 	UIManager default
 		requestDebuggerOpeningNamed: 'computation has been terminated'
 		inContext: thisContext


### PR DESCRIPTION
Fixes the following examples:

`[[^ 1] on: BlockCannotReturn do: #resume ] fork.  "VM crash"`

`[[true ifTrue: [^ 1]] on: BlockCannotReturn do: #resume ] fork.  "Illegal return from ^1"`

Both examples will consistently cause a walk-back indicating an illegal return attempt.
