### PR TITLE
Add class comment as tooltip in Calypso.

### DIFF
--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Browser/ClyAbstractClassTableDecorator.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Browser/ClyAbstractClassTableDecorator.class.st
@@ -20,7 +20,8 @@ ClyAbstractClassTableDecorator class >> decorateTableCell: anItemCellMorph of: a
 
 	nameMorph := anItemCellMorph label.
 	nameMorph emphasis: TextEmphasis italic emphasisCode.
-	nameMorph color: (nameMorph color contrastingColorAdjustment) contrastingColorAdjustment
+	nameMorph color: (nameMorph color contrastingColorAdjustment) contrastingColorAdjustment.
+	super decorateTableCell: anItemCellMorph of: aDataSourceItem.
 ]
 
 { #category : 'testing' }

--- a/src/Calypso-SystemTools-Core/ClyClassIconTableDecorator.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassIconTableDecorator.class.st
@@ -25,7 +25,3 @@ ClyClassIconTableDecorator class >> decorateMainTableCell: anItemCellMorph of: a
 
     anItemCellMorph definitionMorph: icon asMorph
 ]
-
-{ #category : 'decoration' }
-ClyClassIconTableDecorator class >> decorateTableCell: anItemCellMorph of: aDataSourceItem [
-]

--- a/src/Calypso-SystemTools-Core/ClyClassTableDecorator.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassTableDecorator.class.st
@@ -13,6 +13,14 @@ Class {
 }
 
 { #category : 'decoration' }
+ClyClassTableDecorator class >> decorateTableCell: anItemCellMorph of: aDataSourceItem [
+
+	| labelMorphExtension |
+	labelMorphExtension := anItemCellMorph label assureExtension.
+	labelMorphExtension balloonText: aDataSourceItem actualObject comment. 
+]
+
+{ #category : 'decoration' }
 ClyClassTableDecorator class >> decorationStrategy [
 	<classAnnotation>
 


### PR DESCRIPTION
This PR add class comment as tooltip in Calypso as requested in this #5940.
For now, as Calypso relies on StringMorph, this is implemented as a balloon text tooltip although a future enhacement could display the Microdown comment.

<img width="862" alt="Screenshot 2023-12-01 at 14 51 50" src="https://github.com/pharo-project/pharo/assets/4825959/0e6a7d19-55f4-407c-bd11-686a2870767b">
