### PR TITLE
Extend FFIExternalStructureReferenceHandle with tfPointerAddress

### DIFF
--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIStructuresTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIStructuresTest.class.st
@@ -81,6 +81,35 @@ TFUFFIStructuresTest >> testPassingByParameterAStructInPharo [
 ]
 
 { #category : #tests }
+TFUFFIStructuresTest >> testPassingByReferenceAStructInArrayInC [
+
+	| pointArray return aPoint |
+	pointArray := FFIExternalArray externalNewType: TFPointTestStruct size: 3.
+	pointArray autoRelease.
+
+	aPoint := pointArray third.
+	aPoint x: 17.
+	aPoint y: 23.
+
+	return := self passStructByReference: aPoint.
+	self assert: return tfPointerAddress equals: aPoint getHandle tfPointerAddress
+]
+
+{ #category : #tests }
+TFUFFIStructuresTest >> testPassingByReferenceAStructInArrayInPharo [
+
+	| pointArray return aPoint |
+	pointArray := FFIExternalArray newType: TFPointTestStruct size: 3.
+
+	aPoint := pointArray third.
+	aPoint x: 17.
+	aPoint y: 23.
+
+	return := self passStructByReference: aPoint.
+	self assert: return tfPointerAddress equals: aPoint getHandle tfPointerAddress
+]
+
+{ #category : #tests }
 TFUFFIStructuresTest >> testPassingByReferenceAStructInC [
 
 	| aPoint return |

--- a/src/ThreadedFFI-UFFI/FFIExternalStructureReferenceHandle.extension.st
+++ b/src/ThreadedFFI-UFFI/FFIExternalStructureReferenceHandle.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #FFIExternalStructureReferenceHandle }
+
+{ #category : #'*ThreadedFFI-UFFI' }
+FFIExternalStructureReferenceHandle >> tfPointerAddress [
+
+	^ handle tfPointerAddress + startOffset
+]


### PR DESCRIPTION
Backport of https://github.com/pharo-project/pharo/pull/15666

Related to https://github.com/pharo-project/pharo/issues/4452