### PR TITLE
Make TraitedClass part of the trait composition of TraitedMetaclasses

### DIFF
--- a/src/Fuel-Core/FLTraitedMetaclassCluster.class.st
+++ b/src/Fuel-Core/FLTraitedMetaclassCluster.class.st
@@ -43,18 +43,17 @@ FLTraitedMetaclassCluster >> referencesOf: aMetaclass do: aBlock [
 		value: aMetaclass baseLocalMethods;
 		value: aMetaclass localMethodDict;
 		value: aMetaclass baseComposition;
-		value: aMetaclass traitComposition
+		value: aMetaclass basicTraitComposition
 ]
 
 { #category : 'serialize/materialize' }
 FLTraitedMetaclassCluster >> serializeReferencesOf: aMetaclass with: anEncoder [
-	super
-		serializeReferencesOf: aMetaclass
-		with: anEncoder.
-		
+
+	super serializeReferencesOf: aMetaclass with: anEncoder.
+
 	anEncoder
 		encodeReferenceTo: aMetaclass baseLocalMethods;
 		encodeReferenceTo: aMetaclass localMethodDict;
 		encodeReferenceTo: aMetaclass baseComposition;
-		encodeReferenceTo: aMetaclass traitComposition
+		encodeReferenceTo: aMetaclass basicTraitComposition
 ]

--- a/src/Shift-ClassBuilder-Tests/ShiftTraitBuilderTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShiftTraitBuilderTest.class.st
@@ -61,7 +61,7 @@ ShiftTraitBuilderTest >> testCreatingEmptyTraitHasDefaultElements [
 	self assert: newTrait name equals: #TTestTrait.
 	self assert: newTrait slotNames equals: #(  ).
 	self assert: newTrait traitComposition equals: {  } asTraitComposition.
-	self assert: newTrait class traitComposition equals: {  } asTraitComposition.
+	self assert: newTrait class traitComposition equals: {  } asTraitComposition + TraitedClass.
 	self assert: newTrait classVarNames equals: #(  ).
 	self assert: newTrait package name equals: self packageNameForTest
 ]

--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -346,13 +346,13 @@ TraitTest >> testMethodsAddedInMetaclass [
 
 { #category : 'tests' }
 TraitTest >> testMethodsAddedInMetaclassNotPresentInSubclasses [
+
 	| t1 c1 c2 |
-
 	t1 := self createT1.
-	c1 := self newClass: #C1 with: #(g h) traits: t1.
-	c2 := self newClass: #C2 superclass: c1 traits: {}.
+	c1 := self newClass: #C1 with: #( g h ) traits: t1.
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
 
-	self assertCollection: c2 class selectors sorted equals: #()
+	self assertCollection: c2 class localSelectors sorted equals: #(  )
 ]
 
 { #category : 'tests' }
@@ -365,9 +365,7 @@ TraitTest >> testMethodsAddedInMetaclassPresentInSubclassesAfterChangingSupercla
 	c1 := self newClass: #C1 with: #(g h) traits: t1.
 	c2 := self newClass: #C2 superclass: c1 traits: {t2}.
 
-	self assertCollection: c2 class selectors sorted equals: #().
-	c1 := self newClass: #C1 with: #(g h) traits: {}.
-
+	self assertCollection: c2 class localSelectors sorted equals: #().
 	self assertCollection: c2 class selectors sorted equals: TraitedClass selectors sorted
 ]
 
@@ -381,9 +379,7 @@ TraitTest >> testMethodsAddedInMetaclassPresentInSubclassesAfterRemovingSupercla
 	c1 := self newClass: #C1 with: #(g h) traits: t1.
 	c2 := self newClass: #C2 superclass: c1 traits: {t2}.
 
-	self assertCollection: c2 class selectors sorted equals: #().
-	c1 removeFromSystem.
-
+	self assertCollection: c2 class localSelectors sorted equals: #().
 	self assertCollection: c2 class selectors sorted equals: TraitedClass selectors sorted
 ]
 
@@ -583,12 +579,16 @@ TraitTest >> testRemovingTraitsRemoveTraitedClassMethodsWithSubclasses [
 	c2 := self newClass: #C2 superclass: c1 traits: t2.
 
 	self assert: (c1 class includesSelector: #traits).
-	self deny: (c2 class includesSelector: #traits).
+	self deny: (c1 class includesLocalSelector: #traits).
+	self assert: (c2 class includesSelector: #traits).
+	self deny: (c2 class includesLocalSelector: #traits).
 
 	c1 := self newClass: #C1 with: #(g h) traits: {}.
 
+	"Now c1 has no more traits, c2 remains unchanged"
 	self deny: (c1 class includesSelector: #traits).
-	self assert: (c2 class includesSelector: #traits)
+	self assert: (c2 class includesSelector: #traits).
+	self deny: (c2 class includesLocalSelector: #traits).
 ]
 
 { #category : 'tests' }

--- a/src/Traits/TraitedMetaclass.class.st
+++ b/src/Traits/TraitedMetaclass.class.st
@@ -63,6 +63,13 @@ TraitedMetaclass >> baseLocalMethods: anObject [
 	baseLocalMethods := anObject
 ]
 
+{ #category : 'accessing' }
+TraitedMetaclass >> basicTraitComposition [
+	"Return the declared trait composition, mainly for serialization purposes"
+
+	^ composition
+]
+
 { #category : 'fileout' }
 TraitedMetaclass >> definitionStringFor: aConfiguredPrinter [
 

--- a/src/Traits/TraitedMetaclass.class.st
+++ b/src/Traits/TraitedMetaclass.class.st
@@ -125,7 +125,7 @@ TraitedMetaclass >> findOriginMethodOf: aMethod [
 { #category : 'testing' }
 TraitedMetaclass >> hasTraitComposition [
 
-	^ self traitComposition isEmpty not
+	^ composition isEmpty not
 ]
 
 { #category : 'testing - method dictionary' }
@@ -308,7 +308,14 @@ TraitedMetaclass >> slots [
 
 { #category : 'accessing' }
 TraitedMetaclass >> traitComposition [
-	^ composition
+
+	"Return the trait composition used publicly to compute usages and (re) compilation.
+	It must contain TraitedClass to consider the methods defined there.
+	
+	Internally use directly the instance variable `composition`"
+
+	(composition includesTrait: TraitedClass) ifTrue: [ ^ composition ].
+	^ composition + TraitedClass asTraitComposition
 ]
 
 { #category : 'accessing' }
@@ -323,7 +330,8 @@ TraitedMetaclass >> traitComposition: aComposition [
 
 { #category : 'accessing' }
 TraitedMetaclass >> traitCompositionString [
-	^ self traitComposition asString
+
+	^ composition asString
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
When changing the superclass of spec tests in https://github.com/pharo-spec/Spec/pull/1496, a release test broke.
Completely unrelated to the original PR.

```smalltalk
ProperPackagesTest debug: #testPackageExtensionsStartsWithProperPackageName.
=> OK

newTestCase := (TestCase << #NewTestCase)
	package: #toto;
	install.
	
(newTestCase << #SpBaseTest)
	install.
	
ProperPackagesTest debug: #testPackageExtensionsStartsWithProperPackageName.
=> Bug
```

We tracked down this issue to a trait propagation issue related to `TraitedMetaclass`es.
Turns out that methods added to `TraitedClass` should be automatically propagated to traited metaclasses, but they were not. This issue actually happens with lots of classes.

```smalltalk
TraitedMetaclass allInstances size select: [ :e | e methodDictionary keys includesAll: TraitedClass selectors ]
101 out of 1221
```

Now, the issue was visible only because one of those methods was an extension method breaking one release test.
But the issue was deeper.

Turns out, that `TraitedMetaclass`es only knew the selectors that `TraitedClass` had at the moment of their build.
All methods added afterwards were not propagated to them.
This is why many of these classes do not have the extension method, that's added later during the build.

This PR fixes that by adding considering `TraitedClass` as a trait of the `TraitedMetaclass`.