### PR TITLE
Packages: Unify way to name tags

### DIFF
--- a/src/Calypso-SystemPlugins-FileOut-Queries/ClyTaggedClassGroup.extension.st
+++ b/src/Calypso-SystemPlugins-FileOut-Queries/ClyTaggedClassGroup.extension.st
@@ -3,6 +3,5 @@ Extension { #name : 'ClyTaggedClassGroup' }
 { #category : '*Calypso-SystemPlugins-FileOut-Queries' }
 ClyTaggedClassGroup >> fileOut [
 
-	classQuery scope packagesDo: [ :each |
-		(each classTagNamed: self tag) fileOut]
+	classQuery scope packagesDo: [ :each | (each tagNamed: self tag) fileOut ]
 ]

--- a/src/Calypso-SystemQueries/Package.extension.st
+++ b/src/Calypso-SystemQueries/Package.extension.st
@@ -68,5 +68,7 @@ Package >> tagsForClasses [
 	"Any class could be tagged for user purpose.
 	Now we implement it on top of PackageTag"
 
-	^self classTags reject: [:each | each isRoot] thenCollect: [:each | each name]
+	^ self tags
+		  reject: [ :each | each isRoot ]
+		  thenCollect: [ :each | each name ]
 ]

--- a/src/CodeExport/Package.extension.st
+++ b/src/CodeExport/Package.extension.st
@@ -6,7 +6,7 @@ Package >> fileOut [
 	| internalStream |
 	internalStream := (String new: 1000) writeStream.
 
-	self classTags do: [ :tag | tag fileOutOn: internalStream ].
+	self tags do: [ :tag | tag fileOutOn: internalStream ].
 	extensionSelectors keysAndValuesDo: [ :class :selectors | selectors do: [ :selector | class fileOutMethod: selector on: internalStream ] ].
 
 	^ CodeExporter writeSourceCodeFrom: internalStream baseName: self name isSt: true

--- a/src/Deprecated12/Package.extension.st
+++ b/src/Deprecated12/Package.extension.st
@@ -63,7 +63,7 @@ Package >> classNamesForClassTag: aSymbol [
 
 	self deprecated: 'This method is too specific and will be remove in future versions of Pharo. If you are using it you can inline the method'.
 
-	^ (self classTagNamed: aSymbol ifAbsent: [ ^ #(  ) ]) classNames
+	^ (self tagNamed: aSymbol ifAbsent: [ ^ #(  ) ]) classNames
 ]
 
 { #category : '*Deprecated12' }
@@ -71,6 +71,32 @@ Package >> classTagForClass: aClass [
 
 	self deprecated: 'Use #tagOf: instead' transformWith: '`@rcv classTagForClass: `@arg' -> '`@rcv tagOf: `@arg'.
 	^ self tagOf: aClass
+]
+
+{ #category : '*Deprecated12' }
+Package >> classTagNamed: aSymbol [
+
+	self deprecated: 'Use #tagNamed: instead.' transformWith: '`@rcv classTagNamed: `@arg' -> '`@rcv tagNamed: `@arg'.
+	^ self tagNamed: aSymbol
+]
+
+{ #category : '*Deprecated12' }
+Package >> classTagNamed: aSymbol ifAbsent: aBlock [
+
+	self deprecated: 'Use #tagNamed:ifAbsent: instead.' transformWith: '`@rcv classTagNamed: `@arg ifAbsent: `@arg2' -> '`@rcv tagNamed: `@arg ifAbsent: `@arg2'.
+	^ self tags
+		  detect: [ :each | each name = aSymbol ]
+		  ifNone: aBlock
+]
+
+{ #category : '*Deprecated12' }
+Package >> classTagNamed: aSymbol ifPresent: aBlock [
+
+	self deprecated: 'Use #tagNamed:ifPresent: instead.' transformWith: '`@rcv classTagNamed: `@arg ifPresent: `@arg2' -> '`@rcv tagNamed: `@arg ifPresent: `@arg2'.
+	^ self tags
+		  detect: [ :each | each name = aSymbol ]
+		  ifFound: [ :tag | aBlock cull: tag ]
+		  ifNone: [ nil ]
 ]
 
 { #category : '*Deprecated12' }

--- a/src/Deprecated12/Package.extension.st
+++ b/src/Deprecated12/Package.extension.st
@@ -4,9 +4,9 @@ Extension { #name : 'Package' }
 Package >> actualClassTags [
 
 	self deprecated: 'This method is too specific and will be removed in future versions of Pharo.'.
-	(classTags size = 1 and: [ classTags anyOne isRoot ]) ifTrue: [ ^ #(  ) ].
+	(tags size = 1 and: [ tags anyOne isRoot ]) ifTrue: [ ^ #(  ) ].
 
-	^ classTags
+	^ tags
 ]
 
 { #category : '*Deprecated12' }
@@ -71,6 +71,13 @@ Package >> classTagForClass: aClass [
 
 	self deprecated: 'Use #tagOf: instead' transformWith: '`@rcv classTagForClass: `@arg' -> '`@rcv tagOf: `@arg'.
 	^ self tagOf: aClass
+]
+
+{ #category : '*Deprecated12' }
+Package >> classTags [
+
+	self deprecated: 'Use #tags instead.' transformWith: '`@rcv classTags' -> '`@rcv tags'.
+	^ self tags
 ]
 
 { #category : '*Deprecated12' }

--- a/src/Deprecated12/PackageOrganizer.extension.st
+++ b/src/Deprecated12/PackageOrganizer.extension.st
@@ -156,7 +156,7 @@ PackageOrganizer >> removeEmptyPackages [
 PackageOrganizer >> tagForCategory: category [
 
 	(self packageMatchingExtensionName: category) ifNotNil: [ :package |
-		package classTagNamed: (category withoutPrefix: package name , '-') ifPresent: [ :tag | ^ tag ] ].
+		package tagNamed: (category withoutPrefix: package name , '-') ifPresent: [ :tag | ^ tag ] ].
 
 	^ nil
 ]

--- a/src/Deprecated12/PackageOrganizer.extension.st
+++ b/src/Deprecated12/PackageOrganizer.extension.st
@@ -15,7 +15,7 @@ PackageOrganizer >> categories [
 	categories := Set new.
 	self packages do: [ :p |
 		categories add: p name.
-		categories addAll: (p classTags collect: [ :tag | tag categoryName ]) ].
+		categories addAll: (p tags collect: [ :tag | tag categoryName ]) ].
 
 	^ categories asArray
 ]

--- a/src/EpiceaBrowsers/EpBrowseVisitor.class.st
+++ b/src/EpiceaBrowsers/EpBrowseVisitor.class.st
@@ -51,6 +51,6 @@ EpBrowseVisitor >> visitPackageTagChange: aPackageTagChange [
 	Smalltalk tools browser openOnPackage: ((self packageOrganizer
 			  packageNamed: aPackageTagChange packageName
 			  ifAbsent: [ ^ self inform: 'Package named ' , aPackageTagChange packageName , ' not found in the system' ])
-			 classTagNamed: aPackageTagChange tagName
+			 tagNamed: aPackageTagChange tagName
 			 ifAbsent: [ ^ self inform: 'Tag named ' , aPackageTagChange tagName , ' not found in package named ' , aPackageTagChange packageName ])
 ]

--- a/src/General-Rules/ReClassNotCategorizedRule.class.st
+++ b/src/General-Rules/ReClassNotCategorizedRule.class.st
@@ -29,7 +29,7 @@ ReClassNotCategorizedRule >> basicCheck: aClass [
 
 	aClass isMeta ifTrue: [ ^ false ].
 
-	^ aClass packageTag isRoot and: [ aClass package classTags size > 1 ]
+	^ aClass packageTag isRoot and: [ aClass package tags size > 1 ]
 ]
 
 { #category : 'accessing' }

--- a/src/InitializePackagesCommandLineHandler/PackageOrganizer.extension.st
+++ b/src/InitializePackagesCommandLineHandler/PackageOrganizer.extension.st
@@ -8,7 +8,7 @@ PackageOrganizer >> basicBootstrapInitialize [
 
 	"This is a hack because of a weird behavior produced by the bootstrap were the package or tags end up containing classes that are not the same instances than we have in the system dictionary..To be investigated..."
 	self packages do: [ :package |
-		package classTags do: [ :tag |
+		package tags do: [ :tag |
 			tag instVarNamed: #classes put: (tag classes collect: [ :class | allBehaviors detect: [ :aClass | aClass name = class name ] ]) ] ].
 
 	self flag: #todo. "This next step should not be needed when we will not use announcements to manage method addition"

--- a/src/Kernel/Package.class.st
+++ b/src/Kernel/Package.class.st
@@ -127,29 +127,6 @@ Package >> addMethod: aCompiledMethod [
 	^ aCompiledMethod
 ]
 
-{ #category : 'tags' }
-Package >> classTagNamed: aSymbol [
-
-	^ self tags detect: [ :each | each name = aSymbol ]
-]
-
-{ #category : 'tags' }
-Package >> classTagNamed: aSymbol ifAbsent: aBlock [
-
-	^ self tags
-		  detect: [ :each | each name = aSymbol ]
-		  ifNone: aBlock
-]
-
-{ #category : 'tags' }
-Package >> classTagNamed: aSymbol ifPresent: aBlock [
-
-	^ self tags
-		  detect: [ :each | each name = aSymbol ]
-		  ifFound: [ :tag | aBlock cull: tag ]
-		  ifNone: [ nil ]
-]
-
 { #category : 'accessing' }
 Package >> classes [
 	"Return all the classes"
@@ -160,7 +137,7 @@ Package >> classes [
 Package >> classesTaggedWith: aSymbol [
 	"Returns the classes tagged using aSymbol"
 
-	^ (self classTagNamed: aSymbol ifAbsent: [ ^ #(  ) ]) classes
+	^ (self tagNamed: aSymbol ifAbsent: [ ^ #(  ) ]) classes
 ]
 
 { #category : 'accessing' }
@@ -244,7 +221,7 @@ Package >> ensureTag: aTag [
 		           ifTrue: [ aTag ]
 		           ifFalse: [ aTag name ].
 
-	(self hasTag: aTag) ifTrue: [ ^ self classTagNamed: tagName ].
+	(self hasTag: aTag) ifTrue: [ ^ self tagNamed: tagName ].
 
 	newTag := PackageTag package: self name: tagName.
 	tags add: newTag.
@@ -684,7 +661,7 @@ Package >> removeTag: aTag [
 
 	| tag |
 	tag := aTag isString
-		       ifTrue: [ self classTagNamed: aTag ifAbsent: [ ^ self ] ]
+		       ifTrue: [ self tagNamed: aTag ifAbsent: [ ^ self ] ]
 		       ifFalse: [ aTag ].
 
 	"The #asArray is there to not remove elements from the #classes inst var while iterating it."
@@ -692,7 +669,7 @@ Package >> removeTag: aTag [
 
 	tags remove: tag ifAbsent: [ ^ self ].
 
-	self codeChangeAnnouncer  announce: (PackageTagRemoved to: tag)
+	self codeChangeAnnouncer announce: (PackageTagRemoved to: tag)
 ]
 
 { #category : 'tags' }
@@ -701,7 +678,7 @@ Package >> renameTag: aTag to: newName [
 	(self hasTag: aTag) ifFalse: [ ^ self ].
 
 	(aTag isString
-		 ifTrue: [ self classTagNamed: aTag ]
+		 ifTrue: [ self tagNamed: aTag ]
 		 ifFalse: [ aTag ]) renameTo: newName
 ]
 
@@ -766,6 +743,29 @@ Package >> selectorsForClass: aClass [
 	^ (self includesClass: aClass)
 		ifFalse: [self extensionSelectorsForClass: aClass]
 		ifTrue: [self definedSelectorsForClass: aClass]
+]
+
+{ #category : 'tags' }
+Package >> tagNamed: aSymbol [
+
+	^ self tags detect: [ :each | each name = aSymbol ]
+]
+
+{ #category : 'tags' }
+Package >> tagNamed: aSymbol ifAbsent: aBlock [
+
+	^ self tags
+		  detect: [ :each | each name = aSymbol ]
+		  ifNone: aBlock
+]
+
+{ #category : 'tags' }
+Package >> tagNamed: aSymbol ifPresent: aBlock [
+
+	^ self tags
+		  detect: [ :each | each name = aSymbol ]
+		  ifFound: [ :tag | aBlock cull: tag ]
+		  ifNone: [ nil ]
 ]
 
 { #category : 'tags' }

--- a/src/Kernel/Package.class.st
+++ b/src/Kernel/Package.class.st
@@ -49,8 +49,8 @@ Class {
 	#instVars : [
 		'extensionSelectors',
 		'name',
-		'classTags',
-		'organizer'
+		'organizer',
+		'tags'
 	],
 	#classVars : [
 		'Properties'
@@ -127,34 +127,27 @@ Package >> addMethod: aCompiledMethod [
 	^ aCompiledMethod
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> classTagNamed: aSymbol [
 
-	^ self classTags detect: [ :each | each name = aSymbol ]
+	^ self tags detect: [ :each | each name = aSymbol ]
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> classTagNamed: aSymbol ifAbsent: aBlock [
 
-	^ self classTags
+	^ self tags
 		  detect: [ :each | each name = aSymbol ]
 		  ifNone: aBlock
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> classTagNamed: aSymbol ifPresent: aBlock [
 
-	^ self classTags
+	^ self tags
 		  detect: [ :each | each name = aSymbol ]
 		  ifFound: [ :tag | aBlock cull: tag ]
 		  ifNone: [ nil ]
-]
-
-{ #category : 'class tags' }
-Package >> classTags [
-	"Returns the tags of the receiver"
-
-	^ classTags
 ]
 
 { #category : 'accessing' }
@@ -163,7 +156,7 @@ Package >> classes [
 	^ self definedClasses, self extendedClasses
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> classesTaggedWith: aSymbol [
 	"Returns the classes tagged using aSymbol"
 
@@ -186,7 +179,7 @@ Package >> definedClassNames [
 { #category : 'accessing' }
 Package >> definedClasses [
 
-	^ self classTags flatCollect: [ :tag | tag classes ]
+	^ self tags flatCollect: [ :tag | tag classes ]
 ]
 
 { #category : 'accessing' }
@@ -242,7 +235,7 @@ Package >> ensureProperties [
 	^ Properties at: self ifAbsentPut: WeakKeyDictionary new
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> ensureTag: aTag [
 
 	| tagName newTag |
@@ -254,7 +247,7 @@ Package >> ensureTag: aTag [
 	(self hasTag: aTag) ifTrue: [ ^ self classTagNamed: tagName ].
 
 	newTag := PackageTag package: self name: tagName.
-	classTags add: newTag.
+	tags add: newTag.
 
 	self codeChangeAnnouncer announce: (PackageTagAdded to: newTag).
 	^ newTag
@@ -365,9 +358,10 @@ Package >> includesClass: aClass [
 	"Returns true if the receiver includes aClass in the classes that are defined within it: only class definition are considered - not class extensions"
 
 	"This check is here for speed reason. We first check that the package of the class is myself, and if it is, we also need to check that I contains the class because if the class is removed it will still know I am its package but I will not contain it anymore."
+
 	aClass package = self ifFalse: [ ^ false ].
-	
-	^ self classTags anySatisfy: [ :tag | tag includesClass: aClass ]
+
+	^ self tags anySatisfy: [ :tag | tag includesClass: aClass ]
 ]
 
 { #category : 'testing' }
@@ -379,7 +373,8 @@ Package >> includesClassNamed: aSymbol [
 
 { #category : 'testing' }
 Package >> includesClassTagNamed: aString [
-	^ self classTags anySatisfy: [ :each | each name = aString ]
+
+	^ self tags anySatisfy: [ :each | each name = aString ]
 ]
 
 { #category : 'testing' }
@@ -415,7 +410,7 @@ Package >> initialize [
 
 	super initialize.
 	extensionSelectors := IdentityDictionary new.
-	classTags := Set new
+	tags := Set new
 ]
 
 { #category : 'testing' }
@@ -562,7 +557,7 @@ Package >> packageName [
 { #category : 'system compatibility' }
 Package >> packages [
 	"Compatibility with monticello and old PackageInfo"
-	^ self classTags
+	^ self tags
 ]
 
 { #category : 'printing' }
@@ -619,22 +614,22 @@ Package >> removeAllExtensionMethodsFromClass: aClass [
 Package >> removeClass: aClass [
 	"I remove the class and potential empty tags from myself."
 
-	self classTags
+	self tags
 		detect: [ :tag | tag includesClass: aClass ]
 		ifFound: [ :tag | tag removeClass: aClass ]
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> removeEmptyTags [
 
-	(self classTags select: [ :tag | tag isEmpty ]) do: [ :emptyTag | self removeTag: emptyTag ]
+	(self tags select: [ :tag | tag isEmpty ]) do: [ :emptyTag | self removeTag: emptyTag ]
 ]
 
 { #category : 'removing' }
 Package >> removeFromSystem [
 	"Copy to not remove collection over which we are iterating."
 
-	self classTags copy do: [ :tag | tag removeFromSystem ].
+	self tags copy do: [ :tag | tag removeFromSystem ].
 	self extensionMethods do: [ :method | method removeFromSystem ].
 
 	self organizer unregisterPackage: self
@@ -684,7 +679,7 @@ Package >> removeProperty: propName ifAbsent: aBlock [
 	^ property
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> removeTag: aTag [
 
 	| tag |
@@ -695,12 +690,12 @@ Package >> removeTag: aTag [
 	"The #asArray is there to not remove elements from the #classes inst var while iterating it."
 	tag classes asArray do: [ :class | class removeFromSystem ].
 
-	classTags remove: tag ifAbsent: [ ^ self ].
+	tags remove: tag ifAbsent: [ ^ self ].
 
 	self codeChangeAnnouncer  announce: (PackageTagRemoved to: tag)
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> renameTag: aTag to: newName [
 
 	(self hasTag: aTag) ifFalse: [ ^ self ].
@@ -730,7 +725,7 @@ Package >> renameTo: aSymbol [
 	self codeChangeAnnouncer  announce: (PackageRenamed to: self oldName: oldName newName: newName)
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> rootTag [
 
 	^ self ensureTag: self rootTagName
@@ -773,19 +768,26 @@ Package >> selectorsForClass: aClass [
 		ifTrue: [self definedSelectorsForClass: aClass]
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> tagNames [
 
-	^ self classTags collect: [ :tag | tag name ]
+	^ self tags collect: [ :tag | tag name ]
 ]
 
-{ #category : 'class tags' }
+{ #category : 'tags' }
 Package >> tagOf: aClass [
 
-	^ self classTags
+	^ self tags
 		  detect: [ :tag | tag includesClass: aClass ]
 		  ifNone: [
 			  self error: ('No tag containing {1} found in package {2}' format: {
 						   aClass name.
 						   self name }) ]
+]
+
+{ #category : 'tags' }
+Package >> tags [
+	"Returns the tags of the receiver"
+
+	^ tags
 ]

--- a/src/RPackage-Tests/PackageAndClassesTest.class.st
+++ b/src/RPackage-Tests/PackageAndClassesTest.class.st
@@ -348,7 +348,7 @@ PackageAndClassesTest >> testRemoveClassInTag [
 
 	xPackage moveClass: a1 toTag: 'a1-tag'.
 	xPackage moveClass: b1 toTag: 'b1-tag'.
-	self assert: xPackage classTags size equals: 2.
+	self assert: xPackage tags size equals: 2.
 
 	self assert: (xPackage includesClass: a1).
 	self assert: (xPackage includesClass: b1).
@@ -360,7 +360,7 @@ PackageAndClassesTest >> testRemoveClassInTag [
 
 	xPackage removeClass: b1.
 	self deny: (xPackage includesClass: b1).
-	self assert: xPackage classTags size equals: 0
+	self assert: xPackage tags size equals: 0
 ]
 
 { #category : 'tests - removing classes' }

--- a/src/RPackage-Tests/PackageOnModelTest.class.st
+++ b/src/RPackage-Tests/PackageOnModelTest.class.st
@@ -93,16 +93,16 @@ PackageOnModelTest >> testAddTagNames [
 	xPackage moveClass: b1 toTag: #foo.
 	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: xPackage tags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
-	self assert: ((xPackage classTagNamed: #foo) classNames includes: #A1DefinedInX).
-	self assert: ((xPackage classTagNamed: #foo) classNames includes: #B1DefinedInX).
-	self assert: (xPackage classTagNamed: #foo) classNames size equals: 2.
+	self assert: ((xPackage tagNamed: #foo) classNames includes: #A1DefinedInX).
+	self assert: ((xPackage tagNamed: #foo) classNames includes: #B1DefinedInX).
+	self assert: (xPackage tagNamed: #foo) classNames size equals: 2.
 
 	xPackage ensureTag: #foo.
 	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #baz ]).
 	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #foo ]).
-	self assert: ((xPackage classTagNamed: #foo) classNames includes: #A1DefinedInX).
-	self assert: ((xPackage classTagNamed: #foo) classNames includes: #B1DefinedInX).
-	self assert: (xPackage classTagNamed: #foo) classNames size equals: 2
+	self assert: ((xPackage tagNamed: #foo) classNames includes: #A1DefinedInX).
+	self assert: ((xPackage tagNamed: #foo) classNames includes: #B1DefinedInX).
+	self assert: (xPackage tagNamed: #foo) classNames size equals: 2
 ]
 
 { #category : 'tests - tag class' }

--- a/src/RPackage-Tests/PackageOnModelTest.class.st
+++ b/src/RPackage-Tests/PackageOnModelTest.class.st
@@ -60,22 +60,22 @@ PackageOnModelTest >> setUp [
 { #category : 'tests - tag class' }
 PackageOnModelTest >> testAddTag [
 
-	self assert: xPackage classTags size equals: 1. "We start with the root tag"
+	self assert: xPackage tags size equals: 1. "We start with the root tag"
 	xPackage ensureTag: #baz.
-	self assert: (xPackage classTags anySatisfy: [ :tag | tag name = #baz ]).
-	self assert: xPackage classTags size equals: 2.
+	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #baz ]).
+	self assert: xPackage tags size equals: 2.
 
 	xPackage moveClass: a1 toTag: #foo.
 	xPackage moveClass: b1 toTag: #foo.
-	self assert: (xPackage classTags anySatisfy: [ :tag | tag name = #foo ]).
-	self assert: xPackage classTags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
+	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #foo ]).
+	self assert: xPackage tags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
 	self assert: (((xPackage classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInX).
 	self assert: (((xPackage classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInX).
 	self assert: (xPackage classesTaggedWith: #foo) size equals: 2.
 
 	xPackage ensureTag: #foo.
-	self assert: (xPackage classTags anySatisfy: [ :tag | tag name = #baz ]).
-	self assert: (xPackage classTags anySatisfy: [ :tag | tag name = #foo ]).
+	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #baz ]).
+	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: (((xPackage classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInX).
 	self assert: (((xPackage classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #B1DefinedInX).
 	self assert: (xPackage classesTaggedWith: #foo) size equals: 2
@@ -84,22 +84,22 @@ PackageOnModelTest >> testAddTag [
 { #category : 'tests - tag class' }
 PackageOnModelTest >> testAddTagNames [
 
-	self assert: xPackage classTags size equals: 1. "We start with the root tag"
+	self assert: xPackage tags size equals: 1. "We start with the root tag"
 	xPackage ensureTag: #baz.
-	self assert: (xPackage classTags anySatisfy: [ :tag | tag name = #baz ]).
-	self assert: xPackage classTags size equals: 2.
+	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #baz ]).
+	self assert: xPackage tags size equals: 2.
 
 	xPackage moveClass: a1 toTag: #foo.
 	xPackage moveClass: b1 toTag: #foo.
-	self assert: (xPackage classTags anySatisfy: [ :tag | tag name = #foo ]).
-	self assert: xPackage classTags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
+	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #foo ]).
+	self assert: xPackage tags size equals: 2. "foo and baz. The root tag got automatically removed since it was empty."
 	self assert: ((xPackage classTagNamed: #foo) classNames includes: #A1DefinedInX).
 	self assert: ((xPackage classTagNamed: #foo) classNames includes: #B1DefinedInX).
 	self assert: (xPackage classTagNamed: #foo) classNames size equals: 2.
 
 	xPackage ensureTag: #foo.
-	self assert: (xPackage classTags anySatisfy: [ :tag | tag name = #baz ]).
-	self assert: (xPackage classTags anySatisfy: [ :tag | tag name = #foo ]).
+	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #baz ]).
+	self assert: (xPackage tags anySatisfy: [ :tag | tag name = #foo ]).
 	self assert: ((xPackage classTagNamed: #foo) classNames includes: #A1DefinedInX).
 	self assert: ((xPackage classTagNamed: #foo) classNames includes: #B1DefinedInX).
 	self assert: (xPackage classTagNamed: #foo) classNames size equals: 2
@@ -108,7 +108,7 @@ PackageOnModelTest >> testAddTagNames [
 { #category : 'tests - tag class' }
 PackageOnModelTest >> testAddTagsToAClass [
 
-	self assert: xPackage classTags size equals: 1. "We start with the root tag"
+	self assert: xPackage tags size equals: 1. "We start with the root tag"
 
 	xPackage moveClass: a1 toTag: #foo.
 	self assert: (((xPackage classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInX).
@@ -157,7 +157,7 @@ PackageOnModelTest >> testDefinedSelectorsForClass [
 { #category : 'tests - tag class' }
 PackageOnModelTest >> testEmpty [
 
-	self assertEmpty: (Package named: 'new package') classTags
+	self assertEmpty: (Package named: 'new package') tags
 ]
 
 { #category : 'tests - accessing' }

--- a/src/RPackage-Tests/PackageRenameTest.class.st
+++ b/src/RPackage-Tests/PackageRenameTest.class.st
@@ -18,15 +18,15 @@ PackageRenameTest >> testRenamePackage [
 	class := self newClassNamed: #TestClass in: package tag: 'TAG'.
 
 	self assert: (package includesClass: class).
-	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
-	self assert: ((package classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
+	self assert: (package tagNamed: #TAG ifAbsent: [ nil ]) notNil.
+	self assert: ((package tagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
 	self assert: workingCopy modified.
 
 	package renameTo: 'TestRename'.
 
 	self assert: (package includesClass: class).
-	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
-	self assert: ((package classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
+	self assert: (package tagNamed: #TAG ifAbsent: [ nil ]) notNil.
+	self assert: ((package tagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
 	self assert: class category equals: #'TestRename-TAG'.
 	self deny: (self packageOrganizer hasPackage: #Test1).
 	self deny: (MCWorkingCopy hasPackageNamed: #Test1).
@@ -45,15 +45,15 @@ PackageRenameTest >> testRenamePackageToOwnTagName [
 	class1 := self newClassNamed: #TestClass1 in: package tag: 'Core'.
 	class2 := self newClassNamed: #TestClass2 in: package tag: 'Util'.
 
-	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) notNil.
-	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) notNil.
+	self assert: (package tagNamed: #Core ifAbsent: [ nil ]) notNil.
+	self assert: (package tagNamed: #Util ifAbsent: [ nil ]) notNil.
 	package renameTo: 'Test1-Core'.
 	self assert: (package includesClass: class1).
 	self assert: (package includesClass: class2).
-	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) notNil.
-	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) notNil.
-	self assert: ((package classTagNamed: #Core ifAbsent: [ nil ]) includesClass: class1).
-	self assert: ((package classTagNamed: #Util ifAbsent: [ nil ]) includesClass: class2).
+	self assert: (package tagNamed: #Core ifAbsent: [ nil ]) notNil.
+	self assert: (package tagNamed: #Util ifAbsent: [ nil ]) notNil.
+	self assert: ((package tagNamed: #Core ifAbsent: [ nil ]) includesClass: class1).
+	self assert: ((package tagNamed: #Util ifAbsent: [ nil ]) includesClass: class2).
 
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1-Core'.
 	self assert: workingCopy modified
@@ -69,8 +69,8 @@ PackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 	class2 := self newClassNamed: #TestClass2 in: package tag: 'Util'.
 	class3 := self newClassNamed: #TestClass3 in: package.
 
-	self assert: (package classTagNamed: #Core ifAbsent: [ nil ]) isNotNil.
-	self assert: (package classTagNamed: #Util ifAbsent: [ nil ]) isNotNil.
+	self assert: (package tagNamed: #Core ifAbsent: [ nil ]) isNotNil.
+	self assert: (package tagNamed: #Util ifAbsent: [ nil ]) isNotNil.
 	self assert: (package tagOf: class1) name equals: #Core.
 	self assert: (package tagOf: class2) name equals: #Util.
 	self assert: (package tagOf: class3) isRoot.
@@ -152,8 +152,8 @@ PackageRenameTest >> testUnregisterPackage [
 	workingCopy := MCWorkingCopy forPackageNamed: 'Test1'.
 	class := self newClassNamed: #TestClass in: package tag: 'TAG'.
 	self assert: (package includesClass: class).
-	self assert: (package classTagNamed: #TAG ifAbsent: [ nil ]) notNil.
-	self assert: ((package classTagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
+	self assert: (package tagNamed: #TAG ifAbsent: [ nil ]) notNil.
+	self assert: ((package tagNamed: #TAG ifAbsent: [ nil ]) includesClass: class).
 	self assert: workingCopy modified.
 
 	package removeFromSystem.

--- a/src/RPackage-Tests/PackageTagTest.class.st
+++ b/src/RPackage-Tests/PackageTagTest.class.st
@@ -17,7 +17,7 @@ PackageTagTest >> testAddClass [
 
 	self assert: (xPackage includesClass: class).
 	self assert: (xPackage hasTag: #TAG).
-	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
+	self assert: ((xPackage tagNamed: #TAG) includesClass: class).
 
 	yPackage := self ensureYPackage.
 	yTag := yPackage ensureTag: #YTag.
@@ -40,7 +40,7 @@ PackageTagTest >> testAddClassSettingPackageTag [
 
 	self assert: (xPackage includesClass: class).
 	self assert: (xPackage hasTag: #TAG).
-	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
+	self assert: ((xPackage tagNamed: #TAG) includesClass: class).
 
 	yPackage := self ensureYPackage.
 	yTag := yPackage ensureTag: #YTag.
@@ -76,7 +76,7 @@ PackageTagTest >> testAddTrait [
 
 	self assert: (xPackage includesClass: class).
 	self assert: (xPackage hasTag: #TAG).
-	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
+	self assert: ((xPackage tagNamed: #TAG) includesClass: class).
 
 	yPackage := self ensureYPackage.
 	yTag := yPackage ensureTag: #YTag.
@@ -99,7 +99,7 @@ PackageTagTest >> testAddTraitSettingPackageTag [
 
 	self assert: (xPackage includesClass: class).
 	self assert: (xPackage hasTag: #TAG).
-	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
+	self assert: ((xPackage tagNamed: #TAG) includesClass: class).
 
 	yPackage := self ensureYPackage.
 	yTag := yPackage ensureTag: #YTag.
@@ -149,7 +149,7 @@ PackageTagTest >> testPromoteAsPackage [
 	class := self newClassNamed: 'TestClass' in: package1 tag: 'TAG1'.
 	class compile: 'foo ^42' classified: 'accessing'.
 
-	tag1 := package1 classTagNamed: 'TAG1'.
+	tag1 := package1 tagNamed: 'TAG1'.
 
 	tag1 promoteAsPackage.
 

--- a/src/RPackage-Tests/PackageTest.class.st
+++ b/src/RPackage-Tests/PackageTest.class.st
@@ -556,7 +556,7 @@ PackageTest >> testRemoveTag [
 
 	a1 := self newClassNamed: #A1DefinedInX in: p1.
 	b1 := self newClassNamed: #B1DefinedInX in: p1.
-	self assert: p1 classTags size equals: 1. "We start with the root tag"
+	self assert: p1 tags size equals: 1. "We start with the root tag"
 
 	p1 moveClass: a1 toTag: #foo.
 	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInX).
@@ -582,7 +582,7 @@ PackageTest >> testRemoveTagRemoveClasses [
 	p1 := self ensurePackage: #P1.
 
 	a1 := self newClassNamed: #A1DefinedInX in: p1.
-	self assert: p1 classTags size equals: 1. "We start with the root tag"
+	self assert: p1 tags size equals: 1. "We start with the root tag"
 
 	p1 moveClass: a1 toTag: #foo.
 	self assert: (((p1 classesTaggedWith: #foo) collect: [ :each | each name ]) includes: #A1DefinedInX).

--- a/src/RPackage-Tests/PackageTest.class.st
+++ b/src/RPackage-Tests/PackageTest.class.st
@@ -166,7 +166,7 @@ PackageTest >> testDemoteToRPackageNamed [
 	package2 := self organizer packageNamed: 'Test1'.
 	self assert: package2 isNotNil.
 	self assert: (package2 classes includes: class).
-	self assert: ((package2 classTagNamed: 'TAG1') classes includes: class)
+	self assert: ((package2 tagNamed: 'TAG1') classes includes: class)
 ]
 
 { #category : 'tests - demotion' }
@@ -185,7 +185,7 @@ PackageTest >> testDemoteToRPackageNamedExistingPackage [
 	self assert: package2 isNotNil.
 	self assert: package2 equals: packageExisting.
 	self assert: (package2 classes includes: class).
-	self assert: ((package2 classTagNamed: 'TAG1') classes includes: class)
+	self assert: ((package2 tagNamed: 'TAG1') classes includes: class)
 ]
 
 { #category : 'tests - demotion' }
@@ -215,7 +215,7 @@ PackageTest >> testDemoteToRPackageNamedMultilevelPackage [
 	package2 := self organizer packageNamed: 'Test1-TAG1'.
 	self assert: package2 isNotNil.
 	self assert: (package2 classes includes: class).
-	self assert: ((package2 classTagNamed: 'X1') classes includes: class)
+	self assert: ((package2 tagNamed: 'X1') classes includes: class)
 ]
 
 { #category : 'tests - demotion' }
@@ -235,7 +235,7 @@ PackageTest >> testDemoteToRPackageNamedWithExtension [
 	packageDemoted := self organizer packageNamed: 'Test1'.
 	self assert: packageDemoted isNotNil.
 	self assert: (packageDemoted classes includes: class).
-	self assert: ((packageDemoted classTagNamed: 'TAG1') classes includes: class).
+	self assert: ((packageDemoted tagNamed: 'TAG1') classes includes: class).
 	self assert: (packageDemoted extensionMethods includes: classOther >> #bar).
 	self assert: (classOther >> #bar) protocolName equals: '*Test1-TAG1'.
 	self assert: (packageDemoted classes includesAll: {
@@ -397,7 +397,7 @@ PackageTest >> testMoveClassToTag [
 
 	self assert: (xPackage includesClass: class).
 	self assert: (xPackage hasTag: #TAG).
-	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
+	self assert: ((xPackage tagNamed: #TAG) includesClass: class).
 
 	yPackage := self ensureYPackage.
 	yTag := yPackage ensureTag: #YTag.
@@ -442,11 +442,11 @@ PackageTest >> testMoveClassToTagName [
 
 	self assert: (xPackage includesClass: class).
 	self assert: (xPackage hasTag: #TAG).
-	self assert: ((xPackage classTagNamed: #TAG) includesClass: class).
+	self assert: ((xPackage tagNamed: #TAG) includesClass: class).
 
 	yPackage := self ensureYPackage.
 	yPackage moveClass: class toTag: #YTag.
-	yTag := yPackage classTagNamed: #YTag.
+	yTag := yPackage tagNamed: #YTag.
 
 	self deny: (xPackage includesClass: class).
 	self assert: (yPackage includesClass: class).

--- a/src/ReleaseTests/ProperPackagesTest.class.st
+++ b/src/ReleaseTests/ProperPackagesTest.class.st
@@ -29,7 +29,7 @@ ProperPackagesTest >> testProperClassTagCasing [
 	| violations |
 	violations := OrderedCollection new.
 	self packageOrganizer packages do: [ :package |
-		package classTags do: [ :classTag | classTag name first isLowercase ifTrue: [ violations add: package -> classTag ] ] ].
+		package tags do: [ :classTag | classTag name first isLowercase ifTrue: [ violations add: package -> classTag ] ] ].
 	self assert: violations isEmpty description: 'Class Tags should be uppercase'
 ]
 

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -140,7 +140,7 @@ ReleaseTest >> testExistingPackageNamesDoesNotContainIllegalCharacters [
 
 	self packageOrganizer packages do: [ :package |
 		self deny: (package name includesAnyOf: illegalCharacters).
-		package classTags do: [ :tag | self deny: (tag name includesAnyOf: illegalCharacters) ] ]
+		package tags do: [ :tag | self deny: (tag name includesAnyOf: illegalCharacters) ] ]
 ]
 
 { #category : 'tests' }

--- a/src/Ring-OldChunkImporter/RingChunkImporter.class.st
+++ b/src/Ring-OldChunkImporter/RingChunkImporter.class.st
@@ -22,7 +22,7 @@ RingChunkImporter class >> example [
 
 	| internalStream |
 	internalStream := (String new: 1000) writeStream.
-	((self packageOrganizer packageNamed: 'Ring-Deprecated-ChunkImporter') classTagNamed: #Base) fileOutOn: internalStream.
+	((self packageOrganizer packageNamed: 'Ring-Deprecated-ChunkImporter') tagNamed: #Base) fileOutOn: internalStream.
 	(self fromStream: internalStream contents readStream) inspect
 ]
 

--- a/src/SystemCommands-PackageCommands/SycPromotePackageFromTagCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycPromotePackageFromTagCommand.class.st
@@ -40,7 +40,7 @@ SycPromotePackageFromTagCommand >> defaultMenuItemName [
 { #category : 'execution' }
 SycPromotePackageFromTagCommand >> execute [
 
-	(package classTagNamed: classTag) promoteAsPackage
+	(package tagNamed: classTag) promoteAsPackage
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
Package tags have different names in the system. During the past months I tried to unify those name little by little and here is a new step.

Most of the time tags have now 3 names:
- tag
- package tag
- class tag

I propose to keep package tag when we are outside the code of the packages because this is what is mostly used. And keep the name "tag" inside the packages since the prefix would be redondant. 

Thus I propose to rename some of the API using ClassTag. This is what is used the less currently