### PR TITLE
Fix class and trait definition printing to consider package tags

### DIFF
--- a/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateClassCommand.class.st
+++ b/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateClassCommand.class.st
@@ -35,19 +35,12 @@ ClyCreateClassCommand >> defaultMenuItemName [
 
 { #category : 'command execution' }
 ClyCreateClassCommand >> execute [
-	| classDefinition p resultTrait |
-	p := package name.
-	packageTag ifNotNil: [ p := p , '-' , packageTag ].
-	classDefinition := ClassDefinitionPrinter fluid classDefinitionTemplateInPackage: p.
-	classDefinition := self morphicUIManager
-		                   multiLineRequest: 'Define class definition:'
-		                   initialAnswer: classDefinition
-		                   answerHeight: 250.
+
+	| classDefinition resultTrait |
+	classDefinition := ClassDefinitionPrinter fluid classDefinitionTemplateInPackage: package name tag: packageTag named: #MyClass.
+	classDefinition := self morphicUIManager multiLineRequest: 'Define class definition:' initialAnswer: classDefinition answerHeight: 250.
 	classDefinition isEmptyOrNil ifTrue: [ ^ self ].
-	resultTrait := browser
-		               compileANewClassFrom: classDefinition
-		               notifying: nil
-		               startingFrom: nil.
+	resultTrait := browser compileANewClassFrom: classDefinition notifying: nil startingFrom: nil.
 	resultTrait ifNotNil: [ browser selectClass: resultTrait ]
 ]
 

--- a/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTestCaseCommand.class.st
+++ b/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTestCaseCommand.class.st
@@ -35,19 +35,12 @@ ClyCreateTestCaseCommand >> defaultMenuItemName [
 
 { #category : 'command execution' }
 ClyCreateTestCaseCommand >> execute [
-	| classDefinition p resultClass |
-	p := package name.
-	packageTag ifNotNil: [ p := p , '-' , packageTag ].
-	classDefinition := ClassDefinitionPrinter fluid testClassDefinitionTemplateInPackage: p.
-	classDefinition := self morphicUIManager
-		                   multiLineRequest: 'Define test class:'
-		                   initialAnswer: classDefinition
-		                   answerHeight: 250.
+
+	| classDefinition resultClass |
+	classDefinition := ClassDefinitionPrinter fluid testClassDefinitionTemplateInPackage: package name tag: packageTag.
+	classDefinition := self morphicUIManager multiLineRequest: 'Define test class:' initialAnswer: classDefinition answerHeight: 250.
 	classDefinition isEmptyOrNil ifTrue: [ ^ self ].
-	resultClass := browser
-		               compileANewClassFrom: classDefinition
-		               notifying: nil
-		               startingFrom: nil.
+	resultClass := browser compileANewClassFrom: classDefinition notifying: nil startingFrom: nil.
 	resultClass ifNotNil: [ browser selectClass: resultClass ]
 ]
 

--- a/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTraitCommand.class.st
+++ b/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTraitCommand.class.st
@@ -47,19 +47,12 @@ ClyCreateTraitCommand >> defaultMenuItemName [
 
 { #category : 'command execution' }
 ClyCreateTraitCommand >> execute [
-	| traitDefinition category resultTrait |
-	category := package name.
-	packageTag ifNotNil: [ category := category , '-' , packageTag ].
-	traitDefinition := ClassDefinitionPrinter fluid traitDefinitionTemplateInPackage: category.
-	traitDefinition := self morphicUIManager
-		                   multiLineRequest: 'Define trait:'
-		                   initialAnswer: traitDefinition
-		                   answerHeight: 250.
+
+	| traitDefinition resultTrait |
+	traitDefinition := ClassDefinitionPrinter fluid traitDefinitionTemplateInPackage: package name tag: packageTag named: #TMyTrait.
+	traitDefinition := self morphicUIManager multiLineRequest: 'Define trait:' initialAnswer: traitDefinition answerHeight: 250.
 	traitDefinition isEmptyOrNil ifTrue: [ ^ self ].
-	resultTrait := browser
-		               compileANewClassFrom: traitDefinition
-		               notifying: nil
-		               startingFrom: nil.
+	resultTrait := browser compileANewClassFrom: traitDefinition notifying: nil startingFrom: nil.
 	resultTrait ifNotNil: [ browser selectClass: resultTrait ]
 ]
 

--- a/src/ClassDefinitionPrinters/ClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/ClassDefinitionPrinter.class.st
@@ -114,16 +114,6 @@ ClassDefinitionPrinter >> classDefinitionString [
 	^ self subclassResponsibility
 ]
 
-{ #category : 'accessing' }
-ClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName [
-	^ self classDefinitionTemplateInPackage: aPackageName named: #MyClass
-]
-
-{ #category : 'template' }
-ClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName named: aClassName [
-	^ self subclassResponsibility
-]
-
 { #category : 'printing' }
 ClassDefinitionPrinter >> definitionString [
 	"The method is part of the double dispatch. It is an extra starting point.
@@ -150,23 +140,8 @@ ClassDefinitionPrinter >> metaclassDefinitionString [
 	^ self subclassResponsibility
 ]
 
-{ #category : 'template' }
-ClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString [
-	^ self subclassResponsibility
-]
-
 { #category : 'public api' }
 ClassDefinitionPrinter >> traitDefinitionString [
-	^ self subclassResponsibility
-]
-
-{ #category : 'template' }
-ClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString [
-	^ self traitDefinitionTemplateInPackage: aString named: #TMyTrait
-]
-
-{ #category : 'template' }
-ClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName named: aTraitName [ 
 	^ self subclassResponsibility
 ]
 

--- a/src/ClassDefinitionPrinters/FluidClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/FluidClassDefinitionPrinter.class.st
@@ -64,17 +64,30 @@ FluidClassDefinitionPrinter >> classDefinitionString [
 ]
 
 { #category : 'template' }
-FluidClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName named: aClassName [
+FluidClassDefinitionPrinter >> classDefinitionTemplateInPackage: aPackageName tag: aTagName named: aClassName [
 
-		^ String streamContents: [ :s |
-						s nextPutAll: 'Object << '; print: aClassName asSymbol; crtab.
-						s nextPutAll: 'layout: FixedLayout;'; crtab.
-						s nextPutAll: 'traits: {};'; crtab.
-						s nextPutAll: 'slots: {};'; crtab.
-						s nextPutAll: 'sharedVariables: {};'; crtab.
-						s nextPutAll: 'sharedPools: {};'; crtab.
-						s nextPutAll: 'tag: '''' ;';crtab.
-						s nextPutAll: 'package: '''; nextPutAll: aPackageName; nextPutAll: '''' ]
+	^ String streamContents: [ :s |
+		  s
+			  nextPutAll: 'Object << ';
+			  print: aClassName asSymbol;
+			  crtab;
+			  nextPutAll: 'layout: FixedLayout;';
+			  crtab;
+			  nextPutAll: 'traits: {};';
+			  crtab;
+			  nextPutAll: 'slots: {};';
+			  crtab;
+			  nextPutAll: 'sharedVariables: {};';
+			  crtab;
+			  nextPutAll: 'sharedPools: {};';
+			  crtab;
+			  nextPutAll: 'tag: ''';
+			  nextPutAll: (aTagName ifNil: [ '' ]);
+			  nextPutAll: ''' ;';
+			  crtab;
+			  nextPutAll: 'package: ''';
+			  nextPutAll: aPackageName;
+			  nextPutAll: '''' ]
 ]
 
 { #category : 'elementary operations' }
@@ -432,13 +445,19 @@ FluidClassDefinitionPrinter >> tagOn: aStream [
 ]
 
 { #category : 'printing' }
-FluidClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aPackageName [
+FluidClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aPackageName tag: aTagName [
 
-		^ String streamContents: [ :s |
-						s nextPutAll: 'TestCase << #MyTest'; crtab.
-						s nextPutAll: 'slots: {};'; crtab.
-						s nextPutAll: 'tag: '''' ;';crtab.
-						s nextPutAll: 'package: ''', aPackageName, '''' ]
+	^ String streamContents: [ :s |
+		  s
+			  nextPutAll: 'TestCase << #MyTest';
+			  crtab;
+			  nextPutAll: 'slots: {};';
+			  crtab;
+			  nextPutAll: 'tag: ''';
+			  nextPutAll: (aTagName ifNil: [ '' ]);
+			  nextPutAll: ''' ;';
+			  crtab;
+			  nextPutAll: 'package: ''' , aPackageName , '''' ]
 ]
 
 { #category : 'definition double dispatch API' }
@@ -455,23 +474,21 @@ FluidClassDefinitionPrinter >> traitDefinitionString [
 ]
 
 { #category : 'template' }
-FluidClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName named: aTraitName [
+FluidClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName tag: aTagName named: aTraitName [
 
 	^ String streamContents: [ :s |
 		  s
 			  nextPutAll: 'Trait << ';
 			  print: aTraitName asSymbol;
-			  crtab.
-		  s
+			  crtab;
 			  nextPutAll: 'traits: {};';
-			  crtab.
-		  s
+			  crtab;
 			  nextPutAll: 'slots: {};';
-			  crtab.
-		  s
-			  nextPutAll: 'tag: '''' ;';
-			  crtab.
-		  s
+			  crtab;
+			  nextPutAll: 'tag: ''';
+			  nextPutAll: (aTagName ifNil: [ '' ]);
+			  nextPutAll: ''' ;';
+			  crtab;
 			  nextPutAll: 'package: ''';
 			  nextPutAll: aPackageName;
 			  nextPutAll: '''' ]

--- a/src/ClassDefinitionPrinters/LegacyClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/LegacyClassDefinitionPrinter.class.st
@@ -51,29 +51,6 @@ LegacyClassDefinitionPrinter >> classDefinitionString [
 	^ aStream contents
 ]
 
-{ #category : 'template' }
-LegacyClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString named: aClassName [
-
-	^ String streamContents: [ :s |
-		  s
-			  nextPutAll: 'Object subclass: ';
-			  print: aClassName asSymbol;
-			  crtab.
-		  s
-			  nextPutAll: 'instanceVariableNames: '''' ';
-			  crtab.
-		  s
-			  nextPutAll: 'classVariableNames: ''''';
-			  crtab.
-		  s
-			  nextPutAll: 'poolDictionaries: ''''';
-			  crtab.
-		  s
-			  nextPutAll: 'category ''';
-			  nextPutAll: aString;
-			  nextPutAll: '''' ]
-]
-
 { #category : 'public API' }
 LegacyClassDefinitionPrinter >> metaclassDefinitionString [
 
@@ -83,17 +60,6 @@ LegacyClassDefinitionPrinter >> metaclassDefinitionString [
 			crtab;
 			nextPutAll: 'instanceVariableNames: ';
 			store: forClass instanceVariablesString ]
-]
-
-{ #category : 'template' }
-LegacyClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString [
-
-	^ String streamContents: [ :s |
-			s nextPutAll: 'TestCase subclass: #MyTest' ; crtab.
-			s nextPutAll: 'instanceVariableNames: '''' '; crtab.
-			s nextPutAll: 'classVariableNames: '''''; crtab.
-			s nextPutAll: 'poolDictionaries: '''''; crtab.
-			s nextPutAll: 'category ''', aString, '''' ]
 ]
 
 { #category : 'public API' }
@@ -111,20 +77,6 @@ LegacyClassDefinitionPrinter >> traitDefinitionString [
 			nextPutAll: ' package: ';
 			nextPutAll: forClass category asString printString
 	]
-]
-
-{ #category : 'template' }
-LegacyClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString named: aTraitName [
-
-	^ String streamContents: [ :s |
-		  s
-			  nextPutAll: 'Trait named: ';
-			  print: aTraitName asSymbol;
-			  nextPutAll: ' uses: {}
-	 package: '''.
-		  s
-			  nextPutAll: aString;
-			  nextPut: $' ]
 ]
 
 { #category : 'public API' }

--- a/src/ClassDefinitionPrinters/OldPharoClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/OldPharoClassDefinitionPrinter.class.st
@@ -84,26 +84,6 @@ OldPharoClassDefinitionPrinter >> classDefinitionString [
 		  ifFalse: [ self basicClassDefinitionString ]
 ]
 
-{ #category : 'template' }
-OldPharoClassDefinitionPrinter >> classDefinitionTemplateInPackage: aString named: aClassName [
-
-	^ String streamContents: [ :s |
-		  s 
-			nextPutAll: 'Object subclass: ';
-		  	print: aClassName asSymbol; 
-		  	crtab.
-		  s
-			  nextPutAll: 'instanceVariableNames: '''' ';
-			  crtab.
-		  s
-			  nextPutAll: 'classVariableNames: ''''';
-			  crtab.
-		  s
-			  nextPutAll: 'package: ''';
-			  nextPutAll: aString;
-			  nextPutAll: '''' ]
-]
-
 { #category : 'low-level elements' }
 OldPharoClassDefinitionPrinter >> classVariablesOn: stream [
 
@@ -112,12 +92,6 @@ OldPharoClassDefinitionPrinter >> classVariablesOn: stream [
 		nextPutAll: 'classVariableNames: '''.
 	forClass classVariablesOn: stream.
 	stream nextPut: $'
-]
-
-{ #category : 'template' }
-OldPharoClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aString [
-
-	^ self traitDefinitionTemplateInPackage: aString
 ]
 
 { #category : 'low-level elements' }
@@ -159,16 +133,6 @@ OldPharoClassDefinitionPrinter >> poolOn: stream [
 			store: poolString ]
 ]
 
-{ #category : 'template' }
-OldPharoClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aString [
-
-	^ String streamContents: [ :s |
-			s nextPutAll: 'TestCase subclass: #MyTest' ; crtab.
-			s nextPutAll: 'instanceVariableNames: '''' '; crtab.
-			s nextPutAll: 'classVariableNames: '''''; crtab.
-			s nextPutAll: 'package: ''', aString, '''' ]
-]
-
 { #category : 'low-level elements' }
 OldPharoClassDefinitionPrinter >> traitCompositionOn: stream [
 
@@ -185,20 +149,6 @@ OldPharoClassDefinitionPrinter >> traitDefinitionString [
 	^ forClass needsSlotClassDefinition
 		ifTrue: [ (ClassDefinitionPrinter fluid for: forClass) traitDefinitionString ]
 		ifFalse: [ self basicTraitDefinitionString ]
-]
-
-{ #category : 'template' }
-OldPharoClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aString named: aTraitName [
-
-	^ String streamContents: [ :s |
-		  s
-			  nextPutAll: 'Trait named: ';
-			  print: aTraitName asSymbol;
-			  nextPutAll: ' uses: {}
-	 package: '''.
-		  s
-			  nextPutAll: aString;
-			  nextPut: $' ]
 ]
 
 { #category : 'public API' }

--- a/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
+++ b/src/Kernel-Tests/FluidClassDefinitionPrinterTest.class.st
@@ -205,9 +205,7 @@ FluidClassDefinitionPrinterTest >> testExpandedTime [
 { #category : 'tests - template' }
 FluidClassDefinitionPrinterTest >> testFullClassTemplate [
 
-	self
-		assert: (FluidClassDefinitionPrinter new classDefinitionTemplateInPackage: 'Kernel')
-		equals:  'Object << #MyClass
+	self assert: (FluidClassDefinitionPrinter new classDefinitionTemplateInPackage: 'Kernel' tag: nil named: #MyClass) equals: 'Object << #MyClass
 	layout: FixedLayout;
 	traits: {};
 	slots: {};

--- a/src/OpalCompiler-UI/OCCodeReparator.class.st
+++ b/src/OpalCompiler-UI/OCCodeReparator.class.st
@@ -70,14 +70,10 @@ OCCodeReparator >> declareTempAndPaste: name [
 OCCodeReparator >> defineClass: classSymbol [
 	"Prompts the user to define a new class."
 
-	| systemCategory classDefinition |
-	systemCategory := node methodNode methodClass category ifNil: [ 'Unknown' ].
-	classDefinition := ClassDefinitionPrinter fluid
-		                   classDefinitionTemplateInPackage: systemCategory
-		                   named: classSymbol.
-	^ self
-		  defineClassOrTrait: classSymbol
-		  definitionString: classDefinition
+	| class classDefinition |
+	class := node methodNode methodClass.
+	classDefinition := ClassDefinitionPrinter fluid classDefinitionTemplateInPackage: class package name tag: class packageTag name named: classSymbol.
+	^ self defineClassOrTrait: classSymbol definitionString: classDefinition
 ]
 
 { #category : 'correcting' }
@@ -109,16 +105,12 @@ OCCodeReparator >> defineClassOrTrait: aSymbol definitionString: aString [
 OCCodeReparator >> defineTrait: traitName [
 	"Prompts the user to define a new trait."
 
-	| traitSymbol systemCategory traitDefinition |
+	| traitSymbol class traitDefinition |
 	traitSymbol := traitName asSymbol.
-	
-	systemCategory := node methodNode methodClass category ifNil: [ 'Unknown' ].
-	traitDefinition := ClassDefinitionPrinter fluid
-		                   traitDefinitionTemplateInPackage: systemCategory
-		                   named: traitSymbol.
-	^ self
-		  defineClassOrTrait: traitSymbol
-		  definitionString: traitDefinition
+
+	class := node methodNode methodClass.
+	traitDefinition := ClassDefinitionPrinter fluid traitDefinitionTemplateInPackage: class package name tag: class packageTag name named: traitSymbol.
+	^ self defineClassOrTrait: traitSymbol definitionString: traitDefinition
 ]
 
 { #category : 'accessing' }

--- a/src/Traits-Tests/TraitFluidClassDefinitionPrinterTest.class.st
+++ b/src/Traits-Tests/TraitFluidClassDefinitionPrinterTest.class.st
@@ -127,8 +127,7 @@ TraitFluidClassDefinitionPrinterTest >> testExpandedTrait3ClassTrait [
 { #category : 'tests - template' }
 TraitFluidClassDefinitionPrinterTest >> testFullTraitTemplate [
 
-	self
-		assert: (FluidClassDefinitionPrinter new traitDefinitionTemplateInPackage: 'Traits') equals: 'Trait << #TMyTrait
+	self assert: (FluidClassDefinitionPrinter new traitDefinitionTemplateInPackage: 'Traits' tag: nil named: #TMyTrait) equals: 'Trait << #TMyTrait
 	traits: {};
 	slots: {};
 	tag: '''' ;


### PR DESCRIPTION
This fixes the printing a class, test class and trait template printing depending on the package to also consider the package tag. 

It also removes the printing for the old formats since they are not supportedby Pharo anymore to keep only the fluid format.