### PR TITLE
Deprecate old API for traits

### DIFF
--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -167,7 +167,7 @@ EpCodeChangeIntegrationTest >> testMetaclassInstanceVariableAdditionWithTrait [
 	aTrait := classFactory newTrait.
 
 	self assert: (self countLogEventsWith: EpClassModification) equals: 0.
-	aClass classSide uses: aTrait asTraitComposition instanceVariableNames: 'x'.
+	aClass classSide trait: aTrait asTraitComposition slots: #( x ).
 	self assert: (self countLogEventsWith: EpClassModification) equals: 1
 ]
 

--- a/src/Traits-Tests/TraitFileOutTest.class.st
+++ b/src/Traits-Tests/TraitFileOutTest.class.st
@@ -45,7 +45,7 @@ TraitFileOutTest >> setUp [
 	cb compile: 'cb' classified: #cat1.
 
 	"make the class of cb also use tc:"
-	cb class uses: ta classTrait + tc instanceVariableNames: ''
+	cb class trait: ta classTrait + tc
 ]
 
 { #category : 'running' }

--- a/src/Traits-Tests/TraitInTraitClassTest.class.st
+++ b/src/Traits-Tests/TraitInTraitClassTest.class.st
@@ -9,23 +9,21 @@ Class {
 TraitInTraitClassTest >> testAddingSlotToClassSide [
 
 	| t1 |
-
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {} slots: #(aSlot).
+	t1 classTrait trait: {  } slots: #( aSlot ).
 
 	self assert: t1 classTrait slots size equals: 1.
-	self assert: t1 classTrait slots anyOne name equals: #aSlot.
+	self assert: t1 classTrait slots anyOne name equals: #aSlot
 ]
 
 { #category : 'tests' }
 TraitInTraitClassTest >> testAddingSpecialSlotToClassSide [
 
 	| t1 |
-
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {} slots: {#aSlot => WeakSlot}.
+	t1 classTrait trait: {  } slots: { (#aSlot => WeakSlot) }.
 
 	self assert: t1 classTrait slots size equals: 1.
 	self assert: t1 classTrait slots anyOne name equals: #aSlot.
-	self assert: t1 classTrait slots anyOne species equals: WeakSlot.
+	self assert: t1 classTrait slots anyOne species equals: WeakSlot
 ]

--- a/src/Traits-Tests/TraitMCDefinitionsTest.class.st
+++ b/src/Traits-Tests/TraitMCDefinitionsTest.class.st
@@ -54,13 +54,14 @@ TraitMCDefinitionsTest >> testDefinitionHasCorrectStringWithoutSlots [
 TraitMCDefinitionsTest >> testDefinitionOfClassSideTrait [
 
 	| t1 definition |
-
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {} slots: #(aSlot).
+	t1 classTrait trait: {  } slots: #( aSlot ).
 
 	definition := t1 asClassDefinition.
 
-	self assert: definition classInstanceVariables equals: {#aSlot => InstanceVariableSlot}
+	self
+		assert: definition classInstanceVariables
+		equals: { (#aSlot => InstanceVariableSlot) }
 ]
 
 { #category : 'tests' }

--- a/src/Traits-Tests/TraitPrecedenceCompositionTest.class.st
+++ b/src/Traits-Tests/TraitPrecedenceCompositionTest.class.st
@@ -10,10 +10,10 @@ TraitPrecedenceCompositionTest >> testClassCompositionOnPrecedenceKeepsPreferenc
 
 	| t1 t2 original copy |
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {  } slots: #(  ).
+	t1 classTrait trait: {  } slots: #(  ).
 
 	t2 := self newTrait: #T2.
-	t2 classTrait uses: {  } slots: #(  ).
+	t2 classTrait trait: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
@@ -21,24 +21,25 @@ TraitPrecedenceCompositionTest >> testClassCompositionOnPrecedenceKeepsPreferenc
 	original := t2 + t1 withPrecedenceOf: t2.
 	copy := original classComposition.
 
-	self assert: original preferedTrait innerClass equals: copy preferedTrait innerClass instanceSide
+	self
+		assert: original preferedTrait innerClass
+		equals: copy preferedTrait innerClass instanceSide
 ]
 
 { #category : 'tests' }
 TraitPrecedenceCompositionTest >> testCopyingAPrecedenceKeepsPreference [
 
 	| t1 t2 original copy |
-
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {} slots: #().
+	t1 classTrait trait: {  } slots: #(  ).
 
 	t2 := self newTrait: #T2.
-	t2 classTrait uses: {} slots: #().
+	t2 classTrait trait: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 
-	original := (t2 + t1) withPrecedenceOf: t2.
+	original := t2 + t1 withPrecedenceOf: t2.
 	copy := original copyTraitExpression.
 
 	self assert: original preferedTrait equals: copy preferedTrait
@@ -49,13 +50,13 @@ TraitPrecedenceCompositionTest >> testPrecedencesAreGeneratedInClassDefinition [
 
 	| t1 t2 t3 c1 |
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {  } slots: #(  ).
+	t1 classTrait trait: {  } slots: #(  ).
 
 	t2 := self newTrait: #T2.
-	t2 classTrait uses: {  } slots: #(  ).
+	t2 classTrait trait: {  } slots: #(  ).
 
 	t3 := self newTrait: #T3.
-	t3 classTrait uses: {  } slots: #(  ).
+	t3 classTrait trait: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
@@ -63,7 +64,9 @@ TraitPrecedenceCompositionTest >> testPrecedencesAreGeneratedInClassDefinition [
 
 	c1 := self newClass: #C1 traits: (t2 + t1 + t3 withPrecedenceOf: t2).
 
-	self assert: (ClassDefinitionPrinter oldPharo for: c1) definitionString equals: 'Object subclass: #C1
+	self
+		assert: (ClassDefinitionPrinter oldPharo for: c1) definitionString
+		equals: 'Object subclass: #C1
 	uses: (T2 + T1 + T3 withPrecedenceOf: T2)
 	instanceVariableNames: ''''
 	classVariableNames: ''''
@@ -75,21 +78,25 @@ TraitPrecedenceCompositionTest >> testPrecedencesAreGeneratedInClassDefinitionWi
 
 	| t1 t2 t3 c1 |
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {  } slots: #(  ).
+	t1 classTrait trait: {  } slots: #(  ).
 
 	t2 := self newTrait: #T2.
-	t2 classTrait uses: {  } slots: #(  ).
+	t2 classTrait trait: {  } slots: #(  ).
 
 	t3 := self newTrait: #T3.
-	t3 classTrait uses: {  } slots: #(  ).
+	t3 classTrait trait: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 	t3 compile: 'm2 ^ 11'.
 
-	c1 := self newClass: #C1  traits: (t2 + (t1 -- #aSlot) + t3 withPrecedenceOf: t2).
+	c1 := self
+		      newClass: #C1
+		      traits: (t2 + (t1 -- #aSlot) + t3 withPrecedenceOf: t2).
 
-	self assert: (ClassDefinitionPrinter oldPharo for: c1) definitionString equals: 'Object subclass: #C1
+	self
+		assert: (ClassDefinitionPrinter oldPharo for: c1) definitionString
+		equals: 'Object subclass: #C1
 	uses: (T2 + (T1 -- #aSlot) + T3 withPrecedenceOf: T2)
 	instanceVariableNames: ''''
 	classVariableNames: ''''
@@ -99,95 +106,93 @@ TraitPrecedenceCompositionTest >> testPrecedencesAreGeneratedInClassDefinitionWi
 { #category : 'tests' }
 TraitPrecedenceCompositionTest >> testPrecedencesCanBeCombined [
 
+	<ignoreNotImplementedSelectors: #( m1 m2 )>
 	| t1 t2 t3 c1 |
-	<ignoreNotImplementedSelectors: #(m1 m2)>
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {} slots: #().
+	t1 classTrait trait: {  } slots: #(  ).
 
 	t2 := self newTrait: #T2.
-	t2 classTrait uses: {} slots: #().
+	t2 classTrait trait: {  } slots: #(  ).
 
 	t3 := self newTrait: #T3.
-	t3 classTrait uses: {} slots: #().
+	t3 classTrait trait: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 
 	t3 compile: 'm2 ^ 11'.
 
-	c1 := self newClass: #C1 traits: (((t2 + t1) withPrecedenceOf: t2) + t3).
+	c1 := self newClass: #C1 traits: (t2 + t1 withPrecedenceOf: t2) + t3.
 
-	self assert: (c1 new m1) equals: 33.
-	self assert: (c1 new m2) equals: 11
+	self assert: c1 new m1 equals: 33.
+	self assert: c1 new m2 equals: 11
 ]
 
 { #category : 'tests' }
 TraitPrecedenceCompositionTest >> testWithPrecedenceIsNonAConflict [
 
 	| t1 t2 c1 |
-
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {} slots: #().
+	t1 classTrait trait: {  } slots: #(  ).
 
 	t2 := self newTrait: #T2.
-	t2 classTrait uses: {} slots: #().
+	t2 classTrait trait: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 
-	c1 := self newClass: #C1 traits: ((t1 + t2) withPrecedenceOf: t2).
+	c1 := self newClass: #C1 traits: (t1 + t2 withPrecedenceOf: t2).
 
 	self deny: (c1 >> #m1) isConflict
 ]
 
 { #category : 'tests' }
 TraitPrecedenceCompositionTest >> testWithPrecedenceUsesThePreferedOne [
-	<ignoreNotImplementedSelectors: #(m1)>
-	| t1 t2 c1 |
 
+	<ignoreNotImplementedSelectors: #( m1 )>
+	| t1 t2 c1 |
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {} slots: #().
+	t1 classTrait trait: {  } slots: #(  ).
 
 	t2 := self newTrait: #T2.
-	t2 classTrait uses: {} slots: #().
+	t2 classTrait trait: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 
-	c1 := self newClass: #C1 traits: ((t1 + t2) withPrecedenceOf: t2).
+	c1 := self newClass: #C1 traits: (t1 + t2 withPrecedenceOf: t2).
 
-	self assert: (c1 new m1) equals: 33
+	self assert: c1 new m1 equals: 33
 ]
 
 { #category : 'tests' }
 TraitPrecedenceCompositionTest >> testWithPrecedenceUsesThePreferedOneWithoutCaringOrderOfSequence [
-	<ignoreNotImplementedSelectors: #(m1)>
-	| t1 t2 c1 |
 
+	<ignoreNotImplementedSelectors: #( m1 )>
+	| t1 t2 c1 |
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {} slots: #().
+	t1 classTrait trait: {  } slots: #(  ).
 
 	t2 := self newTrait: #T2.
-	t2 classTrait uses: {} slots: #().
+	t2 classTrait trait: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.
 
-	c1 := self newClass: #C1 traits: ((t2 + t1) withPrecedenceOf: t2).
+	c1 := self newClass: #C1 traits: (t2 + t1 withPrecedenceOf: t2).
 
-	self assert: (c1 new m1) equals: 33
+	self assert: c1 new m1 equals: 33
 ]
 
 { #category : 'tests' }
 TraitPrecedenceCompositionTest >> testWithoutPrecedenceIsAConflict [
 
 	| t1 t2 c1 |
-
 	t1 := self newTrait: #T1.
-	t1 classTrait uses: {} slots: #().
+	t1 classTrait trait: {  } slots: #(  ).
 
 	t2 := self newTrait: #T2.
-	t2 classTrait uses: {} slots: #().
+	t2 classTrait trait: {  } slots: #(  ).
 
 	t1 compile: 'm1 ^ 42'.
 	t2 compile: 'm1 ^ 33'.

--- a/src/Traits/Metaclass.extension.st
+++ b/src/Traits/Metaclass.extension.st
@@ -25,6 +25,10 @@ Metaclass >> trait: aTraitCompositionOrArray [
 
 { #category : '*Traits' }
 Metaclass >> trait: aTraitCompositionOrArray instanceVariableNames: instVarString [
+	self
+		deprecated: 'Use #trait:slots: instead.'
+		transformWith: '`@rcv trait: `@arg1 instanceVariableNames: `@arg2' -> '`@rcv trait: `@arg1 slots: `@arg2 asSlotCollection'.
+
 
 	^ self trait: aTraitCompositionOrArray slots: instVarString asSlotCollection
 ]
@@ -45,27 +49,25 @@ Metaclass >> trait: aTraitCompositionOrArray slots: slotArray [
 
 { #category : '*Traits' }
 Metaclass >> uses: aTraitCompositionOrArray [
-	"This method will be deprecated better use trait."
 
-	self trait: aTraitCompositionOrArray slots: #()
+	self deprecated: 'Please use #trait: instead' transformWith: '`@receiver trait: `@arg' -> '`@receiver trait: `@arg'.
+
+	^ self trait: aTraitCompositionOrArray
 ]
 
 { #category : '*Traits' }
 Metaclass >> uses: aTraitCompositionOrArray instanceVariableNames: instVarString [
-	"This method will be deprecated better use trait:slots: or trait:instanceVariableNames:"
-	^ self uses: aTraitCompositionOrArray slots: instVarString asSlotCollection
+	
+	self
+		deprecated: 'Use #trait:slots: instead.'
+		transformWith: '`@rcv uses: `@arg1 instanceVariableNames: `@arg2' -> '`@rcv trait: `@arg1 slots: `@arg2 asSlotCollection'.
+	^ self trait: aTraitCompositionOrArray slots: instVarString asSlotCollection
 ]
 
 { #category : '*Traits' }
 Metaclass >> uses: aTraitCompositionOrArray slots: slotArray [
-	| theClass |
-	theClass := self instanceSide.
-
-	theClass := theClass classInstaller
-		update: theClass
-		to: [ :builder |
-			builder
-				classTraitComposition: aTraitCompositionOrArray asTraitComposition;
-				classSlots: slotArray ].
-	^ theClass classSide
+	
+	self
+		deprecated: 'Use #trait:slots: instead.'
+		transformWith: '`@rcv uses: `@arg1 slots: `@arg2' -> '`@rcv trait: `@arg1 slots: `@arg2'.
 ]


### PR DESCRIPTION
This finally deprecates

#trait:instanceVariableNames:
#uses:instanceVariableNames:
#uses:slots:
#uses:

We keep for now #trait:slots: and #trait:, but it feels as if using the classbuilder for that might be nicer. But that is for later.