### PR TITLE
Prevent logging exceptions twice when debugger is opened

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -60,7 +60,8 @@ DebugSession class >> defaultContextModelClass [
 
 { #category : 'settings' }
 DebugSession class >> logDebuggerStackToFile [
-	^ LogDebuggerStackToFile ifNil: [LogDebuggerStackToFile := true]
+	^ LogDebuggerStackToFile 
+		ifNil: [ LogDebuggerStackToFile := false ]
 ]
 
 { #category : 'settings' }

--- a/src/Debugger-Model/DebuggerSettings.class.st
+++ b/src/Debugger-Model/DebuggerSettings.class.st
@@ -95,7 +95,7 @@ DebuggerSettings class >> generalDebuggingSettingsOn: aBuilder [
 			(aBuilder setting: #logDebuggerStackToFile)
 				label: 'Write message to debug log file when fall into debugger';
 				target: DebugSession;
-				default: true;
+				default: false;
 				description:
 					'If true, whenever you fall into a debugger a summary of its stack will be written to a file named'.
 


### PR DESCRIPTION
Change logDebuggerStackToFile default setting to false since when set to true, it makes the debug session log twice on every request as reported in #15620.
