### PR TITLE
ClassInstalle: clients can use  #update:to: instead of #fillFor:

### DIFF
--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -574,15 +574,14 @@ Class >> deprecationRefactorings [
 { #category : 'copying' }
 Class >> duplicateClassWithNewName: aSymbol [
 
-	| copysName class |
+	| copysName |
 	copysName := aSymbol asSymbol.
 	copysName = self name ifTrue: [ ^ self ].
 	(self environment includesKey: copysName) ifTrue: [ ^ self error: copysName , ' already exists' ].
-	class := self classInstaller make: [ :builder |
-		         builder
-			         fillFor: self;
-			         name: copysName ].
-	^ class
+	
+	^ self classInstaller 
+		update: self 
+		to: [ :builder | builder name: copysName ]
 ]
 
 { #category : 'organization' }

--- a/src/Kernel-Tests/ClassDescriptionTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionTest.class.st
@@ -241,10 +241,8 @@ ClassDescriptionTest >> testIsInstalled [
 
 	self deny: class isInstalled description: 'The class was built but not installed so it should not be installed.'.
 
-	class := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         fillFor: class;
-			         package: self compilationTestPackageName ].
+	class := self class classInstaller update: class to: [ :aBuilder |
+		         aBuilder package: self compilationTestPackageName ].
 
 	self assert: class isInstalled description: 'The class got installed in the system and thus should be installed.'.
 

--- a/src/Shift-ClassBuilder-Tests/ShClassInstallerAnnouncementsTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShClassInstallerAnnouncementsTest.class.st
@@ -39,10 +39,9 @@ ShClassInstallerAnnouncementsTest >> testClassRepackagingShouldAnnounceClassModi
 		self assert: ann classRepackaged name equals: #SHClass ].
 
 	[
-	ShiftClassInstaller make: [ :builder |
-		builder
-			fillFor: aClass;
-			package: self generatedClassesPackageName , '2' ].
+	ShiftClassInstaller 
+		update: aClass 
+		to: [ :builder | builder package: self generatedClassesPackageName , '2' ].
 
 	self assert: numberOfAnnouncements equals: 1 ] ensure: [ self packageOrganizer removePackage: self generatedClassesPackageName , '2' ]
 ]

--- a/src/Traits-Tests/MethodAnnouncementsTest.extension.st
+++ b/src/Traits-Tests/MethodAnnouncementsTest.extension.st
@@ -11,10 +11,9 @@ MethodAnnouncementsTest >> testCompileMethodAnnounceAdditionOnlyInTrait [
 			         name: 'TraitForTest';
 			         package: self packageNameForTests , '2' ].
 
-	class := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         fillFor: class;
-			         traits: trait ].
+	class := class classInstaller 
+		update: class
+		to: [ :aBuilder | aBuilder traits: trait ].
 
 	self when: MethodAdded do: [ :ann |
 		self assert: ann method selector equals: #king.
@@ -41,10 +40,9 @@ MethodAnnouncementsTest >> testRemoveMethodAnnounceRemovalOnlyInTrait [
 			         name: 'TraitForTest';
 			         package: self packageNameForTests , '2' ].
 
-	class := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         fillFor: class;
-			         traits: trait ].
+	class := class classInstaller 
+		update: class
+		to: [ :aBuilder | aBuilder traits: trait ].
 
 	trait compiler
 		protocol: #titan;
@@ -73,10 +71,9 @@ MethodAnnouncementsTest >> testUpdateMethodAnnounceModificationOnlyInTrait [
 			         name: 'TraitForTest';
 			         package: self packageNameForTests , '2' ].
 
-	class := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         fillFor: class;
-			         traits: trait ].
+	class := class classInstaller 
+		update: class
+		to: [ :aBuilder | aBuilder traits: trait ].
 
 	trait compiler
 		protocol: #titan;
@@ -107,10 +104,9 @@ MethodAnnouncementsTest >> testUpdateMethodAnnounceRecategorizationOnlyInTrait [
 			         name: 'TraitForTest';
 			         package: self packageNameForTests , '2' ].
 
-	class := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         fillFor: class;
-			         traits: trait ].
+	class := class classInstaller 
+		update: class
+		to: [ :aBuilder | aBuilder traits: trait ].
 
 	trait compiler
 		protocol: #demon;

--- a/src/Traits-Tests/ProtocolAnnouncementsTest.extension.st
+++ b/src/Traits-Tests/ProtocolAnnouncementsTest.extension.st
@@ -11,10 +11,9 @@ ProtocolAnnouncementsTest >> testAddProtocolAnnouncedOnlyInTrait [
 			         name: 'TraitForTest';
 			         package: self packageNameForTests , '2' ].
 
-	class := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         fillFor: class;
-			         traits: trait ].
+	class := class classInstaller 
+		update: class
+		to: [ :aBuilder | aBuilder traits: trait ].
 
 	self when: ProtocolAdded do: [ :ann |
 		self assert: ann protocol name equals: #king.

--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -833,12 +833,13 @@ TraitTest >> testUsingTraitInAnonymousSubClassAndRedefiningIt [
 
 	self deny: (Object subclasses includes: aClass).
 
-	t1 := t1 classInstaller make: [ :aBuilder |
-		  aBuilder
-			  fillFor: t1;
-			  slots: #(aSlot);
-			  package: self packageNameForTests;
-			  beTrait ].
+	t1 := t1 classInstaller 
+				update: t1
+				to: [ :aBuilder |
+		  						aBuilder
+			  					slots: #(aSlot);
+								 package: self packageNameForTests;
+			  					beTrait ].
 		
 	self assert: (aClass hasSlotNamed: #aSlot).
 


### PR DESCRIPTION
change some user to use #update:to: instead of #fillFor:

Not yet touched: #ClassFactoryForTestCase, which needs to provide the  #update:to: API, for later