### PR TITLE
Little fix/enhancement on BenchTFFI*

### DIFF
--- a/src/ThreadedFFI-UFFI-Tests/BenchTFFI.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/BenchTFFI.class.st
@@ -1,0 +1,36 @@
+"
+I am an abstract base for concrete TFFI benchmarks, expressed on my subclasses.
+"
+Class {
+	#name : 'BenchTFFI',
+	#superclass : 'Object',
+	#category : 'ThreadedFFI-UFFI-Tests-Benchs',
+	#package : 'ThreadedFFI-UFFI-Tests',
+	#tag : 'Benchs'
+}
+
+{ #category : 'accessing' }
+BenchTFFI >> calloutAPIClass [
+
+	^ TFCalloutAPI
+]
+
+{ #category : 'private' }
+BenchTFFI >> doCallWith: aFloat another: aDouble [
+
+	^ self ffiCall: #(float sumAFloatAndADouble(float aFloat, double aDouble))
+]
+
+{ #category : 'accessing' }
+BenchTFFI >> ffiLibrary [
+
+	^ self subclassResponsibility
+]
+
+{ #category : 'running' }
+BenchTFFI >> runCall [
+
+	| return |
+	^ [ return := self doCallWith: 1.0 another: 2.0.
+		 self assert: return = 3.0 ] bench
+]

--- a/src/ThreadedFFI-UFFI-Tests/BenchTFFISameThread.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/BenchTFFISameThread.class.st
@@ -3,17 +3,11 @@ I am a simple benchmark class to test the TFFISameThread scheme
 "
 Class {
 	#name : 'BenchTFFISameThread',
-	#superclass : 'Object',
+	#superclass : 'BenchTFFI',
 	#category : 'ThreadedFFI-UFFI-Tests-Benchs',
 	#package : 'ThreadedFFI-UFFI-Tests',
 	#tag : 'Benchs'
 }
-
-{ #category : 'accessing' }
-BenchTFFISameThread >> calloutAPIClass [
-
-	^ TFCalloutAPI
-]
 
 { #category : 'private' }
 BenchTFFISameThread >> doCallWith: aFloat another: aDouble [
@@ -29,9 +23,7 @@ BenchTFFISameThread >> ffiLibrary [
 
 { #category : 'running' }
 BenchTFFISameThread >> runCall [
-	<script: 'self new runCall'>
-	| return |
+	<script: 'self new runCall traceCr'>
 
-	^ [ return := self doCallWith: 1.0 another: 2.0.
-		 self assert: return = 3.0 ] bench
+	^ super runCall
 ]

--- a/src/ThreadedFFI-UFFI-Tests/BenchTFFIWorker.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/BenchTFFIWorker.class.st
@@ -3,14 +3,27 @@ I am a simple benchmark class to test the TFFIWorker scheme
 "
 Class {
 	#name : 'BenchTFFIWorker',
-	#superclass : 'BenchTFFISameThread',
+	#superclass : 'BenchTFFI',
 	#category : 'ThreadedFFI-UFFI-Tests-Benchs',
 	#package : 'ThreadedFFI-UFFI-Tests',
 	#tag : 'Benchs'
 }
 
+{ #category : 'private' }
+BenchTFFIWorker >> doCallWith: aFloat another: aDouble [
+
+	^ self ffiCall: #(float sumAFloatAndADouble(float aFloat, double aDouble))
+]
+
 { #category : 'accessing' }
 BenchTFFIWorker >> ffiLibrary [
 
 	^ TFTestLibraryUsingWorker uniqueInstance
+]
+
+{ #category : 'running' }
+BenchTFFIWorker >> runCall [
+	<script: 'self new runCall traceCr'>
+
+	^ super runCall
 ]


### PR DESCRIPTION
Today, with @tesonep, we ran these benchmarks and discovered they need a manual fix to correctly bench: Compile the ffiCall: method in the subclass. 

In this change request I fixed it by creating a common superclass.