### PR TITLE
Ring: Improve Ring model to use it for Iceberg tests

### DIFF
--- a/src/Ring-Core/RGEnvironmentQueryInterface.class.st
+++ b/src/Ring-Core/RGEnvironmentQueryInterface.class.st
@@ -170,6 +170,13 @@ RGEnvironmentQueryInterface >> includesClassNamed: aSymbol [
 	"
 ]
 
+{ #category : 'testing' }
+RGEnvironmentQueryInterface >> includesPackageNamed: aString [
+
+	self packagesDo: [ :each | each name = aString ifTrue: [ ^ true ] ].
+	^ false
+]
+
 { #category : 'caching' }
 RGEnvironmentQueryInterface >> invalidateName: aSymbol [
 

--- a/src/Ring-Monticello/MCClassDefinition.extension.st
+++ b/src/Ring-Monticello/MCClassDefinition.extension.st
@@ -49,12 +49,11 @@ MCClassDefinition >> ensureRingDefinitionIn: anRGEnvironment [
 { #category : '*Ring-Monticello' }
 MCClassDefinition >> ensureRingDefinitionIn: anRGEnvironment package: anRGPackage [
 
-	| def |
-
-	def := self ensureRingDefinitionIn: anRGEnvironment.
-	def package: anRGPackage.
-	def category: def tags first. "fix tags to do not contain package names"
-	^ def
+	| definition |
+	definition := self ensureRingDefinitionIn: anRGEnvironment.
+	definition package: anRGPackage.
+	definition category: (definition tags ifEmpty: [ UndefinedPackageTag undefinedPackageTagName ] ifNotEmpty: [ :tags | tags first ]). "fix tags to do not contain package names"
+	^ definition
 ]
 
 { #category : '*Ring-Monticello' }

--- a/src/Ring-Monticello/RGTraitStrategy.extension.st
+++ b/src/Ring-Monticello/RGTraitStrategy.extension.st
@@ -2,11 +2,19 @@ Extension { #name : 'RGTraitStrategy' }
 
 { #category : '*Ring-Monticello' }
 RGTraitStrategy >> asMCDefinition [
-	"We are missing the package tag here. We should add it"
+
 	^ (MCTraitDefinition named: self owner name)
 		  traitComposition: self owner traitCompositionString;
-		  packageName: self package name;
 		  classTraitComposition: self classSide traitCompositionString;
+		  packageName: self package name;
+		  tagName: (self category = self package name
+				   ifTrue: [ nil ]
+				   ifFalse: [ self category withoutPrefix: self package name , '-' ]);
+		  instVarNames: self instVarNames;
+		  classVarNames: self classVarNames;
+		  poolDictionaryNames: self sharedPoolNames;
+		  classInstVarNames: self classSide instVarNames;
 		  comment: self comment content;
+		  commentStamp: self comment stamp;
 		  yourself
 ]

--- a/src/Ring-Monticello/RGTraitStrategy.extension.st
+++ b/src/Ring-Monticello/RGTraitStrategy.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : 'RGTraitStrategy' }
+
+{ #category : '*Ring-Monticello' }
+RGTraitStrategy >> asMCDefinition [
+	"We are missing the package tag here. We should add it"
+	^ (MCTraitDefinition named: self owner name)
+		  traitComposition: self owner traitCompositionString;
+		  packageName: self package name;
+		  classTraitComposition: self classSide traitCompositionString;
+		  comment: self comment content;
+		  yourself
+]

--- a/src/Ring-Monticello/RGTraitV2Strategy.extension.st
+++ b/src/Ring-Monticello/RGTraitV2Strategy.extension.st
@@ -3,16 +3,17 @@ Extension { #name : 'RGTraitV2Strategy' }
 { #category : '*Ring-Monticello' }
 RGTraitV2Strategy >> asMCDefinition [
 
-	^ (MCClassDefinition named: self name)
-		  superclassName: (self superclass ifNotNil: [ :aSuperclass | aSuperclass name ]);
+	^ (MCTraitDefinition named: self owner name)
 		  traitComposition: self owner traitCompositionString;
-		  classTraitComposition: self owner metaclass traitCompositionString;
-		  packageName: self category;
+		  classTraitComposition: self classSide traitCompositionString;
+		  packageName: self package name;
+		  tagName: (self category = self package name
+				   ifTrue: [ nil ]
+				   ifFalse: [ self category withoutPrefix: self package name , '-' ]);
 		  instVarNames: self instVarNames;
 		  classVarNames: self classVarNames;
 		  poolDictionaryNames: self sharedPoolNames;
-		  classInstVarNames: self metaclass instVarNames;
-		  type: self mcType;
+		  classInstVarNames: self classSide instVarNames;
 		  comment: self comment content;
 		  commentStamp: self comment stamp;
 		  yourself


### PR DESCRIPTION
This change updates Ring to be able to use it in Iceberg's tests

- Add missing RGTraitStrategy>>#asMCDefinition and fix the one of TraitsV2
- Add missing #includesPackageNamed: 
- Fix ensureRingDefinitionIn:package: went there is not tag