### PR TITLE
Improve ReMultiplePeriodsTerminatingStatementRule

### DIFF
--- a/src/General-Rules-Tests/ReMultiplePeriodsTerminatingStatementRuleTest.class.st
+++ b/src/General-Rules-Tests/ReMultiplePeriodsTerminatingStatementRuleTest.class.st
@@ -9,13 +9,31 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'utilities' }
+ReMultiplePeriodsTerminatingStatementRuleTest >> myCritiques [
+
+	| critiques |
+	critiques := super myCritiques.
+	self subjectUnderTest  new
+		check: (self class >> #sampleMethod2) forCritiquesDo:[:critique | critiques add: critique].
+	^ critiques
+]
+
 { #category : 'sample' }
 ReMultiplePeriodsTerminatingStatementRuleTest >> sampleMethod [
 	"I have two periods between statements"
 	2+3.  .
 	{1.2..3}.
-	99.
+	99."I put a dot after my comment".
+	100.
 .
+]
+
+{ #category : 'sample' }
+ReMultiplePeriodsTerminatingStatementRuleTest >> sampleMethod2 [
+	"I have two statements and two dots"
+
+	self asString."foobar". self asString
 ]
 
 { #category : 'tests' }
@@ -23,6 +41,12 @@ ReMultiplePeriodsTerminatingStatementRuleTest >> testRule [
 	| critiques |
 	critiques := self myCritiques .
 
-	self assert: critiques size equals: 2.
-	self assert: (self sourceAtChritique: critiques first) equals: '.  .'
+	self assert: critiques size equals: 4.
+	self assert: (critiques allButLast allSatisfy: [ :cr | cr sourceAnchor sourceEntity selector = #sampleMethod ]).
+	self assert: (self sourceAtChritique: critiques first) equals: '.  .'.
+	self assert: (self sourceAtChritique: critiques second) equals: '."I put a dot after my comment".'.
+	self assert: (self sourceAtChritique: critiques third) equals: '.',(Character cr asString),'.'.
+	
+	self assert: critiques fourth sourceAnchor sourceEntity selector equals: #sampleMethod2.
+	self assert: (self sourceAtChritique: critiques fourth) equals: '."foobar".'
 ]

--- a/src/General-Rules/ReMultiplePeriodsTerminatingStatementRule.class.st
+++ b/src/General-Rules/ReMultiplePeriodsTerminatingStatementRule.class.st
@@ -23,12 +23,9 @@ ReMultiplePeriodsTerminatingStatementRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReMultiplePeriodsTerminatingStatementRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
-	aMethod ast
-		nodesDo: [ :node |
-			(node isSequence and:
-			[ node periods size > node statements size ])
-				ifTrue: [
-					self periodPairs: node critiqueBlock: aCriticBlock in: aMethod ] ]
+	aMethod ast nodesDo: [ :node |
+		node isSequence and: [
+			self periodPairs: node critiqueBlock: aCriticBlock in: aMethod ] ]
 ]
 
 { #category : 'accessing' }
@@ -43,17 +40,18 @@ ReMultiplePeriodsTerminatingStatementRule >> name [
 
 { #category : 'running' }
 ReMultiplePeriodsTerminatingStatementRule >> periodPairs: node critiqueBlock: aCriticBlock in: aMethod [
-	| periods |
+
+	| periods critique |
 	periods := node periods.
-	2 to: periods size do: [ :index | |code start stop |
-		start := periods at: index-1.
+	2 to: periods size do: [ :index | | code start stop trimmed |
+		start := periods at: index - 1.
 		stop := periods at: index.
-		code := node methodNode sourceCode copyFrom: start+1 to: stop-1.
-		code trim ifEmpty: [
-			aCriticBlock cull: (ReTrivialCritique
-			withAnchor: (ReIntervalSourceAnchor
-				entity: aMethod
-				interval: (start to: stop))
-			by: self
-			hint: 'two periods') ] ]
+		code := node methodNode sourceCode copyFrom: start + 1 to: stop - 1.
+		trimmed := code trim.
+		(trimmed isEmpty or: [ trimmed first = $" and: [ trimmed last = $" ] ]) ifTrue: [
+			critique := ReTrivialCritique 
+					 withAnchor: (ReIntervalSourceAnchor entity: aMethod interval: (start to: stop))
+					 by: self
+					 hint: 'two periods'.
+			aCriticBlock cull: critique ] ]
 ]


### PR DESCRIPTION
Improvements to the code critique rule to cover:
- empty statements consisting of code comments only
- method bodies with an equal number of periods and statements.

Examples added to the tests

Fixes #15955