### PR TITLE
Fix a ZeroDivide exception when scroll target is 0 calculating scroll deltas

### DIFF
--- a/src/Morphic-Widgets-Scrolling/GeneralScrollPaneMorph.class.st
+++ b/src/Morphic-Widgets-Scrolling/GeneralScrollPaneMorph.class.st
@@ -143,7 +143,7 @@ GeneralScrollPaneMorph >> hScrollbar: anObject [
 GeneralScrollPaneMorph >> hScrollbarInterval [
 	"Answer the computed size of the thumb of the horizontal scrollbar."
 
-	^self scrollBounds width asFloat / self scrollTarget width min: 1.0
+	^ self scrollBounds width asFloat / (self scrollTarget width max: 1.0) min: 1.0
 ]
 
 { #category : 'scrollbars' }

--- a/src/Morphic-Widgets-Scrolling/GeneralScrollPaneMorph.class.st
+++ b/src/Morphic-Widgets-Scrolling/GeneralScrollPaneMorph.class.st
@@ -544,7 +544,7 @@ GeneralScrollPaneMorph >> vScrollbar: anObject [
 GeneralScrollPaneMorph >> vScrollbarInterval [
 	"Answer the computed size of the thumb of the vertical scrollbar."
 
-	^self scrollBounds height asFloat / self scrollTarget height min: 1.0
+	^ (self scrollBounds height asFloat / (self scrollTarget height max: 1.0)) min: 1.0
 ]
 
 { #category : 'scrollbars' }


### PR DESCRIPTION
### Issue
ZeroDivide exception occurs when calculating scroll deltas with a scroll target width of 0 in a scrollable morph.

### Solution
Safeguard the scroll width with a default value of 1.0 when the scroll target is 0, to prevent the exception and ensure smooth scrolling behavior.

Closes #15701