### PR TITLE
15758-duplicateClassWithNewName-leads-to-wrong-packageTag

### DIFF
--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -582,8 +582,6 @@ Class >> duplicateClassWithNewName: aSymbol [
 		         builder
 			         fillFor: self;
 			         name: copysName ].
-	class copyAllMethodsFrom: self.
-	class class copyAllMethodsFrom: self class.
 	^ class
 ]
 

--- a/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
@@ -283,6 +283,23 @@ ShClassInstallerTest >> testDuplicateClassPreserveMethods [
 ]
 
 { #category : 'tests' }
+ShClassInstallerTest >> testDuplicateClassPreservePackage [
+
+	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable}.
+	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
+
+	self assert: newClass2 packageTag name equals: newClass packageTag name.
+	"pacakge knows the new class"
+	self assert: (newClass2 packageTag includesClass: newClass2).
+	self assert: (newClass2 packageTag classes identityIncludes: newClass2).
+	"and still the original"
+	self assert: (newClass packageTag includesClass: newClass).
+	self assert: (newClass packageTag classes identityIncludes: newClass).
+	"packageTag is identity"
+	self assert: newClass packageTag identicalTo: newClass2 packageTag
+]
+
+{ #category : 'tests' }
 ShClassInstallerTest >> testDuplicateClassPreserveSharedVariables [
 
 	newClass := ShiftClassInstaller make: [ :builder |

--- a/src/Shift-ClassBuilder/ShiftAnonymousClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftAnonymousClassInstaller.class.st
@@ -30,5 +30,5 @@ ShiftAnonymousClassInstaller >> notifyChanges [
 ]
 
 { #category : 'notifications' }
-ShiftAnonymousClassInstaller >> recategorize: newClass [
+ShiftAnonymousClassInstaller >> updatePackage: newClass [
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -119,7 +119,6 @@ ShiftClassBuilder >> build [
 	self createClass.
 
 	self oldClass ifNotNil: [
-		self newClass basicTag: self oldClass packageTag.
 		self copyProtocols.
 		self newClass commentSourcePointer: self oldClass commentSourcePointer ].
 

--- a/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
@@ -192,7 +192,7 @@ ShiftClassInstaller >> make [
 		newClass := self oldClass.
 	].
 
-	self recategorize: newClass.
+	self updatePackage: newClass.
 	self comment: newClass.
 
 	self notifyChanges.
@@ -290,13 +290,13 @@ ShiftClassInstaller >> oldClass: anObject [
 	builder oldClass: anObject
 ]
 
-{ #category : 'notifications' }
-ShiftClassInstaller >> recategorize: aClass [
-	"If the package is nil we leave the class unclassified"
-	builder package ifNotNil: [ :package | aClass package: package tag: builder tag ]
-]
-
 { #category : 'building' }
 ShiftClassInstaller >> updateBindings: aBinding of: newClass [
 	newClass methods do: [ :e | e classBinding: aBinding ]
+]
+
+{ #category : 'notifications' }
+ShiftClassInstaller >> updatePackage: aClass [
+	"If the package is nil we leave the class unclassified"
+	builder package ifNotNil: [ :package | aClass package: package tag: builder tag ]
 ]


### PR DESCRIPTION
- add testDuplicateClassPreservePackage
- rename #recategorize: to #updatePackage: in the ClassInstaller
- #duplicateClassWithNewName: does not need to copy methods, this is done by the classbuilder

fixes #15758