### PR TITLE
Fix ‘recolor’ halo icon

### DIFF
--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -178,7 +178,7 @@ HaloMorph class >> iconicHaloSpecifications [
 	(addFontSizeHandle:		leftCenter	bottom			(lightGreen)						#haloFontSize)
 	(addFontStyleHandle:		center		bottom			(lightRed)						#haloFontStyle)
 	(addFontEmphHandle:	rightCenter	bottom			(lightBrown darker)				#haloFontEmph)
-	(addRecolorHandle:		right		bottomCenter	(magenta darker)				#haloRecolon) )
+	(addRecolorHandle:		right		bottomCenter	(magenta darker)				#haloRecolor) )
 ]
 
 { #category : 'class initialization' }


### PR DESCRIPTION
This pull request fixes the icon name for the ‘recolor’ handle in `#iconicHaloSpecifications` for HaloMorph to `#haloRecolor` instead of `#haloRecolon`.