### PR TITLE
Packages: Manage edge case of empty tag name

### DIFF
--- a/src/RPackage-Core/RPackage.class.st
+++ b/src/RPackage-Core/RPackage.class.st
@@ -245,7 +245,7 @@ RPackage >> ensureProperties [
 RPackage >> ensureTag: aTag [
 
 	| tagName newTag |
-	aTag ifNil: [ ^ self rootTag ].
+	(aTag isNil or: [ aTag = '' ]) ifTrue: [ ^ self rootTag ].
 	tagName := aTag isString
 		           ifTrue: [ aTag ]
 		           ifFalse: [ aTag name ].
@@ -255,7 +255,7 @@ RPackage >> ensureTag: aTag [
 	newTag := PackageTag package: self name: tagName.
 	classTags add: newTag.
 
-	self codeChangeAnnouncer  announce: (PackageTagAdded to: newTag).
+	self codeChangeAnnouncer announce: (PackageTagAdded to: newTag).
 	^ newTag
 ]
 

--- a/src/RPackage-Tests/PackageTagTest.class.st
+++ b/src/RPackage-Tests/PackageTagTest.class.st
@@ -55,6 +55,19 @@ PackageTagTest >> testAddClassSettingPackageTag [
 ]
 
 { #category : 'tests' }
+PackageTagTest >> testAddClassTagWithEmptyName [
+
+	| class |
+	class := self newClassNamed: #NewClass in: self xPackageName.
+
+	"When providing an empty tag name we expect to classify the class in the unclassify tag."
+	class packageTag: ''.
+
+	self assert: class packageTag isRoot.
+	self deny: class packageTag name equals: ''
+]
+
+{ #category : 'tests' }
 PackageTagTest >> testAddTrait [
 
 	| xPackage yPackage yTag class |

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -366,6 +366,20 @@ ShClassInstallerTest >> testInstallInSpecificEnvironment [
 ]
 
 { #category : 'tests' }
+ShClassInstallerTest >> testInstallingWithAnEmptyTag [
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestEmptyTag;
+			            tag: '';
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass package name equals: self generatedClassesPackageName.
+	self assert: newClass packageTag isRoot.
+	self deny: newClass packageTag name equals: ''
+]
+
+{ #category : 'tests' }
 ShClassInstallerTest >> testModifyingClassKeepsOrganizationOfMethods [
 
 	newClass := self newClass: #ShCITestClass superclass: subClass slots: #(  ).


### PR DESCRIPTION
Fixes #15508

If the user provides an empty string as tag name, we should not put the class in a tag with an empty name.