### PR TITLE
Improve #denyEmpty:

### DIFF
--- a/src/SUnit-Core-Traits/TAssertable.trait.st
+++ b/src/SUnit-Core-Traits/TAssertable.trait.st
@@ -211,7 +211,9 @@ TAssertable >> denyCollection: actual hasSameElements: expected [
 
 { #category : 'asserting' }
 TAssertable >> denyEmpty: aCollection [
-	^ self assert: aCollection isNotEmpty description: aCollection asString , ' should not have been empty'
+	"Not using #isNotEmpty like this objects as parameter can only implement #isEmpty and not both messages."
+
+	^ self assert: aCollection isEmpty not description: aCollection asString , ' should not have been empty'
 ]
 
 { #category : 'asserting' }

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -433,11 +433,11 @@ TestAsserter >> denyCollection: actualCollection includesAny: subcollection [
 
 { #category : 'asserting' }
 TestAsserter >> denyEmpty: aCollection [
-	"I raise an AssertionFailure if the giving collection is empty. I also provide a specialized message in case I failed"
+	"I raise an AssertionFailure if the giving collection is empty. I also provide a specialized message in case I failed.
+	
+	Not using #isNotEmpty like this objects as parameter can only implement #isEmpty and not both messages."
 
-	^ self
-		  assert: aCollection isNotEmpty
-		  description: aCollection asString , ' should not have been empty'
+	^ self assert: aCollection isEmpty not description: aCollection asString , ' should not have been empty'
 ]
 
 { #category : 'asserting' }


### PR DESCRIPTION
Make #denyEmpty: is #isEmpty instead of #isNotEmpty. Like this, the assertion can work on some objects implementing #isEmpty but not #isNotEmpty (We have 110 implementors of #isEmpty VS 6 implementors of #isNotEmpty in the image)