### PR TITLE
Allow using ProfilerPresenter programatically

### DIFF
--- a/src/ProfilerUI/ProfilerInputPresenter.class.st
+++ b/src/ProfilerUI/ProfilerInputPresenter.class.st
@@ -30,17 +30,19 @@ ProfilerInputPresenter class >> defaultLayout [
 		  yourself
 ]
 
+{ #category : 'accessing' }
+ProfilerInputPresenter >> code: aString [
+
+	codeInput text: aString
+]
+
 { #category : 'initialization' }
 ProfilerInputPresenter >> initializeActions [
 
 	profilerDropList whenSelectedItemChangedDo: [ :item |
 		viewModel profilerClass: item ].
 
-
-	profileItButton action: [
-		codeInput text
-			ifEmpty: [ self notify: 'Must enter code' at: 0 in: codeInput text ]
-			ifNotEmpty: [ viewModel profileCode: codeInput text notifying: self] ]
+	profileItButton action: [ self profileIt ]
 ]
 
 { #category : 'initialization' }
@@ -73,6 +75,14 @@ ProfilerInputPresenter >> notify: errorMessage at: positionIndex in: sourceCode 
 	codeInput takeKeyboardFocus
 ]
 
+{ #category : 'initialization' }
+ProfilerInputPresenter >> profileIt [
+
+	codeInput text
+		ifEmpty: [ self notify: 'Must enter code' at: 0 in: codeInput text ]
+		ifNotEmpty: [ viewModel profileCode: codeInput text notifying: self ]
+]
+
 { #category : 'accessing - model' }
 ProfilerInputPresenter >> setModelBeforeInitialization: aDomainObject [
 
@@ -81,12 +91,14 @@ ProfilerInputPresenter >> setModelBeforeInitialization: aDomainObject [
 
 { #category : 'initialization' }
 ProfilerInputPresenter >> subscribeOnProfilingAnnouncements [
+
 	viewModel announcer
 		when: ProfilingStartedAnnouncement
-		do: [ self enabled: false ];
-
+		do: [ self enabled: false ]
+		for: self;
 		when: ProfilingResultsDisplayedAnnouncement
 		do: [ self enabled: true ]
+		for: self
 ]
 
 { #category : 'initialization' }

--- a/src/ProfilerUI/ProfilerPresenter.class.st
+++ b/src/ProfilerUI/ProfilerPresenter.class.st
@@ -41,6 +41,15 @@ ProfilerPresenter class >> open [
 	^ self new open
 ]
 
+{ #category : 'spying' }
+ProfilerPresenter class >> profileCode: aString [
+
+	^ self new
+		  open;
+		  profileCode: aString asString;
+		  yourself
+]
+
 { #category : 'constants' }
 ProfilerPresenter >> initExtent [
 	^ 800 @ 800
@@ -79,6 +88,13 @@ ProfilerPresenter >> newResultsPresenter [
 { #category : 'constants' }
 ProfilerPresenter >> presenterTitle [
 	^ 'Profiler'
+]
+
+{ #category : 'actions' }
+ProfilerPresenter >> profileCode: aString [
+
+	inputPresenter code: aString.
+	inputPresenter profileIt
 ]
 
 { #category : 'subscription' }


### PR DESCRIPTION
Allow using `ProfilerPresenter` programatically.

Preparation for implementing `Profile It` command in order to fix https://github.com/pharo-project/pharo/issues/12137.