### PR TITLE
Fix rename refactoring call to support class methods.

### DIFF
--- a/src/SystemCommands-MessageCommands/SycRenameMessage2Command.class.st
+++ b/src/SystemCommands-MessageCommands/SycRenameMessage2Command.class.st
@@ -58,7 +58,8 @@ SycRenameMessage2Command >> execute [
 		          scopes: refactoringScopes
 		          model: model
 		          renameMethodSignature: originalMessage
-		          in: refactoredClass.
+		          in: originalMessage methodClass.
+	
 	driver command: self andPostAction: [ toolContext showMessage: originalMessage renamedTo: driver newMessage ].
 	driver runRefactoring.
 	


### PR DESCRIPTION
It was possible to rename class methods because the selectedClass was always the instance side and not the actual class (instance or metaclass) side. 
This fixes it. 