### PR TITLE
Bootstrap: Do not rely on symlink to locate the bootstrap files

### DIFF
--- a/bootstrap/scripts/prepare_image.st
+++ b/bootstrap/scripts/prepare_image.st
@@ -5,7 +5,7 @@
   Iceberg enableMetacelloIntegration: true.
   Iceberg remoteTypeSelector: #httpsUrl.
 
-  repositoryPathString := ((Smalltalk os environment at: 'BOOTSTRAP_REPOSITORY' ifAbsent: ['.']) asFileReference / 'bootstrap' / 'src') fullName.
+  repositoryPathString := ((Smalltalk os environment at: 'BOOTSTRAP_REPOSITORY' ifAbsent: ['.']) asFileReference / 'src') fullName.
 
   Transcript show: '    [+] Loading tonel code to dump files for the Pharo bootstrap process from ' , repositoryPathString; cr.
 

--- a/bootstrap/src/.properties
+++ b/bootstrap/src/.properties
@@ -1,3 +1,0 @@
-{
-	#format : #tonel
-}

--- a/bootstrap/src/BaselineOfPharoBootstrapProcess
+++ b/bootstrap/src/BaselineOfPharoBootstrapProcess
@@ -1,1 +1,0 @@
-../../src/BaselineOfPharoBootstrapProcess

--- a/bootstrap/src/Pharo30Bootstrap
+++ b/bootstrap/src/Pharo30Bootstrap
@@ -1,1 +1,0 @@
-../../src/Pharo30Bootstrap


### PR DESCRIPTION
This removes the use of symlinks to find the bootstrap code. Iceberg does not work well with symlinks and this can simplify the maintenance of the bootstrap.