### PR TITLE
do not use #slotsFromString: / sharedVariablesFromString:

### DIFF
--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -140,7 +140,7 @@ EpCodeChangeIntegrationTest >> testInstanceVariableAddition [
 { #category : 'tests' }
 EpCodeChangeIntegrationTest >> testInstanceVariableRemoval [
 
-	aClass := classFactory make: [ :aBuilder | aBuilder slotsFromString: 'x' ].
+	aClass := classFactory make: [ :aBuilder | aBuilder slots: #(x) ].
 
 	self assert: (self countLogEventsWith: EpClassModification) equals: 0.
 	aClass removeInstVarNamed: #x.

--- a/src/Equals-Tests/TEqualityTest.class.st
+++ b/src/Equals-Tests/TEqualityTest.class.st
@@ -27,7 +27,7 @@ TEqualityTest >> testSetContainsOnlyOneInstanceOfAClassWithIVs [
 	class := classFactory make: [ :aBuilder |
 		         aBuilder
 			         superclass: ComparableObjectForEqualityTest;
-			         slotsFromString: 'x y' ].
+			         slots: #(x y) ].
 	class compile: 'x: newX y: newY
 		x := newX.
 		y := newY'.
@@ -63,11 +63,11 @@ TEqualityTest >> testSetContainsTwoInstancesOfTwoDiffrentClassesWithIVs [
 	otherClass := classFactory make: [ :aBuilder |
 		              aBuilder
 			              superclass: ComparableObjectForEqualityTest;
-			              slotsFromString: 'x y' ].
+			              slots: #(x y) ].
 	yetAnotherClass := classFactory make: [ :aBuilder |
 		                   aBuilder
 			                   superclass: ComparableObjectForEqualityTest;
-			                   slotsFromString: 'x y' ].
+			                   slots: #(x y) ].
 	{
 		otherClass.
 		yetAnotherClass } do: [ :class |
@@ -106,7 +106,7 @@ TEqualityTest >> testTwoInstancesOfTheSameClassWithDifferentIvValuessAreNotEqual
 	class := classFactory make: [ :aBuilder |
 		         aBuilder
 			         superclass: ComparableObjectForEqualityTest;
-			         slotsFromString: 'x y' ].
+			         slots: #(x y) ].
 	class compile: 'x: newX y: newY
 		x := newX.
 		y := newY'.
@@ -133,7 +133,7 @@ TEqualityTest >> testTwoInstancesOfTheSameClassWithSameIvValuessAreEqual [
 	class := classFactory make: [ :aBuilder |
 		         aBuilder
 			         superclass: ComparableObjectForEqualityTest;
-			         slotsFromString: 'x y' ].
+			         slot: #(x y) ].
 	class compile: 'x: newX y: newY
 		x := newX.
 		y := newY'.

--- a/src/Equals-Tests/TEqualityTest.class.st
+++ b/src/Equals-Tests/TEqualityTest.class.st
@@ -133,7 +133,7 @@ TEqualityTest >> testTwoInstancesOfTheSameClassWithSameIvValuessAreEqual [
 	class := classFactory make: [ :aBuilder |
 		         aBuilder
 			         superclass: ComparableObjectForEqualityTest;
-			         slot: #(x y) ].
+			         slots: #(x y) ].
 	class compile: 'x: newX y: newY
 		x := newX.
 		y := newY'.

--- a/src/Fuel-Core-Tests/FLBasicSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLBasicSerializationTest.class.st
@@ -400,7 +400,7 @@ FLBasicSerializationTest >> testExceptions [
 FLBasicSerializationTest >> testExecuteAfterMaterialization [
 
 	| anObject result aClass |
-	aClass := self classFactory silentlyMake: [ :aBuilder | aBuilder slotsFromString: 'a' ].
+	aClass := self classFactory silentlyMake: [ :aBuilder | aBuilder slots: #(a) ].
 	self classFactory silentlyCompile: 'fuelAfterMaterialization a := #A' in: aClass.
 	anObject := aClass new.
 

--- a/src/Fuel-Core-Tests/FLBlockClosureSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLBlockClosureSerializationTest.class.st
@@ -127,7 +127,7 @@ FLBlockClosureSerializationTest >> testBlockClosureChangeSameBytecodesConstant [
 FLBlockClosureSerializationTest >> testBlockClosureMaterializesClassVariablesCorrectly [
 
 	| class closure method |
-	class := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariablesFromString: 'ClassVariableForTesting' ].
+	class := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariables: #(ClassVariableForTesting)].
 	self classFactory silentlyCompile: 'methodWithClosure  ^ [ ClassVariableForTesting ]' in: class.
 
 	method := class methodNamed: #methodWithClosure.

--- a/src/Fuel-Core-Tests/FLCompiledMethodSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLCompiledMethodSerializationTest.class.st
@@ -85,7 +85,7 @@ FLCompiledMethodSerializationTest >> testInstalledModified [
 FLCompiledMethodSerializationTest >> testMethodAccessingAClassVariable [
 
 	| aClassWithVariable aMethod materializedMethod |
-	aClassWithVariable := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariablesFromString: 'A' ].
+	aClassWithVariable := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariables: #(A) ].
 
 	self classFactory silentlyCompile: 'm1 A:= 3' in: aClassWithVariable.
 	aMethod := aClassWithVariable >> #m1.
@@ -101,7 +101,7 @@ FLCompiledMethodSerializationTest >> testMethodAccessingAClassVariable [
 FLCompiledMethodSerializationTest >> testMethodAccessingAClassVariableInADoit [
 
 	| aClassWithVariable aMethod materializedMethod |
-	aClassWithVariable := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariablesFromString: 'A' ].
+	aClassWithVariable := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariables: #(A)].
 
 	self classFactory silentlyCompile: 'DoIt A:= 3' in: aClassWithVariable.
 	aMethod := aClassWithVariable >> #DoIt.

--- a/src/Fuel-Core-Tests/FLConfigurationTest.class.st
+++ b/src/Fuel-Core-Tests/FLConfigurationTest.class.st
@@ -362,7 +362,7 @@ FLConfigurationTest >> testStreamFinalizerDefault [
 
 	<ignoreNotImplementedSelectors: #( _log )>
 	| logClass log |
-	logClass := self classFactory silentlyMake: [ :aBuilder | aBuilder slotsFromString: 'log' ].
+	logClass := self classFactory silentlyMake: [ :aBuilder | aBuilder slots: #(log) ].
 	self classFactory
 		silentlyCompile: 'initialize log := OrderedCollection new' in: logClass;
 		silentlyCompile: '_log ^ log' in: logClass;

--- a/src/Fuel-Core-Tests/FLCreateClassSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLCreateClassSerializationTest.class.st
@@ -105,7 +105,7 @@ FLCreateClassSerializationTest >> testCreateClassWithClassVariable [
 	"Tests materialization a class not defined in the image, with a class variable."
 
 	| aClass materializedClass |
-	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariablesFromString: #ClassVariable ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariables: #(ClassVariable) ].
 	(aClass classVariableNamed: #ClassVariable) write: #test.
 
 	materializedClass := self resultOfSerializeRemoveAndMaterialize: aClass.
@@ -445,7 +445,7 @@ FLCreateClassSerializationTest >> testCreateWithClassVariableAccessors [
 	"Tests materialization of a compiled method in a class not defined in the image. The class defines accessors for a class variable."
 
 	| aClass materializedClass instance |
-	aClass := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariablesFromString: 'AnFLClassVariable' ].
+	aClass := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariables: #(AnFLClassVariable) ].
 	self classFactory
 		silentlyCompile: 'classVariable ^AnFLClassVariable' in: aClass;
 		silentlyCompile: 'classVariable: value AnFLClassVariable := value' in: aClass.

--- a/src/Fuel-Core-Tests/FLCreateClassSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLCreateClassSerializationTest.class.st
@@ -145,13 +145,13 @@ FLCreateClassSerializationTest >> testCreateClassWithCreatedTraitWithInstanceVar
 	The trait has instance variables."
 
 	| aClass aTrait result materializedClass materializedTrait materializedObject |
-	aClass := self classFactory silentlyMake: [ :aBuilder | aBuilder slotsFromString: 'ivar' ].
+	aClass := self classFactory silentlyMake: [ :aBuilder | aBuilder slots: #(ivar) ].
 	self classFactory silentlyCompile: 'ivar: x ivar := x' in: aClass.
 	self classFactory silentlyCompile: 'ivar ^ ivar' in: aClass.
 	aTrait := self classFactory silentlyMake: [ :aBuilder |
 		          aBuilder
 			          beTrait;
-			          slotsFromString: 'traitIvar' ].
+			          slots: #(traitIvar) ].
 	self classFactory silentlyCompile: 'traitIvar: x traitIvar := x' in: aTrait.
 	self classFactory silentlyCompile: 'traitIvar ^ traitIvar' in: aTrait.
 	aClass addToComposition: aTrait.
@@ -188,7 +188,7 @@ FLCreateClassSerializationTest >> testCreateClassWithInstance [
 	"Tests materialization of a class who references an instance of itself."
 
 	| aClass anInstance materializedClass materializedInstance |
-	aClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'name' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder slots: #(name) ].
 	aClass class instanceVariableNames: 'instance'.
 
 	anInstance := aClass new
@@ -272,7 +272,7 @@ FLCreateClassSerializationTest >> testCreateClassWithVariables [
 	"Tests materialization of a class not defined in the image, with instance variables."
 
 	| aClass materializedClass |
-	aClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'var1 var2' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder slots: #(var1 var2) ].
 
 	materializedClass := self resultOfSerializeRemoveAndMaterialize: aClass.
 
@@ -511,7 +511,7 @@ FLCreateClassSerializationTest >> testMaterializationDoesNotModifySerializedClas
 	"Tests that materialization does not change the source class."
 
 	| aClass materializedClass |
-	aClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'var' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder slots: #(var) ].
 
 	self serializer fullySerializeBehavior: aClass.
 	self serialize: aClass.

--- a/src/Fuel-Core-Tests/FLFullBasicSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLFullBasicSerializationTest.class.st
@@ -94,11 +94,11 @@ FLFullBasicSerializationTest >> testCreateClassWithChangedSuperclassFormat [
 	"Tests issue #221"
 
 	| a b |
-	a := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'one' ].
+	a := self classFactory make: [ :aBuilder | aBuilder slots: #(one) ].
 	b := self classFactory make: [ :aBuilder |
 		     aBuilder
 			     superclass: a;
-			     slotsFromString: 'two' ].
+			     slots: #(two) ].
 	self serializer fullySerializeBehavior: b.
 	self serialize: {
 			b new.

--- a/src/Fuel-Core-Tests/FLFullHeaderSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLFullHeaderSerializationTest.class.st
@@ -39,7 +39,7 @@ FLFullHeaderSerializationTest >> testPostMaterializationActions [
 	| aClass |
 	CompilationContext optionCleanBlockClosure ifTrue: [ ^ self skip ].
 
-	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariablesFromString: 'TestClassVariable TestClassVariable2' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariables: #(TestClassVariable TestClassVariable2) ].
 	self classFactory
 		silentlyCompile: 'postLoadMethod TestClassVariable := 1' in: aClass class;
 		silentlyCompile: 'postLoadMethod2 TestClassVariable := 2' in: aClass class;
@@ -72,7 +72,7 @@ FLFullHeaderSerializationTest >> testPreMaterializationActions [
 	| aClass |
 	CompilationContext optionCleanBlockClosure ifTrue: [ ^ self skip ].
 
-	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariablesFromString: 'TestClassVariable TestClassVariable2' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariables: #(TestClassVariable TestClassVariable2) ].
 	self classFactory
 		silentlyCompile: 'postLoadMethod TestClassVariable := 1' in: aClass class;
 		silentlyCompile: 'postLoadMethod2 TestClassVariable := 2' in: aClass class;

--- a/src/Fuel-Core-Tests/FLGlobalTraitSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLGlobalTraitSerializationTest.class.st
@@ -18,13 +18,13 @@ FLGlobalTraitSerializationTest >> testCreateClassWithCreatedTraitWithInstanceVar
 	The trait has instance variables."
 
 	| aClass aTrait result materializedClass materializedTrait materializedObject |
-	aClass := self classFactory silentlyMake: [ :aBuilder | aBuilder slotsFromString: 'ivar' ].
+	aClass := self classFactory silentlyMake: [ :aBuilder | aBuilder slots: #(ivar) ].
 	self classFactory silentlyCompile: 'ivar: x ivar := x' in: aClass.
 	self classFactory silentlyCompile: 'ivar ^ ivar' in: aClass.
 	aTrait := self classFactory silentlyMake: [ :aBuilder |
 		          aBuilder
 			          beTrait;
-			          slotsFromString: 'traitIvar' ].
+			          slots: #(traitIvar) ].
 	self classFactory silentlyCompile: 'traitIvar: x traitIvar := x' in: aTrait.
 	self classFactory silentlyCompile: 'traitIvar ^ traitIvar' in: aTrait.
 	aClass addToComposition: aTrait.

--- a/src/Fuel-Core-Tests/FLHeaderSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLHeaderSerializationTest.class.st
@@ -42,7 +42,7 @@ FLHeaderSerializationTest >> testPostMaterializationActions [
 	| aClass |
 	CompilationContext optionCleanBlockClosure ifTrue: [ ^ self skip ].
 
-	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariablesFromString: 'TestClassVariable TestClassVariable2' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariables: #(TestClassVariable TestClassVariable2) ].
 	self classFactory
 		silentlyCompile: 'postLoadMethod TestClassVariable := 1' in: aClass class;
 		silentlyCompile: 'postLoadMethod2 TestClassVariable := 2' in: aClass class;
@@ -75,7 +75,7 @@ FLHeaderSerializationTest >> testPreMaterializationActions [
 	| aClass |
 	CompilationContext optionCleanBlockClosure ifTrue: [ ^ self skip ].
 
-	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariablesFromString: 'TestClassVariable TestClassVariable2' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder sharedVariables: #(TestClassVariable TestClassVariable2) ].
 	self classFactory
 		silentlyCompile: 'postLoadMethod TestClassVariable := 1' in: aClass class;
 		silentlyCompile: 'postLoadMethod2 TestClassVariable := 2' in: aClass class;

--- a/src/Fuel-Core-Tests/FLHookedSubstitutionTest.class.st
+++ b/src/Fuel-Core-Tests/FLHookedSubstitutionTest.class.st
@@ -26,7 +26,7 @@ FLHookedSubstitutionTest >> testAvoidRecursion [
 FLHookedSubstitutionTest >> testClassWithCachedValueByNil [
 
 	| aClassWithCachedValue result original |
-	aClassWithCachedValue := self classFactory silentlyMake: [ :aBuilder | aBuilder slotsFromString: 'cache' ].
+	aClassWithCachedValue := self classFactory silentlyMake: [ :aBuilder | aBuilder slots: #(cache) ].
 	self classFactory
 		silentlyCompile: 'cache ^cache' in: aClassWithCachedValue;
 		silentlyCompile: 'cache: x cache := x' in: aClassWithCachedValue;
@@ -54,7 +54,7 @@ FLHookedSubstitutionTest >> testObjectByProxyThatBecomesItsContent [
 	"Tests a substitution of an object by a proxy that becomes another object on materialization."
 
 	| aProxyClass result |
-	aProxyClass := self classFactory silentlyMake: [ :aBuilder | aBuilder slotsFromString: 'someState' ].
+	aProxyClass := self classFactory silentlyMake: [ :aBuilder | aBuilder slots: #(someState) ].
 	self classFactory
 		silentlyCompile: 'initialize  someState := 5@1' in: aProxyClass;
 		silentlyCompile: 'fuelAccept: aVisitor

--- a/src/Fuel-Core-Tests/FLHookedSubstitutionTest.class.st
+++ b/src/Fuel-Core-Tests/FLHookedSubstitutionTest.class.st
@@ -72,7 +72,7 @@ FLHookedSubstitutionTest >> testObjectByProxyThatBecomesItsContent [
 FLHookedSubstitutionTest >> testProxyByTarget [
 
 	| aProxyClass result original |
-	aProxyClass := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariablesFromString: 'Target' ].
+	aProxyClass := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariables: #(Target) ].
 	self classFactory
 		silentlyCompile: 'target: x  Target := x' in: aProxyClass;
 		silentlyCompile: 'fuelAccept: aVisitor
@@ -94,7 +94,7 @@ FLHookedSubstitutionTest >> testProxyByTarget [
 FLHookedSubstitutionTest >> testProxyByTargetAnalisysIsPropagated [
 
 	| aProxyClass result pair original |
-	aProxyClass := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariablesFromString: 'Target' ].
+	aProxyClass := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariables: #(Target) ].
 	self classFactory
 		silentlyCompile: 'target: x  Target := x' in: aProxyClass;
 		silentlyCompile: 'fuelAccept: aVisitor
@@ -122,7 +122,7 @@ FLHookedSubstitutionTest >> testProxyByTargetAnalisysIsPropagated [
 FLHookedSubstitutionTest >> testProxyByTargetInsideObjectAndAnalisysIsPropagated [
 
 	| aProxyClass result original pair pairRoot |
-	aProxyClass := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariablesFromString: 'Target' ].
+	aProxyClass := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariables: #(Target) ].
 	self classFactory
 		silentlyCompile: 'target: x  Target := x' in: aProxyClass;
 		silentlyCompile: 'fuelAccept: aVisitor
@@ -154,7 +154,7 @@ FLHookedSubstitutionTest >> testProxyByTargetInsideObjectAndAnalisysIsPropagated
 FLHookedSubstitutionTest >> testProxyInsideObjectByTarget [
 
 	| aProxyClass result original pair |
-	aProxyClass := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariablesFromString: 'Target' ].
+	aProxyClass := self classFactory silentlyMake: [ :aBuilder | aBuilder sharedVariables: #(Target) ].
 	self classFactory
 		silentlyCompile: 'target: x  Target := x' in: aProxyClass;
 		silentlyCompile: 'fuelAccept: aVisitor

--- a/src/Fuel-Core-Tests/FLIgnoredVariablesTest.class.st
+++ b/src/Fuel-Core-Tests/FLIgnoredVariablesTest.class.st
@@ -13,7 +13,7 @@ Class {
 FLIgnoredVariablesTest >> testAllVariablesIgnored [
 
 	| anObject result aClass |
-	aClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'a b' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder slots: #(a b) ].
 	self classFactory silentlyCompile: 'fuelIgnoredInstanceVariableNames ^#(a b)' in: aClass class.
 	anObject := aClass new
 		            instVarAt: 1 put: $A;
@@ -30,7 +30,7 @@ FLIgnoredVariablesTest >> testAllVariablesIgnored [
 FLIgnoredVariablesTest >> testIgnoredValueIsNotMaterialized [
 
 	| anObject materialized aClass |
-	aClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'a' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder slots: #(a) ].
 	self classFactory silentlyCompile: 'fuelIgnoredInstanceVariableNames ^#(a)' in: aClass class.
 	anObject := aClass new
 		            instVarAt: 1 put: #A;
@@ -46,7 +46,7 @@ FLIgnoredVariablesTest >> testIgnoredValueIsNotMaterialized [
 FLIgnoredVariablesTest >> testOneIgnoredVariable [
 
 	| anObject result aClass |
-	aClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'a b c' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder slots: #(a b c) ].
 	self classFactory silentlyCompile: 'fuelIgnoredInstanceVariableNames ^#(b)' in: aClass class.
 	anObject := aClass new
 		            instVarAt: 1 put: $A;
@@ -65,7 +65,7 @@ FLIgnoredVariablesTest >> testOneIgnoredVariable [
 FLIgnoredVariablesTest >> testTwoIgnoredVariables [
 
 	| anObject result aClass |
-	aClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'a b c' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder slots: #(a b c) ].
 	self classFactory silentlyCompile: 'fuelIgnoredInstanceVariableNames ^#(a c)' in: aClass class.
 	anObject := aClass new
 		            instVarAt: 1 put: $A;

--- a/src/Fuel-Core-Tests/FLMigrationTest.class.st
+++ b/src/Fuel-Core-Tests/FLMigrationTest.class.st
@@ -20,7 +20,7 @@ FLMigrationTest >> redefined: aClass with: instanceVariableNames [
 	^ self classFactory make: [ :aBuilder |
 		  aBuilder
 			  fillFor: aClass;
-			  slotsFromString: instanceVariableNames ]
+			  slots: instanceVariableNames ]
 ]
 
 { #category : 'running' }
@@ -94,7 +94,7 @@ FLMigrationTest >> testClassAndVariableRename [
 
 	self serialize: aPoint.
 	self classFactory silentlyRename: pointClass to: (pointClassName , 'Renamed') asSymbol.
-	pointClass := self redefined: pointClass with: 'posY posX'.
+	pointClass := self redefined: pointClass with: #(posY posX).
 
 	self materializer migrateClassNamed: pointClassName toClass: pointClass variables: (Dictionary new
 			 at: 'x' put: 'posX';
@@ -188,7 +188,7 @@ FLMigrationTest >> testVariableInsertion [
 	aPair instVarAt: 2 put: $B.
 
 	self serialize: aPair.
-	self redefined: pairClass with: 'left middle right'.
+	self redefined: pairClass with: #(left middle right).
 	resultPair := self materialized.
 
 	self assert: $A equals: (resultPair instVarAt: 1).
@@ -207,7 +207,7 @@ FLMigrationTest >> testVariableOrderChange [
 	aPair instVarAt: 2 put: $B.
 
 	self serialize: aPair.
-	self redefined: pairClass with: 'right left'.
+	self redefined: pairClass with: #(right left).
 	resultPair := self materialized.
 
 	self assert: $B equals: (resultPair instVarAt: 1).
@@ -225,7 +225,7 @@ FLMigrationTest >> testVariableRemoved [
 	aPair instVarAt: 2 put: $B.
 
 	self serialize: aPair.
-	self redefined: pairClass with: 'right'.
+	self redefined: pairClass with: #(right).
 	resultPair := self materialized.
 
 	self assert: $B equals: (resultPair instVarAt: 1)
@@ -242,7 +242,7 @@ FLMigrationTest >> testVariableRename [
 	aPoint instVarNamed: 'y' put: 11.
 
 	self serialize: aPoint.
-	self redefined: pointClass with: 'posY posX'.
+	self redefined: pointClass with: #(posY posX).
 
 	self materializer migrateClassNamed: pointClassName variables: (Dictionary new
 			 at: 'x' put: 'posX';

--- a/src/Fuel-Core-Tests/FLMigrationTest.class.st
+++ b/src/Fuel-Core-Tests/FLMigrationTest.class.st
@@ -34,7 +34,7 @@ FLMigrationTest >> setUpEnvironment [
 FLMigrationTest >> testBadDestinationVariableRename [
 
 	| pointClass aPoint pointClassName |
-	pointClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'x y' ].
+	pointClass := self classFactory make: [ :aBuilder | aBuilder slots: #(x y) ].
 	pointClassName := pointClass name.
 	aPoint := pointClass new.
 
@@ -53,11 +53,11 @@ FLMigrationTest >> testChangeInSuperclass [
 	"Tests that serializer tolarates when there is a change in the superclass between serialization and materialization"
 
 	| aClass aClassSubclass instance materializedInstance |
-	aClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'a b c' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder slots: #(a b c) ].
 	aClassSubclass := self classFactory make: [ :aBuilder |
 		                  aBuilder
 			                  superclass: aClass;
-			                  slotsFromString: 'd e' ].
+			                  slots: #(d e) ].
 
 	instance := aClassSubclass new.
 	instance instVarNamed: 'a' put: $A.
@@ -86,7 +86,7 @@ FLMigrationTest >> testChangeInSuperclass [
 FLMigrationTest >> testClassAndVariableRename [
 
 	| pointClass aPoint resultPoint pointClassName |
-	pointClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'x y' ].
+	pointClass := self classFactory make: [ :aBuilder | aBuilder slots: #(x y) ].
 	pointClassName := pointClass name.
 	aPoint := pointClass new.
 	aPoint instVarNamed: 'x' put: 7.
@@ -111,7 +111,7 @@ FLMigrationTest >> testClassAndVariableRename [
 FLMigrationTest >> testClassRename [
 
 	| pointClass aPoint resultPoint pointClassName |
-	pointClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'x y' ].
+	pointClass := self classFactory make: [ :aBuilder | aBuilder slots: #(x y) ].
 	pointClassName := pointClass name.
 	aPoint := pointClass new.
 	aPoint instVarNamed: 'x' put: 7.
@@ -151,12 +151,12 @@ FLMigrationTest >> testSuperclassChange [
 	"Tests that serializer tolarates when the superclass changed between serialization and materialization"
 
 	| aClass aClassSubclass instance materializedInstance anotherSuperclass |
-	aClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'a b c' ].
+	aClass := self classFactory make: [ :aBuilder | aBuilder slots: #(a b c) ].
 	aClassSubclass := self classFactory make: [ :aBuilder |
 		                  aBuilder
 			                  superclass: aClass;
-			                  slotsFromString: 'd e' ].
-	anotherSuperclass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'x' ].
+			                  slots: #(d e) ].
+	anotherSuperclass := self classFactory make: [ :aBuilder | aBuilder slots: #(x) ].
 
 	instance := aClassSubclass new.
 	instance instVarNamed: 'a' put: $A.
@@ -182,7 +182,7 @@ FLMigrationTest >> testVariableInsertion [
 	"Tests that serializer tolarates when there is a new instance variable on materialization"
 
 	| pairClass aPair resultPair |
-	pairClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'left right' ].
+	pairClass := self classFactory make: [ :aBuilder | aBuilder slots: #(left right) ].
 	aPair := pairClass new.
 	aPair instVarAt: 1 put: $A.
 	aPair instVarAt: 2 put: $B.
@@ -201,7 +201,7 @@ FLMigrationTest >> testVariableOrderChange [
 	"Tests that serializer tolarates when the order in the instance variables changed between serialization and materialization"
 
 	| pairClass aPair resultPair |
-	pairClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'left right' ].
+	pairClass := self classFactory make: [ :aBuilder | aBuilder slots: #(left right) ].
 	aPair := pairClass new.
 	aPair instVarAt: 1 put: $A.
 	aPair instVarAt: 2 put: $B.
@@ -219,7 +219,7 @@ FLMigrationTest >> testVariableRemoved [
 	"Tests that serializer tolarates when an instance variable is missing on materialization"
 
 	| pairClass aPair resultPair |
-	pairClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'left right' ].
+	pairClass := self classFactory make: [ :aBuilder | aBuilder slots: #(left right) ].
 	aPair := pairClass new.
 	aPair instVarAt: 1 put: $A.
 	aPair instVarAt: 2 put: $B.
@@ -235,7 +235,7 @@ FLMigrationTest >> testVariableRemoved [
 FLMigrationTest >> testVariableRename [
 
 	| pointClass aPoint resultPoint pointClassName |
-	pointClass := self classFactory make: [ :aBuilder | aBuilder slotsFromString: 'x y' ].
+	pointClass := self classFactory make: [ :aBuilder | aBuilder slots: #(x y) ].
 	pointClassName := pointClass name.
 	aPoint := pointClass new.
 	aPoint instVarNamed: 'x' put: 7.

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -537,7 +537,7 @@ ClassTest >> testSubclassInstanceVariableNames [
 	class := self class classInstaller make: [ :aBuilder |
 		       aBuilder
 			       name: #SubclassExample;
-			       slotsFromString: 'x y' ].
+			       slots: #(x y) ].
 
 	self assert: (testEnvironment includesKey: #SubclassExample).
 

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -27,7 +27,6 @@ ClassDescriptionTest >> compilationTestPackageName [
 ClassDescriptionTest >> createTestClass [
 
 	^ ((Object << #TemporaryMockClass)
-		   slots: {  };
 		   package: self compilationTestPackageName) build
 ]
 
@@ -192,7 +191,6 @@ ClassDescriptionTest >> testDeprecatedAliasesAreRemovedByClassRemovalSpecialCase
 
 	| class systemDictionary |
 	class := ((Object << #TemporaryMockClass)
-		          slots: {  };
 		          package: self compilationTestPackageName) install.
 	systemDictionary := class environment.
 

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -94,7 +94,6 @@ FluidClassDefinitionPrinterTest >> testDisplayEmptySlots [
 	| class |
 	ClassDefinitionPrinter displayEmptySlots: true.
 	class := (Object << #CDFluidMock
-	slots: {};
 	tag: 'BasicObjects';
 	package: 'Kernel') build.
 	self assert: (self forClass: class) equals: 'Object << #CDFluidMock
@@ -108,7 +107,6 @@ FluidClassDefinitionPrinterTest >> testDoesNotDisplayEmptySlots [
 	| class |
 	ClassDefinitionPrinter displayEmptySlots: false.
 	class := (Object << #CDFluidMock
-	slots: {};
 	tag: 'BasicObjects';
 	package: 'Kernel') build.
 	self assert: (self forClass: class) equals: 'Object << #CDFluidMock

--- a/src/Kernel-Tests/IVsAndClassVarNamesConflictTest.class.st
+++ b/src/Kernel-Tests/IVsAndClassVarNamesConflictTest.class.st
@@ -29,7 +29,7 @@ IVsAndClassVarNamesConflictTest >> tearDown [
 IVsAndClassVarNamesConflictTest >> testOneCanProceedWhenIntroducingCapitalizedInstanceVariables [
 
 	| class |
-	[ class := classFactory make: [ :aBuilder | aBuilder slotsFromString: 'X Y' ] ]
+	[ class := classFactory make: [ :aBuilder | aBuilder slots: #(X Y) ] ]
 		on: Exception
 		do: [ :ex | ex resume ].
 	self assert: (testingEnvironment keys includes: class name)
@@ -39,7 +39,7 @@ IVsAndClassVarNamesConflictTest >> testOneCanProceedWhenIntroducingCapitalizedIn
 IVsAndClassVarNamesConflictTest >> testOneCanProceedWhenIntroducingClasseVariablesBeginingWithLowerCaseCharacters [
 
 	| class |
-	[ class := classFactory make: [ :aBuilder | aBuilder slotsFromString: 'a BVarName' ] ]
+	[ class := classFactory make: [ :aBuilder | aBuilder slots: #(a BVarName) ] ]
 		on: Exception
 		do: [ :ex | ex resume ].
 	self assert: (testingEnvironment keys includes: class name)

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -307,13 +307,13 @@ RubSmalltalkEditor >> classNamesContainingIt [
 ]
 
 { #category : 'do-its' }
-RubSmalltalkEditor >> compile: aStream for: anObject in: evalContext [
+RubSmalltalkEditor >> compile: source for: anObject in: evalContext [
 	| methodClass |
 	methodClass := evalContext
 		ifNil: [ anObject class ]
 		ifNotNil: [ evalContext methodClass ].
 	^self class compiler
-		source: aStream;
+		source: source;
 		class: methodClass;
 		context: evalContext;
 		isScripting: true;
@@ -508,7 +508,7 @@ RubSmalltalkEditor >> editingMode [
 ]
 
 { #category : 'do-its' }
-RubSmalltalkEditor >> evaluate: aStream andDo: aBlock [
+RubSmalltalkEditor >> evaluate: source andDo: aBlock [
 	"Treat the current selection as an expression; evaluate it and invoke aBlock with the result."
 	| result rcvr ctxt |
 	(self model respondsTo: #doItReceiver)
@@ -518,7 +518,7 @@ RubSmalltalkEditor >> evaluate: aStream andDo: aBlock [
 		
 	"to improve: we need better reporting of errors, to revisit when unifying with Spec"
 	result := rcvr class compiler
-			source: aStream;
+			source: source;
 			requestor: self;
 			context: ctxt;
 			receiver: rcvr;

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -86,8 +86,8 @@ ClassFactoryForTestCaseTest >> testSingleClassCreation [
 	class := factory make: [ :aBuilder |
 		         aBuilder
 			         superclass: Object;
-			         slots: {#a.#b .#c};
-			         sharedVariablesFromString: 'X Y';
+			         slots: #(a b c);
+			         sharedVariables: #(X Y);
 			         tag: factory tagName ].
 	self assert: (self environment allClasses includes: class).
 	self assert: class package name equals: factory packageName.

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -86,7 +86,7 @@ ClassFactoryForTestCaseTest >> testSingleClassCreation [
 	class := factory make: [ :aBuilder |
 		         aBuilder
 			         superclass: Object;
-			         slotsFromString: 'a b c';
+			         slots: {#a.#b .#c};
 			         sharedVariablesFromString: 'X Y';
 			         tag: factory tagName ].
 	self assert: (self environment allClasses includes: class).

--- a/src/Shift-ClassBuilder-Tests/ShCreateClassTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShCreateClassTest.class.st
@@ -112,30 +112,12 @@ ShCreateClassTest >> testSharedVariables [
 ShCreateClassTest >> testSharedVariablesAsArray [
 	builder name: #SHClassWithSharedVariable.
 	result := builder
-		sharedVariablesFromString: #(aSharedVariable);
+		sharedVariables: #(aSharedVariable);
 		build.
 
 	self validateResult.
 	self validateSuperclass: Object.
 	self validateSharedVariables: #(aSharedVariable)
-]
-
-{ #category : 'tests' }
-ShCreateClassTest >> testSharedVariablesAsString [
-	builder name: #SHClassWithSharedVariable.
-	result := builder
-		sharedVariablesFromString: 'aSharedVariable';
-		build.
-
-	self validateResult.
-	self validateSuperclass: Object.
-	self validateSharedVariables: #(aSharedVariable)
-]
-
-{ #category : 'tests' }
-ShCreateClassTest >> testSharedVariablesWithSlot [
-	builder name: #SHClassWithSharedVariable.
-	self should: [ builder sharedVariablesFromString: {#aSharedVariable asSlot} ] raise: Error
 ]
 
 { #category : 'tests' }

--- a/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
+++ b/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
@@ -119,11 +119,6 @@ ShLayoutDefinition >> sharedVariables: anObject [
 ]
 
 { #category : 'accessing' }
-ShLayoutDefinition >> sharedVariablesString [
-	^ (sharedVariables collect:[:e | e key]) joinUsing: ' '
-]
-
-{ #category : 'accessing' }
 ShLayoutDefinition >> slots [
 	^ slots
 ]

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -174,9 +174,6 @@ ShClassInstallerTest >> testClassWithComment [
 		            builder
 			            name: #SHClassWithComment;
 			            superclass: Object;
-			            slots: #(  );
-			            sharedVariables: '';
-			            sharedPools: '';
 			            package: self generatedClassesPackageName;
 			            comment: 'I have a comment';
 			            commentStamp: 'anStamp' ].

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -111,7 +111,7 @@ SlotAnnouncementsTest >> testChangeInSharedVariablesAndSharedPoolsShouldAnnounce
 		builder
 			name: self aClassName;
 			sharedPools: 'TestSharedPool';
-			sharedVariablesFromString: 'A B' ].
+			sharedVariables: #(A B) ].
 
 	self assert: self collectedAnnouncements size equals: 1.
 	self assert: self collectedAnnouncements first newClassDefinition equals: aClass
@@ -133,7 +133,7 @@ SlotAnnouncementsTest >> testChangeInSharedVariablesShouldAnnounceClassModified 
 	aClass := self make: [ :builder |
 		builder
 			name: self aClassName;
-			sharedVariablesFromString: 'A B C' ].
+			sharedVariables: #(A B C) ].
 
 	self assert: self collectedAnnouncements size equals: 1.
 	self assert: self collectedAnnouncements first newClassDefinition equals: aClass

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -147,8 +147,7 @@ SlotAnnouncementsTest >> testChangeInSuperclassShouldNotAnnounceSubclassModified
 	"Create a class and a subclass"
 	aClass := self make: [ :builder |
 		builder
-			name: self aClassName;
-			slots: #() ].
+			name: self aClassName ].
 
 	anotherClass := self make: [ :builder |
 		builder

--- a/src/Slot-Tests/SlotBasicTest.class.st
+++ b/src/Slot-Tests/SlotBasicTest.class.st
@@ -36,18 +36,6 @@ SlotBasicTest >> testAddSharedPool [
 	self assert: (aClass sharedPools includes: TestSharedPool)
 ]
 
-{ #category : 'tests - shared variables' }
-SlotBasicTest >> testAddSharedVariable [
-
-	self make: [ :builder |
-		builder sharedVariablesFromString: '' ].
-
-	aClass := self make: [ :builder |
-		builder sharedVariablesFromString: 'Var' ].
-
-	self assert: aClass classVarNames equals: #(Var)
-]
-
 { #category : 'tests - basic' }
 SlotBasicTest >> testBasicClassBuilding [
 	aClass := self make: [ :builder | builder name: self aClassName ].
@@ -170,9 +158,9 @@ SlotBasicTest >> testRemoveSharedPool [
 
 { #category : 'tests - shared variables' }
 SlotBasicTest >> testRemoveSharedVariable [
-	self make: [ :builder | builder sharedVariablesFromString: 'Var' ].
+	self make: [ :builder | builder sharedVariables: #(Var) ].
 
-	aClass := self make: [ :builder | builder sharedVariablesFromString: '' ].
+	aClass := self make: [ :builder | builder sharedVariables: #() ].
 
 	self assertEmpty: aClass classVarNames
 ]
@@ -234,7 +222,7 @@ SlotBasicTest >> testWithSharedPool [
 SlotBasicTest >> testWithSharedVariable [
 	<ignoreNotImplementedSelectors: #(var:)>
 	aClass := self make: [ :builder |
-		builder sharedVariablesFromString: 'Var' ].
+		builder sharedVariables: #(Var) ].
 	aClass class
 		compile: 'var:x  Var:=x';
 		compile: 'var  ^Var'.
@@ -257,11 +245,4 @@ SlotBasicTest >> testWithoutSharedPools [
 	aClass := self make: [ :builder | builder sharedPools: '' ].
 
 	self assertEmpty: aClass sharedPools
-]
-
-{ #category : 'tests - shared variables' }
-SlotBasicTest >> testWithoutSharedVariables [
-	aClass := self make: [ :builder | builder sharedVariablesFromString: '' ].
-
-	self assertEmpty: aClass classVarNames
 ]

--- a/src/Slot-Tests/SlotClassVariableTest.class.st
+++ b/src/Slot-Tests/SlotClassVariableTest.class.st
@@ -41,7 +41,7 @@ SlotClassVariableTest >> testClassVariableDoesNotDuplicatesSubclassesOfSuperclas
 		builder
 			name: self anotherClassName;
 			superclass: class1;
-			sharedVariablesFromString: 'ASharedVariable' ].
+			sharedVariables: #(ASharedVariable) ].
 	self assert: class1 subclasses equals: { class2 }
 ]
 

--- a/src/Slot-Tests/SlotIntegrationTest.class.st
+++ b/src/Slot-Tests/SlotIntegrationTest.class.st
@@ -326,7 +326,7 @@ SlotIntegrationTest >> testReshapeClassPropagatesToDeepHierarchyClassInterface [
 	aClass := self class classInstaller make: [ :aClassBuilder |
 		aClassBuilder
 			name: self aClassName;
-			slotsFromString: 'x';
+			slots: #(x);
 			package: self slotTestPackageName ].
 
 	self assert: aClass instVarNames equals: #(x).
@@ -348,7 +348,7 @@ SlotIntegrationTest >> testReshapeClassWithClassSlot [
 
 	self assert: aClass class instVarNames equals: #( x ).
 
-	aClass := self class classInstaller update: aClass to: [ :aClassBuilder | aClassBuilder slotsFromString: 'x' ].
+	aClass := self class classInstaller update: aClass to: [ :aClassBuilder | aClassBuilder slots: #(x) ].
 
 	self assert: aClass class instVarNames equals: #( x ).
 	self assert: aClass instVarNames equals: #( x )

--- a/src/Slot-Tests/SlotMigrationTest.class.st
+++ b/src/Slot-Tests/SlotMigrationTest.class.st
@@ -36,7 +36,7 @@ SlotMigrationTest >> testAddSharedVariableKeepSubclasses [
 			builder
 				name: self aClassName;
 				superclass: Object;
-				sharedVariablesFromString: 'Var' ].
+				sharedVariables: #(Var) ].
 
 	self assert: aClass subclasses size equals: 1.
 	self assert: aClass subclasses anyOne identicalTo: anotherClass

--- a/src/System-Changes-Tests/ChangeSetClassChangesTest.class.st
+++ b/src/System-Changes-Tests/ChangeSetClassChangesTest.class.st
@@ -40,7 +40,7 @@ ChangeSetClassChangesTest >> testAddInstanceVariable [
 
 	| class className saveClassDefinition |
 	"Define a class and save its definition"
-	class := factory make: [ :aBuilder | aBuilder slotsFromString: 'zzz' ].
+	class := factory make: [ :aBuilder | aBuilder slots: #(zzz) ].
 	className := class name.
 	saveClassDefinition := class definitionString.
 
@@ -50,7 +50,7 @@ ChangeSetClassChangesTest >> testAddInstanceVariable [
 	factory make: [ :aBuilder |
 		aBuilder
 			fillFor: class;
-			slotsFromString: 'zzz aaa' ].
+			slots: #(zzz aaa) ].
 
 	self deny: class definitionString equals: saveClassDefinition.
 
@@ -64,14 +64,14 @@ ChangeSetClassChangesTest >> testAddInstanceVariableAddsNewChangeRecord [
 	record being updated in the current change set."
 
 	| class saveClassDefinition |
-	class := factory make: [ :aBuilder | aBuilder slotsFromString: 'zzz' ].
+	class := factory make: [ :aBuilder | aBuilder slots: #(zzz) ].
 	saveClassDefinition := class definitionString.
 	ChangeSet current removeClassChanges: class name.
 	"Redefine the class, adding one instance variable"
 	factory make: [ :aBuilder |
 		aBuilder
 			fillFor: class;
-			slotsFromString: 'zzz aaa' ].
+			slots: #(zzz aaa) ].
 
 	self assert: (ChangeSet current changeRecorderFor: class name) priorDefinition equals: saveClassDefinition
 ]

--- a/src/Traits-Tests/TraitChangesTest.class.st
+++ b/src/Traits-Tests/TraitChangesTest.class.st
@@ -59,7 +59,7 @@ TraitChangesTest >> testconfigureBuilderWithNameTraitCompositionInstanceVariable
 	builder := ShiftClassBuilder new
 		           name: #T1;
 		           beTrait;
-		           slotsFromString: 'a b';
+		           slots: #(a b);
 		           package: self packageNameForTests.
 
 	self assert: builder slots size equals: 2.


### PR DESCRIPTION
slotsFromString: should only be used by code that is dealing with old style class defs

This PR fixes lots of tests to use #slots: with an array instead.