### PR TITLE
Deprecate MetacelloIgnorePackageLoaded

### DIFF
--- a/src/Metacello-Core/MetacelloIgnorePackageLoaded.class.st
+++ b/src/Metacello-Core/MetacelloIgnorePackageLoaded.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'MetacelloIgnorePackageLoaded',
+	#superclass : 'Notification',
+	#category : 'Metacello-Core-Exceptions-Notifications',
+	#package : 'Metacello-Core',
+	#tag : 'Exceptions-Notifications'
+}
+
+{ #category : 'testing' }
+MetacelloIgnorePackageLoaded class >> isDeprecated [ 
+
+	^ true
+]


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/15929 part 2

Deprecate MetacelloIgnorePackageLoaded instead of removal.
Although this was seemingly mostly internal, it is used by SmalltalkCI