### PR TITLE
Categorize methods in Metacello

### DIFF
--- a/src/Metacello-Core/MetacelloProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectSpec.class.st
@@ -348,7 +348,7 @@ MetacelloProjectSpec >> copyForScriptingInto: aProjectSpec [
         file: file
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'enumerating' }
 MetacelloProjectSpec >> currentlyLoadedClassesInVersion [
 
 	self versionOrNil ifNotNil: [ :vrsn |

--- a/src/Metacello-Core/MetacelloVersionSpec.class.st
+++ b/src/Metacello-Core/MetacelloVersionSpec.class.st
@@ -232,7 +232,7 @@ MetacelloVersionSpec >> createVersion [
 	^ self versionClass fromSpec: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'enumerating' }
 MetacelloVersionSpec >> currentlyLoadedClassesInVersion [
 
 	| classes |


### PR DESCRIPTION
Fixes annoying ProperMethodCategorizationTest (#testNoUncategorizedMethods) reported by ReleaseTest during CI in Pharo 12 tests.
