### PR TITLE
Display trait icon in Calypso class definition editor

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
@@ -98,7 +98,9 @@ ClyClassDefinitionEditorToolMorph >> decorateContainerTab [
 
 { #category : 'initialization' }
 ClyClassDefinitionEditorToolMorph >> defaultIconName [
-	^#class
+
+	self editingClass isTrait ifTrue: [ ^ #trait ].
+	^ #class
 ]
 
 { #category : 'to sort' }


### PR DESCRIPTION
Fixes #14840 