### PR TITLE
Refactor: another pass on cleaning and splitting preconditions

### DIFF
--- a/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
@@ -83,6 +83,28 @@ RBMoveMethodRefactoring >> addSelfReturn [
 ]
 
 { #category : 'preconditions' }
+RBMoveMethodRefactoring >> applicabilityPreconditions [
+
+	^ (RBCondition definesSelector: selector in: class)
+	  & (RBCondition withBlock: [
+			   self checkForPrimitiveMethod.
+			   self checkForSuperReferences.
+			   self checkAssignmentsToVariable.
+			   self getClassesToMoveTo.
+			   self checkTemporaryVariableNames.
+			   true ])
+]
+
+{ #category : 'preconditions' }
+RBMoveMethodRefactoring >> breakingChangePreconditions [
+
+	^ RBCondition withBlock: [
+		  self getArgumentNameForSelf.
+		  self getNewMethodName.
+		  true ]
+]
+
+{ #category : 'preconditions' }
 RBMoveMethodRefactoring >> checkAssignmentsToVariable [
 	| searcher |
 	variable
@@ -309,17 +331,8 @@ RBMoveMethodRefactoring >> needsToReplaceSelfReferences [
 
 { #category : 'preconditions' }
 RBMoveMethodRefactoring >> preconditions [
-	^(RBCondition definesSelector: selector in: class)
-		& (RBCondition withBlock:
-					[
-					self checkForPrimitiveMethod.
-					self checkForSuperReferences.
-					self checkAssignmentsToVariable.
-					self getClassesToMoveTo.
-					self getArgumentNameForSelf.
-					self checkTemporaryVariableNames.
-					self getNewMethodName.
-					true])
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
@@ -82,14 +82,6 @@ RBMoveMethodRefactoring >> addSelfReturn [
 	parseTree addSelfReturn
 ]
 
-{ #category : 'private' }
-RBMoveMethodRefactoring >> buildParseTree [
-
-	parseTree := ( class parseTreeForSelector: selector ) copy.
-	parseTree ifNil: [ self refactoringError: 'Could not parse method' ].
-	parseTree doSemanticAnalysis
-]
-
 { #category : 'preconditions' }
 RBMoveMethodRefactoring >> checkAssignmentsToVariable [
 	| searcher |
@@ -319,7 +311,7 @@ RBMoveMethodRefactoring >> needsToReplaceSelfReferences [
 RBMoveMethodRefactoring >> preconditions [
 	^(RBCondition definesSelector: selector in: class)
 		& (RBCondition withBlock:
-					[self buildParseTree.
+					[
 					self checkForPrimitiveMethod.
 					self checkForSuperReferences.
 					self checkAssignmentsToVariable.
@@ -328,6 +320,14 @@ RBMoveMethodRefactoring >> preconditions [
 					self checkTemporaryVariableNames.
 					self getNewMethodName.
 					true])
+]
+
+{ #category : 'transforming' }
+RBMoveMethodRefactoring >> prepareForExecution [ 
+
+	parseTree := ( class parseTreeForSelector: selector ) copy.
+	parseTree ifNil: [ self refactoringError: 'Could not parse method' ].
+	parseTree doSemanticAnalysis
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBMoveVariableDefinitionToSmallestValidScopeRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveVariableDefinitionToSmallestValidScopeRefactoring.class.st
@@ -37,6 +37,26 @@ RBMoveVariableDefinitionToSmallestValidScopeRefactoring class >> model: aRBSmall
 		yourself
 ]
 
+{ #category : 'preconditions' }
+RBMoveVariableDefinitionToSmallestValidScopeRefactoring >> applicabilityPreconditions [
+
+	^ (RBCondition definesSelector: selector in: class)
+	  & (RBCondition withBlock: [
+			   | methodSource |
+			   interval first <= interval last ifFalse: [
+				   self refactoringError: 'You must select a variable name' ].
+			   methodSource := class sourceCodeFor: selector.
+			   methodSource size >= interval last ifFalse: [
+				   self refactoringError: 'Invalid range for variable' ].
+			   name := methodSource copyFrom: interval first to: interval last.
+			   (self checkInstanceVariableName: name in: class) ifFalse: [
+				   self refactoringError:
+					   name , ' does not seem to be a valid variable name.' ].
+			   parseTree := class parseTreeForSelector: selector.
+			   self checkParseTree.
+			   true ])
+]
+
 { #category : 'transforming' }
 RBMoveVariableDefinitionToSmallestValidScopeRefactoring >> checkNodes: sequenceNodes [
 	(sequenceNodes
@@ -75,26 +95,6 @@ RBMoveVariableDefinitionToSmallestValidScopeRefactoring >> class: aClass selecto
 	interval := anInterval.
 	class := self classObjectFor: aClass.
 	selector := aSelector
-]
-
-{ #category : 'preconditions' }
-RBMoveVariableDefinitionToSmallestValidScopeRefactoring >> preconditions [
-	^(RBCondition definesSelector: selector in: class)
-		& (RBCondition withBlock:
-					[| methodSource |
-					interval first <= interval last
-						ifFalse: [self refactoringError: 'You must select a variable name'].
-					methodSource := class sourceCodeFor: selector.
-					methodSource size >= interval last
-						ifFalse: [self refactoringError: 'Invalid range for variable'].
-					name := methodSource copyFrom: interval first to: interval last.
-					(self checkInstanceVariableName: name in: class)
-						ifFalse:
-							[self
-								refactoringError: name , ' does not seem to be a valid variable name.'].
-					parseTree := class parseTreeForSelector: selector.
-					self checkParseTree.
-					true])
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
@@ -250,7 +250,7 @@ RBPullUpMethodRefactoring >> copyDownMethods [
 
 { #category : 'preconditions' }
 RBPullUpMethodRefactoring >> preconditions [
-	self requestSuperClass.
+
 	^(selectors inject: (RBCondition hasSuperclass: class)
 		into: [:cond :each | cond & (RBCondition definesSelector: each in: class)])
 			& (RBCondition withBlock:
@@ -295,7 +295,7 @@ RBPullUpMethodRefactoring >> pullUp: selectorCollection from: aClass [
 
 { #category : 'initialization' }
 RBPullUpMethodRefactoring >> pullUp: selectorCollection from: aClass to: aSuperClass [
-	self setOption: #superClass toUse: [ :ref | ].
+
 	class := self classObjectFor: aClass.
 	targetSuperclass := self classObjectFor: aSuperClass .
 	selectors := selectorCollection.
@@ -349,11 +349,6 @@ RBPullUpMethodRefactoring >> removePulledUpMethods [
 	selectors do: [ :each |
 		self generateChangesFor:
 			(RBRemoveMethodTransformation selector: each from: class) ]
-]
-
-{ #category : 'preconditions' }
-RBPullUpMethodRefactoring >> requestSuperClass [
-	^(self options at: #superClass) value: self
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
@@ -49,6 +49,31 @@ RBPullUpMethodRefactoring class >> pullUp: selectorCollection from: aClass to: a
 ]
 
 { #category : 'preconditions' }
+RBPullUpMethodRefactoring >> applicabilityPreconditions [ 
+
+	^(selectors 
+		inject: (RBCondition hasSuperclass: class)
+		into: [:cond :each | 
+			cond 
+			& (RBCondition definesSelector: each in: class)])
+			& (RBCondition withBlock:
+						[
+						self checkClassVars.
+						self checkSuperclass.
+						self checkSuperMessages.
+						true])
+]
+
+{ #category : 'preconditions' }
+RBPullUpMethodRefactoring >> breakingChangePreconditions [
+
+	^ selectors 
+		inject: self trueCondition 
+		into: [ :cond :each |
+		  	cond & (RBCondition withBlock: [ self checkInstVars. true ]) ]
+]
+
+{ #category : 'preconditions' }
 RBPullUpMethodRefactoring >> checkBackReferencesTo: aSelector [
 	"If `aSelector` is defined in `targetSuperclass` or one of its superclasses check for
 	super sends to `aSelector` in `targetSuperclass` hierarchy.
@@ -251,14 +276,7 @@ RBPullUpMethodRefactoring >> copyDownMethods [
 { #category : 'preconditions' }
 RBPullUpMethodRefactoring >> preconditions [
 
-	^(selectors inject: (RBCondition hasSuperclass: class)
-		into: [:cond :each | cond & (RBCondition definesSelector: each in: class)])
-			& (RBCondition withBlock:
-						[self checkInstVars.
-						self checkClassVars.
-						self checkSuperclass.
-						self checkSuperMessages.
-						true])
+	^ self applicabilityPreconditions & self breakingChangePreconditions 
 ]
 
 { #category : 'transforming' }


### PR DESCRIPTION
This PR cleans preconditions of:

- Pull Up Method refactoring
- MoveVariableDefinitionToSmallestValidScope
- MoveMethodRefactoring