### PR TITLE
15334-Browser-Accepting-a-class-definition-with-no-change-does-not-refresh

### DIFF
--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -129,12 +129,14 @@ ClyTextEditorToolMorph >> changesAccepted [
 			textModel text: self editingText.
 			textMorph hasUnacceptedEdits: true.
 			err pass].
+
+		textModel setText: self editingText.
+		
 		applied
 			ifTrue: [ textMorph hasUnacceptedEdits: false.
 				self textUpdated.
 				browser focusActiveTab ]
 			ifFalse: [
-				textModel text: self editingText.
 				textMorph hasUnacceptedEdits: true].
 	]
 ]

--- a/src/Rubric/RubScrolledTextModel.class.st
+++ b/src/Rubric/RubScrolledTextModel.class.st
@@ -164,6 +164,14 @@ RubScrolledTextModel >> primarySelectionInterval [
 	^ primarySelectionInterval
 ]
 
+{ #category : 'private' }
+RubScrolledTextModel >> privateText: atextOrString [
+
+	"Use setText: because I don't update the morph that uses me."
+
+	text := atextOrString asText
+]
+
 { #category : 'view updating' }
 RubScrolledTextModel >> reconfigureViewWith: aBlockWithAScrolledTextMorphAsArgument [
 	self announce: (RubConfigurationChange new configurationBlock: aBlockWithAScrolledTextMorphAsArgument)
@@ -190,7 +198,7 @@ RubScrolledTextModel >> setPrimarySelectionInterval: anInterval [
 
 { #category : 'text managing' }
 RubScrolledTextModel >> setText: aText [
-	self text:  aText.
+	self privateText:  aText.
 	self announcer announce: RubTextUpdatedInModel.
 	^ true
 ]
@@ -211,7 +219,13 @@ RubScrolledTextModel >> text [
 	^ text ifNil: [ text := '' asText ]
 ]
 
-{ #category : 'text managing' }
+{ #category : 'private' }
 RubScrolledTextModel >> text: atextOrString [
-	text := atextOrString asText
+
+	self
+		deprecated: 'You should use setText: or privateText: if you are really in the same class'
+		transformWith: '`@receiver text: `@arg' -> '`@receiver setText: `@arg'.
+		
+			
+	^ self setText: atextOrString
 ]


### PR DESCRIPTION
- When accepting a class we should update always the text to the new definition.
- Deprecating direct access to text: to use setText: that notifies the morphs

Fix #15334 