### PR TITLE
Fix #checkForNewScreenSize on OSWorldRenderer to also check the #actualScreenSize

### DIFF
--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -99,7 +99,7 @@ OSWorldRenderer >> checkForNewScreenSize [
 	windowRenderer := self osWindowRenderer.
 	windowRenderer ifNil: [ ^ self ].
 
-	(display isNil or: [ display extent = self actualDisplaySize ])
+	(display isNil or: [ display extent = self actualDisplaySize and: [ world worldState realWindowExtent = self actualScreenSize ] ])
 		ifTrue: [ ^ self ].
 
 	display := Form extent: self actualDisplaySize depth: 32.


### PR DESCRIPTION
This pull request fixes a bug in `#checkForNewScreenSize` on OSWorldRenderer where `#actualDisplaySize` (introduced in pull request #15647) is checked but `#actualScreenSize` isn’t (when doubling both the #canvasScaleFactor and the world’s #scaleFactor, the #actualScreenSize changes while the #actualDisplaySize can, depending on rounding, stay the same).