### PR TITLE
Repackage some ByteArray methods

### DIFF
--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -49,10 +49,40 @@ ByteArray >> asByteArray [
 	^ self
 ]
 
+{ #category : 'converting' }
+ByteArray >> asByteArrayOfSize: size [
+	"
+		'34523' asByteArray asByteArrayOfSize: 100.
+
+	(((
+		| repeats bytes |
+		repeats := 1000000.
+		bytes := '123456789123456789123456789123456789123456789123456789' asByteArray.
+		 [repeats timesRepeat: (bytes asByteArrayOfSize: 1024) ] timeToRun.
+	)))"
+
+	| bytes |
+	size < self size
+		ifTrue: [^ self error: 'bytearray bigger than ', size asString].
+	bytes := self asByteArray.
+	^ (ByteArray new: (size - bytes size)), bytes
+]
+
 { #category : 'private' }
 ByteArray >> asByteArrayPointer [
 	"Return a ByteArray describing a pointer to the contents of the receiver."
 	^self shouldNotImplement
+]
+
+{ #category : 'converting' }
+ByteArray >> asInteger [
+	"Convert me to an Integer, network byte order, most significant byte first, big endian"
+
+	| integer |
+	integer := 0.
+	self withIndexDo: [ :each :index |
+		integer := integer + (each bitShift: (self size - index) * 8) ].
+	^ integer
 ]
 
 { #category : 'converting' }
@@ -75,6 +105,20 @@ ByteArray >> atAllPut: value [
 
 	<primitive: 145>
 	super atAllPut: value
+]
+
+{ #category : 'bit manipulation' }
+ByteArray >> bitXor: aByteArray [
+	| answer |
+	answer := self copy.
+	1
+		to: (self size min: aByteArray size)
+		do:
+			[ :each |
+			answer
+				at: each
+				put: ((self at: each) bitXor: (aByteArray at: each)) ].
+	^ answer
 ]
 
 { #category : 'accessing' }

--- a/src/System-Hashing/ByteArray.extension.st
+++ b/src/System-Hashing/ByteArray.extension.st
@@ -1,50 +1,6 @@
 Extension { #name : 'ByteArray' }
 
 { #category : '*System-Hashing-Core' }
-ByteArray >> asByteArrayOfSize: size [
-	"
-		'34523' asByteArray asByteArrayOfSize: 100.
-
-	(((
-		| repeats bytes |
-		repeats := 1000000.
-		bytes := '123456789123456789123456789123456789123456789123456789' asByteArray.
-		 [repeats timesRepeat: (bytes asByteArrayOfSize: 1024) ] timeToRun.
-	)))"
-
-	| bytes |
-	size < self size
-		ifTrue: [^ self error: 'bytearray bigger than ', size asString].
-	bytes := self asByteArray.
-	^ (ByteArray new: (size - bytes size)), bytes
-]
-
-{ #category : '*System-Hashing-Core' }
-ByteArray >> asInteger [
-	"Convert me to an Integer, network byte order, most significant byte first, big endian"
-
-	| integer |
-	integer := 0.
-	self withIndexDo: [ :each :index |
-		integer := integer + (each bitShift: (self size - index) * 8) ].
-	^ integer
-]
-
-{ #category : '*System-Hashing-Core' }
-ByteArray >> bitXor: aByteArray [
-	| answer |
-	answer := self copy.
-	1
-		to: (self size min: aByteArray size)
-		do:
-			[ :each |
-			answer
-				at: each
-				put: ((self at: each) bitXor: (aByteArray at: each)) ].
-	^ answer
-]
-
-{ #category : '*System-Hashing-Core' }
 ByteArray >> destroy [
 	1 to: self size do:
 		[ : x |


### PR DESCRIPTION
A few methods of ByteArray are packaged in System-Hashing but they are nice even without the hashing algorithm. I propose to move them directly in ByteArray. This might help me to remove some things from the kernel group of the bootstrap.