### PR TITLE
15941-WeakLayout--isWords-is-unknown-and-break-tests

### DIFF
--- a/src/Kernel-CodeModel/AbstractLayout.class.st
+++ b/src/Kernel-CodeModel/AbstractLayout.class.st
@@ -148,6 +148,21 @@ AbstractLayout >> isBits [
 ]
 
 { #category : 'testing' }
+AbstractLayout >> isBytes [
+	^ false
+]
+
+{ #category : 'testing' }
+AbstractLayout >> isDoubleBytes [
+	^ false
+]
+
+{ #category : 'testing' }
+AbstractLayout >> isDoubleWords [
+	^ false
+]
+
+{ #category : 'testing' }
 AbstractLayout >> isFixedLayout [
 	^false
 ]
@@ -159,6 +174,11 @@ AbstractLayout >> isVariable [
 
 { #category : 'testing' }
 AbstractLayout >> isWeak [
+	^ false
+]
+
+{ #category : 'testing' }
+AbstractLayout >> isWords [
 	^ false
 ]
 

--- a/src/Kernel-CodeModel/BitsLayout.class.st
+++ b/src/Kernel-CodeModel/BitsLayout.class.st
@@ -73,26 +73,6 @@ BitsLayout >> isBits [
 ]
 
 { #category : 'testing' }
-BitsLayout >> isBytes [
-	^ false
-]
-
-{ #category : 'testing' }
-BitsLayout >> isDoubleBytes [
-	^ false
-]
-
-{ #category : 'testing' }
-BitsLayout >> isDoubleWords [
-	^ false
-]
-
-{ #category : 'testing' }
 BitsLayout >> isVariable [
 	^ true
-]
-
-{ #category : 'testing' }
-BitsLayout >> isWords [
-	^ false
 ]

--- a/src/Slot-Tests/SlotBasicTest.class.st
+++ b/src/Slot-Tests/SlotBasicTest.class.st
@@ -138,7 +138,7 @@ SlotBasicTest >> testNewWeakClass [
 	self deny: aClass isFixed.
 	self assert: aClass isVariable.
 	self assert: aClass classLayout isVariable.
-	self assert: aClass isWords.
+	self deny: aClass isWords.
 	self assert: aClass isWeak
 ]
 


### PR DESCRIPTION
Background: in ST80, you have to check isBits first before you can check for bytes/words to get a meaningfull result.

(isWords was defined as "isBytes not" (see https://github.com/pharo-project/pharo/issues/15668 for an open issue discussing that).

Another PR fixed that and just delegate to the layout, but there the isBytetes and friend where only defined for BitLayout (to force a check for isBits fist to mimick the implentation on Behavior).

This PR Moves the isBytes/isWords methods up in the Layout Hiearchy, now it is ok to call the without checking for isBits first.

fixes #15941