### PR TITLE
Add String>>#findClosing:startingAt: generalizing #findCloseParenthesisFor:

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -886,15 +886,6 @@ StringTest >> testFindBetweenSubstrings [
 ]
 
 { #category : 'tests' }
-StringTest >> testFindCloseParenthesisFor [
-
-	self assert: ('(1 + 3(2 * 9) - 15)' findCloseParenthesisFor: 1) equals: 19.
-	self assert: ('(1+(2-3))-3.14159' findCloseParenthesisFor: 1) equals: 9.
-	self assert: ('(1+(2-3))-3.14159' findCloseParenthesisFor: 4) equals: 8.
-	self assert: ('()' findCloseParenthesisFor: 10) equals: 3
-]
-
-{ #category : 'tests' }
 StringTest >> testFindClosingStartingAt [
 
 	self assert: ('(1 + 3(2 * 9) - 15)' findClosing: $) startingAt: 1) equals: 19.

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -900,8 +900,8 @@ StringTest >> testFindClosingStartingAt [
 	self assert: ('(1 + 3(2 * 9) - 15)' findClosing: $) startingAt: 1) equals: 19.
 	self assert: ('(1+(2-3))-3.14159' findClosing: $) startingAt: 1) equals: 9.
 	self assert: ('(1+(2-3))-3.14159' findClosing: $) startingAt: 4) equals: 8.
