### PR TITLE
Browser-keep-new-class-selected

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
@@ -42,8 +42,6 @@ ClyClassDefinitionEditorToolMorph >> applyChangesAsClassDefinition [
 		            startingFrom: editingClass.
 
 	newClass ifNil: [ ^ false ].
-
-	editingClass == newClass ifFalse: [ self removeFromBrowser ].
 	browser selectClass: newClass.
 	^ true
 ]
@@ -75,8 +73,6 @@ ClyClassDefinitionEditorToolMorph >> applyChangesAsOldClassDefinition: ast [
 	newClass := OldClassDefinitionBuilder buildFromAST: ast.
 
 	newClass ifNil: [ ^ false ].
-
-	editingClass == newClass ifFalse: [ self removeFromBrowser ].
 	browser selectClass: newClass.
 	^ true
 ]


### PR DESCRIPTION
When you create a class by editing an existing class, the browser deselects it.

This PR removes the #removeFromBrowser call, it works now as you think it should work