### PR TITLE
Fix for  Calypso discard code with error and prevent to fix it

### DIFF
--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -133,10 +133,9 @@ ClyTextEditorToolMorph >> changesAccepted [
 				  textMorph hasUnacceptedEdits: true.
 				  err pass ].
 
-		  textModel setText: self editingText.
-
 		  applied
 			  ifTrue: [
+				  textModel setText: self editingText.
 				  textMorph hasUnacceptedEdits: false.
 				  self textUpdated.
 				  browser focusActiveTab ]


### PR DESCRIPTION
See the problem while saving code with syntax error:


https://github.com/pharo-project/pharo/assets/4825959/dfc1b578-3716-42a8-b03c-361e8b039758


The PR fixes #15730, by updating the text in Calypso editor only after applied changes are valid:


https://github.com/pharo-project/pharo/assets/4825959/c5f4b75b-db1e-4f1f-bffd-6eb76faa43fb

