### PR TITLE
Bootstrap: Remove Network-UUID from KernelGroup

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -156,7 +156,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}
 echo $(date -u) "[Compiler] Initializing Unicode"
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/02-initUnicode.st --no-source --save --quit "${BOOTSTRAP_REPOSITORY}/resources/unicode/"
 
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Network-UUID.hermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "PharoBootstrapInitialization initializeFileSystem"
 zip "${COMPILER_IMAGE_NAME}.zip" "${COMPILER_IMAGE_NAME}.image"
 

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -164,7 +164,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'Hermes'.
 			'Kernel'.
 			'Kernel-BytecodeEncoders'.
-			'Network-UUID'.
 			'Transcript-NonInteractive'.
 			'PharoBootstrap-Initialization'.
 			'Random-Core'.
@@ -212,6 +211,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'OpalCompiler-Core'}.
 		
 		spec group: 'FileSystemGroup' with: {
+			'Network-UUID'.
 			'FileSystem-Core'.
 			'FileSystem-Disk'}.
 

--- a/src/System-SessionManager/WorkingSession.class.st
+++ b/src/System-SessionManager/WorkingSession.class.st
@@ -11,7 +11,6 @@ Class {
 	#instVars : [
 		'manager',
 		'deferredStartupActions',
-		'id',
 		'creationTime',
 		'properties'
 	],
@@ -59,11 +58,6 @@ WorkingSession >> executeDeferredStartupActions: resuming [
 			action cull: resuming
 			"We do not handle errors on deferred startup actions as there is already the environment ready to use.
 			The current UI manager will handle the error." ]
-]
-
-{ #category : 'accessing' }
-WorkingSession >> id [
-	^ id ifNil: [ id := UUID new ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
Remove unused #id method of WorkingSession that was using Network-UUID. With this done, we can postpone the loading of Network-UUID to be loaded by Hermes right before FileSystem-Core. 

With this we should be able to extract more things from the kernel group (loaded by espell) but when I tried I got weird errors so I'll do that later.