### PR TITLE
Add missing caret in #textToDisplay method.

### DIFF
--- a/src/Refactoring-Changes/RBRenameVariableChange.class.st
+++ b/src/Refactoring-Changes/RBRenameVariableChange.class.st
@@ -166,7 +166,7 @@ RBRenameVariableChange >> removeOldVariable [
 { #category : 'accessing' }
 RBRenameVariableChange >> textToDisplay [
 
-	self printString
+	^ self printString
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Single byte PR to add missing caret in #textToDisplay method, which was causing an error in renaming class variables, as reported in #15991.
