### PR TITLE
add UndefinedClassVariable

### DIFF
--- a/src/ClassParser/CDSharedVariableNode.class.st
+++ b/src/ClassParser/CDSharedVariableNode.class.st
@@ -20,9 +20,14 @@ CDSharedVariableNode class >> slot: aSlot node: aNode [
 
 { #category : 'transforming' }
 CDSharedVariableNode >> asClassVariable [
-	"for not this only supports ClassVariables.
-	We need to create a ClassVariable here using the Variable Definition"
-	^ ClassVariable named: self name
+
+	"when parsing old style definitions, the node is just the string of all ivars"
+	node isLiteralNode ifTrue: [ ^ ClassVariable named: name ]
+
+	"As we controll the creation of the AST, it is safe to evaluate it. The
+	only thing that can go wrong is that the class of the Variable is not yet loaded,
+	we crate an UndefinedClassVariable for that case".
+	^ [ node evaluate ] on: Error do: [ UndefinedClassVariable named: self name ast: node ]
 ]
 
 { #category : 'testing' }

--- a/src/Kernel/UndefinedClassVariable.class.st
+++ b/src/Kernel/UndefinedClassVariable.class.st
@@ -1,8 +1,7 @@
 "
-When loading a class where a ClassVariable subclass is used that is not present in the System, we need to model
-this variabke somehow so we can fix it as soon as the class is loaded.
+When loading a class where a ClassVariable subclass is used that is not present in the System, we need to model this variable somehow so we can fix it as soon as the class is loaded.
 
-The UndefinedClassVariable ingores reads and write (it returns nil). But on access, it checks if the class implementing the Variable has been loaded and if yes, it rebuilds the class definition.
+The UndefinedClassVariable ignores reads and writes (it returns nil). But on access, it checks if the class implementing the Variable has been loaded and if yes, it rebuilds the class definition.
 "
 Class {
 	#name : 'UndefinedClassVariable',

--- a/src/Kernel/UndefinedClassVariable.class.st
+++ b/src/Kernel/UndefinedClassVariable.class.st
@@ -1,0 +1,65 @@
+"
+When loading a class where a ClassVariable subclass is used that is not present in the System, we need to model
+this variabke somehow so we can fix it as soon as the class is loaded.
+
+The UndefinedClassVariable ingores reads and write (it returns nil). But on access, it checks if the class implementing the Variable has been loaded and if yes, it rebuilds the class definition.
+"
+Class {
+	#name : 'UndefinedClassVariable',
+	#superclass : 'LiteralVariable',
+	#instVars : [
+		'ast',
+		'classIsRebuild'
+	],
+	#category : 'Kernel-Variables',
+	#package : 'Kernel',
+	#tag : 'Variables'
+}
+
+{ #category : 'instance creation' }
+UndefinedClassVariable class >> named: aName ast: aSlotClassName [
+	^ (self named: aName) ast: aSlotClassName
+]
+
+{ #category : 'accessing' }
+UndefinedClassVariable >> ast: aMessageNode [
+	classIsRebuild := false.
+	ast := aMessageNode
+]
+
+{ #category : 'private' }
+UndefinedClassVariable >> checkClassRebuild [
+	"break the recursion while rebuilding"
+	classIsRebuild ifTrue: [ ^ self].
+	(self definingClass environment hasClassNamed: self variableClassName) ifFalse: [ ^ self ].
+	classIsRebuild := true.
+	"we rebuild the class, this triggers instance migration"
+	(self definingClass compiler evaluate: self definingClass definitionString) install.
+	"recompile all methods that access me to generat code for the loaded definition"
+	self usingMethods do: [:each | each recompile]
+]
+
+{ #category : 'printing' }
+UndefinedClassVariable >> printOn: aStream [
+	"we print as the definition that could not be loaded"
+	aStream nextPutAll: ast formattedCode
+]
+
+{ #category : 'meta-object-protocol' }
+UndefinedClassVariable >> read [
+	"Undeclared Class Variables read nil always, but check if they can repair the class"
+	 self checkClassRebuild.
+	^ nil
+]
+
+{ #category : 'accessing' }
+UndefinedClassVariable >> variableClassName [
+	^ast arguments first variable name
+]
+
+{ #category : 'meta-object-protocol' }
+UndefinedClassVariable >> write: aValue [
+	"Undeclared Class Variables ignore writes, but check if they can repair the class"
+	 self checkClassRebuild.
+	^ aValue
+]

--- a/src/Kernel/UndefinedSlot.class.st
+++ b/src/Kernel/UndefinedSlot.class.st
@@ -1,9 +1,7 @@
 "
-When loading a class where a Slot is used that is not present in the System, we need to model
-this slot somehow.
+When loading a class where a Slot is used that is not present in the System, we need to model this slot somehow.
 
-The UndefinedSlot ingores reads and write (it returns nil like undeclared variables). But on
-access, it checks if the Slot has been loaded and if yes, it rebuilds the class definition.
+The UndefinedSlot ingores reads and writes (it returns nil). But on access, it checks if the Slot has been loaded and if yes, it rebuilds the class definition.
 "
 Class {
 	#name : 'UndefinedSlot',


### PR DESCRIPTION
When implementing a subclass of ClassVariable, the class can be loaded after classes that use it. For this, we need some kind of Undefined Variable so we can create the definiton later.

We have already UndefinedSlot, this PR adds UndefinedClassVariable and changes the class Parser to use it.

It is not yet used outside of the class parser, that is the next step