### PR TITLE
Replaced `aCollection asOrderedCollection copy` to `OrderedCollection withAll: aCollection`

### DIFF
--- a/src/AST-Core/RBArrayNode.class.st
+++ b/src/AST-Core/RBArrayNode.class.st
@@ -98,9 +98,10 @@ RBArrayNode >> addNodesFirst: aCollection [
 
 { #category : 'accessing' }
 RBArrayNode >> allStatements [
-	^ statements asOrderedCollection copy
-			addAll: super allStatements;
-			yourself
+
+	^ (OrderedCollection withAll: statements)
+		  addAll: super allStatements;
+		  yourself
 ]
 
 { #category : 'accessing' }

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -104,9 +104,10 @@ RBBlockNode >> allDefinedVariables [
 { #category : 'accessing' }
 RBBlockNode >> allStatements [
 	"including temp variable definition."
-	^ self temporaries asOrderedCollection copy
-			addAll: super allStatements;
-			yourself
+
+	^ (OrderedCollection withAll: self temporaries)
+		  addAll: super allStatements;
+		  yourself
 ]
 
 { #category : 'accessing' }

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -150,9 +150,10 @@ RBMethodNode >> allSequenceNodes [
 { #category : 'accessing' }
 RBMethodNode >> allStatements [
 	"return the statements including variable definition."
-	^ self temporaries asOrderedCollection copy
-			addAll: super allStatements;
-			yourself
+
+	^ (OrderedCollection withAll: self temporaries)
+		  addAll: super allStatements;
+		  yourself
 ]
 
 { #category : 'accessing' }

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -205,9 +205,10 @@ RBSequenceNode >> allDefinedVariables [
 
 { #category : 'accessing' }
 RBSequenceNode >> allStatements [
-	^ statements asOrderedCollection copy
-			addAll: super allStatements;
-			yourself
+
+	^ (OrderedCollection withAll: statements)
+		  addAll: super allStatements;
+		  yourself
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Fixes #15926 

The use of `asOrderedCollection copy` seems a little obscure. This PR replaces this with `OrderedCollection withAll: aCollection` to make the intention clearer.