### PR TITLE
adding an ifEmpty guard in RubTextSegmentMorph>>#computeStraightVertices to prevent a random CI crash

### DIFF
--- a/src/Rubric/RubTextSegmentMorph.class.st
+++ b/src/Rubric/RubTextSegmentMorph.class.st
@@ -117,8 +117,9 @@ RubTextSegmentMorph >> computeSmoothVertices [
 
 { #category : 'private' }
 RubTextSegmentMorph >> computeStraightVertices [
-	| firstCB lastCB firstLineIndex lastLineIndex firstLine lastLine 
-	verts lines textarea margins segmentGap textAreaLeft |
+
+	| firstCB lastCB firstLineIndex lastLineIndex firstLine lastLine verts lines textarea margins segmentGap textAreaLeft |
+	self lines ifEmpty: [ ^ self ].
 	firstCB := self characterBlockForIndex: firstIndex.
 	lastCB := self characterBlockForIndex: lastIndex.
 	lines := self lines.
@@ -129,32 +130,32 @@ RubTextSegmentMorph >> computeStraightVertices [
 	firstLine := lines at: firstLineIndex.
 	lastLine := lines at: lastLineIndex.
 	verts := OrderedCollection new.
-	segmentGap := 1@0.
-	firstLine = lastLine ifTrue: [
-		verts add: firstCB bottomLeft.
-		verts add: firstCB topLeft.
-		firstIndex ~= lastIndex ifTrue: [
-			verts add: lastCB topLeft.
-			verts add: lastCB bottomLeft.
-			verts add: firstCB bottomLeft ] ]
-	ifFalse: [ 
-		textAreaLeft := textArea left + margins left.
-		verts 
-			add: firstCB bottomLeft - segmentGap;
-			add: firstCB topLeft - segmentGap.
-		firstLineIndex to: lastLineIndex - 1 do: [ :index | | line |
-			line := lines at: index.
-			verts 
-				add: line actualWidth + margins left @ line top + segmentGap;
-				add: line actualWidth + margins left @ line bottom + segmentGap.
-		].
-		
-		verts
-			add: lastCB topLeft + segmentGap;
-			add: lastCB bottomLeft + segmentGap;
-			add: textAreaLeft @ lastLine bottom - segmentGap;
-			add: textAreaLeft @ firstLine bottom - segmentGap.
-	].
+	segmentGap := 1 @ 0.
+	firstLine = lastLine
+		ifTrue: [
+			verts add: firstCB bottomLeft.
+			verts add: firstCB topLeft.
+			firstIndex ~= lastIndex ifTrue: [
+				verts add: lastCB topLeft.
+				verts add: lastCB bottomLeft.
+				verts add: firstCB bottomLeft ] ]
+		ifFalse: [
+			textAreaLeft := textArea left + margins left.
+			verts
+				add: firstCB bottomLeft - segmentGap;
+				add: firstCB topLeft - segmentGap.
+			firstLineIndex to: lastLineIndex - 1 do: [ :index |
+				| line |
+				line := lines at: index.
+				verts
+					add: line actualWidth + margins left @ line top + segmentGap;
+					add: line actualWidth + margins left @ line bottom + segmentGap ].
+
+			verts
+				add: lastCB topLeft + segmentGap;
+				add: lastCB bottomLeft + segmentGap;
+				add: textAreaLeft @ lastLine bottom - segmentGap;
+				add: textAreaLeft @ firstLine bottom - segmentGap ].
 	self setVertices: verts
 ]
 


### PR DESCRIPTION
Partially fixes https://github.com/pharo-spec/NewTools/issues/664
See discussion here: https://github.com/pharo-spec/NewTools/pull/665

Sometimes a random CI crash can happen because of an announcement when the extent of a morph have changed, which would cause to call in the end `RubTextSegmentMorph>>computeStraightVertices`. This method then calls the method `#characterBlockForIndex` which searches for the character bloc containing the character at a specific index.
To do that, `RubParagraph>>characterBlockForIndex:` first searches for the index of the line that contains this character:

```Smalltalk
characterBlockForIndex: index
	"Answer a CharacterBlock for the character in text at index."
	| line |
	line := self lines at: (self lineIndexOfCharacterIndex: index).
	^ (RubCharacterBlockScanner new text: self text textStyle: self textStyle)
		characterBlockAtPoint: nil index: ((index max: line first) min: self text size+1)
		in: line
```

However, if there are no lines in the paragraph, `self lineIndexOfCharacterIndex: index` returns 1, which would raise `SubscriptOutOfBounds` because `self lines at: (self lineIndexOfCharacterIndex: index)` tries to access the first element of an empty collection.

Here is the stack trace:

```
SubscriptOutOfBounds: 1 in an OrderedCollection()
[:err |
		"Handle a drawing error"
		| errCtx errMorph |
		errCtx := thisContext.
		[
			errCtx := errCtx sender.
			"Search the sender chain to find the morph causing the problem"
			[errCtx isNotNil and:[(errCtx receiver isMorph) not]]
				whileTrue:[errCtx := errCtx sender].
			"If we're at the root of the context chain then we have a fatal drawing problem"
			errCtx ifNil:[^self handleFatalDrawingError: err description].
			errMorph := errCtx receiver.
			"If the morph causing the problem has already the #drawError flag set,
			then search for the next morph above in the caller chain."
			errMorph hasProperty: #errorOnDraw
		] whileTrue.
		errMorph setProperty: #errorOnDraw toValue: true.
		"Install the old error handler, so we can re-raise the error"
		err signal.
	] in WorldState>>displayWorldSafely: in Block: [:err |...
FullBlockClosure(BlockClosure)>>cull:
[:ex | errorHandlerBlock cull: ex] in FullBlockClosure(BlockClosure)>>onErrorDo: in Block: [:ex | errorHandlerBlock cull: ex]
FullBlockClosure(BlockClosure)>>cull:
Context>>evaluateSignal:
Context>>handleSignal:
Context>>handleSignal:
SubscriptOutOfBounds(Exception)>>signal
SubscriptOutOfBounds class>>signalFor:lowerBound:upperBound:in:
SubscriptOutOfBounds class>>signalFor:lowerBound:upperBound:
SubscriptOutOfBounds class>>signalFor:
OrderedCollection(Object)>>errorSubscriptBounds:
OrderedCollection>>at:
RubParagraph>>characterBlockForIndex:
RubShoutStylerDecorator(RubParagraphDecorator)>>characterBlockForIndex:
RubPrimarySelectionMorph(RubTextSegmentMorph)>>characterBlockForIndex:
RubPrimarySelectionMorph(RubTextSegmentMorph)>>computeStraightVertices
RubPrimarySelectionMorph(RubTextSegmentMorph)>>computeVertices
RubPrimarySelectionMorph(RubTextSegmentMorph)>>whenExtentChanged:
MessageSend>>value:
MessageSend>>cull:
MessageSend>>cull:cull:
[ action cull: anAnnouncement cull: announcer ] in AnnouncementSubscription(AbstractAnnouncementSubscription)>>deliver: in Block: [ action cull: anAnnouncement cull: announcer ]
FullBlockClosure(BlockClosure)>>on:do:
FullBlockClosure(BlockClosure)>>on:fork:
AnnouncementSubscription(AbstractAnnouncementSubscription)>>deliver:
[ subscription deliver: anAnnouncement ] in SubscriptionRegistry>>deliver:to:startingAt: in Block: [ subscription deliver: anAnnouncement ]
FullBlockClosure(BlockClosure)>>ifCurtailed:
SubscriptionRegistry>>deliver:to:startingAt:
SubscriptionRegistry>>deliver:to:
```

I fixed that by adding a `self lines ifEmpty: [ ^ self]` guard in `RubTextSegmentMorph>>#computeStraightVertices` to prevent this crash.

I don't know if this fix is very correct, but at least, it seems to fix this Ci crash...