### PR TITLE
Rename tests packages

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -74,7 +74,6 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'System-Changes-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
 		spec package: 'System-Sources-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
 		spec package: 'System-Announcements-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
-		spec package: 'RPackage-Tests'.
 		spec package: 'Monticello-Tests'.
 		spec package: 'MonticelloGUI-Tests'.
 		spec package: 'Network-Mail'.

--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -17,7 +17,6 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'Debugging-Utils-Tests';
 			package: 'NumberParser-Tests';
 			package: 'AST-Core-Tests';
-			package: 'RPackage-Tests';
 			package: 'Monticello-Tests';	"required by MonticelloMocks"
 			package: 'System-Installers-Tests' ;
 			package: 'MonticelloMocks';

--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -13,6 +13,9 @@ BaselineOfGeneralTests >> baseline: spec [
 	| repository |
 	repository := self packageRepositoryURL.
 	spec for: #'common' do: [
+		
+		spec baseline: 'KernelTests' with: [ spec repository: repository ].
+
 		spec
 			package: 'Debugging-Utils-Tests';
 			package: 'NumberParser-Tests';

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -46,7 +46,6 @@ BaselineOfIDE >> baseline: spec [
 		spec baseline: 'BasicTools' with: [ spec repository: self repository ].
 		spec baseline: 'Athens' with: [ spec repository: self repository ].
 		spec baseline: 'Flashback' with: [ spec repository: self repository ].
-		spec baseline: 'KernelTests' with: [ spec repository: self repository ].
 
 		self
 			load: 'Shift' group: 'shift-tests' spec: spec;

--- a/src/BaselineOfKernelTests/BaselineOfKernelTests.class.st
+++ b/src/BaselineOfKernelTests/BaselineOfKernelTests.class.st
@@ -7,42 +7,45 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfKernelTests >> baseline: spec [
-	<baseline>
-	spec for: #'common' do: [
-		spec 
-			package: 	'CodeImport-Tests'	; 
 
-			package: 	'Collections-Abstract-Tests';					
-			package: 	'Collections-Atomic-Tests';
-			package: 'Collections-Native-Tests';	
-			package:	'Collections-Sequenceable-Tests';
-			package: 	'Collections-Stack-Tests';	
-			package: 	'Collections-Streams-Tests';		
-			package: 	'Collections-Strings-Tests';	
-			package: 	'Collections-Support-Tests';								
-			package: 	'Collections-Unordered-Tests';
-			package: 	'Collections-Weak-Tests' with: [ spec requires: #('Collections-Unordered-Tests') ];					
-			package: 	'Collections-Tests' with: [ spec requires: #('Collections-Abstract-Tests' 'Collections-Atomic-Tests' 'Collections-Native-Tests' 'Collections-Sequenceable-Tests'  
-					   'Collections-Streams-Tests' 'Collections-Strings-Tests' 'Collections-Support-Tests' 'Collections-Stack-Tests' 'Collections-Weak-Tests') ];
-			package: 	'Kernel-Tests'; 
-			package: 	'Kernel-Tests-Extended' ;
-			package: 	'Kernel-Tests-WithCompiler';
-			package: 	'Announcements-Core-Tests';
-			package: 	'Compression-Tests'; 
-			package: 	'FileSystem-Tests-Core' with: [ spec requires: #('Collections-Tests') ];
-			package: 	'FileSystem-Tests-Disk';
-			package: 	'FileSystem-Tests-Attributes';
-			package: 	'Files-Tests' ;
-			package: 	'Jobs-Tests' ;
-			package: 	'AST-Core-Tests';
-			package: 	'OpalCompiler-Tests' with: [ spec requires: #('AST-Core-Tests') ];
-			package: 	'Random-Tests';
-			package: 	'Ring-Definitions-Tests-Core';
-			package: 	'Ring-Definitions-Tests-Containers'; 
-			package: 	'System-Object Events-Tests';
-			package: 	'System-OSEnvironments-Tests';
-			package: 	'Zinc-Character-Encoding-Tests' ;
-			package: 	'System-Platforms-Tests';
+	<baseline>
+	spec for: #common do: [
+		spec
+			package: 'CodeImport-Tests';
+			package: 'Collections-Abstract-Tests';
+			package: 'Collections-Atomic-Tests';
+			package: 'Collections-Native-Tests';
+			package: 'Collections-Sequenceable-Tests';
+			package: 'Collections-Stack-Tests';
+			package: 'Collections-Streams-Tests';
+			package: 'Collections-Strings-Tests';
+			package: 'Collections-Support-Tests';
+			package: 'Collections-Unordered-Tests';
+			package: 'Collections-Weak-Tests' with: [ spec requires: #( 'Collections-Unordered-Tests' ) ];
+			package: 'Collections-Tests' with: [
+				spec requires:
+						#( 'Collections-Abstract-Tests' 'Collections-Atomic-Tests' 'Collections-Native-Tests' 'Collections-Sequenceable-Tests' 'Collections-Streams-Tests'
+						   'Collections-Strings-Tests' 'Collections-Support-Tests' 'Collections-Stack-Tests' 'Collections-Weak-Tests' ) ];
+			package: 'Kernel-Tests';
+			package: 'Kernel-Packages-Tests';
+			package: 'Kernel-Tests-Extended';
+			package: 'Kernel-Tests-WithCompiler';
+			package: 'Announcements-Core-Tests';
+			package: 'Compression-Tests';
+			package: 'FileSystem-Tests-Core' with: [ spec requires: #( 'Collections-Tests' ) ];
+			package: 'FileSystem-Tests-Disk';
+			package: 'FileSystem-Tests-Attributes';
+			package: 'Files-Tests';
+			package: 'Jobs-Tests';
+			package: 'AST-Core-Tests';
+			package: 'OpalCompiler-Tests' with: [ spec requires: #( 'AST-Core-Tests' ) ];
+			package: 'Random-Tests';
+			package: 'Ring-Definitions-Tests-Core';
+			package: 'Ring-Definitions-Tests-Containers';
+			package: 'System-Object Events-Tests';
+			package: 'System-OSEnvironments-Tests';
+			package: 'Zinc-Character-Encoding-Tests';
+			package: 'System-Platforms-Tests';
 			package: 'System-Finalization-Tests';
-			package: 	'Text-Tests' ]
+			package: 'Text-Tests' ]
 ]

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -140,6 +140,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		spec package: 'SUnit-Core'.
 		spec package: 'SUnit-Tests'.
 		spec package: 'Kernel-Tests'.
+		spec package: 'Kernel-Packages-Tests'.
 		spec package: 'JenkinsTools-Core'.
 		spec package: 'InitializePackagesCommandLineHandler'.
 		
@@ -226,6 +227,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'SUnit-Core'.
 			'SUnit-Tests'.
 			'Kernel-Tests'.
+			'Kernel-Packages-Tests'.
 			'JenkinsTools-Core'}.
 
 	]

--- a/src/Kernel-Packages-Tests/PackageAndClassesTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageAndClassesTest.class.st
@@ -4,8 +4,8 @@ SUnit tests for RPackage classes synchronisation
 Class {
 	#name : 'PackageAndClassesTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'tests' }

--- a/src/Kernel-Packages-Tests/PackageAndMethodsTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageAndMethodsTest.class.st
@@ -4,8 +4,8 @@ SUnit tests for RPackage method synchronization
 Class {
 	#name : 'PackageAndMethodsTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'tests - extension methods' }

--- a/src/Kernel-Packages-Tests/PackageAndTraitOnModelTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageAndTraitOnModelTest.class.st
@@ -12,8 +12,8 @@ Class {
 		'yPackage',
 		'zPackage'
 	],
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'running' }

--- a/src/Kernel-Packages-Tests/PackageAndTraitsTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageAndTraitsTest.class.st
@@ -5,8 +5,8 @@ SUnit tests for Package trait synchronization
 Class {
 	#name : 'PackageAndTraitsTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'tests - operations on methods' }

--- a/src/Kernel-Packages-Tests/PackageAnnouncementsTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageAnnouncementsTest.class.st
@@ -4,8 +4,8 @@ Class {
 	#instVars : [
 		'numberOfAnnouncements'
 	],
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'running' }

--- a/src/Kernel-Packages-Tests/PackageObsoleteTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageObsoleteTest.class.st
@@ -7,8 +7,8 @@ Class {
 	#instVars : [
 		'notRun'
 	],
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'accessing' }

--- a/src/Kernel-Packages-Tests/PackageOnModelTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageOnModelTest.class.st
@@ -29,8 +29,8 @@ Class {
 		'yPackage',
 		'zPackage'
 	],
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'running' }

--- a/src/Kernel-Packages-Tests/PackageOrganizerTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageOrganizerTest.class.st
@@ -8,8 +8,8 @@ Therefore the new created PackageOrganizer is not registered to listen to event.
 Class {
 	#name : 'PackageOrganizerTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'utilities' }

--- a/src/Kernel-Packages-Tests/PackageRenameTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageRenameTest.class.st
@@ -4,8 +4,8 @@ SUnit tests on renaming packages
 Class {
 	#name : 'PackageRenameTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'tests' }

--- a/src/Kernel-Packages-Tests/PackageTagTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageTagTest.class.st
@@ -4,8 +4,8 @@ SUnit tests for Package tags
 Class {
 	#name : 'PackageTagTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'tests' }

--- a/src/Kernel-Packages-Tests/PackageTest.class.st
+++ b/src/Kernel-Packages-Tests/PackageTest.class.st
@@ -4,8 +4,8 @@ SUnit tests for Package
 Class {
 	#name : 'PackageTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'tests - classes' }
@@ -261,7 +261,7 @@ PackageTest >> testHasProperty [
 PackageTest >> testHierarchyRoots [
 
 	| roots |
-	roots := (self packageOrganizer packageNamed: #'RPackage-Tests') hierarchyRoots.
+	roots := (self packageOrganizer packageNamed: #'Kernel-Packages-Tests') hierarchyRoots.
 	roots := roots collect: [ :each | each name ].
 	#( #PackageTestCase ) do: [ :each | roots includes: each ]
 ]

--- a/src/Kernel-Packages-Tests/PackageTestCase.class.st
+++ b/src/Kernel-Packages-Tests/PackageTestCase.class.st
@@ -7,8 +7,8 @@ Class {
 	#instVars : [
 		'testEnvironment'
 	],
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'testing' }

--- a/src/Kernel-Packages-Tests/UndefinedPackageTagTest.class.st
+++ b/src/Kernel-Packages-Tests/UndefinedPackageTagTest.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : 'UndefinedPackageTagTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'tests' }

--- a/src/Kernel-Packages-Tests/UndefinedPackageTest.class.st
+++ b/src/Kernel-Packages-Tests/UndefinedPackageTest.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : 'UndefinedPackageTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-Packages-Tests',
+	#package : 'Kernel-Packages-Tests'
 }
 
 { #category : 'tests' }

--- a/src/Kernel-Packages-Tests/package.st
+++ b/src/Kernel-Packages-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Kernel-Packages-Tests' }

--- a/src/Monticello-Tests/PackageMonticelloSynchronisationTest.class.st
+++ b/src/Monticello-Tests/PackageMonticelloSynchronisationTest.class.st
@@ -2,21 +2,21 @@
 SUnit tests for Package Monticello synchronization
 "
 Class {
-	#name : 'RPackageMonticelloSynchronisationTest',
+	#name : 'PackageMonticelloSynchronisationTest',
 	#superclass : 'PackageTestCase',
-	#category : 'Monticello-Tests-RPackage',
+	#category : 'Monticello-Tests-Package',
 	#package : 'Monticello-Tests',
-	#tag : 'RPackage'
+	#tag : 'Package'
 }
 
 { #category : 'accessing' }
-RPackageMonticelloSynchronisationTest >> allWorkingCopies [
+PackageMonticelloSynchronisationTest >> allWorkingCopies [
 
 	^ MCWorkingCopy allWorkingCopies
 ]
 
 { #category : 'tests - operations on MCPackages' }
-RPackageMonticelloSynchronisationTest >> testAddMCPackageCreatesAPackage [
+PackageMonticelloSynchronisationTest >> testAddMCPackageCreatesAPackage [
 	"test that when we create a MCPackage, a corresponding package is created"
 
 	MCWorkingCopy ensureForPackageNamed: #Zork packageOrganizer: self organizer.
@@ -24,7 +24,7 @@ RPackageMonticelloSynchronisationTest >> testAddMCPackageCreatesAPackage [
 ]
 
 { #category : 'tests - operations on MCPackages' }
-RPackageMonticelloSynchronisationTest >> testAddMCPackageForCategoryAlreadyExistingDoesNotCreateAPackage [
+PackageMonticelloSynchronisationTest >> testAddMCPackageForCategoryAlreadyExistingDoesNotCreateAPackage [
 	"test that when we create a MCPackage and that a category of this name already exists, no package is created"
 
 	| tmpPackage |
@@ -35,7 +35,7 @@ RPackageMonticelloSynchronisationTest >> testAddMCPackageForCategoryAlreadyExist
 ]
 
 { #category : 'tests - operations on MCPackages' }
-RPackageMonticelloSynchronisationTest >> testUnloadMCPackageRemovesRPackage [
+PackageMonticelloSynchronisationTest >> testUnloadMCPackageRemovesPackage [
 	"test that when we remove a MC Package, the corresponding Package is removed from the organizer"
 
 	MCWorkingCopy ensureForPackageNamed: 'XXXXX' packageOrganizer: self organizer.
@@ -45,7 +45,7 @@ RPackageMonticelloSynchronisationTest >> testUnloadMCPackageRemovesRPackage [
 ]
 
 { #category : 'tests - operations on MCPackages' }
-RPackageMonticelloSynchronisationTest >> testUnregisterMCPackageKeepsRPackage [
+PackageMonticelloSynchronisationTest >> testUnregisterMCPackageKeepsPackage [
 	"test that when we remove a MC Package, the corresponding Package is removed from the organizer"
 
 	MCWorkingCopy ensureForPackageNamed: 'XXXXX' packageOrganizer: self organizer.

--- a/src/RPackage-Tests/package.st
+++ b/src/RPackage-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'RPackage-Tests' }


### PR DESCRIPTION
Rename RPackage-Tests into Kernel-Packages-Tests. Also do some renamings in Monticello tests.

I have the impression that some groups and packages are declared in the BaselineOfPharoBootstrap but are not used by the bootstrap.