### PR TITLE
ClassBuilder: cleanups and  #hasSameDefinitionAs: 

### DIFF
--- a/src/Kernel-CodeModel/ClassVariable.class.st
+++ b/src/Kernel-CodeModel/ClassVariable.class.st
@@ -63,6 +63,13 @@ ClassVariable >> emitValue: methodBuilder [
 ]
 
 { #category : 'testing' }
+ClassVariable >> hasSameDefinitionAs: otherVariable [
+
+ 	"Equal definition. ClassVariable values are not to be taken into account"
+ 	^self class = otherVariable class and: [self key = otherVariable key]
+]
+
+{ #category : 'testing' }
 ClassVariable >> isAccessedBy: aBehavior [
 
 	^ (aBehavior hasMethodAccessingVariable: self) or: [ aBehavior class hasMethodAccessingVariable: self ]

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -108,7 +108,9 @@ ClassTest >> testAddSlot [
 	self assert: tutu instVarNames equals: #('x').
 	self assert: tutu name equals: #TUTU.
 	tutu addSlot: #y => InstanceVariableSlot.
-	self assert: tutu instVarNames equals: #('x' 'y')
+	self assert: tutu instVarNames equals: #('x' 'y').
+	self assert: (tutu slotNamed: #x) definingClass identicalTo: tutu.
+	self assert: (tutu slotNamed: #y) definingClass identicalTo: tutu.
 ]
 
 { #category : 'tests' }
@@ -122,7 +124,9 @@ ClassTest >> testAddSlotAnonymous [
 	self assert: tutu getName isNil.
 	tutu := tutu addSlot: #y => InstanceVariableSlot.
 	self assert: tutu getName isNil.
-	self assert: tutu instVarNames equals: #('x' 'y')
+	self assert: tutu instVarNames equals: #('x' 'y').
+	self assert: (tutu slotNamed: #x) definingClass identicalTo: tutu.
+	self assert: (tutu slotNamed: #y) definingClass identicalTo: tutu.
 ]
 
 { #category : 'tests - access' }
@@ -479,6 +483,19 @@ ClassTest >> testRemoveClassSlot [
 	self assert: tutu class instVarNames equals: #(#X).
 	tutu removeClassSlot: slot1.
 	self assert: tutu class instVarNames equals: #()
+]
+
+{ #category : 'tests' }
+ClassTest >> testRemoveSlot [
+
+	| slotx tutu |
+	tutu := testEnvironment at: #TUTU.
+	tutu addSlot: (slotx := #x => InstanceVariableSlot).
+	tutu addSlot: #y => InstanceVariableSlot.
+	self assert: tutu instVarNames equals: #('x' 'y').
+	tutu removeSlot: slotx.
+	self assert: tutu instVarNames equals: #('y').
+	self assert: (tutu slotNamed: #y) definingClass identicalTo: tutu.
 ]
 
 { #category : 'tests - access' }

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -109,6 +109,34 @@ ReleaseTest >> testAllGlobalBindingAreGlobalVariables [
 ]
 
 { #category : 'tests - variables' }
+ReleaseTest >> testAllInstanceVariablesDefiningClass [
+	"Make sure that all slots (ivars) have a correct defining class
+	This should never happen but the test is a good way to avoid future bugs"
+	| violating |
+
+	violating := Smalltalk globals allBehaviors select: [ :class |
+		class localSlots anySatisfy: [:var | var definingClass ~= class ]].
+
+	self
+		assert: violating isEmpty
+		description: 'Slot with wrong defining Class in: ', violating asArray asString
+]
+
+{ #category : 'tests - variables' }
+ReleaseTest >> testAllInstanceVariablesOwningClass [
+	"Make sure that all slots (ivars) have a correct owning class
+	This should never happen but the test is a good way to avoid future bugs"
+	| violating |
+
+	violating := Smalltalk globals allBehaviors select: [ :class |
+		class slots anySatisfy: [:var | var owningClass ~= class ]].
+
+	self
+		assert: violating isEmpty
+		description: 'Slot with wrong owning Class in: ', violating asArray asString
+]
+
+{ #category : 'tests - variables' }
 ReleaseTest >> testAllInstanceVariablesStartLowercase [
 	"Make sure that all class instance variable names start with a lowercase letter"
 	| violating |
@@ -119,6 +147,20 @@ ReleaseTest >> testAllInstanceVariablesStartLowercase [
 	self
 		assert: violating isEmpty
 		description: 'Instance variable names must start with a lowercase letter: ', violating asArray asString
+]
+
+{ #category : 'tests - variables' }
+ReleaseTest >> testAllSharedVariablesOwningClass [
+	"Make sure that all SharedVariables (ClassVariables) have a correct owning class
+	This should never happen but the test is a good way to avoid future bugs"
+	| violating |
+
+	violating := Smalltalk globals allBehaviors select: [ :class |
+		class classVariables anySatisfy: [:var | var owningClass ~= class instanceSide]].
+
+	self
+		assert: violating isEmpty
+		description: 'ClassVar with wrong owning Class in: ', violating asArray asString
 ]
 
 { #category : 'tests - variables' }

--- a/src/Shift-ClassBuilder/ShAbstractClassChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShAbstractClassChangeDetector.class.st
@@ -41,7 +41,7 @@ ShAbstractClassChangeDetector >> compareClass [
 ]
 
 { #category : 'changes' }
-ShAbstractClassChangeDetector >> compareSlotCollection: a with: b [
+ShAbstractClassChangeDetector >> compareVariables: a with: b [
 
 	(a size = b size) ifFalse: [ ^ false].
 

--- a/src/Shift-ClassBuilder/ShClassSlotChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShClassSlotChangeDetector.class.st
@@ -14,7 +14,7 @@ ShClassSlotChangeDetector >> initialize [
 	super initialize.
 	builderAccessor := [ :e | e classSlots ].
 	classAccessor := [ :e | e class slots ].
-	comparer := [ :a :b |  self compareSlotCollection: a with: b ]
+	comparer := [ :a :b |  self compareVariables: a with: b ]
 ]
 
 { #category : 'changes' }

--- a/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
+++ b/src/Shift-ClassBuilder/ShLayoutDefinition.class.st
@@ -40,24 +40,6 @@ ShLayoutDefinition >> classSlots: anObject [
 	classSlots := anObject collect: [ :e | e asSlot ]
 ]
 
-{ #category : 'accessing' }
-ShLayoutDefinition >> copy: slotCollection ifUsedIn: aClass [
-	"I only copy the slot if it is not virtual and it is the same in the oldClass.
-	 They are copied as they have the index as instance variable, the index can change in the new class."
-
-	aClass slots isEmpty ifTrue: [ ^ slotCollection ].
-
-	^ slotCollection
-		collect: [ :aSlot |
-			aClass
-				slotNamed: aSlot name
-				ifFound: [ :oldSlot |
-					(oldSlot == aSlot and: [ aSlot isVirtual not ])
-						ifTrue: [ aSlot copy ]
-						ifFalse: [ aSlot ] ]
-				ifNone: [ aSlot ] ]
-]
-
 { #category : 'initialization' }
 ShLayoutDefinition >> initialize [
 

--- a/src/Shift-ClassBuilder/ShSharedVariablesChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShSharedVariablesChangeDetector.class.st
@@ -17,7 +17,14 @@ ShSharedVariablesChangeDetector >> compareFrom: a to: b [
 { #category : 'initialization' }
 ShSharedVariablesChangeDetector >> initialize [
 	super initialize.
-	builderAccessor := [ :e | e layoutDefinition sharedVariables collect:[ :x | x key -> x class ] as: Array ].
-	classAccessor := [ :e | e classVariables collect: [ :x | x key -> x class ] as: Array ].
+	builderAccessor := [ :e | e sharedVariables collect: [ :x | x key -> x class ] ].
+	classAccessor := [ :e | e classVariables collect: [ :x | x key -> x class ] ].
 	comparer := [ :a :b | self compareFrom: a to: b ]
+	
+	"We should use #compareVariableCollection:with: to compare. To check why the bootstrap fails"
+	
+	"builderAccessor := [ :e | e layoutDefinition sharedVariables ].
+ 	classAccessor := [ :e | e classVariables ].
+ 	comparer := [ :a :b | self compareVariableCollection: a with: b ]"
+	
 ]

--- a/src/Shift-ClassBuilder/ShSlotChangeDetector.class.st
+++ b/src/Shift-ClassBuilder/ShSlotChangeDetector.class.st
@@ -13,7 +13,7 @@ Class {
 ShSlotChangeDetector >> initialize [
 
 	super initialize.
-	builderAccessor := [ :e | e allSlots asArray ].
-	classAccessor := [ :e | e allSlots asArray ].
-	comparer := [ :a :b | self compareSlotCollection: a with: b ]
+	builderAccessor := [ :e | e allSlots ].
+	classAccessor := [ :e | e allSlots ].
+	comparer := [ :a :b | self compareVariables: a with: b ]
 ]

--- a/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
@@ -49,6 +49,7 @@ ShiftClassInstaller class >> make: aBlock [
 
 { #category : 'building' }
 ShiftClassInstaller class >> remake: aClass basedOn: aBuilder [
+	"This sets #markIsInRemake, used by the classBuilder when updating subclasses and Traits users"
 	self new
 		make: [ :anotherBuilder |
 			anotherBuilder fillFor: aClass.

--- a/src/Slot-Tests/SlotErrorsTest.class.st
+++ b/src/Slot-Tests/SlotErrorsTest.class.st
@@ -12,12 +12,6 @@ SlotErrorsTest >> assertInvalidClassName: aName [
 	self should: [
 		self make: [ :builder |
 			builder name: aName ] ]
-		raise: InvalidGlobalName.
-	self flag: 'should remove class if not raised'.
-
-	self should: [
-		Smalltalk classInstaller
-			validateClassName: aName ]
 		raise: InvalidGlobalName
 ]
 
@@ -231,11 +225,4 @@ SlotErrorsTest >> testUndeclareSlotFixWhenSlotIsLoaded [
 	self assert: (mySlot read: instance) equals: nil.
 	mySlot write: 1 to: instance.
 	self assert: (mySlot read: instance) equals: 1
-]
-
-{ #category : 'tests' }
-SlotErrorsTest >> testValidateClassName [
-
-	Smalltalk classInstaller
-		validateClassName: #GoodClassNameThatShouldNotExist
 ]

--- a/src/VariablesLibrary/AbstractInitializedClassVariable.class.st
+++ b/src/VariablesLibrary/AbstractInitializedClassVariable.class.st
@@ -23,8 +23,20 @@ AbstractInitializedClassVariable class >> isAbstract [
 ]
 
 { #category : 'accessing' }
+AbstractInitializedClassVariable >> default [
+	^ default
+]
+
+{ #category : 'accessing' }
 AbstractInitializedClassVariable >> default: anObject [
 	default := anObject
+]
+
+{ #category : 'testing' }
+AbstractInitializedClassVariable >> hasSameDefinitionAs: otherVariable [
+	
+ 	^(super hasSameDefinitionAs: otherVariable) 
+		and: [ default = otherVariable default ]
 ]
 
 { #category : 'printing' }


### PR DESCRIPTION
- remove unused #copy:ifUsedIn:
- extend the concept of #hasSameDefinitionAs: to ClassVariables, but do not use it yet
- some smaller cleanups