### PR TITLE
Ring: Use Fluid syntax for definition string

### DIFF
--- a/src/Ring-Core-Tests/RGClassStrategyTest.class.st
+++ b/src/Ring-Core-Tests/RGClassStrategyTest.class.st
@@ -61,7 +61,7 @@ RGClassStrategyTest >> testDefinition [
 	aClass := RGClass named: #SomeClass.
 	aClass superclass name: #Object.
 
-	self assert: (aClass definition beginsWith: 'Object subclass: #SomeClass')
+	self assert: (aClass definition beginsWith: 'Object << #SomeClass')
 ]
 
 { #category : 'tests' }
@@ -76,7 +76,7 @@ RGClassStrategyTest >> testDefinitionWithSlots [
 	expression := 'ToManyRelationSlot inverse: #director inClass: #SlotExampleMovie'.
 	slot expression: expression.
 
-	self assert: (aClass definition beginsWith: 'Object subclass: #SomeClass').
+	self assert: (aClass definition beginsWith: 'Object << #SomeClass').
 	self assert: (aClass definition includesSubstring: ('#iVar => ', expression))
 ]
 

--- a/src/Ring-Core-Tests/RGClassTest.class.st
+++ b/src/Ring-Core-Tests/RGClassTest.class.st
@@ -111,6 +111,7 @@ RGClassTest >> testCopyForBehaviorDefinitionForClass [
 
 { #category : 'tests' }
 RGClassTest >> testDefinition [
+
 	| env aClass |
 	env := RGEnvironment new.
 
@@ -119,13 +120,10 @@ RGClassTest >> testDefinition [
 	aClass package: (env ensurePackageNamed: 'Kernel-Objects').
 	aClass addClassVariable: (RGClassVariable named: #DependentsFields parent: aClass).
 
-	self
-		assert: aClass definition
-		equals:
-			'ProtoObject subclass: #Object
-	instanceVariableNames: ''''
-	classVariableNames: ''DependentsFields''
-	package: ''Kernel-Objects'''
+	self assert: aClass definition equals: 'ProtoObject << #Object
+	slots: {  };
+	sharedVariables: { #DependentsFields };
+	package: #''Kernel-Objects'''
 ]
 
 { #category : 'tests' }

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -1014,6 +1014,25 @@ RGBehavior >> selectors [
 ]
 
 { #category : 'accessing - definition' }
+RGBehavior >> sharedPoolsDefinitionString [
+	"Answer a string of my class variable names separated by spaces."
+
+	^ String streamContents: [ :str |
+		  str nextPutAll: '{ '.
+		  self sharedPools
+			  do: [ :pool |
+				  str
+					  nextPut: $#;
+					  nextPutAll: pool name ]
+			  separatedBy: [
+				  str
+					  space;
+					  nextPut: $.;
+					  space ].
+		  str nextPutAll: '}' ]
+]
+
+{ #category : 'accessing - definition' }
 RGBehavior >> sharedPoolsString [
 	"Answer a string of my class variable names separated by spaces."
 

--- a/src/Ring-Core/RGClassStrategy.class.st
+++ b/src/Ring-Core/RGClassStrategy.class.st
@@ -211,58 +211,53 @@ RGClassStrategy >> defaultSharedPools [
 { #category : 'testing' }
 RGClassStrategy >> definition [
 
-	| aStream poolString |
+	^ String streamContents: [ :aStream |
+		  owner superclass
+			  ifNil: [ aStream nextPutAll: 'nil' ]
+			  ifNotNil: [ aStream nextPutAll: self owner superclass name ].
+		  aStream
+			  nextPutAll: ' << #';
+			  nextPutAll: self owner name.
 
-	self owner slotsNeedFullDefinition
-		ifTrue: [ ^ self definitionWithSlots ].
+		  self layout isFixedLayout ifFalse: [
+			  aStream
+				  crtab;
+				  nextPutAll: 'layout: ';
+				  nextPutAll: self layout layoutName;
+				  nextPutAll: ';' ].
 
-	poolString := self owner sharedPoolsString.
-	aStream := (String new: 800) writeStream.
-	owner superclass
-		ifNil: [ aStream nextPutAll: 'ProtoObject' ]
-		ifNotNil: [ aStream nextPutAll: self owner superclass name ].
-	aStream
-		nextPutAll: self kindOfSubclass;
-		store: self owner name.
-	self owner hasTraitComposition
-		ifTrue:
-			[ aStream
-				cr;
-				tab;
-				nextPutAll: 'uses: ';
-				nextPutAll: self owner traitCompositionString ].
-	aStream
-		cr;
-		tab;
-		nextPutAll: 'instanceVariableNames: ';
-		store: self owner instanceVariablesString.
-	aStream
-		cr;
-		tab;
-		nextPutAll: 'classVariableNames: ';
-		store: self owner classVariablesString.
-	poolString = ''
-		ifFalse:
-			[ aStream
-				cr;
-				tab;
-				nextPutAll: 'poolDictionaries: ';
-				store: poolString ].
-	aStream
-		cr;
-		tab;
-		nextPutAll: 'package: ';
-		store: self owner category asString.
-	owner superclass
-		ifNil:
-			[ aStream
-				nextPutAll: '.';
-				cr.
-			aStream nextPutAll: self owner name.
-			aStream
-				space;
-				nextPutAll: 'superclass: nil' ].
-	^ aStream contents
+		  self owner hasTraitComposition ifTrue: [
+			  aStream
+				  crtab;
+				  nextPutAll: 'traits: ';
+				  nextPutAll: self owner traitCompositionString;
+				  nextPut: $; ].
+		  aStream
+			  crtab;
+			  nextPutAll: 'slots: ';
+			  nextPutAll: self owner slotDefinitionString;
+			  nextPut: $;.
+		  aStream
+			  crtab;
+			  nextPutAll: 'sharedVariables: ';
+			  nextPutAll: self owner classVariableDefinitionString;
+			  nextPut: $;.
+		  self owner sharedPools ifNotEmpty: [
+			  aStream
+				  crtab;
+				  nextPutAll: 'sharedPools: ';
+				  nextPutAll: self owner sharedPoolsDefinitionString;
+			  nextPut: $;. ].
+		  self owner packageTag ifNotNil: [ :tag |
+			  aStream
+				  crtab;
+				  nextPutAll: 'tags: ';
+				  nextPutAll: tag;
+				  nextPut: $; ].
+		  aStream
+			  crtab;
+			  nextPutAll: 'package: ';
+			  print: self owner package name ]
 ]
 
 { #category : 'fileout' }
@@ -280,44 +275,6 @@ RGClassStrategy >> definitionStringFor: aRGPackage [
 		classDefinitionNamed: self owner name
 		ifAbsent: [ self error: 'No class definition found for the recever' ])
 			definitionString
-]
-
-{ #category : 'testing' }
-RGClassStrategy >> definitionWithSlots [
-
-	| aStream poolString|
-
-	poolString := self owner sharedPoolsString.
-
-	aStream := (String new: 800) writeStream.
-	self owner superclass
-		ifNil: [aStream nextPutAll: 'ProtoObject']
-		ifNotNil: [aStream nextPutAll: self owner superclass name].
-	aStream nextPutAll: ' subclass: ';
-			store: self owner name.
-	(self owner hasTraitComposition) ifTrue: [
-		aStream cr; tab; nextPutAll: 'uses: ';
-			nextPutAll: self owner traitCompositionString].
-
-	(self layout layoutName = #FixedLayout) ifFalse: [
-		aStream cr; tab; nextPutAll: 'layout: ';
-			nextPutAll: self layout layoutName].
-	aStream cr; tab; nextPutAll: 'slots: ';
-			nextPutAll: self owner slotDefinitionString.
-	aStream cr; tab; nextPutAll: 'classVariables: ';
-			nextPutAll: self owner classVariableDefinitionString.
-	poolString = '' ifFalse: [
-		aStream cr; tab; nextPutAll: 'poolDictionaries: ';
-			store: poolString].
-	aStream cr; tab; nextPutAll: 'package: ';
-			store: self category asString.
-
-	self owner superclass ifNil: [
-		aStream nextPutAll: '.'; cr.
-		aStream nextPutAll: self owner name.
-		aStream space; nextPutAll: 'superclass: nil'. ].
-
-	^ aStream contents
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
In Ring the method #definition returns an old syntax definition string. I propose here to print a fluid syntax instead. 

I think there is more work needed to manage the traits but that'll be later.  I detected that in Moose because it uses ring definitions