### PR TITLE
Cleanup/extract method first pass

### DIFF
--- a/src/Refactoring-Transformations-Tests/RBExtractMethodAndOccurrencesTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodAndOccurrencesTest.class.st
@@ -1,35 +1,26 @@
 Class {
-	#name : 'RBExtractMethodAndOccurrencesParametrizedTest',
+	#name : 'RBExtractMethodAndOccurrencesTest',
 	#superclass : 'RBAbstractRefactoringTest',
 	#category : 'Refactoring-Transformations-Tests-SingleParametrized',
 	#package : 'Refactoring-Transformations-Tests',
 	#tag : 'SingleParametrized'
 }
 
-{ #category : 'tests' }
-RBExtractMethodAndOccurrencesParametrizedTest class >> testParameters [
-	^ ParametrizedTestMatrix new
-		addCase: { #rbClass -> RBExtractMethodAndOccurrences };
-		yourself
-]
-
-{ #category : 'accessing' }
-RBExtractMethodAndOccurrencesParametrizedTest >> constructor [
-	^ #extract:from:in:
-]
-
 { #category : 'running' }
-RBExtractMethodAndOccurrencesParametrizedTest >> setUp [
+RBExtractMethodAndOccurrencesTest >> setUp [
 	super setUp.
 	model := self rbModelForExtractMethodTest
 ]
 
 { #category : 'tests' }
-RBExtractMethodAndOccurrencesParametrizedTest >> testExtractMethodWithTwoArgsAndOcurrences [
+RBExtractMethodAndOccurrencesTest >> testExtractMethodWithTwoArgsAndOcurrences [
 	|class refactoring|
 	class := model classNamed: #MyClassA.
-	refactoring := self createRefactoringWithModel: model
-		andArguments: { (116 to: 245) . #displayName . class }.
+	refactoring := RBExtractMethodAndOccurrences
+						model: model
+						extract: (116 to: 245)
+						from: #displayName
+						in: class.
 	self setupSearchInAllHierarchyFor: refactoring toReturn: true.
 	self setupMethodNameFor: refactoring toReturn: #stringArg:streamArg:.
 	self executeRefactoring: refactoring.
@@ -59,11 +50,14 @@ RBExtractMethodAndOccurrencesParametrizedTest >> testExtractMethodWithTwoArgsAnd
 ]
 
 { #category : 'tests' }
-RBExtractMethodAndOccurrencesParametrizedTest >> testExtractSimpleMethodAndOcurrences [
+RBExtractMethodAndOccurrencesTest >> testExtractSimpleMethodAndOcurrences [
 	|class refactoring|
 	class := model classNamed: #MyClassA.
-	refactoring := self createRefactoringWithModel: model
-		andArguments: { (291 to: 311) . #myMethod . class }.
+	refactoring := RBExtractMethodAndOccurrences
+						model: model
+						extract: (291 to: 311)
+						from: #myMethod
+						in: class.
 	self setupSearchInAllHierarchyFor: refactoring toReturn: true.
 	self setupMethodNameFor: refactoring toReturn: #extractedMethod.
 	self executeRefactoring: refactoring.
@@ -108,9 +102,9 @@ RBExtractMethodAndOccurrencesParametrizedTest >> testExtractSimpleMethodAndOcurr
 ]
 
 { #category : 'failure tests' }
-RBExtractMethodAndOccurrencesParametrizedTest >> testFailureBadInterval [
+RBExtractMethodAndOccurrencesTest >> testFailureBadInterval [
 	|class|
 	class := model classNamed: #MyClassA.
-	self shouldFail: (self createRefactoringWithModel: model
-		andArguments: { (127 to: 136) . #myMethod . class })
+	self shouldFail: (RBExtractMethodAndOccurrences model: model
+		extract: (127 to: 136) from: #myMethod in: class)
 ]

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodRefactoringTest.class.st
@@ -1,27 +1,15 @@
 Class {
-	#name : 'RBExtractMethodParametrizedTest',
+	#name : 'RBExtractMethodRefactoringTest',
 	#superclass : 'RBAbstractRefactoringTest',
-	#category : 'Refactoring-Transformations-Tests-SingleParametrized',
+	#category : 'Refactoring-Transformations-Tests-Test',
 	#package : 'Refactoring-Transformations-Tests',
-	#tag : 'SingleParametrized'
+	#tag : 'Test'
 }
 
 { #category : 'tests' }
-RBExtractMethodParametrizedTest class >> testParameters [
-	^ ParametrizedTestMatrix new
-		addCase: { #rbClass -> RBExtractMethodRefactoring };
-		yourself
-]
-
-{ #category : 'accessing' }
-RBExtractMethodParametrizedTest >> constructor [
-	^ #extract:from:in:
-]
-
-{ #category : 'tests' }
-RBExtractMethodParametrizedTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
+RBExtractMethodRefactoringTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments: {(52 to: 133) . #openEditor . RBLintRuleTestData }.
+	refactoring := RBExtractMethodRefactoring extract: (52 to: 133) from: #openEditor in: RBLintRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
@@ -36,9 +24,9 @@ RBExtractMethodParametrizedTest >> testExtractMethodAtEndOfMethodThatNeedsReturn
 ]
 
 { #category : 'tests' }
-RBExtractMethodParametrizedTest >> testExtractMethodThatMovesTemporaryVariable [
+RBExtractMethodRefactoringTest >> testExtractMethodThatMovesTemporaryVariable [
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments: { (22 to: 280) . #superSends . RBTransformationRuleTestData }.
+	refactoring := RBExtractMethodRefactoring extract: (22 to: 280) from: #superSends in: RBTransformationRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo1.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
@@ -59,9 +47,9 @@ RBExtractMethodParametrizedTest >> testExtractMethodThatMovesTemporaryVariable [
 ]
 
 { #category : 'tests' }
-RBExtractMethodParametrizedTest >> testExtractMethodThatNeedsArgument [
+RBExtractMethodRefactoringTest >> testExtractMethodThatNeedsArgument [
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments: { (143 to: 340) . #checkMethod: . RBTransformationRuleTestData }.
+	refactoring := RBExtractMethodRefactoring extract: (143 to: 340) from: #checkMethod: in: RBTransformationRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTransformationRuleTestData.
@@ -78,9 +66,9 @@ RBExtractMethodParametrizedTest >> testExtractMethodThatNeedsArgument [
 ]
 
 { #category : 'tests' }
-RBExtractMethodParametrizedTest >> testExtractMethodThatNeedsTemporaryVariable [
+RBExtractMethodRefactoringTest >> testExtractMethodThatNeedsTemporaryVariable [
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments: { (78 to: 197) . #displayName . RBLintRuleTestData }.
+	refactoring := RBExtractMethodRefactoring extract: (78 to: 197) from: #displayName in: RBLintRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBLintRuleTestData.
@@ -98,9 +86,9 @@ RBExtractMethodParametrizedTest >> testExtractMethodThatNeedsTemporaryVariable [
 ]
 
 { #category : 'tests' }
-RBExtractMethodParametrizedTest >> testExtractMethodToSuperclass [
+RBExtractMethodRefactoringTest >> testExtractMethodToSuperclass [
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments: { (143 to: 340) . #checkMethod: . RBTransformationRuleTestData }.
+	refactoring := RBExtractMethodRefactoring extract: (143 to: 340) from: #checkMethod: in: RBTransformationRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
 	self setupExtractionClassFor: refactoring toReturn: RBFooLintRuleTestData.
 	self executeRefactoring: refactoring.
@@ -120,9 +108,9 @@ RBExtractMethodParametrizedTest >> testExtractMethodToSuperclass [
 ]
 
 { #category : 'tests' }
-RBExtractMethodParametrizedTest >> testExtractWithRenamingOfParameters [
+RBExtractMethodRefactoringTest >> testExtractWithRenamingOfParameters [
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments: { (78 to: 197) . #displayName . RBLintRuleTestData }.
+	refactoring := RBExtractMethodRefactoring extract: (78 to: 197) from: #displayName in: RBLintRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
 	refactoring
 		parameterMap:
@@ -153,38 +141,35 @@ RBExtractMethodParametrizedTest >> testExtractWithRenamingOfParameters [
 ]
 
 { #category : 'failure tests' }
-RBExtractMethodParametrizedTest >> testFailureBadInterval [
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (24 to: 30) . #testMethod . RBClassDataForRefactoringTest }).
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (80 to: 147) . #subclassOf:overrides: . RBBasicLintRuleTestData class })
+RBExtractMethodRefactoringTest >> testFailureBadInterval [
+	self shouldFail: (RBExtractMethodRefactoring extract: (24 to: 30) from: #testMethod in: RBClassDataForRefactoringTest ).
+	self shouldFail: (RBExtractMethodRefactoring extract: (80 to: 147) from: #subclassOf:overrides: in: RBBasicLintRuleTestData class )
 ]
 
 { #category : 'failure tests' }
-RBExtractMethodParametrizedTest >> testFailureExtract [
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (80 to: 269) . #subclassOf:overrides: . RBBasicLintRuleTestData class }).
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (53 to: 56) . #subclassOf:overrides: . RBBasicLintRuleTestData class }).
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (77 to: 222) . #subclassResponsibilityNotDefined . RBBasicLintRuleTestData class })
+RBExtractMethodRefactoringTest >> testFailureExtract [
+	self shouldFail: (RBExtractMethodRefactoring extract: (80 to: 269) from: #subclassOf:overrides: in: RBBasicLintRuleTestData class ).
+	self shouldFail: (RBExtractMethodRefactoring extract: (53 to: 56) from: #subclassOf:overrides: in: RBBasicLintRuleTestData class).
+	self shouldFail: (RBExtractMethodRefactoring extract: (77 to: 222) from: #subclassResponsibilityNotDefined in: RBBasicLintRuleTestData class )
 ]
 
 { #category : 'failure tests' }
-RBExtractMethodParametrizedTest >> testFailureNonExistantSelector [
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (10 to: 20) . #checkClass1: . RBBasicLintRuleTestData })
+RBExtractMethodRefactoringTest >> testFailureNonExistantSelector [
+	self shouldFail: (RBExtractMethodRefactoring extract: (10 to: 20) from: #checkClass1: in: RBBasicLintRuleTestData)
 ]
 
 { #category : 'tests' }
-RBExtractMethodParametrizedTest >> testModelExtractMethodWithTemporariesSelected [
+RBExtractMethodRefactoringTest >> testModelExtractMethodWithTemporariesSelected [
 	| class refactoring |
 	model := RBNamespace new.
 	class := model classNamed: self class name.
 	class compile: 'foo [| temp | temp := 5. temp * temp] value'
 		classified: #(#accessing).
-	refactoring := self createRefactoringWithModel: model
-		andArguments: { (6 to: 36) . #foo . class }.
+	refactoring := RBExtractMethodRefactoring
+						model: model
+						extract: (6 to: 36)
+						from: #foo 
+						in: class.
 	self setupMethodNameFor: refactoring toReturn: #foobar.
 	self executeRefactoring: refactoring.
 	
@@ -198,15 +183,18 @@ RBExtractMethodParametrizedTest >> testModelExtractMethodWithTemporariesSelected
 ]
 
 { #category : 'tests' }
-RBExtractMethodParametrizedTest >> testModelExtractMethodWithTemporaryAssigned [
+RBExtractMethodRefactoringTest >> testModelExtractMethodWithTemporaryAssigned [
 	| class refactoring |
 	model := RBNamespace new.
 	class := model classNamed: self class name.
 	class
 		compile: 'foo 				| temp bar | 				bar := 5. 				temp := bar * bar. 				Transcript show: temp printString; cr. 				^temp * temp'
 		classified: #(#accessing).
-	refactoring := self createRefactoringWithModel: model
-		andArguments: { (26 to: 102) . #foo . class }.
+	refactoring := RBExtractMethodRefactoring
+						model: model
+						extract: (26 to: 102)
+						from: #foo
+						in:class.
 	self setupMethodNameFor: refactoring toReturn: #foobar.
 	self executeRefactoring: refactoring.
 	self assert: (class parseTreeForSelector: #foo)
@@ -219,10 +207,13 @@ RBExtractMethodParametrizedTest >> testModelExtractMethodWithTemporaryAssigned [
 ]
 
 { #category : 'tests' }
-RBExtractMethodParametrizedTest >> testValidateRenameParameters [
+RBExtractMethodRefactoringTest >> testValidateRenameParameters [
 	| refactoring |
-	refactoring := self createRefactoringWithModel: model
-		andArguments: { (78 to: 197) . #displayName . RBLintRuleTestData }.
+	refactoring := RBExtractMethodRefactoring
+						model: model
+						extract: (78 to: 197)
+						from: #displayName
+						in: RBLintRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
 	refactoring parameterMap: (Dictionary new at: #nameStream put: #nameStream; yourself ).
 	"Fail when use instance variables as new parameters"

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodToComponentRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodToComponentRefactoringTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'RBExtractMethodToComponentParametrizedTest',
+	#name : 'RBExtractMethodToComponentRefactoringTest',
 	#superclass : 'RBAbstractRefactoringTest',
 	#category : 'Refactoring-Transformations-Tests-SingleParametrized',
 	#package : 'Refactoring-Transformations-Tests',
@@ -7,21 +7,9 @@ Class {
 }
 
 { #category : 'tests' }
-RBExtractMethodToComponentParametrizedTest class >> testParameters [
-	^ ParametrizedTestMatrix new
-		addCase: { #rbClass -> RBExtractMethodToComponentRefactoring };
-		yourself
-]
-
-{ #category : 'accessing' }
-RBExtractMethodToComponentParametrizedTest >> constructor [
-	^ #extract:from:in:
-]
-
-{ #category : 'tests' }
-RBExtractMethodToComponentParametrizedTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
+RBExtractMethodToComponentRefactoringTest >> testExtractMethodAtEndOfMethodThatNeedsReturn [
 	| refactoring class selectorsSize |
-	refactoring := self createRefactoringWithArguments: { (52 to: 133) . #openEditor . RBLintRuleTestData }.
+	refactoring := RBExtractMethodToComponentRefactoring extract: (52 to: 133) from: #openEditor in: RBLintRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
 	self setupSelfArgumentNameFor: refactoring toReturn: 'asdf'.
 	self setupVariableToMoveToFor: refactoring toReturn: 'rules'.
@@ -52,33 +40,33 @@ RBExtractMethodToComponentParametrizedTest >> testExtractMethodAtEndOfMethodThat
 ]
 
 { #category : 'failure tests' }
-RBExtractMethodToComponentParametrizedTest >> testFailureBadInterval [
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (24 to: 30) . #testMethod . RBClassDataForRefactoringTest }).
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (80 to: 147) . #subclassOf:overrides: . RBBasicLintRuleTestData class })
+RBExtractMethodToComponentRefactoringTest >> testFailureBadInterval [
+	self shouldFail: (RBExtractMethodToComponentRefactoring
+		extract: (24 to: 30) from: #testMethod in: RBClassDataForRefactoringTest).
+	self shouldFail: (RBExtractMethodToComponentRefactoring
+		extract: (80 to: 147) from: #subclassOf:overrides: in: RBBasicLintRuleTestData class)
 ]
 
 { #category : 'failure tests' }
-RBExtractMethodToComponentParametrizedTest >> testFailureExtract [
-	self shouldFail: (self createRefactoringWithArguments:
-		{(80 to: 269) . #subclassOf:overrides: . RBBasicLintRuleTestData class }).
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (53 to: 56) . #subclassOf:overrides: . RBBasicLintRuleTestData class }).
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (77 to: 222) . #subclassResponsibilityNotDefined . RBBasicLintRuleTestData class })
+RBExtractMethodToComponentRefactoringTest >> testFailureExtract [
+	self shouldFail: (RBExtractMethodToComponentRefactoring
+		extract: (80 to: 269) from: #subclassOf:overrides: in: RBBasicLintRuleTestData class).
+	self shouldFail: (RBExtractMethodToComponentRefactoring
+		extract: (53 to: 56) from: #subclassOf:overrides: in: RBBasicLintRuleTestData class).
+	self shouldFail: (RBExtractMethodToComponentRefactoring
+		extract: (77 to: 222) from: #subclassResponsibilityNotDefined in: RBBasicLintRuleTestData class)
 ]
 
 { #category : 'failure tests' }
-RBExtractMethodToComponentParametrizedTest >> testFailureNonExistantSelector [
-	self shouldFail: (self createRefactoringWithArguments:
-		{ (10 to: 20) . #checkClass1: . RBBasicLintRuleTestData })
+RBExtractMethodToComponentRefactoringTest >> testFailureNonExistantSelector [
+	self shouldFail: (RBExtractMethodToComponentRefactoring
+		extract: (10 to: 20) from: #checkClass1: in: RBBasicLintRuleTestData)
 ]
 
 { #category : 'tests' }
-RBExtractMethodToComponentParametrizedTest >> testMoveWithoutSelfReference [
+RBExtractMethodToComponentRefactoringTest >> testMoveWithoutSelfReference [
 	| refactoring class selectorsSize |
-	refactoring := self createRefactoringWithArguments: { (118 to: 285) . #copyDictionary: . RBReadBeforeWrittenTester }.
+	refactoring := RBExtractMethodToComponentRefactoring extract: (118 to: 285) from: #copyDictionary: in: RBReadBeforeWrittenTester.
 	self setupMethodNameFor: refactoring toReturn: #copyWithAssociations.
 	self setupVariableToMoveToFor: refactoring toReturn: 'aDictionary'.
 	self setupVariableTypesFor: refactoring toReturn: (Array with: (refactoring model classNamed: #Dictionary)).

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -138,45 +138,6 @@ RBExtractMethodTransformationTest >> testNeedsReturn [
 ]
 
 { #category : 'tests' }
-RBExtractMethodTransformationTest >> testRefactoring [
-
-	| transformation class |
-	model := self modelOnClasses: { RBTransformationRuleTestData }.
-
-	transformation := (RBExtractMethodTransformation
-		                   model: model
-		                   extract:
-			                   '(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
-			ifFalse: [builder
-						compile: rewriteRule tree printString
-						in: class
-						classified: aSmalllintContext protocols]'
-		                   from: #checkMethod:
-		                   to: #foo:
-		                   in: #RBTransformationRuleTestData)
-		                  generateChanges.
-
-	self assert: transformation model changes changes size equals: 2.
-
-	class := transformation model classNamed:
-		         #RBTransformationRuleTestData.
-	self
-		assert: (class parseTreeForSelector: #checkMethod:)
-		equals: (self parseMethod: 'checkMethod: aSmalllintContext
-			class := aSmalllintContext selectedClass.
-			(rewriteRule executeTree: aSmalllintContext parseTree)
-				ifTrue: [self foo: aSmalllintContext]').
-	self
-		assert: (class parseTreeForSelector: #foo:)
-		equals: (self parseMethod: 'foo: aSmalllintContext
-			(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
-				ifFalse: [ builder
-							compile: rewriteRule tree printString
-							in: class
-							classified: aSmalllintContext protocols ]')
-]
-
-{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testTransform [
 
 	| transformation class |
@@ -229,10 +190,12 @@ RBExtractMethodTransformationTest >> testWithArgument [
 
 	refactoring := (RBExtractMethodTransformation
 		                model: model
-		                extract: (self
-				                 sourceCodeAt: (143 to: 340)
-				                 forMethod: #checkMethod:
-				                 in: RBTransformationRuleTestData)
+		                extract:
+			                '(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
+			ifFalse: [builder
+						compile: rewriteRule tree printString
+						in: class
+						classified: aSmalllintContext protocols]'
 		                from: #checkMethod:
 		                to: #foo:
 		                in: #RBTransformationRuleTestData) generateChanges.

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -183,6 +183,40 @@ RBExtractMethodTransformationTest >> testTransform [
 ]
 
 { #category : 'tests' }
+RBExtractMethodTransformationTest >> testWhenTemporaryVariableBecomesArgumentOfExtractedMethod [
+
+	| refactoring class |
+	model := self modelOnClasses: { RBDummyLintRuleTest }.
+	refactoring := (RBExtractMethodTransformation
+							 model: model
+		                extract: (self
+				                 sourceCodeAt: (78 to: 197)
+				                 forMethod: #displayName
+				                 in: RBDummyLintRuleTest)
+		                from: #displayName
+		                to: #foo:
+		                in: #RBDummyLintRuleTest) generateChanges.
+
+	self assert: refactoring model changes changes size equals: 2.
+
+	class := refactoring model classNamed: #RBDummyLintRuleTest.
+	self
+		assert: (class parseTreeForSelector: #displayName)
+		equals: (self parseMethod: 'displayName
+					| nameStream |
+					nameStream := WriteStream on: (String new: 64).
+					self foo: nameStream.
+					^nameStream contents').
+	self
+		assert: (class parseTreeForSelector: #foo:)
+		equals: (self parseMethod: 'foo: nameStream
+					nameStream nextPutAll: self name;
+								nextPutAll: '' (''.
+					self problemCount printOn: nameStream.
+					nameStream nextPut: $).')
+]
+
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testWithArgument [
 
 	| refactoring class |
@@ -316,38 +350,4 @@ RBExtractMethodTransformationTest >> testWithTemporaryVariable [
 						ifNone: [nil]) isNil]
 							-> ''self `@message: ``@args'').
 				^rule')
-]
-
-{ #category : 'tests' }
-RBExtractMethodTransformationTest >> testWithTemporaryVariable2 [
-
-	| refactoring class |
-	model := self modelOnClasses: { RBDummyLintRuleTest }.
-	refactoring := (RBExtractMethodTransformation
-							 model: model
-		                extract: (self
-				                 sourceCodeAt: (78 to: 197)
-				                 forMethod: #displayName
-				                 in: RBDummyLintRuleTest)
-		                from: #displayName
-		                to: #foo:
-		                in: #RBDummyLintRuleTest) generateChanges.
-
-	self assert: refactoring model changes changes size equals: 2.
-
-	class := refactoring model classNamed: #RBDummyLintRuleTest.
-	self
-		assert: (class parseTreeForSelector: #displayName)
-		equals: (self parseMethod: 'displayName
-					| nameStream |
-					nameStream := WriteStream on: (String new: 64).
-					self foo: nameStream.
-					^nameStream contents').
-	self
-		assert: (class parseTreeForSelector: #foo:)
-		equals: (self parseMethod: 'foo: nameStream
-					nameStream nextPutAll: self name;
-								nextPutAll: '' (''.
-					self problemCount printOn: nameStream.
-					nameStream nextPut: $).')
 ]

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -95,7 +95,7 @@ RBExtractMethodTransformationTest >> testFailureCannotExtractTwoAssignmentsToTem
 ]
 
 { #category : 'tests - failures' }
-RBExtractMethodTransformationTest >> testMethodDoesNotExist [
+RBExtractMethodTransformationTest >> testFailureWhenMethodDoesNotExist [
 
 	self shouldFail: (RBExtractMethodTransformation
 			extract: 'bla'

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -247,6 +247,8 @@ RBExtractMethodTransformationTest >> testWithTemporariesSelected [
 
 { #category : 'tests' }
 RBExtractMethodTransformationTest >> testWithTemporaryAssigned [
+	"test when selected code contains temporary that has assignment
+	extracted method will also have that temporary"
 
 	| class method refactoring |
 	model := self modelOnClasses: { self class }.
@@ -261,7 +263,9 @@ RBExtractMethodTransformationTest >> testWithTemporaryAssigned [
 
 	refactoring := (RBExtractMethodTransformation
 		                model: model
-		                extract: (method copyFrom: 24 to: 98)
+		                extract: 'bar := 5.
+			temp := bar * bar.
+			Transcript show: temp printString; cr.'
 		                from: #foo
 		                to: #foobar
 		                in: class) generateChanges.

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -107,6 +107,9 @@ RBExtractMethodTransformationTest >> testFailureWhenMethodDoesNotExist [
 
 { #category : 'tests' }
 RBExtractMethodTransformationTest >> testNeedsReturn [
+	"When code to be extracted contains explicit returns,
+	then when replacing it with the extracted method name,
+	we should return the result of the method"
 
 	| refactoring class |
 	model := self modelOnClasses: { RBDummyLintRuleTest }.

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -60,7 +60,7 @@ RBExtractMethodTransformationTest >> testFailureBadInterval [
 ]
 
 { #category : 'tests - failures' }
-RBExtractMethodTransformationTest >> testFailureExtract [
+RBExtractMethodTransformationTest >> testFailureCannotExtractProperSubtreeFromInterval [
 
 	self shouldFail: (RBExtractMethodTransformation
 			 extract: (self
@@ -79,6 +79,10 @@ RBExtractMethodTransformationTest >> testFailureExtract [
 			 from: #subclassOf:overrides:
 			 to: #foo
 			 in: #'RBBasicLintRuleTestData class').
+]
+
+{ #category : 'tests' }
+RBExtractMethodTransformationTest >> testFailureCannotExtractTwoAssignmentsToTemporaries [
 
 	self shouldFail: (RBExtractMethodTransformation
 			 extract: (self

--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodAndOccurrencesCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodAndOccurrencesCommand.class.st
@@ -1,5 +1,8 @@
+"
+I am a command to extract selected ast node into separate method 
+"
 Class {
-	#name : 'SycExtractMethod2Command',
+	#name : 'SycExtractMethodAndOccurrencesCommand',
 	#superclass : 'SycSourceCodeRefactoringCommand',
 	#traits : 'TRefactoringCommandSupport',
 	#classTraits : 'TRefactoringCommandSupport classTrait',
@@ -11,90 +14,52 @@ Class {
 }
 
 { #category : 'testing' }
-SycExtractMethod2Command class >> canBeExecutedInContext: aSourceCodeContext [
+SycExtractMethodAndOccurrencesCommand class >> canBeExecutedInContext: aSourceCodeContext [
 
 	^ (super canBeExecutedInContext: aSourceCodeContext) and: [
 		  aSourceCodeContext isMethodSelected not ]
 ]
 
 { #category : 'testing' }
-SycExtractMethod2Command class >> methodEditorShortcutActivation [
+SycExtractMethodAndOccurrencesCommand class >> methodEditorShortcutActivation [
 	<classAnnotation>
 
 	^CmdShortcutActivation by: $e meta, $m meta for: ClySourceCodeContext
 ]
 
 { #category : 'converting' }
-SycExtractMethod2Command >> asRefactorings [
+SycExtractMethodAndOccurrencesCommand >> asRefactorings [
 
 	| selectedInterval refactoring |
 	selectedInterval := selectedTextInterval ifEmpty: [
 		                    sourceNode sourceInterval ].
-
-	refactoring := RBExtractMethodTransformation
-		               extract: (method sourceCode
-				                copyFrom: selectedInterval first
-				                to: selectedInterval last)
+	refactoring := RBExtractMethodAndOccurrences
+		               extract: selectedInterval
 		               from: method selector
-		               to: self getNewSelector selector
 		               in: method origin.
 	self setUpOptionsOf: refactoring.
 	^ { refactoring }
 ]
 
 { #category : 'accessing' }
-SycExtractMethod2Command >> defaultMenuIconName [
+SycExtractMethodAndOccurrencesCommand >> defaultMenuIconName [
 	^ #glamorousRestart
 ]
 
 { #category : 'accessing' }
-SycExtractMethod2Command >> defaultMenuItemName [
-
-	^ 'Extract method 2'
+SycExtractMethodAndOccurrencesCommand >> defaultMenuItemName [
+	^ 'Extract method and occurances'
 ]
 
 { #category : 'execution' }
-SycExtractMethod2Command >> execute [
-
-	self executeRefactoring: self asRefactorings
-]
-
-{ #category : 'private' }
-SycExtractMethod2Command >> executeRefactoring: refactoring [
-
-	self initializeDefaultOptionsOf: refactoring.
-	[ refactoring execute ]
-		on: RBRefactoringError
-		do: [ :e | UIManager default alert: e messageText ]
-]
-
-{ #category : 'converting' }
-SycExtractMethod2Command >> getNewSelector [
-
-	| invalidArgs methodName dialog |
-	methodName := RBMethodName 
-							selector: #fooForNow
-		  					arguments: #().
-	invalidArgs := self computeInvalidArgNamesForSelector: method selector.
-	dialog := SycMethodNameEditorPresenter
-		          openOn: methodName
-		          withInvalidArgs: invalidArgs
-		          canRenameArgs: true
-		          canRemoveArgs: false
-		          canAddArgs: false.
-	dialog cancelled ifTrue: [ CmdCommandAborted signal ].
-	^ methodName
-]
-
-{ #category : 'execution' }
-SycExtractMethod2Command >> readParametersFromContext: aSourceCodeContext [
+SycExtractMethodAndOccurrencesCommand >> readParametersFromContext: aSourceCodeContext [
 	super readParametersFromContext: aSourceCodeContext.
 	self setUpModelFromContext: aSourceCodeContext.
 	selectedTextInterval := aSourceCodeContext selectedTextInterval
 ]
 
 { #category : 'execution' }
-SycExtractMethod2Command >> setUpOptionToChangeExtractionClass: refactoring [
+SycExtractMethodAndOccurrencesCommand >> setUpOptionToChangeExtractionClass: refactoring [
 
 	refactoring setOption: #extractionClass toUse: [ :ref | | cls superclasses |
 		cls := ref methodClass realClass.
@@ -112,7 +77,7 @@ SycExtractMethod2Command >> setUpOptionToChangeExtractionClass: refactoring [
 ]
 
 { #category : 'execution' }
-SycExtractMethod2Command >> setUpOptionToChangeMethodNameDuring: refactoring [
+SycExtractMethodAndOccurrencesCommand >> setUpOptionToChangeMethodNameDuring: refactoring [
 
 	| dialog |
 	refactoring setOption: #methodName toUse: [ :methodName :ref | | invalidArgs |
@@ -128,18 +93,17 @@ SycExtractMethod2Command >> setUpOptionToChangeMethodNameDuring: refactoring [
 ]
 
 { #category : 'execution' }
-SycExtractMethod2Command >> setUpOptionToOverrideExistingMethodDuring: aRefactoring [
+SycExtractMethodAndOccurrencesCommand >> setUpOptionToOverrideExistingMethodDuring: aRefactoring [
 
 	aRefactoring setOption: #alreadyDefined toUse:  [ :ref :class :selector |
 		ref refactoringWarning: 'Method ', selector printString, ' will override method in ', class name]
 ]
 
 { #category : 'execution' }
-SycExtractMethod2Command >> setUpOptionsOf: refactoring [
+SycExtractMethodAndOccurrencesCommand >> setUpOptionsOf: refactoring [
 
 	self initializeDefaultOptionsOf: refactoring.
 	self setUpOptionToChangeExtractionClass: refactoring.
-
 	self setUpOptionToOverrideExistingMethodDuring: refactoring.
 	self setUpOptionToChangeMethodNameDuring: refactoring
 ]

--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -24,7 +24,7 @@ SycExtractMethodCommand class >> canBeExecutedInContext: aSourceCodeContext [
 SycExtractMethodCommand class >> methodEditorShortcutActivation [
 	<classAnnotation>
 
-	^CmdShortcutActivation by: $e meta, $m meta for: ClySourceCodeContext
+	^CmdShortcutActivation by: $e meta, $m meta, $t meta for: ClySourceCodeContext
 ]
 
 { #category : 'converting' }
@@ -33,9 +33,13 @@ SycExtractMethodCommand >> asRefactorings [
 	| selectedInterval refactoring |
 	selectedInterval := selectedTextInterval ifEmpty: [
 		                    sourceNode sourceInterval ].
-	refactoring := RBExtractMethodAndOccurrences
-		               extract: selectedInterval
+
+	refactoring := RBExtractMethodTransformation
+		               extract: (method sourceCode
+				                copyFrom: selectedInterval first
+				                to: selectedInterval last)
 		               from: method selector
+		               to: self getNewSelector selector
 		               in: method origin.
 	self setUpOptionsOf: refactoring.
 	^ { refactoring }
@@ -48,7 +52,26 @@ SycExtractMethodCommand >> defaultMenuIconName [
 
 { #category : 'accessing' }
 SycExtractMethodCommand >> defaultMenuItemName [
+
 	^ 'Extract method'
+]
+
+{ #category : 'converting' }
+SycExtractMethodCommand >> getNewSelector [
+
+	| invalidArgs methodName dialog |
+	methodName := RBMethodName 
+							selector: #fooForNow
+		  					arguments: #().
+	invalidArgs := self computeInvalidArgNamesForSelector: method selector.
+	dialog := SycMethodNameEditorPresenter
+		          openOn: methodName
+		          withInvalidArgs: invalidArgs
+		          canRenameArgs: true
+		          canRemoveArgs: false
+		          canAddArgs: false.
+	dialog cancelled ifTrue: [ CmdCommandAborted signal ].
+	^ methodName
 ]
 
 { #category : 'execution' }
@@ -104,6 +127,7 @@ SycExtractMethodCommand >> setUpOptionsOf: refactoring [
 
 	self initializeDefaultOptionsOf: refactoring.
 	self setUpOptionToChangeExtractionClass: refactoring.
+
 	self setUpOptionToOverrideExistingMethodDuring: refactoring.
 	self setUpOptionToChangeMethodNameDuring: refactoring
 ]

--- a/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
@@ -32,7 +32,7 @@ SycSourceCodeCommand class >> method: aMethod node: aRBProgramNode [
 		sourceNode: aRBProgramNode
 ]
 
-{ #category : 'execution' }
+{ #category : 'converting' }
 SycSourceCodeCommand >> asRefactorings [
 	self subclassResponsibility
 ]


### PR DESCRIPTION
Started working on extract method. I did a pass on tests and commands:

* All parametrized tests that have single scenario are migrated to classic tests
* Renamed and added comments for ExtractMethodTransformation tests for better understanding
* Give better name to extract method commands
  * extract method - was called extract method 2
  * extract method and occurrences - was called extract method
* A few other small fixes