### PR TITLE
Cleanup: old instance migration code (from before Shift)

### DIFF
--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -735,26 +735,6 @@ ClassDescription >> newInstanceFrom: oldInstance variable: variable size: instSi
 	^ new
 ]
 
-{ #category : 'private' }
-ClassDescription >> newInstanceFrom: oldInstance variable: variable size: instSize map: map [
-	"Create a new instance of the receiver based on the given old instance.
-	The supplied map contains a mapping of the old instVar names into
-	the receiver's instVars"
-	| new |
-	variable
-		ifTrue: [new := self basicNew: oldInstance basicSize]
-		ifFalse: [new := self basicNew].
-	1 to: instSize do:
-		[:offset |  (map at: offset) > 0 ifTrue:
-			[new instVarAt: offset
-					put: (oldInstance instVarAt: (map at: offset))]].
-	variable
-		ifTrue: [1 to: oldInstance basicSize do:
-					[:offset |
-					new basicAt: offset put: (oldInstance basicAt: offset)]].
-	^new
-]
-
 { #category : 'accessing - method dictionary' }
 ClassDescription >> noteAddedSelector: aSelector meta: isMeta [
 	"A hook allowing some classes to react to adding of certain selectors"

--- a/src/Kernel-CodeModel/CompiledMethod.class.st
+++ b/src/Kernel-CodeModel/CompiledMethod.class.st
@@ -109,20 +109,6 @@ CompiledMethod class >> new [
 	^self basicNew: 2 header: 1024
 ]
 
-{ #category : 'private' }
-CompiledMethod class >> newInstanceFrom: oldInstance variable: variable size: instSize map: map [
-	"Create a new instance of the receiver based on the given old instance.
-	The supplied map contains a mapping of the old instVar names into
-	the receiver's instVars"
-	| new |
-	new := self newFrom: oldInstance.
-	1 to: instSize do:
-		[:offset |  (map at: offset) > 0 ifTrue:
-			[new instVarAt: offset
-					put: (oldInstance instVarAt: (map at: offset))]].
-	^new
-]
-
 { #category : 'class initialization' }
 CompiledMethod class >> smallFrameSize [
 

--- a/src/Kernel-CodeModel/Metaclass.class.st
+++ b/src/Kernel-CodeModel/Metaclass.class.st
@@ -49,22 +49,6 @@ Metaclass >> addSubclass: aClass [
 	"Do nothing."
 ]
 
-{ #category : 'initialize-release' }
-Metaclass >> adoptInstance: oldInstance from: oldMetaClass [
-	"Recreate any existing instances of the argument, oldClass, as instances of
-	the receiver, which is a newly changed class. Permute variables as
-	necessary."
-	<reflection: 'Object Modification - Object class change'>
-	thisClass class == self ifTrue:[^self error:'Metaclasses have only one instance'].
-	oldMetaClass isMeta ifFalse:[^self error:'Argument must be Metaclass'].
-	oldInstance class == oldMetaClass ifFalse:[^self error:'Not the class of argument'].
-	^thisClass := self
-		newInstanceFrom: oldInstance
-		variable: self isVariable
-		size: self instSize
-		map: (self instVarMappingFrom: oldMetaClass)
-]
-
 { #category : 'compiling' }
 Metaclass >> binding [
 	"return an association that can be used as the binding


### PR DESCRIPTION
this removes some methods that are lefovers from before ShiftClassBuilder was introduced

(dead code now)