### PR TITLE
Disable automated transform for deprecation of Object>>asOrderedCollection

### DIFF
--- a/src/Deprecated12/Object.extension.st
+++ b/src/Deprecated12/Object.extension.st
@@ -6,6 +6,7 @@ Object >> asOrderedCollection [
 	self
 		deprecated:
 		'The usage of this method is not recommended. We want to have a smaller Object api. We will remove this method in the next Pharo version.'
-		transformWith: '`@receiver asOrderedCollection' -> 'OrderedCollection with: `@receiver'.
+"Automatic transform removed. See https://github.com/pharo-project/pharo/issues/14197"
+		"transformWith: '`@receiver asOrderedCollection' -> 'OrderedCollection with: `@receiver'".
 	^ OrderedCollection with: self
 ]


### PR DESCRIPTION
See https://github.com/pharo-project/pharo/issues/14197
Applies the same change for Pharo12