### PR TITLE
Fix #15386 DrTests keeps filter when minimizing - maximizing

### DIFF
--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -207,13 +207,21 @@ DrTests >> pluginsDropList [
 	^ pluginsDropList
 ]
 
-{ #category : 'initialization' }
-DrTests >> reloadConfiguration: aDTPluginConfiguration withResults: aDTPluginResult andPlugin: aDTPlugin [
+{ #category : 'accessing' }
+DrTests >> receivePluginPresenter: aPluginPresenter [
 
+	self layout replace: pluginPresenter with: aPluginPresenter.
+	pluginPresenter := aPluginPresenter
+]
+
+{ #category : 'initialization' }
+DrTests >> reloadConfiguration: aDTPluginConfiguration withResults: aDTPluginResult andPlugin: aDTPlugin andPresenter: aDTPluginPresenter [
+	
 	self
 		updateStatus: 'Tests finished.';
 		currentPlugin: aDTPlugin;
 		testsConfiguration: aDTPluginConfiguration;
+		receivePluginPresenter: aDTPluginPresenter;
 		updateWithPluginResult: aDTPluginResult
 ]
 
@@ -248,6 +256,7 @@ DrTests >> switchToMiniDrTest [
 		testsConfiguration: self testsConfiguration;
 		currentPlugin: self currentPlugin;
 		updateWithPluginResult: self pluginResult;
+		receivePluginPresenter: self pluginPresenter;
 		yourself)
 		open
 ]

--- a/src/DrTests/MiniDrTests.class.st
+++ b/src/DrTests/MiniDrTests.class.st
@@ -5,7 +5,8 @@ Class {
 	#name : 'MiniDrTests',
 	#superclass : 'AbstractDrTestsPresenter',
 	#instVars : [
-		'startButton'
+		'startButton',
+		'pluginPresenter'
 	],
 	#category : 'DrTests-Spec',
 	#package : 'DrTests',
@@ -58,6 +59,18 @@ MiniDrTests >> initializeWindow: aWindowPresenter [
 ]
 
 { #category : 'accessing' }
+MiniDrTests >> pluginPresenter [
+
+	^ pluginPresenter
+]
+
+{ #category : 'accessing' }
+MiniDrTests >> receivePluginPresenter: aPluginPresenter [
+
+	pluginPresenter := aPluginPresenter
+]
+
+{ #category : 'accessing' }
 MiniDrTests >> startButton [
 	^ startButton
 ]
@@ -67,8 +80,9 @@ MiniDrTests >> switchToDrTest [
 
 	(DrTests newApplication: self application)
 		reloadConfiguration: testsConfiguration
-			withResults: pluginResult
-			andPlugin: currentPlugin;
+		withResults: pluginResult
+		andPlugin: currentPlugin
+		andPresenter: self pluginPresenter;
 		open
 ]
 


### PR DESCRIPTION
Fixes #15386.

DrTests now keeps filter and custom selections when doing a minimize - maximize.