### PR TITLE
15592-MNU-when-looking-for-the-writers-of-a-shared-pool-variable

### DIFF
--- a/src/Kernel/CleanBlockClosure.class.st
+++ b/src/Kernel/CleanBlockClosure.class.st
@@ -153,3 +153,9 @@ CleanBlockClosure >> writesField: varIndex [
 	"Clean blocks by definition do not read fields"
 	^false
 ]
+
+{ #category : 'scanning' }
+CleanBlockClosure >> writesRef: literalAssociation [
+	"Clean blocks can access Literal Variables"
+	^self compiledBlock writesRef: literalAssociation
+]

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -58,7 +58,10 @@ ClassVariableTest >> testNotReadInMethod [
 { #category : 'tests - properties' }
 ClassVariableTest >> testNotWrittenInMethodWhenItIsOnlyRead [
 
+	| constantlockForTest |
 	DefaultTimeLimit printString. "reading class variable".
+	"add a clean block to check that is works"
+	constantlockForTest := [  ].
 
 	self deny: ((TestCase classVariableNamed: #DefaultTimeLimit) isWrittenIn: self class >> testSelector)
 ]


### PR DESCRIPTION

fixes #15592
Add a test via testNotWrittenInMethodWhenItIsOnlyRead (which uses #writesRef:)