### PR TITLE
Replace UIManager progress bars with Job

### DIFF
--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -138,18 +138,18 @@ ZipArchive >> close [
 ZipArchive >> extractAllTo: aDirectory [
 	"Extract all elements to the given directory; notifying user via UI on progress and if existing files exist"
 
-	UIManager default
-		informUserDuring: [:bar |
-			bar max: self numberOfMembers.
-			self extractAllTo: aDirectory informing: bar ]
+	[ : job |
+		job max: self numberOfMembers.
+		self extractAllTo: aDirectory informing: job ] 
+			asJob run
 ]
 
 { #category : 'archive operations' }
-ZipArchive >> extractAllTo: aDirectory informing: bar [
+ZipArchive >> extractAllTo: aDirectory informing: job [
 	"Extract all elements to the given directory; notifying user via UI on progress and if existing files exist"
 
-	| bar1 barValue |
-	bar1 := bar ifNil: [ DummySystemProgressItem new ].
+	| job1 barValue |
+	job1 := job ifNil: [ DummySystemProgressItem new ].
 	barValue := 0.
 	self members select: #isDirectory thenDo: [ :entry |
 		| dir shouldUpdateInfos lastUpdate |
@@ -157,24 +157,24 @@ ZipArchive >> extractAllTo: aDirectory informing: bar [
 		(shouldUpdateInfos := (Time millisecondsSince: lastUpdate) >= 100)
 			ifTrue: [
 				lastUpdate := Time millisecondClockValue.
-				bar1 label: 'Creating ' , entry fileName ].
+				job1 title: 'Creating ' , entry fileName ].
 		dir := (entry fileName findTokens: '/')
 			       inject: aDirectory
 			       into: [ :base :part | base / part ].
 		dir ensureCreateDirectory.
 		barValue := barValue + 1.
-		shouldUpdateInfos ifTrue: [ bar1 value: barValue ] ].
+		shouldUpdateInfos ifTrue: [ job1 currentValue: barValue ] ].
 	self members reject: #isDirectory thenDo: [ :entry |
 		| shouldUpdateInfos lastUpdate |
 		lastUpdate := 0.
 		(shouldUpdateInfos := (Time millisecondsSince: lastUpdate) >= 100)
 			ifTrue: [
 				lastUpdate := Time millisecondClockValue.
-				bar1 label: 'Extracting ' , entry fileName ].
+				job1 title: 'Extracting ' , entry fileName ].
 		entry extractInDirectory: aDirectory.
 		barValue := barValue + 1.
 		shouldUpdateInfos ifTrue: [
-			bar1 value: barValue.
+			job1 currentValue: barValue.
 			lastUpdate := Time millisecondClockValue ] ].
 	^ self
 ]

--- a/src/EpiceaBrowsers/EpLogBrowserPresenter.class.st
+++ b/src/EpiceaBrowsers/EpLogBrowserPresenter.class.st
@@ -207,10 +207,11 @@ EpLogBrowserPresenter >> cachedLogEntries [
 	^ (cachedLogEntries isNotNil and: [ cachedLogEntries size = log entriesCount ])
 		ifTrue: [ cachedLogEntries ]
 		ifFalse: [
-			'Reading log'
-				displayProgressFrom: 0 to: 1
-				during: [ cachedLogEntries := log entries ]
-			]
+			[ : job | 
+				job title: 'Reading log'.
+				cachedLogEntries := log entries
+			] asJob run ].
+
 ]
 
 { #category : 'refreshing' }

--- a/src/Jobs/Collection.extension.st
+++ b/src/Jobs/Collection.extension.st
@@ -28,28 +28,32 @@ Collection >> do: aBlock displayingProgress: aStringOrBlock every: msecs [
                        displayingProgress:[:aClass| 'Processing ', aClass name]
                        every: 0."
 
-	| size labelBlock count oldLabel lastUpdate |
+	| size labelBlock oldLabel lastUpdate |
 	self isEmpty ifTrue: [ ^ self ].
 	oldLabel := nil.
-	count := lastUpdate := 0.
+	lastUpdate := 0.
 	size := self size.
-	'' displayProgressFrom: 0 to: size during: [:bar |
-		labelBlock := aStringOrBlock isString
-			ifTrue: [
-				bar label: aStringOrBlock.
-				[ :dummyItem | aStringOrBlock] ]
-			ifFalse: [ aStringOrBlock ].
+	
+	[ : job |	
+		| newLabel |
+		job max: size.
+		self doWithIndex: [ : each : index |
+			"Handle String or Block progress label"
+			labelBlock := aStringOrBlock isString
+				ifTrue: [
+					job title: aStringOrBlock.
+					[ :dummyItem | aStringOrBlock] ]
+				ifFalse: [ aStringOrBlock ].
 
-		self do: [ :each | | newLabel |
-			"Special handling for first and last element"
-			(count = 0 or: [ count + 1 = size or: [(Time millisecondsSince: lastUpdate) >= msecs]]) 
+			(index = 1 or: [ index + 1 = size or: [(Time millisecondsSince: lastUpdate) >= msecs]]) 
 				ifTrue: [ 
-					bar current: count.
+					job currentValue: index..
 					oldLabel = (newLabel := (labelBlock cull: each) ifNil: [oldLabel]) 
 						ifFalse: [
-							bar label: newLabel.
+							job title: newLabel.
 							oldLabel := newLabel ].
 				lastUpdate := Time millisecondClockValue ].
-			aBlock value: each.
-			count := count + 1 ] ]
+			aBlock value: each ] 
+	] asJob run
+	
 ]

--- a/src/Jobs/String.extension.st
+++ b/src/Jobs/String.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'String' }
 
