### PR TITLE
Faster TaskIt test run

### DIFF
--- a/src/TaskIt-Tests/TKTFutureTest.class.st
+++ b/src/TaskIt-Tests/TKTFutureTest.class.st
@@ -540,7 +540,7 @@ TKTFutureTest >> testFutureSuccessCallbackExecutesInNewProcess [
 	runner := TKTNewProcessTaskRunner new.
 	future := runner future: [ 1 + 1 ].
 
-	30 timesRepeat: [
+	15 timesRepeat: [
 		future onSuccessDo: [ :r | processIds nextPut: Processor activeProcess identityHash ] ].
 
 	1 second wait.
@@ -548,7 +548,7 @@ TKTFutureTest >> testFutureSuccessCallbackExecutesInNewProcess [
 	processIdsSet := Set new.
 	[processIds isEmpty] whileFalse: [ processIdsSet add: processIds next ].
 
-	self assert: processIdsSet size equals: 30
+	self assert: processIdsSet size equals: 15
 ]
 
 { #category : 'tests - callbacks' }

--- a/src/TaskIt/TKTService.class.st
+++ b/src/TaskIt/TKTService.class.st
@@ -151,7 +151,6 @@ TKTService >> process [
 { #category : 'starting' }
 TKTService >> restart [
 	self stop.
-	0.5 second wait.
 	stopRequested := false.
 	stopCallbacks := Set new.
 	self start


### PR DESCRIPTION
the taskIt tests now take more than 1 minute to run. it seems one reason is the wait in TKTService>>#restart.

Tests are green without it