### PR TITLE
Fix date printer during the bootstrap

### DIFF
--- a/src/Kernel/BasicDatePrinter.class.st
+++ b/src/Kernel/BasicDatePrinter.class.st
@@ -18,7 +18,9 @@ Class {
 
 { #category : 'accessing' }
 BasicDatePrinter class >> default [
-	^ ExtendedDatePrinter new
+
+	"We should have a registration mecanism in the future."
+	^ (self environment at: #ExtendedDatePrinter ifAbsent: [ self ]) new
 ]
 
 { #category : 'printing' }


### PR DESCRIPTION
Working with the bootstrap I often have errors that are hidden because Pharo is trying to print logs but those los print the date with a date printer that is not yet loaded. 

This adds a guard for this case. Could be improved later with a registration mecanism