### PR TITLE
Cleanup ClassParser: remove tokens

### DIFF
--- a/src/ClassParser/CDBehaviorDefinitionNode.class.st
+++ b/src/ClassParser/CDBehaviorDefinitionNode.class.st
@@ -112,11 +112,6 @@ CDBehaviorDefinitionNode >> layoutClass: aClass [
 ]
 
 { #category : 'accessing' }
-CDBehaviorDefinitionNode >> selector [
-	^ self subclassResponsibility
-]
-
-{ #category : 'accessing' }
 CDBehaviorDefinitionNode >> slotNodes [
 
 	^ slotNodes

--- a/src/ClassParser/CDClassDefinitionNode.class.st
+++ b/src/ClassParser/CDClassDefinitionNode.class.st
@@ -63,16 +63,10 @@ CDClassDefinitionNode >> packageNameNode [
 ]
 
 { #category : 'accessing' }
-CDClassDefinitionNode >> packageNameNode: aNode astNode: astNode [
+CDClassDefinitionNode >> packageNameNode: aRBNode astNode: astNode [
 
-	packageNameNode := aNode.
-	self addChild: aNode
-]
-
-{ #category : 'testing' }
-CDClassDefinitionNode >> selector [
-
-	^ tokens at: 2
+	packageNameNode := (CDPackageNode on: aRBNode) packageName: aRBNode value.
+	self addChild: aRBNode
 ]
 
 { #category : 'accessing' }

--- a/src/ClassParser/CDMetaclassDefinitionNode.class.st
+++ b/src/ClassParser/CDMetaclassDefinitionNode.class.st
@@ -22,9 +22,3 @@ CDMetaclassDefinitionNode >> isClassSide [
 CDMetaclassDefinitionNode >> isInstanceSide [
 	^ false
 ]
-
-{ #category : 'testing' }
-CDMetaclassDefinitionNode >> selector [
-
-	^ tokens at: 3
-]

--- a/src/ClassParser/CDNode.class.st
+++ b/src/ClassParser/CDNode.class.st
@@ -12,8 +12,7 @@ Class {
 	#instVars : [
 		'parent',
 		'originalNode',
-		'children',
-		'tokens'
+		'children'
 	],
 	#category : 'ClassParser-Model',
 	#package : 'ClassParser',
@@ -27,10 +26,10 @@ CDNode class >> isAbstract [
 ]
 
 { #category : 'instance creation' }
-CDNode class >> on: aRBMessageNode [
+CDNode class >> on: aRBNode [
 
 	^ self new
-		originalNode: aRBMessageNode;
+		originalNode: aRBNode;
 		yourself
 ]
 
@@ -149,14 +148,4 @@ CDNode >> start [
 CDNode >> stop [
 
 	^ originalNode stop
-]
-
-{ #category : 'accessing' }
-CDNode >> tokens [
-	^ tokens
-]
-
-{ #category : 'accessing' }
-CDNode >> tokens: aCollectionOfTokens [
-	tokens := aCollectionOfTokens
 ]


### PR DESCRIPTION
CDNode had a ivar "tokens", the idea was to use this to map CDNodes to text. But we do retain the original RB Nodes, and start/stop is implemented using those.

- tokens are always nil, the methods #selector is not send and does not work (and what is a selector of a class definition?)
- packageNameNode was set to a literal, but it should use a wrapper. There is CDPackageNode,  which was not used