### PR TITLE
Rpackage some Debugging-Core classes

### DIFF
--- a/src/Debugging-Core/CompiledCode.extension.st
+++ b/src/Debugging-Core/CompiledCode.extension.st
@@ -16,10 +16,3 @@ CompiledCode >> rangeForPC: aPC [
  	"return which code to hightlight in the debugger"		
  	^(self sourceNodeForPC: aPC) debugHighlightRange
 ]
-
-{ #category : '*Debugging-Core' }
-CompiledCode >> symbolicBytecodes [
-	"Answer Collection that contains of all the byte codes in a method as an instance of SymbolicInstruction"
-
-	^SymbolicBytecodeBuilder decode: self
-]

--- a/src/Debugging-Core/InstructionStream.extension.st
+++ b/src/Debugging-Core/InstructionStream.extension.st
@@ -24,13 +24,6 @@ InstructionStream >> atEnd [
 ]
 
 { #category : '*Debugging-Core' }
-InstructionStream >> decodeNextInstruction [
-	"Return the next bytecode instruction as a message that an InstructionClient would understand.  This advances the pc by one instruction."
-
-	^ self interpretNextInstructionFor: MessageCatcher new
-]
-
-{ #category : '*Debugging-Core' }
 InstructionStream >> followingBytecode [
 	"Answer the bytecode of the following bytecode (different to nextByte)."
 

--- a/src/OpalCompiler-Core/CompiledCode.extension.st
+++ b/src/OpalCompiler-Core/CompiledCode.extension.st
@@ -32,3 +32,10 @@ CompiledCode >> irPrimitive [
 		primNode spec: (self literalAt: 1)].
 	^ primNode
 ]
+
+{ #category : '*OpalCompiler-Core' }
+CompiledCode >> symbolicBytecodes [
+	"Answer Collection that contains of all the byte codes in a method as an instance of SymbolicInstruction"
+
+	^SymbolicBytecodeBuilder decode: self
+]

--- a/src/OpalCompiler-Core/SymbolicBytecode.class.st
+++ b/src/OpalCompiler-Core/SymbolicBytecode.class.st
@@ -14,8 +14,9 @@ Class {
 		'offset',
 		'bytes'
 	],
-	#category : 'Debugging-Core',
-	#package : 'Debugging-Core'
+	#category : 'OpalCompiler-Core-Bytecode',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Bytecode'
 }
 
 { #category : 'comparing' }

--- a/src/OpalCompiler-Core/SymbolicBytecodeBuilder.class.st
+++ b/src/OpalCompiler-Core/SymbolicBytecodeBuilder.class.st
@@ -12,8 +12,9 @@ Class {
 		'oldPC',
 		'symbolicBytecodes'
 	],
-	#category : 'Debugging-Core',
-	#package : 'Debugging-Core'
+	#category : 'OpalCompiler-Core-Bytecode',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Bytecode'
 }
 
 { #category : 'decoding' }

--- a/src/OpalCompiler-Tests/InstructionStream.extension.st
+++ b/src/OpalCompiler-Tests/InstructionStream.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : 'InstructionStream' }
 
 { #category : '*OpalCompiler-Tests' }
+InstructionStream >> decodeNextInstruction [
+	"Return the next bytecode instruction as a message that an InstructionClient would understand.  This advances the pc by one instruction."
+
+	^ self interpretNextInstructionFor: MessageCatcher new
+]
+
+{ #category : '*OpalCompiler-Tests' }
 InstructionStream >> peekInstruction [
 	"Return the next bytecode instruction as a message that an InstructionClient would understand.  The pc remains unchanged."
 

--- a/src/OpalCompiler-Tests/MessageCatcher.class.st
+++ b/src/OpalCompiler-Tests/MessageCatcher.class.st
@@ -10,14 +10,15 @@ Class {
 	#instVars : [
 		'accumulator'
 	],
-	#category : 'Debugging-Core',
-	#package : 'Debugging-Core'
+	#category : 'OpalCompiler-Tests-Source',
+	#package : 'OpalCompiler-Tests',
+	#tag : 'Source'
 }
 
 { #category : 'reflective operations' }
 MessageCatcher >> doesNotUnderstand: aMessage [
 
-	accumulator ifNotNil: [accumulator add: aMessage].
+	accumulator ifNotNil: [ accumulator add: aMessage ].
 	^ aMessage
 ]
 


### PR DESCRIPTION
I have the impression that Debugging-Core was a package created to extract classes and methods from the Kernel but we did not know where to put the stuff.

Here I repackage some classes from it.

Next step could be to repackage the extension methods because some of them are used in the kernel but not present in kernel and most of them are used only in some debugger packages