### PR TITLE
Add #drawFormSet:at: and #translucentFormSet:at: to AthensCanvasWrapper

### DIFF
--- a/src/Athens-Morphic/AthensCanvasWrapper.class.st
+++ b/src/Athens-Morphic/AthensCanvasWrapper.class.st
@@ -164,6 +164,12 @@ AthensCanvasWrapper >> draw: anObject [
 ]
 
 { #category : 'canvas drawing - images' }
+AthensCanvasWrapper >> drawFormSet: formSet at: point [
+
+	^ self drawImage: formSet asForm at: point
+]
+
+{ #category : 'canvas drawing - images' }
 AthensCanvasWrapper >> drawImage: aForm at: aPoint [
 	"Draw the given Form, which is assumed to be a Form or ColorForm"
 
@@ -548,6 +554,12 @@ AthensCanvasWrapper >> translateBy: offset clippingTo: aRect during: aBlock [
 { #category : 'canvas drawing - support' }
 AthensCanvasWrapper >> translateBy: offset during: aBlock [
 	^ self copyOrigin: origin + offset clipRect: self clipRect
+]
+
+{ #category : 'canvas drawing - images' }
+AthensCanvasWrapper >> translucentFormSet: formSet at: point [
+
+	^ self translucentImage: formSet asForm at: point
 ]
 
 { #category : 'canvas drawing - images' }


### PR DESCRIPTION
This pull request adds `#drawFormSet:at:` and `#translucentFormSet:at:` to AthensCanvasWrapper as a copy of the methods added to Canvas in commit a1f2d8e636aa8b43 (AthensCanvasWrapper is intended to be compatible with, but is not a subclass of, Canvas).