### PR TITLE
Add back currentlyLoadedClassesInVersion in metacello registrations

### DIFF
--- a/src/Metacello-Core/MetacelloPackageSpec.class.st
+++ b/src/Metacello-Core/MetacelloPackageSpec.class.st
@@ -381,3 +381,14 @@ MetacelloPackageSpec >> setPreLoadDoIt: aSymbol [
 
 	preLoadDoIt := aSymbol
 ]
+
+{ #category : 'accessing' }
+MetacelloPackageSpec >> workingCopy [
+	"Answer a working copy, or nil if the package is not loaded."
+
+	| wcs |
+	wcs := MCWorkingCopy allWorkingCopies select: [ :each |
+		       each packageName = self name ].
+	wcs isEmpty ifTrue: [ ^ nil ].
+	^ wcs detectMax: [ :ea | ea package name size ]
+]

--- a/src/Metacello-Core/MetacelloProjectRegistration.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistration.class.st
@@ -300,6 +300,12 @@ MetacelloProjectRegistration >> currentVersionString [
 ]
 
 { #category : 'testing' }
+MetacelloProjectRegistration >> currentlyLoadedClassesInProject [
+
+	^ self projectSpec currentlyLoadedClassesInVersion asSet
+]
+
+{ #category : 'testing' }
 MetacelloProjectRegistration >> hasLoadConflicts: aProjectRegistration [
 	"5 combinations of loads with no load conflicts:
         No configs and baselines =

--- a/src/Metacello-Core/MetacelloProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectSpec.class.st
@@ -348,6 +348,14 @@ MetacelloProjectSpec >> copyForScriptingInto: aProjectSpec [
         file: file
 ]
 
+{ #category : 'as yet unclassified' }
+MetacelloProjectSpec >> currentlyLoadedClassesInVersion [
+
+	self versionOrNil ifNotNil: [ :vrsn |
+		^ vrsn spec currentlyLoadedClassesInVersion ].
+	^ #(  )
+]
+
 { #category : 'loading' }
 MetacelloProjectSpec >> ensureProjectLoadedWithEngine: anEngine [
 	"Ensure that the MetacelloProject is loaded in image. 
@@ -875,7 +883,7 @@ MetacelloProjectSpec >> versionOrNil [
 
 	^ [ self version ]
 		  on: MetacelloVersionDoesNotExistError
-		  do: [ :ex | ^ nil ]
+		  do: [ :ex | nil ]
 ]
 
 { #category : 'querying' }

--- a/src/Metacello-Core/MetacelloVersionSpec.class.st
+++ b/src/Metacello-Core/MetacelloVersionSpec.class.st
@@ -232,6 +232,23 @@ MetacelloVersionSpec >> createVersion [
 	^ self versionClass fromSpec: self
 ]
 
+{ #category : 'as yet unclassified' }
+MetacelloVersionSpec >> currentlyLoadedClassesInVersion [
+
+	| classes |
+	classes := Set new.
+	self
+		projectDo: [ :ignored |  ]
+		packageDo: [ :packageSpec |
+			([ packageSpec workingCopy ]
+				 on: Error
+				 do: [ :ex | ex return: nil ]) ifNotNil: [ :workingCopy |
+				workingCopy systemPackage ifNotNil: [ :package |
+					classes addAll: package classes ] ] ]
+		groupDo: [ :ignored |  ].
+	^ classes
+]
+
 { #category : 'loading' }
 MetacelloVersionSpec >> defaultPackageNames [
 	"if there is a package named 'default' (a group) then it defines the default package names,


### PR DESCRIPTION
It is used by smalltalk ci to find runnable test classes in the loaded packages

Fix #15939

To evaluate in the future if this API (hidden in the registrations) should be exposed in some other way.