### PR TITLE
Ensure real superclass setting in RBInsertNewClassRefactoring

### DIFF
--- a/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
@@ -71,7 +71,7 @@ RBInsertNewClassRefactoring >> privateTransform [
 	self model
 		defineClass: [ :aBuilder |
 			aBuilder
-				superclass: superclass;
+				superclass: (self model classObjectFor: superclass);
 				name: className;
 				package: packageName;
 				tag: tagName;

--- a/src/Refactoring-Transformations-Tests/RBInsertClassParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBInsertClassParametrizedTest.class.st
@@ -145,3 +145,26 @@ RBInsertClassParametrizedTest >> testModelInsertClass [
 	self assert: subclass classSide superclass equals: insertedClass classSide.
 	self assert: (insertedClass classSide subclasses includes: subclass classSide)
 ]
+
+{ #category : 'tests' }
+RBInsertClassParametrizedTest >> testModelInsertClassFromBehaviorSuperclass [
+
+	| refactoring insertedClass superClass subclass |
+	superClass := model classNamed: #Foo.
+	subclass := model classNamed: #Bar.
+
+	refactoring := (rbClass model: model className: #InsertedClass)
+		               superclass: superClass;
+		               subclasses: { subclass };
+		               packageName: #'Refactoring-Testing'.
+
+	self executeRefactoring: refactoring.
+
+	insertedClass := model classNamed: #InsertedClass.
+	self assert: insertedClass superclass equals: superClass.
+	self assert: insertedClass classSide superclass equals: superClass classSide.
+
+	self assert: subclass superclass equals: insertedClass.
+	self assert: subclass classSide superclass equals: insertedClass classSide.
+
+]

--- a/src/Refactoring-Transformations/RBInsertNewClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBInsertNewClassTransformation.class.st
@@ -117,9 +117,9 @@ RBInsertNewClassTransformation >> subclasses: aCollection [
 ]
 
 { #category : 'api' }
-RBInsertNewClassTransformation >> superclass: superclassName [
+RBInsertNewClassTransformation >> superclass: aSuperclass [
 
-	superclass := superclassName asSymbol
+	superclass := aSuperclass
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This PR fixes the refactoring browser problem reported in #15602. 

It modifies the RB code to ensure real superclass setting in RBInsertNewClassRefactoring>>privateTransform (this is to avoid setting the RBClass instead of the real superclass).
Also set the real superclass in RBInsertNewClassTransformation instead of the superclass name.
Add also a test reproducing the wrong behavior which now passes for both tests parameters (insert and transformation refactorings).