### PR TITLE
simplify and comment #sharedVariablesFromString 

### DIFF
--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -583,13 +583,9 @@ ShiftClassBuilder >> sharedVariables: aCollection [
 ]
 
 { #category : 'accessing' }
-ShiftClassBuilder >> sharedVariablesFromString: aStringOrArray [
-	layoutDefinition sharedVariables: (aStringOrArray isString
-        ifTrue: [ (aStringOrArray substrings: ' ') collect: [ :x | x asSymbol => ClassVariable ] ]
-        ifFalse: [ aStringOrArray collect: [ :x |
-                x isSymbol
-                    ifTrue: [ x => ClassVariable ]
-                    ifFalse: [ self error: 'Shared variables can only be String or an array of Symbols' ] ] ])
+ShiftClassBuilder >> sharedVariablesFromString: aString [
+	"Note: this method should not be used outside of old style class definitions"
+	layoutDefinition sharedVariables: aString asClassVariableCollection
 ]
 
 { #category : 'accessing' }
@@ -605,6 +601,7 @@ ShiftClassBuilder >> slots: aCollection [
 
 { #category : 'accessing' }
 ShiftClassBuilder >> slotsFromString: aString [
+	"Note: this method should not be used outside of old style class definitions"
 	self slots: aString asSlotCollection
 ]
 

--- a/src/Slot-Core/String.extension.st
+++ b/src/Slot-Core/String.extension.st
@@ -6,6 +6,16 @@ String >> asClassVariable [
 ]
 
 { #category : '*Slot-Core' }
+String >> asClassVariableCollection [
+	"Parse as class variables. Use space, tab and cr as separators
+	Example:
+	  'a b' asClassVariableCollection --> {a => Slot. b => Slot}
+	"
+
+	^(self substrings: Character separators) collect: [ :substring | substring asSymbol asClassVariable ]
+]
+
+{ #category : '*Slot-Core' }
 String >> asSlot [
 	^ InstanceVariableSlot named: self
 ]

--- a/src/Slot-Core/String.extension.st
+++ b/src/Slot-Core/String.extension.st
@@ -9,7 +9,7 @@ String >> asClassVariable [
 String >> asClassVariableCollection [
 	"Parse as class variables. Use space, tab and cr as separators
 	Example:
-	  'a b' asClassVariableCollection --> {a => Slot. b => Slot}
+	  'A B' asClassVariableCollection --> {{#a => ClassVariable. #b => ClassVariable}
 	"
 
 	^(self substrings: Character separators) collect: [ :substring | substring asSymbol asClassVariable ]

--- a/src/Slot-Tests/ClassVariableTest.class.st
+++ b/src/Slot-Tests/ClassVariableTest.class.st
@@ -15,6 +15,13 @@ Class {
 	#tag : 'VariablesAndSlots'
 }
 
+{ #category : 'tests' }
+ClassVariableTest >> testAsClassVariableCollection [
+
+ 	self assert: 'a b' asClassVariableCollection equals: {#a => ClassVariable. #b => ClassVariable}.
+	self assert: ('a _a a_a b b_' asClassVariableCollection collect: [ :i | i name ]) equals: #(#a #_a #a_a #b #b_)
+]
+
 { #category : 'tests - properties' }
 ClassVariableTest >> testIsReadInMethod [
 


### PR DESCRIPTION
this PR
- adds comments to #slotsFromString: and #sharedVariablesFromString: (fixes #15682)
- implement #sharedVariablesFromString: the same as the slots version, using #asClassVariableCollection