### PR TITLE
Fix method definitions saved in class pane

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
@@ -19,7 +19,7 @@ ClyClassDefinitionEditorToolMorph >> applyChanges [
 	code := self pendingText.
 
 	"The next line are here for the compatibility with the old class definition."
-	ast := RBParser parseExpression: code.
+	ast := RBParser parseFaultyExpression: code.
 	(OldClassDefinitionBuilder isOldClassCreation: ast) ifTrue: [
 		Warning signal:
 			'The class definition used is the old Pharo class definition. Now the Fluid class definition should be used. Check the comment of ShiftClassBuilder to know the syntax.'.


### PR DESCRIPTION
Use a faulty parser to parse the expression in the class pane in case this is a method and not a class declaration.

Fixes #15495