### PR TITLE
Restore #removeMethod:inClass: method

### DIFF
--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -181,6 +181,20 @@ SystemNavigationTest >> testReferencesToAClassInBlock [
 ]
 
 { #category : 'tests' }
+SystemNavigationTest >> testRemoveMethodInClass [
+
+	| methodToRemove selector class |
+
+	selector := #aMethod.
+	class := self classFactory silentlyNewClass.
+	class compileSilently: selector asString , ' ^ self'.
+
+	methodToRemove := class >> selector.
+	self assert: (self systemNavigationToTest removeMethod: methodToRemove inClass: class).
+	self should: [ class >> selector ] raise: NotFound
+]
+
+{ #category : 'tests' }
 SystemNavigationTest >> testSenderOfASelectorInBlock [
 
 	| senders selector class otherClass |

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -417,3 +417,18 @@ want to REMOVE the class ' , className
 			'
 from the system?'
 ]
+
+{ #category : 'removing' }
+SystemNavigation >> removeMethod: aCompiledMethod inClass: aClass [
+	"If a message is selected, create a Confirmer so the user can verify that
+	the currently selected message should be removed from the system. If
+	so, remove it. "
+	| messageName |
+
+	aCompiledMethod ifNil: [ ^ false ].
+	messageName := aCompiledMethod selector.
+	(aClass includesLocalSelector: messageName)
+		ifTrue: [ aClass removeSelector: messageName ].
+
+	^ true
+]


### PR DESCRIPTION
This PR restore a probably unnoticed method removal in SystemNavigation, reported in #15874 
Also add test to prevent future accidental deletions.
