### PR TITLE
15665-Not-possible-to-edit-slots-when-using-new-definition-format--RBLiteralValueNode-DNU-name 

### DIFF
--- a/src/ClassParser-Tests/CDFluidClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDFluidClassParserTest.class.st
@@ -394,7 +394,7 @@ CDFluidClassParserTest >> testUnrestrictedClassVariable [
 	self assert: def sharedVariables first class equals: CDSharedVariableNode.
 	self assert: def sharedVariables first name equals: #A.
 	self assert: def sharedVariables first variableClassName equals: #ClassVariable.
-	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: orginalSetting..
+	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: orginalSetting
 ]
 
 { #category : 'tests - (r) class variables' }
@@ -412,7 +412,7 @@ CDFluidClassParserTest >> testUnrestrictedClassVariableSimple [
 	self assert: def sharedVariables first class equals: CDSharedVariableNode.
 	self assert: def sharedVariables first name equals: #A.
 	self assert: def sharedVariables first variableClassName equals: #ClassVariable.
-	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: orginalSetting..
+	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: orginalSetting
 ]
 
 { #category : 'tests - (r) slots' }

--- a/src/ClassParser-Tests/CDFluidClassParserTest.class.st
+++ b/src/ClassParser-Tests/CDFluidClassParserTest.class.st
@@ -379,25 +379,80 @@ CDFluidClassParserTest >> testTraitSequence [
 	self assert: def traitDefinition sequence first name equals: #MyTrait
 ]
 
-{ #category : 'tests - (r) slots' }
-CDFluidClassParserTest >> testUnrestrictedSlots [
+{ #category : 'tests - (r) class variables' }
+CDFluidClassParserTest >> testUnrestrictedClassVariable [
 
-	| parser defString def slot |
+	| orginalSetting parser defString def |
+	orginalSetting := CDFluidClassDefinitionParser unrestrictedVariableDefinitions.
+	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: true.
 	parser := self classDefinitionParserClass new.
-	
-	"check that we can experiment with if we enable the setting"
-	self classDefinitionParserClass  unrestrictedVariableDefinitions: true.
-	
+
 	defString := 'Object << #MyObject
-		slots: { Slot named: #slotName  };
+		sharedVariables: { ClassVariable named: #A };
 		package: #MyPackage'.
 	def := parser parse: defString.
-	slot := def slots first.
-	self assert: slot name equals: #slotName. 
-	self assert: slot variableClassName equals: #Slot.
-	self classDefinitionParserClass  unrestrictedVariableDefinitions: false.
-	"if it is the default false, we do no allow it"
-	self should: [ 	def := parser parse: defString ] raise: Error
+	self assert: def sharedVariables first class equals: CDSharedVariableNode.
+	self assert: def sharedVariables first name equals: #A.
+	self assert: def sharedVariables first variableClassName equals: #ClassVariable.
+	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: orginalSetting..
+]
+
+{ #category : 'tests - (r) class variables' }
+CDFluidClassParserTest >> testUnrestrictedClassVariableSimple [
+
+	| orginalSetting parser defString def |
+	orginalSetting := CDFluidClassDefinitionParser unrestrictedVariableDefinitions.
+	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: true.
+	parser := self classDefinitionParserClass new.
+
+	defString := 'Object << #MyObject
+		sharedVariables: { #A };
+		package: #MyPackage'.
+	def := parser parse: defString.
+	self assert: def sharedVariables first class equals: CDSharedVariableNode.
+	self assert: def sharedVariables first name equals: #A.
+	self assert: def sharedVariables first variableClassName equals: #ClassVariable.
+	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: orginalSetting..
+]
+
+{ #category : 'tests - (r) slots' }
+CDFluidClassParserTest >> testUnrestrictedSlot [
+
+	| orginalSetting parser defString def |
+	orginalSetting := CDFluidClassDefinitionParser unrestrictedVariableDefinitions.
+	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: true.
+	parser := self classDefinitionParserClass new.
+
+	defString := 'Object << #MyObject
+		slots: { InstanceVariableSlot named: #a. #b };
+		package: #MyPackage'.
+	def := parser parse: defString.
+	self assert: def slots size equals: 2.
+	self assert: def slots first name equals: #a.
+	self assert: def slots second name equals: #b.
+	self assert: def slots first variableClassName equals: #InstanceVariableSlot.
+	self assert: def slots second variableClassName equals: #InstanceVariableSlot.
+	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: orginalSetting
+]
+
+{ #category : 'tests - (r) slots' }
+CDFluidClassParserTest >> testUnrestrictedSlotsSimple [
+
+	| orginalSetting parser defString def |
+	orginalSetting := CDFluidClassDefinitionParser unrestrictedVariableDefinitions.
+	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: true.
+	parser := self classDefinitionParserClass new.
+
+	defString := 'Object << #MyObject
+		slots: { #a. #b };
+		package: #MyPackage'.
+	def := parser parse: defString.
+	self assert: def slots size equals: 2.
+	self assert: def slots first name equals: #a.
+	self assert: def slots second name equals: #b.
+	self assert: def slots first variableClassName equals: #InstanceVariableSlot.
+	self assert: def slots second variableClassName equals: #InstanceVariableSlot.
+	CDFluidClassDefinitionParser unrestrictedVariableDefinitions: orginalSetting
 ]
 
 { #category : 'tests - (r) kinds' }

--- a/src/ClassParser/CDFluidClassDefinitionParser.class.st
+++ b/src/ClassParser/CDFluidClassDefinitionParser.class.st
@@ -226,12 +226,14 @@ CDFluidClassDefinitionParser >> handleSharedVarableNodeSimple: slotDefNode [
 { #category : 'parsing - variables' }
 CDFluidClassDefinitionParser >> handleSharedVariabeNode: variableDefNode [
 	 | variable |
+	
+	"when a class variable is just #ClassVars"
+	variableDefNode isLiteralNode ifTrue: [ ^ classDefinition addSharedVariable: (self handleSharedVarableNodeSimple: variableDefNode)].
+	
 	"Setting, default off, to allow experiments"
 	self class unrestrictedVariableDefinitions ifTrue: [ 
 		^ classDefinition addSharedVariable: (self handleUnrestrictedSharedVariableDefinition: variableDefNode) ].
 	
-	"when a class variable is just #ClassVars"
-	variableDefNode isLiteralNode ifTrue: [ variable := self handleSharedVarableNodeSimple: variableDefNode].
 	"#ClassVar => SomeVar default: 5; default2: 4"
 	variableDefNode isCascade ifTrue: [ variable := self handleSharedVariableNodeCascade: variableDefNode].
 	"when a class var is just #var => SomeVar"
@@ -311,12 +313,14 @@ CDFluidClassDefinitionParser >> handleSharedVariableNodesFromArrayNode: aRBArray
 CDFluidClassDefinitionParser >> handleSlotNode: slotDefNode [
 	 | slot |
 	
+	"when a slot is just #inst"
+	slotDefNode isLiteralNode ifTrue: [
+		^ classDefinition addSlot: ( self handleSlotNodeSimple: slotDefNode)].
+	
 	"Setting, default off, to allow experiments"
 	self class unrestrictedVariableDefinitions ifTrue: [ 
 		^ classDefinition addSlot: (self handleUnrestrictedSlotDefinition: slotDefNode) ].
 	
-	"when a slot is just #inst"
-	slotDefNode isLiteralNode ifTrue: [ slot := self handleSlotNodeSimple: slotDefNode].
 	"#inst => InstanceVariableSlot default: 5; default2: 4"
 	slotDefNode isCascade ifTrue: [ slot := self handleSlotNodeCascade: slotDefNode].
 	"when a slot is just #inst => InstanceVariableSlot."
@@ -421,9 +425,9 @@ CDFluidClassDefinitionParser >> handleTraitUsesFromNode: aNode [
 CDFluidClassDefinitionParser >> handleUnrestrictedSharedVariableDefinition: variableDefNode [
 
 	"If the preference is enabled, allow unrestricted shared variable definitions. 
-	TAKE CARE: There is no way to know the name nor the class witout executing the code of the defintion.
-	This means that a) code will be evaluated which could have side effects and b) you need to load the Slot Class
-	before any users, as an UndefinedSlot can not be created, as we do not know the name"
+	TAKE CARE: There is no way to know the name nor the class without executing the code of the defintion.
+	This means that a) code will be evaluated which could have side effects and b) you need to load the Variable class
+	before any users, as an UndefinedClassVariable can not be created, as we do not know the name"
 
 	| variableInstance |
 	"create the instance of the Variable by evaluating the defintion, we use this to fill out the name and variableClassName"
@@ -431,7 +435,7 @@ CDFluidClassDefinitionParser >> handleUnrestrictedSharedVariableDefinition: vari
 
 	^ CDSharedVariableNode new
 		  node: variableDefNode;
-		  name: variableDefNode name;
+		  name: variableInstance name;
 		  variableClassName: variableInstance class name;
 		  start: variableDefNode start;
 		  stop: variableDefNode stop


### PR DESCRIPTION
- Improve tests for Unrestricted Variables
- fix typos
- make sure to parse simple defs correctly in Unrestricted mode

fixes #15665