### PR TITLE
Ring: Fix RGPackage>>#asMCSnapshot

### DIFF
--- a/src/Ring-Monticello/RGPackage.extension.st
+++ b/src/Ring-Monticello/RGPackage.extension.st
@@ -4,11 +4,10 @@ Extension { #name : 'RGPackage' }
 RGPackage >> asMCSnapshot [
 
 	| definitions |
-
-	definitions := ((((self definedBehaviors reject: [:each | each isMeta]) sorted: [:a :b | a name < b name ]) collect: [:each | each asMCDefinition]), (self extensionMethods collect: [:each | each asMCDefinition])) asOrderedCollection.
-	definitions addAll: ((self definedBehaviors, (self definedBehaviors collect: [:each | each classSide])) flatCollect: [ :behavior |
-		(behavior localMethods reject: [:each | (each  parent instanceSide package = each package) not])
-			collect: [ :method | method asMCDefinition] ]).
-
+	definitions := OrderedCollection new.
+	definitions addAll: ((self definedBehaviors reject: [ :each | each isMeta ]) collect: [ :each | each asMCDefinition ]).
+	definitions addAll: (self extensionMethods collect: [ :each | each asMCDefinition ]).
+	definitions addAll: (self definedBehaviors , (self definedBehaviors collect: [ :each | each classSide ]) flatCollect: [ :behavior |  (behavior localMethods select: [ :each | each parent instanceSide package = each package ]) collect: [ :method | method asMCDefinition ] ]).
+	definitions add: (MCOrganizationDefinition packageName: name).
 	^ MCSnapshot fromDefinitions: definitions
 ]

--- a/src/Ring-Tests-Monticello/RGMCPackageTest.class.st
+++ b/src/Ring-Tests-Monticello/RGMCPackageTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : 'RGMCPackageTest',
+	#superclass : 'RGMCTest',
+	#category : 'Ring-Tests-Monticello',
+	#package : 'Ring-Tests-Monticello'
+}
+
+{ #category : 'tests' }
+RGMCPackageTest >> testAsMCSnapshotHasOrganization [
+
+	| newPackage snapshot |
+	newPackage := RGPackage named: 'Collections-Sequenceable'.
+	snapshot := newPackage asMCSnapshot.
+
+	self assert: snapshot definitions size equals: 1.
+	self assert: snapshot definitions anyOne isOrganizationDefinition.
+	self assert: snapshot definitions anyOne packageName equals: 'Collections-Sequenceable'
+]


### PR DESCRIPTION
I am working on using the ring version of the image to run Iceberg tests and avoid to depend on an unmaintained external project. Here is a fix to be able to use the in image version of Ring.

RGPackage>>#asMCSnapshot was not creating a MCOrganizationDefinition which is necessary to load a package