### PR TITLE
Move the call of the Deprecation>>transform to the Deprecation>>defaultAction

### DIFF
--- a/src/Kernel-Tests/DeprecationTest.class.st
+++ b/src/Kernel-Tests/DeprecationTest.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : 'DeprecationTest',
+	#superclass : 'TestCase',
+	#category : 'Kernel-Tests-Exceptions',
+	#package : 'Kernel-Tests',
+	#tag : 'Exceptions'
+}
+
+{ #category : 'tests' }
+DeprecationTest >> testTransformingDeprecation [
+
+	| classFactory oldRaiseWarning oldActivateTransformations |
+	classFactory := ClassFactoryForTestCase new.
+	classFactory 
+		silentlyCompile: 'sendsDeprecatedMessageWithTransform ^ self deprecatedMessageWithTransform'
+		in: ExampleForDeprecationTest.
+		
+	self assert: ((ExampleForDeprecationTest compiledMethodAt: #sendsDeprecatedMessageWithTransform) sendsSelector: #deprecatedMessageWithTransform).
+	self deny: ((ExampleForDeprecationTest compiledMethodAt: #sendsDeprecatedMessageWithTransform) sendsSelector: #newMessage).
+	
+	[ 
+		oldRaiseWarning := Deprecation raiseWarning.
+		oldActivateTransformations := Deprecation activateTransformations.
+		Deprecation raiseWarning: false.
+		Deprecation activateTransformations: true.
+		ExampleForDeprecationTest new sendsDeprecatedMessageWithTransform
+	] ensure: [
+			Deprecation raiseWarning: oldRaiseWarning.
+			Deprecation activateTransformations: oldActivateTransformations ].
+	
+	self deny: ((ExampleForDeprecationTest compiledMethodAt: #sendsDeprecatedMessageWithTransform) sendsSelector: #deprecatedMessageWithTransform).
+	self assert: ((ExampleForDeprecationTest compiledMethodAt: #sendsDeprecatedMessageWithTransform) sendsSelector: #newMessage).
+
+	ExampleForDeprecationTest 
+		removeSelector: #sendsDeprecatedMessageWithTransform
+]

--- a/src/Kernel-Tests/ExampleForDeprecationTest.class.st
+++ b/src/Kernel-Tests/ExampleForDeprecationTest.class.st
@@ -1,0 +1,18 @@
+"
+I am a class used by DeprecationTest
+"
+Class {
+	#name : 'ExampleForDeprecationTest',
+	#superclass : 'Object',
+	#category : 'Kernel-Tests-Exceptions',
+	#package : 'Kernel-Tests',
+	#tag : 'Exceptions'
+}
+
+{ #category : 'helpers' }
+ExampleForDeprecationTest >> deprecatedMessageWithTransform [
+
+	self
+		deprecated: 'This method is part of the DeprecationTest.'
+		transformWith: '`@receiver deprecatedMessageWithTransform' -> '`@receiver newMessage'
+]

--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -132,11 +132,11 @@ Deprecation >> date: aDate [
 
 { #category : 'handling' }
 Deprecation >> defaultAction [
-	Log
-		ifNotNil: [:log | log add: self].
-	self logTranscript.
-	self raiseWarning
-		ifTrue: [super defaultAction]
+
+	Log ifNotNil: [ :log | log add: self ].
+	self showWarning ifTrue: [ self logTranscript ].
+	self raiseWarning ifTrue: [ super defaultAction ].
+	self shouldTransform ifTrue: [ self transform ]
 ]
 
 { #category : 'private' }
@@ -168,8 +168,7 @@ Deprecation >> hash [
 
 { #category : 'private' }
 Deprecation >> logTranscript [
-	self showWarning
-		ifTrue: [ DeprecationPerformedNotification signal: self messageText ]
+	DeprecationPerformedNotification signal: self messageText
 ]
 
 { #category : 'accessing' }
@@ -232,22 +231,20 @@ Deprecation >> signal [
 { #category : 'handling' }
 Deprecation >> transform [
 	| node rewriteRule aMethod |
-	self shouldTransform ifFalse: [ ^ self signal].
-	self rewriterClass ifNil:[ ^ self signal ].
+	self rewriterClass ifNil:[ ^ self ].
 	aMethod := self contextOfSender homeMethod.
-	aMethod isDoIt ifTrue:[ ^ self signal ]. "no need to transform doits"
+	aMethod isDoIt ifTrue:[ ^ self ]. "no need to transform doits"
 	node := self contextOfSender sourceNodeExecuted.
 	RecursionStopper during: [
 		rewriteRule := self rewriterClass new
 			replace: rule key with: rule value.
 		(rewriteRule executeTree: node)
-			ifFalse: [ ^ self signal ].
+			ifFalse: [ ^ self ].
 		node replaceWith: rewriteRule tree.
 		Author
 			useAuthor: 'AutoDeprecationRefactoring'
-			during: [aMethod origin compile: aMethod ast formattedCode classified: aMethod protocol].
-		Log  ifNotNil: [:log | log add: self].
-		self logTranscript]
+			during: [ aMethod origin compile: aMethod ast formattedCode classified: aMethod protocol ].
+		Log ifNotNil: [ :log | log add: self ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -660,7 +660,7 @@ Object >> deprecated: anExplanationString on: date in: version transformWith: aR
 		date: date;
 		version: version;
 		rule: aRule;
-		transform
+		signal
 ]
 
 { #category : 'deprecation' }
@@ -674,7 +674,7 @@ Object >> deprecated: anExplanationString on: date in: version transformWith: aR
 		version: version;
 		rule: aRule;
 		condition: conditionBlock;
-		transform
+		signal
 ]
 
 { #category : 'deprecation' }
@@ -685,7 +685,7 @@ Object >> deprecated: anExplanationString transformWith: aRule [
 		context: thisContext sender;
 		explanation: anExplanationString;
 		rule: aRule;
-		transform
+		signal
 ]
 
 { #category : 'deprecation' }
@@ -697,7 +697,7 @@ Object >> deprecated: anExplanationString transformWith: aRule when: conditionBl
 		explanation: anExplanationString;
 		rule: aRule;
 		condition: conditionBlock;
-		transform
+		signal
 ]
 
 { #category : 'displaying' }


### PR DESCRIPTION
This PR changes how transforming deprecations get executed. 

Before this PR, transforming deprecations were only signaled as exceptions if the transformation was not possible, which then made it fall back to 'normal' deprecation behavior (i.e. transcript log or dialog warning). Because of this difference, a blocking dialog was never raised for transforming deprecations. It was also not possible to capture a transforming deprecation in an error handler, like a 'normal' deprecation.

In this PR, instead of calling `Deprecation>>transform`, we call `Deprecation>>signal` at all times and call `Deprecation>>transform` from `Deprecation>>defaultAction`. We also add a testcase for the transforming deprecation.

For now, the only observable result is that a transforming deprecation now also respects the 'open blocking dialog' setting. A next step could be to use the blocking dialog to ask the user for a more informative action on wether or not to execute the transformation. 

The testcase added in this PR can only work after merging the PR https://github.com/pharo-project/pharo/pull/16036 since it depends on correct behaviour of deprecation warnings in SUnit testcases.