### PR TITLE
Deprecate asClass

### DIFF
--- a/src/General-Rules-Tests/ReAbstractRuleTestCase.class.st
+++ b/src/General-Rules-Tests/ReAbstractRuleTestCase.class.st
@@ -58,5 +58,7 @@ ReAbstractRuleTestCase >> sourceAtChritique: critique [
 
 { #category : 'utilities' }
 ReAbstractRuleTestCase >> subjectUnderTest [
-	^(self class name allButLast: 4) asClass
+
+	^ (self class name allButLast: 4) asClassInEnvironment:
+		  self class environment
 ]

--- a/src/ScriptingExtensions-Tests/StringTest.extension.st
+++ b/src/ScriptingExtensions-Tests/StringTest.extension.st
@@ -1,13 +1,6 @@
 Extension { #name : 'StringTest' }
 
 { #category : '*ScriptingExtensions-Tests' }
-StringTest >> testAsClass [
-	self
-		assert: 'String' asClass
-		equals: String
-]
-
-{ #category : '*ScriptingExtensions-Tests' }
 StringTest >> testAsClassIfAbsent [
 
 	self
@@ -25,4 +18,12 @@ StringTest >> testAsClassIfPresent [
 		self assert: class equals: String ].
 
 	'+' asClassIfPresent: [ ^ self fail ]
+]
+
+{ #category : '*ScriptingExtensions-Tests' }
+StringTest >> testAsClassInEnvironment [
+
+	self
+		assert: ('String' asClassInEnvironment: self class environment)
+		equals: String
 ]

--- a/src/ScriptingExtensions-Tests/SymbolTest.extension.st
+++ b/src/ScriptingExtensions-Tests/SymbolTest.extension.st
@@ -1,13 +1,6 @@
 Extension { #name : 'SymbolTest' }
 
 { #category : '*ScriptingExtensions-Tests' }
-SymbolTest >> testAsClass [
-	self
-		assert: #Symbol asClass
-		equals: Symbol
-]
-
-{ #category : '*ScriptingExtensions-Tests' }
 SymbolTest >> testAsClassIfAbsent [
 
 	self
@@ -25,4 +18,12 @@ SymbolTest >> testAsClassIfPresent [
 		self assert: class equals: Symbol ].
 
 	#'+' asClassIfPresent: [ ^ self fail ]
+]
+
+{ #category : '*ScriptingExtensions-Tests' }
+SymbolTest >> testAsClassInEnvironment [
+
+	self
+		assert: (#Symbol asClassInEnvironment: self class environment)
+		equals: Symbol
 ]

--- a/src/ScriptingExtensions/String.extension.st
+++ b/src/ScriptingExtensions/String.extension.st
@@ -2,7 +2,10 @@ Extension { #name : 'String' }
 
 { #category : '*ScriptingExtensions' }
 String >> asClass [
-	"returns a global class with my name"
+	"Returns a global class with my name"
+
+	self deprecated: 'Use #asClassInEnvironment: with an appropriate environment instead' transformWith: '`@receiver asClass' -> '`@receiver asClassInEnvironment: self class environment'.
+
 	^ self asClassInEnvironment: Smalltalk globals
 ]
 


### PR DESCRIPTION
- deprecate #asClass with a transformation that should work for 99% of the cases by using the same environment
- adjust current three senders
- better use #testAsClassInEnvironment than #testAsClass as selector as it is more intention revealing what is tested

Fix #14970