### PR TITLE
Refactorings: second pass on preconditions

### DIFF
--- a/src/Refactoring-Core/RBAbstractClassVariableReferencesRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractClassVariableReferencesRefactoring.class.st
@@ -60,6 +60,15 @@ RBAbstractClassVariableReferencesRefactoring >> accessorsRefactoring [
 		ifNotNil: [ accessorsRefactoring ]
 ]
 
+{ #category : 'preconditions' }
+RBAbstractClassVariableReferencesRefactoring >> applicabilityPreconditions [ 
+	^(RBCondition isMetaclass: class) not
+		& (RBCondition directlyDefinesClassVariable: variableName asSymbol in: class)
+			& ((RBCondition withBlock:
+						[(#(#Object #Behavior #ClassDescription #Class) includes: class name) not])
+					errorMacro: 'This refactoring does not work for Object, Behavior, ClassDescription, or Class')
+]
+
 { #category : 'transforming' }
 RBAbstractClassVariableReferencesRefactoring >> createAccessors [
 	self generateChangesFor: self accessorsRefactoring
@@ -67,11 +76,8 @@ RBAbstractClassVariableReferencesRefactoring >> createAccessors [
 
 { #category : 'preconditions' }
 RBAbstractClassVariableReferencesRefactoring >> preconditions [
-	^(RBCondition isMetaclass: class) not
-		& (RBCondition directlyDefinesClassVariable: variableName asSymbol in: class)
-			& ((RBCondition withBlock:
-						[(#(#Object #Behavior #ClassDescription #Class) includes: class name) not])
-					errorMacro: 'This refactoring does not work for Object, Behavior, ClassDescription, or Class')
+
+	^ self applicabilityPreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
@@ -51,6 +51,12 @@ RBAbstractInstanceVariableRefactoring >> accessorsRefactoring [
 		ifNotNil: [ accessorsRefactoring ]
 ]
 
+{ #category : 'preconditions' }
+RBAbstractInstanceVariableRefactoring >> applicabilityPreconditions [ 
+
+	^ RBCondition directlyDefinesInstanceVariable: variableName in: class
+]
+
 { #category : 'transforming' }
 RBAbstractInstanceVariableRefactoring >> createAccessors [
 	self generateChangesFor: self accessorsRefactoring
@@ -58,7 +64,8 @@ RBAbstractInstanceVariableRefactoring >> createAccessors [
 
 { #category : 'preconditions' }
 RBAbstractInstanceVariableRefactoring >> preconditions [
-	^ RBCondition directlyDefinesInstanceVariable: variableName in: class
+
+	^ self applicabilityPreconditions 
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
@@ -62,12 +62,6 @@ RBAbstractInstanceVariableRefactoring >> createAccessors [
 	self generateChangesFor: self accessorsRefactoring
 ]
 
-{ #category : 'preconditions' }
-RBAbstractInstanceVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions 
-]
-
 { #category : 'transforming' }
 RBAbstractInstanceVariableRefactoring >> privateTransform [
 	self createAccessors.

--- a/src/Refactoring-Core/RBAddClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddClassVariableRefactoring.class.st
@@ -27,12 +27,6 @@ RBAddClassVariableRefactoring >> breakingChangePreconditions [
 		   definesVariable: variableName asString) not
 ]
 
-{ #category : 'preconditions' }
-RBAddClassVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions
-]
-
 { #category : 'transforming' }
 RBAddClassVariableRefactoring >> privateTransform [
 	class addClassVariable: variableName

--- a/src/Refactoring-Core/RBAddInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddInstanceVariableRefactoring.class.st
@@ -24,12 +24,6 @@ RBAddInstanceVariableRefactoring >> breakingChangePreconditions [
 	^ (RBCondition hierarchyOf: class definesVariable: variableName) not
 ]
 
-{ #category : 'preconditions' }
-RBAddInstanceVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions
-]
-
 { #category : 'transforming' }
 RBAddInstanceVariableRefactoring >> privateTransform [
 	class addInstanceVariable: variableName

--- a/src/Refactoring-Core/RBAddMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddMethodRefactoring.class.st
@@ -53,6 +53,12 @@ RBAddMethodRefactoring class >> sourceCode: aString in: aClass withProtocol: aPr
 ]
 
 { #category : 'preconditions' }
+RBAddMethodRefactoring >> applicabilityPreconditions [ 
+
+	^ (RBCondition canUnderstand: transformation selector in: class) not
+]
+
+{ #category : 'preconditions' }
 RBAddMethodRefactoring >> checkPreconditions [
 	"We should have same preconditions checking API for all refactorings.
 	Some of them do it like: 
@@ -69,7 +75,7 @@ RBAddMethodRefactoring >> checkPreconditions [
 { #category : 'preconditions' }
 RBAddMethodRefactoring >> preconditions [
 
-	^ (RBCondition canUnderstand: transformation selector in: class) not
+	^ self applicabilityPreconditions 
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBAddOverrideMethodTransformation.class.st
+++ b/src/Refactoring-Core/RBAddOverrideMethodTransformation.class.st
@@ -14,7 +14,7 @@ Class {
 }
 
 { #category : 'preconditions' }
-RBAddOverrideMethodTransformation >> preconditions [
+RBAddOverrideMethodTransformation >> applicabilityPreconditions [ 
 
 	^ (RBCondition definesSelector: transformation selector in: class) not
 ]

--- a/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
@@ -93,6 +93,14 @@ RBCreateAccessorsForVariableTransformation class >> variable: aVarName class: aC
 		classVariable: aBoolean; yourself
 ]
 
+{ #category : 'preconditions' }
+RBCreateAccessorsForVariableTransformation >> applicabilityPreconditions [ 
+
+	^ classVariable
+		ifTrue: [RBCondition definesClassVariable: variableName asSymbol in: class]
+		ifFalse: [RBCondition definesInstanceVariable: variableName in: class]
+]
+
 { #category : 'initialization' }
 RBCreateAccessorsForVariableTransformation >> classVariable: aBoolean [
 	classVariable := aBoolean
@@ -249,9 +257,7 @@ RBCreateAccessorsForVariableTransformation >> possibleSetterSelectors [
 RBCreateAccessorsForVariableTransformation >> preconditions [
 	"Checks that the class actually defines the variable from which we will build setter and getter."
 
-	^ classVariable
-		ifTrue: [RBCondition definesClassVariable: variableName asSymbol in: class]
-		ifFalse: [RBCondition definesInstanceVariable: variableName in: class]
+	^ self applicabilityPreconditions 
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBCreateLazyAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateLazyAccessorsForVariableTransformation.class.st
@@ -62,6 +62,14 @@ RBCreateLazyAccessorsForVariableTransformation class >> variable: aVarName class
 ]
 
 { #category : 'preconditions' }
+RBCreateLazyAccessorsForVariableTransformation >> applicabilityPreconditions [ 
+	"In addition check that the initialization is valid"
+
+	^ super applicabilityPreconditions 
+		& (RBCondition withBlock: [  self verifyInitializationExpressionOf: self defaultValue. true ])
+]
+
+{ #category : 'preconditions' }
 RBCreateLazyAccessorsForVariableTransformation >> checkVariableReferencesIn: aParseTree [
 
 	| searcher |
@@ -115,14 +123,6 @@ RBCreateLazyAccessorsForVariableTransformation >> defineGetterMethod [
 			 withProtocol: #accessing).
 
 	^ selector
-]
-
-{ #category : 'preconditions' }
-RBCreateLazyAccessorsForVariableTransformation >> preconditions [
-	"In addition check that the initialization is valid"
-
-	^ super preconditions
-		& (RBCondition withBlock: [  self verifyInitializationExpressionOf: self defaultValue. true ])
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineAllSendersRefactoring.class.st
@@ -57,6 +57,12 @@ RBInlineAllSendersRefactoring class >> sendersOf: aSelector in: aClass [
 		in: aClass
 ]
 
+{ #category : 'preconditions' }
+RBInlineAllSendersRefactoring >> applicabilityPreconditions [
+
+	^ RBCondition canUnderstand: selector in: class
+]
+
 { #category : 'transforming' }
 RBInlineAllSendersRefactoring >> checkInlinedMethods [
 	numberReplaced = 0
@@ -126,7 +132,8 @@ RBInlineAllSendersRefactoring >> numberOfSelfSendsIn: aParseTree [
 
 { #category : 'preconditions' }
 RBInlineAllSendersRefactoring >> preconditions [
-	^RBCondition canUnderstand: selector in: class
+
+	^ self applicabilityPreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBInlineMethodFromComponentRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodFromComponentRefactoring.class.st
@@ -58,6 +58,20 @@ RBInlineMethodFromComponentRefactoring >> addSelfReferenceToSourceMessage [
 ]
 
 { #category : 'transforming' }
+RBInlineMethodFromComponentRefactoring >> checkSelectedMessage [
+
+	sourceParseTree := class parseTreeForSelector: sourceSelector.
+	sourceParseTree ifNil: [ self refactoringError: 'Could not parse sources' ].
+	sourceMessage := sourceParseTree whichNodeIsContainedBy: sourceInterval.
+	sourceMessage
+		ifNil: [ self refactoringError: 'The selection doesn''t appear to be a message send' ].
+	sourceMessage isCascade
+		ifTrue: [ sourceMessage := sourceMessage messages last ].
+	sourceMessage isMessage
+		ifFalse: [ self refactoringError: 'The selection doesn''t appear to be a message send' ]
+]
+
+{ #category : 'transforming' }
 RBInlineMethodFromComponentRefactoring >> checkSuperMessages [
 	inlineParseTree superMessages isEmpty
 		ifFalse:
@@ -78,20 +92,6 @@ RBInlineMethodFromComponentRefactoring >> classOfTheMethodToInline [
 	classOfTheMethodToInline := self requestImplementorToInline: imps.
 	classOfTheMethodToInline ifNil: [ self refactoringError: 'No implementor selected' ].
 	^ classOfTheMethodToInline
-]
-
-{ #category : 'transforming' }
-RBInlineMethodFromComponentRefactoring >> findSelectedMessage [
-
-	sourceParseTree := class parseTreeForSelector: sourceSelector.
-	sourceParseTree ifNil: [ self refactoringError: 'Could not parse sources' ].
-	sourceMessage := sourceParseTree whichNodeIsContainedBy: sourceInterval.
-	sourceMessage
-		ifNil: [ self refactoringError: 'The selection doesn''t appear to be a message send' ].
-	sourceMessage isCascade
-		ifTrue: [ sourceMessage := sourceMessage messages last ].
-	sourceMessage isMessage
-		ifFalse: [ self refactoringError: 'The selection doesn''t appear to be a message send' ]
 ]
 
 { #category : 'testing' }

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -58,6 +58,55 @@ RBInlineMethodRefactoring >> addTemporary: sourceNode assignedTo: replacementNod
 					value: replacementNode)
 ]
 
+{ #category : 'preconditions' }
+RBInlineMethodRefactoring >> applicabilityPreconditions [ 
+	"Even though it looks complex it only does preconditions and set up. `transform` does actual refactoring"
+	^ (RBCondition definesSelector: sourceSelector in: class)
+		& (RBCondition withBlock:
+					[self checkSelectedMessage.
+					self checkOverridden ifTrue: [
+						self isOverridden
+						ifTrue:
+							[self
+								refactoringWarning: ('<1p>>><2s> is overriden. Do you want to inline it anyway?', String cr, 'You can break you hooks with this inline.'
+										expandMacrosWith: self classOfTheMethodToInline
+										with: self inlineSelector)] ].
+					self parseInlineMethod.
+					self isPrimitive
+						ifTrue: [self refactoringError: 'Cannot inline primitives'].
+					self checkSuperMessages.
+					self rewriteInlinedTree.
+					(sourceMessage parent isReturn or: [self hasMultipleReturns not])
+						ifFalse:
+							[self
+								refactoringError: 'Cannot inline method since it contains multiple returns that cannot be rewritten'].
+					true])
+]
+
+{ #category : 'preconditions' }
+RBInlineMethodRefactoring >> breakingChangePreconditions [ 
+	"Even though it looks complex it only does preconditions and set up. `transform` does actual refactoring"
+	^ (RBCondition withBlock:
+					[self checkSelectedMessage.
+					self checkOverridden ifTrue: [
+						self isOverridden
+						ifTrue:
+							[self
+								refactoringWarning: ('<1p>>><2s> is overriden. Do you want to inline it anyway?', String cr, 'You can break you hooks with this inline.'
+										expandMacrosWith: self classOfTheMethodToInline
+										with: self inlineSelector)] ].
+					self parseInlineMethod.
+					self isPrimitive
+						ifTrue: [self refactoringError: 'Cannot inline primitives'].
+					self checkSuperMessages.
+					self rewriteInlinedTree.
+					(sourceMessage parent isReturn or: [self hasMultipleReturns not])
+						ifFalse:
+							[self
+								refactoringError: 'Cannot inline method since it contains multiple returns that cannot be rewritten'].
+					true])
+]
+
 { #category : 'accessing' }
 RBInlineMethodRefactoring >> checkOverridden [
 	^ checkOverridden ifNil: [ checkOverridden := true ]
@@ -66,6 +115,21 @@ RBInlineMethodRefactoring >> checkOverridden [
 { #category : 'accessing' }
 RBInlineMethodRefactoring >> checkOverridden: aBoolean [
 	checkOverridden := aBoolean
+]
+
+{ #category : 'transforming' }
+RBInlineMethodRefactoring >> checkSelectedMessage [
+
+	sourceParseTree ifNil: [ self refactoringError: 'Could not parse sources' ].
+	sourceMessage := sourceParseTree whichNodeIsContainedBy: sourceInterval.
+	sourceMessage
+		ifNil: [ self refactoringError: 'The selection doesn''t appear to be a message send' ].
+	sourceMessage isCascade
+		ifTrue: [ sourceMessage := sourceMessage messages last ].
+	sourceMessage isMessage
+		ifFalse: [ self refactoringError: 'The selection doesn''t appear to be a message send' ].
+	(sourceMessage receiver isSelfVariable or: [ sourceMessage receiver isSuperVariable ])
+		ifFalse: [ self refactoringError: 'Cannot inline non-self messages' ]
 ]
 
 { #category : 'transforming' }
@@ -102,22 +166,6 @@ RBInlineMethodRefactoring >> compileMethod [
 	class compileTree: sourceParseTree
 ]
 
-{ #category : 'transforming' }
-RBInlineMethodRefactoring >> findSelectedMessage [
-
-	sourceParseTree := class parseTreeForSelector: sourceSelector.
-	sourceParseTree ifNil: [ self refactoringError: 'Could not parse sources' ].
-	sourceMessage := sourceParseTree whichNodeIsContainedBy: sourceInterval.
-	sourceMessage
-		ifNil: [ self refactoringError: 'The selection doesn''t appear to be a message send' ].
-	sourceMessage isCascade
-		ifTrue: [ sourceMessage := sourceMessage messages last ].
-	sourceMessage isMessage
-		ifFalse: [ self refactoringError: 'The selection doesn''t appear to be a message send' ].
-	(sourceMessage receiver isSelfVariable or: [ sourceMessage receiver isSuperVariable ])
-		ifFalse: [ self refactoringError: 'Cannot inline non-self messages' ]
-]
-
 { #category : 'testing' }
 RBInlineMethodRefactoring >> hasMultipleReturns [
 	"Do we have multiple returns? If the last statement isn't a return, then we have an implicit return of self."
@@ -151,7 +199,7 @@ RBInlineMethodRefactoring >> inlineParseTree [
 { #category : 'transforming' }
 RBInlineMethodRefactoring >> inlineSelector [
 
-	sourceMessage ifNil: [ self findSelectedMessage ].
+	sourceMessage ifNil: [ self checkSelectedMessage ].
 	^ sourceMessage selector
 ]
 
@@ -280,7 +328,7 @@ RBInlineMethodRefactoring >> preconditions [
 	"Even though it looks complex it only does preconditions and set up. `transform` does actual refactoring"
 	^ (RBCondition definesSelector: sourceSelector in: class)
 		& (RBCondition withBlock:
-					[self findSelectedMessage.
+					[self checkSelectedMessage.
 					self checkOverridden ifTrue: [
 						self isOverridden
 						ifTrue:

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -104,15 +104,22 @@ RBInlineMethodRefactoring >> checkOverridden: aBoolean [
 { #category : 'transforming' }
 RBInlineMethodRefactoring >> checkSelectedMessage [
 
-	sourceParseTree ifNil: [ self refactoringError: 'Could not parse sources' ].
-	sourceMessage
-		ifNil: [ self refactoringError: 'The selection doesn''t appear to be a message send' ].
-	sourceMessage isCascade
-		ifTrue: [ sourceMessage := sourceMessage messages last ].
-	sourceMessage isMessage
-		ifFalse: [ self refactoringError: 'The selection doesn''t appear to be a message send' ].
-	(sourceMessage receiver isSelfVariable or: [ sourceMessage receiver isSuperVariable ])
-		ifFalse: [ self refactoringError: 'Cannot inline non-self messages' ]
+	sourceParseTree := class parseTreeForSelector: sourceSelector.
+	sourceParseTree ifNil: [
+		self refactoringError: 'Could not parse sources' ].
+	sourceMessage := sourceParseTree whichNodeIsContainedBy:
+		                 sourceInterval.
+	sourceMessage ifNil: [
+		self refactoringError:
+			'The selection doesn''t appear to be a message send' ].
+	sourceMessage isCascade ifTrue: [
+		sourceMessage := sourceMessage messages last ].
+	sourceMessage isMessage ifFalse: [
+		self refactoringError:
+			'The selection doesn''t appear to be a message send' ].
+	(sourceMessage receiver isSelfVariable or: [
+		 sourceMessage receiver isSuperVariable ]) ifFalse: [
+		self refactoringError: 'Cannot inline non-self messages' ]
 ]
 
 { #category : 'transforming' }
@@ -308,15 +315,6 @@ RBInlineMethodRefactoring >> parseInlineMethod [
 RBInlineMethodRefactoring >> preconditions [ 
 
 	^ self applicabilityPreconditions & self breakingChangePreconditions 
-]
-
-{ #category : 'transforming' }
-RBInlineMethodRefactoring >> prepareForExecution [
-
-	sourceParseTree := class parseTreeForSelector: sourceSelector.
-	sourceParseTree ifNotNil: [
-		sourceMessage := sourceParseTree whichNodeIsContainedBy:
-			                 sourceInterval ]
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -225,9 +225,8 @@ RBInlineMethodRefactoring >> insertInlinedMethod [
 
 { #category : 'testing' }
 RBInlineMethodRefactoring >> isOverridden [
-	| selector|
-	selector := self inlineSelector.
-	^ class subclassRedefines: selector
+
+	^ class subclassRedefines: self inlineSelector
 ]
 
 { #category : 'testing' }

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -301,6 +301,12 @@ RBInlineMethodRefactoring >> preconditions [
 ]
 
 { #category : 'transforming' }
+RBInlineMethodRefactoring >> prepareForExecution [
+
+	sourceParseTree := class parseTreeForSelector: sourceSelector
+]
+
+{ #category : 'transforming' }
 RBInlineMethodRefactoring >> privateTransform [
 	self
 		renameConflictingTemporaries;

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -121,7 +121,6 @@ RBInlineMethodRefactoring >> checkOverridden: aBoolean [
 RBInlineMethodRefactoring >> checkSelectedMessage [
 
 	sourceParseTree ifNil: [ self refactoringError: 'Could not parse sources' ].
-	sourceMessage := sourceParseTree whichNodeIsContainedBy: sourceInterval.
 	sourceMessage
 		ifNil: [ self refactoringError: 'The selection doesn''t appear to be a message send' ].
 	sourceMessage isCascade
@@ -199,7 +198,6 @@ RBInlineMethodRefactoring >> inlineParseTree [
 { #category : 'transforming' }
 RBInlineMethodRefactoring >> inlineSelector [
 
-	sourceMessage ifNil: [ self checkSelectedMessage ].
 	^ sourceMessage selector
 ]
 
@@ -351,7 +349,10 @@ RBInlineMethodRefactoring >> preconditions [
 { #category : 'transforming' }
 RBInlineMethodRefactoring >> prepareForExecution [
 
-	sourceParseTree := class parseTreeForSelector: sourceSelector
+	sourceParseTree := class parseTreeForSelector: sourceSelector.
+	sourceParseTree ifNotNil: [
+		sourceMessage := sourceParseTree whichNodeIsContainedBy:
+			                 sourceInterval ]
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineMethodRefactoring.class.st
@@ -59,52 +59,36 @@ RBInlineMethodRefactoring >> addTemporary: sourceNode assignedTo: replacementNod
 ]
 
 { #category : 'preconditions' }
-RBInlineMethodRefactoring >> applicabilityPreconditions [ 
+RBInlineMethodRefactoring >> applicabilityPreconditions [
 	"Even though it looks complex it only does preconditions and set up. `transform` does actual refactoring"
+
 	^ (RBCondition definesSelector: sourceSelector in: class)
-		& (RBCondition withBlock:
-					[self checkSelectedMessage.
-					self checkOverridden ifTrue: [
-						self isOverridden
-						ifTrue:
-							[self
-								refactoringWarning: ('<1p>>><2s> is overriden. Do you want to inline it anyway?', String cr, 'You can break you hooks with this inline.'
-										expandMacrosWith: self classOfTheMethodToInline
-										with: self inlineSelector)] ].
-					self parseInlineMethod.
-					self isPrimitive
-						ifTrue: [self refactoringError: 'Cannot inline primitives'].
-					self checkSuperMessages.
-					self rewriteInlinedTree.
-					(sourceMessage parent isReturn or: [self hasMultipleReturns not])
-						ifFalse:
-							[self
-								refactoringError: 'Cannot inline method since it contains multiple returns that cannot be rewritten'].
-					true])
+	  & (RBCondition withBlock: [
+			   self checkSelectedMessage.
+			   self parseInlineMethod.
+			   self isPrimitive ifTrue: [
+				   self refactoringError: 'Cannot inline primitives' ].
+			   self checkSuperMessages.
+			   self rewriteInlinedTree.
+			   (sourceMessage parent isReturn or: [
+				    self hasMultipleReturns not ]) ifFalse: [
+				   self refactoringError:
+					   'Cannot inline method since it contains multiple returns that cannot be rewritten' ].
+			   true ])
 ]
 
 { #category : 'preconditions' }
-RBInlineMethodRefactoring >> breakingChangePreconditions [ 
-	"Even though it looks complex it only does preconditions and set up. `transform` does actual refactoring"
-	^ (RBCondition withBlock:
-					[self checkSelectedMessage.
-					self checkOverridden ifTrue: [
-						self isOverridden
-						ifTrue:
-							[self
-								refactoringWarning: ('<1p>>><2s> is overriden. Do you want to inline it anyway?', String cr, 'You can break you hooks with this inline.'
-										expandMacrosWith: self classOfTheMethodToInline
-										with: self inlineSelector)] ].
-					self parseInlineMethod.
-					self isPrimitive
-						ifTrue: [self refactoringError: 'Cannot inline primitives'].
-					self checkSuperMessages.
-					self rewriteInlinedTree.
-					(sourceMessage parent isReturn or: [self hasMultipleReturns not])
-						ifFalse:
-							[self
-								refactoringError: 'Cannot inline method since it contains multiple returns that cannot be rewritten'].
-					true])
+RBInlineMethodRefactoring >> breakingChangePreconditions [
+
+	^ RBCondition withBlock: [
+		  self checkOverridden ifTrue: [
+			  self isOverridden ifTrue: [
+				  self refactoringWarning:
+					  ('<1p>>><2s> is overriden. Do you want to inline it anyway?'
+					   , String cr , 'You can break you hooks with this inline.'
+						   expandMacrosWith: self classOfTheMethodToInline
+						   with: self inlineSelector) ] ].
+		  true ]
 ]
 
 { #category : 'accessing' }
@@ -322,28 +306,9 @@ RBInlineMethodRefactoring >> parseInlineMethod [
 ]
 
 { #category : 'preconditions' }
-RBInlineMethodRefactoring >> preconditions [
-	"Even though it looks complex it only does preconditions and set up. `transform` does actual refactoring"
-	^ (RBCondition definesSelector: sourceSelector in: class)
-		& (RBCondition withBlock:
-					[self checkSelectedMessage.
-					self checkOverridden ifTrue: [
-						self isOverridden
-						ifTrue:
-							[self
-								refactoringWarning: ('<1p>>><2s> is overriden. Do you want to inline it anyway?', String cr, 'You can break you hooks with this inline.'
-										expandMacrosWith: self classOfTheMethodToInline
-										with: self inlineSelector)] ].
-					self parseInlineMethod.
-					self isPrimitive
-						ifTrue: [self refactoringError: 'Cannot inline primitives'].
-					self checkSuperMessages.
-					self rewriteInlinedTree.
-					(sourceMessage parent isReturn or: [self hasMultipleReturns not])
-						ifFalse:
-							[self
-								refactoringError: 'Cannot inline method since it contains multiple returns that cannot be rewritten'].
-					true])
+RBInlineMethodRefactoring >> preconditions [ 
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions 
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBInlineTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineTemporaryRefactoring.class.st
@@ -49,11 +49,13 @@ RBInlineTemporaryRefactoring >> applicabilityPreconditions [
 { #category : 'preconditions' }
 RBInlineTemporaryRefactoring >> checkSelectedInterval [
 
+	sourceTree := class parseTreeForSelector: selector.
 	sourceTree ifNil: [ self refactoringError: 'Could not parse source' ].
-
+	assignmentNode := sourceTree whichNodeIsContainedBy: sourceInterval.
 	assignmentNode isAssignment
 		ifFalse: [ self refactoringError: 'The selected node is not an assignment statement' ].
-
+	definingNode := assignmentNode whoDefines:
+		                assignmentNode variable name.
 	self hasOnlyOneAssignment
 		ifFalse: [ self refactoringError: 'There are multiple assignments to the variable' ].
 	( RBReadBeforeWrittenTester
@@ -88,17 +90,6 @@ RBInlineTemporaryRefactoring >> inline: anInterval from: aSelector in: aClass [
 RBInlineTemporaryRefactoring >> preconditions [
 
 	^ self applicabilityPreconditions
-]
-
-{ #category : 'transforming' }
-RBInlineTemporaryRefactoring >> prepareForExecution [
-
-	sourceTree := class parseTreeForSelector: selector.
-	sourceTree ifNil: [ ^ self ].
-	assignmentNode := sourceTree whichNodeIsContainedBy: sourceInterval.
-	assignmentNode ifNil: [ ^ self ].
-	definingNode := assignmentNode whoDefines:
-		                assignmentNode variable name
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBInlineTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineTemporaryRefactoring.class.st
@@ -37,6 +37,31 @@ RBInlineTemporaryRefactoring class >> model: aRBSmalltalk inline: anInterval fro
 		yourself
 ]
 
+{ #category : 'preconditions' }
+RBInlineTemporaryRefactoring >> applicabilityPreconditions [ 
+
+	^ (RBCondition definesSelector: selector in: class)
+	  & (RBCondition withBlock: [
+			   self checkSelectedInterval.
+			   true ])
+]
+
+{ #category : 'preconditions' }
+RBInlineTemporaryRefactoring >> checkSelectedInterval [
+
+	sourceTree ifNil: [ self refactoringError: 'Could not parse source' ].
+
+	assignmentNode isAssignment
+		ifFalse: [ self refactoringError: 'The selected node is not an assignment statement' ].
+
+	self hasOnlyOneAssignment
+		ifFalse: [ self refactoringError: 'There are multiple assignments to the variable' ].
+	( RBReadBeforeWrittenTester
+		isVariable: assignmentNode variable name
+		writtenBeforeReadIn: definingNode )
+		ifFalse: [ self refactoringError: 'The variable is possible read before it is assigned' ]
+]
+
 { #category : 'transforming' }
 RBInlineTemporaryRefactoring >> compileMethod [
 	class compileTree: sourceTree
@@ -61,10 +86,19 @@ RBInlineTemporaryRefactoring >> inline: anInterval from: aSelector in: aClass [
 
 { #category : 'preconditions' }
 RBInlineTemporaryRefactoring >> preconditions [
-	^(RBCondition definesSelector: selector in: class)
-		& (RBCondition withBlock:
-					[self verifySelectedInterval.
-					true])
+
+	^ self applicabilityPreconditions
+]
+
+{ #category : 'transforming' }
+RBInlineTemporaryRefactoring >> prepareForExecution [
+
+	sourceTree := class parseTreeForSelector: selector.
+	sourceTree ifNil: [ ^ self ].
+	assignmentNode := sourceTree whichNodeIsContainedBy: sourceInterval.
+	assignmentNode ifNil: [ ^ self ].
+	definingNode := assignmentNode whoDefines:
+		                assignmentNode variable name
 ]
 
 { #category : 'transforming' }
@@ -104,21 +138,4 @@ RBInlineTemporaryRefactoring >> storeOn: aStream [
 		nextPutAll: ' in: '.
 	class storeOn: aStream.
 	aStream nextPut: $)
-]
-
-{ #category : 'preconditions' }
-RBInlineTemporaryRefactoring >> verifySelectedInterval [
-
-	sourceTree := class parseTreeForSelector: selector.
-	sourceTree ifNil: [ self refactoringError: 'Could not parse source' ].
-	assignmentNode := sourceTree whichNodeIsContainedBy: sourceInterval.
-	assignmentNode isAssignment
-		ifFalse: [ self refactoringError: 'The selected node is not an assignment statement' ].
-	definingNode := assignmentNode whoDefines: assignmentNode variable name.
-	self hasOnlyOneAssignment
-		ifFalse: [ self refactoringError: 'There are multiple assignments to the variable' ].
-	( RBReadBeforeWrittenTester
-		isVariable: assignmentNode variable name
-		writtenBeforeReadIn: definingNode )
-		ifFalse: [ self refactoringError: 'The variable is possible read before it is assigned' ]
 ]

--- a/src/Refactoring-Core/RBMergeInstanceVariableIntoAnother.class.st
+++ b/src/Refactoring-Core/RBMergeInstanceVariableIntoAnother.class.st
@@ -42,13 +42,20 @@ Class {
 }
 
 { #category : 'preconditions' }
+RBMergeInstanceVariableIntoAnother >> applicabilityPreconditions [
+
+	^ (RBCondition withBlock: [
+		   variableName = newName ifTrue: [
+			   self refactoringError: 'The variable merged must be different' ].
+		   true ])
+	  & (RBCondition definesInstanceVariable: variableName in: class)
+	  & (RBCondition definesInstanceVariable: newName in: class)
+]
+
+{ #category : 'preconditions' }
 RBMergeInstanceVariableIntoAnother >> preconditions [
-	^ (RBCondition
-		withBlock: [ (variableName = newName)
-			ifTrue: [ self refactoringError: 'The variable merged must be different' ].
-		true ])
-		& (RBCondition definesInstanceVariable: variableName in: class)
-			& (RBCondition definesInstanceVariable: newName in: class)
+
+	^ self applicabilityPreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBMergeInstanceVariableIntoAnother.class.st
+++ b/src/Refactoring-Core/RBMergeInstanceVariableIntoAnother.class.st
@@ -59,12 +59,6 @@ RBMergeInstanceVariableIntoAnother >> applicabilityPreconditions [
 			   instanceVariables: { newName }) }
 ]
 
-{ #category : 'preconditions' }
-RBMergeInstanceVariableIntoAnother >> preconditions [
-
-	^ self applicabilityPreconditions
-]
-
 { #category : 'transforming' }
 RBMergeInstanceVariableIntoAnother >> privateTransform [
 	renameAccessors ifTrue: [

--- a/src/Refactoring-Core/RBMergeInstanceVariableIntoAnother.class.st
+++ b/src/Refactoring-Core/RBMergeInstanceVariableIntoAnother.class.st
@@ -44,12 +44,19 @@ Class {
 { #category : 'preconditions' }
 RBMergeInstanceVariableIntoAnother >> applicabilityPreconditions [
 
-	^ (RBCondition withBlock: [
-		   variableName = newName ifTrue: [
-			   self refactoringError: 'The variable merged must be different' ].
-		   true ])
-	  & (RBCondition definesInstanceVariable: variableName in: class)
-	  & (RBCondition definesInstanceVariable: newName in: class)
+	^ {
+		  (RBCondition withBlock: [
+			   variableName = newName ifTrue: [
+				   self refactoringError: 'The variable merged must be different' ].
+			   true ]).
+		  (ReDefinesInstanceVariableCondition
+			   classNamed: class name
+			   inModel: self model
+			   instanceVariables: { variableName }).
+		  (ReDefinesInstanceVariableCondition
+			   classNamed: class name
+			   inModel: self model
+			   instanceVariables: { newName }) }
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Core/RBMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBMethodRefactoring.class.st
@@ -24,3 +24,9 @@ RBMethodRefactoring class >> isAbstract [
 RBMethodRefactoring >> methodClass [
 	^ class
 ]
+
+{ #category : 'preconditions' }
+RBMethodRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions
+]

--- a/src/Refactoring-Core/RBMoveMethodToClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodToClassRefactoring.class.st
@@ -36,6 +36,12 @@ RBMoveMethodToClassRefactoring class >> model: aRBSmalltalk method: aMethod clas
 		yourself
 ]
 
+{ #category : 'preconditions' }
+RBMoveMethodToClassRefactoring >> applicabilityPreconditions [
+
+	^ (RBCondition definesSelector: method selector in: class) not
+]
+
 { #category : 'transforming' }
 RBMoveMethodToClassRefactoring >> classModelOf: aClass [
 	^ self model classObjectFor: aClass
@@ -49,7 +55,8 @@ RBMoveMethodToClassRefactoring >> method: aMethod class: aClass [
 
 { #category : 'preconditions' }
 RBMoveMethodToClassRefactoring >> preconditions [
-	^(RBCondition definesSelector: method selector in: class) not
+
+	^ self applicabilityPreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBProtectInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBProtectInstanceVariableRefactoring.class.st
@@ -12,6 +12,12 @@ Class {
 	#tag : 'Refactorings'
 }
 
+{ #category : 'preconditions' }
+RBProtectInstanceVariableRefactoring >> applicabilityPreconditions [ 
+
+	^RBCondition definesInstanceVariable: variableName in: class
+]
+
 { #category : 'private - accessing' }
 RBProtectInstanceVariableRefactoring >> getterSetterMethods [
 	| matcher |
@@ -45,7 +51,8 @@ RBProtectInstanceVariableRefactoring >> inline: aSelector [
 
 { #category : 'preconditions' }
 RBProtectInstanceVariableRefactoring >> preconditions [
-	^RBCondition definesInstanceVariable: variableName in: class
+
+	^ self applicabilityPreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBProtectInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBProtectInstanceVariableRefactoring.class.st
@@ -49,12 +49,6 @@ RBProtectInstanceVariableRefactoring >> inline: aSelector [
 		do: []
 ]
 
-{ #category : 'preconditions' }
-RBProtectInstanceVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions
-]
-
 { #category : 'transforming' }
 RBProtectInstanceVariableRefactoring >> privateTransform [
 	self setOption: #inlineExpression toUse: [:ref :string | true].

--- a/src/Refactoring-Core/RBPullUpClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpClassVariableRefactoring.class.st
@@ -15,12 +15,6 @@ RBPullUpClassVariableRefactoring >> applicabilityPreconditions [
 	^(RBCondition isMetaclass: class) not
 ]
 
-{ #category : 'preconditions' }
-RBPullUpClassVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions
-]
-
 { #category : 'transforming' }
 RBPullUpClassVariableRefactoring >> privateTransform [
 	| subclass |

--- a/src/Refactoring-Core/RBPullUpClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpClassVariableRefactoring.class.st
@@ -10,8 +10,15 @@ Class {
 }
 
 { #category : 'preconditions' }
-RBPullUpClassVariableRefactoring >> preconditions [
+RBPullUpClassVariableRefactoring >> applicabilityPreconditions [ 
+
 	^(RBCondition isMetaclass: class) not
+]
+
+{ #category : 'preconditions' }
+RBPullUpClassVariableRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBPullUpInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpInstanceVariableRefactoring.class.st
@@ -10,17 +10,31 @@ Class {
 }
 
 { #category : 'preconditions' }
+RBPullUpInstanceVariableRefactoring >> applicabilityPreconditions [
+
+	^ RBCondition withBlock: [
+		  (class hierarchyDefinesInstanceVariable: variableName) ifFalse: [
+			  self refactoringError: 'No subclass defines ' , variableName ].
+		  true ]
+]
+
+{ #category : 'preconditions' }
+RBPullUpInstanceVariableRefactoring >> breakingChangePreconditions [
+
+	^ RBCondition withBlock: [
+		  (class subclasses anySatisfy: [ :each |
+			   (each directlyDefinesInstanceVariable: variableName) not ])
+			  ifTrue: [
+				  self refactoringWarning:
+					  'Not all subclasses have an instance variable named.<n> Do you want pull up this variable anyway?'
+					  , variableName , '.' ].
+		  true ]
+]
+
+{ #category : 'preconditions' }
 RBPullUpInstanceVariableRefactoring >> preconditions [
-	^RBCondition withBlock:
-			[(class hierarchyDefinesInstanceVariable: variableName)
-				ifFalse: [self refactoringError: 'No subclass defines ' , variableName].
-			(class subclasses
-				anySatisfy: [:each | (each directlyDefinesInstanceVariable: variableName) not])
-				ifTrue:
-					[self
-						refactoringWarning: 'Not all subclasses have an instance variable named.<n> Do you want pull up this variable anyway?'
-								, variableName , '.'].
-			true]
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions 
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBPullUpInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpInstanceVariableRefactoring.class.st
@@ -31,12 +31,6 @@ RBPullUpInstanceVariableRefactoring >> breakingChangePreconditions [
 		  true ]
 ]
 
-{ #category : 'preconditions' }
-RBPullUpInstanceVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions 
-]
-
 { #category : 'transforming' }
 RBPullUpInstanceVariableRefactoring >> privateTransform [
 	class allSubclasses do:

--- a/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
@@ -15,6 +15,21 @@ Class {
 }
 
 { #category : 'preconditions' }
+RBPushDownClassVariableRefactoring >> applicabilityPreconditions [ 
+
+	^ RBCondition definesClassVariable: variableName in: class
+]
+
+{ #category : 'preconditions' }
+RBPushDownClassVariableRefactoring >> breakingChangePreconditions [
+	"Preconditions are that only one subclass refers to the class variable."
+
+	^ RBCondition withBlock: [
+		  self findDestinationClass.
+		  true ]
+]
+
+{ #category : 'preconditions' }
 RBPushDownClassVariableRefactoring >> findDestinationClass [
 	| classes |
 	classes := class withAllSubclasses reject: [ :each |
@@ -35,12 +50,8 @@ RBPushDownClassVariableRefactoring >> findDestinationClass [
 
 { #category : 'preconditions' }
 RBPushDownClassVariableRefactoring >> preconditions [
-	"Preconditions are that only one subclass refers to the class variable."
 
-	^(RBCondition definesClassVariable: variableName in: class)
-		& (RBCondition withBlock:
-					[self findDestinationClass.
-					true])
+	^ self applicabilityPreconditions & self breakingChangePreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
@@ -48,12 +48,6 @@ RBPushDownClassVariableRefactoring >> findDestinationClass [
 	^ destinationClass
 ]
 
-{ #category : 'preconditions' }
-RBPushDownClassVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions
-]
-
 { #category : 'transforming' }
 RBPushDownClassVariableRefactoring >> privateTransform [
 

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -146,6 +146,15 @@ RBRefactoring >> copyOptionsFrom: aDictionary [
 ]
 
 { #category : 'preconditions' }
+RBRefactoring >> eagerlyCheckApplicabilityPreconditions [
+
+	self applicabilityPreconditions
+		do: [ :cond | cond check ifFalse:
+				[ self refactoringError:
+					(String streamContents: [ :aStream | cond violationMessageOn: aStream ] ) ] ]
+]
+
+{ #category : 'preconditions' }
 RBRefactoring >> failedApplicabilityPreconditions [
 	"Returne the failed preconditions without raising error. It should only be called by drivers."
 	

--- a/src/Refactoring-Core/RBRemoveAllSendersRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveAllSendersRefactoring.class.st
@@ -65,11 +65,6 @@ RBRemoveAllSendersRefactoring >> messagePattern [
 	^ 'self ' , (self buildSelectorString: selector)
 ]
 
-{ #category : 'preconditions' }
-RBRemoveAllSendersRefactoring >> preconditions [
-	^ self trueCondition
-]
-
 { #category : 'transforming' }
 RBRemoveAllSendersRefactoring >> privateTransform [
 	self removeSelfSenders

--- a/src/Refactoring-Core/RBRemoveSenderRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveSenderRefactoring.class.st
@@ -66,18 +66,35 @@ RBRemoveSenderRefactoring class >> remove: anInterval inMethod: aSelector forCla
 		forClass: aClass
 ]
 
+{ #category : 'preconditions' }
+RBRemoveSenderRefactoring >> applicabilityPreconditions [ 
+	^ (RBCondition withBlock: [class ifNil:
+			[self refactoringError: 'Invalid class name']. true]) &
+	(RBCondition definesSelector: sourceSelector in: class)
+		& (RBCondition withBlock:
+					[self checkSelectedMessage.
+					"self parseInlineMethod."
+					self rewriteInlinedTree.
+					(sourceMessage parent isReturn or: [self hasMultipleReturns not])
+						ifFalse:
+							[self
+								refactoringError: 'Cannot inline method since it contains multiple returns that cannot be rewritten'].
+					true])
+]
+
 { #category : 'transforming' }
-RBRemoveSenderRefactoring >> findSelectedMessage [
-	super findSelectedMessage.
-	sourceMessage isDirectlyUsed
-		ifTrue: [ self refactoringError: 'The sender is directly used' ]
+RBRemoveSenderRefactoring >> checkSelectedMessage [
+
+	super checkSelectedMessage.
+	sourceMessage isDirectlyUsed ifTrue: [
+		self refactoringError: 'The sender is directly used' ]
 ]
 
 { #category : 'accessing' }
 RBRemoveSenderRefactoring >> inlineParseTree [
 
 	| aSymbol |
-	aSymbol := sourceMessage selector.
+	aSymbol := self inlineSelector.
 	^ inlineParseTree ifNil: [inlineParseTree := RBMethodNode
 		selector:  aSymbol
 		arguments: ( (1 to: aSymbol numArgs) collect: [ :e | RBVariableNode named: 'arg', e asString ])
@@ -92,18 +109,8 @@ RBRemoveSenderRefactoring >> nameOfTheClassOfTheMethodToInline [
 
 { #category : 'preconditions' }
 RBRemoveSenderRefactoring >> preconditions [
-	^ (RBCondition withBlock: [class ifNil:
-			[self refactoringError: 'Invalid class name']. true]) &
-	(RBCondition definesSelector: sourceSelector in: class)
-		& (RBCondition withBlock:
-					[self findSelectedMessage.
-					"self parseInlineMethod."
-					self rewriteInlinedTree.
-					(sourceMessage parent isReturn or: [self hasMultipleReturns not])
-						ifFalse:
-							[self
-								refactoringError: 'Cannot inline method since it contains multiple returns that cannot be rewritten'].
-					true])
+
+	^ self applicabilityPreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBRenameInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameInstanceVariableRefactoring.class.st
@@ -88,6 +88,12 @@ RBRenameInstanceVariableRefactoring >> browsedEnvironment [
 	^ browsedEnvironment ifNil: [ browsedEnvironment := RBBrowserEnvironment new ]
 ]
 
+{ #category : 'scripting api - conditions' }
+RBRenameInstanceVariableRefactoring >> checkPreconditions [ 
+
+	self checkApplicabilityPreconditions 
+]
+
 { #category : 'initialization' }
 RBRenameInstanceVariableRefactoring >> initialize [
 	super initialize.
@@ -106,10 +112,8 @@ RBRenameInstanceVariableRefactoring >> newName: anObject [
 
 { #category : 'preconditions' }
 RBRenameInstanceVariableRefactoring >> preconditions [
-	^(RBCondition isValidInstanceVariableName: newName for: class)
-		& (RBCondition definesInstanceVariable: variableName in: class)
-			& (RBCondition hierarchyOf: class definesVariable: newName) not
-			& (RBCondition isGlobal: newName in: self model) not
+
+	^ self applicabilityPreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBRenameInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameInstanceVariableRefactoring.class.st
@@ -74,13 +74,13 @@ RBRenameInstanceVariableRefactoring >> applicabilityPreconditions [
 
 	^ {
 		  (ReIsValidInstanceVariableName name: newName).
-		  (ReNameIsGlobalCondition new model: model className: newName) not.
-		  (ReIsVariableNotDefinedInHierarchy name: newName class: class).
-		  "For now only rename a instance variable that is locally defined in a class."
-		  (ReDirectlyDefinesInstanceVariableCondition
+		  (ReDefinesInstanceVariableCondition
 			   classNamed: class name
 			   inModel: self model
-			   instanceVariables: { variableName }) }
+			   instanceVariables: { variableName }).
+		  (ReIsVariableNotDefinedInHierarchy name: newName class: class).
+		  (ReNameIsGlobalCondition new model: self model className: newName)
+			  not }
 ]
 
 { #category : 'refactoring' }

--- a/src/Refactoring-Core/RBRenameInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameInstanceVariableRefactoring.class.st
@@ -110,12 +110,6 @@ RBRenameInstanceVariableRefactoring >> newName: anObject [
 	newName := anObject
 ]
 
-{ #category : 'preconditions' }
-RBRenameInstanceVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions
-]
-
 { #category : 'transforming' }
 RBRenameInstanceVariableRefactoring >> privateTransform [
 	renameAccessors ifTrue: [

--- a/src/Refactoring-Core/RBVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBVariableRefactoring.class.st
@@ -33,6 +33,12 @@ RBVariableRefactoring class >> variable: aVarName class: aClass [
 		variable: aVarName class: aClass
 ]
 
+{ #category : 'preconditions' }
+RBVariableRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
+]
+
 { #category : 'initialization' }
 RBVariableRefactoring >> refactoredClassName [
 	^ class name

--- a/src/Refactoring-Core/ReDefinesInstanceVariableCondition.class.st
+++ b/src/Refactoring-Core/ReDefinesInstanceVariableCondition.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : 'ReDefinesInstanceVariableCondition',
+	#superclass : 'ReClassCondition',
+	#instVars : [
+		'instanceVariables'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'instance creation' }
+ReDefinesInstanceVariableCondition class >> classNamed: aString inModel: aRBNamespace instanceVariables: aCollection [ 
+	
+	^ (self classNamed: aString inModel: aRBNamespace)
+		instanceVariables: aCollection;
+		yourself
+]
+
+{ #category : 'checking' }
+ReDefinesInstanceVariableCondition >> check [
+	
+	violators := instanceVariables reject: [ :shared | aClass definesInstanceVariable: shared ].
+	^ violators isEmpty
+]
+
+{ #category : 'private' }
+ReDefinesInstanceVariableCondition >> errorBlock [
+	^ [ aClass printString
+				, ' <1?: > define <1?s:> instance variable ' , instanceVariables ]
+]
+
+{ #category : 'accessing' }
+ReDefinesInstanceVariableCondition >> instanceVariables: aColOfStrings [
+
+	instanceVariables := aColOfStrings
+]
+
+{ #category : 'displaying' }
+ReDefinesInstanceVariableCondition >> violationMessageOn: aStream [
+
+	^ violators do: [ :violator |
+		  aStream
+			nextPutAll: 
+				('The variable {1} is not defined in the class {2} or its subclasses' 
+					format: { violator. className });
+			nextPut: Character cr ]
+]

--- a/src/Refactoring-Core/ReIsNotAMetaclass.class.st
+++ b/src/Refactoring-Core/ReIsNotAMetaclass.class.st
@@ -11,6 +11,12 @@ ReIsNotAMetaclass >> check [
 	^ aClass isMeta not
 ]
 
+{ #category : 'displaying' }
+ReIsNotAMetaclass >> violationMessageOn: aWriteStream [ 
+	
+	aWriteStream nextPutAll: 'Class ', aClass name , ' is a metaclass'
+]
+
 { #category : 'checking' }
 ReIsNotAMetaclass >> violators [
 	^ { aClass }

--- a/src/Refactoring-Core/ReRemoveClassRefactoring.class.st
+++ b/src/Refactoring-Core/ReRemoveClassRefactoring.class.st
@@ -84,15 +84,6 @@ ReRemoveClassRefactoring >> classNames: aClassNameCollection [
 ]
 
 { #category : 'preconditions' }
-ReRemoveClassRefactoring >> eagerlyCheckApplicabilityPreconditions [
-
-	self applicabilityPreconditions
-		do: [ :cond | cond check ifFalse:
-				[ self refactoringError:
-					(String streamContents: [ :aStream | cond violationMessageOn: aStream ] ) ] ]
-]
-
-{ #category : 'preconditions' }
 ReRemoveClassRefactoring >> environmentWithUsersOf: aClassable [
 	^ RBClassEnvironment
 		onEnvironment: RBBrowserEnvironment new

--- a/src/Refactoring-Core/ReRemoveInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/ReRemoveInstanceVariableRefactoring.class.st
@@ -63,12 +63,6 @@ ReRemoveInstanceVariableRefactoring >> generateChanges [
 	^ self changes
 ]
 
-{ #category : 'preconditions' }
-ReRemoveInstanceVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions 
-]
-
 { #category : 'printing' }
 ReRemoveInstanceVariableRefactoring >> printOn: aStream [
 

--- a/src/Refactoring-Core/ReRemoveSharedVariableRefactoring.class.st
+++ b/src/Refactoring-Core/ReRemoveSharedVariableRefactoring.class.st
@@ -64,12 +64,6 @@ ReRemoveSharedVariableRefactoring >> generateChanges [
 	^ self changes
 ]
 
-{ #category : 'preconditions' }
-ReRemoveSharedVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions 
-]
-
 { #category : 'transforming' }
 ReRemoveSharedVariableRefactoring >> privateTransform [
 	class removeClassVariable: variableName

--- a/src/Refactoring-Core/ReRenameSharedVariableRefactoring.class.st
+++ b/src/Refactoring-Core/ReRenameSharedVariableRefactoring.class.st
@@ -65,12 +65,6 @@ ReRenameSharedVariableRefactoring >> newName: anObject [
 	newName := anObject
 ]
 
-{ #category : 'preconditions' }
-ReRenameSharedVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions
-]
-
 { #category : 'transforming' }
 ReRenameSharedVariableRefactoring >> privateTransform [
 	class

--- a/src/Refactoring-Core/ReRenameSharedVariableRefactoring.class.st
+++ b/src/Refactoring-Core/ReRenameSharedVariableRefactoring.class.st
@@ -49,6 +49,12 @@ ReRenameSharedVariableRefactoring >> applicabilityPreconditions [
 			   sharedVariables: { variableName }) }
 ]
 
+{ #category : 'scripting api - conditions' }
+ReRenameSharedVariableRefactoring >> checkPreconditions [ 
+
+	self checkApplicabilityPreconditions 
+]
+
 { #category : 'accessing' }
 ReRenameSharedVariableRefactoring >> newName [
 	^ newName
@@ -61,11 +67,8 @@ ReRenameSharedVariableRefactoring >> newName: anObject [
 
 { #category : 'preconditions' }
 ReRenameSharedVariableRefactoring >> preconditions [
-	^(RBCondition isMetaclass: class) not
-		& (RBCondition isValidClassVarName: newName asString for: class)
-			& (RBCondition definesClassVariable: variableName asString in: class)
-			& (RBCondition hierarchyOf: class definesVariable: newName asString) not
-			& (RBCondition isGlobal: newName asString in: self model) not
+
+	^ self applicabilityPreconditions
 ]
 
 { #category : 'transforming' }


### PR DESCRIPTION
This PR does a second pass on preconditions:

- extracts applicability preconditions from refactoring preconditions
- in a few places it extracts breaking changes as well
- introduces new condition `DefinesInstanceVariable`
- small cleaning of inline method refactoring's precondition

I will continue to iterate on this and migrate all preconditions to either applicability or breaking change.