### PR TITLE
Make FreeTypeFont reuse instances

### DIFF
--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -22,10 +22,22 @@ Class {
 		'FT2Constants',
 		'FreeTypeCacheConstants'
 	],
+	#classInstVars : [
+		'all'
+	],
 	#category : 'FreeType-Fonts',
 	#package : 'FreeType',
 	#tag : 'Fonts'
 }
+
+{ #category : 'accessing' }
+FreeTypeFont class >> all [
+
+	^ all ifNil: [
+		all := WeakSet new
+			addAll: self allInstances;
+			yourself ]
+]
 
 { #category : 'instance creation' }
 FreeTypeFont class >> face: freeTypeFace pointSize: pointSize [
@@ -36,7 +48,7 @@ FreeTypeFont class >> face: freeTypeFace pointSize: pointSize [
 { #category : 'instance creation' }
 FreeTypeFont class >> face: freeTypeFace pointSize: pointSize simulatedEmphasis: simulatedEmphasis [
 
-	^ self new
+	^ (self all add: self new)
 		setFace: freeTypeFace pointSize: pointSize;
 		simulatedEmphasis: simulatedEmphasis;
 		yourself

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -48,10 +48,16 @@ FreeTypeFont class >> face: freeTypeFace pointSize: pointSize [
 { #category : 'instance creation' }
 FreeTypeFont class >> face: freeTypeFace pointSize: pointSize simulatedEmphasis: simulatedEmphasis [
 
-	^ (self all add: self new)
-		setFace: freeTypeFace pointSize: pointSize;
-		simulatedEmphasis: simulatedEmphasis;
-		yourself
+	^ self all
+		detect: [ :font |
+			font face = freeTypeFace and: [
+				font pointSize = pointSize and: [
+					font basicSimulatedEmphasis = simulatedEmphasis ] ] ]
+		ifNone: [
+			(self all add: self new)
+				setFace: freeTypeFace pointSize: pointSize;
+				simulatedEmphasis: simulatedEmphasis;
+				yourself ]
 ]
 
 { #category : 'instance creation' }
@@ -103,6 +109,12 @@ FreeTypeFont >> ascent [
 FreeTypeFont >> basicAscent [
 
 	^(self face ascender * self pixelSize // self face unitsPerEm)
+]
+
+{ #category : 'private' }
+FreeTypeFont >> basicSimulatedEmphasis [
+
+	^ simulatedEmphasis
 ]
 
 { #category : 'glyph lookup' }

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -28,6 +28,14 @@ Class {
 }
 
 { #category : 'instance creation' }
+FreeTypeFont class >> face: freeTypeFace pointSize: pointSize [
+
+	^ self new
+		setFace: freeTypeFace pointSize: pointSize;
+		yourself
+]
+
+{ #category : 'instance creation' }
 FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAbstract [
 	| pointSize index |
 	pointSize := aLogicalFont pointSize.
@@ -51,10 +59,9 @@ FreeTypeFont class >> fromBytes: aByteArray pointSize: anInteger [
 ]
 
 { #category : 'instance creation' }
-FreeTypeFont class >> fromBytes: aByteArray pointSize: anInteger  index: i [
-	^self new
-		setFace: (FreeTypeFace fromBytes: aByteArray index: i) pointSize: anInteger;
-		yourself
+FreeTypeFont class >> fromBytes: aByteArray pointSize: anInteger index: i [
+
+	^ self face: (FreeTypeFace fromBytes: aByteArray index: i) pointSize: anInteger
 ]
 
 { #category : 'instance creation' }
@@ -64,9 +71,8 @@ FreeTypeFont class >> fromFile: aFileName pointSize: anInteger [
 
 { #category : 'instance creation' }
 FreeTypeFont class >> fromFile: aFileName pointSize: anInteger index: i [
-	^self new
-		setFace: (FreeTypeFace fromFile: aFileName index: i) pointSize: anInteger;
-		yourself
+
+	^ self face: (FreeTypeFace fromFile: aFileName index: i) pointSize: anInteger
 ]
 
 { #category : 'measuring' }

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -30,20 +30,27 @@ Class {
 { #category : 'instance creation' }
 FreeTypeFont class >> face: freeTypeFace pointSize: pointSize [
 
+	^ self face: freeTypeFace pointSize: pointSize simulatedEmphasis: nil
+]
+
+{ #category : 'instance creation' }
+FreeTypeFont class >> face: freeTypeFace pointSize: pointSize simulatedEmphasis: simulatedEmphasis [
+
 	^ self new
 		setFace: freeTypeFace pointSize: pointSize;
+		simulatedEmphasis: simulatedEmphasis;
 		yourself
 ]
 
 { #category : 'instance creation' }
-FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAbstract [
+FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAbstract simulatedEmphasis: simulatedEmphasis [
 	| pointSize index face |
 	pointSize := aLogicalFont pointSize.
 	index := aFreeTypeFileInfoAbstract index.
 	face := aFreeTypeFileInfoAbstract isEmbedded
 		ifTrue: [ FreeTypeFace fromBytes: aFreeTypeFileInfoAbstract fileContents index: index ]
 		ifFalse: [ FreeTypeFace fromFile: aFreeTypeFileInfoAbstract absolutePath index: index ].
-	^ self face: face pointSize: pointSize
+	^ self face: face pointSize: pointSize simulatedEmphasis: simulatedEmphasis
 ]
 
 { #category : 'instance creation' }

--- a/src/FreeType/FreeTypeFont.class.st
+++ b/src/FreeType/FreeTypeFont.class.st
@@ -37,20 +37,13 @@ FreeTypeFont class >> face: freeTypeFace pointSize: pointSize [
 
 { #category : 'instance creation' }
 FreeTypeFont class >> forLogicalFont: aLogicalFont fileInfo: aFreeTypeFileInfoAbstract [
-	| pointSize index |
+	| pointSize index face |
 	pointSize := aLogicalFont pointSize.
 	index := aFreeTypeFileInfoAbstract index.
-	^aFreeTypeFileInfoAbstract isEmbedded
-		ifTrue:[
-			self
-				fromBytes: aFreeTypeFileInfoAbstract fileContents
-				pointSize: pointSize
-				index: index]
-		ifFalse:[
-			self
-				fromFile: aFreeTypeFileInfoAbstract absolutePath
-				pointSize: pointSize
-				index: index]
+	face := aFreeTypeFileInfoAbstract isEmbedded
+		ifTrue: [ FreeTypeFace fromBytes: aFreeTypeFileInfoAbstract fileContents index: index ]
+		ifFalse: [ FreeTypeFace fromFile: aFreeTypeFileInfoAbstract absolutePath index: index ].
+	^ self face: face pointSize: pointSize
 ]
 
 { #category : 'instance creation' }

--- a/src/FreeType/FreeTypeFontProvider.class.st
+++ b/src/FreeType/FreeTypeFontProvider.class.st
@@ -180,7 +180,7 @@ FreeTypeFontProvider >> fontFor: aLogicalFont familyName: familyName [
 	FT2Library current isAvailable ifFalse:[^nil].
 	info:= self fontInfoFor: aLogicalFont familyName: familyName.
 	info ifNil:[^nil].
-	answer := FreeTypeFont forLogicalFont: aLogicalFont fileInfo: info.
+	simulatedSqueakEmphasis := nil.
 	needsSimulatedBold := aLogicalFont isBoldOrBolder and:[(info isBolderThan: 500) not].
 	needsSimulatedSlant := aLogicalFont isItalicOrOblique and: [info isItalicOrOblique not].
 	(needsSimulatedBold or:[needsSimulatedSlant])
@@ -193,8 +193,8 @@ FreeTypeFontProvider >> fontFor: aLogicalFont familyName: familyName [
 					simulatedSqueakEmphasis := simulatedSqueakEmphasis + squeakBoldEmphasis].
 			needsSimulatedSlant
 				ifTrue:[
-					simulatedSqueakEmphasis := simulatedSqueakEmphasis + squeakItalicEmphasis].
-			answer simulatedEmphasis: simulatedSqueakEmphasis].
+					simulatedSqueakEmphasis := simulatedSqueakEmphasis + squeakItalicEmphasis]].
+	answer := FreeTypeFont forLogicalFont: aLogicalFont fileInfo: info simulatedEmphasis: simulatedSqueakEmphasis.
 	answer face validate.
 	answer face isValid ifFalse:[^nil].  "we may get this if startup causes text display BEFORE receiver has been updated from the system"
 	^answer


### PR DESCRIPTION
This pull request makes FreeTypeFont reuse instances like FreeTypeFace and LogicalFont do. That allows the FreeTypeCache to be used more efficiently in the following example:

```smalltalk
FreeTypeCache clearCurrent.
2 timesRepeat: [
	(FormCanvas extent: 690@54)
		fillColor: Color white;
		drawString: String loremIpsum from: 1 to: 40 at: 5@0
			font: (LogicalFont familyName: 'Source Sans Pro' pointSize: 30)
			color: Color black.
	Smalltalk garbageCollect ].
(FreeTypeCache current instVarNamed: #fontTable) copy
```

Without the changes of this pull request, the glyphs from the first iteration are not reused in the second iteration: the ‘fontTable’ has two keys. While LogicalFont tries to reuse instances, that does not apply in this example because of the garbage collection. But the corresponding FreeTypeFont does not get collected as it is still in the FreeTypeCache, so it can also be reused when getting the `#realFont` of the new LogicalFont, given that FreeTypeFace already reuses the extant instance. Hence, with the changes of this pull request, the glyphs do get reused: the ‘fontTable’ has only one key.

This pull request is a remake of pull request #15751 without the removal of the methods used in the documentation.