### PR TITLE
Revert "Activate strict FFI"

### DIFF
--- a/src/Athens-Cairo/AthensCairoCanvas.class.st
+++ b/src/Athens-Cairo/AthensCairoCanvas.class.st
@@ -227,8 +227,8 @@ AthensCairoCanvas >> primResetDashes: anOffset [
                                                          double offset);"
 	^ self ffiCall: #(void cairo_set_dash (
 				self,
-				void* 0,
-				int 0,
+				0,
+				0,
 				double anOffset) )
 ]
 

--- a/src/Athens-Cairo/CairoFontMetricsProvider.class.st
+++ b/src/Athens-Cairo/CairoFontMetricsProvider.class.st
@@ -42,17 +42,11 @@ CairoFontMetricsProvider >> cairoFont [
 
 { #category : 'private' }
 CairoFontMetricsProvider >> convertString: utf8String len: strlen ofFont: aScaledFont toGlyphs: glyphs numGlyphs: numGlyphs x: x y: y [
-	"cairo_status_t
-	cairo_scaled_font_text_to_glyphs (cairo_scaled_font_t *scaled_font,
-                                  double x,
-                                  double y,
-                                  const char *utf8,
-                                  int utf8_len,
-                                  cairo_glyph_t **glyphs,
-                                  int *num_glyphs,
-                                  cairo_text_cluster_t **clusters,
-                                  int *num_clusters,
-                                  cairo_text_cluster_flags_t *cluster_flags);"
+"
+all of this for using
+http://www.cairographics.org/manual/cairo-User-Fonts.html#cairo-user-scaled-font-text-to-glyphs-func-t
+
+"
 	^ self ffiCall: #(
 		cairo_status_t cairo_scaled_font_text_to_glyphs (CairoScaledFont aScaledFont,
 			double x,
@@ -61,9 +55,9 @@ CairoFontMetricsProvider >> convertString: utf8String len: strlen ofFont: aScale
 			int strlen,
 			void ** glyphs,
 			int * numGlyphs,
-			void* 0,
-			void* 0,
-			void* 0))
+			NULL,
+			NULL,
+			NULL))
 ]
 
 { #category : 'accessing' }

--- a/src/System-OSEnvironments/UnixEnvironment.class.st
+++ b/src/System-OSEnvironments/UnixEnvironment.class.st
@@ -285,9 +285,9 @@ UnixEnvironment >> removeKey: key encoded: anEncoding [
 	^ self rawRemoveKey: (key encodeWith: anEncoding)
 ]
 
-{ #category : 'accessing' }
+{ #category : 'private' }
 UnixEnvironment >> setEnv: nameString value: valueString [
-	"int setenv(const char *name, const char *value, int overwrite);"
+	"This method calls the Standard C Library setenv() function"
 
-	^ self ffiCall: #(int setenv #(String nameString , String valueString , int 1)) module: LibC
+	^ self ffiCall: #(int setenv #(String nameString , String valueString , 1)) module: LibC
 ]

--- a/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
@@ -51,12 +51,12 @@ FFICalloutAPITest >> ffiLongLongAbs: number [
 
 { #category : 'primitives constant' }
 FFICalloutAPITest >> ffiTestConstantFormat: format to: buffer [
-	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, int 65, int 65, int 1 ) ) fixedArgumentCount: 2
+	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, 65, 65, 1 ) ) fixedArgumentCount: 2
 ]
 
 { #category : 'primitives constant' }
 FFICalloutAPITest >> ffiTestContantFormat: format value: aNumber to: buffer [
-	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, int 65, int 65, long aNumber ) ) fixedArgumentCount: 2
+	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, 65, 65, long aNumber ) ) fixedArgumentCount: 2
 ]
 
 { #category : 'primitives atomic' }

--- a/src/UnifiedFFI/FFILibrary.class.st
+++ b/src/UnifiedFFI/FFILibrary.class.st
@@ -32,7 +32,7 @@ FFILibrary class >> new [
 { #category : 'options' }
 FFILibrary class >> options [
 
-	^ #( #+ optStrict )
+	^ #()
 ]
 
 { #category : 'instance creation' }

--- a/src/UnifiedFFI/FFIStrictResolutionMode.class.st
+++ b/src/UnifiedFFI/FFIStrictResolutionMode.class.st
@@ -18,15 +18,5 @@ FFIStrictResolutionMode >> isStrict [
 { #category : 'resolution' }
 FFIStrictResolutionMode >> resolveUndeclaredTypeForArgument: aFFIValueArgument withResolver: aResolver [
 
-	"Make strict all declarations except those using self.
-	This is safe because:
-	 - We can infer self from the current class
-	 - the only implementor of prepareAsSelfFromCalloutDeclaration are those classes representing pointers"
-	aFFIValueArgument value == #self ifTrue: [
-		| externalType |
-		externalType := aResolver requestor asExternalTypeOn: aResolver.
-		^ externalType prepareAsSelfFromCalloutDeclaration ].
-
-	"Otherwise, this is an untyped literal which is unsupported"
 	aResolver unsupportedUntypedLiteral: aFFIValueArgument value
 ]


### PR DESCRIPTION
Reverts pharo-project/pharo#15506 because it is creating problems during image boot.

FFIUnsupportedUntypedLiteral
FFICallout>>unsupportedUntypedLiteral:
FFIStrictResolutionMode>>resolveUndeclaredTypeForArgument:withResolver:
FFICallout>>resolveUntypedArgument:
FFIUndefinedTypeDeclaration>>resolveUsing:forArgument:
FFIConstantArgument>>resolveUsing:
[ :e | e resolveUsing: aResolver ] in FFIFunctionSpec>>resolveUsing: in Block: [ :e | e resolveUsing: aResolver ]
OrderedCollection>>do:
FFIFunctionSpec>>resolveUsing:
TFCalloutMethodBuilder(FFICalloutMethodBuilder)>>generateMethodFromSpec:
TFCalloutMethodBuilder(FFICalloutMethodBuilder)>>generate
TFCalloutMethodBuilder(FFICalloutMethodBuilder)>>build:
TFCalloutAPI(FFICalloutAPI)>>function:library:
SDL_Texture(Object)>>ffiCall:library:options:fixedArgumentCount:
SDL_Texture(Object)>>ffiCall:library:options:
SDL_Texture(Object)>>ffiCall:
SDL_Texture>>lockPixels:pitch: