### PR TITLE
15640-Objectclone-has-code-for-CompiledCode

### DIFF
--- a/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
+++ b/src/Kernel-Tests-Extended/CompiledMethodTest.class.st
@@ -330,6 +330,22 @@ CompiledMethodTest >> testBytecode [
 	self assertCollection: (Object>>#halt) bytecodes equals: expectedResult
 ]
 
+{ #category : 'tests - copying' }
+CompiledMethodTest >> testClone [
+	<pragma: #pragma> "for testing"
+	| method copy |
+	method := thisContext method.
+	self assert: method pragmas notEmpty.
+	copy := method clone.
+	self assert: (method equivalentTo: copy).
+	self assert: method header equals: copy header.
+	self assert: method equals: copy.
+	self assert: method ~~ copy.
+	"this is a shallow copy"
+	self deny: copy penultimateLiteral method identicalTo: copy.
+	copy pragmas do: [ :p | self deny: p method identicalTo: copy ]
+]
+
 { #category : 'tests - accessing' }
 CompiledMethodTest >> testComments [
 	"I am the first comment to be found in this test"

--- a/src/Kernel/Behavior.class.st
+++ b/src/Kernel/Behavior.class.st
@@ -1037,12 +1037,6 @@ Behavior >> isCompact [
 	^false
 ]
 
-{ #category : 'testing' }
-Behavior >> isCompiledMethodClass [
-	"Answer whether the receiver has compiled method instances that mix pointers and bytes."
-	^self instSpec >= 24
-]
-
 { #category : 'testing - method dictionary' }
 Behavior >> isDisabledSelector: selector [
 	<reflection: 'Class structural inspection - Selectors and methods inspection'>

--- a/src/Kernel/CompiledBlock.class.st
+++ b/src/Kernel/CompiledBlock.class.st
@@ -234,3 +234,8 @@ CompiledBlock >> stepIntoQuickMethods [
 CompiledBlock >> stepIntoQuickMethods: aBoolean [
 	^self method stepIntoQuickMethods: aBoolean
 ]
+
+{ #category : 'constants' }
+CompiledBlock >> trailerSize [
+	^ 0
+]

--- a/src/Kernel/CompiledCode.class.st
+++ b/src/Kernel/CompiledCode.class.st
@@ -223,6 +223,20 @@ CompiledCode >> clearSignFlag [
 		[self objectAt: 1 put: self header - SmallInteger minVal]
 ]
 
+{ #category : 'copying' }
+CompiledCode >> clone [
+	"Answer a shallow copy of the receiver."
+	<primitive: 148 error: ec>
+	| newObject |
+	ec == #'insufficient object memory' ifFalse:
+		[^self primitiveFailed].
+	"If the primitive fails due to insufficient memory, instantiate via basicNew: to invoke the garbage collector before retrying, and use copyFrom: to copy state."
+	newObject := self class
+		basicNew: self basicSize - self initialPC + 1 + self class trailerSize 
+		header: self header.
+	^newObject copyFrom: self
+]
+
 { #category : 'accessing' }
 CompiledCode >> comment [
 	"Return the first comment of the receiver"

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -627,17 +627,10 @@ Object >> clone [
 	| class newObject |
 	ec == #'insufficient object memory' ifFalse:
 		[^self primitiveFailed].
-	"If the primitive fails due to insufficient memory, instantiate via basicNew: to invoke
-	 the garbage collector before retrying, and use copyFrom: to copy state."
+	"If the primitive fails due to insufficient memory, instantiate via basicNew: to invoke the garbage collector before retrying, and use copyFrom: to copy state."
 	newObject := (class := self class) isVariable
-					ifTrue:
-						[class isCompiledMethodClass
-							ifTrue:
-								[class basicNew: self basicSize - self initialPC + 1 + CompiledMethod trailerSize header: self header]
-							ifFalse:
-								[class basicNew: self basicSize]]
-					ifFalse:
-						[class basicNew].
+					ifTrue: [class basicNew: self basicSize]
+					ifFalse: [class basicNew].
 	^newObject copyFrom: self
 ]
 


### PR DESCRIPTION
- remove #isCompiledMethodClass, people should check the class layout (the method was true for CompiledCode, too, very confusing)
- add #trailerSize to CompiledCode
- implement #clone in CompiledCode
- simplify #clone in Object

fixes #15640