### PR TITLE
15684-ClassBuilder-Enhance-ShSharedVariablesChangeDetector

### DIFF
--- a/src/Collections-Support/Association.class.st
+++ b/src/Collections-Support/Association.class.st
@@ -42,6 +42,13 @@ Association >> hasLiteral: aLiteral [
 	^false
 ]
 
+{ #category : 'testing' }
+Association >> hasSameDefinitionAs: otherVariable [
+
+	"As the bootstrap creates class Variables as Associations, we need to be able to compare"
+	^self class == otherVariable class and: [self key = otherVariable key]
+]
+
 { #category : 'variables-toclean' }
 Association >> isAssociation [
 	^ true

--- a/src/Collections-Support/Association.class.st
+++ b/src/Collections-Support/Association.class.st
@@ -46,7 +46,7 @@ Association >> hasLiteral: aLiteral [
 Association >> hasSameDefinitionAs: otherVariable [
 
 	"As the bootstrap creates class Variables as Associations, we need to be able to compare"
-	^self class == otherVariable class and: [self key = otherVariable key]
+	^self class = otherVariable class and: [self key = otherVariable key]
 ]
 
 { #category : 'variables-toclean' }

--- a/src/Kernel-CodeModel/ClassVariable.class.st
+++ b/src/Kernel-CodeModel/ClassVariable.class.st
@@ -63,6 +63,13 @@ ClassVariable >> emitValue: methodBuilder [
 ]
 
 { #category : 'testing' }
+ClassVariable >> hasSameDefinitionAs: otherVariable [
+
+	"Equal definition. ClassVariable values are not to be taken into account"
+	^self key = otherVariable key
+]
+
+{ #category : 'testing' }
 ClassVariable >> isAccessedBy: aBehavior [
 
 	^ (aBehavior hasMethodAccessingVariable: self) or: [ aBehavior class hasMethodAccessingVariable: self ]

--- a/src/Kernel-CodeModel/ClassVariable.class.st
+++ b/src/Kernel-CodeModel/ClassVariable.class.st
@@ -66,7 +66,7 @@ ClassVariable >> emitValue: methodBuilder [
 ClassVariable >> hasSameDefinitionAs: otherVariable [
 
 	"Equal definition. ClassVariable values are not to be taken into account"
-	^self class == otherVariable class and: [self key = otherVariable key]
+	^self class = otherVariable class and: [self key = otherVariable key]
 ]
 
 { #category : 'testing' }

--- a/src/Kernel-CodeModel/ClassVariable.class.st
+++ b/src/Kernel-CodeModel/ClassVariable.class.st
@@ -66,7 +66,7 @@ ClassVariable >> emitValue: methodBuilder [
 ClassVariable >> hasSameDefinitionAs: otherVariable [
 
 	"Equal definition. ClassVariable values are not to be taken into account"
-	^self key = otherVariable key
+	^self class == otherVariable class and: [self key = otherVariable key]
 ]
 
 { #category : 'testing' }

--- a/src/Shift-ClassBuilder/ShAbstractClassChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShAbstractClassChangeDetector.class.st
@@ -41,12 +41,11 @@ ShAbstractClassChangeDetector >> compareClass [
 ]
 
 { #category : 'changes' }
-ShAbstractClassChangeDetector >> compareSlotCollection: a with: b [
-
+ShAbstractClassChangeDetector >> compareVariableCollection: a with: b [
 	(a size = b size) ifFalse: [ ^ false].
 
-	a with: b do: [ :aSlot :bSlot |
-			(aSlot hasSameDefinitionAs: bSlot) ifFalse: [ ^ false ] ].
+	a with: b do: [ :aVar :bVar |
+			(aVar hasSameDefinitionAs: bVar) ifFalse: [ ^ false ] ].
 
 	^ true
 ]

--- a/src/Shift-ClassBuilder/ShClassSlotChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShClassSlotChangeDetector.class.st
@@ -14,7 +14,7 @@ ShClassSlotChangeDetector >> initialize [
 	super initialize.
 	builderAccessor := [ :e | e classSlots ].
 	classAccessor := [ :e | e class slots ].
-	comparer := [ :a :b |  self compareSlotCollection: a with: b ]
+	comparer := [ :a :b |  self compareVariableCollection: a with: b ]
 ]
 
 { #category : 'changes' }

--- a/src/Shift-ClassBuilder/ShSharedVariablesChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShSharedVariablesChangeDetector.class.st
@@ -10,14 +10,9 @@ Class {
 }
 
 { #category : 'initialization' }
-ShSharedVariablesChangeDetector >> compareFrom: a to: b [
-	^ a asDictionary = b asDictionary
-]
-
-{ #category : 'initialization' }
 ShSharedVariablesChangeDetector >> initialize [
 	super initialize.
-	builderAccessor := [ :e | e layoutDefinition sharedVariables collect:[ :x | x key -> x class ] as: Array ].
-	classAccessor := [ :e | e classVariables collect: [ :x | x key -> x class ] as: Array ].
-	comparer := [ :a :b | self compareFrom: a to: b ]
+	builderAccessor := [ :e | e sharedVariables asArray ].
+	classAccessor := [ :e | e classVariables asArray ].
+	comparer := [ :a :b | self compareVariableCollection: a with: b ]
 ]

--- a/src/Shift-ClassBuilder/ShSharedVariablesChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShSharedVariablesChangeDetector.class.st
@@ -18,15 +18,7 @@ ShSharedVariablesChangeDetector >> compareFrom: a to: b [
 ShSharedVariablesChangeDetector >> initialize [
 	super initialize.
 	
-	builderAccessor := [ :e | e layoutDefinition sharedVariables collect:[ :x | x key -> x class ] as: Array ].
-	classAccessor := [ :e | e classVariables collect: [ :x | x key -> x class ] as: Array ].
-	comparer := [ :a :b | self compareFrom: a to: b ]
-	
-	"TODO
-	This should use #compareVariableCollection:with:, but then we detect changes that lead to a crash during full image reload, possibly to the code in #migrateClassTo: that uses become,
-	
 	builderAccessor := [ :e | e sharedVariables asArray ].
 	classAccessor := [ :e | e classVariables asArray ].
 	comparer := [ :a :b | self compareVariableCollection: a with: b ]
-	"
 ]

--- a/src/Shift-ClassBuilder/ShSharedVariablesChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShSharedVariablesChangeDetector.class.st
@@ -18,7 +18,7 @@ ShSharedVariablesChangeDetector >> compareFrom: a to: b [
 ShSharedVariablesChangeDetector >> initialize [
 	super initialize.
 	
-	builderAccessor := [ :e | e sharedVariables asArray ].
-	classAccessor := [ :e | e classVariables asArray ].
+	builderAccessor := [ :e | e layoutDefinition sharedVariables ].
+	classAccessor := [ :e | e classVariables ].
 	comparer := [ :a :b | self compareVariableCollection: a with: b ]
 ]

--- a/src/Shift-ClassBuilder/ShSharedVariablesChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShSharedVariablesChangeDetector.class.st
@@ -10,9 +10,23 @@ Class {
 }
 
 { #category : 'initialization' }
+ShSharedVariablesChangeDetector >> compareFrom: a to: b [
+	^ a asDictionary = b asDictionary
+]
+
+{ #category : 'initialization' }
 ShSharedVariablesChangeDetector >> initialize [
 	super initialize.
+	
+	builderAccessor := [ :e | e layoutDefinition sharedVariables collect:[ :x | x key -> x class ] as: Array ].
+	classAccessor := [ :e | e classVariables collect: [ :x | x key -> x class ] as: Array ].
+	comparer := [ :a :b | self compareFrom: a to: b ]
+	
+	"TODO
+	This should use #compareVariableCollection:with:, but then we detect changes that lead to a crash during full image reload, possibly to the code in #migrateClassTo: that uses become,
+	
 	builderAccessor := [ :e | e sharedVariables asArray ].
 	classAccessor := [ :e | e classVariables asArray ].
 	comparer := [ :a :b | self compareVariableCollection: a with: b ]
+	"
 ]

--- a/src/Shift-ClassBuilder/ShSlotChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShSlotChangeDetector.class.st
@@ -15,5 +15,5 @@ ShSlotChangeDetector >> initialize [
 	super initialize.
 	builderAccessor := [ :e | e allSlots asArray ].
 	classAccessor := [ :e | e allSlots asArray ].
-	comparer := [ :a :b | self compareSlotCollection: a with: b ]
+	comparer := [ :a :b | self compareVariableCollection: a with: b ]
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -213,7 +213,6 @@ ShiftClassBuilder >> commentStamp: anObject [
 ShiftClassBuilder >> compareWithOldClass [
 	oldClass ifNil: [ ^ self ].
 	changeComparers do: [ :e | e compareClass: oldClass with: self ].
-
 	changes ifEmpty: [ ShNoChangesInClass signal. ]
 ]
 

--- a/src/VariablesLibrary/AbstractInitializedClassVariable.class.st
+++ b/src/VariablesLibrary/AbstractInitializedClassVariable.class.st
@@ -23,8 +23,18 @@ AbstractInitializedClassVariable class >> isAbstract [
 ]
 
 { #category : 'accessing' }
+AbstractInitializedClassVariable >> default [
+	^ default
+]
+
+{ #category : 'accessing' }
 AbstractInitializedClassVariable >> default: anObject [
 	default := anObject
+]
+
+{ #category : 'testing' }
+AbstractInitializedClassVariable >> hasSameDefinitionAs: otherVariable [
+	^(super hasSameDefinitionAs: otherVariable) and: [ default = otherVariable default ]
 ]
 
 { #category : 'printing' }


### PR DESCRIPTION
This is the described change so that ClassVariables are compared with #hasSameDefinitionAs: instead of just the names.

This is *not* yet enough  to fix the problem, will open another PR for that.

fixes #15684