### PR TITLE
Improve the way to know if a class includes a trait

### DIFF
--- a/src/Traits/Behavior.extension.st
+++ b/src/Traits/Behavior.extension.st
@@ -14,6 +14,12 @@ Behavior >> hasTraitComposition [
 ]
 
 { #category : '*Traits' }
+Behavior >> includesTrait: aTrait [
+
+	^ false
+]
+
+{ #category : '*Traits' }
 Behavior >> isAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my or in another composition somewhere deeper in

--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -256,10 +256,11 @@ TaAbstractComposition >> hash [
 	^ self subclassResponsibility
 ]
 
-{ #category : 'querying' }
+{ #category : 'testing' }
 TaAbstractComposition >> includesTrait: aTrait [
 	"Checks if the trait is used in the trait composition"
-	^ self allTraits includes: aTrait
+
+	^ self subclassResponsibility
 ]
 
 { #category : 'operations' }

--- a/src/Traits/TaCompositionElement.class.st
+++ b/src/Traits/TaCompositionElement.class.st
@@ -94,6 +94,14 @@ TaCompositionElement >> hash [
 	^ self innerClass hash
 ]
 
+{ #category : 'testing' }
+TaCompositionElement >> includesTrait: aTrait [
+
+	innerClass = aTrait ifTrue: [ ^ true ].
+
+	^ innerClass traitComposition includesTrait: aTrait
+]
+
 { #category : 'transforming selectors' }
 TaCompositionElement >> initializeSelectorForMe [
 	^ ('initializeTalent_' , self name) asSymbol

--- a/src/Traits/TaEmptyComposition.class.st
+++ b/src/Traits/TaEmptyComposition.class.st
@@ -89,6 +89,12 @@ TaEmptyComposition >> hash [
 ]
 
 { #category : 'testing' }
+TaEmptyComposition >> includesTrait: aTrait [
+
+	^ false
+]
+
+{ #category : 'testing' }
 TaEmptyComposition >> isAliasSelector: aString [
 
 	^ false

--- a/src/Traits/TaSequence.class.st
+++ b/src/Traits/TaSequence.class.st
@@ -122,6 +122,12 @@ TaSequence >> hash [
 	^ self class hash
 ]
 
+{ #category : 'testing' }
+TaSequence >> includesTrait: aTrait [
+
+	^ members anySatisfy: [ :member | member includesTrait: aTrait ]
+]
+
 { #category : 'initialization' }
 TaSequence >> initialize [
 	super initialize.

--- a/src/Traits/TaSingleComposition.class.st
+++ b/src/Traits/TaSingleComposition.class.st
@@ -62,6 +62,12 @@ TaSingleComposition >> hash [
 	^ inner hash
 ]
 
+{ #category : 'testing' }
+TaSingleComposition >> includesTrait: aTrait [
+
+	^ inner includesTrait: aTrait
+]
+
 { #category : 'transforming selectors' }
 TaSingleComposition >> initializeSelectorForMe [
 	^ inner initializeSelectorForMe

--- a/src/Traits/TraitedClass.class.st
+++ b/src/Traits/TraitedClass.class.st
@@ -146,6 +146,13 @@ TraitedClass >> includesLocalSelector: aSymbol [
 ]
 
 { #category : 'testing' }
+TraitedClass >> includesTrait: aTrait [
+
+	<reflection: 'Class structural inspection - Traits'>
+	^ self traitComposition includesTrait: aTrait
+]
+
+{ #category : 'testing' }
 TraitedClass >> isAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my or in another composition somewhere deeper in

--- a/src/Traits/TraitedMetaclass.class.st
+++ b/src/Traits/TraitedMetaclass.class.st
@@ -141,6 +141,13 @@ TraitedMetaclass >> includesLocalSelector: aSymbol [
 	^ self isLocalSelector: aSymbol
 ]
 
+{ #category : 'testing' }
+TraitedMetaclass >> includesTrait: aTrait [
+
+	<reflection: 'Class structural inspection - Traits'>
+	^ self traitComposition includesTrait: aTrait
+]
+
 { #category : 'initialization' }
 TraitedMetaclass >> initialize [
 	super initialize.


### PR DESCRIPTION
This change adds #includesTraits: on Behavior so that we do not have to ask the trait composition and is speeding up #includesTraits by having a specific implementation by kind of composition so that we do not collect all traits when the trait is present.

This allows to divide the computation of a moose visualisation by a factor of 3.5.

If this passes I would like to backport it to P11 if possible so that we can make some visualization more usable on bigger models