### PR TITLE
Fixing Calypso Extension on Iceberg

### DIFF
--- a/src/Calypso-SystemPlugins-Monticello-Browser/IceTipHiedraHistoryBrowser.extension.st
+++ b/src/Calypso-SystemPlugins-Monticello-Browser/IceTipHiedraHistoryBrowser.extension.st
@@ -5,5 +5,5 @@ IceTipHiedraHistoryBrowser class >> calypsoCommandsWith: presenter forRootGroup:
 	<extensionCommands>
 
 	aCommandGroup / self selectionCommandGroupName register:
-		ClyBrowseIcebergCommitCommand forSpec
+		(ClyBrowseIcebergCommitCommand forSpecContext: presenter)
 ]

--- a/src/Calypso-SystemPlugins-Monticello-Browser/IceTipRepositoriesBrowser.extension.st
+++ b/src/Calypso-SystemPlugins-Monticello-Browser/IceTipRepositoriesBrowser.extension.st
@@ -5,5 +5,5 @@ IceTipRepositoriesBrowser class >> calypsoCommandsWith: presenter forRootGroup: 
 	<extensionCommands>
 
 	aCommandGroup / self selectionCommandGroupName register:
-		ClyBrowseIcebergRepositoryCommand forSpec
+		(ClyBrowseIcebergRepositoryCommand forSpecContext: presenter)
 ]

--- a/src/Calypso-SystemPlugins-Monticello-Browser/IceTipWorkingCopyBrowser.extension.st
+++ b/src/Calypso-SystemPlugins-Monticello-Browser/IceTipWorkingCopyBrowser.extension.st
@@ -2,8 +2,8 @@ Extension { #name : 'IceTipWorkingCopyBrowser' }
 
 { #category : '*Calypso-SystemPlugins-Monticello-Browser' }
 IceTipWorkingCopyBrowser class >> calypsoCommandsWith: presenter forRootGroup: aCommandGroup [
-	<extensionCommands>
 
+	<extensionCommands>
 	aCommandGroup / self selectionCommandGroupName register:
-		ClyBrowseIcebergPackageCommand forSpec
+		(ClyBrowseIcebergPackageCommand forSpecContext: presenter)
 ]


### PR DESCRIPTION
- Extensions should create the commands with the context.