### PR TITLE
Clean up the Undeclared in ClassFactoryForTestCase when we clean up

### DIFF
--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -116,7 +116,7 @@ ClassFactoryForTestCase >> delete: aBehavior [
 			aBehavior removeFromSystemUnlogged ]
 		ifFalse: [ aBehavior removeFromSystem ].
 	"We know that we can remove the key from Undeclared, as it was added by #removeFromSystem"
-	Undeclared removeKey: name
+	Undeclared removeKey: name ifAbsent: [ "might be an anonymous class" ]
 ]
 
 { #category : 'cleaning' }

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -105,15 +105,18 @@ ClassFactoryForTestCase >> defaultSuperclass [
 
 { #category : 'cleaning' }
 ClassFactoryForTestCase >> delete: aBehavior [
-
+	| name |
 	createdBehaviors remove: aBehavior ifAbsent: [  ].
 	aBehavior isObsolete ifTrue: [ ^ self ].
+	name := aBehavior name. "save it as it will be obsolete later"
 	self class environment at: #ChangeSet ifPresent: [ :changeSet | changeSet current removeClassAndMetaClassChanges: aBehavior ].
 	(createdSilently includes: aBehavior)
 		ifTrue: [
 			createdSilently remove: aBehavior.
 			aBehavior removeFromSystemUnlogged ]
-		ifFalse: [ aBehavior removeFromSystem ]
+		ifFalse: [ aBehavior removeFromSystem ].
+	"We know that we can remove the key from Undeclared, as it was added by #removeFromSystem"
+	Undeclared removeKey: name
 ]
 
 { #category : 'cleaning' }


### PR DESCRIPTION
I want later to have the Undeclared handling working in a way that this is not needed. As this now references Undeclared, we will naturally check it later when we clean up how undeclareds are managed.

fixes  #15552