### PR TITLE
ClassInstaller: use the oldClass of the builder

### DIFF
--- a/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
@@ -50,7 +50,8 @@ ShClassInstallerTest >> newClass: className superclass: aSuperclass slots: slots
 
 { #category : 'running' }
 ShClassInstallerTest >> tearDown [
-
+	newClass  ifNotNil: [:c | c removeFromSystem].
+	newClass2 ifNotNil: [:c | c removeFromSystem].
 	self packageOrganizer removePackage: self generatedClassesPackageName.
 	super tearDown
 ]

--- a/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
@@ -283,13 +283,33 @@ ShClassInstallerTest >> testDuplicateClassPreserveMethods [
 ]
 
 { #category : 'tests' }
+ShClassInstallerTest >> testDuplicateClassPreserveSharedVariables [
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		  builder
+			  name: #ShCITestClass;
+			  sharedVariables: {#ShVariable};
+			  package: self generatedClassesPackageName ].
+
+	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
+
+	self assert: (newClass2 hasClassVarNamed: #ShVariable).
+	"Did we copy the Class Variables?"
+	self assert: (newClass2 classVariableNamed: #ShVariable) definingClass equals: newClass2.
+	self assert: (newClass classVariableNamed: #ShVariable) definingClass equals: newClass
+]
+
+{ #category : 'tests' }
 ShClassInstallerTest >> testDuplicateClassPreserveSlots [
 
 	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable => BooleanSlot}.
 	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
 
 	self assert: (newClass2 hasSlotNamed: #anInstanceVariable).
-	self assert: (newClass2 slotNamed: #anInstanceVariable) class equals: BooleanSlot
+	self assert: (newClass2 slotNamed: #anInstanceVariable) class equals: BooleanSlot.
+	"Make sure the slots are copied"
+	self assert: (newClass slotNamed: #anInstanceVariable) definingClass equals: newClass.
+	self assert: (newClass2 slotNamed: #anInstanceVariable) definingClass equals: newClass2
 ]
 
 { #category : 'tests' }

--- a/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
+++ b/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
@@ -58,16 +58,6 @@ ShLayoutDefinition >> copy: slotCollection ifUsedIn: aClass [
 				ifNone: [ aSlot ] ]
 ]
 
-{ #category : 'accessing' }
-ShLayoutDefinition >> copySlotsIfUsedIn: oldClass [
-	"I copy the slots if they are used in oldClass. As the slots has state (usually the index) they cannot be shared between the old and the new class."
-
-	oldClass ifNil: [ ^ self ].
-
-	slots := self copy: slots ifUsedIn: oldClass.
-	classSlots := self copy: classSlots ifUsedIn: oldClass class
-]
-
 { #category : 'initialization' }
 ShLayoutDefinition >> initialize [
 

--- a/src/Shift-ClassBuilder/ShiftAnonymousClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftAnonymousClassInstaller.class.st
@@ -25,11 +25,6 @@ ShiftAnonymousClassInstaller >> installInEnvironment: newClass [
 ShiftAnonymousClassInstaller >> installSubclassInSuperclass: newClass [
 ]
 
-{ #category : 'building' }
-ShiftAnonymousClassInstaller >> lookupOldClass [
-	^ self
-]
-
 { #category : 'notifications' }
 ShiftAnonymousClassInstaller >> notifyChanges [
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -109,8 +109,6 @@ ShiftClassBuilder >> build [
 	self validateSuperclass.
 	self compareWithOldClass.
 
-	self layoutDefinition copySlotsIfUsedIn: oldClass.
-
 	"If this is the first build, when building a class.
 	We need to check if there is no conflicts with existing subclasses.
 	If we are in a remake, it have been done when building the superclass modified before."
@@ -331,8 +329,8 @@ ShiftClassBuilder >> fillFor: aClass [
 		superclass: aClass superclass;
 		name: aClass getName;
 		layoutClass: aClass classLayout class;
-		slots: aClass localSlots;
-		classSlots: aClass class localSlots;
+		slots: (aClass localSlots collect: [:var | var copy]);
+		classSlots: (aClass class localSlots collect: [:var | var copy]);
 		"we have to copy the class variables, as they contain the values"
 		sharedVariables: (aClass classVariables collect: [:var | var copy]);
 		sharedPools: (aClass sharedPools collect: [ :each | each name ]) asArray;
@@ -436,6 +434,7 @@ ShiftClassBuilder >> isInRemake [
 ShiftClassBuilder >> isRebuild [
 	"Are we rebuilding an existing class?"
 	oldClass ifNil: [ ^false ].
+	oldClass isAnonymous ifTrue: [ ^true ].
 	^name = oldClass name
 ]
 
@@ -464,7 +463,6 @@ ShiftClassBuilder >> layoutDefinition [
 
 { #category : 'accessing' }
 ShiftClassBuilder >> markIsInRemake [
-
 	inRemake := true
 ]
 

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -211,10 +211,10 @@ ShiftClassBuilder >> commentStamp: anObject [
 
 { #category : 'changes' }
 ShiftClassBuilder >> compareWithOldClass [
-	oldClass ifNil: [ ^ self ].
+	self isRebuild ifFalse: [ ^ self ].
 	changeComparers do: [ :e | e compareClass: oldClass with: self ].
 
-	changes ifEmpty: [ ShNoChangesInClass signal. ]
+	(changes isEmpty and: [ oldClass name == name ]) ifTrue:  [ ShNoChangesInClass signal. ]
 ]
 
 { #category : 'compiling' }
@@ -429,6 +429,13 @@ ShiftClassBuilder >> isInRemake [
 	"If the builder is in remake (when propagating changes to subclasses)"
 
 	^ inRemake
+]
+
+{ #category : 'testing' }
+ShiftClassBuilder >> isRebuild [
+	"Are we rebuilding an existing class?"
+	oldClass ifNil: [ ^false ].
+	^name = oldClass name
 ]
 
 { #category : 'accessing' }

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -211,10 +211,11 @@ ShiftClassBuilder >> commentStamp: anObject [
 
 { #category : 'changes' }
 ShiftClassBuilder >> compareWithOldClass [
+	"Comparing changes only needs to be done when updating (rebuilding) and existing class"
 	self isRebuild ifFalse: [ ^ self ].
+	
 	changeComparers do: [ :e | e compareClass: oldClass with: self ].
-
-	(changes isEmpty and: [ oldClass name == name ]) ifTrue:  [ ShNoChangesInClass signal. ]
+	changes isEmpty ifTrue: [ ShNoChangesInClass signal ]
 ]
 
 { #category : 'compiling' }

--- a/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
@@ -49,11 +49,10 @@ ShiftClassInstaller class >> make: aBlock [
 
 { #category : 'building' }
 ShiftClassInstaller class >> remake: aClass basedOn: aBuilder [
-
 	self new
-		installingEnvironment: aBuilder installingEnvironment;
 		make: [ :anotherBuilder |
 			anotherBuilder fillFor: aClass.
+			anotherBuilder installingEnvironment: aBuilder installingEnvironment.
 			anotherBuilder buildEnvironment: aBuilder buildEnvironment.
 			anotherBuilder markIsInRemake.
 			aBuilder propagateChangesTo: anotherBuilder ]

--- a/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
@@ -51,7 +51,6 @@ ShiftClassInstaller class >> make: aBlock [
 ShiftClassInstaller class >> remake: aClass basedOn: aBuilder [
 
 	self new
-		oldClass: aClass;
 		installingEnvironment: aBuilder installingEnvironment;
 		make: [ :anotherBuilder |
 			anotherBuilder fillFor: aClass.
@@ -64,7 +63,6 @@ ShiftClassInstaller class >> remake: aClass basedOn: aBuilder [
 ShiftClassInstaller class >> update: oldClass to: aBlock [
 	^ self new
 		fillFor: oldClass;
-		oldClass: oldClass;
 		make: aBlock
 ]
 
@@ -87,7 +85,7 @@ ShiftClassInstaller >> comment: newClass [
 ShiftClassInstaller >> copyObject: oldObject to: newClass [
 
 	| newObject |
-	newObject := (newClass isVariable and: [ oldClass isVariable ])
+	newObject := (newClass isVariable and: [ self oldClass isVariable ])
 		             ifTrue: [
 			             | createdObject |
 			             createdObject := newClass basicNew: oldObject basicSize.
@@ -172,19 +170,10 @@ ShiftClassInstaller >> installingEnvironment: anEnvironment [
 ]
 
 { #category : 'building' }
-ShiftClassInstaller >> lookupOldClass [
-
-	oldClass ifNil: [ oldClass := self installingEnvironment at: builder name ifAbsent: [ nil ] ]
-]
-
-{ #category : 'building' }
 ShiftClassInstaller >> make [
 	| newClass |
 
-	self lookupOldClass.
-
 	[
-		builder oldClass: oldClass.
 		newClass := builder build.
 
 		self installInEnvironment: newClass.
@@ -201,7 +190,7 @@ ShiftClassInstaller >> make [
 		
 	] on: ShNoChangesInClass do:[
 		"If there are no changes in the building, I am not building or replacing nothing"
-		newClass := oldClass.
+		newClass := self oldClass.
 	].
 
 	self recategorize: newClass.
@@ -230,23 +219,23 @@ ShiftClassInstaller >> makeWithBuilder: aBuilder [
 ShiftClassInstaller >> migrateClassTo: newClass [
 	| slotsToMigrate oldClassVariables newClassVariables|
 
-	oldClass ifNil:[^ self].
+	self oldClass ifNil:[^ self].
 	self assert: newClass isNotNil.
 
-	oldClass 	superclass removeSubclass: oldClass.
+	self oldClass superclass removeSubclass: self oldClass.
 
-	newClass subclasses: oldClass subclasses.
+	newClass subclasses: self oldClass subclasses.
 
 	slotsToMigrate := newClass class allSlots reject:[:e | builder builderEnhancer hasToSkipSlot: e ].
 	slotsToMigrate do: [ :newSlot | 
 		"the slot might need to initialize the new class"
 		newSlot wantsInitialization ifTrue: [ newSlot initialize: newClass ].
-		oldClass class slotNamed: newSlot name ifFound: [ :oldSlot | newSlot write: (oldSlot read: oldClass) to: newClass ] ].
+		self oldClass class slotNamed: newSlot name ifFound: [ :oldSlot | newSlot write: (oldSlot read: self oldClass) to: newClass ] ].
 
 	oldClassVariables := OrderedCollection new.
 	newClassVariables := OrderedCollection new.
 
-	oldClass classVariables do: [ :oldVar | | newVar |
+	self oldClass classVariables do: [ :oldVar | | newVar |
 		(newClass hasClassVarNamed: oldVar key)
 			ifTrue: [
 				newVar := newClass classVariableNamed: oldVar key.
@@ -258,7 +247,7 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 		(self builder hasToMigrateInstances)
 			ifTrue: [ builder builderEnhancer migrateInstancesTo: newClass installer: self ].
 
-		{ oldClass. builder oldMetaclass } , oldClassVariables asArray
+		{ self oldClass. builder oldMetaclass } , oldClassVariables asArray
 			elementsForwardIdentityTo: { newClass. builder newMetaclass }, newClassVariables asArray.
 
 		self fixSlotScope: newClass.
@@ -271,7 +260,7 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 { #category : 'migrating' }
 ShiftClassInstaller >> migrateInstancesTo: newClass [
 	| oldObjects newObjects readOnlyOldObjectsFlags |
-	oldObjects := oldClass allInstances.
+	oldObjects := self oldClass allInstances.
 	oldObjects ifEmpty: [ ^ self ].
 
 	readOnlyOldObjectsFlags := OrderedCollection new: oldObjects size.
@@ -292,7 +281,7 @@ ShiftClassInstaller >> notifyChanges [
 
 { #category : 'accessing' }
 ShiftClassInstaller >> oldClass [
-	^ oldClass
+	^ builder oldClass
 ]
 
 { #category : 'accessing' }

--- a/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
@@ -219,7 +219,7 @@ ShiftClassInstaller >> makeWithBuilder: aBuilder [
 ShiftClassInstaller >> migrateClassTo: newClass [
 	| slotsToMigrate oldClassVariables newClassVariables|
 
-	self oldClass ifNil:[^ self].
+	builder isRebuild ifFalse: [^ self].
 	self assert: newClass isNotNil.
 
 	self oldClass superclass removeSubclass: self oldClass.
@@ -260,6 +260,8 @@ ShiftClassInstaller >> migrateClassTo: newClass [
 { #category : 'migrating' }
 ShiftClassInstaller >> migrateInstancesTo: newClass [
 	| oldObjects newObjects readOnlyOldObjectsFlags |
+	
+	builder isRebuild ifFalse: [^ self].
 	oldObjects := self oldClass allInstances.
 	oldObjects ifEmpty: [ ^ self ].
 

--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -803,7 +803,13 @@ TraitTest >> testUsingTraitInAnonymousSubClassAndRedefiningIt [
 
 	self deny: (Object subclasses includes: aClass).
 
-	t1 := self newTrait: #T1 with: #(aSlot).
+	t1 := t1 classInstaller make: [ :aBuilder |
+		  aBuilder
+			  fillFor: t1;
+			  slots: #(aSlot);
+			  package: self packageNameForTests;
+			  beTrait ].
+		
 	self assert: (aClass hasSlotNamed: #aSlot).
 
 	self deny: (Object subclasses includes: aClass)


### PR DESCRIPTION
remove the use of the oldClass ivar in the ClassInstaller. Always use the oldClass of the builder

The ivar has to be removed with a PR created from source, as it can not be done from the image