### PR TITLE
Support removing old change sorter

### DIFF
--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -82,13 +82,7 @@ PharoCommonTools class >> settingsOn: aBuilder [
 						targetSelector: #tools;
 						label: 'Filelist';
 						default: (self environment at: #FileList);
-						domainValues: Smalltalk tools recentFileListTools];
-		with: [
-					(aBuilder pickOne: #changeSorterTool)
-						target: Smalltalk;
-						targetSelector: #tools;
-						label: 'Changesorter';
-						domainValues: Smalltalk tools recentChangeSorterTools]
+						domainValues: Smalltalk tools recentFileListTools]
 ]
 
 { #category : 'system startup' }

--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -139,22 +139,6 @@ PharoCommonTools >> changeList [
 	^ self toolNamed: #changeList
 ]
 
-{ #category : 'registry access' }
-PharoCommonTools >> changeSorter [
-
-	^ self toolNamed: #changeSorter
-]
-
-{ #category : 'tools' }
-PharoCommonTools >> changeSorterTool [
-	^ self changeSorter
-]
-
-{ #category : 'tools' }
-PharoCommonTools >> changeSorterTool: aTool [
-	^ self register: aTool as: #changeSorter
-]
-
 { #category : 'cleanup' }
 PharoCommonTools >> cleanUp [
 	recentTools keysAndValuesDo:[:name :toolSet|
@@ -242,11 +226,6 @@ PharoCommonTools >> processBrowser [
 { #category : 'registration' }
 PharoCommonTools >> recentBrowserTools [
 	^ self recentToolsFor: #browser
-]
-
-{ #category : 'registration' }
-PharoCommonTools >> recentChangeSorterTools [
-	^ self recentToolsFor: #changeSorter
 ]
 
 { #category : 'registration' }

--- a/src/Tool-Registry/ToolRegistry.class.st
+++ b/src/Tool-Registry/ToolRegistry.class.st
@@ -148,7 +148,6 @@ ToolRegistry >> menuItems [
 		('Process Browser' 			#openProcessBrowser)
 		-
 		('Monticello Browser'		#openMonticelloBrowser)
-		('Change Sorter'			#openChangeSorter)
 	)
 ]
 


### PR DESCRIPTION
This PR removes menu item entries associated with the Change Sorter tool, and it should be applied before the [respective PR in NewTools](https://github.com/pharo-spec/NewTools/pull/634) so the release tests [does not fail](https://github.com/pharo-spec/NewTools/actions/runs/7047396827/job/19181252462?pr=634) with the orphaned packages detection.
 
