### PR TITLE
Packages: Add pre and post unload hooks + fix bug in manifest

### DIFF
--- a/src/Deprecated12/TheManifestBuilder.extension.st
+++ b/src/Deprecated12/TheManifestBuilder.extension.st
@@ -3,12 +3,6 @@ Extension { #name : 'TheManifestBuilder' }
 { #category : '*Deprecated12' }
 TheManifestBuilder class >> ofPackageNamed: aPackageName [
 
-	| builder |
 	self deprecated: 'Call #ofPackage: instead because the only senders of this method is in NewTools and has the package directly.'.
-	builder := self new.
-	self allManifestClasses
-		detect: [ :each | each package name = aPackageName ]
-		ifFound: [ :manifestClass | builder manifestClass: manifestClass ]
-		ifNone: [ builder createManifestNamed: aPackageName ].
-	^ builder
+	^ self ofPackage: (self packageOrganizer packageNamed: aPackageName)
 ]

--- a/src/Kernel/Package.class.st
+++ b/src/Kernel/Package.class.st
@@ -645,6 +645,7 @@ Package >> removeFromSystem [
 
 	self organizer unregisterPackage: self.
 
+	"Now that the package is removed we can execute the potential postLoad. Since the class is already removed, we saved the method to execute earlier and we execute it now."
 	postUnloadMethod ifNotNil: [ :method | method valueWithReceiver: method methodClass ]
 ]
 

--- a/src/Kernel/Package.class.st
+++ b/src/Kernel/Package.class.st
@@ -634,10 +634,18 @@ Package >> removeEmptyTags [
 Package >> removeFromSystem [
 	"Copy to not remove collection over which we are iterating."
 
+	| postUnloadMethod |
+	"In case the package manifest is here, make sure we execute the preUnload and postUnload metods before and after the unloading."
+	self packageManifestOrNil ifNotNil: [ :manifest |
+		postUnloadMethod := manifest class lookupSelector: #postUnload.
+		manifest preUnload ].
+
 	self classTags copy do: [ :tag | tag removeFromSystem ].
 	self extensionMethods do: [ :method | method removeFromSystem ].
 
-	self organizer unregisterPackage: self
+	self organizer unregisterPackage: self.
+
+	postUnloadMethod ifNotNil: [ :method | method valueWithReceiver: method methodClass ]
 ]
 
 { #category : 'add method - compiled method' }

--- a/src/Kernel/PackageManifest.class.st
+++ b/src/Kernel/PackageManifest.class.st
@@ -47,17 +47,27 @@ PackageManifest class >> manuallyResolvedDependencies [
 ]
 
 { #category : 'unloading' }
+PackageManifest class >> postUnload [
+	"Override this method to specify clean-up actions that should be done after package unloading."
+
+	self postUnloadAction ifNotNil: [ :block |
+		Warning signal:
+			'#postUnloadAction should be replaced by #postUnload doing the actual action instead of returning a block. This branch should be removed in Pharo 13 to keep only the empty post unload method.'.
+		block value ]
+]
+
+{ #category : 'unloading' }
 PackageManifest class >> postUnloadAction [
+	"This method should not be overriden and should be removed in Pharo 13"
 
-	"override to return block that will be executed after the package unloading. Keep in mind that all package classes are already removed from the system including the manifest class"
-
-	^ [ "do nothing" ]
+	^ nil
 ]
 
 { #category : 'unloading' }
 PackageManifest class >> preUnload [
+	"Override this method to specify clean-up actions that should be done before package unloading."
 
-	"override this method to specify clean-up actions that should be done before package unloading."
+	
 ]
 
 { #category : 'code-critics' }

--- a/src/Manifest-Core/Package.extension.st
+++ b/src/Manifest-Core/Package.extension.st
@@ -21,7 +21,6 @@ Package >> packageComment: aDescription [
 
 { #category : '*Manifest-Core' }
 Package >> packageManifest [
-	^ self definedClasses
-		detect: [ :each | each isManifest ]
-		ifNone: [ TheManifestBuilder new createManifestNamed: self name]
+
+	^ TheManifestBuilder ofPackage: self
 ]

--- a/src/Manifest-Core/TheManifestBuilder.class.st
+++ b/src/Manifest-Core/TheManifestBuilder.class.st
@@ -76,13 +76,9 @@ TheManifestBuilder class >> manifestTag [
 ]
 
 { #category : 'instance creation' }
-TheManifestBuilder class >> of: aItem [
-	| mb  |
+TheManifestBuilder class >> of: anItem [
 
-	mb := self new.
-	(mb manifestOf: aItem)
-			ifNil: [mb createManifestOf: aItem].
-	^ mb
+	^ self ofPackage: anItem package
 ]
 
 { #category : 'instance creation' }
@@ -90,11 +86,10 @@ TheManifestBuilder class >> ofPackage: aPackage [
 
 	| builder |
 	builder := self new.
-	self allManifestClasses
-		detect: [ :each | each package = aPackage ]
-		ifFound: [ :manifestClass | builder manifestClass: manifestClass ]
-		ifNone: [ builder createManifestNamed: aPackage name ].
-	^ builder
+	^ self allManifestClasses
+		  detect: [ :each | each package = aPackage ]
+		  ifFound: [ :manifestClass | builder manifestClass: manifestClass ]
+		  ifNone: [ builder createManifestOf: aPackage ]
 ]
 
 { #category : 'accessing - tags' }
@@ -328,23 +323,16 @@ TheManifestBuilder >> containsTruePositive: aItem onRule: ruleId version: versio
 ]
 
 { #category : 'manifest' }
-TheManifestBuilder >> createManifestNamed: packageName [
+TheManifestBuilder >> createManifestOf: aPackage [
 
-	manifestClass := self class classInstaller make: [ :aBuilder |
-		aBuilder name: (self class manifestClassNameFor: packageName);
-			superclass: PackageManifest;
-			package: packageName ].
-
-	manifestClass
-		packageTag: self class manifestTag;
-		comment: self class manifestClassComment.
-	^ manifestClass
-]
-
-{ #category : 'manifest' }
-TheManifestBuilder >> createManifestOf: elem [
-
-	self createManifestNamed: (self packageNameOf: elem)
+	^ manifestClass := self class classInstaller make: [ :aBuilder |
+		                   aBuilder
+			                   name: (self class manifestClassNameFor: aPackage name);
+			                   superclass: PackageManifest;
+			                   installingEnvironment: aPackage environment;
+			                   package: aPackage name;
+			                   tag: self class manifestTag;
+			                   comment: self class manifestClassComment ]
 ]
 
 { #category : 'private' }

--- a/src/Manifest-Tests/BuilderManifestTest.class.st
+++ b/src/Manifest-Tests/BuilderManifestTest.class.st
@@ -204,19 +204,6 @@ BuilderManifestTest >> testContainsToDo [
 ]
 
 { #category : 'tests' }
-BuilderManifestTest >> testCreationManifest [
-
-	manifestBuilder := TheManifestBuilder new.
-	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class |
-		class
-			removeFromChanges;
-			removeFromSystem ].
-	self assert: (manifestBuilder manifestOf: MFClassA) isNil.
-	self assert: (manifestBuilder createManifestOf: MFClassA) isNotNil.
-	self assert: (manifestBuilder manifestOf: MFClassA) isNotNil
-]
-
-{ #category : 'tests' }
 BuilderManifestTest >> testCreationManifestOn [
 
 	manifestBuilder := TheManifestBuilder new.

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -581,18 +581,11 @@ MCWorkingCopy >> uniqueVersionNameIn: aRepository [
 
 { #category : 'operations' }
 MCWorkingCopy >> unload [
-	"Unloads mcpackage, rpackage, classes and method extensions from this working copy"
+	"Unloads mcpackage, package, classes and method extensions from this working copy"
 
-	| postUnloadAction |
-	postUnloadAction := [  ].
-	self systemPackage ifNotNil: [ :aPackage |
-		aPackage packageManifestOrNil ifNotNil: [ :manifest |
-			postUnloadAction := manifest postUnloadAction.
-			manifest preUnload ] ].
 	MCPackageLoader unloadPackage: self package.
 	self systemPackage ifNotNil: [ :aPackage | aPackage removeFromSystem ].
-	self unregister.
-	postUnloadAction value
+	self unregister
 ]
 
 { #category : 'operations' }

--- a/src/RPackage-Tests/PackageOrganizerTest.class.st
+++ b/src/RPackage-Tests/PackageOrganizerTest.class.st
@@ -359,7 +359,6 @@ PackageOrganizerTest >> testRemoveEmptyPackagesAndTags [
 PackageOrganizerTest >> testRemovePackage [
 
 	| xPackage yPackage zPackage a1 a2 b1 b2 a3 |
-	"taken from setup of RPackageReadOnlyCompleteSetup"
 	xPackage := self ensureXPackage.
 	yPackage := self ensureYPackage.
 	zPackage := self ensureZPackage.
@@ -387,6 +386,60 @@ PackageOrganizerTest >> testRemovePackage [
 	self deny: (self organizer packageOf: b1) isNil.
 	self deny: (self organizer packageOf: b2) isNil.
 	self deny: (self organizer packageOf: a3) isNil
+]
+
+{ #category : 'tests' }
+PackageOrganizerTest >> testRemovePackageLaunchClassUnloadHook [
+
+	| xPackage a1 |
+	xPackage := self ensureXPackage.
+
+	a1 := self newClassNamed: #A1DefinedInX in: xPackage.
+
+	a1 compile: 'methodDefinedInP1 ^ #methodDefinedInP1'.
+	a1 class compile: 'unload self packageOrganizer ensurePackage: #Generated'.
+
+	self organizer removePackage: xPackage.
+
+	self deny: (self organizer packageOf: a1) isNil.
+	self deny: (self organizer hasPackage: self xPackageName).
+	self assert: (self organizer hasPackage: #Generated)
+]
+
+{ #category : 'tests' }
+PackageOrganizerTest >> testRemovePackageLaunchPackagePostUnloadHook [
+
+	| xPackage |
+	xPackage := self ensureXPackage.
+
+	xPackage packageManifest class compile:
+		('postUnload (self packageOrganizer hasPackage: ''{1}'') ifFalse: [ self packageOrganizer ensurePackage: #Generated ]' format: { self xPackageName }).
+
+	self assert: (self organizer hasPackage: self xPackageName).
+	self deny: (self organizer hasPackage: #Generated).
+
+	self organizer removePackage: xPackage.
+
+	self deny: (self organizer hasPackage: self xPackageName).
+	self assert: (self organizer hasPackage: #Generated)
+]
+
+{ #category : 'tests' }
+PackageOrganizerTest >> testRemovePackageLaunchPackagePreUnloadHook [
+
+	| xPackage |
+	xPackage := self ensureXPackage.
+
+	xPackage packageManifest class compile:
+		('preUnload (self packageOrganizer hasPackage: ''{1}'') ifTrue: [ self packageOrganizer ensurePackage: #Generated ]' format: { self xPackageName }).
+
+	self assert: (self organizer hasPackage: self xPackageName).
+	self deny: (self organizer hasPackage: #Generated).
+
+	self organizer removePackage: xPackage.
+
+	self deny: (self organizer hasPackage: self xPackageName).
+	self assert: (self organizer hasPackage: #Generated)
 ]
 
 { #category : 'tests' }

--- a/src/RPackage-Tests/PackageTest.class.st
+++ b/src/RPackage-Tests/PackageTest.class.st
@@ -456,6 +456,17 @@ PackageTest >> testMoveClassToTagName [
 	self assert: class packageTag package equals: yPackage
 ]
 
+{ #category : 'tests' }
+PackageTest >> testPackageManifestIsInTheRightEnvironment [
+
+	| xPackage manifest |
+	xPackage := self ensureXPackage.
+
+	manifest := xPackage packageManifest.
+
+	self assert: xPackage environment identicalTo: manifest environment
+]
+
 { #category : 'tests - properties' }
 PackageTest >> testPropertyAtPut [
 


### PR DESCRIPTION
This change impacts multiple things:
- Move the concept of pre/post unload hooks from Monticello to Packages. With this, the code will not be executed only if you do #unload on a MCPackage but also if you remove a Package from the system. (with tests)
- Transform #postLoadAction to #postLoad that execute directly the unload code instead of returning a block 
- Fix bug in PackageManifest were the manifest was generated in the global environment even for packages that were in another environment (with test)

Fixes #14617
Fixes #14073