### PR TITLE
deprecate #anyUserOfClassVarNamed:

### DIFF
--- a/src/Deprecated12/Class.extension.st
+++ b/src/Deprecated12/Class.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : 'Class' }
 
 { #category : '*Deprecated12' }
+Class >> anyUserOfClassVarNamed: aSymbol [
+	self deprecated: 'use #usingClasses on the Variable instead'.
+	^ (self classVariableNamed: aSymbol) usingClasses
+		ifEmpty: [ nil ]
+		ifNotEmpty: [:notEmpty | notEmpty anyOne]
+]
+
+{ #category : '*Deprecated12' }
 Class >> basicCategory [
 
 	self deprecated: 'Use #category now' transformWith: '`@rcv basicCategory' -> '`@rcv category'.

--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -189,14 +189,6 @@ Class >> allSharedPools [
 			aSet addAll: self sharedPools; yourself]
 ]
 
-{ #category : 'class variables' }
-Class >> anyUserOfClassVarNamed: aSymbol [
-	"maybe this should be deprecated"
-	^ (self classVariableNamed: aSymbol) usingClasses
-		ifEmpty: [ nil ]
-		ifNotEmpty: [:notEmpty | notEmpty anyOne]
-]
-
 { #category : 'deprecation' }
 Class >> applyDeprecation [
 

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -140,11 +140,6 @@ ClassTest >> testAllSharedPools [
 	self assertEmpty: SubclassPoolUser sharedPools
 ]
 
-{ #category : 'tests - class variables' }
-ClassTest >> testAnyUserOfClassVarNamed [
-	self assert: ((Object anyUserOfClassVarNamed: #DependentsFields) isKindOf: Object)
-]
-
 { #category : 'tests' }
 ClassTest >> testChangingShapeDoesNotPutNilInMethodsLastLiteralKey [
 	"Test that when the shape of a class changes, the key of the last literal of the methods is not nil"


### PR DESCRIPTION
This PR deprecates anyUserOfClassVarNamed:

(see discussion in https://github.com/pharo-project/pharo/pull/15717 )