### PR TITLE
Fix:  #hasSameDefinitionAs: for IndexedSlot

### DIFF
--- a/src/Kernel-CodeModel/IndexedSlot.class.st
+++ b/src/Kernel-CodeModel/IndexedSlot.class.st
@@ -24,12 +24,6 @@ IndexedSlot >> = other [
 ]
 
 { #category : 'comparing' }
-IndexedSlot >> hasSameDefinitionAs: other [
-	"Definiton does not contain index"
-	^super = other
-]
-
-{ #category : 'comparing' }
 IndexedSlot >> hash [
 	^ (self species hash bitXor: self name hash) bitXor: (self index ifNil: [ 0 ])
 ]

--- a/src/Kernel-CodeModel/Slot.class.st
+++ b/src/Kernel-CodeModel/Slot.class.st
@@ -162,10 +162,8 @@ Slot >> ensureSlotInitializationFor: aClass [
 { #category : 'comparing' }
 Slot >> hasSameDefinitionAs: otherSlot [
 
-	"equal definition. Slots an have additional state that is not part of the definitoon
-	(e.g. the index in IndexSlot).
-	This method then is overriden to not take that state into account"
-	^self = otherSlot
+	"Equal definition. Slots an have additional state that is not part of the definition (e.g. the index in IndexSlot), and data that is part of it (see subclass override)"
+	^self class = otherSlot class and: [self name = otherSlot name]
 ]
 
 { #category : 'initialization' }

--- a/src/Slot-Tests/SlotBasicTest.class.st
+++ b/src/Slot-Tests/SlotBasicTest.class.st
@@ -70,6 +70,17 @@ SlotBasicTest >> testClassWithCommentAndStamp [
 	self assert: aClass commentStamp equals: (Object>>#halt) stamp
 ]
 
+{ #category : 'tests' }
+SlotBasicTest >> testInitializedSlotUpdateClass [
+	"When we update a Slot that has a default value, the slot us updated, tests #hasSameDefinitionAs:"
+	aClass := self make: [ :builder | builder slots: {#slot => InitializedSlot default: 5}].
+
+	self assert: (aClass slotNamed: #slot) default equals: 5.
+	aClass := self make: [ :builder | builder slots: {#slot => InitializedSlot default: 4}].
+	self assert: (aClass slotNamed: #slot) default equals: 4
+
+]
+
 { #category : 'tests - basic' }
 SlotBasicTest >> testNewCompiledMethodClass [
 

--- a/src/VariablesLibrary/AbstractInitializedSlot.class.st
+++ b/src/VariablesLibrary/AbstractInitializedSlot.class.st
@@ -41,6 +41,13 @@ AbstractInitializedSlot >> default: anObject [
 ]
 
 { #category : 'comparing' }
+AbstractInitializedSlot >> hasSameDefinitionAs: otherVariable [
+	
+ 	^(super hasSameDefinitionAs: otherVariable) 
+		and: [ default = otherVariable default ]
+]
+
+{ #category : 'comparing' }
 AbstractInitializedSlot >> hash [
 	^super hash bitXor: default hash
 ]


### PR DESCRIPTION
- add a tests where we change just the additional data of a slot (here an IntializedSlot)
- add #hasSameDefinitionAs:
- fix #hasSameDefinitionAs: of Slot/IndexedSlot