### PR TITLE
Traits: Fix update of source pointers

### DIFF
--- a/src/Deprecated12/CompiledMethod.extension.st
+++ b/src/Deprecated12/CompiledMethod.extension.st
@@ -27,6 +27,13 @@ CompiledMethod >> isTaggedWith: aSymbol [
 ]
 
 { #category : '*Deprecated12' }
+CompiledMethod >> setSourcePointer: srcPointer [
+
+	self deprecated: 'Use #sourcePointer: instead' transformWith: '`@rcv setSourcePointer: `@arg' -> '`@rcv sourcePointer: `@arg'.
+	self sourcePointer: srcPointer
+]
+
+{ #category : '*Deprecated12' }
 CompiledMethod >> tagWith: aSymbol [
 
 	self deprecated: 'Use #protocol: instead.' transformWith: '`@rcv tagWith: `@arg' -> '`@rcv protocol: `@arg'.

--- a/src/Kernel-CodeModel/Behavior.class.st
+++ b/src/Kernel-CodeModel/Behavior.class.st
@@ -1305,6 +1305,11 @@ Behavior >> nonObsoleteClass [
 	^ self environment at: self originalName
 ]
 
+{ #category : 'private' }
+Behavior >> notifySourcePointerOf: aSelector updateTo: srcPointer [
+	"By default we do nothing and traits can hook here to update the users."
+]
+
 { #category : 'initialization' }
 Behavior >> obsolete [
 	"nothing to be done"

--- a/src/Kernel-CodeModel/CompiledMethod.class.st
+++ b/src/Kernel-CodeModel/CompiledMethod.class.st
@@ -180,8 +180,8 @@ CompiledMethod >> classBinding: aBinding [
 
 { #category : 'source code management' }
 CompiledMethod >> clearSourcePointer [
-	"we use #setSourcePointer: to not clear the property #source"
-	self setSourcePointer: 0
+
+	self sourcePointer: 0
 ]
 
 { #category : 'accessing' }
@@ -880,18 +880,6 @@ CompiledMethod >> selector: aSelector [
 				self literalAt: nl - 1 put: aSelector]
 ]
 
-{ #category : 'source code management' }
-CompiledMethod >> setSourcePointer: srcPointer [
-
-	| trailerBytes trailerSize start |
-	"Drop the #source property if any"
-	self removeProperty: #source.
-	trailerSize := self class trailerSize.
-	trailerBytes := srcPointer asByteArrayOfSize: trailerSize.
-	start := self size - trailerSize.
-	start + 1 to: self size do: [:n | self at: n put: (trailerBytes at: n - start) ]
-]
-
 { #category : 'accessing' }
 CompiledMethod >> sourceCode [
 	"Retrieve or reconstruct the source code for this method."
@@ -925,9 +913,16 @@ CompiledMethod >> sourcePointer [
 { #category : 'source code management' }
 CompiledMethod >> sourcePointer: srcPointer [
 
+	| trailerBytes trailerSize start |
 	"Drop the #source property if any"
 	self removeProperty: #source.
-	self setSourcePointer: srcPointer
+	trailerSize := self class trailerSize.
+	trailerBytes := srcPointer asByteArrayOfSize: trailerSize.
+	start := self size - trailerSize.
+	start + 1 to: self size do: [ :n | self at: n put: (trailerBytes at: n - start) ].
+
+	"In case the mtehod is definied in a trait, we need to update the source pointers of the copies."
+	self origin = self methodClass ifTrue: [ self origin notifySourcePointerOf: self selector updateTo: self sourcePointer ]
 ]
 
 { #category : 'debugger support' }

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -160,8 +160,7 @@ PharoChangesCondenser >> swapSourcePointerOfClassOrTrait: classOrTrait [
 { #category : 'private - 2 swapping' }
 PharoChangesCondenser >> swapSourcePointerOfMethod: method [
 
-	remoteStringMap at: method ifPresent: [ :remoteString |
-		method setSourcePointer: remoteString sourcePointer ]
+	remoteStringMap at: method ifPresent: [ :remoteString | method sourcePointer: remoteString sourcePointer ]
 ]
 
 { #category : 'private - 2 swapping' }

--- a/src/Traits-Tests/TraitMethodDescriptionTest.class.st
+++ b/src/Traits-Tests/TraitMethodDescriptionTest.class.st
@@ -7,14 +7,13 @@ Class {
 
 { #category : 'tests' }
 TraitMethodDescriptionTest >> testArgumentNames [
+
 	self t1 compile: 'zork1: myArgument zork2: mySecondArgument ^true'.
 	self t2 compile: 'zork1: myArgument zork2: somethingElse ^false'.
-	self assert: ((self t5 sourceCodeAt: #zork1:zork2:) asString
-				beginsWith: 'zork1: arg1 zork2: arg2').
+	self assert: ((self t5 sourceCodeAt: #zork1:zork2:) asString beginsWith: 'zork1: myArgument zork2: somethingElse').
 	self t1 compile: 'zork1: myArgument zork2: mySecondArgument ^true'.
 	self t2 compile: 'zork1: somethingElse zork2: myArgument ^false'.
-	self assert: ((self t5 sourceCodeAt: #zork1:zork2:) asString
-				beginsWith: 'zork1: arg1 zork2: arg2')
+	self assert: ((self t5 sourceCodeAt: #zork1:zork2:) asString beginsWith: 'zork1: somethingElse zork2: myArgument')
 ]
 
 { #category : 'tests' }
@@ -33,7 +32,7 @@ TraitMethodDescriptionTest >> testConflictMethodCreation [
 	self t1 compile: '@ myArgument ^true'.
 	self t2 compile: '@myArgument ^false'.
 	self
-		assert: ((self t5 sourceCodeAt: #@) asString beginsWith: '@ anObject').
+		assert: ((self t5 sourceCodeAt: #@) asString beginsWith: '@myArgument').
 	self should: [self c2 new @ 17] raise: Error.
 
 	"keyword"
@@ -41,17 +40,17 @@ TraitMethodDescriptionTest >> testConflictMethodCreation [
 		^true'.
 	self t2 compile: 'zork: myArgument ^false'.
 	self assert: ((self t5 sourceCodeAt: #zork:) asString
-				beginsWith: 'zork: arg1').
+				beginsWith: 'zork: myArgument').
 	self should: [self c2 new zork: 17] raise: Error.
 	self t1 compile: 'zork:myArgument ^true'.
 	self t2 compile: 'zork:myArgument ^false'.
 	self assert: ((self t5 sourceCodeAt: #zork:) asString
-				beginsWith: 'zork: arg1').
+				beginsWith: 'zork:myArgument').
 	self should: [self c2 new zork: 17] raise: Error.
 	self t1 compile: 'zork1: t1 zork2: t2 ^true'.
 	self t2 compile: 'zork1: anObject zork2: anotherObject ^false'.
 	self assert: ((self t5 sourceCodeAt: #zork1:zork2:) asString
-				beginsWith: 'zork1: arg1 zork2: arg2').
+				beginsWith: 'zork1: anObject zork2: anotherObject').
 	self should: [self c2 new zork1: 1 zork2: 2] raise: Error
 ]
 

--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -776,6 +776,36 @@ TraitTest >> testTraitThatHasAPragmaHasCorrectTraitSourceAfterRecompile [
 ]
 
 { #category : 'tests' }
+TraitTest >> testTraitUsingTraitsPreserveSourceCode [
+
+	| t1 t2 source |
+	t1 := self createT1.
+	t2 := self newTrait: #T2 traits: t1.
+
+	source := 'aMethod: aString
+	^ aMethod'.
+	t1 compile: source.
+
+	self assert: (t1 >> #aMethod:) sourceCode equals: source.
+	self assert: (t2 >> #aMethod:) sourceCode equals: source
+]
+
+{ #category : 'tests' }
+TraitTest >> testTraitUsingTraitsPreserveSourceCodeOnClassSide [
+
+	| t1 t2 source |
+	t1 := self createT1.
+	t2 := self newTrait: #T2 traits: t1.
+
+	source := 'aMethod: aString
+	^ aMethod'.
+	t1 class compile: source.
+
+	self assert: (t1 class >> #aMethod:) sourceCode equals: source.
+	self assert: (t2 class >> #aMethod:) sourceCode equals: source
+]
+
+{ #category : 'tests' }
 TraitTest >> testTraitsMethodClassSanity [
 
 	(Smalltalk globals allTraits flatCollect: #traitUsers) asSet do: [ :trait |

--- a/src/Traits/MetaclassForTraits.class.st
+++ b/src/Traits/MetaclassForTraits.class.st
@@ -106,6 +106,15 @@ MetaclassForTraits >> notifyOfRecategorizedSelector: selector from: oldProtocol 
 	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldProtocol to: newProtocol ]
 ]
 
+{ #category : 'private' }
+MetaclassForTraits >> notifySourcePointerOf: aSelector updateTo: srcPointer [
+	"By default we do nothing and traits can hook here to update the users."
+
+	self users do: [ :user |
+		user compiledMethodAt: aSelector ifPresent: [ :method | method sourcePointer: srcPointer ].
+		user notifySourcePointerOf: aSelector updateTo: srcPointer ]
+]
+
 { #category : 'printing' }
 MetaclassForTraits >> printOn: aStream [
 	aStream

--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -141,12 +141,9 @@ TaAbstractComposition >> compile: selector into: aClass [
 		             source: sourceCode;
 		             permitUndeclared: true;
 		             compile.
-	newMethod sourcePointer: method sourcePointer.
 	selector == newMethod selector ifFalse: [ self error: 'selector changed!' ].
 
-	(selector ~= method selector or: [ self changesSourceCode: selector ])
-		ifTrue: [ self saveSourceCode: sourceCode ofMethod: newMethod ]
-		ifFalse: [ newMethod setSourcePointer: method sourcePointer ].
+	(selector ~= method selector or: [ self changesSourceCode: selector ]) ifTrue: [ self saveSourceCode: sourceCode ofMethod: newMethod ].
 
 	aClass classify: selector under: (self protocolForMethod: method).
 
@@ -202,8 +199,6 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 	newMethod := aCompiledMethod copy.
 	newMethod selector: aSelector.
 	newMethod methodClass: aClass.
-
-	newMethod setSourcePointer: aCompiledMethod sourcePointer.
 
 	"This step should not announce anything in the system."
 	SystemAnnouncer uniqueInstance suspendAllWhile: [ aClass classify: aSelector under: aCompiledMethod protocolName ].

--- a/src/Traits/Trait.class.st
+++ b/src/Traits/Trait.class.st
@@ -185,6 +185,15 @@ Trait >> notifyOfRecategorizedSelector: selector from: oldProtocol to: newProtoc
 	self traitUsers do: [ :e | e recategorizeSelector: selector from: oldProtocol to: newProtocol ]
 ]
 
+{ #category : 'private' }
+Trait >> notifySourcePointerOf: aSelector updateTo: srcPointer [
+	"By default we do nothing and traits can hook here to update the users."
+
+	self users do: [ :user |
+		user compiledMethodAt: aSelector ifPresent: [ :method | method sourcePointer: srcPointer ].
+		user notifySourcePointerOf: aSelector updateTo: srcPointer ]
+]
+
 { #category : 'accessing - method dictionary' }
 Trait >> rebuildMethodDictionary [
 	"I extend the behavior in TraitedMetaclass propagating the changes to my users"


### PR DESCRIPTION
It seems that traits were setting the source pointers of the copied methods in system dictionary while adding the method to the class. 

A problem is that the logging of the source code now happens after we install the methods in the system because some info were missing if we logged this before. This result in the fact that currently we have copied methods missing their source pointer. 

I propose an alternative here by updating the source pointer of the copied methods in the users upon the update of the source pointer in the original method instead of doing it while adding the method to the user.

Also I deprecated #setSourcePointer: that seems to be doing the same is #sourcePointer: now (the removal of the source property was duplicated..)

I'm not so sure about this change so if @tesonep has some time to give feedback I'd appreciate it :) 

This bug was detected while I was trying to use Moose in Pharo 12