### PR TITLE
Refactor ImageFillStyle to replace ‘form’ by ‘formSet’

### DIFF
--- a/src/Athens-Balloon/ImageFillStyle.extension.st
+++ b/src/Athens-Balloon/ImageFillStyle.extension.st
@@ -5,6 +5,6 @@ ImageFillStyle >> asAthensPaintOn: anAthensCanvas [
 
 	^ (anAthensCanvas cacheAt: self ifAbsentPut: [
 		anAthensCanvas surface
-		createFormPaint: form ])
+		createFormPaint: self form ])
 		origin: origin
 ]

--- a/src/Graphics-Canvas/ImageFillStyle.class.st
+++ b/src/Graphics-Canvas/ImageFillStyle.class.st
@@ -5,7 +5,7 @@ Class {
 	#name : 'ImageFillStyle',
 	#superclass : 'OrientedFillStyle',
 	#instVars : [
-		'form',
+		'formSet',
 		'extent',
 		'offset'
 	],
@@ -16,9 +16,15 @@ Class {
 
 { #category : 'instance creation' }
 ImageFillStyle class >> form: aForm [
-	"Answer a new instance of the receiver with the given form."
 
-	^self new form: aForm
+	^ self formSet: (FormSet form: aForm)
+]
+
+{ #category : 'instance creation' }
+ImageFillStyle class >> formSet: aFormSet [
+	"Answer a new instance of the receiver with the given form set."
+
+	^self new formSet: aFormSet
 ]
 
 { #category : 'comparing' }
@@ -52,17 +58,29 @@ ImageFillStyle >> extent: anObject [
 
 { #category : 'accessing' }
 ImageFillStyle >> form [
-	"Answer the value of form"
 
-	^ form
+	^ formSet asForm
 ]
 
 { #category : 'accessing' }
 ImageFillStyle >> form: aForm [
-	"Set the value of form"
 
-	form := aForm.
-	self direction: aForm extent
+	self formSet: (FormSet form: aForm)
+]
+
+{ #category : 'accessing' }
+ImageFillStyle >> formSet [
+	"Answer the value of formSet"
+
+	^ formSet
+]
+
+{ #category : 'accessing' }
+ImageFillStyle >> formSet: aFormSet [
+	"Set the value of formSet"
+
+	formSet := aFormSet.
+	self direction: aFormSet extent
 ]
 
 { #category : 'comparing' }

--- a/src/Morphic-Widgets-Tabs/TabBarMorph.class.st
+++ b/src/Morphic-Widgets-Tabs/TabBarMorph.class.st
@@ -176,29 +176,29 @@ TabBarMorph >> createActionButtonFor: anAction [
 { #category : 'private' }
 TabBarMorph >> createMenuButton [
 	"Answer a button for the window menu."
-	| form msb |
+	| formSet msb |
 
-	form := self theme windowMenuForm.
-	msb := MultistateButtonMorph new extent: form extent.
-	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
+	formSet := self theme windowMenuFormSet.
+	msb := MultistateButtonMorph new extent: formSet extent.
+	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
 
-	form := self theme windowMenuPassiveForm.
-	msb extent: form extent.
-	msb activeDisabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	msb passiveDisabledNotOverUpFillStyle: (ImageFillStyle form: form).
+	formSet := self theme windowMenuPassiveFormSet.
+	msb extent: formSet extent.
+	msb activeDisabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	msb passiveDisabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
 
-	form := self theme windowMenuForm.
-	msb extent: form extent.
+	formSet := self theme windowMenuFormSet.
+	msb extent: formSet extent.
 	msb
-		activeEnabledOverUpFillStyle: (ImageFillStyle form: form);
-		passiveEnabledOverUpFillStyle: (ImageFillStyle form: form).
+		activeEnabledOverUpFillStyle: (ImageFillStyle formSet: formSet);
+		passiveEnabledOverUpFillStyle: (ImageFillStyle formSet: formSet).
 
-	form := self theme windowMenuPassiveForm.
+	formSet := self theme windowMenuPassiveFormSet.
 	msb
-		extent: form extent;
-		activeEnabledOverDownFillStyle: (ImageFillStyle form: form);
-		passiveEnabledOverDownFillStyle: (ImageFillStyle form: form);
+		extent: formSet extent;
+		activeEnabledOverDownFillStyle: (ImageFillStyle formSet: formSet);
+		passiveEnabledOverDownFillStyle: (ImageFillStyle formSet: formSet);
 		addUpAction: [ self popUpMenu ];
 		setBalloonText: 'tab menu' translated;
 		extent: 16@16.

--- a/src/Polymorph-Widgets/ImageFillStyle.extension.st
+++ b/src/Polymorph-Widgets/ImageFillStyle.extension.st
@@ -6,10 +6,10 @@ ImageFillStyle >> fillRectangle: aRectangle on: aCanvas [
 
 	self extent
 		ifNil: [aCanvas
-				translucentImage: self form
+				translucentFormSet: self formSet
 				at: self origin]
 		ifNotNil: [aCanvas clipBy: (self origin + self offset extent: self extent) during: [:c |
 					c
-						translucentImage: self form
+						translucentFormSet: self formSet
 						at: self origin]]
 ]

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -2649,25 +2649,25 @@ UITheme >> newCloseButtonIn: aThemedMorph for: aModel [
 UITheme >> newCloseControlIn: aThemedMorph for: aModel action: aValuable help: helpText [
 	"Answer a button for closing things."
 
-	|form msb|
-	form := self windowCloseForm.
-	msb := MultistateButtonMorph new extent: form extent.
-	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowClosePassiveForm.
-	msb extent: form extent.
-	msb activeDisabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	msb passiveDisabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowCloseOverForm.
-	msb extent: form extent.
+	|formSet msb|
+	formSet := self windowCloseFormSet.
+	msb := MultistateButtonMorph new extent: formSet extent.
+	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowClosePassiveFormSet.
+	msb extent: formSet extent.
+	msb activeDisabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	msb passiveDisabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowCloseOverFormSet.
+	msb extent: formSet extent.
 	msb
-		activeEnabledOverUpFillStyle: (ImageFillStyle form: form);
-		passiveEnabledOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowClosePassiveForm.
+		activeEnabledOverUpFillStyle: (ImageFillStyle formSet: formSet);
+		passiveEnabledOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowClosePassiveFormSet.
 	msb
-		extent: form extent;
-		activeEnabledOverDownFillStyle: (ImageFillStyle form: form);
-		passiveEnabledOverDownFillStyle: (ImageFillStyle form: form);
+		extent: formSet extent;
+		activeEnabledOverDownFillStyle: (ImageFillStyle formSet: formSet);
+		passiveEnabledOverDownFillStyle: (ImageFillStyle formSet: formSet);
 		addUpAction: aValuable;
 		setBalloonText: helpText.
 	^msb
@@ -4943,23 +4943,41 @@ UITheme >> windowBottomOffset [
 
 { #category : 'label-styles - windows' }
 UITheme >> windowCloseForm [
-	"Answer the form to use for the close button of a window."
 
-	^ self iconNamed: #windowClose
+	^ self windowCloseFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowCloseFormSet [
+	"Answer the form set to use for the close button of a window."
+
+	^ self iconFormSetNamed: #windowClose
 ]
 
 { #category : 'label-styles - windows' }
 UITheme >> windowCloseOverForm [
-	"Answer the form to use for mouse over window close buttons"
 
-	^ self iconNamed: #windowClose
+	^ self windowCloseOverFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowCloseOverFormSet [
+	"Answer the form set to use for mouse over window close buttons"
+
+	^ self iconFormSetNamed: #windowClose
 ]
 
 { #category : 'label-styles - windows' }
 UITheme >> windowClosePassiveForm [
-	"Answer the form to use for passive (background) window close buttons"
 
-	^ self iconNamed: #windowCloseInactive
+	^ self windowClosePassiveFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowClosePassiveFormSet [
+	"Answer the form set to use for passive (background) window close buttons"
+
+	^ self iconFormSetNamed: #windowCloseInactive
 ]
 
 { #category : 'sounds' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -1263,25 +1263,25 @@ UITheme >> createMenuBoxFor: aSystemWindow [
 		actionSelector: #offerWindowMenu;
 		setBalloonText: 'window menu' translated"
 
-	|form msb|
-	form := self windowMenuForm.
-	msb := MultistateButtonMorph new extent: form extent.
-	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowMenuPassiveForm.
-	msb extent: form extent.
-	msb activeDisabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	msb passiveDisabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowMenuForm.
-	msb extent: form extent.
+	|formSet msb|
+	formSet := self windowMenuFormSet.
+	msb := MultistateButtonMorph new extent: formSet extent.
+	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowMenuPassiveFormSet.
+	msb extent: formSet extent.
+	msb activeDisabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	msb passiveDisabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowMenuFormSet.
+	msb extent: formSet extent.
 	msb
-		activeEnabledOverUpFillStyle: (ImageFillStyle form: form);
-		passiveEnabledOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowMenuPassiveForm.
+		activeEnabledOverUpFillStyle: (ImageFillStyle formSet: formSet);
+		passiveEnabledOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowMenuPassiveFormSet.
 	msb
-		extent: form extent;
-		activeEnabledOverDownFillStyle: (ImageFillStyle form: form);
-		passiveEnabledOverDownFillStyle: (ImageFillStyle form: form);
+		extent: formSet extent;
+		activeEnabledOverDownFillStyle: (ImageFillStyle formSet: formSet);
+		passiveEnabledOverDownFillStyle: (ImageFillStyle formSet: formSet);
 		addUpAction: [aSystemWindow offerWindowMenu];
 		setBalloonText: 'window menu' translated;
 		extent: aSystemWindow boxExtent.
@@ -3646,9 +3646,15 @@ UITheme >> newWindowIn: aThemedMorph for: aModel title: titleString [
 
 { #category : 'initialization' }
 UITheme >> newWindowMenuPassiveForm [
-	"Answer a new form for a window menu box."
 
-	^ self iconNamed: #windowMenuInactive
+	^ self newWindowMenuPassiveFormSet asForm
+]
+
+{ #category : 'initialization' }
+UITheme >> newWindowMenuPassiveFormSet [
+	"Answer a new form set for a window menu box."
+
+	^ self iconFormSetNamed: #windowMenuInactive
 ]
 
 { #category : 'morph creation' }
@@ -5128,9 +5134,15 @@ UITheme >> windowMaximizeSound [
 
 { #category : 'label-styles - windows' }
 UITheme >> windowMenuForm [
-	"Answer the form to use for the menu button of a window."
 
-	^ self iconNamed: #windowMenu
+	^ self windowMenuFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowMenuFormSet [
+	"Answer the form set to use for the menu button of a window."
+
+	^ self iconFormSetNamed: #windowMenu
 ]
 
 { #category : 'label-styles - windows' }
@@ -5142,9 +5154,15 @@ UITheme >> windowMenuIconFor: aWindow [
 
 { #category : 'label-styles - windows' }
 UITheme >> windowMenuPassiveForm [
-	"Answer the form to use for passive (background) window menu buttons"
 
-	^self newWindowMenuPassiveForm
+	^self windowMenuPassiveFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowMenuPassiveFormSet [
+	"Answer the form set to use for passive (background) window menu buttons"
+
+	^self newWindowMenuPassiveFormSet
 ]
 
 { #category : 'label-styles - windows' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -1229,23 +1229,23 @@ UITheme >> createCollapseBoxFor: aSystemWindow [
 UITheme >> createExpandBoxFor: aSystemWindow [
 	"Answer a button for maximising/restoring the window."
 
-	|form msb|
-	form := self windowMaximizeForm.
-	msb := MultistateButtonMorph new extent: form extent.
-	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowMaximizePassiveForm.
-	msb extent: form extent.
-	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowMaximizeOverForm.
-	msb extent: form extent.
+	|formSet msb|
+	formSet := self windowMaximizeFormSet.
+	msb := MultistateButtonMorph new extent: formSet extent.
+	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowMaximizePassiveFormSet.
+	msb extent: formSet extent.
+	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowMaximizeOverFormSet.
+	msb extent: formSet extent.
 	msb
-		activeEnabledOverUpFillStyle: (ImageFillStyle form: form);
-		passiveEnabledOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowMaximizePassiveForm.
+		activeEnabledOverUpFillStyle: (ImageFillStyle formSet: formSet);
+		passiveEnabledOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowMaximizePassiveFormSet.
 	msb
-		extent: form extent;
-		activeEnabledOverDownFillStyle: (ImageFillStyle form: form);
-		passiveEnabledOverDownFillStyle: (ImageFillStyle form: form);
+		extent: formSet extent;
+		activeEnabledOverDownFillStyle: (ImageFillStyle formSet: formSet);
+		passiveEnabledOverDownFillStyle: (ImageFillStyle formSet: formSet);
 		addUpAction: [aSystemWindow expandBoxHit];
 		setBalloonText: 'Expand to full screen' translated;
 		extent: aSystemWindow boxExtent.
@@ -5082,23 +5082,41 @@ UITheme >> windowLeftOffset [
 
 { #category : 'label-styles - windows' }
 UITheme >> windowMaximizeForm [
-	"Answer the form to use for the maximize button of a window."
 
-	^ self iconNamed: #windowMaximize
+	^ self windowMaximizeFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowMaximizeFormSet [
+	"Answer the form set to use for the maximize button of a window."
+
+	^ self iconFormSetNamed: #windowMaximize
 ]
 
 { #category : 'label-styles - windows' }
 UITheme >> windowMaximizeOverForm [
-	"Answer the form to use for mouse over window maximize buttons"
 
-	^ self iconNamed: #windowMaximize
+	^ self windowMaximizeOverFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowMaximizeOverFormSet [
+	"Answer the form set to use for mouse over window maximize buttons"
+
+	^ self iconFormSetNamed: #windowMaximize
 ]
 
 { #category : 'label-styles - windows' }
 UITheme >> windowMaximizePassiveForm [
-	"Answer the form to use for passive (background) window maximize/restore buttons"
 
-	^ self iconNamed: #windowMaximizeInactive
+	^ self windowMaximizePassiveFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowMaximizePassiveFormSet [
+	"Answer the form set to use for passive (background) window maximize/restore buttons"
+
+	^ self iconFormSetNamed: #windowMaximizeInactive
 ]
 
 { #category : 'sounds' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -3872,9 +3872,15 @@ UITheme >> radioButtonDisabledFillStyleFor: aRadioButton [
 
 { #category : 'fill-styles' }
 UITheme >> radioButtonForm [
-	"Answer the form to use for a normal radio button."
 
-	^ self iconNamed: #radioButtonUnselected
+	^ self radioButtonFormSet asForm
+]
+
+{ #category : 'fill-styles' }
+UITheme >> radioButtonFormSet [
+	"Answer the form set to use for a normal radio button."
+
+	^ self iconFormSetNamed: #radioButtonUnselected
 ]
 
 { #category : 'label-styles' }
@@ -3895,7 +3901,7 @@ UITheme >> radioButtonNormalBorderStyleFor: aRadioButton [
 UITheme >> radioButtonNormalFillStyleFor: aRadioButton [
 	"Return the normal radio button fillStyle for the given button."
 
-	^(ImageFillStyle form: self radioButtonForm) origin: aRadioButton topLeft
+	^(ImageFillStyle formSet: self radioButtonFormSet) origin: aRadioButton topLeft
 ]
 
 { #category : 'border-styles - buttons' }
@@ -3923,14 +3929,20 @@ UITheme >> radioButtonSelectedDisabledFillStyleFor: aRadioButton [
 UITheme >> radioButtonSelectedFillStyleFor: aRadioButton [
 	"Return the selected radio button fillStyle for the given button."
 
-	^(ImageFillStyle form: self radioButtonSelectedForm) origin: aRadioButton topLeft
+	^(ImageFillStyle formSet: self radioButtonSelectedFormSet) origin: aRadioButton topLeft
 ]
 
 { #category : 'fill-styles' }
 UITheme >> radioButtonSelectedForm [
-	"Answer the form to use for a selected radio button."
 
-	^ self iconNamed: #radioButtonSelected
+	^ self radioButtonSelectedFormSet asForm
+]
+
+{ #category : 'fill-styles' }
+UITheme >> radioButtonSelectedFormSet [
+	"Answer the form set to use for a selected radio button."
+
+	^ self iconFormSetNamed: #radioButtonSelected
 ]
 
 { #category : 'fill-styles' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -1202,23 +1202,23 @@ UITheme >> createCloseBoxFor: aSystemWindow [
 UITheme >> createCollapseBoxFor: aSystemWindow [
 	"Answer a button for minimising the window."
 
-	|form msb|
-	form := self windowMinimizeForm.
-	msb := MultistateButtonMorph new extent: form extent.
-	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowMinimizePassiveForm.
-	msb extent: form extent.
-	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowMinimizeOverForm.
-	msb extent: form extent.
+	|formSet msb|
+	formSet := self windowMinimizeFormSet.
+	msb := MultistateButtonMorph new extent: formSet extent.
+	msb activeEnabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowMinimizePassiveFormSet.
+	msb extent: formSet extent.
+	msb passiveEnabledNotOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowMinimizeOverFormSet.
+	msb extent: formSet extent.
 	msb
-		activeEnabledOverUpFillStyle: (ImageFillStyle form: form);
-		passiveEnabledOverUpFillStyle: (ImageFillStyle form: form).
-	form := self windowMinimizePassiveForm.
+		activeEnabledOverUpFillStyle: (ImageFillStyle formSet: formSet);
+		passiveEnabledOverUpFillStyle: (ImageFillStyle formSet: formSet).
+	formSet := self windowMinimizePassiveFormSet.
 	msb
-		extent: form extent;
-		activeEnabledOverDownFillStyle: (ImageFillStyle form: form);
-		passiveEnabledOverDownFillStyle: (ImageFillStyle form: form);
+		extent: formSet extent;
+		activeEnabledOverDownFillStyle: (ImageFillStyle formSet: formSet);
+		passiveEnabledOverDownFillStyle: (ImageFillStyle formSet: formSet);
 		addUpAction: [aSystemWindow collapseBoxHit];
 		setBalloonText: 'Collapse this window' translated;
 		extent: aSystemWindow boxExtent.
@@ -5131,23 +5131,41 @@ UITheme >> windowMenuPassiveForm [
 
 { #category : 'label-styles - windows' }
 UITheme >> windowMinimizeForm [
-	"Answer the form to use for the minimize button of a window."
 
-	^ self iconNamed: #windowMinimize
+	^ self windowMinimizeFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowMinimizeFormSet [
+	"Answer the form set to use for the minimize button of a window."
+
+	^ self iconFormSetNamed: #windowMinimize
 ]
 
 { #category : 'label-styles - windows' }
 UITheme >> windowMinimizeOverForm [
-	"Answer the form to use for mouse over window minimize buttons"
 
-	^ self iconNamed: #windowMinimize
+	^ self windowMinimizeOverFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowMinimizeOverFormSet [
+	"Answer the form set to use for mouse over window minimize buttons"
+
+	^ self iconFormSetNamed: #windowMinimize
 ]
 
 { #category : 'label-styles - windows' }
 UITheme >> windowMinimizePassiveForm [
-	"Answer the form to use for passive (background) window minimize buttons"
 
-	^ self iconNamed: #windowMinimizeInactive
+	^ self windowMinimizePassiveFormSet asForm
+]
+
+{ #category : 'label-styles - windows' }
+UITheme >> windowMinimizePassiveFormSet [
+	"Answer the form set to use for passive (background) window minimize buttons"
+
+	^ self iconFormSetNamed: #windowMinimizeInactive
 ]
 
 { #category : 'sounds' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -606,7 +606,7 @@ UITheme >> checkboxButtonNormalBorderStyleFor: aChecboxButton [
 UITheme >> checkboxButtonNormalFillStyleFor: aCheckboxButton [
 	"Return the normal checkbox button fillStyle for the given checkbox button."
 
-	^(ImageFillStyle form: self checkboxForm) origin: aCheckboxButton topLeft
+	^(ImageFillStyle formSet: self checkboxFormSet) origin: aCheckboxButton topLeft
 ]
 
 { #category : 'border-styles - buttons' }
@@ -634,7 +634,7 @@ UITheme >> checkboxButtonSelectedDisabledFillStyleFor: aCheckboxButton [
 UITheme >> checkboxButtonSelectedFillStyleFor: aCheckboxButton [
 	"Return the selected checkbox button fillStyle for the given checkbox button."
 
-	^(ImageFillStyle form: self checkboxSelectedForm) origin: aCheckboxButton topLeft
+	^(ImageFillStyle formSet: self checkboxSelectedFormSet) origin: aCheckboxButton topLeft
 ]
 
 { #category : 'border-styles - buttons' }
@@ -646,9 +646,15 @@ UITheme >> checkboxCornerStyleFor: aCheckbox [
 
 { #category : 'forms' }
 UITheme >> checkboxForm [
-	"Answer the form to use for a normal checkbox."
 
-	^self  checkboxUnselectedForm
+	^self  checkboxFormSet asForm
+]
+
+{ #category : 'forms' }
+UITheme >> checkboxFormSet [
+	"Answer the form set to use for a normal checkbox."
+
+	^self  checkboxUnselectedFormSet
 ]
 
 { #category : 'label-styles - buttons' }
@@ -688,16 +694,28 @@ UITheme >> checkboxMarkerForm [
 
 { #category : 'fill-styles - buttons' }
 UITheme >> checkboxSelectedForm [
-	"Answer the form to use for a selected checkbox."
 
-	^ self iconNamed: #checkboxSelected
+	^ self checkboxSelectedFormSet asForm
+]
+
+{ #category : 'fill-styles - buttons' }
+UITheme >> checkboxSelectedFormSet [
+	"Answer the form set to use for a selected checkbox."
+
+	^ self iconFormSetNamed: #checkboxSelected
 ]
 
 { #category : 'forms' }
 UITheme >> checkboxUnselectedForm [
-	"Answer the form to use for a selected checkbox."
 
-	^ self iconNamed: #checkboxUnselected
+	^ self checkboxUnselectedFormSet asForm
+]
+
+{ #category : 'forms' }
+UITheme >> checkboxUnselectedFormSet [
+	"Answer the form set to use for a selected checkbox."
+
+	^ self iconFormSetNamed: #checkboxUnselected
 ]
 
 { #category : 'services' }


### PR DESCRIPTION
This pull request refactors ImageFillStyle to replace the instance variable ‘form’ (holding a Form) by an instance variable ‘formSet’ (holding a FormSet). It also makes methods in which ImageFillStyle is instantiated with the Form for an icon use the corresponding FormSet for that icon instead.

Note that the instance creation method `#form:` for ImageFillStyle, and some of the methods that are changed on UITheme, are now no longer used in the base Pharo packages, but I kept them for compatibility with other packages.