### PR TITLE
Cleanup: reduce users of #classPool

### DIFF
--- a/src/Fuel-Core-Tests/FLCreateClassSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLCreateClassSerializationTest.class.st
@@ -105,14 +105,14 @@ FLCreateClassSerializationTest >> testCreateClassWithClassVariable [
 	"Tests materialization a class not defined in the image, with a class variable."
 
 	| aClass materializedClass |
-	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariablesFromString: 'ClassVariable' ].
-	aClass classPool at: 'ClassVariable' put: #test.
+	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariablesFromString: #ClassVariable ].
+	(aClass classVariableNamed: #ClassVariable) write: #test.
 
 	materializedClass := self resultOfSerializeRemoveAndMaterialize: aClass.
 
 	self assert: 1 equals: materializedClass classVarNames size.
 	self assert: (materializedClass classVarNames includes: #ClassVariable).
-	self assert: #test equals: (materializedClass classPool at: #ClassVariable).
+	self assert: #test equals: (materializedClass readClassVariableNamed: #ClassVariable).
 	self assert: materializedClass classVariables first class identicalTo: ClassVariable
 ]
 
@@ -242,8 +242,8 @@ FLCreateClassSerializationTest >> testCreateClassWithSharedPoolAndMethodReferenc
 
 	self assert: materializedClass sharedPools size equals: 1.
 	self assert: sharedPool identicalTo: materializedClass sharedPools first.
-	self assert: (materializedClass >> #xxx literalAt: 1) value identicalTo: (sharedPool classPool at: #ClassVar1).
-	self assert: (materializedClass class >> #yyy literalAt: 1) value identicalTo: (sharedPool classPool at: #ClassVar1).
+	self assert: (materializedClass >> #xxx literalAt: 1) value identicalTo: (sharedPool readClassVariableNamed: #ClassVar1).
+	self assert: (materializedClass class >> #yyy literalAt: 1) value identicalTo: (sharedPool readClassVariableNamed: #ClassVar1).
 	self assert: (materializedClass new perform: #xxx) identicalTo: anObject.
 	self assert: (materializedClass perform: #yyy) identicalTo: anObject
 ]

--- a/src/Fuel-Core-Tests/FLFullBasicSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLFullBasicSerializationTest.class.st
@@ -48,7 +48,7 @@ FLFullBasicSerializationTest >> testClassSideCompiledMethod [
 FLFullBasicSerializationTest >> testClassVariable [
 	"An association included in a global class is treated as global by default."
 
-	self assertSerializationIdentityOf: (self class classPool associationAt: #ClassVariableForTesting)
+	self assertSerializationIdentityOf: (self class classVarNamed: #ClassVariableForTesting)
 ]
 
 { #category : 'tests' }

--- a/src/Fuel-Core/FLGlobalClassVariableCluster.class.st
+++ b/src/Fuel-Core/FLGlobalClassVariableCluster.class.st
@@ -21,7 +21,7 @@ FLGlobalClassVariableCluster >> materializeInstanceWith: aDecoder [
 	| keyName ownerClass |
 	ownerClass := aDecoder nextEncodedReference.
 	keyName := aDecoder nextEncodedReference.
-	^ownerClass classPool associationAt: keyName
+	^ownerClass classVariableNamed: keyName
 ]
 
 { #category : 'analyzing' }

--- a/src/Gofer-Deprecated/GoferOperationTest.extension.st
+++ b/src/Gofer-Deprecated/GoferOperationTest.extension.st
@@ -103,11 +103,11 @@ GoferOperationTest >> testReinitialize [
 		addClassVarNamed: #ClassSide.
 	class compile: 'initialize InstanceSide := true'.
 	class class compile: 'initialize ClassSide := true'.
-	self assert: (class classPool at: #InstanceSide) isNil.
-	self assert: (class classPool at: #ClassSide) isNil.
+	self assert: (class classVariableNamed: #InstanceSide) read isNil.
+	self assert: (class classVariableNamed: #ClassSide) read isNil.
 	gofer reinitialize.
-	self assert: (class classPool at: #InstanceSide) isNil.
-	self assert: (class classPool at: #ClassSide)
+	self assert: (class classVariableNamed: #InstanceSide) read isNil.
+	self assert: (class classVariableNamed: #ClassSide) read
 ]
 
 { #category : '*Gofer-Deprecated' }

--- a/src/Gofer-Deprecated/GoferOperationTest.extension.st
+++ b/src/Gofer-Deprecated/GoferOperationTest.extension.st
@@ -103,11 +103,11 @@ GoferOperationTest >> testReinitialize [
 		addClassVarNamed: #ClassSide.
 	class compile: 'initialize InstanceSide := true'.
 	class class compile: 'initialize ClassSide := true'.
-	self assert: (class classVariableNamed: #InstanceSide) read isNil.
-	self assert: (class classVariableNamed: #ClassSide) read isNil.
+	self assert: (class readClassVariableNamed: #InstanceSide) isNil.
+	self assert: (class readClassVariableNamed: #ClassSide)  isNil.
 	gofer reinitialize.
-	self assert: (class classVariableNamed: #InstanceSide) read isNil.
-	self assert: (class classVariableNamed: #ClassSide) read
+	self assert: (class readClassVariableNamed: #InstanceSide) isNil.
+	self assert: (class readClassVariableNamed: #ClassSide)
 ]
 
 { #category : '*Gofer-Deprecated' }

--- a/src/Kernel-Tests-Extended/UnicodeTest.class.st
+++ b/src/Kernel-Tests-Extended/UnicodeTest.class.st
@@ -130,7 +130,7 @@ UnicodeTest >> testIsInitialQuote [
 { #category : 'tests - categorization' }
 UnicodeTest >> testIsLetter [
 	| letterCategories methodAnswer catFromTable |
-	letterCategories := #(Ll Lm Lo Lt Lu) collect: [ :c | Unicode classPool at: c ].
+	letterCategories := #(Ll Lm Lo Lt Lu) collect: [ :c | Unicode classVariableNamed: c ].
 	self aRandomSelectionOfCodePointsDo: [ :cp |
 			methodAnswer := Unicode isLetter: (Character codePoint: cp).
 			catFromTable := self unicodeCategoryTableLookup: cp.

--- a/src/Kernel-Tests-Extended/UnicodeTest.class.st
+++ b/src/Kernel-Tests-Extended/UnicodeTest.class.st
@@ -130,7 +130,7 @@ UnicodeTest >> testIsInitialQuote [
 { #category : 'tests - categorization' }
 UnicodeTest >> testIsLetter [
 	| letterCategories methodAnswer catFromTable |
-	letterCategories := #(Ll Lm Lo Lt Lu) collect: [ :c | Unicode classVariableNamed: c ].
+	letterCategories := #(Ll Lm Lo Lt Lu) collect: [ :c | Unicode readClassVariableNamed: c ].
 	self aRandomSelectionOfCodePointsDo: [ :cp |
 			methodAnswer := Unicode isLetter: (Character codePoint: cp).
 			catFromTable := self unicodeCategoryTableLookup: cp.

--- a/src/Kernel/Class.class.st
+++ b/src/Kernel/Class.class.st
@@ -193,7 +193,7 @@ Class >> allSharedPools [
 Class >> anyUserOfClassVarNamed: aSymbol [
 	self withAllSubclasses do: [ :subclass |
  		{subclass . subclass class} do: [ :classOrMeta |
-			(classOrMeta whichMethodsReferTo: (self classPool associationAt: aSymbol))
+			(classOrMeta whichMethodsReferTo: (self classVariableNamed: aSymbol))
 				ifNotEmpty: [ ^classOrMeta ]]].
 	^nil
 ]

--- a/src/Multilingual-Encodings/Unicode.class.st
+++ b/src/Multilingual-Encodings/Unicode.class.st
@@ -501,8 +501,8 @@ Unicode class >> initializeTagConstants [
 						and: [sym first isUppercase and: [sym last isLowercase]]]) asSortedCollection
 		inject: 1
 		into: [:index :sym | sym = #Cn
-				ifTrue: [self classPool at: sym put: 0. index]
-				ifFalse: [self classPool at: sym put: index. index + 1]]
+				ifTrue:  [(self classVariableNamed: sym) write: 0. index]
+				ifFalse: [(self classVariableNamed: sym) write: index. index + 1]]
 ]
 
 { #category : 'private' }

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -186,13 +186,13 @@ SystemNavigation >> browseClassVarRefs: aClass [
 	index := (UIManager default chooseFrom: (labelStream contents substrings) lines: lines).
 	index = 0 ifTrue: [^ self].
 	^ self browseAllReferencesTo:
-		((owningClasses at: index) classPool associationAt: (allVars at: index))
+		((owningClasses at: index) classVariableNamed: (allVars at: index))
 ]
 
 { #category : '*Tool-Base' }
 SystemNavigation >> browseClassVariables: aClass [
 
-	^ aClass classPool inspectWithLabel: 'Class Variables in ' , aClass name
+	^ aClass classVariables inspectWithLabel: 'Class Variables in ' , aClass name
 ]
 
 { #category : '*Tool-Base' }

--- a/src/UnifiedFFI-Tests/FFIExternalStructurePlatformTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIExternalStructurePlatformTest.class.st
@@ -24,8 +24,8 @@ FFIExternalStructurePlatformTest >> testStructureHasCorrectOffsets32bits [
 	self is32bit ifFalse: [ ^ self skip ].
 
 	FFITestStructureByPlatform compiledSpec. "Ensure fields are initialized"
-	self assert: (FFITestStructureByPlatform classPool at: #OFFSET_LONG) equals: 1.
-	self assert: (FFITestStructureByPlatform classPool at: #OFFSET_POINTER) equals: 5
+	self assert: (FFITestStructureByPlatform readClassVariableNamed: #OFFSET_LONG) equals: 1.
+	self assert: (FFITestStructureByPlatform readClassVariableNamed: #OFFSET_POINTER) equals: 5
 ]
 
 { #category : 'tests' }
@@ -33,8 +33,8 @@ FFIExternalStructurePlatformTest >> testStructureHasCorrectOffsets64bits [
 	self is64bit ifFalse: [ ^ self skip ].
 
 	FFITestStructureByPlatform compiledSpec. "Ensure fields are initialized"
-	self assert: (FFITestStructureByPlatform classPool at: #OFFSET_LONG) equals: 1.
-	self assert: (FFITestStructureByPlatform classPool at: #OFFSET_POINTER) equals: 9
+	self assert: (FFITestStructureByPlatform readClassVariableNamed: #OFFSET_LONG) equals: 1.
+	self assert: (FFITestStructureByPlatform readClassVariableNamed: #OFFSET_POINTER) equals: 9
 ]
 
 { #category : 'tests' }

--- a/src/UnifiedFFI-Tests/FFIFunctionResolutionTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIFunctionResolutionTest.class.st
@@ -143,7 +143,7 @@ FFIFunctionResolutionTest >> testResolveClassVariableShouldSetClassVariableLoade
 	argument resolveUsing: resolver.
 	argument loader emitArgument: self context: context.
 
-	self assert: stack pop equals: { #classVariable . (String classPool bindingOf: #AsciiOrder )}.
+	self assert: stack pop equals: { #classVariable . (String classVariableNamed: #AsciiOrder )}.
 	self assert: argument resolvedType class equals: int32Type
 ]
 


### PR DESCRIPTION
Small refactoring to remove the users of #classPool, use the Reflective API for class variables instead
