### PR TITLE
Announcer: Reduce usage of global SystemAnnouncer

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodCodeEditorToolMorph.class.st
@@ -71,11 +71,8 @@ ClyMethodCodeEditorToolMorph >> applyDecorations [
 { #category : 'controlling' }
 ClyMethodCodeEditorToolMorph >> attachToSystem [
 
-	browser system
-		when: (ClyMethodChange of: self editingMethod)
-		send: #triggerUpdate
-		to: self.
-	SystemAnnouncer uniqueInstance weak when: ASTCacheReset send: #resetASTCache to: self
+	browser system when: (ClyMethodChange of: self editingMethod) send: #triggerUpdate to: self.
+	self class codeSupportAnnouncer weak when: ASTCacheReset send: #resetASTCache to: self
 ]
 
 { #category : 'testing' }

--- a/src/CodeImport/DoItChunk.class.st
+++ b/src/CodeImport/DoItChunk.class.st
@@ -31,7 +31,7 @@ DoItChunk >> importFor: requestor logSource: logSource [
 	| ast |
 	(contents beginsWith: '----') ifTrue: [ ^ self ].
 
-	SystemAnnouncer announce: (DoItChunkImported new
+	self class codeSupportAnnouncer announce: (DoItChunkImported new
 			 contents: contents;
 			 logSource: logSource;
 			 yourself).

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -51,7 +51,8 @@ Class {
 
 { #category : 'private' }
 EFFormatter class >> announceASettingChange [
-	SystemAnnouncer announce: EFSettingChanged
+
+	self codeSupportAnnouncer announce: EFSettingChanged
 ]
 
 { #category : 'private' }

--- a/src/Graphics-Display Objects/DisplayScreen.class.st
+++ b/src/Graphics-Display Objects/DisplayScreen.class.st
@@ -183,9 +183,9 @@ DisplayScreen >> fullscreen [
 { #category : 'screen managing' }
 DisplayScreen >> fullscreen: aBoolean [
 
-	SystemAnnouncer announce: (FullscreenAnnouncement new
-		displayScreen: self;
-		fullscreen: (LastScreenModeSelected := aBoolean))
+	self class codeSupportAnnouncer announce: (FullscreenAnnouncement new
+			 displayScreen: self;
+			 fullscreen: (LastScreenModeSelected := aBoolean))
 ]
 
 { #category : 'other' }

--- a/src/Hermes/HEInstaller.class.st
+++ b/src/Hermes/HEInstaller.class.st
@@ -182,7 +182,7 @@ HEInstaller >> installMethods: exportedClass into: aClass [
 { #category : 'installing package' }
 HEInstaller >> installPackage: aHEPackage [
 
-	SystemAnnouncer uniqueInstance delayAnnouncementsAfter: [ self doInstallPackage: aHEPackage ]
+	self class codeChangeAnnouncer delayAnnouncementsAfter: [ self doInstallPackage: aHEPackage ]
 ]
 
 { #category : 'messages' }

--- a/src/Monticello/MCVersionLoader.class.st
+++ b/src/Monticello/MCVersionLoader.class.st
@@ -45,10 +45,11 @@ MCVersionLoader >> announceLoad: aString do: aBlock [
 
 { #category : 'private' }
 MCVersionLoader >> announceLoadStop: aString [
-	SystemAnnouncer announce: (MCVersionLoaderStopped new
-		versionLoader: self;
-		label: aString; 
-		yourself)
+
+	self class codeSupportAnnouncer announce: (MCVersionLoaderStopped new
+			 versionLoader: self;
+			 label: aString;
+			 yourself)
 ]
 
 { #category : 'private' }

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -187,11 +187,11 @@ MCWorkingCopy class >> registerForNotifications [
 { #category : 'event registration' }
 MCWorkingCopy class >> registerInterestOnSystemChanges [
 
-	SystemAnnouncer uniqueInstance weak
+	self class codeChangeAnnouncer weak
 		when: PackageAdded send: #packageAdded: to: self;
 		when: PackageRenamed send: #packageRenamed: to: self;
 		when: PackageRemoved send: #packageRemoved: to: self;
-		when: ClassAnnouncement, MethodAnnouncement send: #handleClassAndMethodsChange: to: self
+		when: ClassAnnouncement , MethodAnnouncement send: #handleClassAndMethodsChange: to: self
 ]
 
 { #category : 'private' }

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -390,10 +390,11 @@ WorldMorph >> handsReverseDo: aBlock [
 
 { #category : 'initialization' }
 WorldMorph >> initialize [
-	worldState := WorldState new.
- 	super initialize.
 
-	SystemAnnouncer uniqueInstance weak when: FullscreenAnnouncement send: #fullscreenChanged: to: self
+	worldState := WorldState new.
+	super initialize.
+
+	self class codeSupportAnnouncer weak when: FullscreenAnnouncement send: #fullscreenChanged: to: self
 ]
 
 { #category : 'change reporting' }

--- a/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarMorph.class.st
@@ -48,10 +48,9 @@ MenubarMorph class >> initialize [
 { #category : 'instance creation' }
 MenubarMorph class >> install [
 	"Unsubscribe to subscribe only once"
-	SystemAnnouncer uniqueInstance unsubscribe: self.
-	SystemAnnouncer uniqueInstance weak
-		when: MethodAnnouncement
-		send: #methodAnnouncementReceived: to: self
+
+	self codeChangeAnnouncer unsubscribe: self.
+	self codeChangeAnnouncer weak when: MethodAnnouncement send: #methodAnnouncementReceived: to: self
 ]
 
 { #category : 'setting' }

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -107,9 +107,10 @@ ThemeIcons class >> current [
 
 { #category : 'instance creation' }
 ThemeIcons class >> current: aPack [
+
 	aPack hasIcons ifFalse: [ aPack loadIconsFromUrl ].
 	Current := aPack.
-	SystemAnnouncer announce: IconSetChanged
+	self codeSupportAnnouncer announce: IconSetChanged
 ]
 
 { #category : 'accessing' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -89,26 +89,21 @@ UITheme class >> current: aUITheme [
 	SystemProgressMorph reset. "reset to use new fill styles"
 	ScrollBarMorph initializeImagesCache. "reset to use new arrows"
 
-	self class environment at: #SHPreferences ifPresent: [ :shPreferences |
-		shPreferences setStyleTable: aUITheme shStyleTable ].
+	self class environment at: #SHPreferences ifPresent: [ :shPreferences | shPreferences setStyleTable: aUITheme shStyleTable ].
 
-	self class environment at: #PolymorphSystemSettings ifPresent: [ :polymorphSystemSettings |
-		polymorphSystemSettings desktopColor: aUITheme desktopColor ].
+	self class environment at: #PolymorphSystemSettings ifPresent: [ :polymorphSystemSettings | polymorphSystemSettings desktopColor: aUITheme desktopColor ].
 
-	self class environment at: #NECPreferences ifPresent: [ :necPreferences |
-		necPreferences backgroundColor: aUITheme windowColor ].
+	self class environment at: #NECPreferences ifPresent: [ :necPreferences | necPreferences backgroundColor: aUITheme windowColor ].
 
-	self class environment at: #Paragraph ifPresent: [ :paragraph |
-		paragraph insertionPointColor: aUITheme caretColor ].
+	self class environment at: #Paragraph ifPresent: [ :paragraph | paragraph insertionPointColor: aUITheme caretColor ].
 
-	self class environment at: #BalloonMorph ifPresent: [ :balloonMorph |
-		balloonMorph setBalloonColorTo: aUITheme balloonBackgroundColor ].
+	self class environment at: #BalloonMorph ifPresent: [ :balloonMorph | balloonMorph setBalloonColorTo: aUITheme balloonBackgroundColor ].
 
 	aUITheme updateWorldDockingBars.
 	self currentWorld themeChanged.
-	(SystemWindow allSubInstances select:[:e | e owner isNil]) do: [ :each | each themeChanged ].
+	(SystemWindow allSubInstances select: [ :e | e owner isNil ]) do: [ :each | each themeChanged ].
 
-	SystemAnnouncer announce: UIThemeChanged
+	self codeSupportAnnouncer announce: UIThemeChanged
 ]
 
 { #category : 'accessing' }

--- a/src/PragmaCollector/PragmaCollector.class.st
+++ b/src/PragmaCollector/PragmaCollector.class.st
@@ -167,13 +167,13 @@ PragmaCollector >> initialize [
 PragmaCollector >> installSystemNotifications [
 	"Allows myself to be kept up-to-date regarding system changes"
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
+	self noMoreNotifications.
 
-	SystemAnnouncer uniqueInstance weak
-			when: ClassRemoved send: #classRemovedEventOccurs: to: self;
-			when: MethodRemoved send: #removedEventOccurs: to: self;
-			when: MethodAdded send: #addedEventOccurs: to: self;
-			when: MethodModified send: #modifiedEventOccurs: to: self
+	self class codeChangeAnnouncer weak
+		when: ClassRemoved send: #classRemovedEventOccurs: to: self;
+		when: MethodRemoved send: #removedEventOccurs: to: self;
+		when: MethodAdded send: #addedEventOccurs: to: self;
+		when: MethodModified send: #modifiedEventOccurs: to: self
 ]
 
 { #category : 'testing' }
@@ -232,7 +232,8 @@ PragmaCollector >> noMoreAnnounceWhile: aBlock [
 { #category : 'system changes' }
 PragmaCollector >> noMoreNotifications [
 	"Do not receiver any system change notification anymore"
-	SystemAnnouncer uniqueInstance unsubscribe: self
+
+	self class codeChangeAnnouncer unsubscribe: self
 ]
 
 { #category : 'system changes' }

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -152,7 +152,7 @@ RBRefactoryChangeManager >> clearUndoRedoList [
 { #category : 'initialization' }
 RBRefactoryChangeManager >> connectToChanges [
 
-	SystemAnnouncer uniqueInstance weak
+	self class codeChangeAnnouncer weak
 		when: PackageTagAnnouncement,
 				ClassAdded,
 				ClassModifiedClassDefinition,
@@ -169,7 +169,7 @@ RBRefactoryChangeManager >> connectToChanges [
 { #category : 'initialization' }
 RBRefactoryChangeManager >> disconnectFromChanges [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self
+	self class codeChangeAnnouncer unsubscribe: self
 ]
 
 { #category : 'testing' }

--- a/src/Reflectivity/ExecutionCounter.class.st
+++ b/src/Reflectivity/ExecutionCounter.class.st
@@ -69,12 +69,13 @@ ExecutionCounter class >> installOn: aRBProgramNode [
 
 { #category : 'class initialization' }
 ExecutionCounter class >> registerInterestToSystemAnnouncement [
-	<systemEventRegistration>
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
-	SystemAnnouncer uniqueInstance weak when: MethodRemoved send: #handleMethodRemoved: to: self.
-	SystemAnnouncer uniqueInstance weak when: MethodModified send: #handleMethodModified: to: self.
-	SystemAnnouncer uniqueInstance weak when: ClassRemoved send: #handleClassRemoved: to: self
+	<systemEventRegistration>
+	self codeChangeAnnouncer unsubscribe: self.
+	self codeChangeAnnouncer weak
+		when: MethodRemoved send: #handleMethodRemoved: to: self;
+		when: MethodModified send: #handleMethodModified: to: self;
+		when: ClassRemoved send: #handleClassRemoved: to: self
 ]
 
 { #category : 'cleanup' }

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -367,11 +367,9 @@ TestCase class >> historyAnnouncer [
 
 { #category : 'class initialization' }
 TestCase class >> initialize [
-	SystemAnnouncer uniqueInstance unsubscribe: self.
-	SystemAnnouncer uniqueInstance weak
-		when: MethodAdded, MethodModified, MethodRemoved
-		send: #methodChanged:
-		to: self
+
+	self codeChangeAnnouncer unsubscribe: self.
+	self codeChangeAnnouncer weak when: MethodAdded , MethodModified , MethodRemoved send: #methodChanged: to: self
 ]
 
 { #category : 'testing' }

--- a/src/System-Changes/ChangeSet.class.st
+++ b/src/System-Changes/ChangeSet.class.st
@@ -327,10 +327,11 @@ ChangeSet class >> newChanges: aChangeSet [
 ChangeSet class >> newChanges: aChangeSet withOld: old [
 	"Set the system ChangeSet to be the argument, aChangeSet."
 
-	SystemAnnouncer uniqueInstance unsubscribe: old.
+	self codeChangeAnnouncer unsubscribe: old.
+	self codeSupportAnnouncer unsubscribe: old.
 	current := aChangeSet.
 
-	SystemAnnouncer uniqueInstance weak
+	self codeChangeAnnouncer weak
 		when: ClassRemoved send: #classRemoved: to: aChangeSet;
 		when: ClassAdded send: #classAdded: to: aChangeSet;
 		when: ClassCommented send: #classCommented: to: aChangeSet;
@@ -338,15 +339,17 @@ ChangeSet class >> newChanges: aChangeSet withOld: old [
 		when: ProtocolAnnouncement send: #classReorganized: to: aChangeSet;
 		when: ClassRepackaged send: #classRepackaged: to: aChangeSet;
 		when: ClassModifiedClassDefinition send: #classModified: to: aChangeSet;
-
-
 		when: MethodAdded send: #methodAdded: to: aChangeSet;
 		when: MethodModified send: #methodModified: to: aChangeSet;
 		when: MethodRemoved send: #methodRemoved: to: aChangeSet;
-		when: MethodRecategorized send: #methodRecategorized: to: aChangeSet;
-		when: DoItChunkImported send: #doItChunkImported: to: aChangeSet.
+		when: MethodRecategorized send: #methodRecategorized: to: aChangeSet.
 
-	SystemAnnouncer announce: (CurrentChangeSetChanged new old: old; new: aChangeSet ; yourself)
+	self codeSupportAnnouncer weak when: DoItChunkImported send: #doItChunkImported: to: aChangeSet.
+
+	self codeSupportAnnouncer announce: (CurrentChangeSetChanged new
+			 old: old;
+			 new: aChangeSet;
+			 yourself)
 ]
 
 { #category : 'services' }

--- a/src/System-SessionManager/SessionManager.class.st
+++ b/src/System-SessionManager/SessionManager.class.st
@@ -226,17 +226,17 @@ SessionManager >> installSession: aWorkingSession [
 
 { #category : 'snapshot and quit' }
 SessionManager >> launchSnapshot: save andQuit: quit [
+
 	| isImageStarting snapshotResult |
 	ChangesLog default logSnapshot: save andQuit: quit.
 
-	self currentSession stop: quit.	"Image not usable from here until the session is restarted!"
+	self currentSession stop: quit. "Image not usable from here until the session is restarted!"
 	save
 		ifTrue: [
-					snapshotResult := Smalltalk snapshotPrimitive.	"<-- PC frozen here on image file"
-					isImageStarting := snapshotResult == true. ]
+			snapshotResult := Smalltalk snapshotPrimitive. "<-- PC frozen here on image file"
+			isImageStarting := snapshotResult == true ]
 		ifFalse: [ isImageStarting := false ].
-	(quit and: [ isImageStarting not ])
-		ifTrue: [ Smalltalk quitPrimitive ].
+	(quit and: [ isImageStarting not ]) ifTrue: [ Smalltalk quitPrimitive ].
 
 	"create a new session object if we're booting"
 	isImageStarting ifTrue: [ self installNewSession ].
@@ -244,8 +244,7 @@ SessionManager >> launchSnapshot: save andQuit: quit [
 	self currentSession start: isImageStarting.
 	snapshotResult
 		ifNil: [ self error: 'Failed to write image file (disk full?)' ]
-		ifNotNil: [
-			SystemAnnouncer uniqueInstance snapshotDone: isImageStarting ].
+		ifNotNil: [ self class codeSupportAnnouncer snapshotDone: isImageStarting ].
 
 	"We return the resuming state, which may be useful for users to know the state of the image"
 	^ isImageStarting

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -421,8 +421,8 @@ SystemDictionary >> renameClass: aClass from: oldName [
 	self add: oldref. "Old association preserves old refs"
 	SessionManager default renamedClass: aClass from: oldName to: aClass name.
 	self flushClassNameCache.
-	SystemAnnouncer uniqueInstance classRenamed: aClass from: oldName to: aClass name.
-	aClass subclassesDo: [ :subclass | SystemAnnouncer uniqueInstance classParentOf: subclass renamedFrom: oldName to: aClass name ]
+	self class codeChangeAnnouncer classRenamed: aClass from: oldName to: aClass name.
+	aClass subclassesDo: [ :subclass | self class codeChangeAnnouncer classParentOf: subclass renamedFrom: oldName to: aClass name ]
 ]
 
 { #category : 'renaming' }


### PR DESCRIPTION
SystemAnnouncer will be deprecated in the future. This change removes some usage of the global instance to use the new #codeChangeAnnouncer and #codeSupportAnnouncer