### PR TITLE
Cleanup: move extension methods Slot package to where the classes are

### DIFF
--- a/src/Kernel-CodeModel/String.extension.st
+++ b/src/Kernel-CodeModel/String.extension.st
@@ -1,11 +1,11 @@
 Extension { #name : 'String' }
 
-{ #category : '*Slot-Core' }
+{ #category : '*Kernel-CodeModel' }
 String >> asClassVariable [
 	^ ClassVariable named: self
 ]
 
-{ #category : '*Slot-Core' }
+{ #category : '*Kernel-CodeModel' }
 String >> asClassVariableCollection [
 	"Parse as class variables. Use space, tab and cr as separators
 	Example:
@@ -15,12 +15,12 @@ String >> asClassVariableCollection [
 	^(self substrings: Character separators) collect: [ :substring | substring asSymbol asClassVariable ]
 ]
 
-{ #category : '*Slot-Core' }
+{ #category : '*Kernel-CodeModel' }
 String >> asSlot [
 	^ InstanceVariableSlot named: self
 ]
 
-{ #category : '*Slot-Core' }
+{ #category : '*Kernel-CodeModel' }
 String >> asSlotCollection [
 	"Parse as slots. Use space, tab and cr as separators
 	Example:

--- a/src/Kernel-CodeModel/Symbol.extension.st
+++ b/src/Kernel-CodeModel/Symbol.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'Symbol' }
 
-{ #category : '*Slot-Core' }
+{ #category : '*Kernel-CodeModel' }
 Symbol >> => aVariable [
 	"If the slot we give as argument is not present in the image, we create an UndefinedSlot with the AST of the slot definition"
 


### PR DESCRIPTION
Move the extension methods from package Slot to the code model package