### PR TITLE
Classbuilder: rewrite users of #sharedPools: with string arguments

### DIFF
--- a/src/ClassParser/CDClassDefinitionNode.class.st
+++ b/src/ClassParser/CDClassDefinitionNode.class.st
@@ -71,7 +71,8 @@ CDClassDefinitionNode >> packageNameNode: aRBNode astNode: astNode [
 
 { #category : 'accessing' }
 CDClassDefinitionNode >> sharedPools [
-	^ sharedPools ifNil: [ self sharedPools: OrderedCollection new ]
+	sharedPools ifNil: [ self sharedPools: OrderedCollection new. ].
+	^sharedPools
 ]
 
 { #category : 'accessing' }

--- a/src/ClassParser/CDClassDefinitionNode.class.st
+++ b/src/ClassParser/CDClassDefinitionNode.class.st
@@ -71,8 +71,7 @@ CDClassDefinitionNode >> packageNameNode: aRBNode astNode: astNode [
 
 { #category : 'accessing' }
 CDClassDefinitionNode >> sharedPools [
-	sharedPools ifNil: [ self sharedPools: OrderedCollection new. ].
-	^sharedPools
+	^ sharedPools ifNil: [ self sharedPools: OrderedCollection new ]
 ]
 
 { #category : 'accessing' }

--- a/src/ClassParser/ShiftClassBuilder.extension.st
+++ b/src/ClassParser/ShiftClassBuilder.extension.st
@@ -19,7 +19,7 @@ ShiftClassBuilder >> buildFromAST: aCDClassDefinitionNode [
 
 	aCDClassDefinitionNode tag ifNotNil: [ :aTag | self tag: aTag ].
 
-	self layoutDefinition sharedPools: (aCDClassDefinitionNode sharedPools collect: [ :e | e name ]).
+	self layoutDefinition sharedPoolsFromString: (aCDClassDefinitionNode sharedPools collect: [ :e | e name ]).
 
 	aCDClassDefinitionNode traitDefinition ifNotNil: [ :traitDef |
 		traitDef originalNode formattedCode.

--- a/src/ClassParser/ShiftClassBuilder.extension.st
+++ b/src/ClassParser/ShiftClassBuilder.extension.st
@@ -19,7 +19,7 @@ ShiftClassBuilder >> buildFromAST: aCDClassDefinitionNode [
 
 	aCDClassDefinitionNode tag ifNotNil: [ :aTag | self tag: aTag ].
 
-	self layoutDefinition sharedPoolsFromString: (aCDClassDefinitionNode sharedPools collect: [ :e | e name ]).
+	self sharedPools: (aCDClassDefinitionNode sharedPools collect: [ :e | e name ]).
 
 	aCDClassDefinitionNode traitDefinition ifNotNil: [ :traitDef |
 		traitDef originalNode formattedCode.

--- a/src/CodeImport/OldClassDefinitionBuilder.class.st
+++ b/src/CodeImport/OldClassDefinitionBuilder.class.st
@@ -192,7 +192,7 @@ OldClassDefinitionBuilder >> build [
 		  aBuilder package: converter packageName.
 		  aBuilder tag: converter tagName.
 
-		  poolDictionariesNames ifNotNil: [ aBuilder sharedPools: poolDictionariesNames ].
+		  poolDictionariesNames ifNotNil: [ aBuilder sharedPoolsFromString: poolDictionariesNames ].
 		  isTrait ifTrue: [ aBuilder beTrait ].
 		  traitsDefinition ifNotNil: [ aBuilder traitComposition: (self class compiler evaluate: traitsDefinition) ] ]
 ]

--- a/src/Deprecated12/UndefinedObject.extension.st
+++ b/src/Deprecated12/UndefinedObject.extension.st
@@ -15,7 +15,7 @@ UndefinedObject >> subclass: nameOfClass instanceVariableNames: instVarNameList 
 					name: `@name;
 					slotsFromString: `@instVar;
 					sharedVariablesFromString: `@classVar;
-					sharedPools: `@pools;
+					sharedPoolsFromString: `@pools;
 					category: `@package;
 					environment: `@rcv environment ]'.
 	Warning signal: 'Attempt to create ' , nameOfClass , ' as a subclass of nil.  Possibly a class is being loaded before its superclass.'.
@@ -25,7 +25,7 @@ UndefinedObject >> subclass: nameOfClass instanceVariableNames: instVarNameList 
 			  name: nameOfClass;
 			  slotsFromString: instVarNameList;
 			  sharedVariablesFromString: classVarNames;
-			  sharedPools: poolDictnames;
+			  sharedPoolsFromString: poolDictnames;
 			  category: category;
 			  environment: self environment ]
 ]

--- a/src/Refactoring-Changes-Tests/RBRefactoringChangeTest.class.st
+++ b/src/Refactoring-Changes-Tests/RBRefactoringChangeTest.class.st
@@ -100,7 +100,7 @@ RBRefactoringChangeTest >> testAddClassInteractively [
 			          name: self class name;
 			          slots: { #instVar };
 			          sharedVariables: { #ClassVar };
-			          sharedPools: 'PoolDict';
+			          sharedPools: #(PoolDict);
 			          tag: self class packageTag name;
 			          package: self class package name ].
 	self assert: change superclassName equals: self class superclass name.

--- a/src/Refactoring-Core-Tests/RBClassTest.class.st
+++ b/src/Refactoring-Core-Tests/RBClassTest.class.st
@@ -24,7 +24,7 @@ RBClassTest >> setUp [
 			superclass: Object;
 			slots: { #instanceVariable1. #instanceVariable2 };
 			sharedVariables: { #ClassVariable1 };
-			sharedPools: 'TextConstants';
+			sharedPools: { #TextConstants };
 			package: #'Refactory-Testing' ].
 	newClass := rbNamespace classNamed: #SomeClassName
 ]

--- a/src/Refactoring-Core-Tests/RBConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/RBConditionTest.class.st
@@ -24,7 +24,7 @@ RBConditionTest >> setUp [
 			name: #SomeClassName;
 			slots: { #instanceVariable1. #instanceVariable2 };
 			sharedVariables: { #ClassVariable1 };
-			sharedPools: 'TextConstants';
+			sharedPools: { #TextConstants };
 			package: #'Refactory-Testing' ].
 	newClass := rbNamespace classNamed: #SomeClassName
 ]

--- a/src/Refactoring-Core-Tests/RBNamespaceTest.class.st
+++ b/src/Refactoring-Core-Tests/RBNamespaceTest.class.st
@@ -256,7 +256,7 @@ RBNamespaceTest >> testRedefineClassChange [
 			name: #RBNamespaceTest;
 			slots: { #a };
 			sharedVariables: { #A };
-			sharedPools: 'TextConstants';
+			sharedPools: #(TextConstants);
 			package: #'Refactory-Testing' ].
 	self assert: (namespace includesClassNamed: #Object).
 	self assert: (namespace classNamed: #Object) isNotNil

--- a/src/Refactoring-Core-Tests/RBSharedPoolTest.class.st
+++ b/src/Refactoring-Core-Tests/RBSharedPoolTest.class.st
@@ -37,7 +37,7 @@ RBSharedPoolTest >> setUp [
 			name: #DateAndTime;
 			slots: { #seconds. #offset. #julianDayNumber. #nanos };
 			sharedVariables: { #ClockProvider. #LocalTimeZoneCache };
-			sharedPools: 'ChronologyConstants';
+			sharedPools: #(ChronologyConstants);
 			package: 'Kernel-Chronology' ].
 
 	userOf := rbNamespace classNamed: #DateAndTime

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -700,7 +700,7 @@ RBNamespace >> reparentClasses: aRBClassCollection to: newClass [
 				name: aClass name;
 				slots: aClass instanceVariableNames;
 				sharedVariables: aClass classVariableNames;
-				sharedPools: (' ' join: aClass sharedPoolNames);
+				sharedPoolsFromString: (' ' join: aClass sharedPoolNames);
 				package: aClass packageName;
 				tag: aClass tagName ] ]
 ]

--- a/src/Refactoring-Transformations-Tests/RBPullUpMethodParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPullUpMethodParametrizedTest.class.st
@@ -60,7 +60,7 @@ RBPullUpMethodParametrizedTest >> addClassHierarchyForPools [
 			aBuilder
 				superclassName: #TotoSuperclass;
 				name: #Toto;
-				sharedPools: 'TotoSharedPool';
+				sharedPools: #(TotoSharedPool);
 				package: #'Refactory-Test data' ].
 
 	(model classNamed: #Toto) compile: 'poolReference ^ SP' classified: #( #accessing )

--- a/src/ReleaseTests/ObsoleteTest.class.st
+++ b/src/ReleaseTests/ObsoleteTest.class.st
@@ -52,7 +52,7 @@ ObsoleteTest >> testFixObsoleteSharedPools [
 	| poolClass obsoletePoolName testClass preFixObsoleteClassNames postFixObsoleteClassNames |
 	poolClass := classFactory newClass. "provides unique name over time via class variable counter"
 
-	testClass := classFactory make: [ :aBuilder | aBuilder sharedPools: poolClass name asString ].
+	testClass := classFactory make: [ :aBuilder | aBuilder sharedPools: { poolClass } ].
 
 	classFactory delete: poolClass.
 	obsoletePoolName := poolClass name.

--- a/src/Shift-ClassBuilder-Tests/ShAbstractChangeDetectorTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShAbstractChangeDetectorTest.class.st
@@ -74,7 +74,7 @@ ShAbstractChangeDetectorTest >> setUp [
 			               slots: { #ivar1 };
 			               classSlots: { #classVar1 };
 			               sharedVariables: { #Var1 };
-			               sharedPools: 'TestSharedPool';
+			               sharedPools: { #TestSharedPool };
 			               layoutClass: FixedLayout;
 			               package: self packageName ].
 

--- a/src/Shift-ClassBuilder-Tests/ShCreateClassTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShCreateClassTest.class.st
@@ -88,7 +88,7 @@ ShCreateClassTest >> testEmptyClass [
 ShCreateClassTest >> testSharedPool [
 	builder name: #SHClassWithSharedPool.
 	result := builder
-		sharedPools: 'ShTestSharedPool';
+		sharedPools: #(ShTestSharedPool);
 		build.
 
 	self validateResult.

--- a/src/Shift-ClassBuilder-Tests/ShSharedPoolChangeDetectorTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShSharedPoolChangeDetectorTest.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : 'tests' }
 ShSharedPoolChangeDetectorTest >> testChangeInSharedPoolsIsDetected [
 
-	newBuilder sharedPools: 'TestSharedPool2'.
+	newBuilder sharedPools: {#TestSharedPool2}.
 
 	self denyEmpty: self newComparer compareClass.
 	self assertChangeAreDetected
@@ -18,7 +18,7 @@ ShSharedPoolChangeDetectorTest >> testChangeInSharedPoolsIsDetected [
 { #category : 'tests' }
 ShSharedPoolChangeDetectorTest >> testNoChangeInSharedPoolsDetected [
 
-	newBuilder sharedPools: 'TestSharedPool'.
+	newBuilder sharedPools: #(TestSharedPool).
 
 	self assertEmpty: self newComparer compareClass.
 	self assertChangeArentDetected

--- a/src/Shift-ClassBuilder-Tests/ShiftClassBuilderTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShiftClassBuilderTest.class.st
@@ -86,7 +86,7 @@ ShiftClassBuilderTest >> testBuilderSharedPools [
 	builder
 		slots: { #string. #runs };
 		tag: 'Base';
-		sharedPools: 'TextConstants';
+		sharedPools: #(TextConstants);
 		package: 'Text-Core'.
 
 	self assert: builder sharedPools equals: #( TextConstants )

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -334,7 +334,7 @@ ShiftClassBuilder >> fillFor: aClass [
 		classSlots: aClass class localSlots;
 		"we have to copy the class variables, as they contain the values"
 		sharedVariables: (aClass classVariables collect: [:var | var copy]);
-		sharedPools: aClass sharedPoolsString;
+		sharedPools: (aClass sharedPools collect: [ :each | each name ]) asArray;
 		package: aClass package name;
 		installingEnvironment: aClass environment;
 		oldClass: aClass.
@@ -568,6 +568,15 @@ ShiftClassBuilder >> sharedPools: aCollectionOrString [
 	pools := aCollectionOrString isString
 			 ifTrue: [ (aCollectionOrString substrings: ' ') collect: [ :e | e asSymbol ] ]
 			 ifFalse: [ aCollectionOrString collect: [ :each | each isSymbol ifFalse: [ each name ] ifTrue: [ each ] ].	 ].
+	
+	self layoutDefinition sharedPools: pools.
+]
+
+{ #category : 'accessing' }
+ShiftClassBuilder >> sharedPoolsFromString: aCollectionOrString [
+	"This should be only used for old style class defs"
+	| pools |
+	pools := (aCollectionOrString substrings: ' ') collect: [ :e | e asSymbol ].
 	
 	self layoutDefinition sharedPools: pools.
 ]

--- a/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassInstaller-Tests/ShClassInstallerTest.class.st
@@ -44,8 +44,6 @@ ShClassInstallerTest >> newClass: className superclass: aSuperclass slots: slots
 			  superclass: aSuperclass;
 			  slots: slots;
 			  classSlots: metaclassSlots;
-			  sharedVariables: '';
-			  sharedPools: '';
 			  package: self generatedClassesPackageName ]
 ]
 
@@ -85,7 +83,7 @@ ShClassInstallerTest >> testChangingASharedPoolUpdatesCorrectlyUsers [
 	newClass2 := ShiftClassInstaller make: [ :builder |
 		             builder
 			             name: #ShCITestClass;
-			             sharedPools: 'ShCITestSharedPool';
+			             sharedPools: #(ShCITestSharedPool);
 			             package: self generatedClassesPackageName ].
 
 	newClass2 compile: 'a ^A'.

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -88,7 +88,7 @@ SlotAnnouncementsTest >> testChangeInSharedPoolShouldAnnounceClassModified [
 	aClass := self make: [ :builder |
 		builder
 			name: self aClassName;
-			sharedPools: 'TestSharedPool' ].
+			sharedPools: #(TestSharedPool) ].
 
 	self assert: self collectedAnnouncements size equals: 1.
 	self assert: self collectedAnnouncements first newClassDefinition equals: aClass
@@ -110,7 +110,7 @@ SlotAnnouncementsTest >> testChangeInSharedVariablesAndSharedPoolsShouldAnnounce
 	aClass := self make: [ :builder |
 		builder
 			name: self aClassName;
-			sharedPools: 'TestSharedPool';
+			sharedPools: #(TestSharedPool);
 			sharedVariables: #(A B) ].
 
 	self assert: self collectedAnnouncements size equals: 1.
@@ -236,7 +236,7 @@ SlotAnnouncementsTest >> testCreateAndChangeWithoutCommentDoesNotAnnounce [
 		make: [ :builder |
 			builder
 				name: self aClassName;
-				sharedPools: 'TestSharedPool' ].
+				sharedPools: #(TestSharedPool) ].
 
 	self assertEmpty: self collectedAnnouncements
 ]
@@ -278,7 +278,7 @@ SlotAnnouncementsTest >> testEmptyCommentDoesNotAnnounce [
 			builder
 				name: self aClassName;
 				comment: '';
-				sharedPools: 'TestSharedPool' ].
+				sharedPools: #(TestSharedPool) ].
 
 	self assertEmpty: self collectedAnnouncements
 ]

--- a/src/Slot-Tests/SlotBasicTest.class.st
+++ b/src/Slot-Tests/SlotBasicTest.class.st
@@ -31,7 +31,7 @@ SlotBasicTest >> testAddSharedPool [
 		builder sharedPools: '' ].
 
 	aClass := self make: [ :builder |
-		builder sharedPools: 'TestSharedPool' ].
+		builder sharedPools: #(TestSharedPool) ].
 
 	self assert: (aClass sharedPools includes: TestSharedPool)
 ]
@@ -151,7 +151,7 @@ SlotBasicTest >> testRemoveClassSlotAndMigrate [
 
 { #category : 'tests - shared pools' }
 SlotBasicTest >> testRemoveSharedPool [
-	self make: [ :builder | builder sharedPools: 'TestSharedPool' ].
+	self make: [ :builder | builder sharedPools: #(TestSharedPool) ].
 
 	aClass := self make: [ :builder | builder sharedPools: '' ].
 
@@ -213,7 +213,7 @@ SlotBasicTest >> testWithClassSlots [
 SlotBasicTest >> testWithSharedPool [
 
 	aClass := self make: [ :builder |
-		builder sharedPools: 'TestSharedPool' ].
+		builder sharedPools: #(TestSharedPool) ].
 	aClass class compile: 'one ^One'.
 
 	self assert: (aClass sharedPools includes: TestSharedPool).
@@ -240,11 +240,4 @@ SlotBasicTest >> testWithoutClassSlots [
 	aClass := self make: [ :builder | builder classSlots: #() ].
 
 	self assertEmpty: aClass classVarNames
-]
-
-{ #category : 'tests - shared pools' }
-SlotBasicTest >> testWithoutSharedPools [
-	aClass := self make: [ :builder | builder sharedPools: '' ].
-
-	self assertEmpty: aClass sharedPools
 ]

--- a/src/Traits-Tests/TraitSlotScopeTest.class.st
+++ b/src/Traits-Tests/TraitSlotScopeTest.class.st
@@ -215,7 +215,7 @@ TraitSlotScopeTest >> testSubClassWithTraitsAfterModificationOfParentSharedPools
 		      aClassBuilder
 			      name: #C1;
 			      traitComposition: t1;
-			      sharedPools: 'X1';
+			      sharedPools: #(X1);
 			      package: self packageNameForTests ].
 
 	self assert: c2 classLayout slotScope parentScope identicalTo: c2 superclass classLayout slotScope.


### PR DESCRIPTION
- change some users that use sharedPools: with a string as a paramet.
- add #sharedPoolsFromString: to be used in old style class def implementation