### PR TITLE
Reduce users of ChangeSet

### DIFF
--- a/src/Deprecated12/Class.extension.st
+++ b/src/Deprecated12/Class.extension.st
@@ -262,6 +262,12 @@ Class >> immediateSubclass: aName uses: aTraitComposition instanceVariableNames:
 ]
 
 { #category : '*Deprecated12' }
+Class >> removeFromChanges [
+
+	self deprecated: 'The ChangeSet system is been removed in Pharo 12 since Epicea replaces all its features already.'
+]
+
+{ #category : '*Deprecated12' }
 Class >> subclass: t instanceVariableNames: ins [
 
 	self

--- a/src/Kernel-Tests-Extended/ClassTest.class.st
+++ b/src/Kernel-Tests-Extended/ClassTest.class.st
@@ -22,9 +22,7 @@ ClassTest >> classToBeTested [
 { #category : 'setup' }
 ClassTest >> deleteClass [
 
-	testEnvironment at: className ifPresent: [ :class |
-		testingEnvironment at: #ChangeSet ifPresent: [ class removeFromChanges ].
-		class removeFromSystemUnlogged ]
+	testEnvironment at: className ifPresent: [ :class | class removeFromSystemUnlogged ]
 ]
 
 { #category : 'setup' }
@@ -215,18 +213,9 @@ ClassTest >> testClassVariableEntanglement [
 				self assert: secondClass myVar equals: 456.
 				self assert: thirdClass myVar equals: 789.
 
-			 ] ensure: [
-				thirdClass
-					removeFromChanges;
-					removeFromSystemUnlogged ].
-		 ] ensure: [
-			secondClass
-				removeFromChanges;
-				removeFromSystemUnlogged ].
-	 ] ensure: [
-		firstClass
-			removeFromChanges;
-			removeFromSystemUnlogged ]
+			 ] ensure: [ thirdClass removeFromSystemUnlogged ].
+		 ] ensure: [ secondClass removeFromSystemUnlogged ].
+	 ] ensure: [ firstClass removeFromSystemUnlogged ]
 ]
 
 { #category : 'tests - accessing - comments' }

--- a/src/Manifest-Tests/BuilderManifestTest.class.st
+++ b/src/Manifest-Tests/BuilderManifestTest.class.st
@@ -22,10 +22,7 @@ BuilderManifestTest >> setUp [
 { #category : 'running' }
 BuilderManifestTest >> tearDown [
 
-	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class |
-		class
-			removeFromChanges;
-			removeFromSystem ].
+	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class | class removeFromSystem ].
 	super tearDown
 ]
 
@@ -207,10 +204,7 @@ BuilderManifestTest >> testContainsToDo [
 BuilderManifestTest >> testCreationManifest [
 
 	manifestBuilder := TheManifestBuilder new.
-	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class |
-		class
-			removeFromChanges;
-			removeFromSystem ].
+	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class | class removeFromSystem ].
 	self assert: (manifestBuilder manifestOf: MFClassA) isNil.
 	self assert: (manifestBuilder createManifestOf: MFClassA) isNotNil.
 	self assert: (manifestBuilder manifestOf: MFClassA) isNotNil
@@ -220,10 +214,7 @@ BuilderManifestTest >> testCreationManifest [
 BuilderManifestTest >> testCreationManifestOn [
 
 	manifestBuilder := TheManifestBuilder new.
-	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class |
-		class
-			removeFromChanges;
-			removeFromSystem ].
+	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class | class removeFromSystem ].
 	self assert: (manifestBuilder manifestOf: MFClassA) isNil.
 	self assert: (TheManifestBuilder of: MFClassA) isNotNil.
 	self assert: (manifestBuilder manifestOf: MFClassA) isNotNil

--- a/src/Manifest-Tests/SmalllintManifestCheckerTest.class.st
+++ b/src/Manifest-Tests/SmalllintManifestCheckerTest.class.st
@@ -36,10 +36,7 @@ SmalllintManifestCheckerTest >> setUp [
 { #category : 'running' }
 SmalllintManifestCheckerTest >> tearDown [
 
-	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class |
-		class
-			removeFromChanges;
-			removeFromSystem ].
+	testingEnvironment at: #ManifestManifestResourcesTests ifPresent: [ :class | class removeFromSystem ].
 	super tearDown
 ]
 

--- a/src/Monticello-GUI-Diff/PSMCPatchMorph.class.st
+++ b/src/Monticello-GUI-Diff/PSMCPatchMorph.class.st
@@ -295,7 +295,7 @@ PSMCPatchMorph >> revertChange: aChange [
 	| loader |
 	loader := MCPackageLoader new.
 	aChange inverse applyTo: loader.
-	loader loadWithName: ChangeSet current name
+	loader load
 ]
 
 { #category : 'private' }

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -136,7 +136,7 @@ MCPackageLoader >> installSnapshot: aSnapshot [
 MCPackageLoader >> load [
 
 	self validate.
-	self useNewChangeSetDuring: [ self basicLoad ]
+	self basicLoad
 ]
 
 { #category : 'private' }
@@ -172,18 +172,6 @@ MCPackageLoader >> loadClassDefinitions [
 
 	"Finally we warn about the errors we could not fix."
 	errorDefinitions ifNotEmpty: [ self warnAboutErrors: errorDefinitions ]
-]
-
-{ #category : 'public' }
-MCPackageLoader >> loadWithName: baseName [
-	self validate.
-	self useChangeSetNamed: baseName during: [self basicLoad]
-]
-
-{ #category : 'public' }
-MCPackageLoader >> loadWithNameLike: baseName [
-	self validate.
-	self useNewChangeSetNamedLike: baseName during: [self basicLoad]
 ]
 
 { #category : 'patch ops' }
@@ -240,27 +228,6 @@ MCPackageLoader >> updatePackage: aPackage withSnapshot: aSnapshot [
 	patch applyTo: self.
 	packageSnap definitions do: [:ea | self provisions addAll: ea provisions]
 
-]
-
-{ #category : 'private' }
-MCPackageLoader >> useChangeSetNamed: baseName during: aBlock [
-	"Use the named change set, or create one with the given name."
-	| oldChanges newChanges |
-	oldChanges := ChangeSet current.
-	newChanges := (ChangeSet named: baseName) ifNil: [ ChangeSet new name: baseName ].
-	ChangeSet newChanges: newChanges.
-	aBlock ensure: [ ChangeSet newChanges: oldChanges ].
-
-]
-
-{ #category : 'private' }
-MCPackageLoader >> useNewChangeSetDuring: aBlock [
-	^self useNewChangeSetNamedLike: 'MC' during: aBlock
-]
-
-{ #category : 'private' }
-MCPackageLoader >> useNewChangeSetNamedLike: baseName during: aBlock [
-	^self useChangeSetNamed: (ChangeSet uniqueNameLike: baseName) during: aBlock
 ]
 
 { #category : 'private' }

--- a/src/Monticello/MCThreeWayMerger.class.st
+++ b/src/Monticello/MCThreeWayMerger.class.st
@@ -115,15 +115,6 @@ MCThreeWayMerger >> load [
 	loader load
 ]
 
-{ #category : 'operations' }
-MCThreeWayMerger >> loadWithNameLike: baseName [
-	| loader |
-	loader := MCPackageLoader new.
-	loader provisions addAll: self provisions.
-	self applyTo: loader.
-	loader loadWithNameLike: baseName
-]
-
 { #category : 'accessing' }
 MCThreeWayMerger >> mergedSnapshot [
 	^ MCPatcher apply: self to: self baseSnapshot

--- a/src/Monticello/MCVersionLoader.class.st
+++ b/src/Monticello/MCVersionLoader.class.st
@@ -53,7 +53,7 @@ MCVersionLoader >> announceLoadStop: aString [
 ]
 
 { #category : 'private' }
-MCVersionLoader >> basicLoadWithNameLike: aString [
+MCVersionLoader >> basicLoad [
 	| loader |
 	
 	self checkForModificationsIfCancel: [ ^ self] ifMerge: [ ^ self mergeVersions ].
@@ -67,7 +67,7 @@ MCVersionLoader >> basicLoadWithNameLike: aString [
 			ifTrue: [ea patch applyTo: loader]
 			ifFalse: [loader updatePackage: ea package withSnapshot: ea snapshot]].
 		
-	loader loadWithNameLike: aString.
+	loader load.
 	versions do: [:ea | ea workingCopy loaded: ea]
 ]
 
@@ -141,7 +141,8 @@ MCVersionLoader >> load [
 { #category : 'loading' }
 MCVersionLoader >> loadWithNameLike: aString [
 	" this is THE central entrypoint for all loading (gopher, metacello, monticello, ...) "
-	^ self announceLoad: aString do: [ self basicLoadWithNameLike: aString ]
+
+	^ self announceLoad: aString do: [ self basicLoad ]
 ]
 
 { #category : 'checking' }

--- a/src/Monticello/MCVersionMerger.class.st
+++ b/src/Monticello/MCVersionMerger.class.st
@@ -15,9 +15,10 @@ Class {
 
 { #category : 'action' }
 MCVersionMerger class >> mergeVersion: aVersion [
+
 	self new
 		addVersion: aVersion;
-		mergeWithNameLike: aVersion info name
+		merge
 ]
 
 { #category : 'adding' }
@@ -62,16 +63,6 @@ MCVersionMerger >> merge [
 		^ true].
 	
 	^ false
-]
-
-{ #category : 'actions' }
-MCVersionMerger >> mergeWithNameLike: baseName [
-
-	self gatherChanges.
-	
-	self resolveConflicts ifTrue:
-		[merger loadWithNameLike: baseName.
-		records do: [:ea | ea updateWorkingCopy]].
 ]
 
 { #category : 'actions' }

--- a/src/MonticelloGUI/MCMergeBrowser.class.st
+++ b/src/MonticelloGUI/MCMergeBrowser.class.st
@@ -43,21 +43,6 @@ MCMergeBrowser >> cancel [
 ]
 
 { #category : 'actions' }
-MCMergeBrowser >> changeSetNameForInstall [
-	"Answer the name of the change set into which my selection will be installed.
-	Derive this from my label.
-	If I have no label, use the current change set."
-
-	| tokens |
-	label ifNil: [ ^ChangeSet current name ].
-	tokens := label findTokens: ' '.
-	tokens removeAllFoundIn: { 'changes'. 'between'. 'and' }.
-	(tokens size = 3 and: [ tokens second = '<working' ]) ifTrue: [ ^tokens first, '-to-working' ].
-	tokens size = 2 ifFalse: [ ^'InstalledPatches' ].
-	^'{1}-to-{2}' format: tokens 
-]
-
-{ #category : 'actions' }
 MCMergeBrowser >> chooseAllNewerConflicts [
 	"Notify the potential new state of canMerge."
 	
@@ -159,11 +144,12 @@ MCMergeBrowser >> innerButtonRow [
 
 { #category : 'actions' }
 MCMergeBrowser >> installSelection [
+
 	| loader |
-	selection ifNotNil:
-		[loader := MCPackageLoader new.
+	selection ifNotNil: [
+		loader := MCPackageLoader new.
 		selection applyTo: loader.
-		loader loadWithName: self changeSetNameForInstall ]
+		loader load ]
 ]
 
 { #category : 'selecting' }
@@ -203,11 +189,12 @@ MCMergeBrowser >> patch: aPatch [
 
 { #category : 'actions' }
 MCMergeBrowser >> revertSelection [
+
 	| loader |
-	selection ifNotNil:
-		[loader := MCPackageLoader new.
+	selection ifNotNil: [
+		loader := MCPackageLoader new.
 		selection inverse applyTo: loader.
-		loader loadWithName: self changeSetNameForInstall ]
+		loader load ]
 ]
 
 { #category : 'subclassresponsibility' }

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -105,11 +105,11 @@ ClassFactoryForTestCase >> defaultSuperclass [
 
 { #category : 'cleaning' }
 ClassFactoryForTestCase >> delete: aBehavior [
+
 	| name |
 	createdBehaviors remove: aBehavior ifAbsent: [  ].
 	aBehavior isObsolete ifTrue: [ ^ self ].
 	name := aBehavior name. "save it as it will be obsolete later"
-	self class environment at: #ChangeSet ifPresent: [ :changeSet | changeSet current removeClassAndMetaClassChanges: aBehavior ].
 	(createdSilently includes: aBehavior)
 		ifTrue: [
 			createdSilently remove: aBehavior.

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -75,8 +75,7 @@ ClassFactoryForTestCaseTest >> testPackageCleanUp [
 	self assert: (factory createdClasses allSatisfy: [ :class | class isObsolete ]).
 	allClasses := self environment allClasses.
 	self assert: (factory createdClasses noneSatisfy: [ :class | allClasses includes: class ]).
-	self assertEmpty: (self organization packages select: [ :package | package name beginsWith: factory packageName ]).
-	self class environment at: #ChangeSet ifPresent: [ :changeSet | self deny: (changeSet current changedClassNames includesAnyOf: createdClassNames) ]
+	self assertEmpty: (self organization packages select: [ :package | package name beginsWith: factory packageName ])
 ]
 
 { #category : 'testing' }

--- a/src/System-Changes/Class.extension.st
+++ b/src/System-Changes/Class.extension.st
@@ -1,9 +1,0 @@
-Extension { #name : 'Class' }
-
-{ #category : '*System-Changes' }
-Class >> removeFromChanges [
-	"References to the receiver, a class, and its metaclass should no longer be included in the system ChangeSet."
-
-	self class environment at: #ChangeSet ifPresent: [ :changeSet |
-		changeSet current removeClassAndMetaClassChanges: self ]
-]

--- a/src/System-Installers/MczInstaller.class.st
+++ b/src/System-Installers/MczInstaller.class.st
@@ -173,9 +173,7 @@ MczInstaller >> install [
 { #category : 'installation' }
 MczInstaller >> installMember: member [
 
-	self useNewChangeSetDuring:
-		[ CodeImporter evaluateReadStream: (self contentsForMember: member) readStream.
-		]
+	CodeImporter evaluateReadStream: (self contentsForMember: member) readStream
 ]
 
 { #category : 'utilities' }
@@ -196,16 +194,6 @@ MczInstaller >> recordVersionInfo [
 { #category : 'accessing' }
 MczInstaller >> stream: aStream [
 	stream := aStream
-]
-
-{ #category : 'utilities' }
-MczInstaller >> useNewChangeSetDuring: aBlock [
-	| changeHolder oldChanges newChanges |
-	changeHolder := ChangeSet.
-	oldChanges := ChangeSet current.
-	newChanges := ChangeSet new name: (ChangeSet uniqueNameLike: self extractPackageName).
-	changeHolder newChanges: newChanges.
-	[ aBlock value ] ensure: [changeHolder newChanges: oldChanges]
 ]
 
 { #category : 'utilities' }


### PR DESCRIPTION
The change set browser got removed and we currently still have the change set model in the image. 

This PR removes code dealing with the management of the change set so that we can remove it entirely soon. 

It is mostly from Monticello to remove some code that was creating new change sets while loading code. Or also some code that was calling #removeFromChanges 