### PR TITLE
Update bootstrap process to refer to Pharo12

### DIFF
--- a/.github/ISSUE_TEMPLATE/cleanup-report.md
+++ b/.github/ISSUE_TEMPLATE/cleanup-report.md
@@ -19,7 +19,7 @@ A clear and concise description of what you expected to happen.
 Do you require a refactoring? The addition of comments?
 
 **Version information:**
- - Version [e.g. Pharo 11.0]
+ - Version [e.g. Pharo 12.0]
  - Commit [e.g. 22]
 
 **Expected development cost**

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ This repository contains only sources of the Pharo image. The virtual machine so
 
 This repository is being built on a [Jenkins server](https://ci.inria.fr/pharo-ci-jenkins2) and uploaded to [files.pharo.org](https://files.pharo.org).
 
-- [Latest build - 64bit](http://files.pharo.org/image/110/latest-64.zip)
-- [Latest build - 32bit](http://files.pharo.org/image/110/latest.zip)
+- [Latest build - 64bit](http://files.pharo.org/image/120/latest-64.zip)
+- [Latest build - 32bit](http://files.pharo.org/image/120/latest.zip)
 
 The minimal image contains the basic Pharo packages without the graphical user interface. It is useful as a base for server-side applications deployment.
 
-- [Minimal image latest build - 64bit](http://files.pharo.org/image/110/latest-minimal-64.zip)
-- [Minimal image latest build - 32bit](http://files.pharo.org/image/110/latest-minimal-32.zip)
+- [Minimal image latest build - 64bit](http://files.pharo.org/image/120/latest-minimal-64.zip)
+- [Minimal image latest build - 32bit](http://files.pharo.org/image/120/latest-minimal-32.zip)
 
 
 ## Bootstrapping Pharo from sources
@@ -49,13 +49,13 @@ The bootstrapping can be done on a properly-named branch using the following scr
 ./bootstrap/scripts/bootstrap.sh
 ```
 
-This will generate and archive images at various stages of the bootstrap process up to the full image in `Pharo11.0-64bit-hhhhhhh.zip` where hhhhhhh is the hash of the current checkout. Additional information on the stages of the bootstrap and how to snapshot during the process are provided as comments in bootstrap.sh.
+This will generate and archive images at various stages of the bootstrap process up to the full image in `Pharo12.0-64bit-hhhhhhh.zip` where hhhhhhh is the hash of the current checkout. Additional information on the stages of the bootstrap and how to snapshot during the process are provided as comments in bootstrap.sh.
 
-* You can set the `BUILD_NUMBER` environment variable to a unique integer (this is typically used only for the [official builds](https://files.pharo.org/image/110/) and will default to `0` if not specified).
+* You can set the `BUILD_NUMBER` environment variable to a unique integer (this is typically used only for the [official builds](https://files.pharo.org/image/120/) and will default to `0` if not specified).
 * You can set the `BOOTSTRAP_ARCH` environment variable to either `64` (the default) or `32`.
 * You can set the `BOOTSTRAP_REPOSITORY` and `BOOTSTRAP_CACHE` environment variables to do the bootstrap outside of the source repository.
 * You can set the `BOOTSTRAP_VMTARGET` environment variable to make the bootstrap use a virtual machine already present in your system (otherwise it will download it).
-* If you are on a branch that doesn't follow the expected naming convention ('`PharoX.Y`'), then the script will pick an appropriate default (such as `Pharo11.0`). To build Pharo11.0 from a custom branch, you need to set `BRANCH_NAME=Pharo11` before the bootstrap script is run.
+* If you are on a branch that doesn't follow the expected naming convention ('`PharoX.Y`'), then the script will pick an appropriate default (such as `Pharo12.0`). To build Pharo12.0 from a custom branch, you need to set `BRANCH_NAME=Pharo12` before the bootstrap script is run.
 
 ### Bootstrapping with Docker
 

--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -46,7 +46,7 @@ if [ ! -e "${BOOTSTRAP_DOWNLOADS}/vmBootstrap/pharo" ]; then
 	mkdir ${BOOTSTRAP_DOWNLOADS}/vmBootstrap
 	cd ${BOOTSTRAP_DOWNLOADS}/vmBootstrap
 
-	${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 100 vm $BOOTSTRAP_ARCH
+	${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 120 vm $BOOTSTRAP_ARCH
 	cd -
 	echo "Bootstrap VM: $(${VM_BOOTSTRAP} --version)"
 fi 

--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -46,7 +46,7 @@ if [ ! -e "${BOOTSTRAP_DOWNLOADS}/vmBootstrap/pharo" ]; then
 	mkdir ${BOOTSTRAP_DOWNLOADS}/vmBootstrap
 	cd ${BOOTSTRAP_DOWNLOADS}/vmBootstrap
 
-	${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 120 vm $BOOTSTRAP_ARCH
+	${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/getPharoVM.sh 100 vm $BOOTSTRAP_ARCH
 	cd -
 	echo "Bootstrap VM: $(${VM_BOOTSTRAP} --version)"
 fi 


### PR DESCRIPTION
Now that we are doing development on Pharo12, the documentation and bootstrap process should reflect Pharo12.