### PR TITLE
Refactor: extract method transformation cleanup

### DIFF
--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -114,7 +114,6 @@ RBExtractMethodTransformation >> buildTransformationFor: newMethodName withRemov
 RBExtractMethodTransformation >> buildTransformations [
 
 	| selectorOfExistingMethod |
-	subtree := self calculateSubtree.
 	
 	selectorOfExistingMethod := self findMethodWithSimilarBody.
 	selectorOfExistingMethod 

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -74,21 +74,8 @@ RBExtractMethodTransformation >> applicabilityPreconditions [
 	^ self preconditionParsableSubtree
 	  & self preconditionNotInCascadedMessage
 	  & self preconditionTemporariesAreNotReadBeforeWritten
-	  & self preconditionOneAssignmentMaximum & self
-		  preconditionAssignmentsNotReadBeforeWrittenORSubtreeDoesNotContainsReturn
-	  & (RBCondition withBlock: [
-			   | searchSpace |
-			   searchSpace := (self class allMethodsInHierarchyOf:
-				                   self definingClass) reject: [ :m |
-				                  m selector = selector ].
-
-			   (self parseTreeSearcherClass
-				    whichMethodIn: searchSpace
-				    matches: subtree)
-				   ifNotEmpty: [ :opportunities | "we found one method with similar body so we will use it instead of creating a new one"
-					   selectorOfExistingMethod := opportunities anyOne.
-					   true ]
-				   ifEmpty: [ true ] ])
+	  & self preconditionOneAssignmentMaximum
+	  & self preconditionAssignmentsNotReadBeforeWrittenORSubtreeDoesNotContainsReturn
 ]
 
 { #category : 'executing' }
@@ -128,7 +115,7 @@ RBExtractMethodTransformation >> buildTransformationFor: newMethodName withRemov
 RBExtractMethodTransformation >> buildTransformations [
 
 	subtree := self calculateSubtree.
-
+	self findMethodWithSimilarBody.
 	selectorOfExistingMethod
 		ifNotNil: [
 			^ OrderedCollection with: (self parseTreeRewriterClass
@@ -255,6 +242,21 @@ RBExtractMethodTransformation >> extract: aString from: aSelector to: aNewSelect
 	selector := aSelector.
 	newSelector := aNewSelector.
 	sourceCode := aString
+]
+
+{ #category : 'preconditions' }
+RBExtractMethodTransformation >> findMethodWithSimilarBody [
+
+	| searchSpace |
+	searchSpace := (self class allMethodsInHierarchyOf:
+		                self definingClass) reject: [ :m |
+		               m selector = selector ].
+
+	^ (self parseTreeSearcherClass
+		   whichMethodIn: searchSpace
+		   matches: subtree)
+		  ifNotEmpty: [ :opportunities | "we found one method with similar body so we will use it instead of creating a new one"
+			  selectorOfExistingMethod := opportunities anyOne ]
 ]
 
 { #category : 'executing' }

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -69,51 +69,26 @@ RBExtractMethodTransformation class >> model: aRBModel extract: aString from: aS
 ]
 
 { #category : 'preconditions' }
-RBExtractMethodTransformation >> applicabilityPreconditions [ 
+RBExtractMethodTransformation >> applicabilityPreconditions [
 
-	^ (RBCondition withBlock: [
-		   subtree ifNil: [ self refactoringError: 'Cannot extract code.' ].
-		   true ]) & (RBCondition withBlock: [
-		   subtree parent isCascade ifTrue: [
-			   self refactoringError:
-				   'Cannot extract code in a cascaded message' ].
-		   true ]) & (RBCondition withBlock: [
-		   | tempVariables |
-		   tempVariables := self calculateTemporaries.
-		   (RBReadBeforeWrittenTester
-			    readBeforeWritten: tempVariables
-			    in: subtree) ifNotEmpty: [
-			   self refactoringError:
-				   'Cannot extract temporaries if they are read before written.' ].
-		   true ]) & (RBCondition withBlock: [
-		   self calculateAssignments size > 1 ifTrue: [
-			   self refactoringError:
-				   'Cannot extract two or more assignments to temporaries without also extracting all the references.' ].
-		   true ]) & (RBCondition withBlock: [
-		   | assignmentCollection |
-		   assignmentCollection := self calculateAssignments.
-		   assignmentCollection ifNotEmpty: [
-			   ((RBReadBeforeWrittenTester
-				     isVariable: assignmentCollection first
-				     readBeforeWrittenIn: subtree) or: [ subtree containsReturn ])
-				   ifTrue: [
-					   self refactoringError:
-						   ('Cannot extract assignment to <1s> without also extracting all the references.'
-							    expandMacrosWith: assignments asString) ] ].
-		   true ]) & (RBCondition withBlock: [
-		   | searchSpace |
-		   searchSpace := (self class allMethodsInHierarchyOf:
-			                   self definingClass) reject: [ :m |
-			                  m selector = selector ].
+	^ self preconditionParsableSubtree
+	  & self preconditionNotInCascadedMessage
+	  & self preconditionTemporariesAreNotReadBeforeWritten
+	  & self preconditionOneAssignmentMaximum & self
+		  preconditionAssignmentsNotReadBeforeWrittenORSubtreeDoesNotContainsReturn
+	  & (RBCondition withBlock: [
+			   | searchSpace |
+			   searchSpace := (self class allMethodsInHierarchyOf:
+				                   self definingClass) reject: [ :m |
+				                  m selector = selector ].
 
-		   (self parseTreeSearcherClass
-			    whichMethodIn: searchSpace
-			    matches: subtree)
-			   ifNotEmpty: [ :opportunities | "we found one method with similar body so we will use it instead of creating a new one"
-				   selectorOfExistingMethod := opportunities anyOne.
-				   true ]
-			   ifEmpty: [ true ] ])
-	
+			   (self parseTreeSearcherClass
+				    whichMethodIn: searchSpace
+				    matches: subtree)
+				   ifNotEmpty: [ :opportunities | "we found one method with similar body so we will use it instead of creating a new one"
+					   selectorOfExistingMethod := opportunities anyOne.
+					   true ]
+				   ifEmpty: [ true ] ])
 ]
 
 { #category : 'executing' }
@@ -365,6 +340,65 @@ RBExtractMethodTransformation >> newMethodName [
 								 newSelector := nil ] ] ].
 
 	^ methodName
+]
+
+{ #category : 'preconditions' }
+RBExtractMethodTransformation >> preconditionAssignmentsNotReadBeforeWrittenORSubtreeDoesNotContainsReturn [
+
+	^ RBCondition withBlock: [
+		  | assignmentCollection |
+		  assignmentCollection := self calculateAssignments.
+		  assignmentCollection ifNotEmpty: [
+			  ((RBReadBeforeWrittenTester
+				    isVariable: assignmentCollection first
+				    readBeforeWrittenIn: subtree) or: [ subtree containsReturn ])
+				  ifTrue: [
+					  self refactoringError:
+						  ('Cannot extract assignment to <1s> without also extracting all the references.'
+							   expandMacrosWith: assignments asString) ] ].
+		  true ]
+]
+
+{ #category : 'preconditions' }
+RBExtractMethodTransformation >> preconditionNotInCascadedMessage [
+
+	^ RBCondition withBlock: [
+		  subtree parent isCascade ifTrue: [
+			  self refactoringError:
+				  'Cannot extract code in a cascaded message' ].
+		  true ]
+]
+
+{ #category : 'preconditions' }
+RBExtractMethodTransformation >> preconditionOneAssignmentMaximum [
+
+	^ RBCondition withBlock: [
+		  self calculateAssignments size > 1 ifTrue: [
+			  self refactoringError:
+				  'Cannot extract two or more assignments to temporaries without also extracting all the references.' ].
+		  true ]
+]
+
+{ #category : 'preconditions' }
+RBExtractMethodTransformation >> preconditionParsableSubtree [
+
+	^ RBCondition withBlock: [
+		  subtree ifNil: [ self refactoringError: 'Cannot extract code.' ].
+		  true ]
+]
+
+{ #category : 'preconditions' }
+RBExtractMethodTransformation >> preconditionTemporariesAreNotReadBeforeWritten [
+
+	^ RBCondition withBlock: [
+		  | tempVariables |
+		  tempVariables := self calculateTemporaries.
+		  (RBReadBeforeWrittenTester
+			   readBeforeWritten: tempVariables
+			   in: subtree) ifNotEmpty: [
+			  self refactoringError:
+				  'Cannot extract temporaries if they are read before written.' ].
+		  true ]
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -71,8 +71,6 @@ RBExtractMethodTransformation class >> model: aRBModel extract: aString from: aS
 { #category : 'preconditions' }
 RBExtractMethodTransformation >> applicabilityPreconditions [ 
 
-	subtree := self calculateSubtree.
-
 	^ (RBCondition withBlock: [
 		   subtree ifNil: [ self refactoringError: 'Cannot extract code.' ].
 		   true ]) & (RBCondition withBlock: [
@@ -367,6 +365,12 @@ RBExtractMethodTransformation >> newMethodName [
 								 newSelector := nil ] ] ].
 
 	^ methodName
+]
+
+{ #category : 'transforming' }
+RBExtractMethodTransformation >> prepareForExecution [
+
+	subtree := self calculateSubtree
 ]
 
 { #category : 'printing' }

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -28,8 +28,7 @@ Class {
 		'subtree',
 		'arguments',
 		'temporaries',
-		'assignments',
-		'selectorOfExistingMethod'
+		'assignments'
 	],
 	#category : 'Refactoring-Transformations-Model-Unused',
 	#package : 'Refactoring-Transformations',
@@ -114,9 +113,11 @@ RBExtractMethodTransformation >> buildTransformationFor: newMethodName withRemov
 { #category : 'executing' }
 RBExtractMethodTransformation >> buildTransformations [
 
+	| selectorOfExistingMethod |
 	subtree := self calculateSubtree.
-	self findMethodWithSimilarBody.
-	selectorOfExistingMethod
+	
+	selectorOfExistingMethod := self findMethodWithSimilarBody.
+	selectorOfExistingMethod 
 		ifNotNil: [
 			^ OrderedCollection with: (self parseTreeRewriterClass
 					   replaceCode: subtree
@@ -256,7 +257,9 @@ RBExtractMethodTransformation >> findMethodWithSimilarBody [
 		   whichMethodIn: searchSpace
 		   matches: subtree)
 		  ifNotEmpty: [ :opportunities | "we found one method with similar body so we will use it instead of creating a new one"
-			  selectorOfExistingMethod := opportunities anyOne ]
+			  ^ opportunities anyOne ]
+		  ifEmpty: [ ^ nil ]
+		
 ]
 
 { #category : 'executing' }

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -71,13 +71,12 @@ RBExtractMethodTransformation class >> model: aRBModel extract: aString from: aS
 { #category : 'preconditions' }
 RBExtractMethodTransformation >> applicabilityPreconditions [ 
 
-	| aSubtree |
-	aSubtree := self calculateSubtree.
+	subtree := self calculateSubtree.
 
 	^ (RBCondition withBlock: [
-		   aSubtree ifNil: [ self refactoringError: 'Cannot extract code.' ].
+		   subtree ifNil: [ self refactoringError: 'Cannot extract code.' ].
 		   true ]) & (RBCondition withBlock: [
-		   aSubtree parent isCascade ifTrue: [
+		   subtree parent isCascade ifTrue: [
 			   self refactoringError:
 				   'Cannot extract code in a cascaded message' ].
 		   true ]) & (RBCondition withBlock: [
@@ -85,7 +84,7 @@ RBExtractMethodTransformation >> applicabilityPreconditions [
 		   tempVariables := self calculateTemporaries.
 		   (RBReadBeforeWrittenTester
 			    readBeforeWritten: tempVariables
-			    in: aSubtree) ifNotEmpty: [
+			    in: subtree) ifNotEmpty: [
 			   self refactoringError:
 				   'Cannot extract temporaries if they are read before written.' ].
 		   true ]) & (RBCondition withBlock: [
@@ -98,7 +97,7 @@ RBExtractMethodTransformation >> applicabilityPreconditions [
 		   assignmentCollection ifNotEmpty: [
 			   ((RBReadBeforeWrittenTester
 				     isVariable: assignmentCollection first
-				     readBeforeWrittenIn: aSubtree) or: [ aSubtree containsReturn ])
+				     readBeforeWrittenIn: subtree) or: [ subtree containsReturn ])
 				   ifTrue: [
 					   self refactoringError:
 						   ('Cannot extract assignment to <1s> without also extracting all the references.'
@@ -111,7 +110,7 @@ RBExtractMethodTransformation >> applicabilityPreconditions [
 
 		   (self parseTreeSearcherClass
 			    whichMethodIn: searchSpace
-			    matches: aSubtree)
+			    matches: subtree)
 			   ifNotEmpty: [ :opportunities | "we found one method with similar body so we will use it instead of creating a new one"
 				   selectorOfExistingMethod := opportunities anyOne.
 				   true ]


### PR DESCRIPTION
I did a second pass on extract method. This time I focused on extract method transformation. This PR includes:

* Extraction of preconditions into separate methods for easier readability (in the next PR I'll start reifying these preconditions)
* Removing non-precondition-checking code from preconditions
* Utilizing new architecture hooks like `prepareForExecution`
* Removing unnecessary temps and instance variables