### PR TITLE
15769-Backport-15767--Pharo11-Fix-hasSameDefinitionAs-for-IndexedSlot

### DIFF
--- a/src/Kernel/IndexedSlot.class.st
+++ b/src/Kernel/IndexedSlot.class.st
@@ -22,12 +22,6 @@ IndexedSlot >> = other [
 ]
 
 { #category : #comparing }
-IndexedSlot >> hasSameDefinitionAs: other [
-	"Definiton does not contain index"
-	^super = other
-]
-
-{ #category : #comparing }
 IndexedSlot >> hash [
 	^ (self species hash bitXor: self name hash) bitXor: (self index ifNil: [ 0 ])
 ]

--- a/src/Kernel/Slot.class.st
+++ b/src/Kernel/Slot.class.st
@@ -161,10 +161,8 @@ Slot >> ensureSlotInitializationFor: aClass [
 { #category : #comparing }
 Slot >> hasSameDefinitionAs: otherSlot [
 
-	"equal definition. Slots an have additional state that is not part of the definitoon
-	(e.g. the index in IndexSlot).
-	This method then is overriden to not take that state into account"
-	^self = otherSlot
+	"Equal definition. Slots an have additional state that is not part of the definition (e.g. the index in IndexSlot), and data that is part of it (see subclass override)"
+ 	^self class = otherSlot class and: [self name = otherSlot name]
 ]
 
 { #category : #initialization }

--- a/src/Slot-Tests/SlotBasicTest.class.st
+++ b/src/Slot-Tests/SlotBasicTest.class.st
@@ -80,6 +80,16 @@ SlotBasicTest >> testClassWithCommentAndStamp [
 	self assert: aClass organization commentStamp equals: (Object>>#halt) stamp
 ]
 
+{ #category : #'tests - shared variables' }
+SlotBasicTest >> testInitializedSlotUpdateClass [
+ 	"When we update a Slot that has a default value, the slot us updated, tests #hasSameDefinitionAs:"
+ 	aClass := self make: [ :builder | builder slots: {#slot => InitializedSlot default: 5}].
+
+ 	self assert: (aClass slotNamed: #slot) default equals: 5.
+ 	aClass := self make: [ :builder | builder slots: {#slot => InitializedSlot default: 4}].
+ 	self assert: (aClass slotNamed: #slot) default equals: 4
+]
+
 { #category : #'tests - basic' }
 SlotBasicTest >> testNewCompiledMethodClass [
 

--- a/src/VariablesLibrary/AbstractInitializedSlot.class.st
+++ b/src/VariablesLibrary/AbstractInitializedSlot.class.st
@@ -39,6 +39,13 @@ AbstractInitializedSlot >> default: anObject [
 ]
 
 { #category : #comparing }
+AbstractInitializedSlot >> hasSameDefinitionAs: otherVariable [
+
+  	^(super hasSameDefinitionAs: otherVariable) 
+ 		and: [ default = otherVariable default ]
+]
+
+{ #category : #comparing }
 AbstractInitializedSlot >> hash [
 	^super hash bitXor: default hash
 ]


### PR DESCRIPTION
backport

fixes #15769