### PR TITLE
Repackage layout definitions symbols

### DIFF
--- a/src/ClassDefinitionPrinters/Behavior.extension.st
+++ b/src/ClassDefinitionPrinters/Behavior.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'Behavior' }
+
+{ #category : '*ClassDefinitionPrinters' }
+Behavior >> kindOfSubclass [
+	"Answer a String that is the keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
+	<reflection: 'Class structural inspection - Iterating and querying hierarchy'>
+	^ self classLayout kindOfSubclass
+]

--- a/src/ClassDefinitionPrinters/ByteLayout.extension.st
+++ b/src/ClassDefinitionPrinters/ByteLayout.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'ByteLayout' }
+
+{ #category : '*ClassDefinitionPrinters' }
+ByteLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	^#variableByteSubclass:
+]

--- a/src/ClassDefinitionPrinters/CompiledMethodLayout.extension.st
+++ b/src/ClassDefinitionPrinters/CompiledMethodLayout.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'CompiledMethodLayout' }
+
+{ #category : '*ClassDefinitionPrinters' }
+CompiledMethodLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	"there is no way to define classes of this Layput, the system shows them as variable classes"
+	^#variableByteSubclass:
+]

--- a/src/ClassDefinitionPrinters/DoubleByteLayout.extension.st
+++ b/src/ClassDefinitionPrinters/DoubleByteLayout.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'DoubleByteLayout' }
+
+{ #category : '*ClassDefinitionPrinters' }
+DoubleByteLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	^#variableDoubleByteSubclass:
+]

--- a/src/ClassDefinitionPrinters/DoubleWordLayout.extension.st
+++ b/src/ClassDefinitionPrinters/DoubleWordLayout.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'DoubleWordLayout' }
+
+{ #category : '*ClassDefinitionPrinters' }
+DoubleWordLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	^#variableDoubleWordSubclass:
+]

--- a/src/ClassDefinitionPrinters/EphemeronLayout.extension.st
+++ b/src/ClassDefinitionPrinters/EphemeronLayout.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'EphemeronLayout' }
+
+{ #category : '*ClassDefinitionPrinters' }
+EphemeronLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	^#ephemeronSubclass:
+]

--- a/src/ClassDefinitionPrinters/ImmediateLayout.extension.st
+++ b/src/ClassDefinitionPrinters/ImmediateLayout.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'ImmediateLayout' }
+
+{ #category : '*ClassDefinitionPrinters' }
+ImmediateLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	^#immediateSubclass:
+]

--- a/src/ClassDefinitionPrinters/ObjectLayout.extension.st
+++ b/src/ClassDefinitionPrinters/ObjectLayout.extension.st
@@ -1,0 +1,27 @@
+Extension { #name : 'ObjectLayout' }
+
+{ #category : '*ClassDefinitionPrinters' }
+ObjectLayout >> kindOfSubclass [
+	"Answer a String that is the keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
+	^' ',self class subclassDefiningSymbol, ' '
+]
+
+{ #category : '*ClassDefinitionPrinters' }
+ObjectLayout >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else as CompiledMethodLayout answers the same as ByteLayout and user defined Layouts are not
+	supported"
+	^self class subclassDefiningSymbol
+]
+
+{ #category : '*ClassDefinitionPrinters' }
+ObjectLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	"As a fallback we just return a standard class creation symbol. This will be called for user
+	defined Layouts, for old style class definitions that can not support user defined Layouts"
+	^#subclass:
+]

--- a/src/ClassDefinitionPrinters/VariableLayout.extension.st
+++ b/src/ClassDefinitionPrinters/VariableLayout.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'VariableLayout' }
+
+{ #category : '*ClassDefinitionPrinters' }
+VariableLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	^#variableSubclass:
+]

--- a/src/ClassDefinitionPrinters/WeakLayout.extension.st
+++ b/src/ClassDefinitionPrinters/WeakLayout.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'WeakLayout' }
+
+{ #category : '*ClassDefinitionPrinters' }
+WeakLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	^#weakSubclass:
+]

