### PR TITLE
Rework MorphTreeMorph, MorphTreeNodeMorph and SimpleHierarchicalListMorph to remove sends of #treeExpandedForm and #treeUnexpandedForm

### DIFF
--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -256,13 +256,9 @@ ScalingCanvas class >> formCanvas: formCanvas scale: scale [
 { #category : 'class initialization' }
 ScalingCanvas class >> initialize [
 
-	| theme icons iconFormsScale2 |
+	| icons iconFormsScale2 |
 
 	FormMapping := IdentityDictionary new.
-
-	theme := Smalltalk ui theme.
-	(theme formSetsForScale: 1) keysAndValuesDo: [ :formSetName :formSet |
-		FormMapping at: formSet asForm put: (formSet asFormAtScale: 2) ].
 
 	icons := Smalltalk ui icons.
 	icons scale = 1 ifFalse: [ ^ self ].

--- a/src/Morphic-Widgets-List/SimpleHierarchicalListMorph.class.st
+++ b/src/Morphic-Widgets-List/SimpleHierarchicalListMorph.class.st
@@ -457,13 +457,6 @@ SimpleHierarchicalListMorph >> expandRoots [
 	self adjustSubmorphPositions
 ]
 
-{ #category : 'accessing' }
-SimpleHierarchicalListMorph >> expandedForm [
-	"Answer the form to use for expanded items."
-
-	^self theme treeExpandedForm
-]
-
 { #category : 'actions' }
 SimpleHierarchicalListMorph >> expandedFormSetForMorph: aMorph [
 	"Answer the form set to use for expanded items."
@@ -796,13 +789,6 @@ SimpleHierarchicalListMorph >> mouseUp: event [
 		ifTrue: [ self setSelectedMorph: nil ]
 		ifFalse: [ self setSelectedMorph: aMorph ].
 	Cursor normal show
-]
-
-{ #category : 'accessing' }
-SimpleHierarchicalListMorph >> notExpandedForm [
-	"Answer the form to use for unexpanded items."
-
-	^self theme treeUnexpandedForm
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
@@ -862,11 +862,6 @@ MorphTreeMorph >> expandedNodesFrom: aMorpList [
 	^ (aMorpList select: [ :each | each isExpanded]) collect: [ :each | each complexContents]
 ]
 
-{ #category : 'expanding-collapsing' }
-MorphTreeMorph >> expandedToggleImage [
-	^ expandedToggleImage ifNil: [expandedToggleImage := ImageMorph new form: self expandedForm]
-]
-
 { #category : 'geometry' }
 MorphTreeMorph >> extent: newExtent [
 	super extent: newExtent.
@@ -1417,11 +1412,6 @@ MorphTreeMorph >> notExpandedFormSetForMorph: aMorph [
 	^ (aMorph selected and: [self selectionColor luminance < 0.7])
 		ifTrue: [self theme whiteTreeUnexpandedFormSet]
 		ifFalse: [self theme treeUnexpandedFormSet]
-]
-
-{ #category : 'expanding-collapsing' }
-MorphTreeMorph >> notExpandedToggleImage [
-	^ notExpandedToggleImage ifNil: [notExpandedToggleImage := ImageMorph new form: self notExpandedForm]
 ]
 
 { #category : 'updating' }

--- a/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
@@ -1824,11 +1824,6 @@ MorphTreeMorph >> toggleExpandedState: aMorph event: event [
 	self adjustSubmorphPositions
 ]
 
-{ #category : 'expanding-collapsing' }
-MorphTreeMorph >> toggleImageWidth [
-	^ self expandedToggleImage width max: self notExpandedToggleImage width
-]
-
 { #category : 'accessing' }
 MorphTreeMorph >> topHeader [
 	^ topHeader

--- a/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
@@ -839,13 +839,6 @@ MorphTreeMorph >> expandSilently: aMorph suchThat: aBlock [
 ]
 
 { #category : 'expanding-collapsing' }
-MorphTreeMorph >> expandedForm [
-	"Answer the form to use for expanded items."
-
-	^self theme treeExpandedForm
-]
-
-{ #category : 'expanding-collapsing' }
 MorphTreeMorph >> expandedFormSetForMorph: aMorph [
 	"Answer the form set to use for expanded items."
 
@@ -1396,13 +1389,6 @@ MorphTreeMorph >> nodeStringGetter: aValuable [
 	"Set how to get a string for the first column node with a valuable which
 	takes a row  MorphTreeMorphNode as argument"
 	self columns first nodeStringGetter: aValuable
-]
-
-{ #category : 'expanding-collapsing' }
-MorphTreeMorph >> notExpandedForm [
-	"Answer the form to use for unexpanded items."
-
-	^self theme treeUnexpandedForm
 ]
 
 { #category : 'expanding-collapsing' }

--- a/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
@@ -1825,11 +1825,6 @@ MorphTreeMorph >> toggleExpandedState: aMorph event: event [
 ]
 
 { #category : 'expanding-collapsing' }
-MorphTreeMorph >> toggleImageHeight [
-	^ self expandedToggleImage height max: self notExpandedToggleImage height
-]
-
-{ #category : 'expanding-collapsing' }
 MorphTreeMorph >> toggleImageWidth [
 	^ self expandedToggleImage width max: self notExpandedToggleImage width
 ]

--- a/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
@@ -218,8 +218,6 @@ Class {
 		'withHLines',
 		'preferedPaneColor',
 		'indentGap',
-		'expandedToggleImage',
-		'notExpandedToggleImage',
 		'resizerWidth',
 		'gapAfterToggle',
 		'hasToggleAtRoot',
@@ -1467,8 +1465,6 @@ MorphTreeMorph >> release [
 	lineColorBlock := nil.
 	columnResizers := nil.
 	preferedPaneColor := nil.
-	expandedToggleImage := nil.
-	notExpandedToggleImage := nil.
 	columns ifNotNil: [
 		columns do: [ :col | col release ].
 		columns := nil ].

--- a/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
@@ -335,7 +335,7 @@ MorphTreeNodeMorph >> drawLinesToNextSiblingOn: aCanvas hasToggle: hasToggle [
 	nextSibBounds := self nextSibling toggleRectangle.
 	myCenter := myBounds center.
 	vLineX := myCenter x.
-	gap := (container notExpandedForm extent y // 2) + 1.
+	gap := (self notExpandedToggleImageHeight // 2) + 1.
 	vLineTop := myCenter y + (self hasToggle ifTrue: [gap] ifFalse: [0]).
 	vLineBottom := nextSibBounds center y - (self nextSibling hasToggle ifTrue: [gap] ifFalse: [0]).
 	"Draw line from me to next sibling"
@@ -699,6 +699,12 @@ MorphTreeNodeMorph >> nextSibling [
 MorphTreeNodeMorph >> nextSibling: anotherMorph [
 
 	nextSibling := anotherMorph
+]
+
+{ #category : 'accessing' }
+MorphTreeNodeMorph >> notExpandedToggleImageHeight [
+
+	^ container notExpandedForm extent y
 ]
 
 { #category : 'updating' }

--- a/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
@@ -904,7 +904,7 @@ MorphTreeNodeMorph >> selectionFrame [
 
 { #category : 'accessing' }
 MorphTreeNodeMorph >> sensitiveToggleRectangle [
-	^(bounds left + self indentGap) @ bounds top extent: (container toggleImageWidth + container gapAfterToggle) @ bounds height
+	^(bounds left + self indentGap) @ bounds top extent: (self toggleImageWidth + container gapAfterToggle) @ bounds height
 ]
 
 { #category : 'accessing' }
@@ -962,8 +962,14 @@ MorphTreeNodeMorph >> toggleImageFormSet [
 ]
 
 { #category : 'accessing' }
+MorphTreeNodeMorph >> toggleImageWidth [
+
+	^ container toggleImageWidth
+]
+
+{ #category : 'accessing' }
 MorphTreeNodeMorph >> toggleRectangle [
-	^(bounds left + self indentGap) @ bounds top extent: (container toggleImageWidth) @ bounds height
+	^(bounds left + self indentGap) @ bounds top extent: (self toggleImageWidth) @ bounds height
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
@@ -704,7 +704,7 @@ MorphTreeNodeMorph >> nextSibling: anotherMorph [
 { #category : 'accessing' }
 MorphTreeNodeMorph >> notExpandedToggleImageHeight [
 
-	^ container notExpandedForm extent y
+	^ (container notExpandedFormSetForMorph: self) height
 ]
 
 { #category : 'updating' }

--- a/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeNodeMorph.class.st
@@ -964,7 +964,7 @@ MorphTreeNodeMorph >> toggleImageFormSet [
 { #category : 'accessing' }
 MorphTreeNodeMorph >> toggleImageWidth [
 
-	^ container toggleImageWidth
+	^ (container expandedFormSetForMorph: self) width max: (container notExpandedFormSetForMorph: self) width
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This pull request reworks MorphTreeMorph, MorphTreeNodeMorph and SimpleHierarchicalListMorph so that the base Pharo packages have no more senders of `#treeExpandedForm` and `#treeUnexpandedForm`. The implementors, as well as those for `#whiteTreeExpandedForm` and `#whiteTreeUnexpandedForm` which are also no longer sent, are kept for compatibility with other packages. The forms are nevertheless removed from the FormMapping in ScalingCanvas.