### PR TITLE
Add logs on PharoBootstrapInitialization

### DIFF
--- a/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
+++ b/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
@@ -28,7 +28,6 @@ Class {
 PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandling [
 	"This method is run before the new bootstrapped image is saved!"
 	
-	'Starting the initialization of the Pharo image' traceCr.
 	ProcessorScheduler initialize.
 
 	Object initialize.
@@ -42,7 +41,6 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 
 	OSPlatform startUp: true.
 
-	'Initializing primitive types' traceCr.
 	SmallInteger initialize.
 	String initialize.
 	ByteString initialize. 
@@ -90,14 +88,15 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 	ExternalObject initialize.
 	ExternalType initialize.
 
+	'Initializing Session Manager' traceCr.
+	SessionManager default installNewSession.
+	SessionManager initializeKernelRegistrations.
+
 	'Initializing basic command line behaviors' traceCr.
 	"Initialize basic command line behaviour"
 	NonInteractiveTranscript initialize.
 	BasicCommandLineHandler initialize.
 
-	'Initializing Session Manager' traceCr.
-	SessionManager default installNewSession.
-	SessionManager initializeKernelRegistrations.
 	Smalltalk snapshot: true andQuit: true.
 	Processor terminateActive
 ]
@@ -120,7 +119,6 @@ PharoBootstrapInitialization class >> initializeImageOfType: typeName major: maj
 	version description.
 	This method is run before the new bootstrapped image is saved!"
 
-	'Setting system version' traceCr.
 	SystemVersion writeClassVariableNamed: #Current value: (SystemVersion new
 			 type: typeName;
 			 major: major;

--- a/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
+++ b/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
@@ -27,24 +27,28 @@ Class {
 { #category : 'initialization' }
 PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandling [
 	"This method is run before the new bootstrapped image is saved!"
+	
+	'Starting the initialization of the Pharo image' traceCr.
 	ProcessorScheduler initialize.
 
 	Object initialize.
 
 	ChronologyConstants initialize.
 	DateAndTime initialize.
-	SessionManager default installNewSession.
 
 	Delay initialize.
-	SmallInteger initialize.
 
 	ProcessorScheduler startUp.
 
 	OSPlatform startUp: true.
 
+	'Initializing primitive types' traceCr.
+	SmallInteger initialize.
 	String initialize.
-	ByteString initialize. "needed by TextConverter to install LineEnd convention (called by Smalltalk openLog)"
-	ZnUTF8Encoder initialize.
+	ByteString initialize. 
+	Float initialize.
+	
+	ZnUTF8Encoder initialize. "needed by TextConverter to install LineEnd convention (called by Smalltalk openLog)"
 
 	"Weak array class initialization 2 lines"
 	Smalltalk specialObjectsArray at: 42 put: Semaphore new."to put in EPObjectSpace>>#createSpecialObjectsArray?"
@@ -53,40 +57,46 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 	Smalltalk globals
 		at: #Transcript
 		put: (NonInteractiveTranscript stdout install).
-	Float initialize.
 
+
+	UIManager default: NonInteractiveUIManager new.
+	
+	Color initialize.
+	InstructionStream initialize.
+
+	'Initializing Collections' traceCr.
 	CollectionElement initialize.
 	ExternalSemaphoreTable initialize.
 	Collection initialize.
+	
+	'Initializing code model' traceCr.
 	CompiledMethod initialize.
 	Slot initialize.
 	Behavior initialize.
 	Class initialize.
 	Package initialize.
-	
 	"Next three lines are for the deprecated aliases. This should be removed in Pharo 13"
 	PackageTag initialize.
 	PackageOrganizer initialize.
 	PackageConflictError initialize.
 
-	UIManager default: NonInteractiveUIManager new.
-
+	'Initializing sources' traceCr.
 	Smalltalk sourceFileVersionString: 'PharoV60'.
 	(Smalltalk class classVariableNamed: 'LastImagePath') value: Smalltalk imagePath. "set the default value"
 	SourceFiles := SourceFileArray new.
 
-	Color initialize.
-	InstructionStream initialize.
-	SmallInteger initialize.
-
+	'InitializingFFI' traceCr.
 	"FFI"
 	ExternalObject initialize.
 	ExternalType initialize.
 
+	'Initializing basic command line behaviors' traceCr.
 	"Initialize basic command line behaviour"
 	NonInteractiveTranscript initialize.
 	BasicCommandLineHandler initialize.
 
+	'Initializing Session Manager' traceCr.
+	SessionManager default installNewSession.
 	SessionManager initializeKernelRegistrations.
 	Smalltalk snapshot: true andQuit: true.
 	Processor terminateActive
@@ -95,6 +105,8 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 { #category : 'public api' }
 PharoBootstrapInitialization class >> initializeFileSystem [
 	| env |
+	
+	'Initializing File System' traceCr.
 	env := self environment.
 	(env at: #FileLocator) initialize.
 	(env at: #DiskStore) initialize.
@@ -104,22 +116,20 @@ PharoBootstrapInitialization class >> initializeFileSystem [
 
 { #category : 'public api' }
 PharoBootstrapInitialization class >> initializeImageOfType: typeName major: major minor: minor patch: patch suffix: suffix build: buildNumber commitHash: hash [
-
 	"The image main entry point called by an image builder. The arguments specify the image
 	version description.
 	This method is run before the new bootstrapped image is saved!"
 
-	SystemVersion
-		writeClassVariableNamed: #Current
-		value: (SystemVersion new
-					type: typeName;
-					major: major;
-					minor: minor;
-					patch: patch;
-					suffix: suffix;
-					build: buildNumber;
-					commitHash: hash;
-					yourself).
+	'Setting system version' traceCr.
+	SystemVersion writeClassVariableNamed: #Current value: (SystemVersion new
+			 type: typeName;
+			 major: major;
+			 minor: minor;
+			 patch: patch;
+			 suffix: suffix;
+			 build: buildNumber;
+			 commitHash: hash;
+			 yourself).
 
 	self initializeCommandLineHandlerAndErrorHandling
 ]


### PR DESCRIPTION
PharoBootstrapInitialization is doing the initial initialization of the Pharo image after Espell finished to initalize the minimal image. It happened to mu multiple times that this step failed on some of my PR and it is really hard to debug. Here I am adding some logs to be able to pinpoint more easily where the build is failing and help to debug.

I'm also trying to group the initializations that makes sense to be together