### PR TITLE
Add release test for ReDoNotSendSuperInitializeInClassSideRule

### DIFF
--- a/src/General-Rules/ReDoNotSendSuperInitializeInClassSideRule.class.st
+++ b/src/General-Rules/ReDoNotSendSuperInitializeInClassSideRule.class.st
@@ -26,18 +26,6 @@ ReDoNotSendSuperInitializeInClassSideRule class >> uniqueIdentifierName [
 	^'DoNotSendSuperInitializeInClassSideRule'
 ]
 
-{ #category : 'hooks' }
-ReDoNotSendSuperInitializeInClassSideRule >> afterCheck: aNode mappings: mappingDict [
-
-	aNode methodNode ifNotNil: [ :methNode |
-		methNode compiledMethod ifNotNil: [ :method |
-			(method selector = #initialize and: [
-			method methodClass isMeta ])
-				ifTrue: [ ^ true ] ] ].
-
-	^ false
-]
-
 { #category : 'accessing' }
 ReDoNotSendSuperInitializeInClassSideRule >> group [
 	^ 'Potential Bugs'
@@ -54,4 +42,10 @@ ReDoNotSendSuperInitializeInClassSideRule >> initialize [
 { #category : 'accessing' }
 ReDoNotSendSuperInitializeInClassSideRule >> name [
 	^ 'Class-side #initialize should not send "super initialize".'
+]
+
+{ #category : 'testing' }
+ReDoNotSendSuperInitializeInClassSideRule >> shouldCheckMethod: aMethod [
+
+	^ aMethod selector = #initialize and: [ aMethod methodClass isMeta ]
 ]

--- a/src/General-Rules/ReSuperSendsRule.class.st
+++ b/src/General-Rules/ReSuperSendsRule.class.st
@@ -16,13 +16,6 @@ ReSuperSendsRule class >> uniqueIdentifierName [
 	^'SuperSendsRule'
 ]
 
-{ #category : 'hooks' }
-ReSuperSendsRule >> afterCheck: aNode mappings: mappingDict [
-
-	^aNode methodNode methodClass withAllSubclasses noneSatisfy: [: class |
-		class includesSelector: aNode selector ]
-]
-
 { #category : 'accessing' }
 ReSuperSendsRule >> group [
 	^ 'Design Flaws'
@@ -39,4 +32,10 @@ ReSuperSendsRule >> initialize [
 { #category : 'accessing' }
 ReSuperSendsRule >> name [
 	^ 'Rewrite super messages to self messages'
+]
+
+{ #category : 'testing' }
+ReSuperSendsRule >> shouldCheckMethod: aMethod [
+
+	^ aMethod methodClass withAllSubclasses noneSatisfy: [ :class | class includesSelector: aMethod selector ]
 ]

--- a/src/OSWindow-Core/OSTouchPinchDetector.class.st
+++ b/src/OSWindow-Core/OSTouchPinchDetector.class.st
@@ -18,7 +18,6 @@ Class {
 
 { #category : 'class initialization' }
 OSTouchPinchDetector class >> initialize [
-	super initialize.
 	MaxDistanceBetweenFingersLine := 0.2.
 	MinDistanceBeforeDetection := 0.03
 ]

--- a/src/OSWindow-Core/OSTouchScrollDetector.class.st
+++ b/src/OSWindow-Core/OSTouchScrollDetector.class.st
@@ -18,7 +18,6 @@ Class {
 
 { #category : 'class initialization' }
 OSTouchScrollDetector class >> initialize [
-	super initialize.
 	PersistentDirection := false
 ]
 

--- a/src/OSWindow-Core/OSTouchSwipeDetector.class.st
+++ b/src/OSWindow-Core/OSTouchSwipeDetector.class.st
@@ -15,12 +15,6 @@ Class {
 	#tag : 'Gestures'
 }
 
-{ #category : 'class initialization' }
-OSTouchSwipeDetector class >> initialize [
-	super initialize.
-	MinDistToBorder := 0.1
-]
-
 { #category : 'accessing' }
 OSTouchSwipeDetector class >> minDistToBorder [
 	^ MinDistToBorder

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -375,6 +375,12 @@ ReleaseTest >> testNoShadowedVariablesInMethods [
 ]
 
 { #category : 'tests' }
+ReleaseTest >> testNoSuperInitializeOnClassSideInitialization [
+
+	self assertValidLintRule: ReDoNotSendSuperInitializeInClassSideRule new
+]
+
+{ #category : 'tests' }
 ReleaseTest >> testObsoleteClasses [
 	| obsoleteClasses |
 

--- a/src/Renraku/ReAbstractRule.class.st
+++ b/src/Renraku/ReAbstractRule.class.st
@@ -279,3 +279,10 @@ ReAbstractRule >> severity [
 
 	^ #warning
 ]
+
+{ #category : 'testing' }
+ReAbstractRule >> shouldCheckMethod: aMethod [
+	"This is a hook when a rule is checking methods to speed up the rule and skip some methods for the nodes analysis."
+
+	^ true
+]

--- a/src/Renraku/ReSmalllintChecker.class.st
+++ b/src/Renraku/ReSmalllintChecker.class.st
@@ -49,16 +49,17 @@ ReSmalllintChecker >> checkClass: aClass [
 ReSmalllintChecker >> checkMethodsForClass: aClass [
 
 	environment methodsForClass: aClass do: [ :method |
-		| ast |
 		self getCritiquesAbout: method by: methodRules.
 		nodeRules do: [ :r |
-			ast := method ast.
-			"for rewrite rules, we run every rule on a copy of the ast"
-			r isRewriteRule ifTrue: [ ast := ast copy ].
-			ast nodesDo: [ :node |
-				r check: node forCritiquesDo: [ :crit |
-					crit sourceAnchor initializeEnitity: method.
-					self addCritique: crit ] ] ] ]
+			(r shouldCheckMethod: method) ifTrue: [
+				| ast |
+				ast := method ast.
+				"for rewrite rules, we run every rule on a copy of the ast"
+				r isRewriteRule ifTrue: [ ast := ast copy ].
+				ast nodesDo: [ :node |
+					r check: node forCritiquesDo: [ :crit |
+						crit sourceAnchor initializeEnitity: method.
+						self addCritique: crit ] ] ] ] ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
This change adds a release test to ensure the rule ReDoNotSendSuperInitializeInClassSideRule has no violation in Pharo.

It also fixes the last violations and lastly it speeds up the rule by a lot skipping the check for methods that are not class side initialization. This avoids the creation of a lot of ASTs.

Fixes #15970