### PR TITLE
[Backport] Improve the way to know if a class includes a trait

### DIFF
--- a/src/TraitsV2/Behavior.extension.st
+++ b/src/TraitsV2/Behavior.extension.st
@@ -12,6 +12,12 @@ Behavior >> hasTraitComposition [
 ]
 
 { #category : #'*TraitsV2' }
+Behavior >> includesTrait: aTrait [
+
+	^ false
+]
+
+{ #category : #'*TraitsV2' }
 Behavior >> isAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my or in another composition somewhere deeper in

--- a/src/TraitsV2/TaAbstractComposition.class.st
+++ b/src/TraitsV2/TaAbstractComposition.class.st
@@ -273,10 +273,11 @@ TaAbstractComposition >> hash [
 	^ self subclassResponsibility
 ]
 
-{ #category : #querying }
+{ #category : #testing }
 TaAbstractComposition >> includesTrait: aTrait [
 	"Checks if the trait is used in the trait composition"
-	^ self allTraits includes: aTrait
+
+	^ self subclassResponsibility
 ]
 
 { #category : #operations }

--- a/src/TraitsV2/TaCompositionElement.class.st
+++ b/src/TraitsV2/TaCompositionElement.class.st
@@ -90,6 +90,14 @@ TaCompositionElement >> hash [
 	^ self innerClass hash
 ]
 
+{ #category : #testing }
+TaCompositionElement >> includesTrait: aTrait [
+
+	innerClass = aTrait ifTrue: [ ^ true ].
+
+	^ innerClass traitComposition includesTrait: aTrait
+]
+
 { #category : #'transforming selectors' }
 TaCompositionElement >> initializeSelectorForMe [
 	^ ('initializeTalent_' , self name) asSymbol

--- a/src/TraitsV2/TaEmptyComposition.class.st
+++ b/src/TraitsV2/TaEmptyComposition.class.st
@@ -87,6 +87,12 @@ TaEmptyComposition >> hash [
 ]
 
 { #category : #testing }
+TaEmptyComposition >> includesTrait: aTrait [
+
+	^ false
+]
+
+{ #category : #testing }
 TaEmptyComposition >> isAliasSelector: aString [
 
 	^ false

--- a/src/TraitsV2/TaSequence.class.st
+++ b/src/TraitsV2/TaSequence.class.st
@@ -131,6 +131,12 @@ TaSequence >> hash [
 	^ self class hash
 ]
 
+{ #category : #testing }
+TaSequence >> includesTrait: aTrait [
+
+	^ members anySatisfy: [ :member | member includesTrait: aTrait ]
+]
+
 { #category : #initialization }
 TaSequence >> initialize [
 	super initialize.

--- a/src/TraitsV2/TaSingleComposition.class.st
+++ b/src/TraitsV2/TaSingleComposition.class.st
@@ -60,6 +60,12 @@ TaSingleComposition >> hash [
 	^ inner hash
 ]
 
+{ #category : #testing }
+TaSingleComposition >> includesTrait: aTrait [
+
+	^ inner includesTrait: aTrait
+]
+
 { #category : #'transforming selectors' }
 TaSingleComposition >> initializeSelectorForMe [
 	^ inner initializeSelectorForMe

--- a/src/TraitsV2/TraitedClass.class.st
+++ b/src/TraitsV2/TraitedClass.class.st
@@ -195,6 +195,13 @@ TraitedClass >> includesLocalSelector: aSymbol [
 ]
 
 { #category : #testing }
+TraitedClass >> includesTrait: aTrait [
+
+	<reflection: 'Class structural inspection - Traits'>
+	^ self traitComposition includesTrait: aTrait
+]
+
+{ #category : #testing }
 TraitedClass >> isAliasSelector: aSymbol [
 	"Return true if the selector aSymbol is an alias defined
 	in my or in another composition somewhere deeper in

--- a/src/TraitsV2/TraitedMetaclass.class.st
+++ b/src/TraitsV2/TraitedMetaclass.class.st
@@ -149,6 +149,13 @@ TraitedMetaclass >> includesLocalSelector: aSymbol [
 	^ self isLocalSelector: aSymbol
 ]
 
+{ #category : #testing }
+TraitedMetaclass >> includesTrait: aTrait [
+
+	<reflection: 'Class structural inspection - Traits'>
+	^ self traitComposition includesTrait: aTrait
+]
+
 { #category : #initialization }
 TraitedMetaclass >> initialize [
 	super initialize.


### PR DESCRIPTION
Backport of  #15986

This improvements can speedup a lot some Moose visualization which would make it easier to work on some real models and not only toy models. So I'm hoping this could be backported to P11 :)