--- a/src/ClassDefinitionPrinters/WordLayout.extension.st
+++ b/src/ClassDefinitionPrinters/WordLayout.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'WordLayout' }
+
+{ #category : '*ClassDefinitionPrinters' }
+WordLayout class >> subclassDefiningSymbol [
+	"Answer a keyword that describes the receiver's kind of subclass
+	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
+	else!"
+	^#variableWordSubclass:
+]

--- a/src/Kernel-CodeModel/Behavior.class.st
+++ b/src/Kernel-CodeModel/Behavior.class.st
@@ -1163,14 +1163,6 @@ Behavior >> isWords [
 	^self isBytes not
 ]
 
-{ #category : 'testing - class hierarchy' }
-Behavior >> kindOfSubclass [
-	"Answer a String that is the keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
-	<reflection: 'Class structural inspection - Iterating and querying hierarchy'>
-	^ self classLayout kindOfSubclass
-]
-
 { #category : 'accessing - method dictionary' }
 Behavior >> localMethods [
 	"returns the methods of classes excluding the ones of the traits that the class uses"

--- a/src/Kernel-CodeModel/ByteLayout.class.st
+++ b/src/Kernel-CodeModel/ByteLayout.class.st
@@ -16,14 +16,6 @@ ByteLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : 'description' }
-ByteLayout class >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else!"
-	^#variableByteSubclass:
-]
-
 { #category : 'accessing' }
 ByteLayout >> bytesPerSlot [
 

--- a/src/Kernel-CodeModel/CompiledMethodLayout.class.st
+++ b/src/Kernel-CodeModel/CompiledMethodLayout.class.st
@@ -19,15 +19,6 @@ CompiledMethodLayout class >> extending: superLayout scope: aScope host: aClass 
 		yourself
 ]
 
-{ #category : 'description' }
-CompiledMethodLayout class >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else!"
-	"there is no way to define classes of this Layput, the system shows them as variable classes"
-	^#variableByteSubclass:
-]
-
 { #category : 'extending' }
 CompiledMethodLayout >> extend [
 	self error: 'CompiledMethodLayout can not be extendend'

--- a/src/Kernel-CodeModel/DoubleByteLayout.class.st
+++ b/src/Kernel-CodeModel/DoubleByteLayout.class.st
@@ -16,14 +16,6 @@ DoubleByteLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : 'description' }
-DoubleByteLayout class >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else!"
-	^#variableDoubleByteSubclass:
-]
-
 { #category : 'accessing' }
 DoubleByteLayout >> bytesPerSlot [
 

--- a/src/Kernel-CodeModel/DoubleWordLayout.class.st
+++ b/src/Kernel-CodeModel/DoubleWordLayout.class.st
@@ -16,14 +16,6 @@ DoubleWordLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : 'description' }
-DoubleWordLayout class >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else!"
-	^#variableDoubleWordSubclass:
-]
-
 { #category : 'extending' }
 DoubleWordLayout >> extendDoubleWord [
 	^ DoubleWordLayout new

--- a/src/Kernel-CodeModel/EphemeronLayout.class.st
+++ b/src/Kernel-CodeModel/EphemeronLayout.class.st
@@ -17,14 +17,6 @@ EphemeronLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : 'description' }
-EphemeronLayout class >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else!"
-	^#ephemeronSubclass:
-]
-
 { #category : 'format' }
 EphemeronLayout >> instanceSpecification [
 	^ 5

--- a/src/Kernel-CodeModel/ImmediateLayout.class.st
+++ b/src/Kernel-CodeModel/ImmediateLayout.class.st
@@ -18,14 +18,6 @@ ImmediateLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : 'description' }
-ImmediateLayout class >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else!"
-	^#immediateSubclass:
-]
-
 { #category : 'extending' }
 ImmediateLayout >> extend [
 	self error: 'ImmediateLayout can not be extendend'

--- a/src/Kernel-CodeModel/ObjectLayout.class.st
+++ b/src/Kernel-CodeModel/ObjectLayout.class.st
@@ -32,16 +32,6 @@ ObjectLayout class >> layoutForSubclassDefiningSymbol: aSymbol [
 		ifNone: [ FixedLayout ]
 ]
 
-{ #category : 'description' }
-ObjectLayout class >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else!"
-	"As a fallback we just return a standard class creation symbol. This will be called for user
-	defined Layouts, for old style class definitions that can not support user defined Layouts"
-	^#subclass:
-]
-
 { #category : 'extending' }
 ObjectLayout >> extend [
 	"Answer a default extension of me."
@@ -144,20 +134,4 @@ ObjectLayout >> initializeInstance: anInstance [
 { #category : 'format' }
 ObjectLayout >> instanceSpecification [
 	self subclassResponsibility
-]
-
-{ #category : 'testing - class hierarchy' }
-ObjectLayout >> kindOfSubclass [
-	"Answer a String that is the keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, see #subclassDefiningSymbol"
-	^' ',self class subclassDefiningSymbol, ' '
-]
-
-{ #category : 'testing - class hierarchy' }
-ObjectLayout >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else as CompiledMethodLayout answers the same as ByteLayout and user defined Layouts are not
-	supported"
-	^self class subclassDefiningSymbol
 ]

--- a/src/Kernel-CodeModel/VariableLayout.class.st
+++ b/src/Kernel-CodeModel/VariableLayout.class.st
@@ -19,14 +19,6 @@ VariableLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : 'description' }
-VariableLayout class >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else!"
-	^#variableSubclass:
-]
-
 { #category : 'format' }
 VariableLayout >> instanceSpecification [
 	^ self hasFields

--- a/src/Kernel-CodeModel/WeakLayout.class.st
+++ b/src/Kernel-CodeModel/WeakLayout.class.st
@@ -21,14 +21,6 @@ WeakLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : 'description' }
-WeakLayout class >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else!"
-	^#weakSubclass:
-]
-
 { #category : 'format' }
 WeakLayout >> instanceSpecification [
 	^ 4

--- a/src/Kernel-CodeModel/WordLayout.class.st
+++ b/src/Kernel-CodeModel/WordLayout.class.st
@@ -16,14 +16,6 @@ WordLayout class >> extending: superLayout scope: aScope host: aClass [
 		yourself
 ]
 
-{ #category : 'description' }
-WordLayout class >> subclassDefiningSymbol [
-	"Answer a keyword that describes the receiver's kind of subclass
-	Note: this is for printing the ST80 style class definiton, usage makes no sense for anything
-	else!"
-	^#variableWordSubclass:
-]
-
 { #category : 'accessing' }
 WordLayout >> bytesPerSlot [
 


### PR DESCRIPTION
Those are used only to print the ldo format definition string so it should be packaged with the old definition printer and not in the kernel