### PR TITLE
Deprecations from SUnit testcases should be raised

### DIFF
--- a/src/SUnit-Core/Deprecation.extension.st
+++ b/src/SUnit-Core/Deprecation.extension.st
@@ -8,5 +8,6 @@ Deprecation >> manageTestProcessBy: aProcessMonitorTestService [
 
 { #category : '*SUnit-Core' }
 Deprecation >> sunitAnnounce: aTestCase toResult: aTestResult [
-	self resume
+
+	self pass
 ]

--- a/src/SUnit-Tests/SUnitTest.class.st
+++ b/src/SUnit-Tests/SUnitTest.class.st
@@ -168,12 +168,14 @@ SUnitTest >> noop [
 
 { #category : 'testing' }
 SUnitTest >> raiseDeprecationWarnings [
+
 	| oldRaiseWarning |
 	oldRaiseWarning := Deprecation raiseWarning.
-	[ Deprecation raiseWarning: true.
-	self deprecatedMessage.
-	self fail ]
-		ensure: [ Deprecation raiseWarning: oldRaiseWarning ]
+	[
+		Deprecation raiseWarning: true.
+		self deprecatedMessage 
+	] ensure: [ 
+		Deprecation raiseWarning: oldRaiseWarning ]
 ]
 
 { #category : 'private' }
@@ -565,15 +567,18 @@ SUnitTest >> testLongRunningTestThenGreenTest [
 
 { #category : 'testing' }
 SUnitTest >> testRaiseDeprecationWarnings [
-	| case result |
+
+	| case result deprecationWasRaised |
 	case := self newTestCase: #raiseDeprecationWarnings.
-	result := case run.
-	self assert: result defects asArray equals: (Array with: case).
+	deprecationWasRaised := false.
+	[ result := case run ] on: Deprecation do:[ :e | deprecationWasRaised := true. e resume ].
+	self assert: deprecationWasRaised.
+	self assertEmpty: result defects asArray.
 	self
 		assertForTestResult: result
 		runCount: 1
-		passed: 0
-		failed: 1
+		passed: 1
+		failed: 0
 		errors: 0
 ]
 


### PR DESCRIPTION
This PR fixes issue #16034: `Deprecation` exceptions are no longer ignored in SUnit testcases.

The code in this PR makes sure that raising `Deprecation` exceptions from withing SUnit testcases works as everywhere else while still making sure they do not count as test failures (as was the case before as well).