### PR TITLE
Explicitly set initial focus to the query browser table during open

### DIFF
--- a/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
+++ b/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
@@ -132,8 +132,7 @@ ClyOldMessageBrowserAdapter >> open [
 	query
 		criteriaString: autoSelect;
 		criteriaBlock: refreshingBlock.
-	openedBrowser := ClyQueryBrowserMorph openOn: query.
-	openedBrowser selectFirstItem.
+	openedBrowser := ClyQueryBrowserMorph openOn: query
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
@@ -298,10 +298,26 @@ ClyQueryBrowserMorph >> newWindowTitle [
 ]
 
 { #category : 'opening/closing' }
+ClyQueryBrowserMorph >> open [ 
+	super open.
+
+	resultView takeKeyboardFocus
+	
+]
+
+{ #category : 'opening/closing' }
 ClyQueryBrowserMorph >> openAnotherBrowser: aBrowser [
 	(aBrowser isKindOf: ClyQueryBrowserMorph)
 		ifTrue: [ aBrowser openInWindow: self window]
 		ifFalse: [ aBrowser open ]
+]
+
+{ #category : 'opening/closing' }
+ClyQueryBrowserMorph >> openInWindow: aWindow [
+	super openInWindow: aWindow.
+
+	resultView takeKeyboardFocus
+	
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
It is a general fix for #15860.
- cmd+b from just opened query browser and any other shortcuts