### PR TITLE
Position temp definition before first occurrence of extracted expression, and always in outer scope (fixes #14611)

### DIFF
--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -1759,6 +1759,11 @@ RBParserTest >> testQuerying [
 	arg1Node := tree whichNodeIsContainedBy: (102 to: 105).
 	self assert: arg1Node name equals: 'arg1'.
 	self assert: (arg1Node statementNode isMessage and: [ arg1Node statementNode selector value = #+ ]).
+	self assert: (arg1Node statementNodeIn: arg1Node methodOrBlockNode) equals: arg1Node statementNode.
+	self assert: (arg1Node statementNodeIn: arg1Node methodOrBlockNode body) equals: arg1Node statementNode.
+	self assert: (arg1Node statementNodeIn: tree) equals: tree body statements last.
+	self assert: (arg1Node statementNodeIn: tree body) equals: tree body statements last.
+	self should: [ arg1Node statementNodeIn: RBSequenceNode new ] raise: NotFound.
 	self assert: (arg1Node whoDefines: 'arg1') isBlock.
 	self assert: (aNode whoDefines: 'a') isMethod.
 	self assert: (aNode whoDefines: 'b') isSequence.

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -125,6 +125,12 @@ RBBlockNode >> arguments: argCollection [
 	arguments do: [:each | each parent: self ]
 ]
 
+{ #category : 'converting' }
+RBBlockNode >> asSequenceNode [
+
+	^ body
+]
+
 { #category : 'accessing - token' }
 RBBlockNode >> bar [
 	^ bar

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -125,12 +125,6 @@ RBBlockNode >> arguments: argCollection [
 	arguments do: [:each | each parent: self ]
 ]
 
-{ #category : 'converting' }
-RBBlockNode >> asSequenceNode [
-
-	^ body
-]
-
 { #category : 'accessing - token' }
 RBBlockNode >> bar [
 	^ bar

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -1264,6 +1264,24 @@ RBProgramNode >> statementNode [
 	^parent statementNode
 ]
 
+{ #category : 'querying' }
+RBProgramNode >> statementNodeIn: aSequenceBlockOrMethod [
+	"Return the statement within aSequenceBlockOrMethod that ultimately contains us,
+	skipping any intervening nested blocks.
+	
+	Note that to avoid repeatedly comparing large chunks of the tree, we use identity for comparison,
+	so the provided node must have come from the same parse as the receiver."
+
+	| sequence answer |
+	"Retrieve body from method or block node--we need a sequence"
+	sequence := aSequenceBlockOrMethod asSequenceNode.
+	answer := self.
+	[ answer parent == sequence ] whileFalse: [
+		answer := answer parent ifNil: [
+			          ^ NotFound signalFor: self in: aSequenceBlockOrMethod ] ].
+	^ answer
+]
+
 { #category : 'accessing' }
 RBProgramNode >> statements [
 	^ #()

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -1274,7 +1274,9 @@ RBProgramNode >> statementNodeIn: aSequenceBlockOrMethod [
 
 	| sequence answer |
 	"Retrieve body from method or block node--we need a sequence"
-	sequence := aSequenceBlockOrMethod asSequenceNode.
+	sequence := aSequenceBlockOrMethod isSequence
+		            ifTrue: [ aSequenceBlockOrMethod ]
+		            ifFalse: [ aSequenceBlockOrMethod body ].
 	answer := self.
 	[ answer parent == sequence ] whileFalse: [
 		answer := answer parent ifNil: [

--- a/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
@@ -80,14 +80,17 @@ RBExtractToTemporaryRefactoring >> extract: anInterval to: aString from: aSelect
 { #category : 'transforming' }
 RBExtractToTemporaryRefactoring >> insertTemporary [
 
-	| node statementNode nodeReferences |
+	| node statementNode nodeReferences scope |
 	node := self parseTree whichNodeIsContainedBy: sourceInterval.
 	(node isNotNil and: [ node isValue ]) ifFalse: [
 		self refactoringError: 'Cannot assign to non-value nodes' ].
-	nodeReferences := node methodOrBlockNode allChildren select: [ :each |
-		                  each = node ].
-	statementNode := node statementNode.
-	statementNode parent
+	scope := node methodOrBlockNode.
+	nodeReferences := scope allChildren select: [ :each | each = node ].
+	"Insert the assignment before the first occurrence to be replaced,
+	but in the same scope as the selected expression,
+	even if that first occurrence is in a nested block."
+	statementNode := nodeReferences first statementNodeIn: scope.
+	scope body
 		addNode: (self constructAssignmentFrom: node) before: statementNode;
 		addTemporaryNamed: newVariableName.
 	nodeReferences do: [ :each |

--- a/src/Refactoring-DataForTesting/RBClassDataForRefactoringTest.class.st
+++ b/src/Refactoring-DataForTesting/RBClassDataForRefactoringTest.class.st
@@ -160,6 +160,14 @@ RBClassDataForRefactoringTest >> demoMethodWithDuplicatesInBlocks [
 ]
 
 { #category : 'tests' }
+RBClassDataForRefactoringTest >> demoMethodWithDuplicatesInEarlierBlocks [
+
+	(3 to: 10) do: [ :i |
+		self someValue \\ i = 0 ifTrue: [ self doSomethingFor: i ] ].
+	self someValue odd ifTrue: [ self doSomethingElse ]
+]
+
+{ #category : #tests }
 RBClassDataForRefactoringTest >> demoRenameMethod: arg1 PermuteArgs: arg2 [
 	self do: arg1.
 	self do: arg2.

--- a/src/Refactoring-DataForTesting/RBClassDataForRefactoringTest.class.st
+++ b/src/Refactoring-DataForTesting/RBClassDataForRefactoringTest.class.st
@@ -163,11 +163,11 @@ RBClassDataForRefactoringTest >> demoMethodWithDuplicatesInBlocks [
 RBClassDataForRefactoringTest >> demoMethodWithDuplicatesInEarlierBlocks [
 
 	(3 to: 10) do: [ :i |
-		self someValue \\ i = 0 ifTrue: [ self doSomethingFor: i ] ].
-	self someValue odd ifTrue: [ self doSomethingElse ]
+		self someMethod \\ i = 0 ifTrue: [ self performAction: i ] ].
+	self someMethod odd ifTrue: [ self performAction ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBClassDataForRefactoringTest >> demoRenameMethod: arg1 PermuteArgs: arg2 [
 	self do: arg1.
 	self do: arg2.

--- a/src/Refactoring-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
@@ -64,21 +64,21 @@ RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicates [
 	^ answer')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicatesInEarlierNestedScopes [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
-		{ (130 to: 143) . 'someValue' . #demoMethodWithDuplicatesInEarlierBlocks . RBClassDataForRefactoringTest }.
+		{ (130 to: 145) . 'someValue' . #demoMethodWithDuplicatesInEarlierBlocks . RBClassDataForRefactoringTest }.
 	self executeRefactoring: refactoring.
 	self assert: ((refactoring model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #demoMethodWithDuplicatesInEarlierBlocks) equals: (self parseMethod: 'demoMethodWithDuplicatesInEarlierBlocks
 	|someValue|
-	someValue := self someValue.
+	someValue := self someMethod.
 	(3 to: 10) do: [ :i |
-		someValue \\ i = 0 ifTrue: [ self doSomethingFor: i ] ].
-	someValue odd ifTrue: [ self doSomethingElse ]')
+		someValue \\ i = 0 ifTrue: [ self performAction: i ] ].
+	someValue odd ifTrue: [ self performAction ]')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicatesInOtherScopes [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
@@ -64,7 +64,21 @@ RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicates [
 	^ answer')
 ]
 
-{ #category : 'tests' }
+{ #category : #tests }
+RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicatesInEarlierNestedScopes [
+	| refactoring |
+	refactoring := self createRefactoringWithArguments:
+		{ (130 to: 143) . 'someValue' . #demoMethodWithDuplicatesInEarlierBlocks . RBClassDataForRefactoringTest }.
+	self executeRefactoring: refactoring.
+	self assert: ((refactoring model classNamed: #RBClassDataForRefactoringTest) parseTreeForSelector: #demoMethodWithDuplicatesInEarlierBlocks) equals: (self parseMethod: 'demoMethodWithDuplicatesInEarlierBlocks
+	|someValue|
+	someValue := self someValue.
+	(3 to: 10) do: [ :i |
+		someValue \\ i = 0 ifTrue: [ self doSomethingFor: i ] ].
+	someValue odd ifTrue: [ self doSomethingElse ]')
+]
+
+{ #category : #tests }
 RBExtractToTemporaryParametrizedTest >> testExtractToTemporaryWithDuplicatesInOtherScopes [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:

--- a/src/Refactoring-Transformations/RBExtractToTemporaryTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractToTemporaryTransformation.class.st
@@ -91,11 +91,16 @@ RBExtractToTemporaryTransformation >> extract: anInterval to: aString from: aSel
 RBExtractToTemporaryTransformation >> insertTemporary [
 
 	^ { (RBCustomTransformation model: self model with: [ :rbMode |
-		   | node statementNode nodeReferences |
+		   | node statementNode nodeReferences scope |
 		   node := self nodeContainedBy: sourceInterval.
-		   nodeReferences := self referencesTo: node.
-		   statementNode := node statementNode.
-		   statementNode parent
+		   scope := node methodOrBlockNode.
+		   nodeReferences := scope allChildren select: [ :each |
+			                     each = node ].
+		   "Insert the assignment before the first occurrence to be replaced,
+			but in the same scope as the selected expression,
+			even if that first occurrence is in a nested block."
+		   statementNode := nodeReferences first statementNodeIn: scope.
+		   scope body
 			   addNode: (self constructAssignmentFrom: node)
 			   before: statementNode;
 			   addTemporaryNamed: newVariableName.


### PR DESCRIPTION
If the first occurrence of the expression to be extracted is in a child scope (a block) of the occurrence that was actually *selected*, we need to walk up the tree and put the initialization before the whole statement containing that child scope.

Add RBProgramNode>>statementNodeIn: to answer the statement *at a particular level of nesting/in a particular scope* that contains a node.

This should put #14611 fully to rest—the original issue was already fixed in a previous PR, but I thought of this scoping issue in a comment.

One implementation note—I saw that `RBMethodNode` understands `asSequenceNode` to return its body, so it seemed reasonable for `RBBlockNode` to do the same. It is a _little_ weird given that all nodes understand it and just _wrap_ themselves in a sequence node, but I don't think the two use-cases are likely to be confused.