### PR TITLE
15449 debug session must not refer to UI manager

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -272,8 +272,8 @@ BaselineOfIDE >> postload: loader package: packageSpec [
 	Smalltalk tools register: ProcessBrowser as: #processBrowser.
 	Smalltalk tools register: TimeProfiler as: #timeProfiler.
 
-	(MorphicCoreUIManager readClassVariableNamed: #UIProcess) ifNotNil: [ :proc | proc terminate ].
-	MorphicCoreUIManager writeClassVariableNamed: #UIProcess   value: nil.
+	(Process readClassVariableNamed: #UIProcess) ifNotNil: [ :proc | proc terminate ].
+	Process writeClassVariableNamed: #UIProcess   value: nil.
 
 	PolymorphSystemSettings desktopColor: Color veryVeryLightGray lighter.
 	SourceCodeFonts setSourceCodeFonts: 10.

--- a/src/Debugger-Model-Tests/ErrorWasInUIProcessTest.class.st
+++ b/src/Debugger-Model-Tests/ErrorWasInUIProcessTest.class.st
@@ -21,6 +21,6 @@ ErrorWasInUIProcessTest >> testErrorWasInUIProcessIsTrueWhenDebugSessionWasCreat
 	SmalltalkImage current isHeadless ifFalse: [ ^ true ].
 	context := [ 1+1] asContext.
 	"Instead of creating a new process like the other debugger tests, we ask the default ui process to create the DebugSession"
-	session := UIManager default uiProcess newDebugSessionNamed: 'test session' startedAt: context.
+	session := Process uiProcess newDebugSessionNamed: 'test session' startedAt: context.
 	self assert: (session errorWasInUIProcess)
 ]

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -374,11 +374,10 @@ DebugSession >> resume: aValue [
 DebugSession >> resumeProcess [
 	"Make sure the interrupted process is restored properly and restart the low space handler"
 
-	interruptedProcess isTerminated
-		ifFalse: [
-			errorWasInUIProcess
-				ifTrue: [ UIManager default resumeUIProcess: interruptedProcess ]
-				ifFalse: [ interruptedProcess resume ]].
+	interruptedProcess isTerminated ifFalse: [
+		errorWasInUIProcess
+			ifTrue: [ Process resumeUIProcess: interruptedProcess ]
+			ifFalse: [ interruptedProcess resume ] ].
 
 	"restart low space handler"
 	Smalltalk installLowSpaceWatcher

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -108,7 +108,7 @@ DebugSession >> createModelForContext: aContext [
 { #category : 'initialization' }
 DebugSession >> detectUIProcess [
 
-	errorWasInUIProcess := UIManager default uiProcess == interruptedProcess
+	errorWasInUIProcess := Process uiProcess == interruptedProcess
 ]
 
 { #category : 'accessing' }

--- a/src/Debugger-Oups-Tests/OupsDebuggerSystemTest.class.st
+++ b/src/Debugger-Oups-Tests/OupsDebuggerSystemTest.class.st
@@ -32,7 +32,7 @@ OupsDebuggerSystemTest >> createDummyDebugRequestForUIProcess [
 		on: Exception
 		do: [ :e | exception := e ].
 	^ (OupsDummyDebugRequest newForException: exception)
-		  process: UIManager default uiProcess;
+		  process: Process uiProcess;
 		  yourself
 ]
 

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -112,6 +112,14 @@ Process class >> resumeUIProcess: aProcess [
 ]
 
 { #category : 'ui process' }
+Process class >> spawnNewUIProcess: aProcess named: aString [
+
+	UIProcess := aProcess.
+	UIProcess name: aString.
+	UIProcess resume
+]
+
+{ #category : 'ui process' }
 Process class >> terminateUIProcess [
 
 	UIProcess

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -34,7 +34,8 @@ Class {
 	#classVars : [
 		'InheritablePSKeys',
 		'PSKeys',
-		'PSKeysSema'
+		'PSKeysSema',
+		'UIProcess'
 	],
 	#category : 'Kernel-Processes',
 	#package : 'Kernel',
@@ -99,6 +100,34 @@ Process class >> psKeysSema [
 	"Isolate handling of class variable"
 
 	^PSKeysSema ifNil: [ PSKeysSema := Semaphore forMutualExclusion ]
+]
+
+{ #category : 'ui process' }
+Process class >> resumeUIProcess: aProcess [
+	"Adopt aProcess as the project process.
+	The only case in the tools is when a debug session resumes a process"
+
+	UIProcess := aProcess.
+	UIProcess resume
+]
+
+{ #category : 'ui process' }
+Process class >> terminateUIProcess [
+
+	UIProcess
+		suspend;
+		terminate.
+	UIProcess := nil
+]
+
+{ #category : 'ui process' }
+Process class >> uiProcess [
+	^UIProcess
+]
+
+{ #category : 'ui process' }
+Process class >> uiProcess: aProcess [
+	UIProcess := aProcess
 ]
 
 { #category : 'process specific' }

--- a/src/Morphic-Core/MorphicCoreUIManager.class.st
+++ b/src/Morphic-Core/MorphicCoreUIManager.class.st
@@ -11,11 +11,12 @@ Class {
 
 { #category : 'cleanup' }
 MorphicCoreUIManager class >> restartMethods [
-   UIProcess ifNotNil: [
-	| process |
-	process := UIProcess.
-	self new spawnNewProcess.
-	process terminate. ]
+
+	Process uiProcess ifNotNil: [
+		| process |
+		process := Process uiProcess.
+		self new spawnNewProcess.
+		process terminate ]
 ]
 
 { #category : 'ui requests' }

--- a/src/Morphic-Core/MorphicCoreUIManager.class.st
+++ b/src/Morphic-Core/MorphicCoreUIManager.class.st
@@ -56,14 +56,6 @@ MorphicCoreUIManager >> restoreDisplayAfter: aBlock [
 ]
 
 { #category : 'ui process' }
-MorphicCoreUIManager >> resumeUIProcess: aProcess [
-  "Adopt aProcess as the project process -- probably because of proceeding from a debugger"
-
-  UIProcess := aProcess.
-  UIProcess resume
-]
-
-{ #category : 'ui process' }
 MorphicCoreUIManager >> spawnNewProcess [
 
   UIProcess := [

--- a/src/Morphic-Core/MorphicCoreUIManager.class.st
+++ b/src/Morphic-Core/MorphicCoreUIManager.class.st
@@ -4,9 +4,6 @@ This is a very simplified version of MorphicUIManager for Moprhic subset that co
 Class {
 	#name : 'MorphicCoreUIManager',
 	#superclass : 'DummyUIManager',
-	#classVars : [
-		'UIProcess'
-	],
 	#category : 'Morphic-Core-Support',
 	#package : 'Morphic-Core',
 	#tag : 'Support'
@@ -58,17 +55,17 @@ MorphicCoreUIManager >> restoreDisplayAfter: aBlock [
 { #category : 'ui process' }
 MorphicCoreUIManager >> spawnNewProcess [
 
-  UIProcess := [
-	MorphicRenderLoop new doOneCycleWhile: [ true ]
-  ] newProcess priority: Processor userSchedulingPriority.
-  UIProcess name: 'Morphic UI Process'.
-  UIProcess resume
+	Process
+		spawnNewUIProcess:
+			([ MorphicRenderLoop new doOneCycleWhile: [ true ] ] newProcess
+				 priority: Processor userSchedulingPriority)
+		named: 'Morphic UI Process'
 ]
 
 { #category : 'ui process' }
 MorphicCoreUIManager >> terminateUIProcess [
-  UIProcess suspend; terminate.
-  UIProcess := nil "?"
+
+	Process terminateUIProcess
 ]
 
 { #category : 'ui process' }
@@ -76,5 +73,5 @@ MorphicCoreUIManager >> uiProcess [
   " Answer the currently active UI process for morphic world.
   Client should check explicitly if #uiProcess answers nil or not (see other implementations)"
 
-  ^ UIProcess
+  ^ Process uiProcess
 ]

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -36,17 +36,18 @@ MorphicUIManager class >> isValidForCurrentSystemConfiguration [
 
 { #category : 'cleanup' }
 MorphicUIManager class >> restartMethods [
-   UIProcess ifNotNil: [
-	| process |
-	process := UIProcess.
-	self new spawnNewProcess.
-	process terminate. ]
+
+	Process uiProcess ifNotNil: [
+		| process |
+		process := Process uiProcess.
+		self new spawnNewProcess.
+		process terminate ]
 ]
 
 { #category : 'ui process' }
 MorphicUIManager class >> uiProcess [
 
-	^ UIProcess
+	^ Process uiProcess
 ]
 
 { #category : 'private' }
@@ -618,14 +619,6 @@ MorphicUIManager >> restoreDisplayAfter: aBlock [
 	self currentWorld fullRepaintNeeded
 ]
 
-{ #category : 'ui process' }
-MorphicUIManager >> resumeUIProcess: aProcess [
-	"Adopt aProcess as the project process -- probably because of proceeding from a debugger"
-
-	UIProcess := aProcess.
-	UIProcess resume
-]
-
 { #category : 'display' }
 MorphicUIManager >> showWaitCursorWhile: aBlock [
 	Cursor wait showWhile: aBlock
@@ -634,9 +627,10 @@ MorphicUIManager >> showWaitCursorWhile: aBlock [
 { #category : 'ui process' }
 MorphicUIManager >> spawnNewProcess [
 
-	UIProcess := [ MorphicRenderLoop new doOneCycleWhile: [ true ] ] newProcess priority:
-		             Processor userSchedulingPriority.
-	UIProcess
+	Process uiProcess:
+		([ MorphicRenderLoop new doOneCycleWhile: [ true ] ] newProcess
+			 priority: Processor userSchedulingPriority).
+	Process uiProcess
 		name: 'Morphic UI Process';
 		resume
 ]
@@ -650,8 +644,8 @@ MorphicUIManager >> systemNotificationDefaultAction: aNotification [
 
 { #category : 'ui process' }
 MorphicUIManager >> terminateUIProcess [
-	UIProcess suspend; terminate.
-	UIProcess := nil "?"
+
+	Process terminateUIProcess
 ]
 
 { #category : 'accessing' }
@@ -664,7 +658,7 @@ MorphicUIManager >> uiProcess [
 	" Answer the currently active UI process for morphic world.
 	Client should check explicitly if #uiProcess answers nil or not (see other implementations)"
 
-	^ UIProcess
+	^ Process uiProcess
 ]
 
 { #category : 'ui requests' }

--- a/src/Polymorph-Widgets/MorphicUIManager.class.st
+++ b/src/Polymorph-Widgets/MorphicUIManager.class.st
@@ -11,9 +11,6 @@ Class {
 	#instVars : [
 		'activeTranscript'
 	],
-	#classVars : [
-		'UIProcess'
-	],
 	#category : 'Polymorph-Widgets-Themes',
 	#package : 'Polymorph-Widgets',
 	#tag : 'Themes'
@@ -627,12 +624,11 @@ MorphicUIManager >> showWaitCursorWhile: aBlock [
 { #category : 'ui process' }
 MorphicUIManager >> spawnNewProcess [
 
-	Process uiProcess:
-		([ MorphicRenderLoop new doOneCycleWhile: [ true ] ] newProcess
-			 priority: Processor userSchedulingPriority).
-	Process uiProcess
-		name: 'Morphic UI Process';
-		resume
+	Process
+		spawnNewUIProcess:
+			([ MorphicRenderLoop new doOneCycleWhile: [ true ] ] newProcess
+				 priority: Processor userSchedulingPriority)
+		named: 'Morphic UI Process'
 ]
 
 { #category : 'ui requests' }
@@ -658,7 +654,7 @@ MorphicUIManager >> uiProcess [
 	" Answer the currently active UI process for morphic world.
 	Client should check explicitly if #uiProcess answers nil or not (see other implementations)"
 
-	^ Process uiProcess
+	^ self class uiProcess
 ]
 
 { #category : 'ui requests' }


### PR DESCRIPTION
Attempt to fix #15449 

It removes the two UIProcess globals that existed in two distinct Morphic classes, and moves it in Process.
A new api is proposed in Process to access that global instead of direct access by Morphic.