### PR TITLE
Revert #15405 to fix error and unresponsive VM when opening extra world

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -207,15 +207,16 @@ OSSDL2Driver >> eventLoopProcessWithVMWindow [
 
 { #category : 'events-processing' }
 OSSDL2Driver >> eventLoopProcessWithoutPlugin [
-
-	| event delay |
+	| event session |
 	event := SDL_Event new.
-	delay := Delay forMilliseconds: 5.
+	session := Smalltalk session.
 
-	[ event isNull ] whileFalse: [
+	[ session == Smalltalk session]
+	whileTrue: [
 		[ (SDL2 pollEvent: event) > 0 ]
-			whileTrue: [ self processEvent: event ].
-		delay wait ]
+		whileTrue: [ self processEvent: event ].
+
+		(Delay forMilliseconds: 5) wait ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
This pull request reverts pull request #15405 as it caused an error “This Delay has already been scheduled” to be signaled, and the VM to become unresponsive, when opening an extra world through `OSWindowWorldMorph new open`.