### PR TITLE
Cleanup:  setSourcePointer: vs sourcePointer

### DIFF
--- a/src/Kernel-CodeModel/CompiledMethod.class.st
+++ b/src/Kernel-CodeModel/CompiledMethod.class.st
@@ -884,8 +884,6 @@ CompiledMethod >> selector: aSelector [
 CompiledMethod >> setSourcePointer: srcPointer [
 
 	| trailerBytes trailerSize start |
-	"Drop the #source property if any"
-	self removeProperty: #source.
 	trailerSize := self class trailerSize.
 	trailerBytes := srcPointer asByteArrayOfSize: trailerSize.
 	start := self size - trailerSize.

--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -141,12 +141,12 @@ TaAbstractComposition >> compile: selector into: aClass [
 		             source: sourceCode;
 		             permitUndeclared: true;
 		             compile.
-	newMethod sourcePointer: method sourcePointer.
+		
 	selector == newMethod selector ifFalse: [ self error: 'selector changed!' ].
 
 	(selector ~= method selector or: [ self changesSourceCode: selector ])
 		ifTrue: [ self saveSourceCode: sourceCode ofMethod: newMethod ]
-		ifFalse: [ newMethod setSourcePointer: method sourcePointer ].
+		ifFalse: [ newMethod sourcePointer: method sourcePointer ].
 
 	aClass classify: selector under: (self protocolForMethod: method).
 
@@ -203,7 +203,7 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 	newMethod selector: aSelector.
 	newMethod methodClass: aClass.
 
-	newMethod setSourcePointer: aCompiledMethod sourcePointer.
+	newMethod sourcePointer: aCompiledMethod sourcePointer.
 
 	"This step should not announce anything in the system."
 	SystemAnnouncer uniqueInstance suspendAllWhile: [ aClass classify: aSelector under: aCompiledMethod protocolName ].


### PR DESCRIPTION
- setSourcePointer: should not remove the property #source (low level version for Condenser and clearSourcePointer:

- fix users
- remove double sourcePointer setting in TaAbstractComposition>>#compile:into: