### PR TITLE
Change to size_t for ffi calls that currently use ulong for pointers.

### DIFF
--- a/src/Athens-Cairo/AthensCairoPath.class.st
+++ b/src/Athens-Cairo/AthensCairoPath.class.st
@@ -45,5 +45,5 @@ AthensCairoPath >> paintFillsUsing: aPaint on: anAthensCanvas [
 
 { #category : 'instance creation' }
 AthensCairoPath >> primDestroyPath: aHandle [
-	^ self ffiCall: #(void cairo_path_destroy ( ulong aHandle ))
+	^ self ffiCall: #(void cairo_path_destroy ( size_t aHandle ))
 ]

--- a/src/Athens-Cairo/AthensCairoPatternPaint.class.st
+++ b/src/Athens-Cairo/AthensCairoPatternPaint.class.st
@@ -22,7 +22,7 @@ AthensCairoPatternPaint class >> finalizeResourceData: handle [
 
 { #category : 'private' }
 AthensCairoPatternPaint class >> primDestroyPattern: aHandle [
-	^ self ffiCall: #(void cairo_pattern_destroy (ulong aHandle) )
+	^ self ffiCall: #(void cairo_pattern_destroy (size_t aHandle) )
 ]
 
 { #category : 'converting' }

--- a/src/Athens-Cairo/AthensCairoSurface.class.st
+++ b/src/Athens-Cairo/AthensCairoSurface.class.st
@@ -163,7 +163,7 @@ AthensCairoSurface class >> destroyContextHandle: aHandle [
 
 { #category : 'private' }
 AthensCairoSurface class >> destroySurfaceHandle: handle [
-	^ self ffiCall: #( void cairo_surface_destroy ( ulong handle ) )
+	^ self ffiCall: #( void cairo_surface_destroy ( size_t handle ) )
 ]
 
 { #category : 'surface plugin callbacks' }


### PR DESCRIPTION
I've found this issue using a fresh Pharo 12 image on Windows, I haven't checked on earlier versions.

The VM has been compiled on a CI system where *all* cygwin packages are up to date to the latest versions available; for the sake of completeness, the `cmake` has been invoked with the following customizations: `-DPHARO_DEPENDENCIES_PREFER_DOWNLOAD_BINARIES=TRUE -DBUILD_IS_RELEASE=ON -DICEBERG_DEFAULT_REMOTE=httpsUrl -DGENERATE_SOURCES=FALSE -DGENERATED_SOURCE_DIR=<personal-local-dir>`

Without the fix, I get this error when `AthensCairoSurface` objects are going to be released:
![PharoScreenshot](https://github.com/pharo-project/pharo/assets/706810/580d78c7-b420-4888-be16-d36a1b2a89eb)

On Linux all of this doesn't occur up to now.
