### PR TITLE
Integrate Teachable into "SUnit-Mock" via LOADING

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -121,6 +121,13 @@ BaselineOfPharo class >> newToolsRepository [
 	^ (self externalProjectNamed: 'NewTools') repository
 ]
 
+{ #category : 'class initialization' }
+BaselineOfPharo class >> reset [
+	<script>
+
+	ExternalProjects := nil
+]
+
 { #category : 'accessing - external projects' }
 BaselineOfPharo class >> roassal [
 	<externalProject>
@@ -153,6 +160,23 @@ BaselineOfPharo class >> spec [
 BaselineOfPharo class >> specRepository [
 
 	^ (self externalProjectNamed: 'Spec2') repository
+]
+
+{ #category : 'accessing - external projects' }
+BaselineOfPharo class >> teachable [
+	<externalProject>
+
+	^ PharoExternalProject 
+		newName: 'Teachable' 
+		owner: 'astares' 
+		project:'Pharo-Teachable' 
+		version: 'main'
+]
+
+{ #category : 'repository urls' }
+BaselineOfPharo class >> teachableRepository [
+
+	^ (self externalProjectNamed: 'Teachable') repository
 ]
 
 { #category : 'accessing - external projects' }

--- a/src/BaselineOfSUnit/BaselineOfSUnit.class.st
+++ b/src/BaselineOfSUnit/BaselineOfSUnit.class.st
@@ -23,7 +23,7 @@ BaselineOfSUnit class >> defaultPackageNames [
 	^ self packagesOfGroupNamed: #default
 ]
 
-{ #category : 'baseline' }
+{ #category : 'baselines' }
 BaselineOfSUnit >> baseline: spec [
 	<baseline>
 	spec for: #common
@@ -34,14 +34,16 @@ BaselineOfSUnit >> baseline: spec [
 				spec repository: (self packageRepositoryURLForSpec: spec)
 			].
 			
+			self teachable: spec.
+			
 			spec
 				package: 'SUnit-Core';
 				package: 'SUnit-Core-Traits' with: [ spec requires: 'Traits' ];
 				package: 'SUnit-Tests';
 				package: 'SUnit-Visitor' with: [ spec requires: #('SUnit-Core') ];
 				package: 'SUnit-Visitor-Tests' with: [ spec requires: #('SUnit-Visitor') ];
-				package: 'SUnit-MockObjects' with: [ spec requires: #('SUnit-Core') ];
-				package: 'SUnit-MockObjects-Tests' with: [ spec requires: #('SUnit-MockObjects') ];
+				package: 'SUnit-MockObjects' with: [ spec requires: #('Teachable' 'SUnit-Core') ];
+				package: 'SUnit-MockObjects-Tests' with: [ spec requires: #('Teachable-Tests' 'SUnit-MockObjects') ];
 				package: 'SUnit-UI' with: [ spec requires: #('Coverage') ];
 				package: 'SUnit-Support-UITesting-Tests';
 				package: 'SUnit-Support-UITesting';
@@ -55,4 +57,18 @@ BaselineOfSUnit >> baseline: spec [
 				group: 'Tests' with: #('SUnit-Tests' 'SUnit-Support-UITesting-Tests' 'SUnit-Visitor-Tests' 'SUnit-MockObjects-Tests');
 				group: 'JenkinsSupport' with: #('JenkinsTools-Core' 'JenkinsTools-ExtraReports');
 				group: 'default' with: #('SUnit-Core' 'SUnit-Core-Traits' 'SUnit-Tests' 'JenkinsTools-Core' 'JenkinsTools-ExtraReports' 'SUnit-MockObjects') ]
+]
+
+{ #category : 'dependencies' }
+BaselineOfSUnit >> teachable: spec [
+
+	spec baseline: 'Teachable' with: [
+		spec
+			repository: 'github://astares/Pharo-Teachable:v2.2/src';
+			loads: #( 'Core' ) ].
+
+	spec
+		project: 'Teachable-Tests'
+		copyFrom: 'Teachable'
+		with: [ spec loads: #( 'Tests' ) ]
 ]

--- a/src/BaselineOfSUnit/BaselineOfSUnit.class.st
+++ b/src/BaselineOfSUnit/BaselineOfSUnit.class.st
@@ -64,7 +64,7 @@ BaselineOfSUnit >> teachable: spec [
 
 	spec baseline: 'Teachable' with: [
 		spec
-			repository: 'github://astares/Pharo-Teachable:v2.2/src';
+			repository: 'github://astares/Pharo-Teachable:v2.3/src';
 			loads: #( 'Core' ) ].
 
 	spec


### PR DESCRIPTION
- properly declare dependencies to external project
- Fix #15912
- Fix #15806
- additionally provides a #reset method on BaselineOfPharo to be able to recompute external projects
- also fixes a lint issue by proper categorization of #baseline: method