### PR TITLE
Refactor: remaining preconditions

### DIFF
--- a/src/Refactoring-Core/RBCreateCascadeRefactoring.class.st
+++ b/src/Refactoring-Core/RBCreateCascadeRefactoring.class.st
@@ -44,6 +44,25 @@ RBCreateCascadeRefactoring >> addStatementNode: aNode [
 	self refactoringError: aNode formattedCode , ' is not a valid message'
 ]
 
+{ #category : 'preconditions' }
+RBCreateCascadeRefactoring >> applicabilityPreconditions [
+
+	^ (RBCondition definesSelector: selector in: class)
+	  & (RBCondition withBlock: [
+			   self
+				   findSequenceNode;
+				   findStatementNodes.
+			   true ])
+]
+
+{ #category : 'preconditions' }
+RBCreateCascadeRefactoring >> breakingChangePreconditions [
+
+	^ RBCondition withBlock: [
+		  self findReceiverNode.
+		  true ]
+]
+
 { #category : 'initialization' }
 RBCreateCascadeRefactoring >> combine: anInterval from: aSelector in: aClass [
 	class := self classObjectFor: aClass.
@@ -127,9 +146,8 @@ RBCreateCascadeRefactoring >> parseTree [
 
 { #category : 'preconditions' }
 RBCreateCascadeRefactoring >> preconditions [
-	^ (RBCondition definesSelector: selector in: class) & (RBCondition withBlock: [
-		self findSequenceNode; findStatementNodes; findReceiverNode.
-		true ])
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -42,6 +42,18 @@ RBExtractMethodRefactoring class >> model: aRBSmalltalk extract: anInterval from
 		yourself
 ]
 
+{ #category : 'preconditions' }
+RBExtractMethodRefactoring >> applicabilityPreconditions [ 
+	^(RBCondition definesSelector: selector in: class)
+		& (RBCondition withBlock:
+					[self extractMethod.
+					self checkSpecialExtractions.
+					self checkReturn.
+					needsReturn ifTrue: [extractedParseTree addReturn].
+					self checkTemporaries.
+					true])
+]
+
 { #category : 'transforming' }
 RBExtractMethodRefactoring >> checkAssignments: variableNames [
 	| node outsideVars removeAssigned |
@@ -348,18 +360,6 @@ RBExtractMethodRefactoring >> placeholderNode [
 		in: modifiedParseTree.
 	node ifNil: [ self refactoringError: 'Cannot extract code' ].
 	^ node
-]
-
-{ #category : 'preconditions' }
-RBExtractMethodRefactoring >> preconditions [
-	^(RBCondition definesSelector: selector in: class)
-		& (RBCondition withBlock:
-					[self extractMethod.
-					self checkSpecialExtractions.
-					self checkReturn.
-					needsReturn ifTrue: [extractedParseTree addReturn].
-					self checkTemporaries.
-					true])
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
@@ -54,6 +54,23 @@ Class {
 	#tag : 'Refactorings'
 }
 
+{ #category : 'preconditions' }
+RBExtractSetUpMethodRefactoring >> applicabilityPreconditions [ 
+
+	^ (RBCondition definesSelector: selector in: class)
+	& (self requestExistingSelector 
+		ifNil: [ (RBCondition definesSelector: #setUp in: class) not ]
+		ifNotNil: [ self trueCondition ]) 
+	& (RBCondition withBlock: [ class allSuperclasses anySatisfy: [ :e | e name = #TestCase ] ])
+	& (RBCondition withBlock:
+		[self extractMethod.
+		self checkSpecialExtractions.
+		self checkReturn.
+		needsReturn ifTrue: [extractedParseTree addReturn].
+		self checkTemporaries.
+		true])
+]
+
 { #category : 'transforming' }
 RBExtractSetUpMethodRefactoring >> checkAssignments: variableNames [
 	| node outsideVars removeAssigned |
@@ -93,21 +110,6 @@ RBExtractSetUpMethodRefactoring >> nameNewMethod: aSymbol [
 	args := parameters collect: [ :parm | RBVariableNode named: parm ].
 	extractedParseTree renameSelector: aSymbol andArguments: args asArray.
 	modifiedParseTree := RBParseTreeRewriter replace: self methodDelimiter with: '#callToSetUp' in: modifiedParseTree
-]
-
-{ #category : 'preconditions' }
-RBExtractSetUpMethodRefactoring >> preconditions [
-	^(RBCondition definesSelector: selector in: class) &
-	(self requestExistingSelector ifNil: [ (RBCondition definesSelector: #setUp in: class) not ]
-	ifNotNil: [ self trueCondition ]) &
-	(RBCondition withBlock: [ class allSuperclasses anySatisfy: [ :e | e name = #TestCase ] ])
-		& (RBCondition withBlock:
-			[self extractMethod.
-			self checkSpecialExtractions.
-			self checkReturn.
-			needsReturn ifTrue: [extractedParseTree addReturn].
-			self checkTemporaries.
-			true])
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Transformations-Tests/RBAbstractRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBAbstractRefactoringTest.class.st
@@ -31,7 +31,7 @@ RBAbstractRefactoringTest >> createRefactoringWithModel: aRBNamespace andArgumen
 
 { #category : 'parsing' }
 RBAbstractRefactoringTest >> executeRefactoring: aRefactoring [
-	aRefactoring prepareForExecution.
+
 	aRefactoring generateChanges
 ]
 

--- a/src/Refactoring-Transformations/RBChangeMethodNameTransformation.class.st
+++ b/src/Refactoring-Transformations/RBChangeMethodNameTransformation.class.st
@@ -21,6 +21,15 @@ RBChangeMethodNameTransformation >> applicabilityPreconditions [
 
 ]
 
+{ #category : 'preconditions' }
+RBChangeMethodNameTransformation >> breakingChangePreconditions [ 
+
+	^ self implementors
+		inject: self interactionConditions 
+		into: [ :condition :each |
+			condition & (RBCondition hierarchyOf: each canUnderstand: newSelector) not; errorBlock: [] ]
+]
+
 { #category : 'support' }
 RBChangeMethodNameTransformation >> convertAllReferencesTo: aSymbol of: classes using: searchReplacer [
 	(self model allReferencesTo: aSymbol in: classes)
@@ -65,6 +74,7 @@ RBChangeMethodNameTransformation >> implementorsCanBePrimitives [
 
 { #category : 'preconditions' }
 RBChangeMethodNameTransformation >> interactionConditions [
+	"This refactoring only preserves behavior if all implementors are renamed."
 	
 	self flag: #popUp.
 	
@@ -102,16 +112,8 @@ RBChangeMethodNameTransformation >> parseTreeRewriter [
 
 { #category : 'preconditions' }
 RBChangeMethodNameTransformation >> preconditions [
-	"This refactoring only preserves behavior if all implementors are renamed."
 
-	| conditions |
-	conditions := self applicabilityPreconditions. 
-
-	conditions := self implementors
-		inject: conditions into: [ :condition :each |
-			condition & (RBCondition hierarchyOf: each canUnderstand: newSelector) not ].
-
-	^ conditions & self interactionConditions 
+	^ self applicabilityPreconditions & self breakingChangePreconditions 
 ]
 
 { #category : 'support' }

--- a/src/Refactoring-Transformations/RBPullUpVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPullUpVariableTransformation.class.st
@@ -19,6 +19,32 @@ Class {
 	#tag : 'Model-Unused'
 }
 
+{ #category : 'preconditions' }
+RBPullUpVariableTransformation >> applicabilityPreconditions [ 
+
+	^ isClassVariable
+		ifTrue: [ (RBCondition isMetaclass: self definingClass) not ]
+		ifFalse: [ RBCondition withBlock:
+			[(self definingClass hierarchyDefinesInstanceVariable: variableName)
+				ifFalse: [self refactoringError: 'No subclass defines ' , variableName].
+			true] ]
+]
+
+{ #category : 'preconditions' }
+RBPullUpVariableTransformation >> breakingChangePreconditions [ 
+
+	^ isClassVariable
+		ifTrue: [ self trueCondition ]
+		ifFalse: [ RBCondition withBlock:
+			[(self definingClass subclasses
+				anySatisfy: [:each | (each directlyDefinesInstanceVariable: variableName) not])
+				ifTrue:
+					[self
+						refactoringWarning: 'Not all subclasses have an instance variable named.<n> Do you want pull up this variable anyway?'
+								, variableName , '.'].
+			true] ]
+]
+
 { #category : 'executing' }
 RBPullUpVariableTransformation >> buildTransformations [
 
@@ -40,18 +66,8 @@ RBPullUpVariableTransformation >> buildTransformations [
 
 { #category : 'preconditions' }
 RBPullUpVariableTransformation >> preconditions [
-	^ isClassVariable
-		ifTrue: [ (RBCondition isMetaclass: self definingClass) not ]
-		ifFalse: [ RBCondition withBlock:
-			[(self definingClass hierarchyDefinesInstanceVariable: variableName)
-				ifFalse: [self refactoringError: 'No subclass defines ' , variableName].
-			(self definingClass subclasses
-				anySatisfy: [:each | (each directlyDefinesInstanceVariable: variableName) not])
-				ifTrue:
-					[self
-						refactoringWarning: 'Not all subclasses have an instance variable named.<n> Do you want pull up this variable anyway?'
-								, variableName , '.'].
-			true] ]
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
 ]
 
 { #category : 'printing' }

--- a/src/Refactoring-Transformations/RBRemoveParameterTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveParameterTransformation.class.st
@@ -28,6 +28,20 @@ RBRemoveParameterTransformation class >> removeParameter: aString in: aClass sel
 		selector: aSelector
 ]
 
+{ #category : 'preconditions' }
+RBRemoveParameterTransformation >> applicabilityPreconditions [ 
+
+	| imps |
+	self getNewSelector.
+	imps := self model allImplementorsOf: oldSelector.
+	^ imps inject: super applicabilityPreconditions 
+		into:
+			[:cond :each |
+			cond & (RBCondition 
+						withBlock: [ (self hasReferencesToTemporaryIn: each) not ]
+						errorString: 'This argument is still referenced in at least one implementor!!')]
+]
+
 { #category : 'private' }
 RBRemoveParameterTransformation >> computeNewSelector [
 
@@ -63,26 +77,6 @@ RBRemoveParameterTransformation >> hasReferencesToTemporaryIn: each [
 	tree := each parseTreeForSelector: oldSelector.
 	tree ifNil: [ self refactoringError: 'Cannot parse sources.' ].
 	^ tree references: ( tree argumentNames at: parameterIndex )
-]
-
-{ #category : 'private' }
-RBRemoveParameterTransformation >> localPreconditions [
-
-	| imps |
-	self getNewSelector.
-	imps := self model allImplementorsOf: oldSelector.
-	^ imps inject: (RBCondition definesSelector: oldSelector in: class)
-		into:
-			[:cond :each |
-			cond & (RBCondition 
-						withBlock: [ (self hasReferencesToTemporaryIn: each) not ]
-						errorString: 'This argument is still referenced in at least one implementor!!')]
-]
-
-{ #category : 'private' }
-RBRemoveParameterTransformation >> preconditions [ 
-	"It looks like the localPreconditions is doing a side effect!!! argh! "
-	^  self localPreconditions & super preconditions
 ]
 
 { #category : 'private' }

--- a/src/Refactoring-Transformations/RBRenameMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRenameMethodTransformation.class.st
@@ -29,14 +29,22 @@ RBRenameMethodTransformation class >> renameMethod: aSelector in: aClass to: new
 		permutation: aMap
 ]
 
-{ #category : 'accessing' }
-RBRenameMethodTransformation >> applicabilityPreconditions [ 
+{ #category : 'preconditions' }
+RBRenameMethodTransformation >> applicabilityPreconditions [
+	"Check skipping preconditions first, if they fail, check applicability preconditions."
 
-	^ super applicabilityPreconditions & 
-		(RBCondition 
-			withBlock: [oldSelector numArgs = newSelector numArgs]
-			errorString: newSelector printString
-				, ' doesn''t have the correct number of arguments.')
+	^ (RBCondition
+			withBlock: [ newSelector = oldSelector ]
+		   errorString: 'The selector name has <1?not:> changed <1?:to #' , newSelector , '>') 
+	& (RBCondition 
+			withBlock: [ permutation asArray ~= (1 to: oldSelector numArgs) asArray ]
+		   errorString: 'The arguments are <1?:not >permuted')
+	|
+	  super applicabilityPreconditions 
+	  & (RBCondition
+			   withBlock: [ oldSelector numArgs = newSelector numArgs ]
+			   errorString: newSelector printString
+				   , ' doesn''t have the correct number of arguments.')
 ]
 
 { #category : 'accessing' }
@@ -70,18 +78,6 @@ RBRenameMethodTransformation >> parseTreeRewriter [
 	rewriteRule replace: '``@object ' , oldString
 		with: '``@object ' , newString.
 	^rewriteRule
-]
-
-{ #category : 'accessing' }
-RBRenameMethodTransformation >> preconditions [
-	| newCondition |
-	newCondition := (RBCondition
-							withBlock: [ newSelector = oldSelector ]
-							errorString: 'The selector name has <1?not:> changed <1?:to #', newSelector, '>')
-						& (RBCondition
-							withBlock: [permutation asArray ~= (1 to: oldSelector numArgs) asArray]
-							errorString: 'The arguments are <1?:not >permuted').
-	^newCondition | super preconditions
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Migrate all the remaining preconditions and classify them as either applicability or breaking changes. Now it will be easier to analyse preconditions.