### PR TITLE
Refactor: VariableRefactoring doesn't override preconditions

### DIFF
--- a/src/Refactoring-Core/RBAbstractClassVariableReferencesRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractClassVariableReferencesRefactoring.class.st
@@ -74,12 +74,6 @@ RBAbstractClassVariableReferencesRefactoring >> createAccessors [
 	self generateChangesFor: self accessorsRefactoring
 ]
 
-{ #category : 'preconditions' }
-RBAbstractClassVariableReferencesRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions
-]
-
 { #category : 'transforming' }
 RBAbstractClassVariableReferencesRefactoring >> privateTransform [
 	self createAccessors.

--- a/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
@@ -62,6 +62,12 @@ RBAbstractInstanceVariableRefactoring >> createAccessors [
 	self generateChangesFor: self accessorsRefactoring
 ]
 
+{ #category : 'preconditions' }
+RBAbstractInstanceVariableRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
+]
+
 { #category : 'transforming' }
 RBAbstractInstanceVariableRefactoring >> privateTransform [
 	self createAccessors.

--- a/src/Refactoring-Core/RBAddClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddClassVariableRefactoring.class.st
@@ -27,6 +27,12 @@ RBAddClassVariableRefactoring >> breakingChangePreconditions [
 		   definesVariable: variableName asString) not
 ]
 
+{ #category : 'preconditions' }
+RBAddClassVariableRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
+]
+
 { #category : 'transforming' }
 RBAddClassVariableRefactoring >> privateTransform [
 	class addClassVariable: variableName

--- a/src/Refactoring-Core/RBAddInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddInstanceVariableRefactoring.class.st
@@ -24,6 +24,12 @@ RBAddInstanceVariableRefactoring >> breakingChangePreconditions [
 	^ (RBCondition hierarchyOf: class definesVariable: variableName) not
 ]
 
+{ #category : 'preconditions' }
+RBAddInstanceVariableRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
+]
+
 { #category : 'transforming' }
 RBAddInstanceVariableRefactoring >> privateTransform [
 	class addInstanceVariable: variableName

--- a/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/RBCreateAccessorsForVariableTransformation.class.st
@@ -253,13 +253,6 @@ RBCreateAccessorsForVariableTransformation >> possibleSetterSelectors [
 	^self methodsReferencingVariable select: [:each | each numArgs == 1]
 ]
 
-{ #category : 'preconditions' }
-RBCreateAccessorsForVariableTransformation >> preconditions [
-	"Checks that the class actually defines the variable from which we will build setter and getter."
-
-	^ self applicabilityPreconditions 
-]
-
 { #category : 'transforming' }
 RBCreateAccessorsForVariableTransformation >> privateTransform [
 	self

--- a/src/Refactoring-Core/RBPullUpInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpInstanceVariableRefactoring.class.st
@@ -31,6 +31,12 @@ RBPullUpInstanceVariableRefactoring >> breakingChangePreconditions [
 		  true ]
 ]
 
+{ #category : 'preconditions' }
+RBPullUpInstanceVariableRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
+]
+
 { #category : 'transforming' }
 RBPullUpInstanceVariableRefactoring >> privateTransform [
 	class allSubclasses do:

--- a/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
@@ -48,6 +48,12 @@ RBPushDownClassVariableRefactoring >> findDestinationClass [
 	^ destinationClass
 ]
 
+{ #category : 'preconditions' }
+RBPushDownClassVariableRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
+]
+
 { #category : 'transforming' }
 RBPushDownClassVariableRefactoring >> privateTransform [
 

--- a/src/Refactoring-Core/RBPushDownInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownInstanceVariableRefactoring.class.st
@@ -12,7 +12,7 @@ Class {
 }
 
 { #category : 'preconditions' }
-RBPushDownInstanceVariableRefactoring >> preconditions [
+RBPushDownInstanceVariableRefactoring >> applicabilityPreconditions [ 
 
 	| references |
 	references := RBCondition referencesInstanceVariable: variableName in: class.

--- a/src/Refactoring-Core/RBVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBVariableRefactoring.class.st
@@ -33,12 +33,6 @@ RBVariableRefactoring class >> variable: aVarName class: aClass [
 		variable: aVarName class: aClass
 ]
 
-{ #category : 'preconditions' }
-RBVariableRefactoring >> preconditions [
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions
-]
-
 { #category : 'initialization' }
 RBVariableRefactoring >> refactoredClassName [
 	^ class name

--- a/src/Refactoring-Core/ReRemoveInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/ReRemoveInstanceVariableRefactoring.class.st
@@ -63,6 +63,12 @@ ReRemoveInstanceVariableRefactoring >> generateChanges [
 	^ self changes
 ]
 
+{ #category : 'preconditions' }
+ReRemoveInstanceVariableRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
+]
+
 { #category : 'printing' }
 ReRemoveInstanceVariableRefactoring >> printOn: aStream [
 

--- a/src/Refactoring-Core/ReRemoveSharedVariableRefactoring.class.st
+++ b/src/Refactoring-Core/ReRemoveSharedVariableRefactoring.class.st
@@ -64,6 +64,12 @@ ReRemoveSharedVariableRefactoring >> generateChanges [
 	^ self changes
 ]
 
+{ #category : 'preconditions' }
+ReRemoveSharedVariableRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
+]
+
 { #category : 'transforming' }
 ReRemoveSharedVariableRefactoring >> privateTransform [
 	class removeClassVariable: variableName


### PR DESCRIPTION
This PR inverts `VariableRefactoring`s `preconditions` implementation.

Previously it returned both applicability and breaking chagnes, now it removes only applicability (inherited it from super class).
This eases analysis since now only refactorings that have breaking changes actually implement them (or inherit them) and redefine `preconditions`.