### PR TITLE
Extract InstructionClient from Kernel and Opal

### DIFF
--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -14,6 +14,7 @@ BaselineOfGeneralTests >> baseline: spec [
 	repository := self packageRepositoryURL.
 	spec for: #'common' do: [
 		spec
+			package: 'Debugging-Core-Tests';
 			package: 'Debugging-Utils-Tests';
 			package: 'NumberParser-Tests';
 			package: 'AST-Core-Tests';

--- a/src/Debugging-Core-Tests/InstructionClientTest.class.st
+++ b/src/Debugging-Core-Tests/InstructionClientTest.class.st
@@ -7,9 +7,8 @@ This is the unit test for the class InstructionClient. Unit tests are a good way
 Class {
 	#name : 'InstructionClientTest',
 	#superclass : 'TestCase',
-	#category : 'Kernel-Tests-Extended-Methods',
-	#package : 'Kernel-Tests-Extended',
-	#tag : 'Methods'
+	#category : 'Debugging-Core-Tests',
+	#package : 'Debugging-Core-Tests'
 }
 
 { #category : 'tests' }

--- a/src/Debugging-Core-Tests/OCBytecodeDecompilerExamplesTest.class.st
+++ b/src/Debugging-Core-Tests/OCBytecodeDecompilerExamplesTest.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : 'OCBytecodeDecompilerExamplesTest',
 	#superclass : 'TestCase',
-	#category : 'OpalCompiler-Tests-Bytecode',
-	#package : 'OpalCompiler-Tests',
-	#tag : 'Bytecode'
+	#category : 'Debugging-Core-Tests',
+	#package : 'Debugging-Core-Tests'
 }
 
 { #category : 'tests - blocks' }

--- a/src/Debugging-Core-Tests/OCBytecodeDecompilerTest.class.st
+++ b/src/Debugging-Core-Tests/OCBytecodeDecompilerTest.class.st
@@ -4,9 +4,8 @@ Class {
 	#instVars : [
 		'currentCompiler'
 	],
-	#category : 'OpalCompiler-Tests-Bytecode',
-	#package : 'OpalCompiler-Tests',
-	#tag : 'Bytecode'
+	#category : 'Debugging-Core-Tests',
+	#package : 'Debugging-Core-Tests'
 }
 
 { #category : 'running' }

--- a/src/Debugging-Core-Tests/RBCodeSnippetTest.extension.st
+++ b/src/Debugging-Core-Tests/RBCodeSnippetTest.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : 'RBCodeSnippetTest' }
+
+{ #category : '*Debugging-Core-Tests' }
+RBCodeSnippetTest >> testDecompileIR [
+
+	| method ir |
+	method := snippet compile.
+	method ifNil: [ ^ self skip ]. "Another test responsibility"
+	ir := method decompileIR.
+	self assert: ir class equals: IRMethod.
+	"Decompilation lose information. Not sure how to test more"
+]

--- a/src/Debugging-Core-Tests/package.st
+++ b/src/Debugging-Core-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Debugging-Core-Tests' }

--- a/src/Debugging-Core/CompiledMethod.extension.st
+++ b/src/Debugging-Core/CompiledMethod.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'CompiledMethod' }
+
+{ #category : '*Debugging-Core' }
+CompiledMethod >> decompileIR [
+
+	^ IRBytecodeDecompiler new decompile: self
+]

--- a/src/Debugging-Core/IRBytecodeDecompiler.class.st
+++ b/src/Debugging-Core/IRBytecodeDecompiler.class.st
@@ -10,9 +10,8 @@ Class {
 		'newTempVector',
 		'scopeStack'
 	],
-	#category : 'OpalCompiler-Core-Bytecode',
-	#package : 'OpalCompiler-Core',
-	#tag : 'Bytecode'
+	#category : 'Debugging-Core',
+	#package : 'Debugging-Core'
 }
 
 { #category : 'instruction decoding' }

--- a/src/Debugging-Core/InstructionClient.class.st
+++ b/src/Debugging-Core/InstructionClient.class.st
@@ -8,9 +8,8 @@ Class {
 	#instVars : [
 		'mappedInlinePrimitiveHandlers'
 	],
-	#category : 'Kernel-Methods',
-	#package : 'Kernel',
-	#tag : 'Methods'
+	#category : 'Debugging-Core',
+	#package : 'Debugging-Core'
 }
 
 { #category : 'extended instruction decoding' }

--- a/src/OpalCompiler-Core/BytecodeMappedInlinePrimitiveConfiguration.class.st
+++ b/src/OpalCompiler-Core/BytecodeMappedInlinePrimitiveConfiguration.class.st
@@ -6,9 +6,8 @@ They send clients the `addMappedInlinePrimitiveHandler:at:` message to add bytec
 Class {
 	#name : 'BytecodeMappedInlinePrimitiveConfiguration',
 	#superclass : 'Object',
-	#category : 'Kernel-Methods',
-	#package : 'Kernel',
-	#tag : 'Methods'
+	#category : 'OpalCompiler-Core',
+	#package : 'OpalCompiler-Core'
 }
 
 { #category : 'configuring' }

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -10,12 +10,6 @@ CompiledMethod >> decompile [
 ]
 
 { #category : '*OpalCompiler-Core' }
-CompiledMethod >> decompileIR [
-
-	^ IRBytecodeDecompiler new decompile: self
-]
-
-{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> lookupVar: aString [
 	^self ast scope lookupVar: aString
 ]

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -150,17 +150,6 @@ RBCodeSnippetTest >> testDecompile [
 ]
 
 { #category : '*OpalCompiler-Tests' }
-RBCodeSnippetTest >> testDecompileIR [
-
-	| method ir |
-	method := snippet compile.
-	method ifNil: [ ^ self skip ]. "Another test responsibility"
-	ir := method decompileIR.
-	self assert: ir class equals: IRMethod.
-	"Decompilation lose information. Not sure how to test more"
-]
-
-{ #category : '*OpalCompiler-Tests' }
 RBCodeSnippetTest >> testDoSemanticAnalysis [
 	"We should test more than that"
 


### PR DESCRIPTION
InstructionClient and its subclasses are used for decompilation and debugging. Currently some of the classes are in Kernel and Opal. I propose to move all of this in the Debugging-Core package. This will reduce the amount of code loaded by Espell