-{ #category : '*UIManager' }
+{ #category : '*Jobs' }
 String >> displayProgressFrom: minVal to: maxVal during: workBlock [
 	"Display this string as a caption over a progress bar while workBlock is evaluated.
 
@@ -11,9 +11,9 @@ EXAMPLE (Select next 6 lines and Do It)
 	1 to: 10 do: [:x | bar value: x.
 			(Delay forMilliseconds: 500) wait]].
 "
-	^ UIManager default
-		displayProgress: self
-		from: minVal
-		to: maxVal
-		during: workBlock
+	^ workBlock asJob
+			title: self;
+			min: minVal;
+			max: maxVal;
+			run
 ]

--- a/src/MonticelloRemoteRepositories/MCHttpRepository.class.st
+++ b/src/MonticelloRemoteRepositories/MCHttpRepository.class.st
@@ -162,22 +162,23 @@ MCHttpRepository >> description [
 
 { #category : 'i/o' }
 MCHttpRepository >> displayProgress: label during: workBlock [
+
 	| nextUpdateTime |
 	nextUpdateTime := 0.
-	^UIManager default displayProgress: label 
-		from: 0.0 to: 1.0 during:[:bar|
-			[workBlock value] on: HTTPProgress do:[:ex|
-				(ex total == nil or: [ex amount == nil]) ifFalse:[
-					(nextUpdateTime < Time millisecondClockValue 
-						or:[ex total = ex amount]) ifTrue:[
-							bar current: ex amount asFloat / ex total asFloat.
-							nextUpdateTime := Time millisecondClockValue + 100.
-					].
-				].
-				ex resume.
-			]
-		].
-
+	^ [ :bar |
+		  [ workBlock value ]
+		  on: HTTPProgress
+		  do: [ :ex |
+			  (ex total isNil or: [ ex amount isNil ]) ifFalse: [
+					  (nextUpdateTime < Time millisecondClockValue or: [
+							   ex total = ex amount ]) ifTrue: [
+							  bar current: ex amount asFloat / ex total asFloat.
+							  nextUpdateTime := Time millisecondClockValue + 100 ] ].
+			  ex resume ] ] asJob
+		  title: label;
+		  min: 0.0;
+		  max: 1.0;
+		  run
 ]
 
 { #category : 'printing' }

--- a/src/System-Settings-Browser/SettingBrowser.class.st
+++ b/src/System-Settings-Browser/SettingBrowser.class.st
@@ -415,21 +415,28 @@ SettingBrowser >> exportAllSettings: actions by: groupSize withBasename: aString
 
 { #category : 'export' }
 SettingBrowser >> exportSettings [
-	| title nodes actions   |
+
+	| nodes actions |
 
 	nodes := self treeHolder nodeList.
-	title := 'Exporting settings'.
-	title
-		displayProgressFrom: 1
-		to: nodes size
-		during: [:bar | actions := nodes collectWithIndex: [:e :i |
-											bar current: i.
-											bar label: (String streamContents: [:s |
-															s << title << ' (' << (e item label) << ')']).
-											e item exportSettingAction ]].
+	[: job | 
+		| title  |
+		title := 'Exporting settings'.
+		job title: title.
+		1 to: nodes size do: [ : each |
+			actions := nodes collectWithIndex: [ : e : i |
+			job
+				progress: i;
+				title: (String streamContents: [:s |
+					s << title << ' (' << (e item label) << ')']).			
+				e item exportSettingAction ] ] 
+	]  asJob run.
 
 	actions := actions reject: [:e | e isNil ].
-	self exportAllSettings: actions by: 50 withBasename: 'exported_settings'
+	self 
+		exportAllSettings: actions 
+		by: 50 
+		withBasename: 'exported_settings'
 ]
 
 { #category : 'export' }


### PR DESCRIPTION
This PR implements modifications to clean UIManager references related with progress bars.

- Adapt some progress bars which were using the progress method implemented in String (`displayProgressFrom:to:during:`) in this sense `Collection>>#do:displayingProgress:every:` was a central user. This handles #14179 however it moved the extension method from UIManager to Jobs. Senders of this method could be replaced by its job equivalent in a next iteration.
- `EpLogBrowserPresenter>>cachedLogEntries`
- Adapted `ZipArchive>>extractAllTo:`  to use Job based progress bar.
- Adapted `MCHttpRepository>>#displayProgress:during:` to use Job.
- It should be easier now to remove extension method from Jobs package to `UIManager>>#displayProgress:from:to:during: ` in a next iteration. Kept now because it is used by `informUserDuring:` which is used by Spec and Iceberg.
