### PR TITLE
Improved error handling around sending data in Socket/SocketStream (fixes #15614)

### DIFF
--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -1366,14 +1366,14 @@ Socket >> sendData: aStringOrByteArray [
 	| bytesSent bytesToSend count |
 	bytesToSend := aStringOrByteArray size.
 	bytesSent := 0.
-	[bytesSent < bytesToSend] whileTrue: [
-		(self waitForSendDoneFor: 60)
-			ifFalse: [ConnectionTimedOut signal: 'send data timeout; data not sent'].
-		count := self primSocket: socketHandle
-			sendData: aStringOrByteArray
-			startIndex: bytesSent + 1
-			count: (bytesToSend - bytesSent min: 5000).
-		bytesSent := bytesSent + count].
+	[ bytesSent < bytesToSend ] whileTrue: [
+		self waitForSendDoneFor: 60.
+		count := self
+			         primSocket: socketHandle
+			         sendData: aStringOrByteArray
+			         startIndex: bytesSent + 1
+			         count: (bytesToSend - bytesSent min: 5000).
+		bytesSent := bytesSent + count ].
 
 	^ bytesSent
 ]
@@ -1439,17 +1439,15 @@ Socket >> sendSomeData: aStringOrByteArray startIndex: startIndex count: count [
 { #category : 'sending' }
 Socket >> sendSomeData: aStringOrByteArray startIndex: startIndex count: count for: aTimeoutInSeconds [
 	"Send up to count bytes of the given data starting at the given index. Answer the number of bytes actually sent."
+
 	"Note: This operation may have to be repeated multiple times to send a large amount of data."
 
-	| bytesSent |
-	(self waitForSendDoneFor: aTimeoutInSeconds)
-		ifTrue: [
-			bytesSent := self primSocket: socketHandle
-				sendData: aStringOrByteArray
-				startIndex: startIndex
-				count: count ]
-		ifFalse: [ ConnectionTimedOut signal: 'send data timeout; data not sent' ].
-	^ bytesSent
+	self waitForSendDoneFor: aTimeoutInSeconds.
+	^ self
+		  primSocket: socketHandle
+		  sendData: aStringOrByteArray
+		  startIndex: startIndex
+		  count: count
 ]
 
 { #category : 'sending' }
@@ -1479,28 +1477,27 @@ Socket >> sendStreamContents: stream checkBlock: checkBlock [
 { #category : 'datagrams' }
 Socket >> sendUDPData: aStringOrByteArray toHost: hostAddress port: portNumber [
 	"Send a UDP packet containing the given data to the specified host/port."
-	| bytesToSend bytesSent count |
 
+	| bytesToSend bytesSent count |
 	bytesToSend := aStringOrByteArray size.
 	bytesSent := 0.
 	[
-		(self waitForSendDoneFor: 20)
-			ifFalse: [ConnectionTimedOut signal: 'send data timeout; data not sent'].
-		count := self primSocket: socketHandle
-			sendUDPData: aStringOrByteArray
-			toHost: hostAddress
-			port: portNumber
-			startIndex: bytesSent + 1
-			count: bytesToSend - bytesSent.
-		count = 0 ifTrue:
-			["Usually broadcast fails in primitive without the proper option set,
+	self waitForSendDoneFor: 20.
+	count := self
+		         primSocket: socketHandle
+		         sendUDPData: aStringOrByteArray
+		         toHost: hostAddress
+		         port: portNumber
+		         startIndex: bytesSent + 1
+		         count: bytesToSend - bytesSent.
+	count = 0 ifTrue: [ "Usually broadcast fails in primitive without the proper option set,
 			but some platforms simply return count=0"
-			(self broadcastMisconfiguredForSendingTo: hostAddress)
-				ifTrue: [ ^ self broadcastError: hostAddress ].
-			bytesToSend ~= count
-				ifTrue: [ ^NetworkError signal: 'failed to send data']].
-		bytesSent := bytesSent + count.
-		bytesSent < bytesToSend] whileTrue.
+		(self broadcastMisconfiguredForSendingTo: hostAddress) ifTrue: [
+			^ self broadcastError: hostAddress ].
+		bytesToSend ~= count ifTrue: [
+			^ NetworkError signal: 'failed to send data' ] ].
+	bytesSent := bytesSent + count.
+	bytesSent < bytesToSend ] whileTrue.
 
 	^ bytesSent
 ]
@@ -1692,15 +1689,31 @@ Socket >> waitForDisconnectionFor: timeout [
 Socket >> waitForSendDoneFor: timeout [
 	"Wait up until the given deadline for the current send operation to complete. Return true if it completes by the deadline, false if not."
 
-	| startTime msecsDelta msecsEllapsed sendDone |
+	^ self
+		  waitForSendDoneFor: timeout
+		  ifClosed: [ ConnectionClosed signal: 'connection closed while sending data' ]
+		  ifTimedOut: [ ConnectionTimedOut signal: 'send data timeout; data not sent' ]
+]
+
+{ #category : 'waiting' }
+Socket >> waitForSendDoneFor: timeout ifClosed: closedBlock ifTimedOut: timedOutBlock [
+	"Wait up until the given deadline for the current send operation to complete.
+	If it does not, execute <timedOutBlock>. If the connection is closed before
+	the send completes, execute <closedBlock>."
+
+	| startTime msecsDelta |
 	startTime := Time millisecondClockValue.
 	msecsDelta := (timeout * 1000) truncated.
-	[(sendDone := self primSocketSendDone: socketHandle) not and: [ self isConnected
-			"Connection end and final data can happen fast, so test in this order"
-		and: [(msecsEllapsed := Time millisecondsSince: startTime) < msecsDelta]]] whileTrue: [
-			self writeSemaphore waitTimeoutMilliseconds: msecsDelta - msecsEllapsed].
-
-	^ sendDone
+	[ (Time millisecondsSince: startTime) < msecsDelta ] whileTrue: [
+		self sendDone ifTrue: [ ^ self ].
+		self isConnected ifFalse: [ ^ closedBlock value ].
+		self writeSemaphore waitTimeoutMilliseconds:
+			(msecsDelta - (Time millisecondsSince: startTime) max: 0) ].
+	self sendDone ifFalse: [
+		^ (self isConnected
+			   ifTrue: [ timedOutBlock ]
+			   ifFalse: [ closedBlock ]) value ].
+	^ self
 ]
 
 { #category : 'accessing' }

--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -737,26 +737,16 @@ Socket >> listenWithBacklog: anIntegerBacklog [
 Socket >> localAddress [
 	"If in the process of connecting, wait for connection to be established and binding to address completed before resolving."
 
-	^ [ self primSocketLocalAddress: socketHandle ]
-		on: Error
-		do: [ :e |
-			self isWaitingForConnection
-				ifTrue: [ self waitForConnectionFor: Socket standardTimeout ifTimedOut: nil.
-					self primSocketLocalAddress: socketHandle ]
-				ifFalse: [ e pass ] ]
+	^ self retryIfWaitingForConnection: [
+		  self primSocketLocalAddress: socketHandle ]
 ]
 
 { #category : 'accessing' }
 Socket >> localPort [
 	"If in the process of connecting, wait for connection to be established and binding to address completed before resolving."
 
-	^ [ self primSocketLocalPort: socketHandle ]
-		on: Error
-		do: [ :e |
-			self isWaitingForConnection
-				ifTrue: [ self waitForConnectionFor: Socket standardTimeout ifTimedOut: nil.
-					self primSocketLocalPort: socketHandle ]
-				ifFalse: [ e pass ] ]
+	^ self retryIfWaitingForConnection: [
+		  self primSocketLocalPort: socketHandle ]
 ]
 
 { #category : 'accessing' }
@@ -1323,26 +1313,30 @@ Socket >> register [
 Socket >> remoteAddress [
 	"If in the process of connecting, wait for connection to be established and binding to address completed before resolving."
 
-	^ [ self primSocketRemoteAddress: socketHandle ]
-		on: Error
-		do: [ :e |
-			self isWaitingForConnection
-				ifTrue: [ self waitForConnectionFor: Socket standardTimeout ifTimedOut: nil.
-					self primSocketRemoteAddress: socketHandle ]
-				ifFalse: [ e pass ] ]
+	^ self retryIfWaitingForConnection: [
+		  self primSocketRemoteAddress: socketHandle ]
 ]
 
 { #category : 'accessing' }
 Socket >> remotePort [
 	"If in the process of connecting, wait for connection to be established and binding to address completed before resolving."
 
-	^ [ self primSocketRemotePort: socketHandle ]
-		on: Error
-		do: [ :e |
-			self isWaitingForConnection
-				ifTrue: [ self waitForConnectionFor: Socket standardTimeout ifTimedOut: nil.
-					self primSocketRemotePort: socketHandle ]
-				ifFalse: [ e pass ] ]
+	^ self retryIfWaitingForConnection: [ self primSocketRemotePort: socketHandle ]
+]
+
+{ #category : 'waiting' }
+Socket >> retryIfWaitingForConnection: aBlock [
+
+	^ aBlock
+		  on: SocketError
+		  do: [ :e |
+			  self isWaitingForConnection
+				  ifTrue: [
+					  self
+						  waitForConnectionFor: Socket standardTimeout
+						  ifTimedOut: nil.
+					  aBlock value ]
+				  ifFalse: [ e pass ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -1630,18 +1630,14 @@ Socket >> waitForDataFor: timeout [
 Socket >> waitForDataFor: timeout ifClosed: closedBlock ifTimedOut: timedOutBlock [
 	"Wait for the given nr of seconds for data to arrive."
 
-	| startTime msecsDelta |
+	| startTime msecsDelta msecsElapsed |
 	startTime := Time millisecondClockValue.
 	msecsDelta := (timeout * 1000) truncated.
-	[ (Time millisecondsSince: startTime) < msecsDelta ]
-		whileTrue: [ self dataAvailable ifTrue: [ ^ self ].
-			self isConnected ifFalse: [ ^ closedBlock value ].
-			self readSemaphore waitTimeoutMilliseconds: (msecsDelta - (Time millisecondsSince: startTime) max: 0) ].
-
-	self dataAvailable
-		ifFalse: [ ^ (self isConnected
-				ifTrue: [ timedOutBlock ]
-				ifFalse: [ closedBlock ]) value ]
+	[ self dataAvailable ] whileFalse: [
+		self isConnected ifFalse: [ ^ closedBlock value ].
+		(msecsElapsed := Time millisecondsSince: startTime) < msecsDelta
+			ifFalse: [ ^ timedOutBlock value ].
+		self readSemaphore waitTimeoutMilliseconds: msecsDelta - msecsElapsed ]
 ]
 
 { #category : 'waiting' }
@@ -1695,19 +1691,15 @@ Socket >> waitForSendDoneFor: timeout ifClosed: closedBlock ifTimedOut: timedOut
 	If it does not, execute <timedOutBlock>. If the connection is closed before
 	the send completes, execute <closedBlock>."
 
-	| startTime msecsDelta |
+	| startTime msecsDelta msecsElapsed |
 	startTime := Time millisecondClockValue.
 	msecsDelta := (timeout * 1000) truncated.
-	[ (Time millisecondsSince: startTime) < msecsDelta ] whileTrue: [
-		self sendDone ifTrue: [ ^ self ].
+	"Connection end and final data can happen fast, so test in this order"
+	[ self sendDone ] whileFalse: [
 		self isConnected ifFalse: [ ^ closedBlock value ].
-		self writeSemaphore waitTimeoutMilliseconds:
-			(msecsDelta - (Time millisecondsSince: startTime) max: 0) ].
-	self sendDone ifFalse: [
-		^ (self isConnected
-			   ifTrue: [ timedOutBlock ]
-			   ifFalse: [ closedBlock ]) value ].
-	^ self
+		(msecsElapsed := Time millisecondsSince: startTime) < msecsDelta
+			ifFalse: [ ^ timedOutBlock value ].
+		self writeSemaphore waitTimeoutMilliseconds: msecsDelta - msecsElapsed ]
 ]
 
 { #category : 'accessing' }

--- a/src/Network-Kernel/SocketStream.class.st
+++ b/src/Network-Kernel/SocketStream.class.st
@@ -280,14 +280,17 @@ SocketStream >> destroy [
 { #category : 'control' }
 SocketStream >> flush [
 	"If the other end is connected and we have something
-	to send, then we send it and reset the outBuffer."
+	to send, then we send it and reset the outBuffer.
+	If the other end is closed and we are signaling errors, do so."
 
-	((outNextToWrite > 1) and: [socket isOtherEndClosed not])
-		ifTrue: [
-			[socket sendData: outBuffer count: outNextToWrite - 1]
-				on: ConnectionTimedOut
-				do: [:ex | shouldSignal ifFalse: ["swallow"]].
-			outNextToWrite := 1]
+	(outNextToWrite > 1 and: [ socket isOtherEndClosed not ]) ifTrue: [
+		[ socket sendData: outBuffer count: outNextToWrite - 1 ]
+			on: NetworkError
+			do: [ :ex |
+				shouldSignal
+					ifTrue: [ ex pass ]
+					ifFalse: [ "swallow" ] ].
+		outNextToWrite := 1 ]
 ]
 
 { #category : 'private' }
@@ -548,12 +551,17 @@ SocketStream >> nextPutAllFlush: aCollection [
 	and also flushes any other pending data first."
 
 	| toPut |
-	toPut := binary ifTrue: [aCollection asByteArray] ifFalse: [aCollection asString].
+	toPut := binary
+		         ifTrue: [ aCollection asByteArray ]
+		         ifFalse: [ aCollection asString ].
 	self flush. "first flush pending stuff, then directly send"
 	socket isOtherEndClosed ifFalse: [
-		[socket sendData: toPut count: toPut size]
-			on: ConnectionTimedOut
-			do: [:ex | shouldSignal ifFalse: ["swallow"]]]
+		[ socket sendData: toPut count: toPut size ]
+			on: NetworkError
+			do: [ :ex |
+				shouldSignal
+					ifTrue: [ ex pass ]
+					ifFalse: [ "swallow" ] ] ]
 ]
 
 { #category : 'configuration' }

--- a/src/Network-Tests/SocketStreamTest.class.st
+++ b/src/Network-Tests/SocketStreamTest.class.st
@@ -47,6 +47,40 @@ SocketStreamTest >> tearDown [
 ]
 
 { #category : 'stream protocol' }
+SocketStreamTest >> testFlushLargeMessageOtherEndClosed [
+	"A large send will be broken into chunks and fail on the second one."
+
+	serverStream close.
+	self
+		should: [ "256kiB"
+			clientStream
+				nextPutAll: (String new: 2 ** 18 withAll: $a);
+				flush ]
+		raise: ConnectionClosed
+]
+
+{ #category : 'stream protocol' }
+SocketStreamTest >> testFlushOtherEndClosed [
+	"Ensure that #flush properly raises an error when called when the other end is closed."
+
+	serverStream close.
+	"The first send after the other end is closed will not have problems as long as it fits within the send buffer."
+	self
+		shouldnt: [
+			clientStream
+				nextPutAll: 'A line of text';
+				flush ]
+		raise: NetworkError.
+	"The next send will wait for the first to finish and discover the error condition."
+	self
+		should: [
+			clientStream
+				nextPutAll: 'Another line of text';
+				flush ]
+		raise: ConnectionClosed
+]
+
+{ #category : 'stream protocol' }
 SocketStreamTest >> testNextIntoClose [
 	"Ensure that #next:into: will function properly when the connection is closed"
 
@@ -67,6 +101,20 @@ SocketStreamTest >> testNextIntoCloseNonSignaling [
 	clientStream close] fork.
 	self assert: (serverStream next: 100 into: (String new: 100) startingAt: 1)
 		equals: 'A line of text'
+]
+
+{ #category : 'stream protocol' }
+SocketStreamTest >> testNextPutAllFlushOtherEndClosed [
+	"#nextPutAllFlush: does its own error handling, so needs to be tested separately.
+	Having some content in the buffer first means that the direct send of the second buffer will encounter an error."
+
+	serverStream close.
+	self
+		should: [
+			clientStream
+				nextPutAll: 'A line of text';
+				nextPutAllFlush: 'Another line of text' ]
+		raise: ConnectionClosed
 ]
 
 { #category : 'stream protocol' }


### PR DESCRIPTION
Distinguish timeout and connection-closed, and actually pass errors in SocketStream>>flush rather than always swallowing them.

I believe this addresses the core issues in #15614. Adding a `SocketStream>>waitForSendDone` or similar could be a separate issue if desired.