### PR TITLE
Add initialization of ScalingCanvas to BaselineOfMorphic

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -306,6 +306,7 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	UIManager default: MorphicUIManager new.
 	UIManager default uiProcess resume.
 	PharoLightTheme beCurrent.
+	ScalingCanvas initialize.
 	self cleanUpAfterMorphicInitialization.
 
 	GraphicFontSettings setFontsToStyleNamed: #small.


### PR DESCRIPTION
This pull request adds a send of `#initialize` to ScalingCanvas (added in pull request #15647) to the `#postload:package:` of BaselineOfMorphic.