### PR TITLE
Activate strict FFI

### DIFF
--- a/src/Athens-Cairo/AthensCairoCanvas.class.st
+++ b/src/Athens-Cairo/AthensCairoCanvas.class.st
@@ -227,8 +227,8 @@ AthensCairoCanvas >> primResetDashes: anOffset [
                                                          double offset);"
 	^ self ffiCall: #(void cairo_set_dash (
 				self,
-				0,
-				0,
+				void* 0,
+				int 0,
 				double anOffset) )
 ]
 

--- a/src/Athens-Cairo/CairoFontMetricsProvider.class.st
+++ b/src/Athens-Cairo/CairoFontMetricsProvider.class.st
@@ -42,11 +42,17 @@ CairoFontMetricsProvider >> cairoFont [
 
 { #category : 'private' }
 CairoFontMetricsProvider >> convertString: utf8String len: strlen ofFont: aScaledFont toGlyphs: glyphs numGlyphs: numGlyphs x: x y: y [
-"
-all of this for using
-http://www.cairographics.org/manual/cairo-User-Fonts.html#cairo-user-scaled-font-text-to-glyphs-func-t
-
-"
+	"cairo_status_t
+	cairo_scaled_font_text_to_glyphs (cairo_scaled_font_t *scaled_font,
+                                  double x,
+                                  double y,
+                                  const char *utf8,
+                                  int utf8_len,
+                                  cairo_glyph_t **glyphs,
+                                  int *num_glyphs,
+                                  cairo_text_cluster_t **clusters,
+                                  int *num_clusters,
+                                  cairo_text_cluster_flags_t *cluster_flags);"
 	^ self ffiCall: #(
 		cairo_status_t cairo_scaled_font_text_to_glyphs (CairoScaledFont aScaledFont,
 			double x,
@@ -55,9 +61,9 @@ http://www.cairographics.org/manual/cairo-User-Fonts.html#cairo-user-scaled-font
 			int strlen,
 			void ** glyphs,
 			int * numGlyphs,
-			NULL,
-			NULL,
-			NULL))
+			void* 0,
+			void* 0,
+			void* 0))
 ]
 
 { #category : 'accessing' }

--- a/src/OSWindow-SDL2/SDL2.class.st
+++ b/src/OSWindow-SDL2/SDL2.class.st
@@ -334,7 +334,7 @@ SDL2 class >> moduleName [
 
 { #category : 'mouse' }
 SDL2 class >> mouseState [
-	^ self ffiCall: #( Uint32 SDL_GetMouseState ( nil , nil ) )
+	^ self ffiCall: #( Uint32 SDL_GetMouseState ( int* 0 , int* 0) )
 ]
 
 { #category : 'mouse' }
@@ -377,8 +377,8 @@ SDL2 class >> primClipboardText: text [
 { #category : 'cairo' }
 SDL2 class >> primCreateRGBSurfaceForCairoWidth: width height: height [
 	^ self ffiCall: #( SDL_Surface* SDL_CreateRGBSurface
-						( 0 , int width , int height , 32 ,
-						  16r00FF0000 , 16r0000FF00 , 16r000000FF , 0 ) )
+						( Uint32 0 , int width , int height , int 32 ,
+						  Uint32 16r00FF0000 , Uint32 16r0000FF00 , Uint32 16r000000FF , 0 ) )
 ]
 
 { #category : 'audio' }

--- a/src/OSWindow-SDL2/SDL_Renderer.class.st
+++ b/src/OSWindow-SDL2/SDL_Renderer.class.st
@@ -32,7 +32,7 @@ SDL_Renderer >> clear [
 
 { #category : 'rendering' }
 SDL_Renderer >> copy: texture [
-	^ self ffiCall: #( int SDL_RenderCopy ( self , SDL_Texture texture , nil, nil ) )
+	^ self ffiCall: #( int SDL_RenderCopy ( self , SDL_Texture texture , void* 0, void* 0 ) )
 ]
 
 { #category : 'rendering' }
@@ -113,12 +113,12 @@ SDL_Renderer >> initialize [
 
 { #category : 'rendering' }
 SDL_Renderer >> noClipRect [
-	^ self ffiCall: #( int SDL_RenderSetClipRect ( self , nil ) )
+	^ self ffiCall: #( int SDL_RenderSetClipRect ( self , void* nil ) )
 ]
 
 { #category : 'rendering' }
 SDL_Renderer >> noRenderTarget [
-	^ self ffiCall: #( int SDL_SetRenderTarget ( self , nil ) )
+	^ self ffiCall: #( int SDL_SetRenderTarget ( self , void* nil ) )
 ]
 
 { #category : 'rendering' }

--- a/src/OSWindow-SDL2/SDL_Texture.class.st
+++ b/src/OSWindow-SDL2/SDL_Texture.class.st
@@ -54,7 +54,7 @@ SDL_Texture >> initialize [
 
 { #category : 'pixels handling' }
 SDL_Texture >> lockPixels: pixels pitch: pitch [
-	^ self ffiCall: #( int SDL_LockTexture ( self , nil , void** pixels , int* pitch ) )
+	^ self ffiCall: #( int SDL_LockTexture ( self , void* 0 , void** pixels , int* pitch ) )
 ]
 
 { #category : 'private' }
@@ -69,7 +69,7 @@ SDL_Texture >> unlock [
 
 { #category : 'initialization' }
 SDL_Texture >> updateTexturePixels: pixels pitch: pitch [
-	^ self ffiCall: #( int SDL_UpdateTexture ( self , nil , void* pixels , int pitch ) )
+	^ self ffiCall: #( int SDL_UpdateTexture ( self , void* nil , void* pixels , int pitch ) )
 ]
 
 { #category : 'initialization' }

--- a/src/System-OSEnvironments/UnixEnvironment.class.st
+++ b/src/System-OSEnvironments/UnixEnvironment.class.st
@@ -285,9 +285,9 @@ UnixEnvironment >> removeKey: key encoded: anEncoding [
 	^ self rawRemoveKey: (key encodeWith: anEncoding)
 ]
 
-{ #category : 'private' }
+{ #category : 'accessing' }
 UnixEnvironment >> setEnv: nameString value: valueString [
-	"This method calls the Standard C Library setenv() function"
+	"int setenv(const char *name, const char *value, int overwrite);"
 
-	^ self ffiCall: #(int setenv #(String nameString , String valueString , 1)) module: LibC
+	^ self ffiCall: #(int setenv #(String nameString , String valueString , int 1)) module: LibC
 ]

--- a/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutAPITest.class.st
@@ -51,12 +51,12 @@ FFICalloutAPITest >> ffiLongLongAbs: number [
 
 { #category : 'primitives constant' }
 FFICalloutAPITest >> ffiTestConstantFormat: format to: buffer [
-	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, 65, 65, 1 ) ) fixedArgumentCount: 2
+	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, int 65, int 65, int 1 ) ) fixedArgumentCount: 2
 ]
 
 { #category : 'primitives constant' }
 FFICalloutAPITest >> ffiTestContantFormat: format value: aNumber to: buffer [
-	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, 65, 65, long aNumber ) ) fixedArgumentCount: 2
+	^ self ffiCall: #( int sprintf ( ByteArray buffer, String format, int 65, int 65, long aNumber ) ) fixedArgumentCount: 2
 ]
 
 { #category : 'primitives atomic' }

--- a/src/UnifiedFFI/FFILibrary.class.st
+++ b/src/UnifiedFFI/FFILibrary.class.st
@@ -32,7 +32,7 @@ FFILibrary class >> new [
 { #category : 'options' }
 FFILibrary class >> options [
 
-	^ #()
+	^ #( #+ optStrict )
 ]
 
 { #category : 'instance creation' }

--- a/src/UnifiedFFI/FFIStrictResolutionMode.class.st
+++ b/src/UnifiedFFI/FFIStrictResolutionMode.class.st
@@ -18,5 +18,15 @@ FFIStrictResolutionMode >> isStrict [
 { #category : 'resolution' }
 FFIStrictResolutionMode >> resolveUndeclaredTypeForArgument: aFFIValueArgument withResolver: aResolver [
 
+	"Make strict all declarations except those using self.
+	This is safe because:
+	 - We can infer self from the current class
+	 - the only implementor of prepareAsSelfFromCalloutDeclaration are those classes representing pointers"
+	aFFIValueArgument value == #self ifTrue: [
+		| externalType |
+		externalType := aResolver requestor asExternalTypeOn: aResolver.
+		^ externalType prepareAsSelfFromCalloutDeclaration ].
+
+	"Otherwise, this is an untyped literal which is unsupported"
 	aResolver unsupportedUntypedLiteral: aFFIValueArgument value
 ]


### PR DESCRIPTION
FFI callouts should (unless told otherwise) specify the types for all call arguments.
Otherwise this leads to ambiguities that the FFI engine cannot correctly state:

    what is the type of 0? signed or unsigned? 1, 2, 4 or 8 bytes long?
    what is the type of 1.5? a float or a double?
    what is the type of self?

When the strict mode is disabled, types are inferred, and code will execute mistakenly in many cases.
Important: This could lead to crashes.
Instead, the strict mode just throws an exception when this happens.

Notice that this option can be disabled locally per library (just redefining the options method), but I strongly encourage people to fix their lib bindings instead of using the non-strict mode.

Regarding adoption in the Pharo core IDE, we should check if this works as is, or if we should disable it momentarily for some of the libraries used internally in Pharo (e.g., SDL) that would prevent us migrating.

However, this cannot be integrated yet as SDL has some functions that are not properly mapped

```
FFICallout>>unsupportedUntypedLiteral:
FFIStrictResolutionMode>>resolveUndeclaredTypeForArgument:withResolver:
FFICallout>>resolveUntypedArgument:
[…]
SDL_Texture(Object)>>ffiCall:
SDL_Texture>>lockPixels:pitch:
[…]
OSSDL2FormRenderer>>updateAreas:immediate:
OSWorldRenderer>>updateDamage:
```