### PR TITLE
Make FreeTypeFont reuse instances

### DIFF
--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -34,29 +34,13 @@ FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAb
 	index := aFreeTypeFileInfoAbstract index.
 	^aFreeTypeFileInfoAbstract isEmbedded
 		ifTrue:[
-			self
-				fromBytes: aFreeTypeFileInfoAbstract fileContents
-				pointSize: pointSize
-				index: index]
+			self new
+				setFace: (FreeTypeFace fromBytes: aFreeTypeFileInfoAbstract fileContents index: index) pointSize: pointSize;
+				yourself]
 		ifFalse:[
-			self
-				fromFile: aFreeTypeFileInfoAbstract absolutePath
-				pointSize: pointSize
-				index: index]
-]
-
-{ #category : 'instance creation' }
-FreeTypeFont class >> fromBytes: aByteArray pointSize: anInteger  index: i [
-	^self new
-		setFace: (FreeTypeFace fromBytes: aByteArray index: i) pointSize: anInteger;
-		yourself
-]
-
-{ #category : 'instance creation' }
-FreeTypeFont class >> fromFile: aFileName pointSize: anInteger index: i [
-	^self new
-		setFace: (FreeTypeFace fromFile: aFileName index: i) pointSize: anInteger;
-		yourself
+			self new
+				setFace: (FreeTypeFace fromFile: aFreeTypeFileInfoAbstract absolutePath index: index) pointSize: pointSize;
+				yourself]
 ]
 
 { #category : 'measuring' }

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -47,10 +47,16 @@ FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAb
 	face := aFreeTypeFileInfoAbstract isEmbedded
 		ifTrue: [ FreeTypeFace fromBytes: aFreeTypeFileInfoAbstract fileContents index: index ]
 		ifFalse: [ FreeTypeFace fromFile: aFreeTypeFileInfoAbstract absolutePath index: index ].
-	^ (self all add: self new)
-		setFace: face pointSize: pointSize;
-		simulatedEmphasis: simulatedEmphasis;
-		yourself
+	^ self all
+		detect: [ :font |
+			font face = face and: [
+				font pointSize = pointSize and: [
+					font basicSimulatedEmphasis = simulatedEmphasis ] ] ]
+		ifNone: [
+			(self all add: self new)
+				setFace: face pointSize: pointSize;
+				simulatedEmphasis: simulatedEmphasis;
+				yourself ]
 ]
 
 { #category : 'measuring' }
@@ -69,6 +75,12 @@ FreeTypeFont >> ascent [
 FreeTypeFont >> basicAscent [
 
 	^(self face ascender * self pixelSize // self face unitsPerEm)
+]
+
+{ #category : 'private' }
+FreeTypeFont >> basicSimulatedEmphasis [
+
+	^ simulatedEmphasis
 ]
 
 { #category : 'glyph lookup' }

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -22,27 +22,35 @@ Class {
 		'FT2Constants',
 		'FreeTypeCacheConstants'
 	],
+	#classInstVars : [
+		'all'
+	],
 	#category : 'FreeType-Fonts',
 	#package : 'FreeType',
 	#tag : 'Fonts'
 }
 
+{ #category : 'accessing' }
+FreeTypeFont class >> all [
+
+	^ all ifNil: [
+		all := WeakSet new
+			addAll: self allInstances;
+			yourself ]
+]
+
 { #category : 'instance creation' }
 FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAbstract simulatedEmphasis: simulatedEmphasis [
-	| pointSize index font |
+	| pointSize index face |
 	pointSize := aLogicalFont pointSize.
 	index := aFreeTypeFileInfoAbstract index.
-	font := aFreeTypeFileInfoAbstract isEmbedded
-		ifTrue:[
-			self new
-				setFace: (FreeTypeFace fromBytes: aFreeTypeFileInfoAbstract fileContents index: index) pointSize: pointSize;
-				yourself]
-		ifFalse:[
-			self new
-				setFace: (FreeTypeFace fromFile: aFreeTypeFileInfoAbstract absolutePath index: index) pointSize: pointSize;
-				yourself].
-	font simulatedEmphasis: simulatedEmphasis.
-	^ font
+	face := aFreeTypeFileInfoAbstract isEmbedded
+		ifTrue: [ FreeTypeFace fromBytes: aFreeTypeFileInfoAbstract fileContents index: index ]
+		ifFalse: [ FreeTypeFace fromFile: aFreeTypeFileInfoAbstract absolutePath index: index ].
+	^ (self all add: self new)
+		setFace: face pointSize: pointSize;
+		simulatedEmphasis: simulatedEmphasis;
+		yourself
 ]
 
 { #category : 'measuring' }

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -28,11 +28,11 @@ Class {
 }
 
 { #category : 'instance creation' }
-FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAbstract [
-	| pointSize index |
+FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAbstract simulatedEmphasis: simulatedEmphasis [
+	| pointSize index font |
 	pointSize := aLogicalFont pointSize.
 	index := aFreeTypeFileInfoAbstract index.
-	^aFreeTypeFileInfoAbstract isEmbedded
+	font := aFreeTypeFileInfoAbstract isEmbedded
 		ifTrue:[
 			self new
 				setFace: (FreeTypeFace fromBytes: aFreeTypeFileInfoAbstract fileContents index: index) pointSize: pointSize;
@@ -40,7 +40,9 @@ FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAb
 		ifFalse:[
 			self new
 				setFace: (FreeTypeFace fromFile: aFreeTypeFileInfoAbstract absolutePath index: index) pointSize: pointSize;
-				yourself]
+				yourself].
+	font simulatedEmphasis: simulatedEmphasis.
+	^ font
 ]
 
 { #category : 'measuring' }

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -46,20 +46,10 @@ FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAb
 ]
 
 { #category : 'instance creation' }
-FreeTypeFont class >> fromBytes: aByteArray pointSize: anInteger [
-	^self fromBytes: aByteArray pointSize: anInteger index: 0
-]
-
-{ #category : 'instance creation' }
 FreeTypeFont class >> fromBytes: aByteArray pointSize: anInteger  index: i [
 	^self new
 		setFace: (FreeTypeFace fromBytes: aByteArray index: i) pointSize: anInteger;
 		yourself
-]
-
-{ #category : 'instance creation' }
-FreeTypeFont class >> fromFile: aFileName pointSize: anInteger [
-	^ self fromFile: aFileName pointSize: anInteger index: 0
 ]
 
 { #category : 'instance creation' }

--- a/src/FreeType/FreeTypeFontProvider.class.st
+++ b/src/FreeType/FreeTypeFontProvider.class.st
@@ -180,7 +180,7 @@ FreeTypeFontProvider >> fontFor: aLogicalFont familyName: familyName [
 	FT2Library current isAvailable ifFalse:[^nil].
 	info:= self fontInfoFor: aLogicalFont familyName: familyName.
 	info ifNil:[^nil].
-	answer := FreeTypeFont forLogicalFont: aLogicalFont fileInfo: info.
+	simulatedSqueakEmphasis := nil.
 	needsSimulatedBold := aLogicalFont isBoldOrBolder and:[(info isBolderThan: 500) not].
 	needsSimulatedSlant := aLogicalFont isItalicOrOblique and: [info isItalicOrOblique not].
 	(needsSimulatedBold or:[needsSimulatedSlant])
@@ -193,8 +193,8 @@ FreeTypeFontProvider >> fontFor: aLogicalFont familyName: familyName [
 					simulatedSqueakEmphasis := simulatedSqueakEmphasis + squeakBoldEmphasis].
 			needsSimulatedSlant
 				ifTrue:[
-					simulatedSqueakEmphasis := simulatedSqueakEmphasis + squeakItalicEmphasis].
-			answer simulatedEmphasis: simulatedSqueakEmphasis].
+					simulatedSqueakEmphasis := simulatedSqueakEmphasis + squeakItalicEmphasis]].
+	answer := FreeTypeFont forLogicalFont: aLogicalFont fileInfo: info simulatedEmphasis: simulatedSqueakEmphasis.
 	answer face validate.
 	answer face isValid ifFalse:[^nil].  "we may get this if startup causes text display BEFORE receiver has been updated from the system"
 	^answer


### PR DESCRIPTION
This pull request makes FreeTypeFont reuse instances like FreeTypeFace and LogicalFont do. That allows the FreeTypeCache to be used more efficiently in the following example:

```smalltalk
FreeTypeCache clearCurrent.
2 timesRepeat: [
	(FormCanvas extent: 690@54)
		fillColor: Color white;
		drawString: String loremIpsum from: 1 to: 40 at: 5@0
			font: (LogicalFont familyName: 'Source Sans Pro' pointSize: 30)
			color: Color black.
	Smalltalk garbageCollect ].
(FreeTypeCache current instVarNamed: #fontTable) copy
```

Without the changes of this pull request, the glyphs from the first iteration are not reused in the second iteration: the ‘fontTable’ has two keys. While LogicalFont tries to reuse instances, that does not apply in this example because of the garbage collection. But the corresponding FreeTypeFont does not get collected as it is still in the FreeTypeCache, so it can also be reused when getting the `#realFont` of the new LogicalFont, given that FreeTypeFace already reuses the extant instance. Hence, with the changes of this pull request, the glyphs do get reused: the ‘fontTable’ has only one key.