### PR TITLE
Fix infinite loop in ThemeIcons when icon #blank is missing

### DIFF
--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -315,7 +315,10 @@ ThemeIcons >> iconFormSetNamed: aSymbol [
 				ifTrue: [
 					self crTrace: (aSymbol, ' icon not found!').
 					self notFoundIconFormSet ]
-				ifFalse: [ self blankIconFormSet ]])
+				ifFalse: [
+					aSymbol ~= #blank
+						ifTrue: [ self blankIconFormSet ]
+						ifFalse: [ FormSet form: (Form extent: 0@0) ]]])
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This pull request fixes ThemeIcons to take into account that the icon named `#blank` could be missing. Due to the changes in pull request #15399, that can currently lead to an infinite loop as `#blankIconFormSet` sends `#iconFormSetNamed:` which in turn uses `#blankIconFormSet` as a fallback when `#isReportingNotFound` is false. I encountered the loop while backporting that pull request and some others to Pharo 11: when loading the backport there is a point at which all icons are temporarily missing due to the replacement of the instance variable ‘icons’ by ‘iconsPerScale’.

I’m wondering though whether it wouldn’t be better to make `#iconFormSetNamed:` always use `#notFoundIconFormSet` when an icon is missing, with `#isReportingNotFound` just determining whether or not that also gets logged on the transcript.