-	self assert: ('()' findClosing: $) startingAt: 10) equals: 3.
-	
+	self assert: ('()' findClosing: $) startingAt: 10) equals: 0.
+
 	self assert: ('List<String>' findClosing: $> startingAt: 5) equals: 12.
 	self assert: ('Map<T,Map<T,List<T>>>' findClosing: $> startingAt: 4) equals: 21.
 	self assert: ('Map<T,Map<T,List<T>>>' findClosing: $> startingAt: 10) equals: 20

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -895,6 +895,19 @@ StringTest >> testFindCloseParenthesisFor [
 ]
 
 { #category : 'tests' }
+StringTest >> testFindClosingStartingAt [
+
+	self assert: ('(1 + 3(2 * 9) - 15)' findClosing: $) startingAt: 1) equals: 19.
+	self assert: ('(1+(2-3))-3.14159' findClosing: $) startingAt: 1) equals: 9.
+	self assert: ('(1+(2-3))-3.14159' findClosing: $) startingAt: 4) equals: 8.
+	self assert: ('()' findClosing: $) startingAt: 10) equals: 3.
+	
+	self assert: ('List<String>' findClosing: $> startingAt: 5) equals: 12.
+	self assert: ('Map<T,Map<T,List<T>>>' findClosing: $> startingAt: 4) equals: 21.
+	self assert: ('Map<T,Map<T,List<T>>>' findClosing: $> startingAt: 10) equals: 20
+]
+
+{ #category : 'tests' }
 StringTest >> testFindDelimitersStartingAt [
 
 	self assert: ('this is a string' findDelimiters: ' ' startingAt: 1) equals: 5.

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1433,14 +1433,14 @@ String >> findClosing: close startingAt: startIndex [
 	"Assume the opening character is given at startIndex. Find the matching closing character, taking nesting into account."
 
 	| open nestLevel current |
-	self size < startIndex ifTrue: [ ^ self size + 1 ].
+	self size < startIndex ifTrue: [ ^ 0 ].
 	open := self at: startIndex.
 	nestLevel := 1.
 	startIndex + 1 to: self size do: [ :pos |
 		(current := self at: pos) == close
-			ifTrue: [ (nestLevel := nestLevel - 1) = 0 ifTrue: [ ^ pos ] ]
+			ifTrue: [ (nestLevel := nestLevel - 1) == 0 ifTrue: [ ^ pos ] ]
 			ifFalse: [ current == open ifTrue: [ nestLevel := nestLevel + 1 ] ] ].
-	^ self size + 1
+	^ 0
 ]
 
 { #category : 'finding/searching' }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1412,23 +1412,6 @@ String >> findBetweenSubstrings: delimiters [
 ]
 
 { #category : 'finding/searching' }
-String >> findCloseParenthesisFor: startIndex [
-	"assume (self at: startIndex) is $(.  Find the matching $), allowing parentheses to nest."
-	" '(1+(2-3))-3.14159' findCloseParenthesisFor: 1 "
-	" '(1+(2-3))-3.14159' findCloseParenthesisFor: 4 "
-	| pos nestLevel |
-	pos := startIndex+1.
-	nestLevel := 1.
-	[ pos <= self size ] whileTrue: [
-		(self at: pos) = $( ifTrue: [ nestLevel := nestLevel + 1 ].
-		(self at: pos) = $) ifTrue: [ nestLevel := nestLevel - 1 ].
-		nestLevel = 0 ifTrue: [ ^pos ].
-		pos := pos + 1.
-	].
-	^self size + 1
-]
-
-{ #category : 'finding/searching' }
 String >> findClosing: close startingAt: startIndex [
 	"Assume the opening character is given at startIndex. Find the matching closing character, taking nesting into account."
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1429,6 +1429,21 @@ String >> findCloseParenthesisFor: startIndex [
 ]
 
 { #category : 'finding/searching' }
+String >> findClosing: close startingAt: startIndex [
+	"Assume the opening character is given at startIndex. Find the matching closing character, taking nesting into account."
+
+	| open nestLevel current |
+	self size < startIndex ifTrue: [ ^ self size + 1 ].
+	open := self at: startIndex.
+	nestLevel := 1.
+	startIndex + 1 to: self size do: [ :pos |
+		(current := self at: pos) == close
+			ifTrue: [ (nestLevel := nestLevel - 1) = 0 ifTrue: [ ^ pos ] ]
+			ifFalse: [ current == open ifTrue: [ nestLevel := nestLevel + 1 ] ] ].
+	^ self size + 1
+]
+
+{ #category : 'finding/searching' }
 String >> findDelimiters: delimiters startingAt: start [
 	"Answer the index of the character within the receiver, starting at start, that matches one of the delimiters. If the receiver does not contain any of the delimiters, answer size + 1."
 

--- a/src/Deprecated12/String.extension.st
+++ b/src/Deprecated12/String.extension.st
@@ -10,3 +10,21 @@ String class >> crlfcrlf [
 		'Pharo-12.0.0+build.779.sha.e06ae6a0b17ea62c2031af00a73fd2471d563666 (64 Bit)'.
 	^ self crlf , self crlf
 ]
+
+{ #category : '*Deprecated12' }
+String >> findCloseParenthesisFor: startIndex [
+	"assume (self at: startIndex) is $(.  Find the matching $), allowing parentheses to nest."
+	" '(1+(2-3))-3.14159' findCloseParenthesisFor: 1 "
+	" '(1+(2-3))-3.14159' findCloseParenthesisFor: 4 "
+
+	| result |
+	self
+		deprecated:
+		'Use #findClosing:startingAt: instead, it is faster and more generic. Note that this new method returns 0 if the closing character is not found.'
+		transformWith: '`@receiver findCloseParenthesisFor: `@arg'
+			-> '`@receiver findClosing: $) startingAt: `@arg'.
+	result := self findClosing: $) startingAt: startIndex.
+	^ result = 0
+		  ifTrue: [ self size + 1 ]
+		  ifFalse: [ result ]
+]


### PR DESCRIPTION
`findCloseParenthesisFor:` takes nesting into account to find the matching close parenthesis.
This new method generalizes this behavior to any opening and closing characters.
It has the same pitfall: giving an index less than 1 will give an error.
It also has the same return value if no match is found: it returns the size of the collection + 1.
This last point is a bit strange imo, most `find...` methods will return 0 if not found, maybe this should be generalized too?

There is a new edge case: if the same character is both a closing and an opening character, it is currently prioritized as a closing character.
```st
'((' findClosing: $( startingAt: 1. "2"
```
This could be done the other way around, prioritizing as an opening, which would give `3` in this example because the matching closing character is never found.

This new method is faster because:
- it remembers the current character in a variable instead of using `at:` twice
- it uses lazy conditions instead of checking for opening and closing each time
- since we are dealing with characters, we can use identity instead of equality, which is much faster.

```st
string := '(1+(2-3))-3.14159'.
[ string findCloseParenthesisFor: 1 ] benchCompareTo: [ string findClosing: $) startingAt: 1 ] "10784695.783/s * 2.175 = 23454250.950/s"
[ string findCloseParenthesisFor: 4 ] benchCompareTo: [ string findClosing: $) startingAt: 4 ] "21144145.675/s * 1.846 = 39040974.605/s"
```

Note that this method could be in SequenceableCollection instead of String, but then it would be better to use equality.

I also haven't touched `findCloseParenthesisFor:` yet, I'm not sure if it should be deprecated or if it should call this new method.