### PR TITLE
Feat: deprecate class driver

### DIFF
--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -212,6 +212,17 @@ RBAbstractTransformation >> generateChanges [
 	"RBRefactoringManager instance addRefactoring: self"
 ]
 
+{ #category : 'transforming' }
+RBAbstractTransformation >> generateChangesFor: aRefactoring [
+	"I will generate changes and save them in the model, BUT I will not apply them!
+	Use me when a refactorings is composed of multiple other refactorings"
+
+	"Execute the argument but passing the receiver options to that refactoring"
+	aRefactoring copyOptionsFrom: self options.
+	aRefactoring model: self model.
+	aRefactoring generateChanges
+]
+
 { #category : 'accessing' }
 RBAbstractTransformation >> model [
 

--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -88,6 +88,12 @@ RBAbstractTransformation class >> refactoringOptions [
 	^ RefactoringOptions
 ]
 
+{ #category : 'preconditions' }
+RBAbstractTransformation >> applicabilityPreconditions [ 
+	
+	^ self trueCondition 
+]
+
 { #category : 'private' }
 RBAbstractTransformation >> buildSelectorString: aSelector [
 	aSelector numArgs = 0 ifTrue: [^aSelector].
@@ -136,6 +142,19 @@ RBAbstractTransformation >> buildSelectorString: aSelector withPermuteMap: aPerm
 RBAbstractTransformation >> changes [
 
 	^ self model changes
+]
+
+{ #category : 'preconditions' }
+RBAbstractTransformation >> checkApplicabilityPreconditions [
+
+	| conditions errorStrings |
+	conditions := self applicabilityPreconditions.
+	conditions := conditions reject: [ :cond | cond check ].
+	conditions ifEmpty: [ ^ self ].
+	errorStrings := String streamContents: [ :aStream |
+		                conditions do: [ :cond |
+			                cond violationMessageOn: aStream ] ].
+	self refactoringError: errorStrings
 ]
 
 { #category : 'condition definitions' }

--- a/src/Refactoring-Core/RBDeprecateClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBDeprecateClassRefactoring.class.st
@@ -26,7 +26,7 @@ Class {
 
 { #category : 'instance creation' }
 RBDeprecateClassRefactoring class >> deprecate: aDeprecatedClass in: aNewName [
-	^ self new className: aDeprecatedClass name newName: aNewName
+	^ self new className: aDeprecatedClass newName: aNewName
 ]
 
 { #category : 'instance creation' }

--- a/src/Refactoring-Core/RBDeprecateClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBDeprecateClassRefactoring.class.st
@@ -47,6 +47,23 @@ RBDeprecateClassRefactoring >> addMethod: source to: aClass in: aProtocol [
 			withProtocol: aProtocol)
 ]
 
+{ #category : 'preconditions' }
+RBDeprecateClassRefactoring >> applicabilityPreconditions [
+
+	| class |
+	class := self model classNamed: className.
+	^ { (RBClassesExistCondition new classes: { class }).
+		 (RBClassesAreNotMetaClassCondition new classes: { class }).
+		 (RBNameIsGlobalCondition new model: self model className: newName).
+	    (RBValidClassNameCondition new className: newName) }
+]
+
+{ #category : 'preconditions' }
+RBDeprecateClassRefactoring >> checkPreconditions [ 
+
+	self checkApplicabilityPreconditions 
+]
+
 { #category : 'initialization' }
 RBDeprecateClassRefactoring >> className: aName newName: aNewName [
 	className := aName asSymbol.
@@ -126,10 +143,8 @@ RBDeprecateClassRefactoring >> newClass [
 
 { #category : 'preconditions' }
 RBDeprecateClassRefactoring >> preconditions [
-	^((RBCondition withBlock: [deprecatedClass isNotNil and: [deprecatedClass isMeta not]])
-			& (RBCondition isValidClassName: newName)
-			& (RBCondition isGlobal: newName in: self model)) |
-			(RBCondition withBlock: [ self refactoringError: newName , ' is not a valid class name'])
+
+	self applicabilityPreconditions 
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBNameIsGlobalCondition.class.st
+++ b/src/Refactoring-Core/RBNameIsGlobalCondition.class.st
@@ -1,0 +1,39 @@
+Class {
+	#name : 'RBNameIsGlobalCondition',
+	#superclass : 'RBCondition',
+	#instVars : [
+		'className',
+		'model'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'checking' }
+RBNameIsGlobalCondition >> check [  
+
+	^ model includesGlobal: className 
+]
+
+{ #category : 'instance creation' }
+RBNameIsGlobalCondition >> model: aRBNamespace className: aSymbol [
+
+	className := aSymbol asSymbol.
+	model := aRBNamespace 
+]
+
+{ #category : 'displaying' }
+RBNameIsGlobalCondition >> violationMessageOn: aStream [
+
+	self violators do: [ :violator |
+		aStream
+			nextPutAll: violator;
+			nextPutAll: ' is <1?:not >a class or global variable.' ]
+]
+
+{ #category : 'accessing' }
+RBNameIsGlobalCondition >> violators [
+
+	^ self check ifFalse: [ { className } ] ifTrue: [ #() ]
+]

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -113,17 +113,6 @@ RBRefactoring >> copyOptionsFrom: aDictionary [
 	self options: dict
 ]
 
-{ #category : 'transforming' }
-RBRefactoring >> generateChangesFor: aRefactoring [
-	"I will generate changes and save them in the model, BUT I will not apply them!
-	Use me when a refactorings is composed of multiple other refactorings"
-
-	"Execute the argument but passing the receiver options to that refactoring"
-	aRefactoring copyOptionsFrom: self options.
-	aRefactoring model: self model.
-	aRefactoring generateChanges
-]
-
 { #category : 'private' }
 RBRefactoring >> onError: aBlock do: errorBlock [
 	^aBlock on: self class preconditionSignal

--- a/src/Refactoring-Core/RBRemoveClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveClassRefactoring.class.st
@@ -54,19 +54,6 @@ RBRemoveClassRefactoring >> breakingChangePreconditions [
 ]
 
 { #category : 'preconditions' }
-RBRemoveClassRefactoring >> checkApplicabilityPreconditions [
-
-	| conditions errorStrings |
-	conditions := self applicabilityPreconditions.
-	conditions := conditions reject: [ :cond | cond check ].
-	conditions ifEmpty: [ ^ self ].
-	errorStrings := String streamContents: [ :aStream |
-		                conditions do: [ :cond |
-			                cond violationMessageOn: aStream ] ].
-	self refactoringError: errorStrings
-]
-
-{ #category : 'preconditions' }
 RBRemoveClassRefactoring >> checkBreakingChangePreconditions [
 
 	| conditions errorStrings |

--- a/src/Refactoring-Core/RBValidClassNameCondition.class.st
+++ b/src/Refactoring-Core/RBValidClassNameCondition.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : 'RBValidClassNameCondition',
+	#superclass : 'RBCondition',
+	#instVars : [
+		'className'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'checking' }
+RBValidClassNameCondition >> check [ 
+
+	^ self class checkClassVarName: className in: self
+]
+
+{ #category : 'accessing' }
+RBValidClassNameCondition >> className: aSymbol [
+
+	className := aSymbol asSymbol 
+]
+
+{ #category : 'accessing' }
+RBValidClassNameCondition >> violationMessageOn: aStream [
+
+	self violators do: [ :violator |
+		aStream
+			nextPutAll: violator;
+			nextPutAll: ' is <1?:not >a valid class name.' ]
+]
+
+{ #category : 'accessing' }
+RBValidClassNameCondition >> violators [
+
+	^ self check ifFalse: [ { className } ] ifTrue: [ #() ]
+]

--- a/src/Refactoring-Transformations-Tests/RBDeprecateClassParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBDeprecateClassParametrizedTest.class.st
@@ -21,16 +21,16 @@ RBDeprecateClassParametrizedTest >> constructor [
 { #category : 'failure tests' }
 RBDeprecateClassParametrizedTest >> testFailureBadName [
 	self shouldFail: (self createRefactoringWithArguments:
-		{ RBLintRuleTestData . self objectClassVariable }).
+		{ 'RBLintRuleTestData' . self objectClassVariable }).
 	self shouldFail: (self createRefactoringWithArguments:
-		{ RBLintRuleTestData . #'Ob ject' })
+		{ 'RBLintRuleTestData' . #'Ob ject' })
 ]
 
 { #category : 'failure tests' }
 RBDeprecateClassParametrizedTest >> testFailureMetaClassFailure [
 
 	self shouldFail: (self createRefactoringWithArguments: {
-				 self class class.
+				 self class class name.
 				 #Foo })
 ]
 

--- a/src/Refactoring-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
@@ -14,14 +14,13 @@ RBRenameAndDeprecateClassTransformationTest >> testTransform [
 		                   rename: self changeMockClass name
 		                   to: #RBRefactoringChangeMock2) generateChanges.
 
-	self assert: transformation model changes changes size equals: 7.
+	self assert: transformation model changes changes size equals: 3.
 
 	"old class"
 	class := transformation model classNamed: self changeMockClass name.
 	self deny: class isNil.
 	self assertEmpty: class selectors.
 	self assert: class superclass name equals: #RBRefactoringChangeMock2.
-	self assert: class comment equals: 'Deprecated!!! Use superclass'.
 
 	"new class as a superclass"
 	class := transformation model classNamed: #RBRefactoringChangeMock2.

--- a/src/Refactoring-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBTransformationsTest.class.st
@@ -171,29 +171,16 @@ RBTransformationsTest >> testCustomTransform [
 RBTransformationsTest >> testDeprecateClassTransform [
 
 	| transformation class |
-	transformation := (RBDeprecateClassTransformation class:
+	transformation := (RBDeprecateClassTransformation className:
 		                   self changeMockClass name) generateChanges.
 
-	self assert: transformation model changes changes size equals: 4.
-
-	class := transformation model classNamed: self changeMockClass name.
-	self assert: class comment equals: 'Deprecated!!! Use superclass'.
+	self assert: transformation model changes changes size equals: 1.
 
 	class := transformation model metaclassNamed:
 		         self changeMockClass name.
-
 	self
-		assert: (class parseTreeForSelector: #new)
-		equals: (self parseMethod: 'new
-				self deprecated: ''Use superclass '' on: ''4 May 2016''  in: #Pharo60.
-				^ super new').
-	self
-		assert: (class parseTreeForSelector: #deprecated)
-		equals: (self parseMethod: 'deprecated ^ true').
-	self
-		assert: (class parseTreeForSelector: #systemIcon)
-		equals: (self parseMethod: 'systemIcon
-				^ Smalltalk ui icons iconNamed: #packageDelete')
+		assert: (class parseTreeForSelector: #isDeprecated)
+		equals: (self parseMethod: 'isDeprecated ^ true').
 ]
 
 { #category : 'tests' }

--- a/src/Refactoring-Transformations/RBDeprecateClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBDeprecateClassTransformation.class.st
@@ -9,10 +9,7 @@ transformation := (RBDeprecateClassTransformation
 "
 Class {
 	#name : 'RBDeprecateClassTransformation',
-	#superclass : 'RBCompositeTransformation',
-	#instVars : [
-		'className'
-	],
+	#superclass : 'RBClassTransformation',
 	#category : 'Refactoring-Transformations-Model-Unused',
 	#package : 'Refactoring-Transformations',
 	#tag : 'Model-Unused'
@@ -44,15 +41,15 @@ RBDeprecateClassTransformation >> class: aClassName [
 { #category : 'transforming' }
 RBDeprecateClassTransformation >> privateTransform [
 
-	RBAddMethodTransformation
-		sourceCode: (String streamContents: [ :code |
-				 code
-					 nextPutAll: 'deprecated';
-					 nextPutAll: String cr;
-					 nextPutAll: String tab;
-					 nextPutAll: '^ true' ])
-		in: (className , ' class') asSymbol
-		withProtocol: #deprecation
+	self generateChangesFor: (RBAddMethodTransformation
+			 sourceCode: (String streamContents: [ :code |
+					  code
+						  nextPutAll: 'isDeprecated';
+						  nextPutAll: String cr;
+						  nextPutAll: String tab;
+						  nextPutAll: '^ true' ])
+			 in: (className , ' class') asSymbol
+			 withProtocol: #deprecation)
 ]
 
 { #category : 'printing' }

--- a/src/Refactoring-Transformations/RBDeprecateClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBDeprecateClassTransformation.class.st
@@ -35,47 +35,24 @@ RBDeprecateClassTransformation class >> model: aRBModel class: aClassName [
 		yourself
 ]
 
-{ #category : 'executing' }
-RBDeprecateClassTransformation >> buildTransformations [
-
-	^ transformations ifNil: [
-		transformations := OrderedCollection
-			with: (RBAddMethodTransformation
-					sourceCode: (String streamContents: [ :code | code
-						nextPutAll: 'new';
-						nextPutAll: String cr;
-						nextPutAll: String tab;
-						nextPutAll: 'self deprecated: ''Use superclass '' on: ''4 May 2016'' in: #Pharo60.';
-						nextPutAll: String cr;
-						nextPutAll: String tab;
-						nextPutAll: '^ super new' ])
-					in: (className, ' class') asSymbol
-					withProtocol: #deprecation)
-			with: (RBAddMethodTransformation
-					sourceCode: (String streamContents: [ :code | code
-						nextPutAll: 'deprecated';
-						nextPutAll: String cr;
-						nextPutAll: String tab;
-						nextPutAll: '^ true' ])
-					in: (className, ' class') asSymbol
-					withProtocol: #deprecation)
-			with: (RBAddMethodTransformation
-					sourceCode: (String streamContents: [ :code | code
-						nextPutAll: 'systemIcon';
-						nextPutAll: String cr;
-						nextPutAll: String tab;
-						nextPutAll: '^ Smalltalk ui icons iconNamed: #packageDelete' ])
-					in: (className, ' class') asSymbol
-					withProtocol: #deprecation)
-			with: (RBAddClassCommentTransformation
-					 comment: 'Deprecated!!! Use superclass'
-					 in: className) ]
-]
-
 { #category : 'api' }
 RBDeprecateClassTransformation >> class: aClassName [
 
 	className := aClassName
+]
+
+{ #category : 'transforming' }
+RBDeprecateClassTransformation >> privateTransform [
+
+	RBAddMethodTransformation
+		sourceCode: (String streamContents: [ :code |
+				 code
+					 nextPutAll: 'deprecated';
+					 nextPutAll: String cr;
+					 nextPutAll: String tab;
+					 nextPutAll: '^ true' ])
+		in: (className , ' class') asSymbol
+		withProtocol: #deprecation
 ]
 
 { #category : 'printing' }

--- a/src/Refactoring-Transformations/RBDeprecateClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBDeprecateClassTransformation.class.st
@@ -15,27 +15,21 @@ Class {
 	#tag : 'Model-Unused'
 }
 
-{ #category : 'api' }
-RBDeprecateClassTransformation class >> class: aClassName [
+{ #category : 'instance creation' }
+RBDeprecateClassTransformation class >> className: aClassName [
 
 	^ self new
-		class: aClassName;
+		className: aClassName;
 		yourself
 ]
 
-{ #category : 'api' }
-RBDeprecateClassTransformation class >> model: aRBModel class: aClassName [
+{ #category : 'instance creation' }
+RBDeprecateClassTransformation class >> model: aRBModel className: aClassName [
 
 	^ self new
 		model: aRBModel;
-		class: aClassName;
+		className: aClassName;
 		yourself
-]
-
-{ #category : 'api' }
-RBDeprecateClassTransformation >> class: aClassName [
-
-	className := aClassName
 ]
 
 { #category : 'transforming' }
@@ -57,7 +51,7 @@ RBDeprecateClassTransformation >> storeOn: aStream [
 
 	aStream nextPut: $(.
 	self class storeOn: aStream.
-	aStream nextPutAll: ' class: '.
+	aStream nextPutAll: ' className: '.
 	className storeOn: aStream.
 	aStream nextPut: $)
 ]

--- a/src/Refactoring-Transformations/RBDeprecateClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBDeprecateClassTransformation.class.st
@@ -32,6 +32,26 @@ RBDeprecateClassTransformation class >> model: aRBModel className: aClassName [
 		yourself
 ]
 
+{ #category : 'preconditions' }
+RBDeprecateClassTransformation >> applicabilityPreconditions [
+
+	^ {
+		  (RBClassesExistCondition new classes: { class }).
+		  (RBClassesAreNotMetaClassCondition new classes: { class }) }
+]
+
+{ #category : 'preconditions' }
+RBDeprecateClassTransformation >> checkPreconditions [ 
+
+	self checkApplicabilityPreconditions 
+]
+
+{ #category : 'transforming' }
+RBDeprecateClassTransformation >> prepareForExecution [ 
+
+	class := self model classNamed: className
+]
+
 { #category : 'transforming' }
 RBDeprecateClassTransformation >> privateTransform [
 

--- a/src/Refactoring-Transformations/RBRenameAndDeprecateClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRenameAndDeprecateClassTransformation.class.st
@@ -60,7 +60,7 @@ RBRenameAndDeprecateClassTransformation >> buildTransformations [
 					                      yourself)
 			                     with: (RBRenameClassRefactoring rename: className to: newClassName)
 			                     with: (RBRenameClassRefactoring rename: self tmpName to: className)
-			                     with: (RBDeprecateClassTransformation class: className) ]
+			                     with: (RBDeprecateClassTransformation className: className) ]
 ]
 
 { #category : 'api' }

--- a/src/Refactoring-Transformations/RBRenameAndDeprecateClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRenameAndDeprecateClassTransformation.class.st
@@ -76,17 +76,19 @@ RBRenameAndDeprecateClassTransformation >> applicabilityPreconditions [
 RBRenameAndDeprecateClassTransformation >> buildTransformations [
 
 	^ transformations ifNil: [
-		  | class |
-		  class := self model classNamed: className.
-		  transformations := OrderedCollection
-			                     with: ((RBInsertNewClassTransformation className: self tmpName)
-					                      superclass: className asSymbol;
-					                      packageName: class packageName;
-					                      tagName: class tagName;
-					                      yourself)
-			                     with: (RBRenameClassRefactoring rename: className to: newClassName)
-			                     with: (RBRenameClassRefactoring rename: self tmpName to: className)
-			                     with: (RBDeprecateClassTransformation className: className) ]
+		transformations := OrderedCollection
+			with: (RBRenameClassRefactoring
+						model: self model
+						rename: className to: newClassName)
+			with: ((RBInsertNewClassTransformation
+					   model: self model
+						className: className)
+						superclass: newClassName asSymbol;
+						subclasses: #();
+						packageName: (self model classNamed: className) packageName)
+		with: (RBDeprecateClassTransformation
+						model: self model
+						className: className)]
 ]
 
 { #category : 'api' }

--- a/src/Refactoring-Transformations/RBRenameAndDeprecateClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRenameAndDeprecateClassTransformation.class.st
@@ -67,9 +67,11 @@ RBRenameAndDeprecateClassTransformation >> applicabilityPreconditions [
 
 	| class |
 	class := self model classNamed: className.
-	^ (RBCondition withBlock: [ class notNil and: [ class isMeta not ] ])
-	  & (RBCondition isValidClassName: newClassName)
-	  & (RBCondition isGlobal: newClassName in: self model) not
+	^ { (RBClassesExistCondition new classes: { class }).
+		 (RBClassesAreNotMetaClassCondition new classes: { class }).
+		 (RBNameIsGlobalCondition new model: self model
+			   className: newClassName) not.
+	     (RBValidClassNameCondition new className: newClassName) }
 ]
 
 { #category : 'executing' }
@@ -89,6 +91,12 @@ RBRenameAndDeprecateClassTransformation >> buildTransformations [
 		with: (RBDeprecateClassTransformation
 						model: self model
 						className: className)]
+]
+
+{ #category : 'preconditions' }
+RBRenameAndDeprecateClassTransformation >> checkPreconditions [ 
+
+	self checkApplicabilityPreconditions 
 ]
 
 { #category : 'api' }

--- a/src/Refactoring-Transformations/RBRenameAndDeprecateClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRenameAndDeprecateClassTransformation.class.st
@@ -29,6 +29,15 @@ Class {
 }
 
 { #category : 'api' }
+RBRenameAndDeprecateClassTransformation class >> model: aRBModel rename: aClassName [
+
+	^ self new
+		model: aRBModel;
+		className: aClassName
+		yourself
+]
+
+{ #category : 'api' }
 RBRenameAndDeprecateClassTransformation class >> model: aRBModel rename: aClassName to: aNewClassName [
 
 	^ self new
@@ -39,11 +48,28 @@ RBRenameAndDeprecateClassTransformation class >> model: aRBModel rename: aClassN
 ]
 
 { #category : 'api' }
+RBRenameAndDeprecateClassTransformation class >> rename: aClassName [
+
+	^ self new
+		className: aClassName
+]
+
+{ #category : 'api' }
 RBRenameAndDeprecateClassTransformation class >> rename: aClassName to: aNewClassName [
 
 	^ self new
 		className: aClassName
 		newClassName: aNewClassName
+]
+
+{ #category : 'preconditions' }
+RBRenameAndDeprecateClassTransformation >> applicabilityPreconditions [
+
+	| class |
+	class := self model classNamed: className.
+	^ (RBCondition withBlock: [ class notNil and: [ class isMeta not ] ])
+	  & (RBCondition isValidClassName: newClassName)
+	  & (RBCondition isGlobal: newClassName in: self model) not
 ]
 
 { #category : 'executing' }
@@ -64,10 +90,22 @@ RBRenameAndDeprecateClassTransformation >> buildTransformations [
 ]
 
 { #category : 'api' }
+RBRenameAndDeprecateClassTransformation >> className: aClassName [
+
+	className := aClassName asSymbol 
+]
+
+{ #category : 'api' }
 RBRenameAndDeprecateClassTransformation >> className: aClassName newClassName: aNewClassName [
 
-	className := aClassName.
-	newClassName := aNewClassName
+	className := aClassName asSymbol.
+	newClassName := aNewClassName asSymbol 
+]
+
+{ #category : 'api' }
+RBRenameAndDeprecateClassTransformation >> newClassName: aNewClassName [
+
+	newClassName := aNewClassName asSymbol 
 ]
 
 { #category : 'printing' }

--- a/src/Refactoring-Transformations/RBTransformation.class.st
+++ b/src/Refactoring-Transformations/RBTransformation.class.st
@@ -54,12 +54,6 @@ RBTransformation class >> initializeRefactoringOptions [
 		put: [ :ref :env |  self error: #openBrowser ]
 ]
 
-{ #category : 'preconditions' }
-RBTransformation >> applicabilityPreconditions [ 
-	
-	^ self trueCondition 
-]
-
 { #category : 'converting' }
 RBTransformation >> asRefactoring [
 

--- a/src/Refactoring-UI/RBDeprecateAndMigrateReferencesClassChoice.class.st
+++ b/src/Refactoring-UI/RBDeprecateAndMigrateReferencesClassChoice.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'RBDeprecateAndMigrateReferencesClassChoice',
+	#superclass : 'RBDeprecateClassChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
+}
+
+{ #category : 'execution' }
+RBDeprecateAndMigrateReferencesClassChoice >> action [
+
+	driver deprecateAndMigrateReferences
+]
+
+{ #category : 'accessing' }
+RBDeprecateAndMigrateReferencesClassChoice >> description [
+
+	^ 'Deprecate class and migrate all references to another class'
+]

--- a/src/Refactoring-UI/RBDeprecateChoice.class.st
+++ b/src/Refactoring-UI/RBDeprecateChoice.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'RBDeprecateChoice',
+	#superclass : 'RBDeprecateClassChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
+}
+
+{ #category : 'execution' }
+RBDeprecateChoice >> action [
+
+	driver deprecateClass 
+]
+
+{ #category : 'accessing' }
+RBDeprecateChoice >> description [
+
+	^ 'Just add `isDeprecated` method to class side'
+]

--- a/src/Refactoring-UI/RBDeprecateClassChoice.class.st
+++ b/src/Refactoring-UI/RBDeprecateClassChoice.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'RBDeprecateClassChoice',
+	#superclass : 'RBChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
+}
+
+{ #category : 'execution' }
+RBDeprecateClassChoice >> action [
+
+	self subclassResponsibility 
+]

--- a/src/Refactoring-UI/RBDeprecateClassDriver.class.st
+++ b/src/Refactoring-UI/RBDeprecateClassDriver.class.st
@@ -26,7 +26,7 @@ Class {
 	#tag : 'Drivers'
 }
 
-{ #category : 'as yet unclassified' }
+{ #category : 'instance creation' }
 RBDeprecateClassDriver class >> className: aClassName scopes: refactoringScopes [
 
 	^ self new className: aClassName scopes: refactoringScopes

--- a/src/Refactoring-UI/RBDeprecateClassDriver.class.st
+++ b/src/Refactoring-UI/RBDeprecateClassDriver.class.st
@@ -1,0 +1,123 @@
+"
+I am a driver responsible for creating and invoking RenameAndDeprecateClassTransformation.
+
+My responsiblities include:
+- Requesting new class name from the user
+- Configuring refactoring with the new name
+- Executing refactoring
+- Displaying changes to the user
+
+You can invoke me with:
+```smalltalk
+(RBRenameAndDeprecateClassDriver
+	className: 'RBLintRuleTestData'
+	scopes: { RBNamespace new environment }) runRefactoring 
+```
+"
+Class {
+	#name : 'RBDeprecateClassDriver',
+	#superclass : 'RBInteractionDriver',
+	#instVars : [
+		'className',
+		'newClassName'
+	],
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
+}
+
+{ #category : 'as yet unclassified' }
+RBDeprecateClassDriver class >> className: aClassName scopes: refactoringScopes [
+
+	^ self new className: aClassName scopes: refactoringScopes
+]
+
+{ #category : 'initialization' }
+RBDeprecateClassDriver >> className: aClassName scopes: refactoringScopes [
+
+	scopes := refactoringScopes.
+	model := self refactoringScopeOn: scopes first.
+	className := aClassName
+]
+
+{ #category : 'execution' }
+RBDeprecateClassDriver >> deprecateAndMigrateReferences [
+
+	newClassName := self requestClassToMigrateReferencesTo.
+	refactoring := RBDeprecateClassRefactoring deprecate: className in: newClassName.
+	refactoring generateChanges.
+	
+	self openPreviewWithChanges: refactoring changes.
+	
+]
+
+{ #category : 'execution' }
+RBDeprecateClassDriver >> deprecateClass [
+
+	refactoring := RBDeprecateClassTransformation model: model className: className.
+	refactoring generateChanges.
+	
+	self openPreviewWithChanges: refactoring changes.
+]
+
+{ #category : 'execution' }
+RBDeprecateClassDriver >> renameAndDeprecate [
+
+	refactoring := RBRenameAndDeprecateClassTransformation
+		               model: model
+		               rename: className.
+	newClassName := self requestNewClassName.
+	refactoring newClassName: newClassName.
+	"Check if the new name is OK..."
+	refactoring generateChanges.
+	
+	self openPreviewWithChanges: refactoring changes.
+	
+]
+
+{ #category : 'ui - requests' }
+RBDeprecateClassDriver >> requestClassToMigrateReferencesTo [
+
+	newClassName := SpSelectDialog new
+		                title: 'Class to migrate ' , className;
+		                label:
+			                'The new class that will be used to migrate all references of the old class to it.';
+		                items: Smalltalk allClassesAndTraits;
+		                display: [ :each | each name ];
+		                displayIcon: [ :each |
+			                self iconNamed: each systemIconName ];
+		                openModal.
+	^ newClassName name
+]
+
+{ #category : 'ui - requests' }
+RBDeprecateClassDriver >> requestNewClassName [
+
+	newClassName := SpRequestDialog new
+		                title: 'Rename and deprecate class';
+		                label: 'New name of the class';
+		                text: className;
+		                acceptLabel: 'OK';
+		                cancelLabel: 'Cancel';
+		                openModal.
+
+	^ newClassName
+]
+
+{ #category : 'execution' }
+RBDeprecateClassDriver >> runRefactoring [
+
+	| select |
+	select := SpSelectDialog new 
+		title: 'Deprecate class with strategy';
+		label: 'Select a strategy';
+		items: (RBDeprecateClassChoice subclasses collect: [ :each | each  new driver: self]);
+		display: [ :each | each description ];
+		displayIcon: [ :each | self iconNamed: each systemIconName ];
+		openModal.
+	[
+		[ select ifNotNil: [ select action ] ]
+		on: RBApplicabilityChecksFailedError do: [ :err | RBRefactoringError signal: err errorString ]
+	]
+	on: RBBreakingChangeChecksFailedWarning do: [ :err | RBRefactoringWarning signal: err errorString. err resume ]
+]

--- a/src/Refactoring-UI/RBRenameAndDeprecateClassChoice.class.st
+++ b/src/Refactoring-UI/RBRenameAndDeprecateClassChoice.class.st
@@ -15,5 +15,5 @@ RBRenameAndDeprecateClassChoice >> action [
 { #category : 'accessing' }
 RBRenameAndDeprecateClassChoice >> description [
 
-	^ 'Rename this class, subclass it with class that has old name and deprecate that class'
+	^ 'Rename this class, subclass it with a new class that has the old name of the class and deprecate that class'
 ]

--- a/src/Refactoring-UI/RBRenameAndDeprecateClassChoice.class.st
+++ b/src/Refactoring-UI/RBRenameAndDeprecateClassChoice.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'RBRenameAndDeprecateClassChoice',
+	#superclass : 'RBDeprecateClassChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
+}
+
+{ #category : 'execution' }
+RBRenameAndDeprecateClassChoice >> action [
+
+	driver renameAndDeprecate 
+]
+
+{ #category : 'accessing' }
+RBRenameAndDeprecateClassChoice >> description [
+
+	^ 'Rename this class, subclass it with class that has old name and deprecate that class'
+]

--- a/src/SystemCommands-ClassCommands/SycClassCmCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycClassCmCommand.class.st
@@ -5,7 +5,8 @@ Class {
 	#name : 'SycClassCmCommand',
 	#superclass : 'SycCmCommand',
 	#instVars : [
-		'targetClass'
+		'targetClass',
+		'refactoringScopes'
 	],
 	#category : 'SystemCommands-ClassCommands',
 	#package : 'SystemCommands-ClassCommands'
@@ -19,5 +20,6 @@ SycClassCmCommand class >> activationStrategy [
 { #category : 'preparation' }
 SycClassCmCommand >> prepareFullExecution [
 	super prepareFullExecution.
+	refactoringScopes := context refactoringScopes.
 	targetClass := context lastSelectedClass
 ]

--- a/src/SystemCommands-ClassCommands/SycDeprecateClassCmCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycDeprecateClassCmCommand.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'SycDeprecateClassCmCommand',
+	#superclass : 'SycClassCmCommand',
+	#category : 'SystemCommands-ClassCommands',
+	#package : 'SystemCommands-ClassCommands'
+}
+
+{ #category : 'execution' }
+SycDeprecateClassCmCommand >> executeRefactoring [
+
+	(RBDeprecateClassDriver
+		 className: targetClass name
+		 scopes: refactoringScopes) runRefactoring
+]
+
+{ #category : 'testing' }
+SycDeprecateClassCmCommand >> isApplicable [
+
+	^ context lastSelectedClass isDeprecated not
+]
+
+{ #category : 'accessing' }
+SycDeprecateClassCmCommand >> name [
+
+	^ 'Deprecate'
+]

--- a/src/SystemCommands-ClassCommands/SycDeprecateClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycDeprecateClassCommand.class.st
@@ -26,7 +26,7 @@ SycDeprecateClassCommand class >> canBeExecutedInContext: aToolContext [
 { #category : 'converting' }
 SycDeprecateClassCommand >> asRefactorings [
 	| refactoring |
-	refactoring := RBDeprecateClassRefactoring deprecate: targetClass in: newName name.
+	refactoring := RBDeprecateClassRefactoring deprecate: targetClass name in: newName name.
 	^ { refactoring }
 ]
 

--- a/src/SystemCommands-ClassCommands/SycMigrateReferencesOfClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycMigrateReferencesOfClassCommand.class.st
@@ -19,7 +19,7 @@ Class {
 { #category : 'converting' }
 SycMigrateReferencesOfClassCommand >> asRefactorings [
 	| refactoring |
-	refactoring :=  RBDeprecateClassRefactoring deprecate: targetClass in: newName name.
+	refactoring :=  RBDeprecateClassRefactoring deprecate: targetClass name in: newName name.
 	refactoring shouldFixSubclasses: false.
 	refactoring shouldCopyExtensions: false.
 	refactoring shouldRemoveExtensions: false.


### PR DESCRIPTION
This PR introduces interactive driver for deprecate class family of transformations.
Driver offers user three options:

* Just add `isDeprecated` method to the class side (@MarcusDenker I think you'll like this one :))
* Rename class, add a subclass with old class name and deprecate it
* Deprecate class and migrate references to another class

I tried to clean as much as possible, but there is still some work left. I will get back to this after I clean the API a bit.

New driver can be initalized through:
`Right click on a class -> Refactoring -> Deprecate`

Right now we have duplicate commands that don't use driver. Those are:
`Right click on a class -> Deprecate` (this subclasses and renames the class)
`Right click on a class -> Migrate references` (deprecate and migrate references)
If the driver commands seem good, we can remove these commands.