### PR TITLE
15345-Classes-with-shared-pools-cannot-be-created 

### DIFF
--- a/src/Shift-ClassBuilder-Tests/ShiftClassBuilderTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShiftClassBuilderTest.class.st
@@ -350,7 +350,7 @@ ShiftClassBuilderTest >> testFillShiftClassBuilder [
 	self assert: builder superclass equals: Object.
 	self assert: builder name equals: #Point2.
 	self assert: builder slots size equals: 2.
-	self assert: builder sharedPools equals: { ChronologyConstants }.
+	self assert: builder sharedPools equals: { #ChronologyConstants }.
 	self assert: builder package equals: self packageNameForTest.
 	self assert: builder tag equals: #Mafia
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -560,12 +560,14 @@ ShiftClassBuilder >> sharedPools [
 ]
 
 { #category : 'accessing' }
-ShiftClassBuilder >> sharedPools: anObject [
-	"The paramter can be either a collection of symbols or a string that should be converted into a collection of symbols."
-
-	self layoutDefinition sharedPools: (anObject isString
-			 ifTrue: [ (anObject substrings: ' ') collect: [ :e | e asSymbol ] ]
-			 ifFalse: [ anObject ])
+ShiftClassBuilder >> sharedPools: aCollectionOrString [
+	"The paramter can be either a collection of symbols or a string that should be converted into a collection of symbols, or a Class where we get the name"
+	| pools |
+	pools := aCollectionOrString isString
+			 ifTrue: [ (aCollectionOrString substrings: ' ') collect: [ :e | e asSymbol ] ]
+			 ifFalse: [ aCollectionOrString collect: [ :each | each isSymbol ifFalse: [ each name ] ifTrue: [ each ] ].	 ].
+	
+	self layoutDefinition sharedPools: pools.
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This fixes #sharedPools: of the ClassBuilder to be able to accept a collection if globals in addition to a string and a collection of names of pools.

We have to clean this for real later.

fixes #15345