### PR TITLE
Make MorphTreeNodeMorph and IndentingListItemMorph use a FormSet for the expand/collapse toggle

### DIFF
--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -261,8 +261,8 @@ ScalingCanvas class >> initialize [
 	FormMapping := IdentityDictionary new.
 
 	theme := Smalltalk ui theme.
-	(theme formsForScale: 1) keysAndValuesDo: [ :formName :formScale1 |
-		FormMapping at: formScale1 put: ((theme formsForScale: 2) at: formName) ].
+	(theme formSetsForScale: 1) keysAndValuesDo: [ :formSetName :formSet |
+		FormMapping at: formSet asForm put: (formSet asFormAtScale: 2) ].
 
 	icons := Smalltalk ui icons.
 	icons scale = 1 ifFalse: [ ^ self ].

--- a/src/Morphic-Widgets-List/IndentingListItemMorph.class.st
+++ b/src/Morphic-Widgets-List/IndentingListItemMorph.class.st
@@ -230,14 +230,14 @@ IndentingListItemMorph >> drawOn: aCanvas [
 { #category : 'drawing' }
 IndentingListItemMorph >> drawToggleOn: aCanvas in: aRectangle [
 
-	| aForm centeringOffset |
+	| aFormSet centeringOffset |
 	complexContents hasContents ifFalse: [^self].
-	aForm := isExpanded
-		ifTrue: [container expandedFormForMorph: self]
-		ifFalse: [container notExpandedFormForMorph: self].
-	centeringOffset := ((aRectangle height - aForm extent y) / 2.0) truncated.
+	aFormSet := isExpanded
+		ifTrue: [container expandedFormSetForMorph: self]
+		ifFalse: [container notExpandedFormSetForMorph: self].
+	centeringOffset := ((aRectangle height - aFormSet extent y) / 2.0) truncated.
 	^aCanvas
-		translucentImage: aForm
+		translucentFormSet: aFormSet
 		at: (aRectangle topLeft translateBy: 0 @ centeringOffset)
 ]
 

--- a/src/Morphic-Widgets-List/SimpleHierarchicalListMorph.class.st
+++ b/src/Morphic-Widgets-List/SimpleHierarchicalListMorph.class.st
@@ -465,12 +465,12 @@ SimpleHierarchicalListMorph >> expandedForm [
 ]
 
 { #category : 'actions' }
-SimpleHierarchicalListMorph >> expandedFormForMorph: aMorph [
-	"Answer the form to use for expanded items."
+SimpleHierarchicalListMorph >> expandedFormSetForMorph: aMorph [
+	"Answer the form set to use for expanded items."
 
 	^ (self selectedMorph = aMorph and: [self theme selectionColor luminance < 0.6])
-		ifTrue: [self theme whiteTreeExpandedForm]
-		ifFalse: [self theme treeExpandedForm]
+		ifTrue: [self theme whiteTreeExpandedFormSet]
+		ifFalse: [self theme treeExpandedFormSet]
 ]
 
 { #category : 'geometry' }
@@ -806,10 +806,10 @@ SimpleHierarchicalListMorph >> notExpandedForm [
 ]
 
 { #category : 'accessing' }
-SimpleHierarchicalListMorph >> notExpandedFormForMorph: aMorph [
+SimpleHierarchicalListMorph >> notExpandedFormSetForMorph: aMorph [
 	^ (self selectedMorph = aMorph and: [self theme selectionColor luminance < 0.6])
-		ifTrue: [self theme whiteTreeUnexpandedForm]
-		ifFalse: [self theme treeUnexpandedForm]
+		ifTrue: [self theme whiteTreeUnexpandedFormSet]
+		ifFalse: [self theme treeUnexpandedFormSet]
 ]
 
 { #category : 'private' }

--- a/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
@@ -848,12 +848,12 @@ MorphTreeMorph >> expandedForm [
 ]
 
 { #category : 'expanding-collapsing' }
-MorphTreeMorph >> expandedFormForMorph: aMorph [
-	"Answer the form to use for expanded items."
+MorphTreeMorph >> expandedFormSetForMorph: aMorph [
+	"Answer the form set to use for expanded items."
 
 	^ (aMorph selected and: [self selectionColor luminance < 0.7])
-		ifTrue: [self theme whiteTreeExpandedForm]
-		ifFalse: [self theme treeExpandedForm]
+		ifTrue: [self theme whiteTreeExpandedFormSet]
+		ifFalse: [self theme treeExpandedFormSet]
 ]
 
 { #category : 'expanding-collapsing' }
@@ -1413,10 +1413,10 @@ MorphTreeMorph >> notExpandedForm [
 ]
 
 { #category : 'expanding-collapsing' }
-MorphTreeMorph >> notExpandedFormForMorph: aMorph [
+MorphTreeMorph >> notExpandedFormSetForMorph: aMorph [
 	^ (aMorph selected and: [self selectionColor luminance < 0.7])
-		ifTrue: [self theme whiteTreeUnexpandedForm]
-		ifFalse: [self theme treeUnexpandedForm]
+		ifTrue: [self theme whiteTreeUnexpandedFormSet]
+		ifFalse: [self theme treeUnexpandedFormSet]
 ]
 
 { #category : 'expanding-collapsing' }

--- a/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
@@ -384,11 +384,11 @@ MorphTreeNodeMorph >> drawOn: aCanvas [
 { #category : 'drawing' }
 MorphTreeNodeMorph >> drawToggleOn: aCanvas in: aRectangle [
 
-	| aForm centeringOffset |
-	aForm := self toggleImageForm.
-	centeringOffset := ((aRectangle height - aForm extent y) / 2.0) truncated.
+	| aFormSet centeringOffset |
+	aFormSet := self toggleImageFormSet.
+	centeringOffset := ((aRectangle height - aFormSet extent y) / 2.0) truncated.
 	^aCanvas
-		translucentImage: aForm
+		translucentFormSet: aFormSet
 		at: (aRectangle topLeft translateBy: 0 @ centeringOffset)
 ]
 
@@ -955,10 +955,10 @@ MorphTreeNodeMorph >> toggleExpandedState [
 ]
 
 { #category : 'accessing' }
-MorphTreeNodeMorph >> toggleImageForm [
+MorphTreeNodeMorph >> toggleImageFormSet [
 	^ isExpanded
-			ifTrue: [container expandedFormForMorph: self]
-			ifFalse: [container notExpandedFormForMorph: self]
+			ifTrue: [container expandedFormSetForMorph: self]
+			ifFalse: [container notExpandedFormSetForMorph: self]
 ]
 
 { #category : 'accessing' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -18,7 +18,7 @@ Class {
 	#superclass : 'Model',
 	#instVars : [
 		'settings',
-		'forms',
+		'formSets',
 		'soundTheme',
 		'focusIndicator',
 		'windowActiveDropShadowStyle',
@@ -1910,23 +1910,16 @@ UITheme >> focusIndicatorMorphFor: aMorph [
 		privateBounds: aMorph focusBounds
 ]
 
-{ #category : 'accessing' }
-UITheme >> forms: anObject [
-	"Set the value of forms"
+{ #category : 'private' }
+UITheme >> formSetsForCurrentDisplayScaleFactor [
 
-	forms := anObject
+	^ self formSetsForScale: self currentWorld displayScaleFactor
 ]
 
 { #category : 'private' }
-UITheme >> formsForCurrentDisplayScaleFactor [
+UITheme >> formSetsForScale: scale [
 
-	^ self formsForScale: self currentWorld displayScaleFactor
-]
-
-{ #category : 'private' }
-UITheme >> formsForScale: scale [
-
-	^ forms at: scale ifAbsentPut: [ self newFormsForScale: scale ]
+	^ formSets at: scale ifAbsentPut: [ self newFormSetsForScale: scale ]
 ]
 
 { #category : 'accessing - colors' }
@@ -1982,7 +1975,7 @@ UITheme >> initialize [
 	colorPalette := UIThemePalette new
 		colorConfigurator: self class colorConfiguratorClass new;
 		yourself.
-	forms := Dictionary new.
+	formSets := Dictionary new.
 
 	self initializeDefaultSettings.
 	colorPalette themeSettings: settings.
@@ -2824,17 +2817,17 @@ UITheme >> newFocusIndicatorMorphFor: aMorph [
 ]
 
 { #category : 'private' }
-UITheme >> newFormsForScale: scale [
+UITheme >> newFormSetsForScale: scale [
 
 	| size color |
 
 	size := (9 * scale) truncated.
 	color := Color gray: 0.5327468230694037.
 	^ Dictionary new
-		at: #treeExpanded put: (self newTreeForm: true size: size color: color);
-		at: #treeUnexpanded put: (self newTreeForm: false size: size color: color);
-		at: #whiteTreeExpanded put: (self newTreeForm: true size: size color: Color white);
-		at: #whiteTreeUnexpanded put: (self newTreeForm: false size: size color: Color white);
+		at: #treeExpanded put: (self newTreeFormSet: true size: size color: color);
+		at: #treeUnexpanded put: (self newTreeFormSet: false size: size color: color);
+		at: #whiteTreeExpanded put: (self newTreeFormSet: true size: size color: Color white);
+		at: #whiteTreeUnexpanded put: (self newTreeFormSet: false size: size color: Color white);
 		yourself
 ]
 
@@ -3609,6 +3602,14 @@ UITheme >> newTreeForm: expanded size: size color: color [
 	formCanvas := FormCanvas extent: rectangleScaled extent.
 	formCanvas drawPolygon: vertices fillStyle: color.
 	^ formCanvas form magnifyBy: insetDivisor reciprocal smoothing: insetDivisor
+]
+
+{ #category : 'private' }
+UITheme >> newTreeFormSet: expanded size: size color: color [
+
+	^ FormSet forms: {
+		self newTreeForm: expanded size: size color: color.
+		self newTreeForm: expanded size: size * 2 color: color }
 ]
 
 { #category : 'morph creation' }
@@ -4778,9 +4779,15 @@ UITheme >> textFont [
 
 { #category : 'label-styles' }
 UITheme >> treeExpandedForm [
-	"Answer the form to use for an expanded tree item."
 
-	^ self formsForCurrentDisplayScaleFactor at: #treeExpanded
+	^ self treeExpandedFormSet asForm
+]
+
+{ #category : 'label-styles' }
+UITheme >> treeExpandedFormSet [
+	"Answer the form set to use for an expanded tree item."
+
+	^ self formSetsForCurrentDisplayScaleFactor at: #treeExpanded
 ]
 
 { #category : 'basic-colors' }
@@ -4810,9 +4817,15 @@ UITheme >> treeLineWidth [
 
 { #category : 'label-styles' }
 UITheme >> treeUnexpandedForm [
-	"Answer the form to use for an unexpanded tree item."
 
-	^ self formsForCurrentDisplayScaleFactor at: #treeUnexpanded
+	^ self treeUnexpandedFormSet asForm
+]
+
+{ #category : 'label-styles' }
+UITheme >> treeUnexpandedFormSet [
+	"Answer the form set to use for an unexpanded tree item."
+
+	^ self formSetsForCurrentDisplayScaleFactor at: #treeUnexpanded
 ]
 
 { #category : 'accessing - colors' }
@@ -4910,16 +4923,28 @@ UITheme >> warningTextColor [
 
 { #category : 'label-styles' }
 UITheme >> whiteTreeExpandedForm [
-	"Answer the form to use for an expanded tree item when a contrasting one is needed."
 
-	^ self formsForCurrentDisplayScaleFactor at: #whiteTreeExpanded
+	^ self whiteTreeExpandedFormSet asForm
+]
+
+{ #category : 'label-styles' }
+UITheme >> whiteTreeExpandedFormSet [
+	"Answer the form set to use for an expanded tree item when a contrasting one is needed."
+
+	^ self formSetsForCurrentDisplayScaleFactor at: #whiteTreeExpanded
 ]
 
 { #category : 'label-styles' }
 UITheme >> whiteTreeUnexpandedForm [
-	"Answer the form to use for an unexpanded tree item when a contrasting one is needed."
 
-	^ self formsForCurrentDisplayScaleFactor at: #whiteTreeUnexpanded
+	^ self whiteTreeUnexpandedFormSet asForm
+]
+
+{ #category : 'label-styles' }
+UITheme >> whiteTreeUnexpandedFormSet [
+	"Answer the form set to use for an unexpanded tree item when a contrasting one is needed."
+
+	^ self formSetsForCurrentDisplayScaleFactor at: #whiteTreeUnexpanded
 ]
 
 { #category : 'border-styles' }


### PR DESCRIPTION
This pull request refactors UITheme to have methods that answer a FormSet instead of a Form for tree expand/collapse toggles, and makes `#drawToggleOn:in:` on MorphTreeNodeMorph and IndentingListItemMorph use those.