### PR TITLE
Rework #nonCachingFullDrawOn: on HandMorph to use a matching ScalingCanvas for the shadow form

### DIFF
--- a/src/Athens-Morphic/AthensCanvasWrapper.class.st
+++ b/src/Athens-Morphic/AthensCanvasWrapper.class.st
@@ -475,6 +475,12 @@ AthensCanvasWrapper >> origin: aPoint [
 ]
 
 { #category : 'canvas drawing - images' }
+AthensCanvasWrapper >> paintFormSet: aFormSet at: aPoint [
+
+	self paintImage: aFormSet asForm at: aPoint
+]
+
+{ #category : 'canvas drawing - images' }
 AthensCanvasWrapper >> paintImage: aForm at: aPoint [
 	self paintImage: aForm at: aPoint sourceRect: aForm boundingBox
 ]
@@ -511,6 +517,22 @@ AthensCanvasWrapper >> setOrigin: aPoint clipRect: aRectangle [
 	currentClipRect := aRectangle
 ]
 
+{ #category : 'canvas converting' }
+AthensCanvasWrapper >> shadowDrawingCanvasWithExtent: extent shadowColor: shadowColor [
+
+	^ (Display defaultCanvasClass extent: extent depth: 1)
+		asShadowDrawingCanvas: shadowColor
+]
+
+{ #category : 'canvas drawing - images' }
+AthensCanvasWrapper >> stencil: stencilForm at: aPoint color: aColor [
+
+	^ self stencil: stencilForm
+		at: aPoint
+		sourceRect: stencilForm boundingBox
+		color: aColor
+]
+
 { #category : 'canvas drawing' }
 AthensCanvasWrapper >> stencil: stencilForm at: aPoint sourceRect: sourceRect color: aColor [
 	|mask|
@@ -523,6 +545,12 @@ AthensCanvasWrapper >> stencil: stencilForm at: aPoint sourceRect: sourceRect co
 		self canvas draw.
 		mask maskOn: self canvas.
 		]
+]
+
+{ #category : 'canvas drawing - images' }
+AthensCanvasWrapper >> stencilFormSet: stencilFormSet at: aPoint color: aColor [
+
+	^ self stencil: stencilFormSet asForm at: aPoint color: aColor
 ]
 
 { #category : 'canvas drawing - support' }

--- a/src/Graphics-Canvas/Canvas.class.st
+++ b/src/Graphics-Canvas/Canvas.class.st
@@ -612,6 +612,12 @@ Canvas >> origin [
 ]
 
 { #category : 'drawing - images' }
+Canvas >> paintFormSet: aFormSet at: aPoint [
+
+	self paintImage: aFormSet asForm at: aPoint
+]
+
+{ #category : 'drawing - images' }
 Canvas >> paintImage: aForm at: aPoint [
 	"Draw the given Form, which is assumed to be a Form or ColorForm following the convention that zero is the transparent pixel value."
 
@@ -686,6 +692,12 @@ Canvas >> stencil: stencilForm at: aPoint color: aColor [
 Canvas >> stencil: stencilForm at: aPoint sourceRect: sourceRect color: aColor [
 	"Flood this canvas with aColor wherever stencilForm has non-zero pixels"
 	^self subclassResponsibility
+]
+
+{ #category : 'drawing - images' }
+Canvas >> stencilFormSet: stencilFormSet at: aPoint color: aColor [
+
+	^ self stencil: stencilFormSet asForm at: aPoint color: aColor
 ]
 
 { #category : 'drawing - support' }

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -609,6 +609,13 @@ ScalingCanvas >> stencil: stencilForm at: aPoint sourceRect: sourceRect color: a
 		at: aPoint truncated * scale sourceRect: (sourceRect scaleBy: scale) color: aColor
 ]
 
+{ #category : 'drawing - images' }
+ScalingCanvas >> stencilFormSet: stencilFormSet at: aPoint color: aColor [
+
+	formCanvas stencil: (stencilFormSet asFormAtScale: scale)
+		at: aPoint truncated * scale color: aColor
+]
+
 { #category : 'drawing - support' }
 ScalingCanvas >> transformBy: aDisplayTransform clippingTo: aClipRect during: aBlock smoothing: cellSize [
 

--- a/src/Graphics-Canvas/ShadowDrawingCanvas.class.st
+++ b/src/Graphics-Canvas/ShadowDrawingCanvas.class.st
@@ -44,6 +44,15 @@ ShadowDrawingCanvas >> on: aCanvas [
 	shadowColor := Color black
 ]
 
+{ #category : 'drawing - images' }
+ShadowDrawingCanvas >> paintFormSet: aFormSet at: aPoint [
+
+	myCanvas
+		stencilFormSet: aFormSet
+		at: aPoint
+		color: shadowColor
+]
+
 { #category : 'accessing' }
 ShadowDrawingCanvas >> shadowColor [
 	^shadowColor

--- a/src/Morphic-Core/Canvas.extension.st
+++ b/src/Morphic-Core/Canvas.extension.st
@@ -17,3 +17,10 @@ Canvas >> restoreSavedPatch: aForm at: aPoint [
 
 	self drawImage: aForm at: aPoint
 ]
+
+{ #category : '*Morphic-Core' }
+Canvas >> shadowDrawingCanvasWithExtent: extent shadowColor: shadowColor [
+
+	^ (Display defaultCanvasClass extent: extent depth: 1)
+		asShadowDrawingCanvas: shadowColor
+]

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -770,11 +770,16 @@ HandMorph >> nonCachingFullDrawOn: aCanvas [
 
 	submorphs isEmpty ifTrue: [^ self drawOn: aCanvas].  "just draw the hand itself"
 	aCanvas asShadowDrawingCanvas
-		translateBy: self shadowOffset during:[:shadowCanvas| | shadowForm |
+		translateBy: self shadowOffset during:[:shadowCanvas| | shadowForm bnds canvas |
 		"Note: We use a shadow form here to prevent drawing
 		overlapping morphs multiple times using the transparent
 		shadow color."
-		shadowForm := self shadowForm.
+		bnds := Rectangle merging: (submorphs collect: [:m | m fullBounds]).
+		canvas := (Display defaultCanvasClass extent: bnds extent depth: 1)
+			asShadowDrawingCanvas: Color black.
+		canvas translateBy: bnds topLeft negated
+			during:[:tempCanvas| self drawSubmorphsOn: tempCanvas].
+		shadowForm := canvas form offset: bnds topLeft.
 "
 shadowForm displayAt: shadowForm offset negated. Display forceToScreen: (0@0 extent: shadowForm extent).
 "
@@ -1112,18 +1117,6 @@ HandMorph >> sendListenEvent: anEvent to: listenerGroup [
 HandMorph >> sendMouseEvent: anEvent [
 	"Send the event to the morph currently holding the focus, or if none to the owner of the hand."
 	^self sendEvent: anEvent focus: self mouseFocus clear:[self mouseFocus: nil]
-]
-
-{ #category : 'drawing' }
-HandMorph >> shadowForm [
-	"Return a 1-bit shadow of my submorphs.  Assumes submorphs is not empty"
-	| bnds canvas |
-	bnds := Rectangle merging: (submorphs collect: [:m | m fullBounds]).
-	canvas := (Display defaultCanvasClass extent: bnds extent depth: 1)
-		asShadowDrawingCanvas: Color black.
-	canvas translateBy: bnds topLeft negated
-		during:[:tempCanvas| self drawSubmorphsOn: tempCanvas].
-	^ canvas form offset: bnds topLeft
 ]
 
 { #category : 'drop shadows' }

--- a/src/Morphic-Core/HandMorph.class.st
+++ b/src/Morphic-Core/HandMorph.class.st
@@ -770,20 +770,19 @@ HandMorph >> nonCachingFullDrawOn: aCanvas [
 
 	submorphs isEmpty ifTrue: [^ self drawOn: aCanvas].  "just draw the hand itself"
 	aCanvas asShadowDrawingCanvas
-		translateBy: self shadowOffset during:[:shadowCanvas| | shadowForm bnds canvas |
+		translateBy: self shadowOffset during:[:shadowCanvas| | shadowFormSet bnds canvas |
 		"Note: We use a shadow form here to prevent drawing
 		overlapping morphs multiple times using the transparent
 		shadow color."
 		bnds := Rectangle merging: (submorphs collect: [:m | m fullBounds]).
-		canvas := (Display defaultCanvasClass extent: bnds extent depth: 1)
-			asShadowDrawingCanvas: Color black.
+		canvas := aCanvas shadowDrawingCanvasWithExtent: bnds extent shadowColor: Color black.
 		canvas translateBy: bnds topLeft negated
 			during:[:tempCanvas| self drawSubmorphsOn: tempCanvas].
-		shadowForm := canvas form offset: bnds topLeft.
+		shadowFormSet := FormSet extent: bnds extent depth: 1 forms: { canvas form }.
 "
 shadowForm displayAt: shadowForm offset negated. Display forceToScreen: (0@0 extent: shadowForm extent).
 "
-		shadowCanvas paintImage: shadowForm at: shadowForm offset.  "draw shadows"
+		shadowCanvas paintFormSet: shadowFormSet at: bnds topLeft.  "draw shadows"
 	].
 	"draw morphs in front of shadows"
 	self drawSubmorphsOn: aCanvas.

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -5567,17 +5567,6 @@ Morph >> shadowColor: aColor [
 	self setProperty: #shadowColor toValue: aColor
 ]
 
-{ #category : 'drawing' }
-Morph >> shadowForm [
-	"Return a form representing the 'shadow' of the receiver - e.g., all pixels that are occupied by the receiver are one, all others are zero."
-	| canvas |
-	canvas := (Display defaultCanvasClass extent: self fullBounds extent depth: 1)
-				asShadowDrawingCanvas: Color black. "Color black represents one for 1bpp"
-	canvas translateBy: bounds topLeft negated
-		during:[:tempCanvas| tempCanvas fullDrawMorph: self].
-	^ canvas form offset: bounds topLeft
-]
-
 { #category : 'drop shadows' }
 Morph >> shadowOffset [
 	"Return the current shadow offset"

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -4573,28 +4573,6 @@ Morph >> outermostWorldMorph [
 	^self world ifNil: [ self currentWorld ]
 ]
 
-{ #category : 'geometry' }
-Morph >> overlapsShadowForm: itsShadow bounds: itsBounds [
-	"Answer true if itsShadow and my shadow overlap at all"
-	| andForm overlapExtent |
-	overlapExtent := (itsBounds intersect: self fullBounds ifNone: [ ^ false ]) extent.
-	overlapExtent > (0 @ 0)
-		ifFalse: [^ false].
-	andForm := self shadowForm.
-	overlapExtent ~= self fullBounds extent
-		ifTrue: [andForm := andForm
-						contentsOfArea: (0 @ 0 extent: overlapExtent)].
-	andForm := andForm
-				copyBits: (self fullBounds translateBy: itsShadow offset negated)
-				from: itsShadow
-				at: 0 @ 0
-				clippingBox: (0 @ 0 extent: overlapExtent)
-				rule: Form and
-				fillColor: nil.
-	^ andForm bits
-		anySatisfy: [:w | w ~= 0]
-]
-
 { #category : 'structure' }
 Morph >> owner [
 	"Returns the owner of this morph, which may be nil."

--- a/src/Morphic-Core/ScalingCanvas.extension.st
+++ b/src/Morphic-Core/ScalingCanvas.extension.st
@@ -51,3 +51,10 @@ ScalingCanvas >> restoreSavedPatch: savedPatch at: aPoint [
 
 	formCanvas restoreSavedPatch: savedPatch form at: aPoint * scale
 ]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas >> shadowDrawingCanvasWithExtent: extent shadowColor: shadowColor [
+
+	^ (self class formCanvas: (FormCanvas on: (Form extent: extent * scale depth: 1)) scale: scale)
+		asShadowDrawingCanvas: shadowColor
+]


### PR DESCRIPTION
This pull request reworks the shadow form drawing in `#nonCachingFullDrawOn:` on HandMorph to use a ScalingCanvas with the same scale as the argument when it’s a ScalingCanvas. That avoids the upscaling of the shadow form when the `#canvasScaleFactor` is not 1. The method applies when dragging translucent morphs like:

```smalltalk
Morph new
	color: (Color blue alpha: 0.25);
	extent: 1000 asPoint;
	openInWorld
```

And:

```smalltalk
(Text string: 'Pharo'
	attribute: (TextFontReference toFont:
		(LogicalFont familyName: 'Source Sans Pro' pointSize: 400)))
	asTextMorph openInWorld
```

Note that dragging the TextMorph can be slow due to its large glyphs causing the FreeTypeCache to repeatedly reach its maximum size and be cleared. That can be avoided by setting the maximum size to take the `#canvasScaleFactor` into account:

```smalltalk
FreeTypeCache current maximumSize:
	FreeTypeCache defaultMaximumSize * (OSWorldRenderer canvasScaleFactor raisedTo: 2)
```
