### PR TITLE
ClassParser: add support for #unrestrictedVariableDefinitions setting for Shared Variables

### DIFF
--- a/src/ClassParser/CDFluidClassDefinitionParser.class.st
+++ b/src/ClassParser/CDFluidClassDefinitionParser.class.st
@@ -235,6 +235,10 @@ CDFluidClassDefinitionParser >> handleSharedVarableNodeSimple: slotDefNode [
 { #category : 'parsing - variables' }
 CDFluidClassDefinitionParser >> handleSharedVariabeNode: variableDefNode [
 	 | variable |
+	"Setting, default off, to allow experiments"
+	self class unrestrictedVariableDefinitions ifTrue: [ 
+		^ classDefinition addSharedVariable: (self handleUnrestrictedSharedVariableDefinition: variableDefNode) ].
+	
 	"when a class variable is just #ClassVars"
 	variableDefNode isLiteralNode ifTrue: [ variable := self handleSharedVarableNodeSimple: variableDefNode].
 	"#ClassVar => SomeVar default: 5; default2: 4"
@@ -420,6 +424,26 @@ CDFluidClassDefinitionParser >> handleTraitUsesFromNode: aNode [
 	aNode isDynamicArray and: [aNode allStatements ifEmpty: [ ^ self ]].
  	traitComposition := CDTraitCompositionBuilder new buildFrom: aNode.
 	classDefinition traitDefinition: traitComposition
+]
+
+{ #category : 'parsing - variables' }
+CDFluidClassDefinitionParser >> handleUnrestrictedSharedVariableDefinition: variableDefNode [
+
+	"If the preference is enabled, allow unrestricted shared variable definitions. 
+	TAKE CARE: There is no way to know the name nor the class witout executing the code of the defintion.
+	This means that a) code will be evaluated which could have side effects and b) you need to load the Slot Class
+	before any users, as an UndefinedSlot can not be created, as we do not know the name"
+
+	| variableInstance |
+	"create the instance of the Variable by evaluating the defintion, we use this to fill out the name and variableClassName"
+	variableInstance := variableDefNode evaluate.
+
+	^ CDSharedVariableNode new
+		  node: variableDefNode;
+		  name: variableDefNode name;
+		  variableClassName: variableInstance class name;
+		  start: variableDefNode start;
+		  stop: variableDefNode stop
 ]
 
 { #category : 'parsing - variables' }


### PR DESCRIPTION
This adds support for experimenting with Shared Variable definitions (subclasses of ClassVariable) that do not follow the structure know by the classParser (the class parser only supports a very restricted syntax so we can parse without having to execute).

The same mechanism is already ther for Slots. 

This code is not active as the preference is OFF. For what do we have it? So we can start to play with strange class variables  more easily.