### PR TITLE
Traits: Fix wrong source pointer (v2)

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -569,15 +569,16 @@ OpalCompiler >> install [
 	logSource := self logged ifNil: [ true ].
 	protocol := protocol ifNil: [ self priorMethod ifNotNil: [ self priorMethod protocol ] ].
 
-	class addAndClassifySelector: method selector withMethod: method inProtocol: protocol.
+	logSource ifTrue: [
+		method putSource: source withPreamble: [ :file | "It is possible the protocol might be wrong, fro example if the protocol is nil or and extension to the package of the class containing the method. But to fix this problem it would require to find the right protocol before classification and this is some work to do... And this logged protocol is not really used."
+			class
+				printProtocolChunk: protocol 
+				on: file
+				withStamp: changeStamp
+				priorMethod: self priorMethod.
+			file cr ] ].
 
-	logSource ifTrue: [ "For the log we do not use `protocol` because in case it is nil, we keep the current classification or we classify under uncategorize in the method is not present in a protocol yet. So we ask to the method its protocol after classifying it."
-		method
-			putSource: source
-			class: class
-			protocol: method protocol
-			withStamp: changeStamp
-			priorMethod: self priorMethod ].
+	class addAndClassifySelector: method selector withMethod: method inProtocol: protocol.
 
 	class instanceSide noteCompilationOf: method meta: class isClassSide.
 

--- a/src/System-Sources/ClassDescription.extension.st
+++ b/src/System-Sources/ClassDescription.extension.st
@@ -15,7 +15,10 @@ ClassDescription >> printProtocolChunk: protocol on: aFileStream withStamp: chan
 			 strm
 				 nextPutAll: self name;
 				 nextPutAll: ' methodsFor: ';
-				 print: protocol name asString.
+				 print: (protocol ifNotNil: [
+							  protocol isString
+								  ifTrue: [ protocol ]
+								  ifFalse: [ protocol name ] ]) asString.
 			 (changeStamp isNotNil and: [ changeStamp size > 0 or: [ priorMethod isNotNil ] ]) ifTrue: [
 				 strm
 					 nextPutAll: ' stamp: ';

--- a/src/System-Sources/CompiledMethod.extension.st
+++ b/src/System-Sources/CompiledMethod.extension.st
@@ -1,18 +1,6 @@
 Extension { #name : 'CompiledMethod' }
 
 { #category : '*System-Sources' }
-CompiledMethod >> putSource: sourceStr class: class protocol: protocol withStamp: changeStamp priorMethod: priorMethod [
-
-	^ self putSource: sourceStr withPreamble: [ :file |
-		  class
-			  printProtocolChunk: protocol
-			  on: file
-			  withStamp: changeStamp
-			  priorMethod: priorMethod.
-		  file cr ]
-]
-
-{ #category : '*System-Sources' }
 CompiledMethod >> putSource: source withPreamble: preambleBlock [
 	"Store the source code for the receiver on an external file."
 

--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -776,6 +776,36 @@ TraitTest >> testTraitThatHasAPragmaHasCorrectTraitSourceAfterRecompile [
 ]
 
 { #category : 'tests' }
+TraitTest >> testTraitUsingTraitsPreserveSourceCode [
+
+	| t1 t2 source |
+	t1 := self createT1.
+	t2 := self newTrait: #T2 traits: t1.
+
+	source := 'aMethod: aString
+	^ aMethod'.
+	t1 compile: source.
+
+	self assert: (t1 >> #aMethod:) sourceCode equals: source.
+	self assert: (t2 >> #aMethod:) sourceCode equals: source
+]
+
+{ #category : 'tests' }
+TraitTest >> testTraitUsingTraitsPreserveSourceCodeOnClassSide [
+
+	| t1 t2 source |
+	t1 := self createT1.
+	t2 := self newTrait: #T2 traits: t1.
+
+	source := 'aMethod: aString
+	^ aMethod'.
+	t1 class compile: source.
+
+	self assert: (t1 class >> #aMethod:) sourceCode equals: source.
+	self assert: (t2 class >> #aMethod:) sourceCode equals: source
+]
+
+{ #category : 'tests' }
 TraitTest >> testTraitsMethodClassSanity [
 
 	(Smalltalk globals allTraits flatCollect: #traitUsers) asSet do: [ :trait |


### PR DESCRIPTION
This is an alternative to https://github.com/pharo-project/pharo/pull/15732

The bug was introduced while moving the logging of methods after the installation. This change reverts it. This was done because sometime we cannot know the actual protocol of a method before classifying it. But this protocol is not used currently so it is better to have the traits working than to fix a problem that currently does not harm us much