### PR TITLE
Refactor: remove method driver

### DIFF
--- a/src/Refactoring-Core/RBCompositeRefactoring.class.st
+++ b/src/Refactoring-Core/RBCompositeRefactoring.class.st
@@ -29,10 +29,7 @@ RBCompositeRefactoring >> breakingChangePreconditions [
 RBCompositeRefactoring >> generateChanges [
 	
 	self prepareForExecution.
-
-	self applicabilityPreconditions check ifFalse: [
-		^ RBApplicabilityChecksFailedError signal:
-			  self applicabilityPreconditions errorString ].
+	self checkApplicabilityPreconditions.
 	self breakingChangePreconditions check ifFalse: [
 		RBBreakingChangeChecksFailedWarning signal:
 			self breakingChangePreconditions errorString ].

--- a/src/Refactoring-Core/RBDefinesSelectorsCondition.class.st
+++ b/src/Refactoring-Core/RBDefinesSelectorsCondition.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : 'RBDefinesSelectorsCondition',
+	#superclass : 'RBCondition',
+	#instVars : [
+		'class',
+		'selectors',
+		'violators'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'checking' }
+RBDefinesSelectorsCondition >> check [ 
+
+	^ self violators isEmpty
+]
+
+{ #category : 'initialization' }
+RBDefinesSelectorsCondition >> definesSelectors: aSelectorsList in: aClass [
+
+	class := aClass.
+	selectors := aSelectorsList
+]
+
+{ #category : 'displaying' }
+RBDefinesSelectorsCondition >> violationMessageOn: aStream [
+
+	self violators do: [ :violator |
+		aStream
+			nextPutAll: violator;
+			nextPutAll: ' is not defined in the class ';
+			nextPutAll: class name;
+			nextPutAll: '.';
+			space ].
+	aStream nextPutAll: 'Selectors must be defined in the class.'
+]
+
+{ #category : 'accessing' }
+RBDefinesSelectorsCondition >> violators [
+
+	^ violators ifNil: [
+		  violators := selectors reject: [ :aSelector | class directlyDefinesMethod: aSelector ] ]
+]

--- a/src/Refactoring-Core/RBDefinesSelectorsCondition.class.st
+++ b/src/Refactoring-Core/RBDefinesSelectorsCondition.class.st
@@ -1,21 +1,14 @@
 Class {
 	#name : 'RBDefinesSelectorsCondition',
-	#superclass : 'RBCondition',
+	#superclass : 'RBMethodsCondition',
 	#instVars : [
 		'class',
-		'selectors',
-		'violators'
+		'selectors'
 	],
 	#category : 'Refactoring-Core-Conditions',
 	#package : 'Refactoring-Core',
 	#tag : 'Conditions'
 }
-
-{ #category : 'checking' }
-RBDefinesSelectorsCondition >> check [ 
-
-	^ self violators isEmpty
-]
 
 { #category : 'initialization' }
 RBDefinesSelectorsCondition >> definesSelectors: aSelectorsList in: aClass [

--- a/src/Refactoring-Core/RBMethodsCondition.class.st
+++ b/src/Refactoring-Core/RBMethodsCondition.class.st
@@ -1,0 +1,22 @@
+Class {
+	#name : 'RBMethodsCondition',
+	#superclass : 'RBCondition',
+	#instVars : [
+		'violators'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'checking' }
+RBMethodsCondition >> check [ 
+
+	^ self violators isEmpty
+]
+
+{ #category : 'accessing' }
+RBMethodsCondition >> violators [
+
+	^ self subclassResponsibility 
+]

--- a/src/Refactoring-Core/RBMethodsHaveNoSendersCondition.class.st
+++ b/src/Refactoring-Core/RBMethodsHaveNoSendersCondition.class.st
@@ -1,0 +1,55 @@
+Class {
+	#name : 'RBMethodsHaveNoSendersCondition',
+	#superclass : 'RBMethodsCondition',
+	#instVars : [
+		'classSelectorsMapping',
+		'model',
+		'allSelectors'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'accessing' }
+RBMethodsHaveNoSendersCondition >> allSelectors [
+
+	^ allSelectors ifNil: [ allSelectors := classSelectorsMapping flatCollect: #value ]
+]
+
+{ #category : 'initialization' }
+RBMethodsHaveNoSendersCondition >> classSelectorsMapping: aDictionary [
+
+	classSelectorsMapping := aDictionary 
+]
+
+{ #category : 'initialization' }
+RBMethodsHaveNoSendersCondition >> model: aRBNamespace [
+
+	model := aRBNamespace 
+]
+
+{ #category : 'displaying' }
+RBMethodsHaveNoSendersCondition >> violationMessageOn: aStream [
+
+	aStream nextPutAll: 'Method(s) have senders:'.
+	self violators do: [ :violator |
+		aStream
+			nextPutAll: violator;
+			nextPutAll: ';';
+			space ]
+]
+
+{ #category : 'accessing' }
+RBMethodsHaveNoSendersCondition >> violators [
+
+	violators ifNotNil: [ ^ violators ].
+
+	violators := OrderedCollection new.
+	self allSelectors do: [ :aSelector |
+		model allReferencesTo: aSelector do: [ :aRBMethod |
+			(self allSelectors includes: aRBMethod selector) ifFalse: [
+				violators add: aSelector -> aRBMethod ] ] ].
+
+	^ violators
+]

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -43,6 +43,12 @@ RBRefactoring class >> preconditionSignal [
 	^ RBRefactoringError , RBRefactoringWarning
 ]
 
+{ #category : 'preconditions' }
+RBRefactoring >> applicabilityPreconditions [
+
+	^ self trueCondition 
+]
+
 { #category : 'converting' }
 RBRefactoring >> asRefactoring [
 
@@ -55,6 +61,19 @@ RBRefactoring >> canReferenceVariable: aString in: aClass [
 	(aClass definesVariable: aString) ifTrue: [^true].
 	(self model includesGlobal: aString asSymbol) ifTrue: [^true].
 	^(self poolVariableNamesFor: aClass) includes: aString
+]
+
+{ #category : 'preconditions' }
+RBRefactoring >> checkApplicabilityPreconditions [
+
+	| conditions errorStrings |
+	conditions := self applicabilityPreconditions.
+	conditions := conditions reject: [ :cond | cond check ].
+	conditions ifEmpty: [ ^ self ].
+	errorStrings := String streamContents: [ :aStream |
+		                conditions do: [ :cond |
+			                cond violationMessageOn: aStream ] ].
+	self refactoringError: errorStrings
 ]
 
 { #category : 'support' }

--- a/src/Refactoring-Core/RBRemoveClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveClassRefactoring.class.st
@@ -54,19 +54,6 @@ RBRemoveClassRefactoring >> breakingChangePreconditions [
 ]
 
 { #category : 'preconditions' }
-RBRemoveClassRefactoring >> checkApplicabilityPreconditions [
-
-	| conditions errorStrings |
-	conditions := self applicabilityPreconditions.
-	conditions := conditions reject: [ :cond | cond check ].
-	conditions ifEmpty: [ ^ self ].
-	errorStrings := String streamContents: [ :aStream |
-		                conditions do: [ :cond |
-			                cond violationMessageOn: aStream ] ].
-	self refactoringError: errorStrings
-]
-
-{ #category : 'preconditions' }
 RBRemoveClassRefactoring >> checkBreakingChangePreconditions [
 
 	| conditions errorStrings |

--- a/src/Refactoring-Core/RBRemoveMethodsInHierarchyRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodsInHierarchyRefactoring.class.st
@@ -13,11 +13,7 @@ Script
 "
 Class {
 	#name : 'RBRemoveMethodsInHierarchyRefactoring',
-	#superclass : 'RBCompositeRefactoring',
-	#instVars : [
-		'selectors',
-		'class'
-	],
+	#superclass : 'RBRemoveMethodsRefactoring',
 	#category : 'Refactoring-Core-Refactorings',
 	#package : 'Refactoring-Core',
 	#tag : 'Refactorings'
@@ -29,17 +25,12 @@ RBRemoveMethodsInHierarchyRefactoring class >> selectors: aSelectorsCollection f
 	^ self new selectors: aSelectorsCollection from: aClass
 ]
 
-{ #category : 'preconditions' }
-RBRemoveMethodsInHierarchyRefactoring >> applicabilityPreconditions [ 
-
-	^ { RBDefinesSelectorsCondition new definesSelectors: selectors in: class }
-]
-
 { #category : 'transforming' }
 RBRemoveMethodsInHierarchyRefactoring >> initializeRefactorings [
 
-	class withAllSubclasses do: [ :aClass |
-		self remove: selectors in: aClass ]
+	classSelectorMapping keysAndValuesDo: [ :class :selectors |
+		class allSubclasses do: [ :aClass |
+			self remove: selectors in: aClass ] ]
 ]
 
 { #category : 'transforming' }
@@ -55,22 +46,9 @@ RBRemoveMethodsInHierarchyRefactoring >> remove: aSelectorsCollection in: aClass
 				 from: aClass) ]
 ]
 
-{ #category : 'removing' }
+{ #category : 'accessing' }
 RBRemoveMethodsInHierarchyRefactoring >> selectors: aSelectorsCollection from: aClass [
 
-	class := self classObjectFor: aClass.
-	selectors := aSelectorsCollection.
-	refactorings := OrderedCollection new.
+	super selectors: aSelectorsCollection from: aClass.
 	self initializeRefactorings 
-]
-
-{ #category : 'printing' }
-RBRemoveMethodsInHierarchyRefactoring >> storeOn: aStream [
-	aStream nextPut: $(.
-	self class storeOn: aStream.
-	aStream nextPutAll: ' removeMethods: '.
-	selectors asArray storeOn: aStream.
-	aStream nextPutAll: ' from: '.
-	class storeOn: aStream.
-	aStream nextPut: $)
 ]

--- a/src/Refactoring-Core/RBRemoveMethodsInHierarchyRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodsInHierarchyRefactoring.class.st
@@ -32,9 +32,7 @@ RBRemoveMethodsInHierarchyRefactoring class >> selectors: aSelectorsCollection f
 { #category : 'preconditions' }
 RBRemoveMethodsInHierarchyRefactoring >> applicabilityPreconditions [ 
 
-	^ selectors
-			inject: self trueCondition
-			into: [ :cond :sel | cond & (RBCondition definesSelector: sel in: class) ]
+	^ { RBDefinesSelectorsCondition new definesSelectors: selectors in: class }
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBRemoveMethodsInHierarchyRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodsInHierarchyRefactoring.class.st
@@ -36,7 +36,14 @@ RBRemoveMethodsInHierarchyRefactoring >> applicabilityPreconditions [
 ]
 
 { #category : 'transforming' }
-RBRemoveMethodsInHierarchyRefactoring >> delete: aSelectorsCollection in: aClass [
+RBRemoveMethodsInHierarchyRefactoring >> initializeRefactorings [
+
+	class withAllSubclasses do: [ :aClass |
+		self remove: selectors in: aClass ]
+]
+
+{ #category : 'transforming' }
+RBRemoveMethodsInHierarchyRefactoring >> remove: aSelectorsCollection in: aClass [
 
 	| containingMethods |
 	containingMethods := aSelectorsCollection select: [ :sel |
@@ -46,13 +53,6 @@ RBRemoveMethodsInHierarchyRefactoring >> delete: aSelectorsCollection in: aClass
 				 model: self model
 				 selectors: containingMethods
 				 from: aClass) ]
-]
-
-{ #category : 'transforming' }
-RBRemoveMethodsInHierarchyRefactoring >> initializeRefactorings [
-
-	class withAllSubclasses do: [ :aClass |
-		self delete: selectors in: aClass ]
 ]
 
 { #category : 'removing' }

--- a/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
@@ -74,10 +74,7 @@ RBRemoveMethodsRefactoring >> breakingChangePreconditions [
 
 	refactorings do: [ :ref | ref checkSuperMethods ].
 
-	^ RBCondition
-		  withBlock: [ self senders isEmpty ]
-		  errorString:
-		  'Some of the methods have senders outside of the methods being removed'
+	^ RBMethodsHaveNoSendersCondition new model: self model; classSelectorsMapping: classSelectorMapping
 ]
 
 { #category : 'initialization' }
@@ -110,10 +107,4 @@ RBRemoveMethodsRefactoring >> removeMethodChanges [
 RBRemoveMethodsRefactoring >> selectors: aCollection from: aClass [
 
 	self classSelectorMapping: (aCollection collect: [ :selector | aClass -> selector ] ) 
-]
-
-{ #category : 'private' }
-RBRemoveMethodsRefactoring >> senders [
-	
-	^ (refactorings collect: [ :ref | ref sendersExcluding: self allSelectors ]) flattened
 ]

--- a/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
@@ -49,6 +49,12 @@ RBRemoveMethodsRefactoring class >> selectors: aSelectorsCollection from: aClass
 		from: aClass
 ]
 
+{ #category : 'accessing' }
+RBRemoveMethodsRefactoring >> allSelectors [
+	
+	^ allSelectors ifNil: [ allSelectors := classSelectorMapping values flattened ]
+]
+
 { #category : 'preconditions' }
 RBRemoveMethodsRefactoring >> applicabilityPreconditions [ 
 
@@ -95,12 +101,6 @@ RBRemoveMethodsRefactoring >> removeMethodChanges [
 ]
 
 { #category : 'accessing' }
-RBRemoveMethodsRefactoring >> selectors [
-	
-	^ selectors 
-]
-
-{ #category : 'accessing' }
 RBRemoveMethodsRefactoring >> selectors: aCollection from: aClass [
 
 	self classSelectorMapping: (aCollection collect: [ :selector | aClass -> selector ] ) 
@@ -109,5 +109,5 @@ RBRemoveMethodsRefactoring >> selectors: aCollection from: aClass [
 { #category : 'private' }
 RBRemoveMethodsRefactoring >> senders [
 	
-	^ (refactorings collect: [ :ref | ref sendersExcluding: selectors ]) flattened
+	^ (refactorings collect: [ :ref | ref sendersExcluding: self allSelectors ]) flattened
 ]

--- a/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
@@ -74,7 +74,7 @@ RBRemoveMethodsRefactoring >> breakingChangePreconditions [
 
 	refactorings do: [ :ref | ref checkSuperMethods ].
 
-	^ RBMethodsHaveNoSendersCondition new model: self model; classSelectorsMapping: classSelectorMapping
+	^ self preconditionHaveNoSenders 
 ]
 
 { #category : 'preconditions' }
@@ -100,6 +100,12 @@ RBRemoveMethodsRefactoring >> classSelectorMapping: classSelectorMappingList [
 				 model: model
 				 selector: aClassSelectorPair value
 				 from: aClass) ]
+]
+
+{ #category : 'preconditions' }
+RBRemoveMethodsRefactoring >> preconditionHaveNoSenders [
+
+	^ RBMethodsHaveNoSendersCondition new model: self model; classSelectorsMapping: classSelectorMapping
 ]
 
 { #category : 'removing' }

--- a/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
@@ -77,6 +77,12 @@ RBRemoveMethodsRefactoring >> breakingChangePreconditions [
 	^ RBMethodsHaveNoSendersCondition new model: self model; classSelectorsMapping: classSelectorMapping
 ]
 
+{ #category : 'preconditions' }
+RBRemoveMethodsRefactoring >> checkSuperMethods [
+	
+	refactorings do: [ :ref | ref checkSuperMethods ]
+]
+
 { #category : 'initialization' }
 RBRemoveMethodsRefactoring >> classSelectorMapping: classSelectorMappingList [
 

--- a/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
@@ -9,13 +9,28 @@ Class {
 	#name : 'RBRemoveMethodsRefactoring',
 	#superclass : 'RBCompositeRefactoring',
 	#instVars : [
-		'selectors',
-		'class'
+		'classSelectorMapping',
+		'allSelectors'
 	],
 	#category : 'Refactoring-Core-Refactorings',
 	#package : 'Refactoring-Core',
 	#tag : 'Refactorings'
 }
+
+{ #category : 'instance creation' }
+RBRemoveMethodsRefactoring class >> classSelectorMapping: classMethodMappingDict [
+
+	^ self new
+		  classSelectorMapping: classMethodMappingDict
+]
+
+{ #category : 'instance creation' }
+RBRemoveMethodsRefactoring class >> model: model classSelectorMapping: classMethodMappingDict [
+
+	^ self new
+		  model: model;
+		  classSelectorMapping: classMethodMappingDict
+]
 
 { #category : 'instance creation' }
 RBRemoveMethodsRefactoring class >> model: aRBNamespace selectors: aSelectorsCollection from: aClass [
@@ -53,6 +68,25 @@ RBRemoveMethodsRefactoring >> breakingChangePreconditions [
 		  'Some of the methods have senders outside of the methods being removed'
 ]
 
+{ #category : 'initialization' }
+RBRemoveMethodsRefactoring >> classSelectorMapping: classSelectorMappingList [
+
+	classSelectorMapping := Dictionary new.
+	refactorings := OrderedCollection new.
+	classSelectorMappingList do: [ :aClassSelectorPair |
+		| aClass existingValue newValue |
+		aClass := self model classObjectFor: aClassSelectorPair key.
+		existingValue := classSelectorMapping at: aClass ifAbsent: nil.
+		newValue := existingValue
+			            ifNil: [ Array with: aClassSelectorPair value ]
+			            ifNotNil: [ existingValue copyWith: aClassSelectorPair value ].
+		classSelectorMapping at: aClass put: newValue.
+		refactorings add: (RBRemoveMethodRefactoring
+				 model: model
+				 selector: aClassSelectorPair value
+				 from: aClass) ]
+]
+
 { #category : 'removing' }
 RBRemoveMethodsRefactoring >> removeMethodChanges [
 
@@ -69,13 +103,7 @@ RBRemoveMethodsRefactoring >> selectors [
 { #category : 'accessing' }
 RBRemoveMethodsRefactoring >> selectors: aCollection from: aClass [
 
-	selectors := aCollection.
-	class := self model classFor: aClass.
-	refactorings := aCollection collect: [ :method |
-							RBRemoveMethodRefactoring
-								model: model
-								selector: method
-								from: aClass ]
+	self classSelectorMapping: (aCollection collect: [ :selector | aClass -> selector ] ) 
 ]
 
 { #category : 'private' }

--- a/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodsRefactoring.class.st
@@ -56,11 +56,17 @@ RBRemoveMethodsRefactoring >> allSelectors [
 ]
 
 { #category : 'preconditions' }
-RBRemoveMethodsRefactoring >> applicabilityPreconditions [ 
+RBRemoveMethodsRefactoring >> applicabilityPreconditions [
 
-	^ selectors
-			inject: self trueCondition
-			into: [ :cond :sel | cond & (RBCondition definesSelector: sel in: class) ]
+	| preconditions |
+	preconditions := OrderedCollection new.
+	classSelectorMapping
+		keysAndValuesDo: [ :class :selectorsList |
+			preconditions add:
+					(RBDefinesSelectorsCondition new
+						 definesSelectors: selectorsList
+						 in: class) ].
+	^ preconditions
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Transformations-Tests/RBRemoveMethodsRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveMethodsRefactoringTest.class.st
@@ -39,18 +39,14 @@ RBRemoveMethodsRefactoringTest >> testRemovingMethodsFromDifferentClasses [
 	self assert: (class definesMethod: methodReferencing).
 	self assert: (anotherClass definesMethod: anotherMethodWithoutRefs).
 
-	(RBCompositeRefactoring new
+	(RBRemoveMethodsRefactoring new
 		model: model;
-		refactorings: { 
-			RBRemoveMethodsRefactoring
-				model: model
-				selectors: { methodWithoutRefs . methodReferencing }
-				from: class
+		classSelectorMapping: { 
+			RBBasicLintRuleTestData -> methodWithoutRefs
 			.
-			RBRemoveMethodsRefactoring
-				model: model
-				selectors: { anotherMethodWithoutRefs }
-				from: anotherClass 
+			RBBasicLintRuleTestData -> methodReferencing
+			.
+			RBTransformationDummyRuleTest -> anotherMethodWithoutRefs
 		} 
 	) generateChanges.
 

--- a/src/Refactoring-UI/RBDontRemoveButShowSendersChoice.class.st
+++ b/src/Refactoring-UI/RBDontRemoveButShowSendersChoice.class.st
@@ -6,7 +6,7 @@ Class {
 	#tag : 'Choices'
 }
 
-{ #category : 'accessing' }
+{ #category : 'execution' }
 RBDontRemoveButShowSendersChoice >> action [
 
 	driver browseSenders

--- a/src/Refactoring-UI/RBRemoveAndShowSendersChoice.class.st
+++ b/src/Refactoring-UI/RBRemoveAndShowSendersChoice.class.st
@@ -6,10 +6,10 @@ Class {
 	#tag : 'Choices'
 }
 
-{ #category : 'accessing' }
+{ #category : 'execution' }
 RBRemoveAndShowSendersChoice >> action [ 
 	
-	driver removeMethodChanges.
+	driver applyRemoveMethodChanges.
 	driver browseSenders.
 ]
 

--- a/src/Refactoring-UI/RBRemoveChoice.class.st
+++ b/src/Refactoring-UI/RBRemoveChoice.class.st
@@ -6,10 +6,10 @@ Class {
 	#tag : 'Choices'
 }
 
-{ #category : 'accessing' }
+{ #category : 'execution' }
 RBRemoveChoice >> action [
 
-	driver removeMethodChanges
+	driver applyRemoveMethodChanges
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/RBRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveClassDriver.class.st
@@ -58,9 +58,6 @@ RBRemoveClassDriver >> handleBreakingChanges [
 			(RBRemoveClassAndPushStateToSubclassChoice new driver: self) ].
 	haveNoReferences isFalse ifTrue: [
 		items add: (RBBrowseClassReferencesChoice new driver: self) ].
-	
-	items size = 1
-		ifTrue: [ ^ items first action ].
 		
 	select := SpSelectDialog new
 		          title: 'There are potential breaking changes!';

--- a/src/Refactoring-UI/RBRemoveMethodChoice.class.st
+++ b/src/Refactoring-UI/RBRemoveMethodChoice.class.st
@@ -6,7 +6,7 @@ Class {
 	#tag : 'Choices'
 }
 
-{ #category : 'accessing' }
+{ #category : 'execution' }
 RBRemoveMethodChoice >> action [
 
 	self subclassResponsibility 

--- a/src/Refactoring-UI/RBRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveMethodDriver.class.st
@@ -6,7 +6,6 @@ Class {
 	#superclass : 'RBInteractionDriver',
 	#instVars : [
 		'methods',
-		'senders',
 		'haveNoSenders'
 	],
 	#category : 'Refactoring-UI-Drivers',

--- a/src/Refactoring-UI/RBRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveMethodDriver.class.st
@@ -17,7 +17,7 @@ Class {
 { #category : 'execution' }
 RBRemoveMethodDriver >> applyChanges [
 
-	 self openPreviewWithChanges: refactoring generateChanges
+	 self openPreviewWithChanges: refactoring removeMethodChanges
 ]
 
 { #category : 'execution' }
@@ -66,8 +66,7 @@ RBRemoveMethodDriver >> handleBreakingChanges [
 { #category : 'execution' }
 RBRemoveMethodDriver >> removeMethodChanges [ 
 
-	refactoring refactorings do: [ :ref | ref removeMethodChanges ].
-	self openPreviewWithChanges: refactoring changes
+	self openPreviewWithChanges: refactoring removeMethodChanges
 
 ]
 

--- a/src/Refactoring-UI/RBRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveMethodDriver.class.st
@@ -25,20 +25,12 @@ RBRemoveMethodDriver >> browseSenders [
 { #category : 'resources' }
 RBRemoveMethodDriver >> configureRefactoring [
 
-	| refactorings |
-	refactorings := OrderedCollection new.
-	(methods groupedBy: [ :m | m origin ])
-		keysAndValuesDo: [ :k :v |
-			refactorings add: (
-				RBRemoveMethodsRefactoring
-	            model: model
-	            selectors: (v collect: [ :each | each selector ])
-	         		from: k
-				)
-			].
-	refactoring := RBCompositeRefactoring new
-							model: model;
-							refactorings: refactorings 
+	| classSelectorMapping |
+	classSelectorMapping := methods collect: [ :m | m origin -> m selector ].
+
+	refactoring := RBRemoveMethodsRefactoring
+			            model: model
+			            classSelectorMapping: classSelectorMapping
 ]
 
 { #category : 'execution' }
@@ -56,7 +48,7 @@ RBRemoveMethodDriver >> runRefactoring [
 	self configureRefactoring.
 	[
 	[
-	senders := refactoring refactorings flatCollect: [ :ref | ref senders ].
+	senders := refactoring senders.
 
 	senders
 		ifEmpty: [ self openPreviewWithChanges: refactoring generateChanges ]

--- a/src/Refactoring-UI/RBRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveMethodDriver.class.st
@@ -30,8 +30,8 @@ RBRemoveMethodDriver >> applyRemoveMethodChanges [
 RBRemoveMethodDriver >> browseSenders [
 
 	StMessageBrowserPresenter  
-		browse: (senders collect: [ :each | each value methodClass realClass >> each value selector ]) 
-		asSendersOf: (refactoring refactorings flatCollect: [ :ref | ref selectors ])
+		browse: (haveNoSenders violators collect: [ :each | each value methodClass realClass >> each value selector ]) 
+		asSendersOf: (refactoring allSelectors )
 	"this does not work for multiple selectors remove."
 ]
 

--- a/src/Refactoring-UI/RBRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveMethodDriver.class.st
@@ -6,12 +6,19 @@ Class {
 	#superclass : 'RBInteractionDriver',
 	#instVars : [
 		'methods',
-		'senders'
+		'senders',
+		'haveNoSenders'
 	],
 	#category : 'Refactoring-UI-Drivers',
 	#package : 'Refactoring-UI',
 	#tag : 'Drivers'
 }
+
+{ #category : 'execution' }
+RBRemoveMethodDriver >> applyChanges [
+
+	 self openPreviewWithChanges: refactoring generateChanges
+]
 
 { #category : 'execution' }
 RBRemoveMethodDriver >> browseSenders [
@@ -34,6 +41,29 @@ RBRemoveMethodDriver >> configureRefactoring [
 ]
 
 { #category : 'execution' }
+RBRemoveMethodDriver >> handleBreakingChanges [
+
+	| select items |
+	items := OrderedCollection new.
+
+	items add: (RBRemoveChoice new driver: self).
+	items add: (RBRemoveAndShowSendersChoice new driver: self).
+	items add: (RBDontRemoveButShowSendersChoice new driver: self).
+
+	select := SpSelectDialog new
+		          title: 'There are ' , haveNoSenders violators size asString
+			          , ' methods calling method(s) you want to delete';
+		          label: 'Select a strategy';
+		          items: items;
+		          display: [ :each | each description ];
+		          displayIcon: [ :each |
+			          self iconNamed: each systemIconName ];
+		          openModal.
+
+	select ifNotNil: [ select action ]
+]
+
+{ #category : 'execution' }
 RBRemoveMethodDriver >> removeMethodChanges [ 
 
 	refactoring refactorings do: [ :ref | ref removeMethodChanges ].
@@ -44,33 +74,14 @@ RBRemoveMethodDriver >> removeMethodChanges [
 { #category : 'execution' }
 RBRemoveMethodDriver >> runRefactoring [
 
-	| select |
 	self configureRefactoring.
-	[
-	[
-	senders := refactoring senders.
+	refactoring checkApplicabilityPreconditions.
+	
+	haveNoSenders := refactoring preconditionHaveNoSenders.
 
-	senders
-		ifEmpty: [ self openPreviewWithChanges: refactoring generateChanges ]
-		ifNotEmpty: [ 
-		
-		select := SpSelectDialog new 
-			title: 'There are ', senders size asString,  ' methods calling method(s) you want to delete';
-			label: 'Select a strategy';
-			items: (RBRemoveMethodChoice subclasses collect: [ :each | each  new driver: self]);
-			display: [ :each | each description ];
-			displayIcon: [ :each | self iconNamed: each systemIconName ];
-			openModal.
-			
-	select 
-		ifNotNil: [ 
-			select action ]]]
-	
-		on: RBApplicabilityChecksFailedError
-		do: [ :err | ^ RBRefactoringError signal: err messageText ] ]
-		on: RBBreakingChangeChecksFailedWarning
-		do: [ :err |	 err return ]
-	
+	haveNoSenders check
+			ifTrue: [ self applyChanges ]
+			ifFalse: [ self handleBreakingChanges ]
 
 ]
 

--- a/src/Refactoring-UI/RBRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/RBRemoveMethodDriver.class.st
@@ -21,6 +21,12 @@ RBRemoveMethodDriver >> applyChanges [
 ]
 
 { #category : 'execution' }
+RBRemoveMethodDriver >> applyRemoveMethodChanges [ 
+ 
+	self openPreviewWithChanges: refactoring removeMethodChanges
+]
+
+{ #category : 'execution' }
 RBRemoveMethodDriver >> browseSenders [
 
 	StMessageBrowserPresenter  
@@ -61,13 +67,6 @@ RBRemoveMethodDriver >> handleBreakingChanges [
 		          openModal.
 
 	select ifNotNil: [ select action ]
-]
-
-{ #category : 'execution' }
-RBRemoveMethodDriver >> removeMethodChanges [ 
-
-	self openPreviewWithChanges: refactoring removeMethodChanges
-
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
This PR refactors Remove method driver to new driver architecture:

* driver now relies on refactoring to check applicability preconditions
* then, driver gathers breaking changes (methods to be removed shouldn't have senders in this case) and checks them
* if they fail we show user a dialog
* a few preconditions were reified during this transition

This PR is missing reification of last precondition for remove methods, which is `checkSuperMethods`. That one is a bit strange so I've left it for later. I have also created a new task it so we don't forget.