### PR TITLE
Bootstrap: Load System-Hashing and Random-Core later in the bootstrap

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -156,7 +156,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}
 echo $(date -u) "[Compiler] Initializing Unicode"
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/02-initUnicode.st --no-source --save --quit "${BOOTSTRAP_REPOSITORY}/resources/unicode/"
 
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes System-Hashing.hermes Network-UUID.hermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Random-Core.hermes System-Hashing.hermes Network-UUID.hermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "PharoBootstrapInitialization initializeFileSystem"
 zip "${COMPILER_IMAGE_NAME}.zip" "${COMPILER_IMAGE_NAME}.image"
 

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -138,7 +138,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" # I have to run once the image so the next 
 
 echo $(date -u) "[Compiler] Adding more Kernel packages"
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Hermes-Extensions.hermes --save
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes System-Hashing.hermes Math-Operations-Extensions.hermes Debugging-Core.hermes Kernel-Chronology-Extras.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Math-Operations-Extensions.hermes Debugging-Core.hermes Kernel-Chronology-Extras.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes --save --no-fail-on-undeclared
 
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes InitializePackagesCommandLineHandler.hermes --save
 
@@ -156,7 +156,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}
 echo $(date -u) "[Compiler] Initializing Unicode"
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/02-initUnicode.st --no-source --save --quit "${BOOTSTRAP_REPOSITORY}/resources/unicode/"
 
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Network-UUID.hermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes System-Hashing.hermes Network-UUID.hermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "PharoBootstrapInitialization initializeFileSystem"
 zip "${COMPILER_IMAGE_NAME}.zip" "${COMPILER_IMAGE_NAME}.image"
 

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -138,7 +138,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" # I have to run once the image so the next 
 
 echo $(date -u) "[Compiler] Adding more Kernel packages"
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Hermes-Extensions.hermes --save
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Math-Operations-Extensions.hermes Debugging-Core.hermes Kernel-Chronology-Extras.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes System-Hashing.hermes Math-Operations-Extensions.hermes Debugging-Core.hermes Kernel-Chronology-Extras.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes --save --no-fail-on-undeclared
 
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes InitializePackagesCommandLineHandler.hermes --save
 

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -188,7 +188,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		"These packages are added using hermes after bootstrap"
 
 		spec group: 'AdditionalPackages' with: {
-			'System-Hashing'.
 			'ReflectionMirrors-Primitives'.
 			'InitializePackagesCommandLineHandler'.
 			'Kernel-Chronology-Extras'.
@@ -211,6 +210,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'OpalCompiler-Core'}.
 		
 		spec group: 'FileSystemGroup' with: {
+			'System-Hashing'.
 			'Network-UUID'.
 			'FileSystem-Core'.
 			'FileSystem-Disk'}.

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -166,7 +166,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'Kernel-BytecodeEncoders'.
 			'Transcript-NonInteractive'.
 			'PharoBootstrap-Initialization'.
-			'Random-Core'.
 			'Shift-Changes'.
 			'Shift-ClassBuilder'.
 			'Shift-ClassInstaller'.
@@ -210,6 +209,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'OpalCompiler-Core'}.
 		
 		spec group: 'FileSystemGroup' with: {
+			'Random-Core'.
 			'System-Hashing'.
 			'Network-UUID'.
 			'FileSystem-Core'.

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -176,7 +176,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'System-CommandLine'.
 			'System-CommandLineHandler'.
 			'System-Finalization'.
-			'System-Hashing'.
 			'System-Platforms'.
 			'System-SessionManager'.
 			'System-Sources'.
@@ -189,6 +188,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		"These packages are added using hermes after bootstrap"
 
 		spec group: 'AdditionalPackages' with: {
+			'System-Hashing'.
 			'ReflectionMirrors-Primitives'.
 			'InitializePackagesCommandLineHandler'.
 			'Kernel-Chronology-Extras'.

--- a/src/System-BasicCommandLineHandler/CommandLinePasswordManager.class.st
+++ b/src/System-BasicCommandLineHandler/CommandLinePasswordManager.class.st
@@ -103,7 +103,9 @@ CommandLinePasswordManager >> hasPasswordSet [
 CommandLinePasswordManager >> hashString: password [
 	| hash |
 	hash := self hashingPepper , password.
-	(self numberOfHashIterations max: 1) timesRepeat: [ hash := (SHA256 hashMessage: hash) hex ].
+	(self numberOfHashIterations max: 1) timesRepeat: [ 
+		"We do not use a direct reference because this class is loaded after me.. But I should never be called in the bootstrap before loading the class, so this should be fine. Maybe we could have a better integration of the password management of the command lines later?"
+		hash := ((self class environment at: #SHA256) hashMessage: hash) hex ].
 	^ hash
 ]
 

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -106,13 +106,6 @@ SystemDependenciesTest >> knownSUnitDependencies [
 ]
 
 { #category : 'known dependencies' }
-SystemDependenciesTest >> knownSUnitKernelDependencies [
-	"ideally this list should be empty"
-
-	^ #( #'FileSystem-Core' )
-]
-
-{ #category : 'known dependencies' }
 SystemDependenciesTest >> knownSpec2Dependencies [
 
 	^ #(
@@ -439,9 +432,10 @@ SystemDependenciesTest >> testExternalSUnitKernelDependencies [
 		BaselineOfPharoBootstrap kernelPackageNames,
 		BaselineOfPharoBootstrap multilingualPackageNames,
 		BaselineOfPharoBootstrap kernelAdditionalPackagesNames,
+		BaselineOfPharoBootstrap fileSystemPackageNames,
 		BaselineOfPharoBootstrap sUnitPackageNames).
 
-	self assertCollection: dependencies hasSameElements: self knownSUnitKernelDependencies
+	self assertEmpty: dependencies
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
This change loads System-Hashing and Random-Core via Hermes instead of Espell. 

Requires #15609 and #15605