### PR TITLE
Refactor: change method name preconditions

### DIFF
--- a/src/Refactoring-Core/RBAddParameterRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddParameterRefactoring.class.st
@@ -56,6 +56,17 @@ RBAddParameterRefactoring >> addParameterToMethod: aSelector in: aClass newSelec
 ]
 
 { #category : 'preconditions' }
+RBAddParameterRefactoring >> applicabilityPreconditions [
+	^ super applicabilityPreconditions & (RBCondition withBlock:
+		[oldSelector numArgs < newSelector numArgs
+			ifFalse:
+				[self refactoringError: newSelector printString,
+				' doesn''t have the proper number of arguments.'].
+		self newArgs do: [	:arg | self verifyInitializationExpressionOf: arg argValue ].
+		true])
+]
+
+{ #category : 'preconditions' }
 RBAddParameterRefactoring >> checkSendersAccessTo: name [
 
 	(#('self' 'super') includes: name) ifTrue: [ ^ self ].
@@ -97,17 +108,6 @@ RBAddParameterRefactoring >> modifyImplementorParseTree: parseTree in: aClass [
 				argNames at: index	] ])
 				collect: [:e | RBVariableNode named: e ]).
 	self renameArgumentsIn: parseTree
-]
-
-{ #category : 'preconditions' }
-RBAddParameterRefactoring >> myConditions [
-	^RBCondition withBlock:
-		[oldSelector numArgs < newSelector numArgs
-			ifFalse:
-				[self refactoringError: newSelector printString,
-				' doesn''t have the proper number of arguments.'].
-		self newArgs do: [	:arg | self verifyInitializationExpressionOf: arg argValue ].
-		true]
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
+++ b/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
@@ -32,6 +32,21 @@ RBChangeMethodNameRefactoring class >> isAbstract [
 ]
 
 { #category : 'preconditions' }
+RBChangeMethodNameRefactoring >> applicabilityPreconditions [
+
+	^ self myConditions
+	  & (RBCondition definesSelector: oldSelector in: class)
+	  & self isValidMethodNamePrecondition
+]
+
+{ #category : 'preconditions' }
+RBChangeMethodNameRefactoring >> breakingChangePreconditions [ 
+	"This refactoring only preserves behavior if all implementors are renamed."
+
+	^ self doesNotOverrideExistingMethodPrecondition 
+]
+
+{ #category : 'preconditions' }
 RBChangeMethodNameRefactoring >> doesNotOverrideExistingMethodPrecondition [
 	"Check that the new selector is not already defined in superclasses"
 	
@@ -106,12 +121,7 @@ RBChangeMethodNameRefactoring >> permutation: anObject [
 RBChangeMethodNameRefactoring >> preconditions [
 	"This refactoring only preserves behavior if all implementors are renamed."
 
-	| conditions |
-	conditions := self myConditions
-	              & (RBCondition definesSelector: oldSelector in: class)
-	              & self isValidMethodNamePrecondition.
-
-	^ conditions & self doesNotOverrideExistingMethodPrecondition
+	^ self applicabilityPreconditions & self breakingChangePreconditions 
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
+++ b/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
@@ -34,8 +34,7 @@ RBChangeMethodNameRefactoring class >> isAbstract [
 { #category : 'preconditions' }
 RBChangeMethodNameRefactoring >> applicabilityPreconditions [
 
-	^ self myConditions
-	  & (RBCondition definesSelector: oldSelector in: class)
+	^ (RBCondition definesSelector: oldSelector in: class)
 	  & self isValidMethodNamePrecondition
 ]
 
@@ -88,11 +87,6 @@ RBChangeMethodNameRefactoring >> modifyImplementorParseTree: parseTree in: aClas
 	| oldArgs |
 	oldArgs := parseTree arguments.
 	parseTree renameSelector: newSelector andArguments: (permutation collect: [:each | oldArgs at: each])
-]
-
-{ #category : 'preconditions' }
-RBChangeMethodNameRefactoring >> myConditions [
-	"^self subclassResponsibility"
 ]
 
 { #category : 'instance creation' }

--- a/src/Refactoring-Core/RBInlineParameterRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineParameterRefactoring.class.st
@@ -39,7 +39,7 @@ method1
 "
 Class {
 	#name : 'RBInlineParameterRefactoring',
-	#superclass : 'RBParameterRemoval',
+	#superclass : 'RBParameterRemovalRefactoring',
 	#instVars : [
 		'expressions'
 	],

--- a/src/Refactoring-Core/RBInlineParameterRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineParameterRefactoring.class.st
@@ -79,6 +79,19 @@ RBInlineParameterRefactoring >> allExpressionsToInline [
 	^coll asOrderedCollection
 ]
 
+{ #category : 'preconditions' }
+RBInlineParameterRefactoring >> applicabilityPreconditions [
+	self getNewSelector.
+	expressions := self allExpressionsToInline.
+	^ super applicabilityPreconditions
+		& ((RBCondition withBlock: [expressions isNotEmpty ])
+				errorMacro: 'No callers. Use Remove Method instead.')
+			& ((RBCondition withBlock: [expressions size = 1])
+					errorMacro: 'All values passed as this argument must be identical.')
+			& ((RBCondition withBlock: [expressions first isLiteralNode])
+					errorMacro: 'All values passed must be literal.')
+]
+
 { #category : 'private' }
 RBInlineParameterRefactoring >> expressionsToInlineFrom: aTree [
 	| searcher |
@@ -107,19 +120,6 @@ RBInlineParameterRefactoring >> modifyImplementorParseTree: parseTree in: aClass
 	assignment := RBAssignmentNode variable: node copy value: expressions first.
 	parseTree body addNodeFirst: assignment.
 	super modifyImplementorParseTree: parseTree in: aClass
-]
-
-{ #category : 'preconditions' }
-RBInlineParameterRefactoring >> myConditions [
-	self getNewSelector.
-	expressions := self allExpressionsToInline.
-	^(RBCondition definesSelector: oldSelector in: class)
-		& ((RBCondition withBlock: [expressions isNotEmpty ])
-				errorMacro: 'No callers. Use Remove Method instead.')
-			& ((RBCondition withBlock: [expressions size = 1])
-					errorMacro: 'All values passed as this argument must be identical.')
-			& ((RBCondition withBlock: [expressions first isLiteralNode])
-					errorMacro: 'All values passed must be literal.')
 ]
 
 { #category : 'printing' }

--- a/src/Refactoring-Core/RBInlineParameterRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineParameterRefactoring.class.st
@@ -39,7 +39,7 @@ method1
 "
 Class {
 	#name : 'RBInlineParameterRefactoring',
-	#superclass : 'RBRemoveParameterRefactoring',
+	#superclass : 'RBParameterRemoval',
 	#instVars : [
 		'expressions'
 	],

--- a/src/Refactoring-Core/RBParameterRemoval.class.st
+++ b/src/Refactoring-Core/RBParameterRemoval.class.st
@@ -1,0 +1,60 @@
+"
+I am a common superclass for `InlineParameter` and `RemoveParameter` refactoring.
+I have the common state and methods that are shared between the two refactorings.
+"
+Class {
+	#name : 'RBParameterRemoval',
+	#superclass : 'RBChangeMethodNameRefactoring',
+	#instVars : [
+		'parameterIndex',
+		'argument'
+	],
+	#category : 'Refactoring-Core-Refactorings-Unused',
+	#package : 'Refactoring-Core',
+	#tag : 'Refactorings-Unused'
+}
+
+{ #category : 'testing' }
+RBParameterRemoval class >> isAbstract [
+
+	^ self == RBParameterRemoval
+]
+
+{ #category : 'validating' }
+RBParameterRemoval >> applyValidations [
+
+	| tree |
+	(class directlyDefinesMethod: oldSelector) ifFalse: [
+		self refactoringError: 'Method doesn''t exist' ].
+	tree := class parseTreeForSelector: oldSelector.
+	tree ifNil: [ self refactoringError: 'Cannot parse sources' ].
+	argument ifNil: [
+		self refactoringError: 'This method does not have an argument' ].
+	parameterIndex := tree argumentNames
+		                  indexOf: argument
+		                  ifAbsent: [
+		                  self refactoringError: 'Select a parameter!!' ].
+	oldSelector numArgs == 0 ifTrue: [
+		self refactoringError: 'This method contains no arguments' ].
+	oldSelector isInfix ifTrue: [
+		self refactoringError:
+			'Cannot remove parameters of infix selectors' ]
+]
+
+{ #category : 'private' }
+RBParameterRemoval >> computeNewSelector [
+	| keywords |
+
+	keywords := oldSelector keywords asOrderedCollection.
+	keywords size = 1
+		ifTrue: [ ^ (keywords first copyWithout: $:) asSymbol ].
+	keywords removeAt: parameterIndex.
+	^ (String streamContents: [ :str | keywords do: [ :each | str nextPutAll: each ] ]) asSymbol
+]
+
+{ #category : 'private' }
+RBParameterRemoval >> getNewSelector [
+	self applyValidations.
+	permutation := (1 to: oldSelector numArgs) copyWithout: parameterIndex.
+	^ newSelector ifNil: [ newSelector := self computeNewSelector ]
+]

--- a/src/Refactoring-Core/RBParameterRemovalRefactoring.class.st
+++ b/src/Refactoring-Core/RBParameterRemovalRefactoring.class.st
@@ -3,7 +3,7 @@ I am a common superclass for `InlineParameter` and `RemoveParameter` refactoring
 I have the common state and methods that are shared between the two refactorings.
 "
 Class {
-	#name : 'RBParameterRemoval',
+	#name : 'RBParameterRemovalRefactoring',
 	#superclass : 'RBChangeMethodNameRefactoring',
 	#instVars : [
 		'parameterIndex',
@@ -15,13 +15,13 @@ Class {
 }
 
 { #category : 'testing' }
-RBParameterRemoval class >> isAbstract [
+RBParameterRemovalRefactoring class >> isAbstract [
 
-	^ self == RBParameterRemoval
+	^ self == RBParameterRemovalRefactoring
 ]
 
 { #category : 'validating' }
-RBParameterRemoval >> applyValidations [
+RBParameterRemovalRefactoring >> applyValidations [
 
 	| tree |
 	(class directlyDefinesMethod: oldSelector) ifFalse: [
@@ -42,7 +42,7 @@ RBParameterRemoval >> applyValidations [
 ]
 
 { #category : 'private' }
-RBParameterRemoval >> computeNewSelector [
+RBParameterRemovalRefactoring >> computeNewSelector [
 	| keywords |
 
 	keywords := oldSelector keywords asOrderedCollection.
@@ -53,7 +53,7 @@ RBParameterRemoval >> computeNewSelector [
 ]
 
 { #category : 'private' }
-RBParameterRemoval >> getNewSelector [
+RBParameterRemovalRefactoring >> getNewSelector [
 	self applyValidations.
 	permutation := (1 to: oldSelector numArgs) copyWithout: parameterIndex.
 	^ newSelector ifNil: [ newSelector := self computeNewSelector ]

--- a/src/Refactoring-Core/RBRemoveParameterRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveParameterRefactoring.class.st
@@ -32,6 +32,19 @@ RBRemoveParameterRefactoring class >> removeParameter: aString in: aClass select
 		selector: aSelector
 ]
 
+{ #category : 'preconditions' }
+RBRemoveParameterRefactoring >> applicabilityPreconditions [
+	| imps |
+	imps := self model allImplementorsOf: oldSelector.
+	self getNewSelector.
+	^imps inject: (super applicabilityPreconditions)
+		into:
+			[:cond :each |
+			cond
+				& (RBCondition withBlock: [(self hasReferencesToTemporaryIn: each) not]
+						errorString: 'This argument is still referenced in at least one implementor!!')]
+]
+
 { #category : 'transforming' }
 RBRemoveParameterRefactoring >> hasReferencesToTemporaryIn: each [
 
@@ -40,19 +53,6 @@ RBRemoveParameterRefactoring >> hasReferencesToTemporaryIn: each [
 	tree := each parseTreeForSelector: oldSelector.
 	tree ifNil: [ self refactoringError: 'Cannot parse sources.' ].
 	^ tree references: ( tree argumentNames at: parameterIndex )
-]
-
-{ #category : 'preconditions' }
-RBRemoveParameterRefactoring >> myConditions [
-	| imps |
-	imps := self model allImplementorsOf: oldSelector.
-	self getNewSelector.
-	^imps inject: (RBCondition definesSelector: oldSelector in: class)
-		into:
-			[:cond :each |
-			cond
-				& (RBCondition withBlock: [(self hasReferencesToTemporaryIn: each) not]
-						errorString: 'This argument is still referenced in at least one implementor!!')]
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-Core/RBRemoveParameterRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveParameterRefactoring.class.st
@@ -8,11 +8,7 @@ If the method contains more than one argument, I request the user to choose one 
 "
 Class {
 	#name : 'RBRemoveParameterRefactoring',
-	#superclass : 'RBChangeMethodNameRefactoring',
-	#instVars : [
-		'parameterIndex',
-		'argument'
-	],
+	#superclass : 'RBParameterRemoval',
 	#category : 'Refactoring-Core-Refactorings',
 	#package : 'Refactoring-Core',
 	#tag : 'Refactorings'
@@ -34,45 +30,6 @@ RBRemoveParameterRefactoring class >> removeParameter: aString in: aClass select
 		removeParameter: aString
 		in: aClass
 		selector: aSelector
-]
-
-{ #category : 'validating' }
-RBRemoveParameterRefactoring >> applyValidations [
-
-	| tree |
-	(class directlyDefinesMethod: oldSelector) ifFalse: [
-		self refactoringError: 'Method doesn''t exist' ].
-	tree := class parseTreeForSelector: oldSelector.
-	tree ifNil: [ self refactoringError: 'Cannot parse sources' ].
-	argument ifNil: [
-		self refactoringError: 'This method does not have an argument' ].
-	parameterIndex := tree argumentNames
-		                  indexOf: argument
-		                  ifAbsent: [
-		                  self refactoringError: 'Select a parameter!!' ].
-	oldSelector numArgs == 0 ifTrue: [
-		self refactoringError: 'This method contains no arguments' ].
-	oldSelector isInfix ifTrue: [
-		self refactoringError:
-			'Cannot remove parameters of infix selectors' ]
-]
-
-{ #category : 'private' }
-RBRemoveParameterRefactoring >> computeNewSelector [
-	| keywords |
-
-	keywords := oldSelector keywords asOrderedCollection.
-	keywords size = 1
-		ifTrue: [ ^ (keywords first copyWithout: $:) asSymbol ].
-	keywords removeAt: parameterIndex.
-	^ (String streamContents: [ :str | keywords do: [ :each | str nextPutAll: each ] ]) asSymbol
-]
-
-{ #category : 'transforming' }
-RBRemoveParameterRefactoring >> getNewSelector [
-	self applyValidations.
-	permutation := (1 to: oldSelector numArgs) copyWithout: parameterIndex.
-	^ newSelector ifNil: [ newSelector := self computeNewSelector ]
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBRemoveParameterRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveParameterRefactoring.class.st
@@ -8,7 +8,7 @@ If the method contains more than one argument, I request the user to choose one 
 "
 Class {
 	#name : 'RBRemoveParameterRefactoring',
-	#superclass : 'RBParameterRemoval',
+	#superclass : 'RBParameterRemovalRefactoring',
 	#category : 'Refactoring-Core-Refactorings',
 	#package : 'Refactoring-Core',
 	#tag : 'Refactorings'


### PR DESCRIPTION
Removed the `myConditions` and migrated all preconditions to either applicability or breaking changes.