### PR TITLE
Fix ‘drag’ halo icon in #customHaloSpecifications

### DIFF
--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -82,7 +82,7 @@ HaloMorph class >> customHaloSpecifications [
 	^ #(
 	(addDismissHandle:		left			top				(red		muchLighter)			#haloDismiss)
 	(addMenuHandle:		right		top				(red)							#haloMenu)
-	(addDragHandle:			center	top					(brown)							#haloDragddGrowHandle:		right		bottom			(yellow)						#haloScale)
+	(addDragHandle:			center	top					(brown)							#haloDrag)
 	(addScaleHandle:		right		bottom			(lightOrange)					#haloScale)
 
 	(addRecolorHandle:		left			center			(green muchLighter lighter)		#haloRecolor)


### PR DESCRIPTION
This pull request fixes the icon name, and removes the superfluous array elements, for the ‘drag’ handle in `#customHaloSpecifications` for HaloMorph to `#haloDrag` instead of `#haloDragddGrowHandle:`.