### PR TITLE
10612-Add-visitPragmasNodes-as-we-have-visitTemporaryNodes

### DIFF
--- a/src/AST-Core/RBProgramNodeVisitor.class.st
+++ b/src/AST-Core/RBProgramNodeVisitor.class.st
@@ -141,7 +141,7 @@ RBProgramNodeVisitor >> visitMessageNode: aMessageNode [
 { #category : 'visiting' }
 RBProgramNodeVisitor >> visitMethodNode: aMethodNode [
 	self visitArgumentNodes: aMethodNode arguments.
-	aMethodNode pragmas do: [ :each | self visitNode: each ].
+	self visitPragmaNodes: aMethodNode pragmas.
 	self visitNode: aMethodNode body
 ]
 
@@ -170,6 +170,12 @@ RBProgramNodeVisitor >> visitPatternWrapperBlockNode: aRBPatternWrapperBlockNode
 { #category : 'visiting' }
 RBProgramNodeVisitor >> visitPragmaNode: aPragmaNode [
 	aPragmaNode arguments do: [ :each | self visitNode: each ]
+]
+
+{ #category : 'visiting' }
+RBProgramNodeVisitor >> visitPragmaNodes: aNodeCollection [
+	"Sent *once* when visiting a method node"
+	^ aNodeCollection do: [ :each | self visitPragmaNode: each ].
 ]
 
 { #category : 'visiting' }


### PR DESCRIPTION
This changes visitMethodNode: to work the same for pragmas as it works for arguments: we provide a method #visitPragmaNodes: that can be overridden if you want to visit all pragmas once, not every pragma each. (like we have #visitArgumentNodes:)

	
fixes #10612