### PR TITLE
Move IR decompilation from Opal to Flashback

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -45,8 +45,8 @@ BaselineOfIDE >> baseline: spec [
 		spec postLoadDoIt: #postload:package:.
 		spec baseline: 'BasicTools' with: [ spec repository: self repository ].
 		spec baseline: 'Athens' with: [ spec repository: self repository ].
-		spec baseline: 'Flashback' with: [ spec repository: self repository ].
 		spec baseline: 'KernelTests' with: [ spec repository: self repository ].
+		spec baseline: 'Flashback' with: [ spec repository: self repository ].
 
 		self
 			load: 'Shift' group: 'shift-tests' spec: spec;

--- a/src/Flashback-Decompiler-Tests/FBIRBytecodeDecompilerTest.class.st
+++ b/src/Flashback-Decompiler-Tests/FBIRBytecodeDecompilerTest.class.st
@@ -1,29 +1,29 @@
 Class {
-	#name : 'OCBytecodeDecompilerTest',
+	#name : 'FBIRBytecodeDecompilerTest',
 	#superclass : 'TestCase',
 	#instVars : [
 		'currentCompiler'
 	],
-	#category : 'OpalCompiler-Tests-Bytecode',
-	#package : 'OpalCompiler-Tests',
+	#category : 'Flashback-Decompiler-Tests-Bytecode',
+	#package : 'Flashback-Decompiler-Tests',
 	#tag : 'Bytecode'
 }
 
 { #category : 'running' }
-OCBytecodeDecompilerTest >> setUp [
+FBIRBytecodeDecompilerTest >> setUp [
 	super setUp.
 	currentCompiler := SmalltalkImage compilerClass.
 	SmalltalkImage compilerClass: OpalCompiler
 ]
 
 { #category : 'running' }
-OCBytecodeDecompilerTest >> tearDown [
+FBIRBytecodeDecompilerTest >> tearDown [
 	SmalltalkImage compilerClass: currentCompiler.
 	super tearDown
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testBugOffset [
+FBIRBytecodeDecompilerTest >> testBugOffset [
 	| iRMethod aCompiledMethod ir method |
 	iRMethod := IRBuilder new
 		addTemps: #(#a #b);
@@ -38,52 +38,52 @@ OCBytecodeDecompilerTest >> testBugOffset [
 ]
 
 { #category : 'tests - examples' }
-OCBytecodeDecompilerTest >> testDecompileBytecodeDecompilerTestClass [
+FBIRBytecodeDecompilerTest >> testDecompileBytecodeDecompilerTestClass [
 	| decompiledIR aCompiledMethod |
 	self class methods
 		do: [ :each |
-			decompiledIR := IRBytecodeDecompiler new decompile: each.
+			decompiledIR := FBIRBytecodeDecompiler new decompile: each.
 			aCompiledMethod := decompiledIR compiledMethod ]
 ]
 
 { #category : 'tests - examples' }
-OCBytecodeDecompilerTest >> testDecompileBytecodeGeneratorTest [
+FBIRBytecodeDecompilerTest >> testDecompileBytecodeGeneratorTest [
 	| decompiledIR aCompiledMethod |
 	OCBytecodeGeneratorTest methods
 		do: [ :each |
-			decompiledIR := IRBytecodeDecompiler new decompile: each.
+			decompiledIR := FBIRBytecodeDecompiler new decompile: each.
 			aCompiledMethod := decompiledIR compiledMethod ]
 ]
 
 { #category : 'tests - examples' }
-OCBytecodeDecompilerTest >> testDecompileIRBuilderTestClass [
+FBIRBytecodeDecompilerTest >> testDecompileIRBuilderTestClass [
 	| decompiledIR aCompiledMethod |
 	IRBuilderTest methods
 		do: [ :each |
-			decompiledIR := IRBytecodeDecompiler new decompile: each.
+			decompiledIR := FBIRBytecodeDecompiler new decompile: each.
 			aCompiledMethod := decompiledIR compiledMethod ]
 ]
 
 { #category : 'tests - examples' }
-OCBytecodeDecompilerTest >> testDecompilerOrderedCollectionDo [
+FBIRBytecodeDecompilerTest >> testDecompilerOrderedCollectionDo [
 	| cm decompiledIR |
 	cm := OrderedCollection >> #do:.
-	decompiledIR := IRBytecodeDecompiler new decompile: cm.
+	decompiledIR := FBIRBytecodeDecompiler new decompile: cm.
 	decompiledIR compiledMethod
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testDup [
+FBIRBytecodeDecompilerTest >> testDup [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testDup.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testInstVar [
+FBIRBytecodeDecompilerTest >> testInstVar [
 	| ir1 ir2 method method2 |
 	ir1 := IRBuilderTest new testInstVar.
 	method := ir1 compiledMethod.
@@ -95,283 +95,283 @@ OCBytecodeDecompilerTest >> testInstVar [
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testJumpAheadTo [
+FBIRBytecodeDecompilerTest >> testJumpAheadTo [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testJumpAheadTo.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testJumpAheadToIf [
+FBIRBytecodeDecompilerTest >> testJumpAheadToIf [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testJumpAheadToIf.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testJumpBackTo [
+FBIRBytecodeDecompilerTest >> testJumpBackTo [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testJumpBackTo.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralArray [
+FBIRBytecodeDecompilerTest >> testLiteralArray [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testLiteralArray.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralBoolean [
+FBIRBytecodeDecompilerTest >> testLiteralBoolean [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testLiteralBoolean.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralCharacter [
+FBIRBytecodeDecompilerTest >> testLiteralCharacter [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testLiteralCharacter.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralFloat [
+FBIRBytecodeDecompilerTest >> testLiteralFloat [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testLiteralFloat.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralInteger [
+FBIRBytecodeDecompilerTest >> testLiteralInteger [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testLiteralInteger.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralNil [
+FBIRBytecodeDecompilerTest >> testLiteralNil [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testLiteralNil.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralString [
+FBIRBytecodeDecompilerTest >> testLiteralString [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testLiteralString.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralSymbol [
+FBIRBytecodeDecompilerTest >> testLiteralSymbol [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testLiteralSymbol.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralVariableClass [
+FBIRBytecodeDecompilerTest >> testLiteralVariableClass [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testLiteralVariableClass.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralVariableClassVariable [
+FBIRBytecodeDecompilerTest >> testLiteralVariableClassVariable [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testLiteralVariableClassVariable.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testLiteralVariableGlobale [
+FBIRBytecodeDecompilerTest >> testLiteralVariableGlobale [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new setUp; testLiteralVariableGlobale.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testPopTop [
+FBIRBytecodeDecompilerTest >> testPopTop [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testPopTop.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testPushConsArray [
+FBIRBytecodeDecompilerTest >> testPushConsArray [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testPushConsArray.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testPushConsArray2 [
+FBIRBytecodeDecompilerTest >> testPushConsArray2 [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testPushConsArray2.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testPushSelf [
+FBIRBytecodeDecompilerTest >> testPushSelf [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testPushSelf.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testPushTempArgument [
+FBIRBytecodeDecompilerTest >> testPushTempArgument [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testPushTempArgument.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testPushTempTemp [
+FBIRBytecodeDecompilerTest >> testPushTempTemp [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testPushTempTemp.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testPushThisContext [
+FBIRBytecodeDecompilerTest >> testPushThisContext [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testPushThisContext.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testReturnTop [
+FBIRBytecodeDecompilerTest >> testReturnTop [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testReturnTop.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testSendSuper [
+FBIRBytecodeDecompilerTest >> testSendSuper [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testSendSuper.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testStoreIntoVariable [
+FBIRBytecodeDecompilerTest >> testStoreIntoVariable [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testStoreIntoVariable.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests' }
-OCBytecodeDecompilerTest >> testStoreTemp [
+FBIRBytecodeDecompilerTest >> testStoreTemp [
 	| ir1 ir2 method |
 	ir1 := IRBuilderTest new testStoreTemp.
 	method := ir1 compiledMethod.
-	ir2 := IRBytecodeDecompiler new decompile: method.
+	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
 	self assert: ir2 compiledMethod symbolic equals: method symbolic.
 	self assert: ir2 compiledMethod equals: method
 ]
 
 { #category : 'tests - examples' }
-OCBytecodeDecompilerTest >> testWhileTrue [
+FBIRBytecodeDecompilerTest >> testWhileTrue [
 	| cm decompiledIR aCompiledMethod |
 	cm := self class >> #testWhileTrue.
-	decompiledIR := IRBytecodeDecompiler new decompile: cm.
+	decompiledIR := FBIRBytecodeDecompiler new decompile: cm.
 	aCompiledMethod := decompiledIR compiledMethod
 ]

--- a/src/Flashback-Decompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/Flashback-Decompiler-Tests/RBCodeSnippetTest.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : 'RBCodeSnippetTest' }
+
+{ #category : '*Flashback-Decompiler-Tests' }
+RBCodeSnippetTest >> testDecompile [
+
+	| method ast |
+	method := snippet compile.
+	method ifNil: [ ^ self skip ]. "Another test responsibility"
+	ast := method decompile.
+	self assert: ast isMethod.
+	ast := method parseTree.
+	self assert: ast isMethod.
+	"Decompilation lose many information. Not sure how to test more"
+]
+
+{ #category : '*Flashback-Decompiler-Tests' }
+RBCodeSnippetTest >> testDecompileIR [
+
+	| method ir |
+	method := snippet compile.
+	method ifNil: [ ^ self skip ]. "Another test responsibility"
+	ir := method decompileIR.
+	self assert: ir class equals: IRMethod.
+	"Decompilation lose information. Not sure how to test more"
+]

--- a/src/Flashback-Decompiler/CompiledMethod.extension.st
+++ b/src/Flashback-Decompiler/CompiledMethod.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'CompiledMethod' }
+
+{ #category : '*Flashback-Decompiler' }
+CompiledMethod >> decompileIR [
+
+	^ FBIRBytecodeDecompiler new decompile: self
+]

--- a/src/Flashback-Decompiler/FBIRBytecodeDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBIRBytecodeDecompiler.class.st
@@ -1,8 +1,10 @@
 "
 I interpret bytecode instructions, sending the appropriate instruction messages to my IRBuilder, resulting in an IRMethod.
+
+My entry point is `CompiledMethod>>#decompileIR`
 "
 Class {
-	#name : 'IRBytecodeDecompiler',
+	#name : 'FBIRBytecodeDecompiler',
 	#superclass : 'InstructionClient',
 	#instVars : [
 		'instructionStream',
@@ -10,24 +12,24 @@ Class {
 		'newTempVector',
 		'scopeStack'
 	],
-	#category : 'OpalCompiler-Core-Bytecode',
-	#package : 'OpalCompiler-Core',
+	#category : 'Flashback-Decompiler-Bytecode',
+	#package : 'Flashback-Decompiler',
 	#tag : 'Bytecode'
 }
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> blockReturnTop [
+FBIRBytecodeDecompiler >> blockReturnTop [
 	self popScope.
 	irBuilder blockReturnTop
 ]
 
 { #category : 'private' }
-IRBytecodeDecompiler >> checkIfJumpTarget [
+FBIRBytecodeDecompiler >> checkIfJumpTarget [
 	irBuilder testJumpAheadTarget: instructionStream pc
 ]
 
 { #category : 'public access' }
-IRBytecodeDecompiler >> decompile: aCompiledMethod [
+FBIRBytecodeDecompiler >> decompile: aCompiledMethod [
 	instructionStream := InstructionStream on: aCompiledMethod.
 	irBuilder := IRReconstructor new.
 	scopeStack := Stack new.
@@ -50,17 +52,17 @@ IRBytecodeDecompiler >> decompile: aCompiledMethod [
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> doDup [
+FBIRBytecodeDecompiler >> doDup [
 	irBuilder pushDup
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> doPop [
+FBIRBytecodeDecompiler >> doPop [
 	irBuilder popTop
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> interpret [
+FBIRBytecodeDecompiler >> interpret [
 	| endPC |
 	endPC := instructionStream method endPC.
 	[instructionStream pc > endPC ]
@@ -71,7 +73,7 @@ IRBytecodeDecompiler >> interpret [
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> jump: dist [
+FBIRBytecodeDecompiler >> jump: dist [
 	| index seq instr newSeq seqs |
 	index := instructionStream pc + dist.
 
@@ -100,7 +102,7 @@ IRBytecodeDecompiler >> jump: dist [
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> jump: dist if: bool [
+FBIRBytecodeDecompiler >> jump: dist if: bool [
 	| index |
 	index := instructionStream pc + dist .
 
@@ -112,24 +114,24 @@ IRBytecodeDecompiler >> jump: dist if: bool [
 ]
 
 { #category : 'private' }
-IRBytecodeDecompiler >> methodClass [
+FBIRBytecodeDecompiler >> methodClass [
 	^ instructionStream  method methodClass
 ]
 
 { #category : 'quick methods' }
-IRBytecodeDecompiler >> methodReturnConstant: value [
+FBIRBytecodeDecompiler >> methodReturnConstant: value [
 	self pushConstant: value.
 	self methodReturnTop
 ]
 
 { #category : 'quick methods' }
-IRBytecodeDecompiler >> methodReturnReceiver [
+FBIRBytecodeDecompiler >> methodReturnReceiver [
 	self pushReceiver.
 	self methodReturnTop
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> methodReturnTop [
+FBIRBytecodeDecompiler >> methodReturnTop [
 	irBuilder isLastClosureInstruction
 		ifTrue: [
 			self popScope.
@@ -140,25 +142,25 @@ IRBytecodeDecompiler >> methodReturnTop [
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> popIntoLiteralVariable: offset [
+FBIRBytecodeDecompiler >> popIntoLiteralVariable: offset [
 	self storeIntoLiteralVariable: offset.
 	self doPop
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> popIntoReceiverVariable: offset [
+FBIRBytecodeDecompiler >> popIntoReceiverVariable: offset [
 	self storeIntoReceiverVariable: offset.
 	self doPop
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
+FBIRBytecodeDecompiler >> popIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex [
 	self storeIntoRemoteTemp: remoteTempIndex inVectorAt: tempVectorIndex.
 	self doPop
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> popIntoTemporaryVariable: offset [
+FBIRBytecodeDecompiler >> popIntoTemporaryVariable: offset [
 	newTempVector
 		ifNil: [
 			self storeIntoTemporaryVariable: offset.
@@ -172,7 +174,7 @@ IRBytecodeDecompiler >> popIntoTemporaryVariable: offset [
 ]
 
 { #category : 'scope' }
-IRBytecodeDecompiler >> popScope [
+FBIRBytecodeDecompiler >> popScope [
 	| scope tempIndex |
 	scope := self scope.
 
@@ -196,22 +198,22 @@ IRBytecodeDecompiler >> popScope [
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> pushActiveContext [
+FBIRBytecodeDecompiler >> pushActiveContext [
 	irBuilder pushThisContext
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> pushConsArrayWithElements: numElements [
+FBIRBytecodeDecompiler >> pushConsArrayWithElements: numElements [
 	irBuilder pushConsArray: numElements
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> pushConstant: value [
+FBIRBytecodeDecompiler >> pushConstant: value [
 	irBuilder pushLiteral: value
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> pushFullClosure: compiledBlock numCopied: numCopied receiverOnStack: receiverOnStack ignoreOuterContext: ignoreOuterContext [
+FBIRBytecodeDecompiler >> pushFullClosure: compiledBlock numCopied: numCopied receiverOnStack: receiverOnStack ignoreOuterContext: ignoreOuterContext [
 
 	| copiedValues |
 
@@ -222,27 +224,27 @@ IRBytecodeDecompiler >> pushFullClosure: compiledBlock numCopied: numCopied rece
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> pushLiteralVariable: assoc [
+FBIRBytecodeDecompiler >> pushLiteralVariable: assoc [
 	irBuilder pushLiteralVariable: assoc
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> pushNewArrayOfSize: size [
+FBIRBytecodeDecompiler >> pushNewArrayOfSize: size [
 	newTempVector := IRRemoteArray new size: size
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> pushReceiver [
+FBIRBytecodeDecompiler >> pushReceiver [
 	irBuilder pushReceiver
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> pushReceiverVariable: offset [
+FBIRBytecodeDecompiler >> pushReceiverVariable: offset [
 	irBuilder pushInstVar: offset + 1
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> pushRemoteTemp: remoteIndex inVectorAt: tempIndex [
+FBIRBytecodeDecompiler >> pushRemoteTemp: remoteIndex inVectorAt: tempIndex [
 	|  remoteArray remoteTempName |
 	remoteArray := self scope tempAt: tempIndex.
 	remoteTempName := self scope tempAt: remoteIndex inRemote: remoteArray.
@@ -250,7 +252,7 @@ IRBytecodeDecompiler >> pushRemoteTemp: remoteIndex inVectorAt: tempIndex [
 ]
 
 { #category : 'scope' }
-IRBytecodeDecompiler >> pushScope: copiedValues numArgs: numArgs [
+FBIRBytecodeDecompiler >> pushScope: copiedValues numArgs: numArgs [
 	|scope |
 	scope := IRBytecodeScope new numArgs: numArgs.
 	scopeStack push: scope.
@@ -258,12 +260,12 @@ IRBytecodeDecompiler >> pushScope: copiedValues numArgs: numArgs [
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> pushTemporaryVariable: offset [
+FBIRBytecodeDecompiler >> pushTemporaryVariable: offset [
 	irBuilder pushTemp: (self scope tempAt: offset)
 ]
 
 { #category : 'quick methods' }
-IRBytecodeDecompiler >> quickMethod [
+FBIRBytecodeDecompiler >> quickMethod [
 
 	instructionStream method primitive = 256 ifTrue: [
 		^ self methodReturnReceiver
@@ -279,29 +281,29 @@ IRBytecodeDecompiler >> quickMethod [
 ]
 
 { #category : 'scope' }
-IRBytecodeDecompiler >> scope [
+FBIRBytecodeDecompiler >> scope [
 	^ scopeStack top
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> send: selector super: superFlag numArgs: numArgs [
+FBIRBytecodeDecompiler >> send: selector super: superFlag numArgs: numArgs [
 	superFlag
 		ifTrue: [irBuilder send: selector toSuperOf: self methodClass]
 		ifFalse: [irBuilder send: selector]
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> storeIntoLiteralVariable: value [
+FBIRBytecodeDecompiler >> storeIntoLiteralVariable: value [
 	irBuilder storeIntoLiteralVariable: value
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> storeIntoReceiverVariable: offset [
+FBIRBytecodeDecompiler >> storeIntoReceiverVariable: offset [
 	irBuilder storeInstVar: offset + 1
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> storeIntoRemoteTemp: remoteIndex inVectorAt: tempIndex [
+FBIRBytecodeDecompiler >> storeIntoRemoteTemp: remoteIndex inVectorAt: tempIndex [
 	|  remoteArray remoteTempName |
 	remoteArray := self scope tempAt: tempIndex.
 	remoteTempName := self scope tempAt: remoteIndex inRemote: remoteArray.
@@ -309,6 +311,6 @@ IRBytecodeDecompiler >> storeIntoRemoteTemp: remoteIndex inVectorAt: tempIndex [
 ]
 
 { #category : 'instruction decoding' }
-IRBytecodeDecompiler >> storeIntoTemporaryVariable: offset [
+FBIRBytecodeDecompiler >> storeIntoTemporaryVariable: offset [
 	irBuilder storeTemp: (self scope tempAt: offset)
 ]

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -10,12 +10,6 @@ CompiledMethod >> decompile [
 ]
 
 { #category : '*OpalCompiler-Core' }
-CompiledMethod >> decompileIR [
-
-	^ IRBytecodeDecompiler new decompile: self
-]
-
-{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> lookupVar: aString [
 	^self ast scope lookupVar: aString
 ]

--- a/src/OpalCompiler-Tests/OCBytecodeDecompilerExamplesTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeDecompilerExamplesTest.class.st
@@ -14,7 +14,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleBlockArgument [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -30,7 +30,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleBlockExternal [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -46,7 +46,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleBlockExternal2 [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -62,7 +62,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleBlockExternalArg [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -78,7 +78,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleBlockExternalNested [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -94,7 +94,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleBlockInternal [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -110,7 +110,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleBlockNested [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -126,7 +126,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleEmptyMethod [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -142,7 +142,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleIfFalse [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -158,7 +158,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleIfFalseIfTrue [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -174,7 +174,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleIfIfNotNilReturnNil [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -190,7 +190,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleIfNotNilArg [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -205,7 +205,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleIfTrue [
 	method := (OCOpalExamples >> #exampleIfTrue) parseTree generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -221,7 +221,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleIfTrueIfFalse [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -237,7 +237,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleMethodTempInNestedBlock [
 		          parseTree generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -253,7 +253,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleMethodWithOptimizedBlocksA [
 		          parseTree generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -269,7 +269,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleNestedBlockScoping [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -285,7 +285,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleNewArray [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -301,7 +301,7 @@ OCBytecodeDecompilerExamplesTest >> testExamplePushArray [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -317,7 +317,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleReturn1 [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -333,7 +333,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleReturn1plus2 [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -348,7 +348,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSelf [
 	method := (OCOpalExamples >> #exampleSelf) parseTree generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -364,7 +364,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlock [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -381,7 +381,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockArgument1 [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -397,7 +397,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockArgument2 [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -413,7 +413,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockArgument3 [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -429,7 +429,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockArgument4 [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -445,7 +445,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockArgument5 [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -461,7 +461,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockEmpty [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -477,7 +477,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockLocal [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -493,7 +493,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockLocalIf [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -509,7 +509,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockLocalNested [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -525,7 +525,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockLocalWhile [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -541,7 +541,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockNested [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -557,7 +557,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockReturn [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -573,7 +573,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSimpleBlockiVar [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -588,7 +588,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleSuper [
 	method := (OCOpalExamples >> #exampleSuper) parseTree generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -603,7 +603,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleThisContext [
 	method := (OCOpalExamples >> #exampleThisContext) parseTree
 		          generateMethod.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	instance := OCOpalExamples new.
@@ -620,7 +620,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleToDoArgument [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -636,7 +636,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleToDoArgumentNotInlined [
 		          parseTree generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -652,7 +652,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleToDoInsideTemp [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -668,7 +668,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleToDoInsideTempNotInlined [
 		          parseTree generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -684,7 +684,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleToDoOutsideTemp [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -700,7 +700,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleToDoOutsideTempNotInlined [
 		          parseTree generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -716,7 +716,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleToDoValue [
 		          generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -731,7 +731,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleWhileModificationAfterNotInlined 
 	method := (OCOpalExamples >> #exampleWhileModificationAfterNotInlined)
 		          parseTree generateMethod.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -748,7 +748,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleWhileModificationBefore [
 		          parseTree generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -764,7 +764,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleWhileModificationBeforeNotInlined
 	           >> #exampleWhileModificationBeforeNotInlined) parseTree
 		          generateMethod.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -780,7 +780,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleWhileWithTemp [
 	method := (OCOpalExamples >> #exampleWhileWithTemp) parseTree
 		          generateMethod.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -796,7 +796,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleWhileWithTempNotInlined [
 	method := (OCOpalExamples >> #exampleWhileWithTempNotInlined)
 		          parseTree generateMethod.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self
@@ -812,7 +812,7 @@ OCBytecodeDecompilerExamplesTest >> testExampleiVar [
 	method := (OCOpalExamples >> #exampleiVar) parseTree generateMethod.
 	instance := OCOpalExamples new.
 
-	ir := IRBytecodeDecompiler new decompile: method.
+	ir := FBIRBytecodeDecompiler new decompile: method.
 	newMethod := ir compiledMethod.
 
 	self

--- a/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
+++ b/src/OpalCompiler-Tests/RBCodeSnippetTest.extension.st
@@ -137,30 +137,6 @@ RBCodeSnippetTest >> testCompileWithRequestor [
 ]
 
 { #category : '*OpalCompiler-Tests' }
-RBCodeSnippetTest >> testDecompile [
-
-	| method ast |
-	method := snippet compile.
-	method ifNil: [ ^ self skip ]. "Another test responsibility"
-	ast := method decompile.
-	self assert: ast isMethod.
-	ast := method parseTree.
-	self assert: ast isMethod.
-	"Decompilation lose many information. Not sure how to test more"
-]
-
-{ #category : '*OpalCompiler-Tests' }
-RBCodeSnippetTest >> testDecompileIR [
-
-	| method ir |
-	method := snippet compile.
-	method ifNil: [ ^ self skip ]. "Another test responsibility"
-	ir := method decompileIR.
-	self assert: ir class equals: IRMethod.
-	"Decompilation lose information. Not sure how to test more"
-]
-
-{ #category : '*OpalCompiler-Tests' }
 RBCodeSnippetTest >> testDoSemanticAnalysis [
 	"We should test more than that"
 


### PR DESCRIPTION
Because this is a decompiler, it should not be in the compiler but in the decompiler.

I also improved the class comment to add the entry point