### PR TITLE
Deprecate SnapshotDone announcement

### DIFF
--- a/src/Calypso-SystemQueries/SnapshotDone.extension.st
+++ b/src/Calypso-SystemQueries/SnapshotDone.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : 'SnapshotDone' }
-
-{ #category : '*Calypso-SystemQueries' }
-SnapshotDone >> shouldBeConsideredByCalypsoEnvironment [
-	^false
-]

--- a/src/Deprecated12/SnapshotDone.class.st
+++ b/src/Deprecated12/SnapshotDone.class.st
@@ -9,10 +9,19 @@ Class {
 	#instVars : [
 		'isNewImage'
 	],
-	#category : 'System-Announcements-System-Base',
-	#package : 'System-Announcements',
-	#tag : 'System-Base'
+	#category : 'Deprecated12',
+	#package : 'Deprecated12'
 }
+
+{ #category : 'testing' }
+SnapshotDone class >> isDeprecated [
+	"This announcement is deprectaed because people reacting to the startup and shut down of the image should use the SessionManager instead of this announcement.
+	
+	See documentation:
+	https://github.com/pharo-open-documentation/pharo-wiki/blob/master/General/SessionsManagement.md "
+
+	^ true
+]
 
 { #category : 'instance creation' }
 SnapshotDone class >> isNewImage: aBoolean [

--- a/src/Deprecated12/SnapshotDone.class.st
+++ b/src/Deprecated12/SnapshotDone.class.st
@@ -37,3 +37,8 @@ SnapshotDone >> isNewImage [
 SnapshotDone >> isNewImage: anObject [
 	isNewImage := anObject
 ]
+
+{ #category : 'abstract' }
+SnapshotDone >> shouldBeConsideredByCalypsoEnvironment [
+	^false
+]

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -113,9 +113,3 @@ SystemAnnouncer >> methodRepackaged: aMethod from: aPackage to: anotherPackage [
 						oldPackage: aPackage
 						newPackage: anotherPackage)
 ]
-
-{ #category : 'triggering' }
-SystemAnnouncer >> snapshotDone: isNewImage [
-
-	self announce: (SnapshotDone isNewImage: isNewImage)
-]

--- a/src/System-SessionManager/SessionManager.class.st
+++ b/src/System-SessionManager/SessionManager.class.st
@@ -244,7 +244,8 @@ SessionManager >> launchSnapshot: save andQuit: quit [
 	self currentSession start: isImageStarting.
 	snapshotResult
 		ifNil: [ self error: 'Failed to write image file (disk full?)' ]
-		ifNotNil: [ self class codeSupportAnnouncer snapshotDone: isImageStarting ].
+		ifNotNil: [ "This branch should be removed in Pharo 13 with the deprecated announcement."
+			self class environment at: #SnapshotDone ifPresent: [ :class | self class codeSupportAnnouncer announce: (class isNewImage: isImageStarting) ] ].
 
 	"We return the resuming state, which may be useful for users to know the state of the image"
 	^ isImageStarting


### PR DESCRIPTION
This announcement is useless since we have the SessionManager and just gives duplicated ways to react to the image startup. It is better to keep only one way to react to the image startup