### PR TITLE
Fixed lost menu for rename method

### DIFF
--- a/src/Calypso-SystemTools-Core/SycRenameMessageCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycRenameMessageCommand.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : 'SycRenameMessageCommand' }
+
+{ #category : '*Calypso-SystemTools-Core' }
+SycRenameMessageCommand class >> methodMenuActivation [
+	<classAnnotation>
+
+	^ CmdContextMenuActivation byRootGroupItemOrder: 10000 for: ClyMethod asCalypsoItemContext
+]
+
+{ #category : '*Calypso-SystemTools-Core' }
+SycRenameMessageCommand class >> methodShortcutActivation [
+	<classAnnotation>
+
+	^CmdShortcutActivation renamingFor: ClyMethod asCalypsoItemContext
+]

--- a/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
@@ -15,7 +15,7 @@ SycRemoveClassCommand >> defaultMenuIconName [
 
 { #category : 'accessing' }
 SycRemoveClassCommand >> defaultMenuItemName [
-	^'Remove Class'
+	^'(R) Remove'
 ]
 
 { #category : 'execution' }

--- a/src/SystemCommands-ClassCommands/SycRenameClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRenameClassCommand.class.st
@@ -15,7 +15,7 @@ SycRenameClassCommand >> defaultMenuIconName [
 
 { #category : 'accessing' }
 SycRenameClassCommand >> defaultMenuItemName [
-	^'Rename'
+	^'(R) Rename'
 ]
 
 { #category : 'execution' }

--- a/src/SystemCommands-MessageCommands/SycRenameMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycRenameMessageCommand.class.st
@@ -48,7 +48,7 @@ SycRenameMessageCommand >> defaultMenuIconName [
 
 { #category : 'accessing' }
 SycRenameMessageCommand >> defaultMenuItemName [
-	^ 'Rename'
+	^ '(R) Rename'
 ]
 
 { #category : 'execution' }

--- a/src/SystemCommands-MethodCommands/SycRemoveMethod2Command.class.st
+++ b/src/SystemCommands-MethodCommands/SycRemoveMethod2Command.class.st
@@ -29,7 +29,7 @@ SycRemoveMethod2Command >> defaultMenuIconName [
 
 { #category : 'accessing' }
 SycRemoveMethod2Command >> defaultMenuItemName [
-	^'Remove refactoring'
+	^'(R) Remove'
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
- clarify all the migrated refactorings using (R) in the menu as a counterpart for (T)