### PR TITLE
Bootstrap: Update localisation of SourceFileArray

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -158,7 +158,6 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}
 
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "PharoBootstrapInitialization initializeFileSystem"
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "SourceFileArray initialize"
 zip "${COMPILER_IMAGE_NAME}.zip" "${COMPILER_IMAGE_NAME}.image"
 
 # Installing Traits through Hermes 

--- a/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
+++ b/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
@@ -94,12 +94,16 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 
 { #category : 'public api' }
 PharoBootstrapInitialization class >> initializeFileSystem [
+
 	| env |
 	env := self environment.
 	(env at: #FileLocator) initialize.
 	(env at: #DiskStore) initialize.
 	(env at: #FileHandle) initialize.
-	(env at: #File) initialize
+	(env at: #File) initialize.
+
+	"Now that the file system is setup, we can register SourceFileArray to the session manager."
+	SessionManager default registerSystemClassNamed: #SourceFileArray
 ]
 
 { #category : 'public api' }

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -21,12 +21,6 @@ Class {
 	#tag : 'Sources'
 }
 
-{ #category : 'class initialization' }
-SourceFileArray class >> initialize [
-
-	SessionManager default registerSystemClassNamed: self name
-]
-
 { #category : 'system startup' }
 SourceFileArray class >> startUp: resuming [
 


### PR DESCRIPTION
I am trying to remove the dependencies of the core packages of Pharo (the ones dealt with via Espell) over the SessionManager because we could load it via Hermes.

Here is a cleaning moving the initialization of source file array in the PharoBootstrapInitialization class. Also this is now done in the Pharo code and not the bootstrap bash scripts.