### PR TITLE
Fix #removeAllForFont: and #removeAllForType: on FreeTypeCache to support different scales

### DIFF
--- a/src/FreeType-Tests/FreeTypeCacheTest.class.st
+++ b/src/FreeType-Tests/FreeTypeCacheTest.class.st
@@ -456,9 +456,11 @@ FreeTypeCacheTest >> testRemoveAllForFont [
 	| fifo |
 	fullCache maximumSize: nil.
 	1 to: 100 do:[:i |
-		fullCache atFont: font1 charCode: i type: 1 scale: 1 put: font1XGlyph].
+		fullCache atFont: font1 charCode: i type: 1 scale: 1 put: font1XGlyph.
+		fullCache atFont: font1 charCode: i type: 1 scale: 2 put: font1XGlyph].
 	1 to: 100 do:[:i |
-		fullCache atFont: font2 charCode: i type: 2 scale: 1 put: font1YGlyph].
+		fullCache atFont: font2 charCode: i type: 2 scale: 1 put: font1YGlyph.
+		fullCache atFont: font2 charCode: i type: 2 scale: 2 put: font1YGlyph].
 	1 to: 100 do:[:i |
 		fullCache atFont: font3 charCode: i type: 3 scale: 1 put: font1ZGlyph].
 	fifo := fullCache instVarNamed: #fifo.
@@ -480,9 +482,11 @@ FreeTypeCacheTest >> testRemoveAllForType [
 	| fifo |
 	fullCache maximumSize: nil.
 	1 to: 100 do:[:i |
-		fullCache atFont: font1 charCode: i type: 1 scale: 1 put: font1XGlyph].
+		fullCache atFont: font1 charCode: i type: 1 scale: 1 put: font1XGlyph.
+		fullCache atFont: font1 charCode: i type: 1 scale: 2 put: font1XGlyph].
 	1 to: 100 do:[:i |
-		fullCache atFont: font2 charCode: i type: 2 scale: 1 put: font1YGlyph].
+		fullCache atFont: font2 charCode: i type: 2 scale: 1 put: font1YGlyph.
+		fullCache atFont: font2 charCode: i type: 2 scale: 2 put: font1YGlyph].
 	1 to: 100 do:[:i |
 		fullCache atFont: font3 charCode: i type: 3 scale: 1 put: font1ZGlyph].
 	fifo := fullCache instVarNamed: #fifo.

--- a/src/FreeType-Tests/FreeTypeFontTest.class.st
+++ b/src/FreeType-Tests/FreeTypeFontTest.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : 'FreeTypeFontTest',
+	#superclass : 'TestCase',
+	#category : 'FreeType-Tests-Fonts',
+	#package : 'FreeType-Tests',
+	#tag : 'Fonts'
+}
+
+{ #category : 'tests' }
+FreeTypeFontTest >> testReleaseCachedState [
+
+	| font glyphBlock glyphFormXScale1 glyphFormYScale1 glyphFormXScale2 |
+
+	font := FreeTypeFont fromBytes: SourceSansProRegular fontContents pointSize: 30.
+	glyphBlock := [ :character :scale |
+		font glyphOf: character colorValue: (Color black pixelValueForDepth: 32)
+			mono: false subpixelPosition: 0 scale: scale ].
+	glyphFormXScale1 := glyphBlock value: $X value: 1.
+	glyphFormYScale1 := glyphBlock value: $Y value: 1.
+	glyphFormXScale2 := glyphBlock value: $X value: 2.
+	self assert: (glyphBlock value: $X value: 1) identicalTo: glyphFormXScale1.
+	self assert: (glyphBlock value: $Y value: 1) identicalTo: glyphFormYScale1.
+	self assert: (glyphBlock value: $X value: 2) identicalTo: glyphFormXScale2.
+	font releaseCachedState.
+	self deny: (glyphBlock value: $X value: 1) identicalTo: glyphFormXScale1.
+	self deny: (glyphBlock value: $Y value: 1) identicalTo: glyphFormYScale1.
+	self deny: (glyphBlock value: $X value: 2) identicalTo: glyphFormXScale2.
+]

--- a/src/FreeType/FreeTypeCache.class.st
+++ b/src/FreeType/FreeTypeCache.class.st
@@ -231,8 +231,8 @@ FreeTypeCache >> removeAllForFont: aFreeTypeFont [
 	toRemove do: [ :entry |
 		| d |
 		fifo remove: entry.
-		d := (fontTable at: entry font) at: entry charCode.
-		d removeKey: entry type.
+		d := ((fontTable at: entry font) at: entry charCode) at: entry type.
+		d removeKey: entry scale.
 		used := used - (self sizeOf: entry object) ]
 ]
 
@@ -246,8 +246,8 @@ FreeTypeCache >> removeAllForType: typeFlag [
 	toRemove do: [ :entry |
 		| d |
 		fifo remove: entry.
-		d := (fontTable at: entry font) at: entry charCode.
-		d removeKey: entry type.
+		d := ((fontTable at: entry font) at: entry charCode) at: entry type.
+		d removeKey: entry scale.
 		used := used - (self sizeOf: entry object) ]
 ]
 


### PR DESCRIPTION
This pull request corrects pull request #14544: `#removeAllForFont:` and `#removeAllForType:` on FreeTypeCache were not adapted to take into account that the ‘type’ no longer maps directly to the ‘entry’ but to an intermediary ‘scaleTable’.

Without the changes of this pull request, the sends of `#removeAllForFont:` and `#removeAllForType:` in the following example each cause an Error to be signaled:

```smalltalk
font := (LogicalFont familyName: 'Source Sans Pro' pointSize: 30) realFont.
colorValue := Color black pixelValueForDepth: 32.
values := {
	[ FreeTypeCache current removeAllForFont: font ].
	[ FreeTypeCache current removeAllForType: (1 << 32) + colorValue ] }
		collect: [ :removeBlock |
			FreeTypeCache clearCurrent.
			1 to: 2 do: [ :scale |
				font glyphOf: $• colorValue: colorValue mono: false subpixelPosition: 0 scale: scale ].
			removeBlock on: Error do: #yourself ].
FreeTypeCache clearCurrent
```