### PR TITLE
Proper Handling of the Undo Stack in the RBRefactoryChangeManager 

### DIFF
--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -126,7 +126,7 @@ RBRefactoryChangeManager class >> unload [
 RBRefactoryChangeManager >> addUndo: aRefactoringChange [
 	undo push: aRefactoringChange.
 	undo size > UndoSize
-		ifTrue: [ undo removeFirst ].
+		ifTrue: [ undo removeLast ].
 	redo := OrderedCollection new
 ]
 
@@ -244,8 +244,8 @@ RBRefactoryChangeManager >> undoOperation [
 	undo ifEmpty: [ ^ self ].
 	self ignoreChangesWhile: [
 		| change |
-		change := undo removeLast.
-		redo add: change execute ]
+		change := undo pop.
+		redo add: change execute ] 
 ]
 
 { #category : 'public access' }


### PR DESCRIPTION
RBRefactoryChangeManager uses a Stack to handle the undo collection. The stack top is the first element but it is not correctly managed.

This could partially fix  https://github.com/pharo-project/pharo/issues/8103