### PR TITLE
Add ScalingCanvas and #canvasScaleFactor for OSWorldRenderer

### DIFF
--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -217,7 +217,7 @@ FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font
 	^ self drawString: aString from: firstIndex to: lastIndex in: bounds font: fontOrNil color: c scale: 1
 ]
 
-{ #category : 'drawing - text' }
+{ #category : 'scaled drawing' }
 FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font: fontOrNil color: c scale: scale [
 	| font portRect point |
 	port colorMap: nil.
@@ -245,7 +245,7 @@ FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font
 	^ self drawString: aString from: firstIndex to: lastIndex in: bounds font: fontOrNil color: c underline: underline underlineColor: uc strikethrough: strikethrough strikethroughColor: sc scale: 1
 ]
 
-{ #category : 'drawing - text' }
+{ #category : 'scaled drawing' }
 FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font: fontOrNil color: c underline: underline underlineColor: uc strikethrough: strikethrough strikethroughColor: sc scale: scale [
 	| font portRect endPoint point |
 	port colorMap: nil.
@@ -496,7 +496,7 @@ FormCanvas >> paragraph: para bounds: bounds color: c [
 	^ self paragraph: para bounds: bounds color: c scale: 1
 ]
 
-{ #category : 'drawing' }
+{ #category : 'scaled drawing' }
 FormCanvas >> paragraph: para bounds: bounds color: c scale: scale [
 
 	| scanner |

--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -211,7 +211,13 @@ FormCanvas >> drawString: aString from: firstIndex to: lastIndex at: aPoint font
 
 { #category : #'drawing - text' }
 FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font: fontOrNil color: c [
-	| font portRect |
+
+	^ self drawString: aString from: firstIndex to: lastIndex in: bounds font: fontOrNil color: c scale: 1
+]
+
+{ #category : #'drawing - text' }
+FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font: fontOrNil color: c scale: scale [
+	| font portRect point |
 	port colorMap: nil.
 	portRect := port clipRect.
 	port clipByX1: bounds left + origin x
@@ -222,9 +228,12 @@ FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font
 	port combinationRule: Form paint.
 	font installOn: port
 		foregroundColor: c
-		backgroundColor: Color transparent.
+		backgroundColor: Color transparent
+		scale: scale.
+	point := bounds topLeft + origin.
 	font displayString: aString asString on: port
-		from: firstIndex to: lastIndex at: (bounds topLeft + origin) kern: 0.
+		from: firstIndex to: lastIndex at: point kern: 0
+		baselineY: point y + (font ascent * scale) scale: scale.
 	port clipRect: portRect
 ]
 

--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -497,10 +497,17 @@ FormCanvas >> origin [
 { #category : #drawing }
 FormCanvas >> paragraph: para bounds: bounds color: c [
 
+	^ self paragraph: para bounds: bounds color: c scale: 1
+]
+
+{ #category : #drawing }
+FormCanvas >> paragraph: para bounds: bounds color: c scale: scale [
+
 	| scanner |
 	self setPaintColor: c.
 	scanner := (port clippedBy: (bounds translateBy: origin)) displayScannerFor: para
 		foreground: c.
+	scanner scale: scale.
 	para displayOn: (self copyClipRect: bounds) using: scanner at: origin+ bounds topLeft
 ]
 

--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -239,7 +239,13 @@ FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font
 
 { #category : #'drawing - text' }
 FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font: fontOrNil color: c underline: underline underlineColor: uc strikethrough: strikethrough strikethroughColor: sc [
-	| font portRect endPoint |
+
+	^ self drawString: aString from: firstIndex to: lastIndex in: bounds font: fontOrNil color: c underline: underline underlineColor: uc strikethrough: strikethrough strikethroughColor: sc scale: 1
+]
+
+{ #category : #'drawing - text' }
+FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font: fontOrNil color: c underline: underline underlineColor: uc strikethrough: strikethrough strikethroughColor: sc scale: scale [
+	| font portRect endPoint point |
 	port colorMap: nil.
 	portRect := port clipRect.
 	port clipByX1: bounds left + origin x
@@ -250,20 +256,25 @@ FormCanvas >> drawString: aString from: firstIndex to: lastIndex in: bounds font
 	port combinationRule: Form paint.
 	font installOn: port
 		foregroundColor: c
-		backgroundColor: Color transparent.
+		backgroundColor: Color transparent
+		scale: scale.
+	point := bounds topLeft + origin.
 	endPoint := font displayString: aString asString on: port
-		from: firstIndex to: lastIndex at: (bounds topLeft + origin) kern: 0.
+		from: firstIndex to: lastIndex at: point kern: 0
+		baselineY: point y + (font ascent * scale) scale: scale.
 	underline ifTrue:[
 		font installOn: port
 			foregroundColor: uc
-			backgroundColor: Color transparent;
-			displayUnderlineOn: port from: (bounds topLeft + origin + (0@font ascent)) to: endPoint.
+			backgroundColor: Color transparent
+			scale: scale;
+			displayUnderlineOn: port from: (bounds topLeft + origin + (0@(font ascent * scale))) to: endPoint scale: scale.
 		].
 	strikethrough ifTrue: [
 		font installOn: port
 			foregroundColor: uc
-			backgroundColor: Color transparent;
-			displayStrikeoutOn: port from: (bounds topLeft + origin + (0@font ascent)) to: endPoint.
+			backgroundColor: Color transparent
+			scale: scale;
+			displayStrikeoutOn: port from: (bounds topLeft + origin + (0@(font ascent * scale))) to: endPoint scale: scale.
 	].
 
 	port clipRect: portRect

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -54,7 +54,7 @@ ScalingCanvas class >> exampleFillOval [
 ]
 
 { #category : 'examples' }
-ScalingCanvas class >> exampleFillRectangle [
+ScalingCanvas class >> exampleFillRectangle1 [
 
 	^ self privateExampleWithExtent: 11@3 fillColor: Color white scale: 10 drawBlock: [ :canvas |
 		{
@@ -65,6 +65,29 @@ ScalingCanvas class >> exampleFillRectangle [
 			9.9@1.9 extent: 1.9@1.9
 		} do: [ :rectangle |
 			canvas fillRectangle: rectangle color: Color blue ] ]
+]
+
+{ #category : 'examples' }
+ScalingCanvas class >> exampleFillRectangle2 [
+
+	^ self privateExampleWithExtent: 50@50 fillColor: Color white scale: 10 drawBlock: [ :canvas |
+		0 to: 3 do: [ :i |
+			| colors gradientFillStyle rectangleOrigin |
+			colors := { Color red. Color green. Color blue } collect: [ :color | color alpha: 0.25 * (4 - i) ].
+			(gradientFillStyle := GradientFillStyle colors: colors)
+				origin: 2@0;
+				direction: 46@0.
+			canvas fillRectangle: (0@(i * 4) extent: 50@4) fillStyle: gradientFillStyle.
+			(gradientFillStyle := GradientFillStyle colors: colors)
+				origin: 0@48;
+				direction: (0@30) negated.
+			canvas fillRectangle: ((i * 4)@16 extent: 4@34) fillStyle: gradientFillStyle.
+			rectangleOrigin := 16@16 + ((i \\ 2 * 17)@(i // 2 * 17)).
+			(gradientFillStyle := GradientFillStyle colors: colors)
+				origin: rectangleOrigin + (8@8);
+				direction: 10@10;
+				radial: true.
+			canvas fillRectangle: (rectangleOrigin extent: 17@17) fillStyle: gradientFillStyle ] ]
 ]
 
 { #category : 'examples' }
@@ -394,6 +417,20 @@ ScalingCanvas >> fillOval: r color: c borderWidth: borderWidth borderColor: bord
 	self applyClippingTo: r floor
 		during: [ :clippedCanvas |
 			clippedCanvas fillOval: r color: c borderWidth: borderWidth borderColor: borderColor ]
+]
+
+{ #category : 'drawing - rectangles' }
+ScalingCanvas >> fillRectangle: aRectangle basicFillStyle: aFillStyle [
+
+	aFillStyle isGradientFill ifTrue: [
+		formCanvas fillRectangle: (aRectangle floor scaleBy: scale)
+			basicFillStyle: (aFillStyle copy
+				origin: aFillStyle origin * scale + (scale // 2);
+				direction: aFillStyle direction * scale;
+				normal: aFillStyle normal * scale;
+				yourself).
+		^ self ].
+	super fillRectangle: aRectangle basicFillStyle: aFillStyle
 ]
 
 { #category : 'initialization' }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -1,3 +1,8 @@
+"
+A ScalingCanvas provides scaling on an underlying `FormCanvas`.
+
+The method `ScalingCanvas class>>#example` and other methods in the same protocol compare drawing using a FormCanvas and then scaling the Form to drawing using a ScalingCanvas directly on a scaled Form. Using the ScalingCanvas, text is drawn using more detailed character glyphs, and any `FormSet` is drawn using the scale-specific Form if available.
+"
 Class {
 	#name : 'ScalingCanvas',
 	#superclass : 'PluggableCanvas',

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -47,6 +47,20 @@ ScalingCanvas class >> exampleDrawPolygon [
 ]
 
 { #category : 'examples' }
+ScalingCanvas class >> exampleDrawString [
+
+	^ self privateExampleWithExtent: 150@40 fillColor: Color white scale: 4 drawBlock: [ :canvas |
+		| bounds |
+		bounds := 5.5@3.5 corner: 144.5@37.5.
+		canvas
+			frameRectangle: bounds color: Color green;
+			drawString: 'Lorem ipsum' in: bounds
+				font: (LogicalFont familyName: 'Source Sans Pro' pointSize: 20) color: Color blue
+				underline: true underlineColor: Color red
+				strikethrough: true strikethroughColor: Color red ]
+]
+
+{ #category : 'examples' }
 ScalingCanvas class >> exampleFillOval [
 
 	^ self privateExampleWithExtent: 10@10 fillColor: Color white scale: 10 drawBlock: [ :canvas |
@@ -382,17 +396,17 @@ ScalingCanvas >> drawPolygon: vertices color: aColor borderWidth: bw borderColor
 			transformedCanvas drawPolygon: vertices color: aColor borderWidth: bw borderColor: bc ]
 ]
 
-{ #category : 'private' }
+{ #category : 'drawing - text' }
 ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect font: fontOrNil color: c [
 
-	formCanvas drawString: s from: firstIndex to: lastIndex in: (boundsRect scaleBy: scale)
+	formCanvas drawString: s from: firstIndex to: lastIndex in: (boundsRect floor scaleBy: scale)
 		font: fontOrNil color: c scale: scale
 ]
 
 { #category : 'drawing - text' }
 ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect font: fontOrNil color: c underline: underline underlineColor: uc strikethrough: strikethrough strikethroughColor: sc [
 
-	formCanvas drawString: s from: firstIndex to: lastIndex in: (boundsRect scaleBy: scale)
+	formCanvas drawString: s from: firstIndex to: lastIndex in: (boundsRect floor scaleBy: scale)
 		font: fontOrNil color: c
 		underline: underline underlineColor: uc
 		strikethrough: strikethrough strikethroughColor: sc

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -115,3 +115,16 @@ ScalingCanvas >> paragraph: paragraph bounds: bounds color: c [
 
 	formCanvas paragraph: paragraph bounds: (bounds scaleBy: scale) color: c scale: scale
 ]
+
+{ #category : #'drawing - support' }
+ScalingCanvas >> transformBy: aDisplayTransform clippingTo: aClipRect during: aBlock smoothing: cellSize [
+
+	aDisplayTransform isPureTranslation ifTrue: [
+		aBlock value: (self class
+			formCanvas: (formCanvas
+				copyOffset: aDisplayTransform offset negated truncated * scale
+				clipRect: (aClipRect scaleBy: scale))
+			scale: scale).
+		^ self ].
+	super transformBy: aDisplayTransform clippingTo: aClipRect during: aBlock smoothing: cellSize
+]

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -129,6 +129,12 @@ ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect fon
 ]
 
 { #category : 'initialization' }
+ScalingCanvas >> flush [
+
+	formCanvas flush
+]
+
+{ #category : 'initialization' }
 ScalingCanvas >> formCanvas: initialFormCanvas scale: initialScale [
 
 	formCanvas := initialFormCanvas.

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -277,7 +277,7 @@ ScalingCanvas >> apply: aBlock [
 { #category : 'drawing - support' }
 ScalingCanvas >> clipBy: aRectangle during: aBlock [
 
-	formCanvas clipBy: (aRectangle scaleBy: scale) during: [ :transformedFormCanvas |
+	formCanvas clipBy: (aRectangle floor scaleBy: scale) during: [ :transformedFormCanvas |
 		aBlock value: (self class formCanvas: transformedFormCanvas scale: scale) ]
 ]
 
@@ -301,7 +301,7 @@ ScalingCanvas >> contentsOfArea: aRectangle into: aForm [
 { #category : 'copying' }
 ScalingCanvas >> copyClipRect: newClipRect [
 
-	^ self class formCanvas: (formCanvas copyClipRect: (newClipRect scaleBy: scale)) scale: scale
+	^ self class formCanvas: (formCanvas copyClipRect: (newClipRect floor scaleBy: scale)) scale: scale
 ]
 
 { #category : 'accessing' }
@@ -520,7 +520,7 @@ ScalingCanvas >> transformBy: aDisplayTransform clippingTo: aClipRect during: aB
 		aBlock value: (self class
 			formCanvas: (formCanvas
 				copyOffset: aDisplayTransform offset negated truncated * scale
-				clipRect: (aClipRect scaleBy: scale))
+				clipRect: (aClipRect floor scaleBy: scale))
 			scale: scale).
 		^ self ].
 	super transformBy: aDisplayTransform clippingTo: aClipRect during: aBlock smoothing: cellSize
@@ -529,7 +529,7 @@ ScalingCanvas >> transformBy: aDisplayTransform clippingTo: aClipRect during: aB
 { #category : 'other' }
 ScalingCanvas >> translateBy: aPoint clippingTo: aRect during: aBlock [
 
-	formCanvas translateBy: aPoint * scale clippingTo: (aRect scaleBy: scale) during: [ :transformedFormCanvas |
+	formCanvas translateBy: aPoint * scale clippingTo: (aRect floor scaleBy: scale) during: [ :transformedFormCanvas |
 		aBlock value: (self class formCanvas: transformedFormCanvas scale: scale) ]
 ]
 

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -47,6 +47,13 @@ ScalingCanvas class >> exampleDrawPolygon [
 ]
 
 { #category : 'examples' }
+ScalingCanvas class >> exampleFillOval [
+
+	^ self privateExampleWithExtent: 10@10 fillColor: Color white scale: 10 drawBlock: [ :canvas |
+		canvas fillOval: (1.1@1.1 corner: 9.9@9.9) color: Color blue borderWidth: 2 borderColor: Color green ]
+]
+
+{ #category : 'examples' }
 ScalingCanvas class >> exampleFillRectangle [
 
 	^ self privateExampleWithExtent: 11@3 fillColor: Color white scale: 10 drawBlock: [ :canvas |
@@ -268,21 +275,28 @@ ScalingCanvas >> allocateForm: extentPoint [
 { #category : 'private' }
 ScalingCanvas >> apply: aBlock [
 
+	self applyClippingTo: self clipRect during: aBlock
+]
+
+{ #category : 'private' }
+ScalingCanvas >> applyClippingTo: clipRect during: aBlock [
+
 	FreeTypeSettings current forceNonSubPixelDuring: [
-		| clipRect |
-		clipRect := formCanvas clipRect.
+		| scaledClipRect |
+		scaledClipRect := ((clipRect scaleBy: scale)
+			intersect: formCanvas clipRect ifNone: [ 0@0 corner: 0@0 ])
+				intersect: (formCanvas origin negated extent: formCanvas extent) ifNone: [ 0@0 corner: 0@0 ].
 		self depth = 32 ifTrue: [
 			| sourceForm |
-			clipRect := clipRect intersect: (formCanvas origin negated extent: formCanvas extent) ifNone: [ 0@0 corner: 0@0 ].
-			sourceForm := Form extent: clipRect extent / scale depth: 32.
-			(FormCanvas on: sourceForm) translateBy: clipRect origin negated / scale during: aBlock.
-			(formCanvas warpFrom: sourceForm boundingBox innerCorners toRect: clipRect)
+			sourceForm := Form extent: scaledClipRect extent / scale depth: 32.
+			(FormCanvas on: sourceForm) translateBy: scaledClipRect origin negated / scale during: aBlock.
+			(formCanvas warpFrom: sourceForm boundingBox innerCorners toRect: scaledClipRect)
 				combinationRule: Form blend;
 				sourceForm: sourceForm;
 				warpBits
 		] ifFalse: [
 			formCanvas transformBy: (MatrixTransform2x3 withScale: scale)
-				clippingTo: clipRect
+				clippingTo: scaledClipRect
 				during: aBlock ] ]
 ]
 
@@ -341,7 +355,9 @@ ScalingCanvas >> drawPolygon: vertices color: aColor borderWidth: bw borderColor
 		(self scalePolygon: vertices) ifNotNil: [ :scaledPolygon |
 			formCanvas drawPolygon: scaledPolygon color: aColor borderWidth: 0 borderColor: bc.
 			^ self ] ].
-	super drawPolygon: vertices color: aColor borderWidth: bw borderColor: bc
+	self applyClippingTo: (vertices min floor corner: vertices max floor + 1)
+		during: [ :transformedCanvas |
+			transformedCanvas drawPolygon: vertices color: aColor borderWidth: bw borderColor: bc ]
 ]
 
 { #category : 'private' }
@@ -371,6 +387,14 @@ ScalingCanvas >> extent [
 ScalingCanvas >> fillColor: aColor [
 
 	formCanvas fillColor: aColor
+]
+
+{ #category : 'drawing - ovals' }
+ScalingCanvas >> fillOval: r color: c borderWidth: borderWidth borderColor: borderColor [
+
+	self applyClippingTo: r floor
+		during: [ :clippedCanvas |
+			clippedCanvas fillOval: r color: c borderWidth: borderWidth borderColor: borderColor ]
 ]
 
 { #category : 'initialization' }
@@ -421,7 +445,10 @@ ScalingCanvas >> frameAndFillRectangle: r fillColor: fillColor borderWidth: bord
 			formCanvas frameAndFillRectangle: scaledRectangle fillColor: fillColor
 				borderWidth: borderWidth * scale borderColor: borderColor.
 			^ self ] ].
-	super frameAndFillRectangle: r fillColor: fillColor borderWidth: borderWidth borderColor: borderColor
+	self applyClippingTo: r floor
+		during: [ :transformedCanvas |
+			transformedCanvas frameAndFillRectangle: r fillColor: fillColor
+				borderWidth: borderWidth borderColor: borderColor ]
 ]
 
 { #category : 'private' }
@@ -455,7 +482,9 @@ ScalingCanvas >> line: pt1 to: pt2 width: w color: c [
 					to: (pt2 - offset) * scale + scaledOffset
 					width: widthScaled color: c.
 				^ self ].
-	super line: pt1 to: pt2 width: w color: c
+	self applyClippingTo: (((pt1 min: pt2) - (w // 2)) floor corner: ((pt1 max: pt2) + (w // 2)) ceiling + 1)
+		during: [ :transformedCanvas |
+			transformedCanvas line: pt1 to: pt2 width: w color: c ]
 ]
 
 { #category : 'accessing' }
@@ -535,7 +564,9 @@ ScalingCanvas >> transformBy: aDisplayTransform clippingTo: aClipRect during: aB
 				clipRect: (aClipRect floor scaleBy: scale))
 			scale: scale).
 		^ self ].
-	super transformBy: aDisplayTransform clippingTo: aClipRect during: aBlock smoothing: cellSize
+	self applyClippingTo: aClipRect floor
+		during: [ :transformedCanvas |
+			transformedCanvas transformBy: aDisplayTransform clippingTo: aClipRect during: aBlock smoothing: cellSize ]
 ]
 
 { #category : 'other' }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -30,6 +30,23 @@ ScalingCanvas class >> example [
 ]
 
 { #category : 'examples' }
+ScalingCanvas class >> exampleDrawPolygon [
+
+	^ self privateExampleWithExtent: 37@44 fillColor: Color white scale: 7 drawBlock: [ :canvas |
+		{
+			{ 2@2. 2@7. 7@7. 7@2 }.
+			{ 8.1@2.1. 8.1@7.1. 13.1@7.1. 13.1@2.1 }.
+			{ 14.9@2.9. 14.9@7.9. 19.9@7.9. 19.9@2.9 }.
+			{ 2@9. 19@9. 19@15. 11@15. 11@19. 2@19 }.
+			{ 2.9@21.1. 19.1@21.1. 19.1@27.9. 11.5@27.9. 11.5@31.3. 2.9@31.3 }.
+			{ 18@34. 18@39. 3@39. 3@42. 12@42. 12@34 }.
+			{ 25@11. 30@1. 35@11 }.
+			{ 35@22. 26@22. 35@13. 26@13 }.
+		} do: [ :vertices |
+			canvas drawPolygon: vertices fillStyle: (SolidFillStyle color: (Color red alpha: 0.25)) ] ]
+]
+
+{ #category : 'examples' }
 ScalingCanvas class >> exampleFillRectangle [
 
 	^ self privateExampleWithExtent: 11@3 fillColor: Color white scale: 10 drawBlock: [ :canvas |
@@ -188,6 +205,16 @@ ScalingCanvas >> depth [
 	^ formCanvas depth
 ]
 
+{ #category : 'drawing - polygons' }
+ScalingCanvas >> drawPolygon: vertices color: aColor borderWidth: bw borderColor: bc [
+
+	bw = 0 ifTrue: [
+		(self scalePolygon: vertices) ifNotNil: [ :scaledPolygon |
+			formCanvas drawPolygon: scaledPolygon color: aColor borderWidth: 0 borderColor: bc.
+			^ self ] ].
+	super drawPolygon: vertices color: aColor borderWidth: bw borderColor: bc
+]
+
 { #category : 'private' }
 ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect font: fontOrNil color: c [
 
@@ -314,6 +341,19 @@ ScalingCanvas >> paragraph: paragraph bounds: bounds color: c [
 ScalingCanvas >> scale [
 
 	^ scale
+]
+
+{ #category : 'private' }
+ScalingCanvas >> scalePolygon: vertices [
+
+	| previousPoint |
+	
+	vertices ifEmpty: [ ^ #() ].
+	previousPoint := vertices last.
+	^ vertices collect: [ :point |
+		((point x = previousPoint x) or: [ point y = previousPoint y ]) ifFalse: [ ^ nil ].
+		previousPoint := point.
+		point truncated * scale ]
 ]
 
 { #category : 'accessing' }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -128,3 +128,17 @@ ScalingCanvas >> transformBy: aDisplayTransform clippingTo: aClipRect during: aB
 		^ self ].
 	super transformBy: aDisplayTransform clippingTo: aClipRect during: aBlock smoothing: cellSize
 ]
+
+{ #category : #other }
+ScalingCanvas >> translateBy: aPoint clippingTo: aRect during: aBlock [
+
+	formCanvas translateBy: aPoint * scale clippingTo: (aRect scaleBy: scale) during: [ :transformedFormCanvas |
+		aBlock value: (self class formCanvas: transformedFormCanvas scale: scale) ]
+]
+
+{ #category : #'drawing - support' }
+ScalingCanvas >> translateBy: delta during: aBlock [
+
+	formCanvas translateBy: delta * scale during: [ :transformedFormCanvas |
+		aBlock value: (self class formCanvas: transformedFormCanvas scale: scale) ]
+]

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -61,21 +61,51 @@ ScalingCanvas class >> exampleFillRectangle [
 ]
 
 { #category : 'examples' }
-ScalingCanvas class >> exampleFrameAndFillRectangle [
+ScalingCanvas class >> exampleFrameAndFillRectangle1 [
+	
+	^ self privateExampleWithExtent: 80@54 fillColor: Color white scale: 5 drawBlock: [ :canvas |
+		canvas
+			frameAndFillRectangle: (5@5 extent: 20@20)
+				fillColor: Color blue
+				borderWidth: 2 borderColor: Color green;
+			frameAndFillRectangle: (30@5 extent: 20@20)
+				fillColor: Color green
+				borderWidth: 3 borderColor: Color transparent;
+			frameAndFillRectangle: (55@5 extent: 20@20)
+				fillColor: Color transparent
+				borderWidth: 5 borderColor: Color blue;
+			frameAndFillRectangle: (6@31 corner: 49@49)
+				fillColor: Color cyan translucent
+				borderWidth: 4 borderColor: Color red translucent;
+			frameAndFillRectangle: (31@31 corner: 74@49)
+				fillColor: Color blue translucent
+				borderWidth: 4 borderColor: Color yellow translucent ]
+]
 
-	^ self privateExampleWithExtent: 10@24 fillColor: Color white scale: 10 drawBlock: [ :canvas |
+{ #category : 'examples' }
+ScalingCanvas class >> exampleFrameAndFillRectangle2 [
+
+	^ self privateExampleWithExtent: 25@35 fillColor: Color white scale: 10 drawBlock: [ :canvas |
 		{
 			1.0@2.0 extent: 3.0@3.0.
-			1.1@6.1 extent: 3.1@3.1.
-			1.1@10.1 extent: 3.9@3.9.
-			1.9@14.9 extent: 3.1@3.1.
-			1.9@18.9 extent: 3.9@3.9
+			1.1@6.1 extent: 3.0@3.0.
+			1.9@10.9 extent: 3.0@3.0.
+			1.1@14.1 extent: 3.1@3.1.
+			1.1@18.1 extent: 3.9@3.9.
+			1.9@22.9 extent: 3.1@3.1.
+			1.9@26.9 extent: 3.9@3.9
 		} do: [ :rectangle |
 			canvas
 				frameAndFillRectangle: rectangle fillColor: Color blue
 					borderWidth: 0 borderColor: Color green;
-				frameAndFillRectangle: (rectangle translateBy: 5@1) fillColor: (Color blue alpha: 0.5)
-					borderWidth: 0 borderColor: Color green ] ]
+				frameAndFillRectangle: (rectangle translateBy: 5@1) fillColor: Color blue translucent
+					borderWidth: 0 borderColor: Color green;
+				frameAndFillRectangle: (rectangle translateBy: 10@2) fillColor: Color blue translucent
+					borderWidth: 1 borderColor: Color green translucent;
+				frameAndFillRectangle: (rectangle translateBy: 15@3) fillColor: Color blue translucent
+					borderWidth: 1.1 borderColor: Color green translucent;
+				frameAndFillRectangle: (rectangle translateBy: 20@4) fillColor: Color blue translucent
+					borderWidth: 1.9 borderColor: Color green translucent ] ]
 ]
 
 { #category : 'examples' }
@@ -279,15 +309,19 @@ ScalingCanvas >> formCanvas: initialFormCanvas scale: initialScale [
 { #category : 'drawing - rectangles' }
 ScalingCanvas >> frameAndFillRectangle: r fillColor: fillColor borderWidth: borderWidth borderColor: borderColor [
 
-	borderWidth = 0 ifTrue: [
-		| maxCorner origin corner scaledRectangle |
-		maxCorner := (1 << 31 - 1) asPoint - formCanvas origin.
-		origin := r origin truncated * scale.
-		corner := origin + (r extent truncated * scale).
-		scaledRectangle := Rectangle origin: r origin truncated * scale corner: (corner min: maxCorner).
-		formCanvas frameAndFillRectangle: scaledRectangle fillColor: fillColor
-			borderWidth: borderWidth borderColor: borderColor.
-		^ self ].
+	borderWidth truncated = borderWidth ifTrue: [
+		| extent extentTruncated |
+		extent := r extent.
+		extentTruncated := r extent truncated.
+		(borderWidth = 0 or: [ extentTruncated = extent ]) ifTrue: [
+			| maxCorner origin corner scaledRectangle |
+			maxCorner := (1 << 31 - 1) asPoint - formCanvas origin.
+			origin := r origin truncated * scale.
+			corner := origin + (extentTruncated * scale).
+			scaledRectangle := Rectangle origin: origin corner: (corner min: maxCorner).
+			formCanvas frameAndFillRectangle: scaledRectangle fillColor: fillColor
+				borderWidth: borderWidth * scale borderColor: borderColor.
+			^ self ] ].
 	super frameAndFillRectangle: r fillColor: fillColor borderWidth: borderWidth borderColor: borderColor
 ]
 

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -85,6 +85,16 @@ ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect fon
 		font: fontOrNil color: c scale: scale
 ]
 
+{ #category : #'drawing - text' }
+ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect font: fontOrNil color: c underline: underline underlineColor: uc strikethrough: strikethrough strikethroughColor: sc [
+
+	formCanvas drawString: s from: firstIndex to: lastIndex in: (boundsRect scaleBy: scale)
+		font: fontOrNil color: c
+		underline: underline underlineColor: uc
+		strikethrough: strikethrough strikethroughColor: sc
+		scale: scale
+]
+
 { #category : #initialization }
 ScalingCanvas >> formCanvas: initialFormCanvas scale: initialScale [
 

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -214,7 +214,7 @@ ScalingCanvas class >> formCanvas: formCanvas scale: scale [
 { #category : 'class initialization' }
 ScalingCanvas class >> initialize [
 
-	| theme icons iconsScale2 |
+	| theme icons iconFormsScale2 |
 
 	FormMapping := IdentityDictionary new.
 
@@ -224,10 +224,9 @@ ScalingCanvas class >> initialize [
 
 	icons := Smalltalk ui icons.
 	icons scale = 1 ifFalse: [ ^ self ].
-	(iconsScale2 := ThemeIcons named: icons name)
-		loadIconsFromUrlUsingScale: 2.
+	iconFormsScale2 := icons iconsPerScale at: 2 ifAbsent: [ ^ self ].
 	icons allIconNames do: [ :iconName |
-		iconsScale2 icons at: iconName ifPresent: [ :formScale2 |
+		iconFormsScale2 at: iconName ifPresent: [ :formScale2 |
 			FormMapping at: (icons iconNamed: iconName) put: formScale2 ] ]
 ]
 

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -61,6 +61,21 @@ ScalingCanvas class >> exampleFrameAndFillRectangle [
 					borderWidth: 0 borderColor: Color green ] ]
 ]
 
+{ #category : 'examples' }
+ScalingCanvas class >> exampleImageMorph [
+
+	^ self privateExampleWithMorph: (Morph new
+		color: Color veryVeryLightGray;
+		addMorph: ((ImageMorph withForm: (self iconNamed: #glamorousSearch))
+			position: 4@4;
+			yourself);
+		addMorph: ((ImageMorph withForm: (self iconNamed: #glamorousSearch) copy)
+			position: 24@4;
+			yourself);
+		extent: 44@24;
+		yourself)
+]
+
 { #category : 'instance creation' }
 ScalingCanvas class >> formCanvas: formCanvas scale: scale [
 
@@ -252,10 +267,12 @@ ScalingCanvas >> frameAndFillRectangle: r fillColor: fillColor borderWidth: bord
 { #category : 'private' }
 ScalingCanvas >> image: aForm at: aPoint sourceRect: sourceRect rule: rule [
 
-	(scale = 2 and: [ FormMapping includesKey: aForm ]) ifTrue: [
-		formCanvas image: (FormMapping at: aForm) at: aPoint * scale sourceRect: (sourceRect scaleBy: scale) rule: rule.
-		^ self ].
-	super image: aForm at: aPoint sourceRect: sourceRect rule: rule
+	| scaledForm |
+
+	scaledForm := (scale = 2 and: [ FormMapping includesKey: aForm ])
+		ifTrue: [ FormMapping at: aForm ]
+		ifFalse: [ aForm scaledToSize: aForm extent * scale ].
+	formCanvas image: scaledForm at: aPoint truncated * scale sourceRect: (sourceRect scaleBy: scale) rule: rule
 ]
 
 { #category : 'testing' }
@@ -268,6 +285,23 @@ ScalingCanvas >> isShadowDrawing [
 ScalingCanvas >> origin [
 
 	^ formCanvas origin / scale
+]
+
+{ #category : 'drawing - images' }
+ScalingCanvas >> paintImage: aForm at: aPoint [
+
+	self paintImage: aForm
+		at: aPoint
+		sourceRect: aForm boundingBox
+]
+
+{ #category : 'drawing - images' }
+ScalingCanvas >> paintImage: aForm at: aPoint sourceRect: sourceRect [
+
+	^self image: aForm
+		at: aPoint
+		sourceRect: sourceRect
+		rule: Form paint
 ]
 
 { #category : 'drawing' }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -134,6 +134,18 @@ ScalingCanvas >> flush [
 	formCanvas flush
 ]
 
+{ #category : 'accessing' }
+ScalingCanvas >> form [
+
+	^ formCanvas form
+]
+
+{ #category : 'accessing' }
+ScalingCanvas >> formCanvas [
+
+	^ formCanvas
+]
+
 { #category : 'initialization' }
 ScalingCanvas >> formCanvas: initialFormCanvas scale: initialScale [
 
@@ -168,6 +180,12 @@ ScalingCanvas >> image: aForm at: aPoint sourceRect: sourceRect rule: rule [
 ScalingCanvas >> paragraph: paragraph bounds: bounds color: c [
 
 	formCanvas paragraph: paragraph bounds: (bounds scaleBy: scale) color: c scale: scale
+]
+
+{ #category : 'accessing' }
+ScalingCanvas >> scale [
+
+	^ scale
 ]
 
 { #category : 'drawing - support' }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -109,7 +109,7 @@ ScalingCanvas class >> exampleFrameAndFillRectangle2 [
 ]
 
 { #category : 'examples' }
-ScalingCanvas class >> exampleImageMorph [
+ScalingCanvas class >> exampleImageMorph1 [
 
 	^ self privateExampleWithMorph: (Morph new
 		color: Color veryVeryLightGray;
@@ -121,6 +121,34 @@ ScalingCanvas class >> exampleImageMorph [
 			yourself);
 		extent: 44@24;
 		yourself)
+]
+
+{ #category : 'examples' }
+ScalingCanvas class >> exampleImageMorph2 [
+
+	| forms imageMorph |
+	
+	forms := (1 to: 2) collect: [ :scale |
+		(FormCanvas extent: 100 asPoint * scale depth: 1)
+			fillOval: ((0 asPoint extent: 100 asPoint * scale) insetBy: 5 * scale) fillStyle: Color green;
+			form ].
+	(imageMorph := ImageMorph withFormSet: (FormSet forms: forms))
+		color: Color blue.
+	^ self privateExampleWithMorph: imageMorph
+]
+
+{ #category : 'examples' }
+ScalingCanvas class >> exampleImageMorph3 [
+
+	| forms imageMorph |
+	
+	forms := (1 to: 2) collect: [ :scale |
+		(FormCanvas extent: 10 asPoint * scale)
+			fillOval: ((0 asPoint extent: 10 asPoint * scale) insetBy: 1 * scale) fillStyle: Color black;
+			form ].
+	(imageMorph := ImageMorph withFormSet: (FormSet forms: forms))
+		resize: 200@100.
+	^ self privateExampleWithMorph: imageMorph
 ]
 
 { #category : 'examples' }
@@ -280,6 +308,18 @@ ScalingCanvas >> copyClipRect: newClipRect [
 ScalingCanvas >> depth [
 
 	^ formCanvas depth
+]
+
+{ #category : 'drawing - images' }
+ScalingCanvas >> drawFormSet: formSet at: point [
+
+	| form scaledForm |
+
+	form := formSet asForm.
+	scaledForm := (scale = 2 and: [ FormMapping includesKey: form ])
+		ifTrue: [ FormMapping at: form ]
+		ifFalse: [ formSet asFormAtScale: scale ].
+	formCanvas drawImage: scaledForm at: point * scale
 ]
 
 { #category : 'drawing - polygons' }
@@ -498,4 +538,16 @@ ScalingCanvas >> translateBy: delta during: aBlock [
 
 	formCanvas translateBy: delta * scale during: [ :transformedFormCanvas |
 		aBlock value: (self class formCanvas: transformedFormCanvas scale: scale) ]
+]
+
+{ #category : 'drawing - images' }
+ScalingCanvas >> translucentFormSet: formSet at: point [
+
+	| form scaledForm |
+
+	form := formSet asForm.
+	scaledForm := (scale = 2 and: [ FormMapping includesKey: form ])
+		ifTrue: [ FormMapping at: form ]
+		ifFalse: [ formSet asFormAtScale: scale ].
+	formCanvas translucentImage: scaledForm at: point * scale
 ]

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -111,6 +111,12 @@ ScalingCanvas >> copyClipRect: newClipRect [
 	^ self class formCanvas: (formCanvas copyClipRect: (newClipRect scaleBy: scale)) scale: scale
 ]
 
+{ #category : 'accessing' }
+ScalingCanvas >> depth [
+
+	^ formCanvas depth
+]
+
 { #category : 'private' }
 ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect font: fontOrNil color: c [
 
@@ -132,6 +138,18 @@ ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect fon
 ScalingCanvas >> extent [
 
 	^ formCanvas extent / scale
+]
+
+{ #category : 'drawing' }
+ScalingCanvas >> fillColor: aColor [
+
+	formCanvas fillColor: aColor
+]
+
+{ #category : 'initialization' }
+ScalingCanvas >> finish [
+
+	formCanvas finish
 ]
 
 { #category : 'initialization' }
@@ -182,6 +200,12 @@ ScalingCanvas >> image: aForm at: aPoint sourceRect: sourceRect rule: rule [
 	super image: aForm at: aPoint sourceRect: sourceRect rule: rule
 ]
 
+{ #category : 'testing' }
+ScalingCanvas >> isShadowDrawing [
+
+	^ formCanvas isShadowDrawing
+]
+
 { #category : 'accessing' }
 ScalingCanvas >> origin [
 
@@ -198,6 +222,18 @@ ScalingCanvas >> paragraph: paragraph bounds: bounds color: c [
 ScalingCanvas >> scale [
 
 	^ scale
+]
+
+{ #category : 'accessing' }
+ScalingCanvas >> shadowColor [
+
+	^ formCanvas shadowColor
+]
+
+{ #category : 'accessing' }
+ScalingCanvas >> shadowColor: aColor [
+
+	formCanvas shadowColor: aColor
 ]
 
 { #category : 'drawing - support' }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -5,6 +5,9 @@ Class {
 		'formCanvas',
 		'scale'
 	],
+	#classVars : [
+		'FormMapping'
+	],
 	#category : #'Graphics-Canvas-Canvases'
 }
 
@@ -16,7 +19,8 @@ ScalingCanvas class >> example [
 	scale := 2.
 	(morph := MenuMorph new)
 		addTitle: 'Lorem ipsum'.
-	(morph add: 'Dolor sit amet' target: nil selector: #yourself) keyText: 'x'.
+	(morph add: 'Dolor sit amet' target: nil selector: #yourself) keyText: 'x';
+		icon: (self iconNamed: #smallConfiguration).
 	(morph add: 'Consectetur adipiscing elit' target: nil selector: #yourself) keyText: 'y'.
 	morph addLine.
 	(morph add: 'Sed do eiusmod' target: nil selector: #yourself) keyText: 'z'.
@@ -38,6 +42,26 @@ ScalingCanvas class >> example [
 ScalingCanvas class >> formCanvas: formCanvas scale: scale [
 
 	^ self new formCanvas: formCanvas scale: scale
+]
+
+{ #category : #'class initialization' }
+ScalingCanvas class >> initialize [
+
+	| theme icons iconsScale2 |
+
+	FormMapping := IdentityDictionary new.
+
+	theme := Smalltalk ui theme.
+	(theme formsForScale: 1) keysAndValuesDo: [ :formName :formScale1 |
+		FormMapping at: formScale1 put: ((theme formsForScale: 2) at: formName) ].
+
+	icons := Smalltalk ui icons.
+	icons scale = 1 ifFalse: [ ^ self ].
+	(iconsScale2 := ThemeIcons named: icons name)
+		loadIconsFromUrlUsingScale: 2.
+	icons allIconNames do: [ :iconName |
+		iconsScale2 icons at: iconName ifPresent: [ :formScale2 |
+			FormMapping at: (icons iconNamed: iconName) put: formScale2 ] ]
 ]
 
 { #category : #private }
@@ -108,6 +132,15 @@ ScalingCanvas >> formCanvas: initialFormCanvas scale: initialScale [
 	formCanvas := initialFormCanvas.
 	scale := initialScale.
 
+]
+
+{ #category : #private }
+ScalingCanvas >> image: aForm at: aPoint sourceRect: sourceRect rule: rule [
+
+	(scale = 2 and: [ FormMapping includesKey: aForm ]) ifTrue: [
+		formCanvas image: (FormMapping at: aForm) at: aPoint * scale sourceRect: (sourceRect scaleBy: scale) rule: rule.
+		^ self ].
+	super image: aForm at: aPoint sourceRect: sourceRect rule: rule
 ]
 
 { #category : #drawing }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -1,0 +1,65 @@
+Class {
+	#name : #ScalingCanvas,
+	#superclass : #PluggableCanvas,
+	#instVars : [
+		'formCanvas',
+		'scale'
+	],
+	#category : #'Graphics-Canvas-Canvases'
+}
+
+{ #category : #examples }
+ScalingCanvas class >> example [
+
+	| scale morph extent baseForm form1 form2 |
+
+	scale := 2.
+	(morph := MenuMorph new)
+		addTitle: 'Lorem ipsum'.
+	(morph add: 'Dolor sit amet' target: nil selector: #yourself) keyText: 'x'.
+	(morph add: 'Consectetur adipiscing elit' target: nil selector: #yourself) keyText: 'y'.
+	morph addLine.
+	(morph add: 'Sed do eiusmod' target: nil selector: #yourself) keyText: 'z'.
+	extent := morph fullBounds bottomRight.
+	
+	(baseForm := Form extent: extent depth: Display depth)
+		fillColor: Smalltalk ui theme backgroundColor.
+	baseForm getCanvas fullDrawMorph: morph.
+	form1 := baseForm scaledToSize: extent * scale.
+	
+	(form2 := Form extent: extent * scale depth: Display depth)
+		fillColor: Smalltalk ui theme backgroundColor.
+	(self formCanvas: form2 getCanvas scale: scale) fullDrawMorph: morph.
+
+	{ morph. form1. form2 } inspect
+]
+
+{ #category : #'instance creation' }
+ScalingCanvas class >> formCanvas: formCanvas scale: scale [
+
+	^ self new formCanvas: formCanvas scale: scale
+]
+
+{ #category : #private }
+ScalingCanvas >> apply: aBlock [
+
+	FreeTypeSettings current forceNonSubPixelDuring: [
+		formCanvas transformBy: (MatrixTransform2x3 withScale: scale)
+			clippingTo: formCanvas clipRect
+			during: aBlock ]
+]
+
+{ #category : #private }
+ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect font: fontOrNil color: c [
+
+	formCanvas drawString: s from: firstIndex to: lastIndex in: (boundsRect scaleBy: scale)
+		font: fontOrNil color: c scale: scale
+]
+
+{ #category : #initialization }
+ScalingCanvas >> formCanvas: initialFormCanvas scale: initialScale [
+
+	formCanvas := initialFormCanvas.
+	scale := initialScale.
+
+]

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -134,6 +134,19 @@ ScalingCanvas >> formCanvas: initialFormCanvas scale: initialScale [
 
 ]
 
+{ #category : #'drawing - rectangles' }
+ScalingCanvas >> frameAndFillRectangle: r fillColor: fillColor borderWidth: borderWidth borderColor: borderColor [
+
+	borderWidth = 0 ifTrue: [
+		| maxCorner scaledRectangle |
+		maxCorner := (1 << 31 - 1) asPoint - formCanvas origin.
+		scaledRectangle := Rectangle origin: r origin * scale corner: (r corner * scale min: maxCorner).
+		formCanvas frameAndFillRectangle: scaledRectangle fillColor: fillColor
+			borderWidth: borderWidth borderColor: borderColor.
+		^ self ].
+	super frameAndFillRectangle: r fillColor: fillColor borderWidth: borderWidth borderColor: borderColor
+]
+
 { #category : #private }
 ScalingCanvas >> image: aForm at: aPoint sourceRect: sourceRect rule: rule [
 

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -16,9 +16,8 @@ Class {
 { #category : 'examples' }
 ScalingCanvas class >> example [
 
-	| scale morph extent baseForm form1 form2 |
+	| morph |
 
-	scale := 2.
 	(morph := MenuMorph new)
 		addTitle: 'Lorem ipsum'.
 	(morph add: 'Dolor sit amet' target: nil selector: #yourself) keyText: 'x';
@@ -26,18 +25,8 @@ ScalingCanvas class >> example [
 	(morph add: 'Consectetur adipiscing elit' target: nil selector: #yourself) keyText: 'y'.
 	morph addLine.
 	(morph add: 'Sed do eiusmod' target: nil selector: #yourself) keyText: 'z'.
-	extent := morph fullBounds bottomRight.
 	
-	(baseForm := Form extent: extent depth: Display depth)
-		fillColor: Smalltalk ui theme backgroundColor.
-	baseForm getCanvas fullDrawMorph: morph.
-	form1 := baseForm scaledToSize: extent * scale.
-	
-	(form2 := Form extent: extent * scale depth: Display depth)
-		fillColor: Smalltalk ui theme backgroundColor.
-	(self formCanvas: form2 getCanvas scale: scale) fullDrawMorph: morph.
-
-	{ morph. form1. form2 } inspect
+	^ self privateExampleWithMorph: morph
 ]
 
 { #category : 'instance creation' }
@@ -64,6 +53,33 @@ ScalingCanvas class >> initialize [
 	icons allIconNames do: [ :iconName |
 		iconsScale2 icons at: iconName ifPresent: [ :formScale2 |
 			FormMapping at: (icons iconNamed: iconName) put: formScale2 ] ]
+]
+
+{ #category : 'private' }
+ScalingCanvas class >> privateExampleWithExtent: extent fillColor: fillColor scale: scale drawBlock: drawBlock do: doBlock [
+
+	| baseForm form1 form2 |
+	
+	(baseForm := Form extent: extent depth: Display depth)
+		fillColor: fillColor.
+	drawBlock value: baseForm getCanvas.
+	form1 := baseForm scaledToSize: extent * scale.
+	
+	(form2 := Form extent: extent * scale depth: Display depth)
+		fillColor: fillColor.
+	drawBlock value: (self formCanvas: form2 getCanvas scale: scale).
+	
+	^ doBlock value: form1 value: form2
+]
+
+{ #category : 'private' }
+ScalingCanvas class >> privateExampleWithMorph: morph [
+
+	^ self privateExampleWithExtent: morph fullBounds bottomRight
+		fillColor: Smalltalk ui theme backgroundColor
+		scale: 2
+		drawBlock: [ :canvas | canvas fullDrawMorph: morph ]
+		do: [ :form1 :form2 | { morph. form1. form2 } inspect ]
 ]
 
 { #category : 'private' }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -55,6 +55,13 @@ ScalingCanvas >> apply: aBlock [
 			during: aBlock ]
 ]
 
+{ #category : #'drawing - support' }
+ScalingCanvas >> clipBy: aRectangle during: aBlock [
+
+	formCanvas clipBy: (aRectangle scaleBy: scale) during: [ :transformedFormCanvas |
+		aBlock value: (self class formCanvas: transformedFormCanvas scale: scale) ]
+]
+
 { #category : #accessing }
 ScalingCanvas >> clipRect [
 

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -123,6 +123,53 @@ ScalingCanvas class >> exampleImageMorph [
 		yourself)
 ]
 
+{ #category : 'examples' }
+ScalingCanvas class >> exampleLine1 [
+
+	^ self privateExampleWithExtent: 101@101 fillColor: Color white scale: 4 drawBlock: [ :canvas |
+		| center innerRadius outerRadius |
+		center := 50@50.
+		innerRadius := 15.
+		outerRadius := 45.
+		0 to: 359 by: 10 do: [ :degrees |
+			| factors |
+			factors := degrees degreeCos @ degrees degreeSin.
+			canvas line: center + (innerRadius * factors) rounded
+				to: center + (outerRadius * factors) rounded
+				width: 1 color: (Color h: degrees s: 1.0 v: 1.0) ] ]
+]
+
+{ #category : 'examples' }
+ScalingCanvas class >> exampleLine2 [
+
+	^ self privateExampleWithExtent: 61@40 fillColor: Color white scale: 10 drawBlock: [ :canvas |
+		{
+			{ 1. { (1@1) -> (1@1). (1@3) -> (2@3). (1@5) -> (3@5) } }.
+			{ 2. { (6@2) -> (6@2). (6@5) -> (7@5). (6@8) -> (8@8) } }.
+			{ 3. { (11@2) -> (11@2). (11@6) -> (12@6). (11@10) -> (13@10) } }.
+			{ 4. { (18@3) -> (18@3). (18@8) -> (19@8). (18@13) -> (20@13) } }.
+			{ 5. { (25@3) -> (25@3). (25@9) -> (26@9). (25@15) -> (27@15) } }.
+			{ 1. { (23.0@20.0) -> (23.0@20.0). (25.0@20.0) -> (25.1@20.0). (27.0@20.0) -> (27.9@20.0) } }.
+			{ 1. { (23.9@22.0) -> (24.0@22.0). (25.1@22.0) -> (26.0@22.0). (28.0@22.0) -> (28.0@22.0) } }.
+			{ 1.5. { (23.0@24.0) -> (23.0@24.0). (25.1@24.0) -> (26.9@24.0) } }.
+		} do: [ :arguments |
+			arguments bind: [ :width :pointAssociations |
+				pointAssociations do: [ :pointAssociation |
+					canvas
+						line: pointAssociation key
+							to: pointAssociation value
+							width: width color: Color blue;
+						line: pointAssociation key transposed + (0@9)
+							to: pointAssociation value transposed + (0@9)
+							width: width color: Color blue;
+						line: pointAssociation key + (30@0)
+							to: pointAssociation value + (30@0)
+							width: width color: Color blue translucent;
+						line: pointAssociation key transposed + (30@9)
+							to: pointAssociation value transposed + (30@9)
+							width: width color: Color blue translucent ] ] ] ]
+]
+
 { #category : 'instance creation' }
 ScalingCanvas class >> formCanvas: formCanvas scale: scale [
 
@@ -340,6 +387,23 @@ ScalingCanvas >> image: aForm at: aPoint sourceRect: sourceRect rule: rule [
 ScalingCanvas >> isShadowDrawing [
 
 	^ formCanvas isShadowDrawing
+]
+
+{ #category : 'drawing' }
+ScalingCanvas >> line: pt1 to: pt2 width: w color: c [
+
+	(c isTranslucentButNotTransparent not and: [ (w truncated = w) and: [
+		((pt1 x = pt2 x) or: [ pt1 y = pt2 y ]) and: [
+			pt1 truncated = pt1 and: [ pt2 truncated = pt2 ] ] ] ]) ifTrue: [
+				| offset widthScaled scaledOffset |
+				offset := w // 2.
+				widthScaled := w * scale.
+				scaledOffset := widthScaled // 2.
+				formCanvas line: (pt1 - offset) * scale + scaledOffset
+					to: (pt2 - offset) * scale + scaledOffset
+					width: widthScaled color: c.
+				^ self ].
+	super line: pt1 to: pt2 width: w color: c
 ]
 
 { #category : 'accessing' }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -128,6 +128,12 @@ ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect fon
 		scale: scale
 ]
 
+{ #category : 'accessing' }
+ScalingCanvas >> extent [
+
+	^ formCanvas extent / scale
+]
+
 { #category : 'initialization' }
 ScalingCanvas >> flush [
 
@@ -174,6 +180,12 @@ ScalingCanvas >> image: aForm at: aPoint sourceRect: sourceRect rule: rule [
 		formCanvas image: (FormMapping at: aForm) at: aPoint * scale sourceRect: (sourceRect scaleBy: scale) rule: rule.
 		^ self ].
 	super image: aForm at: aPoint sourceRect: sourceRect rule: rule
+]
+
+{ #category : 'accessing' }
+ScalingCanvas >> origin [
+
+	^ formCanvas origin / scale
 ]
 
 { #category : 'drawing' }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -41,12 +41,41 @@ ScalingCanvas class >> formCanvas: formCanvas scale: scale [
 ]
 
 { #category : #private }
+ScalingCanvas >> allocateForm: extentPoint [
+
+	^ formCanvas allocateForm: extentPoint
+]
+
+{ #category : #private }
 ScalingCanvas >> apply: aBlock [
 
 	FreeTypeSettings current forceNonSubPixelDuring: [
 		formCanvas transformBy: (MatrixTransform2x3 withScale: scale)
 			clippingTo: formCanvas clipRect
 			during: aBlock ]
+]
+
+{ #category : #accessing }
+ScalingCanvas >> clipRect [
+
+	^ formCanvas clipRect scaleBy: scale reciprocal
+]
+
+{ #category : #accessing }
+ScalingCanvas >> contentsOfArea: aRectangle into: aForm [
+
+	| contentsForm |
+
+	contentsForm := aForm blankCopyOf: aForm boundingBox scaledBy: scale.
+	formCanvas contentsOfArea: (aRectangle scaleBy: scale) into: contentsForm.
+	(contentsForm scaledToSize: aForm extent) contentsOfArea: aForm boundingBox into: aForm.
+	^ aForm
+]
+
+{ #category : #copying }
+ScalingCanvas >> copyClipRect: newClipRect [
+
+	^ self class formCanvas: (formCanvas copyClipRect: (newClipRect scaleBy: scale)) scale: scale
 ]
 
 { #category : #private }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -109,3 +109,9 @@ ScalingCanvas >> formCanvas: initialFormCanvas scale: initialScale [
 	scale := initialScale.
 
 ]
+
+{ #category : #drawing }
+ScalingCanvas >> paragraph: paragraph bounds: bounds color: c [
+
+	formCanvas paragraph: paragraph bounds: (bounds scaleBy: scale) color: c scale: scale
+]

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -328,6 +328,13 @@ ScalingCanvas >> shadowColor: aColor [
 	formCanvas shadowColor: aColor
 ]
 
+{ #category : 'drawing - images' }
+ScalingCanvas >> stencil: stencilForm at: aPoint sourceRect: sourceRect color: aColor [
+
+	formCanvas stencil: (stencilForm scaledToSize: stencilForm extent * scale)
+		at: aPoint truncated * scale sourceRect: (sourceRect scaleBy: scale) color: aColor
+]
+
 { #category : 'drawing - support' }
 ScalingCanvas >> transformBy: aDisplayTransform clippingTo: aClipRect during: aBlock smoothing: cellSize [
 

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -29,6 +29,38 @@ ScalingCanvas class >> example [
 	^ self privateExampleWithMorph: morph
 ]
 
+{ #category : 'examples' }
+ScalingCanvas class >> exampleFillRectangle [
+
+	^ self privateExampleWithExtent: 11@3 fillColor: Color white scale: 10 drawBlock: [ :canvas |
+		{
+			1.0@1.0 extent: 1.0@1.0.
+			3.1@1.1 extent: 1.1@1.1.
+			5.1@1.1 extent: 1.9@1.9.
+			7.9@1.9 extent: 1.1@1.1.
+			9.9@1.9 extent: 1.9@1.9
+		} do: [ :rectangle |
+			canvas fillRectangle: rectangle color: Color blue ] ]
+]
+
+{ #category : 'examples' }
+ScalingCanvas class >> exampleFrameAndFillRectangle [
+
+	^ self privateExampleWithExtent: 10@24 fillColor: Color white scale: 10 drawBlock: [ :canvas |
+		{
+			1.0@2.0 extent: 3.0@3.0.
+			1.1@6.1 extent: 3.1@3.1.
+			1.1@10.1 extent: 3.9@3.9.
+			1.9@14.9 extent: 3.1@3.1.
+			1.9@18.9 extent: 3.9@3.9
+		} do: [ :rectangle |
+			canvas
+				frameAndFillRectangle: rectangle fillColor: Color blue
+					borderWidth: 0 borderColor: Color green;
+				frameAndFillRectangle: (rectangle translateBy: 5@1) fillColor: (Color blue alpha: 0.5)
+					borderWidth: 0 borderColor: Color green ] ]
+]
+
 { #category : 'instance creation' }
 ScalingCanvas class >> formCanvas: formCanvas scale: scale [
 
@@ -53,6 +85,14 @@ ScalingCanvas class >> initialize [
 	icons allIconNames do: [ :iconName |
 		iconsScale2 icons at: iconName ifPresent: [ :formScale2 |
 			FormMapping at: (icons iconNamed: iconName) put: formScale2 ] ]
+]
+
+{ #category : 'private' }
+ScalingCanvas class >> privateExampleWithExtent: extent fillColor: fillColor scale: scale drawBlock: drawBlock [
+
+	^ self privateExampleWithExtent: extent fillColor: fillColor scale: scale
+		drawBlock: drawBlock
+		do: [ :form1 :form2 | { form1. form2 } inspect ]
 ]
 
 { #category : 'private' }
@@ -198,9 +238,11 @@ ScalingCanvas >> formCanvas: initialFormCanvas scale: initialScale [
 ScalingCanvas >> frameAndFillRectangle: r fillColor: fillColor borderWidth: borderWidth borderColor: borderColor [
 
 	borderWidth = 0 ifTrue: [
-		| maxCorner scaledRectangle |
+		| maxCorner origin corner scaledRectangle |
 		maxCorner := (1 << 31 - 1) asPoint - formCanvas origin.
-		scaledRectangle := Rectangle origin: r origin * scale corner: (r corner * scale min: maxCorner).
+		origin := r origin truncated * scale.
+		corner := origin + (r extent truncated * scale).
+		scaledRectangle := Rectangle origin: r origin truncated * scale corner: (corner min: maxCorner).
 		formCanvas frameAndFillRectangle: scaledRectangle fillColor: fillColor
 			borderWidth: borderWidth borderColor: borderColor.
 		^ self ].

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -269,9 +269,21 @@ ScalingCanvas >> allocateForm: extentPoint [
 ScalingCanvas >> apply: aBlock [
 
 	FreeTypeSettings current forceNonSubPixelDuring: [
-		formCanvas transformBy: (MatrixTransform2x3 withScale: scale)
-			clippingTo: formCanvas clipRect
-			during: aBlock ]
+		| clipRect |
+		clipRect := formCanvas clipRect.
+		self depth = 32 ifTrue: [
+			| sourceForm |
+			clipRect := clipRect intersect: (formCanvas origin negated extent: formCanvas extent) ifNone: [ 0@0 corner: 0@0 ].
+			sourceForm := Form extent: clipRect extent / scale depth: 32.
+			(FormCanvas on: sourceForm) translateBy: clipRect origin negated / scale during: aBlock.
+			(formCanvas warpFrom: sourceForm boundingBox innerCorners toRect: clipRect)
+				combinationRule: Form blend;
+				sourceForm: sourceForm;
+				warpBits
+		] ifFalse: [
+			formCanvas transformBy: (MatrixTransform2x3 withScale: scale)
+				clippingTo: clipRect
+				during: aBlock ] ]
 ]
 
 { #category : 'drawing - support' }

--- a/src/Morphic-Core/ScalingCanvas.extension.st
+++ b/src/Morphic-Core/ScalingCanvas.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : 'ScalingCanvas' }
 
 { #category : '*Morphic-Core' }
+ScalingCanvas >> allocateCanvas: extent [
+
+	^ self class formCanvas: (formCanvas allocateCanvas: extent * scale) scale: scale
+]
+
+{ #category : '*Morphic-Core' }
 ScalingCanvas >> allocateSavedPatch: extent [
 
 	^ ScalingCanvasSavedPatch
@@ -12,6 +18,32 @@ ScalingCanvas >> allocateSavedPatch: extent [
 ScalingCanvas >> contentsOfArea: aRectangle intoSavedPatch: savedPatch [
 
 	formCanvas contentsOfArea: (aRectangle scaleBy: scale) intoSavedPatch: savedPatch form
+]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas >> drawImageOn: aCanvas at: aPoint [
+
+	aCanvas formCanvas drawImage: self form
+		at: aPoint * scale
+		sourceRect: (self form boundingBox scaleBy: scale)
+]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas >> numberOfTransparentPixelsForRoundedCorners [
+
+	^ formCanvas numberOfTransparentPixelsForRoundedCorners * scale * scale
+]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas >> paintImageFromScalingCanvas: aScalingCanvas at: aPoint [
+
+	formCanvas paintImage: aScalingCanvas form at: aPoint * scale
+]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas >> paintImageOn: aCanvas at: aPoint [
+
+	aCanvas paintImageFromScalingCanvas: self at: aPoint
 ]
 
 { #category : '*Morphic-Core' }

--- a/src/Morphic-Core/ScalingCanvas.extension.st
+++ b/src/Morphic-Core/ScalingCanvas.extension.st
@@ -1,0 +1,21 @@
+Extension { #name : 'ScalingCanvas' }
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas >> allocateSavedPatch: extent [
+
+	^ ScalingCanvasSavedPatch
+		form: (formCanvas allocateForm: extent * scale)
+		scale: scale
+]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas >> contentsOfArea: aRectangle intoSavedPatch: savedPatch [
+
+	formCanvas contentsOfArea: (aRectangle scaleBy: scale) intoSavedPatch: savedPatch form
+]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas >> restoreSavedPatch: savedPatch at: aPoint [
+
+	formCanvas restoreSavedPatch: savedPatch form at: aPoint * scale
+]

--- a/src/Morphic-Core/ScalingCanvasSavedPatch.class.st
+++ b/src/Morphic-Core/ScalingCanvasSavedPatch.class.st
@@ -1,3 +1,6 @@
+"
+A ScalingCanvasSavedPatch is used to save a part of a `ScalingCanvas` under a `HandMorph`.
+"
 Class {
 	#name : 'ScalingCanvasSavedPatch',
 	#superclass : 'Object',

--- a/src/Morphic-Core/ScalingCanvasSavedPatch.class.st
+++ b/src/Morphic-Core/ScalingCanvasSavedPatch.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : 'ScalingCanvasSavedPatch',
+	#superclass : 'Object',
+	#instVars : [
+		'form',
+		'scale'
+	],
+	#category : 'Morphic-Core-Kernel',
+	#package : 'Morphic-Core',
+	#tag : 'Kernel'
+}
+
+{ #category : 'instance creation' }
+ScalingCanvasSavedPatch class >> form: form scale: scale [
+
+	^ self basicNew initializeWithForm: form scale: scale
+]
+
+{ #category : 'accessing' }
+ScalingCanvasSavedPatch >> extent [
+
+	^ form extent / scale
+]
+
+{ #category : 'accessing' }
+ScalingCanvasSavedPatch >> form [
+
+	^ form
+]
+
+{ #category : 'initialization' }
+ScalingCanvasSavedPatch >> initializeWithForm: initialForm scale: initialScale [
+
+	self initialize.
+	form := initialForm.
+	scale := initialScale.
+]
+
+{ #category : 'accessing' }
+ScalingCanvasSavedPatch >> offset [
+
+	^ form offset / scale
+]
+
+{ #category : 'accessing' }
+ScalingCanvasSavedPatch >> offset: newOffset [
+
+	form offset: newOffset * scale
+]

--- a/src/Morphic-Core/ShadowDrawingCanvas.extension.st
+++ b/src/Morphic-Core/ShadowDrawingCanvas.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'ShadowDrawingCanvas' }
+
+{ #category : '*Morphic-Core' }
+ShadowDrawingCanvas >> paintImageFromScalingCanvas: aScalingCanvas at: aPoint [
+
+	myCanvas formCanvas asShadowDrawingCanvas
+		paintImage: aScalingCanvas form
+		at: aPoint * aScalingCanvas scale
+]

--- a/src/OSWindow-Core/OSWindowFormRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowFormRenderer.class.st
@@ -8,10 +8,23 @@ Class {
 	#name : #OSWindowFormRenderer,
 	#superclass : #OSWindowRenderer,
 	#instVars : [
-		'form'
+		'form',
+		'canvasBlock'
 	],
 	#category : #'OSWindow-Core-Renderer'
 }
+
+{ #category : #accessing }
+OSWindowFormRenderer >> canvasBlock [
+
+	^ canvasBlock ifNil: [ [ :canvas | canvas ] ]
+]
+
+{ #category : #accessing }
+OSWindowFormRenderer >> canvasBlock: anObject [
+
+	canvasBlock := anObject
+]
 
 { #category : #'morphic integration' }
 OSWindowFormRenderer >> deferUpdatesWhile: aBlock [
@@ -39,7 +52,7 @@ OSWindowFormRenderer >> form: anObject [
 
 { #category : #accessing }
 OSWindowFormRenderer >> getCanvas [
-	^ form getCanvas
+	^ self canvasBlock value: form getCanvas
 ]
 
 { #category : #size }

--- a/src/OSWindow-Core/OSWindowFormRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowFormRenderer.class.st
@@ -15,6 +15,12 @@ Class {
 	#tag : 'Renderer'
 }
 
+{ #category : 'private' }
+OSWindowFormRenderer >> canvasScaleFactor [
+
+	^ OSWorldRenderer canvasScaleFactor
+]
+
 { #category : 'morphic integration' }
 OSWindowFormRenderer >> deferUpdatesWhile: aBlock [
 
@@ -41,7 +47,14 @@ OSWindowFormRenderer >> form: anObject [
 
 { #category : 'accessing' }
 OSWindowFormRenderer >> getCanvas [
-	^ form getCanvas
+
+	| scale formCanvas |
+	
+	scale := self canvasScaleFactor.
+	formCanvas := form getCanvas.
+	^ scale = 1
+		ifTrue: [ formCanvas ]
+		ifFalse: [ ScalingCanvas formCanvas: formCanvas scale: scale ]
 ]
 
 { #category : 'size' }

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -11,10 +11,25 @@ Class {
 		'windowCloseAction',
 		'previousFrameRenderingTime'
 	],
+	#classInstVars : [
+		'canvasScaleFactor'
+	],
 	#category : 'OSWindow-Core-Morphic',
 	#package : 'OSWindow-Core',
 	#tag : 'Morphic'
 }
+
+{ #category : 'accessing' }
+OSWorldRenderer class >> canvasScaleFactor [
+
+	^ canvasScaleFactor ifNil: [ canvasScaleFactor := 1 ]
+]
+
+{ #category : 'accessing' }
+OSWorldRenderer class >> canvasScaleFactor: newScale [
+
+	canvasScaleFactor := 1 max: newScale asInteger
+]
 
 { #category : 'accessing' }
 OSWorldRenderer class >> defaultExtent [
@@ -34,6 +49,19 @@ OSWorldRenderer class >> priority [
 	^ 2
 ]
 
+{ #category : 'settings' }
+OSWorldRenderer class >> settingsOn: aBuilder [
+
+	<systemsettings>
+
+	(aBuilder pickOne: #canvasScaleFactor)
+		parent: #appearance;
+		label: 'Canvas scale factor for OSWorldRenderer';
+		target: self;
+		domainValues: (1 to: 5);
+		default: 1
+]
+
 { #category : 'accessing' }
 OSWorldRenderer >> activateCursor: aCursor withMask: maskForm [
 
@@ -45,8 +73,20 @@ OSWorldRenderer >> activateCursor: aCursor withMask: maskForm [
 ]
 
 { #category : 'accessing' }
+OSWorldRenderer >> actualDisplaySize [
+
+	^ self actualScreenSize * self canvasScaleFactor
+]
+
+{ #category : 'accessing' }
 OSWorldRenderer >> actualScreenSize [
 	^ (self windowExtent / self screenScaleFactor) ceiling max: 1@1
+]
+
+{ #category : 'private' }
+OSWorldRenderer >> canvasScaleFactor [
+
+	^ self class canvasScaleFactor
 ]
 
 { #category : 'events' }
@@ -59,10 +99,10 @@ OSWorldRenderer >> checkForNewScreenSize [
 	windowRenderer := self osWindowRenderer.
 	windowRenderer ifNil: [ ^ self ].
 
-	(display isNil or: [ display extent = self actualScreenSize ])
+	(display isNil or: [ display extent = self actualDisplaySize ])
 		ifTrue: [ ^ self ].
 
-	display := Form extent: self actualScreenSize depth: 32.
+	display := Form extent: self actualDisplaySize depth: 32.
 	windowRenderer form: display.
 
 	world worldState realWindowExtent: self actualScreenSize.
@@ -89,14 +129,22 @@ OSWorldRenderer >> convertWindowMouseEventPosition: aPosition [
 { #category : 'screenshot' }
 OSWorldRenderer >> copyRectangle: aRectangle into: aForm [
 
-	aForm
-		copyBits: (aRectangle origin extent: aForm extent)
+	| scale copiedForm |
+
+	scale := self canvasScaleFactor.
+	copiedForm := scale = 1
+		ifTrue: [ aForm ]
+		ifFalse: [ Form extent: aForm extent * scale depth: aForm depth ].
+	copiedForm
+		copyBits: (aRectangle origin floor * scale extent: copiedForm extent)
 		from: display
 		at: 0 @ 0
-		clippingBox: aForm boundingBox
+		clippingBox: copiedForm boundingBox
 		rule: Form over
 		fillColor: nil.
-
+	scale = 1 ifFalse: [
+		(copiedForm scaledToSize: aForm extent)
+			contentsOfArea: aForm boundingBox into: aForm ].
 	^ aForm
 ]
 
@@ -139,7 +187,7 @@ OSWorldRenderer >> doActivate [
 		windowCentered: true;
 		icon: self defaultWindowIcon.
 
-	display := Form extent: initialExtent depth: 32.
+	display := Form extent: initialExtent * self canvasScaleFactor depth: 32.
 	world extent: initialExtent.
 
 	driver := self pickMostSuitableWindowDriver.
@@ -200,7 +248,7 @@ OSWorldRenderer >> drawWhileProfilingRenderingTimeDuring: aBlock [
 					canvas drawString: line at: 10@(10*index) font: nil color: Color black.
 				].
 
-				self osWindowRenderer updateRectangle: displayRectangle.
+				self osWindowRenderer updateRectangle: (displayRectangle scaleBy: self canvasScaleFactor).
 			]
 		]
 	] timeToRunWithoutGC.
@@ -297,8 +345,12 @@ OSWorldRenderer >> startUp: resuming [
 { #category : 'operations' }
 OSWorldRenderer >> updateDamage: allDamage [
 
+	| scale scaledDamage |
+
+	scale := self canvasScaleFactor.
+	scaledDamage := scale = 1 ifTrue: [ allDamage ] ifFalse: [ allDamage collect: [ :rectangle | rectangle scaleBy: scale ] ].
 	"quickly copy altered rects of canvas to Display:"
-	self osWindowRenderer updateAreas: allDamage immediate: false
+	self osWindowRenderer updateAreas: scaledDamage immediate: false
 ]
 
 { #category : 'events' }

--- a/src/OSWindow-Core/OSWorldRendererScalingCanvas.class.st
+++ b/src/OSWindow-Core/OSWorldRendererScalingCanvas.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : 'OSWorldRendererScalingCanvas',
 	#superclass : 'OSWorldRenderer',
+	#classInstVars : [
+		'isApplicable'
+	],
 	#category : 'OSWindow-Core-Morphic',
 	#package : 'OSWindow-Core',
 	#tag : 'Morphic'
@@ -20,9 +23,21 @@ OSWorldRendererScalingCanvas class >> example [
 ]
 
 { #category : 'accessing' }
+OSWorldRendererScalingCanvas class >> isApplicable [
+
+	^ isApplicable ifNil: [ false ]
+]
+
+{ #category : 'accessing' }
+OSWorldRendererScalingCanvas class >> isApplicable: boolean [
+
+	isApplicable := boolean
+]
+
+{ #category : 'accessing' }
 OSWorldRendererScalingCanvas class >> isApplicableFor: aWorld [
 
-	^ false
+	^ self isApplicable
 ]
 
 { #category : 'utilities' }

--- a/src/OSWindow-Core/OSWorldRendererScalingCanvas.class.st
+++ b/src/OSWindow-Core/OSWorldRendererScalingCanvas.class.st
@@ -36,7 +36,11 @@ OSWorldRendererScalingCanvas >> doActivate [
 
 	super doActivate.
 	self osWindow backendWindow renderer canvasBlock: [ :formCanvas |
-		ScalingCanvas formCanvas: formCanvas scale: world scaleFactor reciprocal ]
+		| scale |
+		scale := world scaleFactor reciprocal.
+		(scale ~= 1 and: [ scale truncated = scale ])
+			ifTrue: [ ScalingCanvas formCanvas: formCanvas scale: scale ]
+			ifFalse: [ formCanvas ] ]
 ]
 
 { #category : 'operations' }

--- a/src/OSWindow-Core/OSWorldRendererScalingCanvas.class.st
+++ b/src/OSWindow-Core/OSWorldRendererScalingCanvas.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : #OSWorldRendererScalingCanvas,
+	#superclass : #OSWorldRenderer,
+	#category : #'OSWindow-Core-Morphic'
+}
+
+{ #category : #examples }
+OSWorldRendererScalingCanvas class >> example [
+
+	| world |
+
+	(world := OSWindowWorldMorph new)
+		scaleFactor: 0.5.
+	world worldState worldRenderer: ((self forWorld: world)
+		windowCloseAction: [ world osWindowCloseButtonPressed ]).
+	world changed.
+	world class addExtraWorld: world
+]
+
+{ #category : #accessing }
+OSWorldRendererScalingCanvas class >> isApplicableFor: aWorld [
+
+	^ false
+]
+
+{ #category : #utilities }
+OSWorldRendererScalingCanvas >> convertWindowMouseEventPosition: aPosition [
+
+	^ super convertWindowMouseEventPosition: aPosition * world scaleFactor
+]
+
+{ #category : #private }
+OSWorldRendererScalingCanvas >> doActivate [
+
+	super doActivate.
+	self osWindow backendWindow renderer canvasBlock: [ :formCanvas |
+		ScalingCanvas formCanvas: formCanvas scale: world scaleFactor reciprocal ]
+]
+
+{ #category : #operations }
+OSWorldRendererScalingCanvas >> updateDamage: allDamage [
+
+	| scale |
+	
+	scale := world scaleFactor reciprocal.
+	super updateDamage: (allDamage collect: [ :damageRect | damageRect scaleBy: scale ])
+]

--- a/src/OSWindow-Core/OSWorldRendererScalingCanvas.class.st
+++ b/src/OSWindow-Core/OSWorldRendererScalingCanvas.class.st
@@ -47,3 +47,9 @@ OSWorldRendererScalingCanvas >> updateDamage: allDamage [
 	scale := world scaleFactor reciprocal.
 	super updateDamage: (allDamage collect: [ :damageRect | damageRect scaleBy: scale ])
 ]
+
+{ #category : 'display box access' }
+OSWorldRendererScalingCanvas >> viewBox [
+
+	^ 0@0 corner: ((self windowExtent / self windowScaleFactor) ceiling max: 1@1)
+]

--- a/src/OSWindow-Core/OSWorldRendererScalingCanvas.class.st
+++ b/src/OSWindow-Core/OSWorldRendererScalingCanvas.class.st
@@ -40,10 +40,23 @@ OSWorldRendererScalingCanvas class >> isApplicableFor: aWorld [
 	^ self isApplicable
 ]
 
+{ #category : 'private' }
+OSWorldRendererScalingCanvas >> canvasScale [
+
+	| scale |
+
+	scale := world scaleFactor reciprocal.
+	^ (scale ~= 1 and: [ scale truncated = scale ])
+		ifTrue: [ scale ]
+		ifFalse: [ nil ]
+]
+
 { #category : 'utilities' }
 OSWorldRendererScalingCanvas >> convertWindowMouseEventPosition: aPosition [
 
-	^ super convertWindowMouseEventPosition: aPosition * world scaleFactor
+	^ self canvasScale
+		ifNil: [ super convertWindowMouseEventPosition: aPosition ]
+		ifNotNil: [ :canvasScale | super convertWindowMouseEventPosition: aPosition * canvasScale reciprocal ]
 ]
 
 { #category : 'private' }
@@ -51,24 +64,21 @@ OSWorldRendererScalingCanvas >> doActivate [
 
 	super doActivate.
 	self osWindow backendWindow renderer canvasBlock: [ :formCanvas |
-		| scale |
-		scale := world scaleFactor reciprocal.
-		(scale ~= 1 and: [ scale truncated = scale ])
-			ifTrue: [ ScalingCanvas formCanvas: formCanvas scale: scale ]
-			ifFalse: [ formCanvas ] ]
+		self canvasScale
+			ifNotNil: [ :scale | ScalingCanvas formCanvas: formCanvas scale: scale ]
+			ifNil: [ formCanvas ] ]
 ]
 
 { #category : 'operations' }
 OSWorldRendererScalingCanvas >> updateDamage: allDamage [
 
-	| scale |
-	
-	scale := world scaleFactor reciprocal.
-	super updateDamage: (allDamage collect: [ :damageRect | damageRect scaleBy: scale ])
+	super updateDamage: (self canvasScale ifNil: [ allDamage ] ifNotNil: [ :canvasScale |
+		allDamage collect: [ :damageRect | damageRect scaleBy: canvasScale ] ])
 ]
 
 { #category : 'display box access' }
 OSWorldRendererScalingCanvas >> viewBox [
 
+	self canvasScale ifNil: [ ^ super viewBox ].
 	^ 0@0 corner: ((self windowExtent / self windowScaleFactor) ceiling max: 1@1)
 ]

--- a/src/Rubric/FormCanvas.extension.st
+++ b/src/Rubric/FormCanvas.extension.st
@@ -3,9 +3,16 @@ Extension { #name : #FormCanvas }
 { #category : #'*Rubric-Editing-Core' }
 FormCanvas >> rubParagraph: para bounds: bounds color: c [
 
+	^ self rubParagraph: para bounds: bounds color: c scale: 1
+]
+
+{ #category : #'*Rubric-Editing-Core' }
+FormCanvas >> rubParagraph: para bounds: bounds color: c scale: scale [
+
 	| scanner |
 	self setPaintColor: c.
 	scanner := (port clippedBy: (bounds translateBy: origin)) rubDisplayScannerFor: para
 		foreground: c.
+	scanner scale: scale.
 	para drawOn: (self copyClipRect: bounds) using: scanner at: origin + bounds topLeft
 ]

--- a/src/Rubric/RubCharacterBlock.class.st
+++ b/src/Rubric/RubCharacterBlock.class.st
@@ -90,6 +90,12 @@ RubCharacterBlock >> extent [
 	^ surface extent
 ]
 
+{ #category : 'truncation and round off' }
+RubCharacterBlock >> floor [
+
+	^ surface floor
+]
+
 { #category : 'accessing' }
 RubCharacterBlock >> height [
 	^ surface height

--- a/src/Rubric/RubCharacterBlock.class.st
+++ b/src/Rubric/RubCharacterBlock.class.st
@@ -162,6 +162,12 @@ RubCharacterBlock >> right [
 	^ surface right
 ]
 
+{ #category : #private }
+RubCharacterBlock >> scaleBy: scale [
+
+	^ self copy surface: (surface scaleBy: scale)
+]
+
 { #category : #accessing }
 RubCharacterBlock >> stringIndex [
 	"Answer the position of the receiver in the string it indexes."

--- a/src/Rubric/ScalingCanvas.extension.st
+++ b/src/Rubric/ScalingCanvas.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #ScalingCanvas }
+
+{ #category : #'*Rubric-Editing-Core' }
+ScalingCanvas >> rubParagraph: paragraph bounds: bounds color: c [
+
+	| clippedCanvas currentParagraph |
+	
+	clippedCanvas := self copyClipRect: bounds.
+	currentParagraph := paragraph.
+	[ currentParagraph next isNil ] whileFalse: [
+		(currentParagraph canDrawDecoratorsOn: clippedCanvas) ifFalse: [ ^ self ].
+		currentParagraph drawOn: clippedCanvas.
+		currentParagraph := currentParagraph next ].
+	formCanvas rubParagraph: currentParagraph bounds: (bounds scaleBy: scale) color: c scale: scale
+]

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -87,7 +87,7 @@ SystemDependenciesTest >> knownLocalMonticelloDependencies [
 SystemDependenciesTest >> knownMorphicCoreDependencies [
 	"ideally this list should be empty"
 
-	^ #( #'Keymapping-KeyCombinations' #'Refactoring-Critics' #'Refactoring-Environment')
+	^ #(#'Fonts-Infrastructure' #'FreeType' #'Keymapping-KeyCombinations' #'Morphic-Base' #'Refactoring-Critics' #'Refactoring-Environment')
 ]
 
 { #category : 'known dependencies' }


### PR DESCRIPTION
This pull request:

* Adds ScalingCanvas as a subclass of PluggableCanvas. A ScalingCanvas provides scaling on an underlying FormCanvas. The class is taken from the [‘Retina display’ scaling experiment mentioned in previous pull requests](https://github.com/pharo-project/pharo/pull/15561#issuecomment-1826439810).
* Introduces a setting `#canvasScaleFactor` for OSWorldRenderer which determines the scale of the Form used to draw a WorldMorph. The world is drawn on a ScalingCanvas, instead of directly on a FormCanvas, when the setting is set to a value other than 1.

The [screenshots listed in pull request #15561](https://github.com/pharo-project/pharo/pull/15561#issuecomment-1826439810) show the effect of setting the `#canvasScaleFactor` to 2 on Macs with a ‘Retina display’.

The `#canvasScaleFactor` can be set through the Settings Browser so that it can also be saved to disk:

<p align="center">
<img width="500" src="https://github.com/pharo-project/pharo/assets/1611248/d08cb129-9fec-4e70-9c49-e2d17c36459d">
</p>

Note that pull request #15561 mentions doing `World scaleFactor: 0.5` as a way to use ScalingCanvas, but this no longer applies as the `#canvasScaleFactor` has been separated from the world `#scaleFactor`. The two factors can be set independently. Though on Macs with a ‘Retina display’, it seems best to set them so that the multiplication of the `#canvasScaleFactor` by the reciprocal of the `#scaleFactor` is 2. The following cycles through such combinations:

```smalltalk
OSWorldRenderer canvasScaleFactor: OSWorldRenderer canvasScaleFactor \\ 5 + 1.
World scaleFactor: OSWorldRenderer canvasScaleFactor / 2; changed.
```

A few methods are refactored on FormCanvas to offer a ‘scale’ parameter for use by a ScalingCanvas. As [previously mentioned](https://github.com/pharo-project/pharo/pull/14665#issuecomment-1720133696), it might be better to turn ScalingCanvas into a subclass of FormCanvas. The FormMapping that is used in ScalingCanvas needs to be removed but is still needed because icons are not yet consistently represented as a FormSet with a Form for more than one scale. The `#canvasScaleFactor` is global while it might be better to have a separate factor per world. These and any other necessary improvements can however be left to ‘future work’; merging this now will make it easier for others to give it a try.

I will update the [Pharo 11 backport](https://github.com/pharo-project/pharo/pull/15561#issuecomment-1828476134) when this pull request is merged.