### PR TITLE
deprecate #noPattern and noPattern:

### DIFF
--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -470,15 +470,33 @@ CompilationContext >> initialize [
 ]
 
 { #category : 'accessing' }
-CompilationContext >> noPattern [
+CompilationContext >> isScripting [
 	^semanticScope isDoItScope
 ]
 
 { #category : 'accessing' }
-CompilationContext >> noPattern: anObject [
+CompilationContext >> isScripting: aBoolean [
 
-	(anObject and: [ self noPattern not ]) ifTrue: [
+	(aBoolean and: [ self isScripting not ]) ifTrue: [
 		semanticScope := OCReceiverDoItSemanticScope targetingNilReceiver ]
+]
+
+{ #category : 'accessing' }
+CompilationContext >> noPattern [
+	self
+		deprecated: 'Use #isScripting instead'
+		transformWith: '`@receiver noPattern' -> '`@receiver isScripting'.
+	^self isScripting
+]
+
+{ #category : 'accessing' }
+CompilationContext >> noPattern: aBoolean [
+
+		self
+		deprecated: 'Use #isScripting: instead'
+		transformWith: '`@receiver noPattern: `@arg' -> '`@receiver isScripting: `@arg'.
+
+	self isScripting: aBoolean
 ]
 
 { #category : 'options' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -543,7 +543,7 @@ OpalCompiler >> generateMethod [
 	ast compiledMethod: method.
 	ast propertyAt: #Undeclareds ifPresent: [ :undeclareds | undeclareds do: [ :var | var registerMethod: method ] ].
 	method propertyAt: #source put: source.
-	self compilationContext noPattern ifTrue: [ method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"
+	self isScripting ifTrue: [ method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"
 
 	"If the prior method was not set explicitly, we set it because we will need it if we are not in the first compilation"
 	self priorMethod ifNil: [
@@ -604,14 +604,13 @@ OpalCompiler >> isInteractive [
 
 { #category : 'accessing' }
 OpalCompiler >> isScripting [
-	^ self semanticScope isDoItScope
+	^ self compilationContext isScripting
 ]
 
 { #category : 'accessing' }
 OpalCompiler >> isScripting: aBoolean [
 
-	(aBoolean and: [ self isScripting not ]) ifTrue: [
-		self semanticScope: OCReceiverDoItSemanticScope targetingNilReceiver ]
+	self compilationContext isScripting: aBoolean
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
We have isScripting now on CompilationContex, it could be possible to move it and have it solely in OpalCompiler (as it is state of the scope). But unifying is a good first step.

fixes #15709