### PR TITLE
Refactor: pass on refactoring preconditions

### DIFF
--- a/src/Refactoring-Transformations-Tests/RBTemporaryToInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBTemporaryToInstanceVariableParametrizedTest.class.st
@@ -38,18 +38,6 @@ RBTemporaryToInstanceVariableParametrizedTest >> setUp [
 ]
 
 { #category : 'failure tests' }
-RBTemporaryToInstanceVariableParametrizedTest >> testFailureHierarchyDefinesVarableNamedAsTemporary [
-
-	| class |
-	self addClassHierarchy.
-	class := model classNamed: #Foo.
-	self shouldWarn: (self createRefactoringWithArguments: {
-				 class.
-				 #someMethod.
-				 'foo' })
-]
-
-{ #category : 'failure tests' }
 RBTemporaryToInstanceVariableParametrizedTest >> testFailureNonExistantName [
 
 	self shouldFail: (self createRefactoringWithArguments: {

--- a/src/Refactoring-Transformations-Tests/RBTemporaryToInstanceVariableRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBTemporaryToInstanceVariableRefactoringTest.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : 'RBTemporaryToInstanceVariableRefactoringTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#category : 'Refactoring-Transformations-Tests-Test',
+	#package : 'Refactoring-Transformations-Tests',
+	#tag : 'Test'
+}
+
+{ #category : 'running' }
+RBTemporaryToInstanceVariableRefactoringTest >> setUp [
+
+	super setUp.
+	model := self rbModelForVariableTest.
+	model defineClass: [ :aBuilder |
+		aBuilder
+			superclassName: #Foo;
+			name: #Foo1;
+			slots: { #foo };
+			package: #'Refactory-Test data' ].
+	(model classNamed: #Foo)
+		compile: 'someMethod | foo | foo := 4. ^foo'
+		classified: #( #accessing )
+]
+
+{ #category : 'tests' }
+RBTemporaryToInstanceVariableRefactoringTest >> testFailureHierarchyDefinesVarableNamedAsTemporary [
+
+	| class |
+	class := model classNamed: #Foo.
+	self
+		should: [
+			(RBTemporaryToInstanceVariableRefactoring
+				 class: class
+				 selector: #someMethod
+				 variable: 'foo') generateChanges ]
+		raise: RBRefactoringWarning
+]

--- a/src/Refactoring-Transformations/RBPackageTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPackageTransformation.class.st
@@ -29,6 +29,15 @@ RBPackageTransformation class >> packageName: aName [
 		packageName: aName
 ]
 
+{ #category : 'preconditions' }
+RBPackageTransformation >> applicabilityPreconditions [
+
+	^ RBCondition
+		  withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
+			  self packageOrganizer hasPackage: packageName ]
+		  errorString: 'The package ' , packageName , ' does not exsit in the system.'
+]
+
 { #category : 'executing' }
 RBPackageTransformation >> packageName [
 
@@ -39,13 +48,4 @@ RBPackageTransformation >> packageName [
 RBPackageTransformation >> packageName: anObject [
 
 	packageName := anObject
-]
-
-{ #category : 'preconditions' }
-RBPackageTransformation >> preconditions [
-
-	^ RBCondition
-		  withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
-			  self packageOrganizer hasPackage: packageName ]
-		  errorString: 'The package ' , packageName , ' does not exsit in the system.'
 ]

--- a/src/Refactoring-Transformations/RBPushDownMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPushDownMethodTransformation.class.st
@@ -53,24 +53,6 @@ RBPushDownMethodTransformation >> applicabilityPreconditions [
 	^ condition 
 ]
 
-{ #category : 'preconditions' }
-RBPushDownMethodTransformation >> breakingChangePreconditions [
-	"Check that that none of the subclasses of `class` is doing a supercall to any of the selectors
-	that will be pushed down.
-	
-	Also, to ensure that an instance of the class is not sent a message which is pushed down,  forces that 
-	we can only push down methods from abstract class. 
-	This should be controlled via a flag on the ui.
-	"
-	
-	| condition |
-	condition := selectors
-		             inject: (RBCondition isAbstractClass: class)
-		             into: [ :cond :each |
-			             cond & (RBCondition subclassesOf: class isDoingASuperSendFor: each) not ].
-	^ condition 
-]
-
 { #category : 'executing' }
 RBPushDownMethodTransformation >> buildTransformations [
 

--- a/src/Refactoring-Transformations/RBRenamePackageTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRenamePackageTransformation.class.st
@@ -37,6 +37,16 @@ RBRenamePackageTransformation class >> rename: aString to: aNewName [
 		packageName: aString newName: aNewName
 ]
 
+{ #category : 'preconditions' }
+RBRenamePackageTransformation >> applicabilityPreconditions [
+	^ super applicabilityPreconditions 
+		& (RBCondition withBlock: [ newName ~= packageName ] errorString: 'The new package name is the same as the old package name.')
+		& (RBCondition
+			   withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
+				   (self packageOrganizer hasPackage: newName) not ]
+			   errorString: 'The system already includes a package named ' , newName)
+]
+
 { #category : 'executing' }
 RBRenamePackageTransformation >> buildTransformations [
 
@@ -61,16 +71,6 @@ RBRenamePackageTransformation >> packageName: aName newName: aNewName [
 	packageName := aName asSymbol.
 	package := self model packageNamed: packageName.
 	newName := aNewName asSymbol
-]
-
-{ #category : 'executing' }
-RBRenamePackageTransformation >> preconditions [
-	^ super preconditions
-		& (RBCondition withBlock: [ newName ~= packageName ] errorString: 'The new package name is the same as the old package name.')
-		& (RBCondition
-			   withBlock: [ "Cyril: I am not sure we should use #packageOrganizer. Maybe we should ask the environment the package manager. But currently the image does not know yet how to work with multiple package managers/modules."
-				   (self packageOrganizer hasPackage: newName) not ]
-			   errorString: 'The system already includes a package named ' , newName)
 ]
 
 { #category : 'executing' }

--- a/src/Refactoring-Transformations/RBTemporaryToInstanceVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBTemporaryToInstanceVariableTransformation.class.st
@@ -114,19 +114,6 @@ RBTemporaryToInstanceVariableTransformation >> applicabilityPreconditions [
 ]
 
 { #category : 'preconditions' }
-RBTemporaryToInstanceVariableTransformation >> breakingChangePreconditions [
-
-	^ RBCondition withBlock: [
-		  (class allSubclasses anySatisfy: [ :cls |
-			   cls definesInstanceVariable: temporaryVariableName asString ])
-			  ifTrue: [
-				  self refactoringWarning:
-					  ('One or more subclasses of <1p> already defines an<n>instance variable with the same name. Proceed anyway?'
-						   expandMacrosWith: class name) ].
-		  true ]
-]
-
-{ #category : 'preconditions' }
 RBTemporaryToInstanceVariableTransformation >> checkForValidTemporaryVariable [
 	| parseTree |
 	parseTree := class parseTreeForSelector: selector.
@@ -150,12 +137,6 @@ RBTemporaryToInstanceVariableTransformation >> class: aClass selector: aSelector
 	class := self model classObjectFor: aClass.
 	selector := aSelector.
 	temporaryVariableName := aVariableName
-]
-
-{ #category : 'preconditions' }
-RBTemporaryToInstanceVariableTransformation >> preconditions [
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions
 ]
 
 { #category : 'executing' }


### PR DESCRIPTION
This PR cleans a bit preconditions in transformations:

- split refactoring and transformation tests
- removed unused breaking changes
- migrates preconditions to applicability preconditions where it makes sense

Now, there are no more `breakingChangePreconditions` in transformations.