### PR TITLE
Fix bug in class trait composition export

### DIFF
--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -319,7 +319,7 @@ ShiftClassBuilder >> fillClassSideFromEnvironment: anEnvironment [
 
 	self metaclassClass: old class class.
 	self classSlots: old class slots.
-	self classTraits: old class basicTraitComposition
+	self classTraits: old class traitComposition
 ]
 
 { #category : 'initialization' }

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -317,8 +317,10 @@ ShiftClassBuilder >> fillClassSideFromEnvironment: anEnvironment [
 	| old |
 	old := anEnvironment at: name ifAbsent: [ ^ self ].
 
+	self metaclassClass: old class class.
 	self classSlots: old class slots.
-	self classTraits: old class traitComposition
+	self classTraits: old class basicTraitComposition.
+	self classTraits: old class basicTraitComposition
 ]
 
 { #category : 'initialization' }

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -319,7 +319,6 @@ ShiftClassBuilder >> fillClassSideFromEnvironment: anEnvironment [
 
 	self metaclassClass: old class class.
 	self classSlots: old class slots.
-	self classTraits: old class basicTraitComposition.
 	self classTraits: old class basicTraitComposition
 ]
 

--- a/src/Traits-Tests/TraitSubclassingTraitedClassTest.class.st
+++ b/src/Traits-Tests/TraitSubclassingTraitedClassTest.class.st
@@ -46,3 +46,149 @@ TraitSubclassingTraitedClassTest >> testCreatingMethodInTraitClassSide [
 	c1 := self newClass: #C1 traits: t1.
 	self assert: c1 someObject equals: #executingOverridenMethod
 ]
+
+{ #category : 'tests' }
+TraitSubclassingTraitedClassTest >> testRedefinedTraitedClassSubclassClassTraitCompositionIncludesTraitedMetaclass [
+
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1.
+	c1 := self newClass: #C1 traits: t1.
+
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
+	
+	"Redefine it"
+	self class classInstaller make: [ :aClassBuilder |
+		aClassBuilder
+			superclass: c1;
+			name: #C2;
+			fillClassSideFromEnvironment: self class environment;
+			yourself ].
+
+	self assert: c2 class traitComposition equals: ({} asTraitComposition + TraitedClass)
+]
+
+{ #category : 'tests' }
+TraitSubclassingTraitedClassTest >> testRedefinedTraitedClassSubclassClassTraitCompositionIncludesTraitedMetaclassAPI2 [
+
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1.
+	c1 := self newClass: #C1 traits: t1.
+
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
+
+	"Redefine it"
+	self class classInstaller make: [ :aClassBuilder |
+		aClassBuilder fillFor: c2 ].
+
+	self
+		assert: c2 class traitComposition
+		equals: {  } asTraitComposition + TraitedClass
+]
+
+{ #category : 'tests' }
+TraitSubclassingTraitedClassTest >> testRedefinedTraitedClassSubclassHasEmptyClassTraitComposition [
+
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1.
+	c1 := self newClass: #C1 traits: t1.
+
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
+
+	"Redefine it"
+	self class classInstaller make: [ :aClassBuilder |
+		aClassBuilder
+			superclass: c1;
+			name: #C2;
+			fillClassSideFromEnvironment: self class environment;
+			yourself ].
+
+	self assert: c2 class basicTraitComposition isEmpty
+]
+
+{ #category : 'tests' }
+TraitSubclassingTraitedClassTest >> testRedefinedTraitedClassSubclassHasEmptyClassTraitCompositionAPI2 [
+
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1.
+	c1 := self newClass: #C1 traits: t1.
+
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
+
+	"Redefine it"
+	self class classInstaller make: [ :aClassBuilder |
+		aClassBuilder fillFor: c2 ].
+
+	self assert: c2 class basicTraitComposition isEmpty
+]
+
+{ #category : 'tests' }
+TraitSubclassingTraitedClassTest >> testRedefinedTraitedClassSubclassHasEmptyTraitComposition [
+
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1.
+	c1 := self newClass: #C1 traits: t1.
+
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
+
+	"Redefine it"
+	self class classInstaller make: [ :aClassBuilder |
+		aClassBuilder
+			superclass: c1;
+			name: #C2;
+			fillClassSideFromEnvironment: self class environment;
+			yourself ].
+
+	self assert: c2 traitComposition isEmpty
+]
+
+{ #category : 'tests' }
+TraitSubclassingTraitedClassTest >> testRedefinedTraitedClassSubclassHasEmptyTraitCompositionAPI2 [
+
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1.
+	c1 := self newClass: #C1 traits: t1.
+
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
+
+	"Redefine it"
+	self class classInstaller make: [ :aClassBuilder |
+		aClassBuilder fillFor: c2 ].
+
+	self assert: c2 traitComposition isEmpty
+]
+
+{ #category : 'tests' }
+TraitSubclassingTraitedClassTest >> testTraitedClassSubclassClassTraitCompositionIncludesTraitedMetaclass [
+
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1.
+	c1 := self newClass: #C1 traits: t1.
+
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
+
+	self assert: c2 class traitComposition equals: ({} asTraitComposition + TraitedClass)
+]
+
+{ #category : 'tests' }
+TraitSubclassingTraitedClassTest >> testTraitedClassSubclassHasEmptyClassTraitComposition [
+
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1.
+	c1 := self newClass: #C1 traits: t1.
+
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
+
+	self assert: c2 class basicTraitComposition isEmpty
+]
+
+{ #category : 'tests' }
+TraitSubclassingTraitedClassTest >> testTraitedClassSubclassHasEmptyTraitComposition [
+
+	| t1 c1 c2 |
+	t1 := self newTrait: #T1.
+	c1 := self newClass: #C1 traits: t1.
+
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
+
+	self assert: c2 traitComposition isEmpty
+]

--- a/src/Traits/TraitBuilderEnhancer.class.st
+++ b/src/Traits/TraitBuilderEnhancer.class.st
@@ -172,11 +172,11 @@ TraitBuilderEnhancer >> eliminateDuplicates: aSlotCollection withSuperclassSlots
 { #category : 'initialization' }
 TraitBuilderEnhancer >> fillBuilder: aBuilder from: aClass [
 
-	(aBuilder superclass isNil and: [ aClass superclass isNil ])
-		ifTrue: [ aBuilder metaSuperclass: aClass class superclass ].
+	(aBuilder superclass isNil and: [ aClass superclass isNil ]) ifTrue: [
+		aBuilder metaSuperclass: aClass class superclass ].
 
 	aBuilder traitComposition: aClass traitComposition.
-	aBuilder classTraitComposition: aClass class traitComposition.
+	aBuilder classTraitComposition: aClass class basicTraitComposition.
 
 	aBuilder metaclassClass: aClass class class
 ]


### PR DESCRIPTION
In the last couple of days we have seen a bug provoking a wrong export of class side trait definitions as follows:

![imagen](https://github.com/pharo-project/pharo/assets/708322/890bdb5d-6895-45cc-8f23-8fb2c94632a9)

I chased this bug to the lowest parts of the system, and the cause seems to be twofold:
 - exporters should use `basicTraitComposition` instead of `traitComposition`
 - (meta) classes using traits were being rebuilt even when it was not necessary because of a wrong computation of the metaclass class. This happened only when using the `fillClassSideFromEnvironment:` method, typically when editing a method from Calypso+fluid.

I managed to write 6 tests, only one was broken. All are green after these changes.
However, it is strange to me why we have `fillClassSideFromEnvironment:`, `fillFor:` and others which seem to be duplicated some behavior?

I'd like a second pair of eyes on the tests and my fixes for real here.

Probably related: https://github.com/pharo-project/pharo/issues/15922
