### PR TITLE
Fix refactoring AddMethodComment

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -512,9 +512,11 @@ StringTest >> testAsSmalltalkComment [
 	exampleStrings do: [ :s | self assert: (s copyWithout: $") equals: (s asComment copyWithout: $") ].
 
 	"finnaly, test for some common kinds of inputs"
+	self assert: '' asComment equals: '""'.
 	self assert: 'abc' asComment equals: '"abc"'.
 	self assert: 'abc"abc' asComment equals: '"abc""abc"'.
-	self assert: 'abc""abc' asComment equals: '"abc""abc"'
+	self assert: 'abc""abc' asComment equals: '"abc""abc"'.
+	self assert: '"abc abc"' asComment equals: '"abc abc"'
 ]
 
 { #category : 'tests' }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -604,33 +604,29 @@ String >> asCamelCase [
 String >> asComment [
 	"return this string, munged so that it can be treated as a comment in Smalltalk code.  Quote marks are added to the beginning and end of the string, and whenever a solitary quote mark appears within the string, it is doubled"
 
-	^String streamContents:  [ :str |
-		| quoteCount first |
+	^ String streamContents: [ :str |
+		  | quoteCount first |
+		  str nextPut: $".
 
-		str nextPut: $".
+		  quoteCount := 0.
+		  first := true.
+		  self withIndexDo: [ :char :index |
+			  char = $"
+				  ifTrue: [
+					  (first or: (index = self size) ) ifFalse: [
+						  str nextPut: char.
+						  quoteCount := quoteCount + 1 ] ]
+				  ifFalse: [
+					  quoteCount odd ifTrue: [ "add a quote to even the number of quotes in a row"
+						  str nextPut: $" ].
+					  quoteCount := 0.
+					  str nextPut: char ].
+			  first := false ].
+		
+		   quoteCount odd
+			  ifTrue: [ "check at the end" str nextPut: $" ].
 
-		quoteCount := 0.
-		first := true.
-		self do: [ :char |
-			char = $"
-				ifTrue: [
-					first ifFalse: [
-						str nextPut: char.
-						quoteCount := quoteCount + 1 ] ]
-				ifFalse: [
-					quoteCount odd ifTrue: [
-						"add a quote to even the number of quotes in a row"
-						str nextPut: $" ].
-					quoteCount := 0.
-					str nextPut: char ].
-			first := false ].
-
-		quoteCount odd ifTrue: [
-			"check at the end"
-			str nextPut: $". ].
-
-		str nextPut: $".
-	]
+		  str nextPut: $" ]
 ]
 
 { #category : 'converting' }

--- a/src/Refactoring-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBTransformationsTest.class.st
@@ -47,6 +47,25 @@ RBTransformationsTest >> testAddMethodCommentTransform [
 ]
 
 { #category : 'tests' }
+RBTransformationsTest >> testAddMethodCommentTransformWithExistingQuotationMarks [ 
+
+	| transformation method |
+	transformation := (RBAddMethodCommentTransformation
+		                   comment: '"New comment for method"'
+		                   inMethod: #one
+		                   inClass: self changeMockClass name)
+		                  generateChanges.
+
+	self assert: transformation model changes changes size equals: 1.
+
+	method := (transformation model classNamed: self changeMockClass name)
+		          methodFor: #one.
+	self
+		assert: method ast comments first contents
+		equals: 'New comment for method'
+]
+
+{ #category : 'tests' }
 RBTransformationsTest >> testAddMethodTransform [
 
 	| transformation class |

--- a/src/Refactoring-Transformations/RBAddMethodCommentTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddMethodCommentTransformation.class.st
@@ -50,15 +50,16 @@ RBAddMethodCommentTransformation >> comment: aString inMethod: aSelector inClass
 	comment := aString
 ]
 
-{ #category : 'executing' }
+{ #category : 'transforming' }
 RBAddMethodCommentTransformation >> privateTransform [
+
 	| tree signature sourceCode |
 	tree := self definingMethod.
 	signature := tree source copyFrom: 1 to: tree body start - 1.
-	sourceCode := signature , String cr , (comment surroundedBy: '"')
-		, String cr , tree body sourceCode.
-	self definingClass
-		compileTree: (self parserClass parseMethod: sourceCode)
+	sourceCode := signature , String cr , comment asComment , String cr
+	              , tree body sourceCode.
+	self definingClass compileTree:
+		(self parserClass parseMethod: sourceCode)
 ]
 
 { #category : 'printing' }


### PR DESCRIPTION
When looking to RBAddMethodCommentTransformation I discover that it uses `surroundedBy: '"'` instead of `asComment` to convert the string to a SmallTalk comment.

So, I first made the modification. 
But I discovered that in some cases the first `"` is not duplicated, and the last is so

"ABC ABC" becomes: "ABC ABC"""

I saw that in `asComment` there is a special handling of the first `"`. So I decided to do the same for the last `"`.
I added a test for the refactoring and I extended the test case of `asComment` with the edging cases I discovered

> Sorry for the number of edits in `asComment` that appear because of code formatting...