### PR TITLE
Report exception message text when class definition loading fails

### DIFF
--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -150,6 +150,7 @@ MCPackageLoader >> loadClassDefinitions [
 	errorDefinitions := OrderedCollection new.
 
 	"We first load the class definitions and store the potential errors"
+	[
 	(additions select: [ :aDefinition | aDefinition isClassDefinition ])
 		do: [ :aDefinition |
 			[ aDefinition load ]
@@ -166,14 +167,11 @@ MCPackageLoader >> loadClassDefinitions [
 			errorDefinitions remove: aClassDefinition.
 			[ aClassDefinition load ]
 				on: Error
-				do: [ : ex | 
-						ex messageText traceCr.
-						errorDefinitions add: aClassDefinition ] ]
+				do: [ :ex | errorDefinitions add: aClassDefinition ] ]
 		displayingProgress: 'Reloading erroneous definitions...'.
-	previousErrors size = errorDefinitions size ] whileFalse.
-
-	"Finally we warn about the errors we could not fix."
-	errorDefinitions ifNotEmpty: [ self warnAboutErrors: errorDefinitions ]
+	previousErrors size = errorDefinitions size ] whileFalse ] ensure: [ "Finally we warn about the errors we could not fix."
+		errorDefinitions ifNotEmpty: [
+			self warnAboutErrors: errorDefinitions ] ]
 ]
 
 { #category : 'patch ops' }

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -144,7 +144,7 @@ MCPackageLoader >> loadClassDefinitions [
 	"Here we are loading the class definitions.
 	
 	When loading a class it is possible that it fails. The reason is that a class can use a trait from this package, but the dependency sorter of Monticello does not sort those traits before the classes using it.
-	In that case we are implementing a retry mechanisme."
+	In that case we are implementing a retry mechanism. If error persist, the exception message is logged to the Transcript"
 
 	| errorDefinitions |
 	errorDefinitions := OrderedCollection new.
@@ -166,7 +166,9 @@ MCPackageLoader >> loadClassDefinitions [
 			errorDefinitions remove: aClassDefinition.
 			[ aClassDefinition load ]
 				on: Error
-				do: [ errorDefinitions add: aClassDefinition ] ]
+				do: [ : ex | 
+						ex messageText traceCr.
+						errorDefinitions add: aClassDefinition ] ]
 		displayingProgress: 'Reloading erroneous definitions...'.
 	previousErrors size = errorDefinitions size ] whileFalse.
 


### PR DESCRIPTION
This PR includes a minor change for Pharo 12 so we can see error messages in the Transcript when loading class definitions fail in `MCPackageLoader`.

It addresses the issue #15958.
