### PR TITLE
DrTest shortcut was not working

### DIFF
--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -37,6 +37,12 @@ DrTests class >> beDefaultTestRunner [
 	self registerToolsOn: Smalltalk tools
 ]
 
+{ #category : 'class initialization' }
+DrTests class >> initialize [
+
+	Smalltalk tools register: self as: #testRunner
+]
+
 { #category : 'world menu' }
 DrTests class >> menuCommandOn: aBuilder [
 


### PR DESCRIPTION
When the old TestRunner got removed, DrTest was not registered as the new TestRunner in the tool registry which prevents some features such as using a shortcut to open dr test