### PR TITLE
Open class browser on Cmd/Ctrl B in the message brp

### DIFF
--- a/src/Calypso-Browser/ClyDataSourceSelection.class.st
+++ b/src/Calypso-Browser/ClyDataSourceSelection.class.st
@@ -156,6 +156,14 @@ ClyDataSourceSelection >> detachedItems [
 ]
 
 { #category : 'controlling' }
+ClyDataSourceSelection >> ensureVisibleFirstItem [
+	
+	rootDataSource table
+		selectIndexes: #();
+	 	selectFirst
+]
+
+{ #category : 'controlling' }
 ClyDataSourceSelection >> ensureVisibleLastItem [
 
 	"in fact first selection index is last selected item"

--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -685,6 +685,16 @@ ClyQueryViewMorph >> restoreSelectedItems [
 	highlighting restoreTableSelection
 ]
 
+{ #category : 'event handling' }
+ClyQueryViewMorph >> selectFirstItem [
+
+	| rowsCount |
+	
+	rowsCount := self dataSource numberOfRows.
+	rowsCount = 0 ifTrue: [ ^ self ].
+	UIManager default defer: [ self selection ensureVisibleFirstItem ]
+]
+
 { #category : 'controlling' }
 ClyQueryViewMorph >> selectLastItem [
 

--- a/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
+++ b/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
@@ -132,7 +132,8 @@ ClyOldMessageBrowserAdapter >> open [
 	query
 		criteriaString: autoSelect;
 		criteriaBlock: refreshingBlock.
-	openedBrowser := ClyQueryBrowserMorph openOn: query
+	openedBrowser := ClyQueryBrowserMorph openOn: query.
+	openedBrowser selectFirstItem.
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
@@ -370,6 +370,14 @@ ClyQueryBrowserMorph >> selectClass: aClass [
 ]
 
 { #category : 'navigation' }
+ClyQueryBrowserMorph >> selectFirstItem [
+
+	self changeStateBy: [
+		resultView selectFirstItem
+	]
+]
+
+{ #category : 'navigation' }
 ClyQueryBrowserMorph >> selectLastItem [
 
 	self changeStateBy: [


### PR DESCRIPTION
This PR fixes a problem in the message browser, described in #15860

After opened, currently the message browser contains a messages list which must be clicked manually to get the Ctrl+B or Cmd+B key binding working. See this video to visualize the problem:

https://github.com/pharo-project/pharo/assets/4825959/66266193-9ec6-40c9-8a20-3e9547f4e1bc

The PR add a method `selectFirstItem` for explicit request to select the first item in the message browser, and a couple of supporting methods.

See the following video to see how should it work after this PR is applied:

https://github.com/pharo-project/pharo/assets/4825959/89a3d4ee-7111-4919-bfd6-e2e193edb8ac