### PR TITLE
UndeclaredVariable read/write: context as argument

### DIFF
--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -7,7 +7,7 @@ CompiledMethod >> ast [
 	"Workaround, see https://github.com/pharo-project/pharo/issues/14871
 	We force recompile to make sure the next call creates a correct BC to AST mapping"
 	
-	 ((self hasLiteral: #runtimeUndeclaredRead) or: [self hasLiteral: #runtimeUndeclaredWrite:])
+	 ((self hasLiteral: #runtimeUndeclaredReadInContext:) or: [self hasLiteral: #runtimeUndeclaredWrite:inContext:])
  			ifTrue: [self isInstalled ifTrue: [self recompile]].
 	
 	^ ASTCache at: self

--- a/src/Kernel-CodeModel/LiteralVariable.class.st
+++ b/src/Kernel-CodeModel/LiteralVariable.class.st
@@ -207,7 +207,7 @@ LiteralVariable >> readInContext: aContext [
 ]
 
 { #category : 'code generation' }
-LiteralVariable >> runtimeUndeclaredRead [
+LiteralVariable >> runtimeUndeclaredReadInContext: aContext [
 	"This method is used internally to compile polymorphic read on undeclared variables.
 	Do not call it youself to not polute senders."
 
@@ -224,7 +224,7 @@ LiteralVariable >> runtimeUndeclaredRead [
 ]
 
 { #category : 'code generation' }
-LiteralVariable >> runtimeUndeclaredWrite: anObject [
+LiteralVariable >> runtimeUndeclaredWrite: anObject inContext: aContext [
 	"This method is used internally to compile polymorphic write on undeclared variables.
 	Do not call it youself to not polute senders."
 

--- a/src/Kernel-CodeModel/UndeclaredVariable.class.st
+++ b/src/Kernel-CodeModel/UndeclaredVariable.class.st
@@ -58,14 +58,16 @@ UndeclaredVariable >> emitStore: aMethodBuilder [
 		popTop;
 		pushLiteral: self;
 		pushTemp: tempName;
-		send: #runtimeUndeclaredWrite:
+		pushThisContext;
+		send: #runtimeUndeclaredWrite:inContext:
 ]
 
 { #category : 'code generation' }
 UndeclaredVariable >> emitValue: aMethodBuilder [
 	aMethodBuilder
 		pushLiteral: self;
-		send: #runtimeUndeclaredRead
+		pushThisContext;
+		send: #runtimeUndeclaredReadInContext:
 ]
 
 { #category : 'registry' }
@@ -106,7 +108,7 @@ UndeclaredVariable >> registeredMethods [
 ]
 
 { #category : 'code generation' }
-UndeclaredVariable >> runtimeUndeclaredRead [
+UndeclaredVariable >> runtimeUndeclaredReadInContext: aContext [
 
 	<debuggerCompleteToSender>
 	^ UndeclaredVariableRead new
@@ -116,7 +118,7 @@ UndeclaredVariable >> runtimeUndeclaredRead [
 ]
 
 { #category : 'code generation' }
-UndeclaredVariable >> runtimeUndeclaredWrite: anObject [
+UndeclaredVariable >> runtimeUndeclaredWrite: anObject inContext: aContext [
 
 	<debuggerCompleteToSender>
 	^ UndeclaredVariableWrite new

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -282,7 +282,7 @@ CompiledCodeTest >> testLiteralsDoNotConsiderTheInnerBlockLiterals [
 	self assertCollection: method literals equals: {
 			2.
 			(UndeclaredVariable key: #test value: nil).
-			#runtimeUndeclaredWrite:.
+			#runtimeUndeclaredWrite:inContext:.
 			(GlobalVariable key: #Class value: Class).
 			block.
 			#doIt:.
@@ -325,11 +325,11 @@ CompiledCodeTest >> testLiteralsEvenTheOnesInTheInnerBlocks [
 		equals: {
 				2.
 				(UndeclaredVariable key: #test value: nil).
-				#runtimeUndeclaredWrite:.
+				.
 				(GlobalVariable key: #Class value: Class).
 				2.
 				(UndeclaredVariable key: #test value: nil).
-				#runtimeUndeclaredWrite:.
+				#runtimeUndeclaredWrite:inContext:..
 				#( #arrayInBlock ).
 				(GlobalVariable key: #Object value: Object).
 				#name.

--- a/src/Kernel-Tests/CompiledCodeTest.class.st
+++ b/src/Kernel-Tests/CompiledCodeTest.class.st
@@ -325,11 +325,11 @@ CompiledCodeTest >> testLiteralsEvenTheOnesInTheInnerBlocks [
 		equals: {
 				2.
 				(UndeclaredVariable key: #test value: nil).
-				.
+				#runtimeUndeclaredWrite:inContext:.
 				(GlobalVariable key: #Class value: Class).
 				2.
 				(UndeclaredVariable key: #test value: nil).
-				#runtimeUndeclaredWrite:inContext:..
+				#runtimeUndeclaredWrite:inContext:.
 				#( #arrayInBlock ).
 				(GlobalVariable key: #Object value: Object).
 				#name.


### PR DESCRIPTION
We want to be able to re-lookup the name when reading an UndeclaredVariable. For that we need to know the class that we read or write the var.

This PR is a small step: change #runtimeUndeclaredWrite: and runtimeUndeclaredRead to have one arg more, the context where the access is done