### PR TITLE
Make FTBasicTreeListItem use a FormSet for the expand/collapse toggle

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTBasicTreeListItem.class.st
+++ b/src/Morphic-Widgets-FastTable/FTBasicTreeListItem.class.st
@@ -87,7 +87,7 @@ FTBasicTreeListItem >> collapsedButton [
 
 	^self defaultButton
 		actionSelector: #expandItem;
-		labelGraphic: Smalltalk ui theme treeUnexpandedForm;
+		labelFormSet: Smalltalk ui theme treeUnexpandedFormSet;
 		helpText: 'Expand Item';
 		yourself
 ]
@@ -139,7 +139,7 @@ FTBasicTreeListItem >> expandedButton [
 
 	^self defaultButton
 		actionSelector: #collapseItem;
-		labelGraphic: Smalltalk ui theme treeExpandedForm;
+		labelFormSet: Smalltalk ui theme treeExpandedFormSet;
 		helpText: 'Collapse Item';
 		yourself
 ]


### PR DESCRIPTION
This pull request makes FTBasicTreeListItem use a FormSet for the expand/collapse toggle.