### PR TITLE
15288-OCStaticASTCompilerPlugin-has-two-priority-mecanism 

### DIFF
--- a/src/OpalCompiler-Core/OCASTCompilerPlugin.class.st
+++ b/src/OpalCompiler-Core/OCASTCompilerPlugin.class.st
@@ -45,10 +45,14 @@ OCASTCompilerPlugin class >> isAbstract [
 	^ self == OCASTCompilerPlugin
 ]
 
+{ #category : 'accessing - defaults' }
+OCASTCompilerPlugin class >> priority [
+	^ self defaultPriority
+]
+
 { #category : 'accessing' }
 OCASTCompilerPlugin >> priority [
-
-	^ self class defaultPriority
+	^ self class priority
 ]
 
 { #category : 'transforming' }

--- a/src/OpalCompiler-Core/OCStaticASTCompilerPlugin.class.st
+++ b/src/OpalCompiler-Core/OCStaticASTCompilerPlugin.class.st
@@ -18,12 +18,6 @@ OCStaticASTCompilerPlugin class >> isAbstract [
 	^ self == OCStaticASTCompilerPlugin
 ]
 
-{ #category : 'private' }
-OCStaticASTCompilerPlugin class >> priority [
-
-	^ 0
-]
-
 { #category : 'instance creation' }
 OCStaticASTCompilerPlugin class >> transform: anAST [
 	"Return a new instance of the receiver transforming the given AST"
@@ -42,11 +36,6 @@ OCStaticASTCompilerPlugin >> copyAST [
 	"Utility method to make a copy of the AST before manipulating it"
 
 	ast := ast copy
-]
-
-{ #category : 'accessing' }
-OCStaticASTCompilerPlugin >> priority [
-	^100 "default. Priority 0 is used by Reflectivity to be the last"
 ]
 
 { #category : 'private - transforming' }

--- a/src/OpalCompiler-Tests/ASTPluginMeaningOfLife.class.st
+++ b/src/OpalCompiler-Tests/ASTPluginMeaningOfLife.class.st
@@ -11,6 +11,11 @@ Class {
 	#tag : 'Plugins'
 }
 
+{ #category : 'private' }
+ASTPluginMeaningOfLife class >> priority [
+	^ 50
+]
+
 { #category : 'private - transforming' }
 ASTPluginMeaningOfLife >> transform [
 


### PR DESCRIPTION
Make sure that the instance side #priority is forwarded to the class side for static plugins. 
- remove the double definition we hat on #OCStaticASTCompilerPlugin
- make sure the demo ASTPluginMeaningOfLife uses some reasonable prio

Fixes #15288