### PR TITLE
Fix ephemeron support in Fuel

### DIFF
--- a/src/Fuel-Core-Tests/FLEphemeronTest.class.st
+++ b/src/Fuel-Core-Tests/FLEphemeronTest.class.st
@@ -7,29 +7,64 @@ Class {
 }
 
 { #category : 'tests' }
-FLEphemeronTest >> testWeakKeyAssociationMourningAfterMaterialization [
-	"This tests serialization / materialization of WeakKeyAssociation, which is an ephemeron class.
-	When the key is not strongly referenced, which is the case here, the garbage collector
-	will send #mourn to the object to finalize it. This will cause the ephemeron to remove itself
-	from its container."
+FLEphemeronTest >> testEphemeronSupport [
+	| unsupported |
+	unsupported := { FinalizationRegistryEntry }.
+	Object allSubclasses
+		select: [ :class |
+			class classLayout class == EphemeronLayout and: [
+				(unsupported includes: class) not ] ]
+		thenDo: [ :class |
+			self assert: (class includesSelector: #fuelCheckEphemeronSupport) ]
+]
 
-	| dictionary ephemeron materializedDictionary materializedAssociation |
-	dictionary := Dictionary new.
-	ephemeron := WeakKeyAssociation new
-		key: Object new;
-		value: 'value';
-		container: dictionary.
-	dictionary add: ephemeron.
+{ #category : 'tests' }
+FLEphemeronTest >> testSupportForFinalizationRegistryEntry [
+	| ephemeron |
+	ephemeron := FinalizationRegistryEntry new.
+	self
+		should: [ ephemeron fuelCheckEphemeronSupport ]
+		raise: FLNotSerializable
+		whoseDescriptionIncludes: 'Unsupported ephemeron implementation'
+		description: 'FinalizationRegistryEntry serialization is not supported'
+]
 
-	materializedDictionary := self resultOfSerializeAndMaterialize: dictionary.
-	self deny: materializedDictionary isEmpty.
-	self assert: materializedDictionary size equals: 1.
-	materializedAssociation := materializedDictionary associations first.
-	self assert: materializedAssociation key isNil.
-	self assert: materializedAssociation value equals: 'value'.
+{ #category : 'tests' }
+FLEphemeronTest >> testSupportForWeakKeyAssociation [
+	| ephemeron errorString |
+	ephemeron := WeakKeyAssociation new.
+	errorString := 'Unsupported use of ephemeron'.
+	self
+		should: [ ephemeron fuelCheckEphemeronSupport ]
+		raise: FLNotSerializable
+		whoseDescriptionIncludes: errorString
+		description: 'WeakKeyAssociation with nil container is not supported'.
+	
+	ephemeron
+		key: 'key'
+		value: 'value'.
+	self
+		should: [ ephemeron fuelCheckEphemeronSupport ]
+		raise: FLNotSerializable
+		whoseDescriptionIncludes: errorString
+		description: 'WeakKeyAssociation with nil container is not supported'.
 		
-	Smalltalk garbageCollect.
-	self deny: materializedDictionary isEmpty
+	ephemeron container: Set new.
+	self
+		should: [ ephemeron fuelCheckEphemeronSupport ]
+		raise: FLNotSerializable
+		whoseDescriptionIncludes: errorString
+		description: 'WeakKeyAssociation is only supported with dictionary containers'.
+		
+	ephemeron container: Dictionary new.
+	self
+		shouldnt: [ ephemeron fuelCheckEphemeronSupport ]
+		raise: FLNotSerializable.
+		
+	ephemeron container: WeakKeyDictionary new.
+	self
+		shouldnt: [ ephemeron fuelCheckEphemeronSupport ]
+		raise: FLNotSerializable
 ]
 
 { #category : 'tests' }

--- a/src/Fuel-Core/EphemeronLayout.extension.st
+++ b/src/Fuel-Core/EphemeronLayout.extension.st
@@ -2,5 +2,7 @@ Extension { #name : 'EphemeronLayout' }
 
 { #category : '*Fuel-Core' }
 EphemeronLayout >> fuelAccept: aGeneralMapper forInstance: anObject [
+	anObject fuelCheckEphemeronSupport.
+	
 	aGeneralMapper visitEphemeron: anObject
 ]

--- a/src/Fuel-Core/FLDictionaryCollectionCluster.class.st
+++ b/src/Fuel-Core/FLDictionaryCollectionCluster.class.st
@@ -4,6 +4,9 @@ A FLDictionaryCollectionCluster is a cluster that rather than using the default 
 Class {
 	#name : 'FLDictionaryCollectionCluster',
 	#superclass : 'FLAbstractCollectionCluster',
+	#instVars : [
+		'ephemeronKeys'
+	],
 	#category : 'Fuel-Core-Clusters-Optimized',
 	#package : 'Fuel-Core',
 	#tag : 'Clusters-Optimized'
@@ -12,6 +15,17 @@ Class {
 { #category : 'serialize/materialize' }
 FLDictionaryCollectionCluster >> encodeExtraInformationForReferencesFor: aDictionary with: anEncoder [
 	anEncoder encodeByte: (self hasRealAssociations: aDictionary) asBit
+]
+
+{ #category : 'analyzing' }
+FLDictionaryCollectionCluster >> ephemeron: anEphemeron do: aBlock [
+	anEphemeron fuelCheckEphemeronSupport.
+	"Add strong reference to key so we know that from
+	now on the ephemeron won't be finalized."
+	ephemeronKeys add: anEphemeron key.
+	"Check that the ephemeron wasn't mourned yet. We might
+	have added the strong reference after finalization."
+	anEphemeron fuelWasMourned ifFalse: [ aBlock value: anEphemeron ]
 ]
 
 { #category : 'testing' }
@@ -25,6 +39,13 @@ FLDictionaryCollectionCluster >> hasRealAssociations: aDictionary [
 		^ assoc class == Association ].
 	
 	^ true
+]
+
+{ #category : 'initialization' }
+FLDictionaryCollectionCluster >> initialize [
+	super initialize.
+	
+	ephemeronKeys := OrderedCollection new
 ]
 
 { #category : 'serialize/materialize' }
@@ -60,5 +81,19 @@ FLDictionaryCollectionCluster >> referencesOf: aDictionary do: aBlock [
 				aBlock
 					value: key;
 					value: value ] ]
-		ifFalse: [ aDictionary associationsDo: aBlock ]
+		ifFalse: [
+			self
+				specialAssociationsOf: aDictionary
+				do: aBlock ]
+]
+
+{ #category : 'analyzing' }
+FLDictionaryCollectionCluster >> specialAssociationsOf: aDictionary do: aBlock [
+	aDictionary associationsDo: [ :association |
+		association fuelIsEphemeron
+			ifFalse: [ aBlock value: association ]
+			ifTrue: [
+				self
+					ephemeron: association
+					do: aBlock ] ]
 ]

--- a/src/Fuel-Core/FLEphemeronCluster.class.st
+++ b/src/Fuel-Core/FLEphemeronCluster.class.st
@@ -23,9 +23,9 @@ FLEphemeronCluster >> clusterReferencesDo: aBlock [
 
 { #category : 'analyzing' }
 FLEphemeronCluster >> referencesOf: anObject do: aBlock [
-	"Do not store strong reference to the key, which is essentially a weak reference.
-	Do not trace the key either. We only want to serialize the key if there's an
-	explicit reference to it in the graph."
+	"Do not trace the key. We only want to serialize the key if there's an
+	explicit reference to it in the graph.
+	See #serializeReferencesOf:with:"
 	| key |
 	key := anObject key.
 	variablesMapping
@@ -38,7 +38,8 @@ FLEphemeronCluster >> referencesOf: anObject do: aBlock [
 { #category : 'serialize/materialize' }
 FLEphemeronCluster >> serializeReferencesOf: anObject with: anEncoder [
 	"As we did not trace the key we can simply encode it here,
-	provided it was strongly referenced from within the graph."
+	provided it was strongly referenced from within the graph.
+	If there's no reference within the graph we encode nil."
 	anEncoder encodeWeakReferenceTo: anObject key.
 	
 	"The references do not contain the key"

--- a/src/Fuel-Core/Object.extension.st
+++ b/src/Fuel-Core/Object.extension.st
@@ -13,6 +13,21 @@ Object >> fuelAfterMaterialization [
 ]
 
 { #category : '*Fuel-Core' }
+Object >> fuelCheckEphemeronSupport [
+	FLNotSerializable signal: 'Unsupported ephemeron implementation'
+]
+
+{ #category : '*Fuel-Core' }
+Object >> fuelIsEphemeron [
+	^ self class classLayout class == EphemeronLayout
+]
+
+{ #category : '*Fuel-Core' }
+Object >> fuelWasMourned [
+	^ false
+]
+
+{ #category : '*Fuel-Core' }
 Object >> serializeOn: aStream [
 	FLSerializer
 		serialize: self

--- a/src/Fuel-Core/WeakKeyAssociation.extension.st
+++ b/src/Fuel-Core/WeakKeyAssociation.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : 'WeakKeyAssociation' }
+
+{ #category : '*Fuel-Core' }
+WeakKeyAssociation >> fuelCheckEphemeronSupport [
+	container isDictionary ifFalse: [
+		FLNotSerializable signal: 'Unsupported use of ephemeron' ]
+]
+
+{ #category : '*Fuel-Core' }
+WeakKeyAssociation >> fuelWasMourned [
+	^ (self container includesKey: key) not
+]


### PR DESCRIPTION
- Raise error if ephemeron implemenation or use are not supported
- Hold strong references to ephemeron keys to prevent the GC from modifying the graph during serialization

Fixes #15669