### PR TITLE
Move continuation out of the Kernel

### DIFF
--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -52,7 +52,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'ScriptingExtensions-Tests';
 			package: 'STON-Tests';
 			package: 'System-Caching-Tests';
-			package: 'System-Clipboard-Tests';
+			package: 'System-Utilities-Tests';
 			package: 'System-Hashing-Tests';
 			package: 'System-History-Tests';
 			package: 'System-Localization-Tests';

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -39,7 +39,7 @@ BaselineOfMorphicCore >> baseline: spec [
 
 		spec package: 'System-Object Events'.
 		spec package: 'System-Caching'.
-		spec package: 'System-Clipboard'.		
+		spec package: 'System-Utilities'.		
 		spec package: 'Graphics-Canvas'.
 		spec package: 'FormCanvas-Core'.
 		spec package: 'Tool-Registry'.

--- a/src/System-Clipboard-Tests/package.st
+++ b/src/System-Clipboard-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'System-Clipboard-Tests' }

--- a/src/System-Clipboard/package.st
+++ b/src/System-Clipboard/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'System-Clipboard' }

--- a/src/System-Utilities-Tests/ClipboardTest.class.st
+++ b/src/System-Utilities-Tests/ClipboardTest.class.st
@@ -7,8 +7,8 @@ Class {
 	#instVars : [
 		'clipboard'
 	],
-	#category : 'System-Clipboard-Tests-Base',
-	#package : 'System-Clipboard-Tests',
+	#category : 'System-Utilities-Tests-Base',
+	#package : 'System-Utilities-Tests',
 	#tag : 'Base'
 }
 

--- a/src/System-Utilities-Tests/ContinuationTest.class.st
+++ b/src/System-Utilities-Tests/ContinuationTest.class.st
@@ -8,9 +8,8 @@ Class {
 		'tmp',
 		'tmp2'
 	],
-	#category : 'Kernel-Tests-Methods',
-	#package : 'Kernel-Tests',
-	#tag : 'Methods'
+	#category : 'System-Utilities-Tests',
+	#package : 'System-Utilities-Tests'
 }
 
 { #category : 'utilities' }

--- a/src/System-Utilities-Tests/ManifestSystemUtilitiesTests.class.st
+++ b/src/System-Utilities-Tests/ManifestSystemUtilitiesTests.class.st
@@ -2,15 +2,15 @@
 Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
 "
 Class {
-	#name : 'ManifestSystemClipboardTests',
+	#name : 'ManifestSystemUtilitiesTests',
 	#superclass : 'PackageManifest',
-	#category : 'System-Clipboard-Tests-Manifest',
-	#package : 'System-Clipboard-Tests',
+	#category : 'System-Utilities-Tests-Manifest',
+	#package : 'System-Utilities-Tests',
 	#tag : 'Manifest'
 }
 
 { #category : 'code-critics' }
-ManifestSystemClipboardTests class >> ruleStringConcatenationRuleV1FalsePositive [
+ManifestSystemUtilitiesTests class >> ruleStringConcatenationRuleV1FalsePositive [
 
 	<ignoreForCoverage>
 	^ #(#(#(#RGMethodDefinition #(#ClipboardTest #testRecentClippingIsLIFOAndRotating #false)) #'2023-11-21T22:11:16.858693+01:00') )

--- a/src/System-Utilities-Tests/TwoInARowStar.class.st
+++ b/src/System-Utilities-Tests/TwoInARowStar.class.st
@@ -5,9 +5,8 @@ Class {
 		'leave',
 		'fill'
 	],
-	#category : 'Kernel-Tests-Methods',
-	#package : 'Kernel-Tests',
-	#tag : 'Methods'
+	#category : 'System-Utilities-Tests',
+	#package : 'System-Utilities-Tests'
 }
 
 { #category : 'API' }

--- a/src/System-Utilities-Tests/package.st
+++ b/src/System-Utilities-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'System-Utilities-Tests' }

--- a/src/System-Utilities/Clipboard.class.st
+++ b/src/System-Utilities/Clipboard.class.st
@@ -15,8 +15,8 @@ Class {
 	#classVars : [
 		'Default'
 	],
-	#category : 'System-Clipboard-Base',
-	#package : 'System-Clipboard',
+	#category : 'System-Utilities-Base',
+	#package : 'System-Utilities',
 	#tag : 'Base'
 }
 

--- a/src/System-Utilities/Continuation.class.st
+++ b/src/System-Utilities/Continuation.class.st
@@ -20,9 +20,8 @@ Class {
 	#instVars : [
 		'values'
 	],
-	#category : 'Kernel-Methods',
-	#package : 'Kernel',
-	#tag : 'Methods'
+	#category : 'System-Utilities',
+	#package : 'System-Utilities'
 }
 
 { #category : 'instance creation' }

--- a/src/System-Utilities/package.st
+++ b/src/System-Utilities/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'System-Utilities' }


### PR DESCRIPTION
Continuations is a class that is not used in the image but might be interesting to have. 

It is currently in Kernel but this is not a right place IMO. I propose to rename System-Clipboard into System-Utilities as it was mentioned in another PR and move the continuations there