### PR TITLE
Cleanup: small refactoring cleanups

### DIFF
--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -198,6 +198,21 @@ RBAbstractTransformation >> convertMethod: selector for: aClass using: searchRep
 		ifTrue: [ aClass compileTree: searchReplacer tree ]
 ]
 
+{ #category : 'accessing' }
+RBAbstractTransformation >> copyOptionsFrom: aDictionary [
+	| dict |
+	dict := self options.
+	dict == self class refactoringOptions
+		ifTrue: [^self options: aDictionary copy].
+	dict keysAndValuesDo:
+			[:key :value |
+			value == (self class refactoringOptions at: key ifAbsent: [nil])
+				ifTrue: [ dict at: key put: (aDictionary at: key) ]].
+	(aDictionary keys difference: dict keys) do:
+		[ :e | dict at: e put: (aDictionary at: e) ].
+	self options: dict
+]
+
 { #category : 'initialize' }
 RBAbstractTransformation >> defaultEnvironment [
 
@@ -411,6 +426,17 @@ RBAbstractTransformation >> selectVariableTypesFrom: initialTypeCollection selec
 		value: self
 		value: initialTypeCollection
 		value: selectedTypeCollection
+]
+
+{ #category : 'accessing' }
+RBAbstractTransformation >> setOption: aSymbol toUse: aBlock [
+	"Unshare on usage"
+	
+	| dict |
+	dict := self options.
+	dict == self class refactoringOptions ifTrue: [dict := dict copy].
+	dict at: aSymbol put: aBlock.
+	self options: dict
 ]
 
 { #category : 'requests' }

--- a/src/Refactoring-Core/RBAbstractVariablesRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractVariablesRefactoring.class.st
@@ -133,6 +133,16 @@ RBAbstractVariablesRefactoring >> abstractVariablesIn: aBRProgramNode from: from
 	self computeVariablesToAbstract
 ]
 
+{ #category : 'preconditions' }
+RBAbstractVariablesRefactoring >> breakingChangePreconditions [
+
+	^ RBCondition withBlock: [ self hasVariablesToAbstract ifTrue: [
+		self refactoringWarning:
+			'This method has direct variable references which<n>will need to be converted to getter/setters.<n>Proceed anyway?'
+				expandMacros ].
+		true ]
+]
+
 { #category : 'transforming' }
 RBAbstractVariablesRefactoring >> classVariableNames [
 	| nonMetaClass |
@@ -176,11 +186,7 @@ RBAbstractVariablesRefactoring >> parseTree [
 
 { #category : 'transforming' }
 RBAbstractVariablesRefactoring >> privateTransform [
-	self hasVariablesToAbstract
-		ifTrue:
-			[self
-				refactoringWarning: 'This method has direct variable references which<n>will need to be converted to getter/setters.<n>Proceed anyway?'
-						expandMacros].
+
 	self abstractInstanceVariables.
 	self abstractClassVariables
 ]

--- a/src/Refactoring-Core/RBExpandReferencedPoolsRefactoring.class.st
+++ b/src/Refactoring-Core/RBExpandReferencedPoolsRefactoring.class.st
@@ -40,6 +40,17 @@ RBExpandReferencedPoolsRefactoring class >> model: aRBNamespace forMethod: aPars
 		yourself
 ]
 
+{ #category : 'preconditions' }
+RBExpandReferencedPoolsRefactoring >> breakingChangePreconditions [
+
+	^ RBCondition withBlock: [
+		  self hasPoolsToMove ifTrue: [
+			  self refactoringWarning:
+				  'This method contains references to pools<n>which may need to be moved.<n>Proceed anyway?'
+					  expandMacros ].
+		  true ]
+]
+
 { #category : 'transforming' }
 RBExpandReferencedPoolsRefactoring >> computePoolsToMove [
 
@@ -89,13 +100,14 @@ RBExpandReferencedPoolsRefactoring >> movePoolVariables [
 ]
 
 { #category : 'transforming' }
+RBExpandReferencedPoolsRefactoring >> prepareForExecution [
+
+	self computePoolsToMove
+]
+
+{ #category : 'transforming' }
 RBExpandReferencedPoolsRefactoring >> privateTransform [
-	self computePoolsToMove.
-	self hasPoolsToMove
-		ifTrue:
-			[self
-				refactoringWarning: 'This method contains references to pools<n>which may need to be moved.<n>Proceed anyway?'
-						expandMacros].
+
 	self movePoolVariables
 ]
 

--- a/src/Refactoring-Core/RBRefactoring.class.st
+++ b/src/Refactoring-Core/RBRefactoring.class.st
@@ -124,21 +124,6 @@ RBRefactoring >> convertClasses: classSet select: aBlock using: searchReplacer [
 						using: searchReplacer]]
 ]
 
-{ #category : 'accessing' }
-RBRefactoring >> copyOptionsFrom: aDictionary [
-	| dict |
-	dict := self options.
-	dict == self class refactoringOptions
-		ifTrue: [^self options: aDictionary copy].
-	dict keysAndValuesDo:
-			[:key :value |
-			value == (self class refactoringOptions at: key ifAbsent: [nil])
-				ifTrue: [ dict at: key put: (aDictionary at: key) ]].
-	(aDictionary keys difference: dict keys) do:
-		[ :e | dict at: e put: (aDictionary at: e) ].
-	self options: dict
-]
-
 { #category : 'preconditions' }
 RBRefactoring >> eagerlyCheckApplicabilityPreconditions [
 
@@ -211,15 +196,6 @@ RBRefactoring >> safeVariableNameFor: aClass temporaries: allTempVars basedOn: a
 			i := i + 1.
 			newString := baseString , i printString ].
 	^ newString
-]
-
-{ #category : 'accessing' }
-RBRefactoring >> setOption: aSymbol toUse: aBlock [
-	| dict |
-	dict := self options.
-	dict == self class refactoringOptions ifTrue: [dict := dict copy].
-	dict at: aSymbol put: aBlock.
-	self options: dict
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Transformations/RBAbstractVariablesTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAbstractVariablesTransformation.class.st
@@ -168,14 +168,9 @@ RBAbstractVariablesTransformation >> parseTree [
 	^tree
 ]
 
-{ #category : 'executing' }
+{ #category : 'transforming' }
 RBAbstractVariablesTransformation >> privateTransform [
-	self flag: #popUp.
-	self hasVariablesToAbstract
-		ifTrue:
-			[self
-				refactoringWarning: 'This method has direct variable references which<n>will need to be converted to getter/setters.<n>Proceed anyway?'
-						expandMacros].
+
 	self abstractInstanceVariables.
 	self abstractClassVariables
 ]

--- a/src/Refactoring-Transformations/RBChangeMethodNameTransformation.class.st
+++ b/src/Refactoring-Transformations/RBChangeMethodNameTransformation.class.st
@@ -63,20 +63,6 @@ RBChangeMethodNameTransformation >> implementorsCanBePrimitives [
 	^false
 ]
 
-{ #category : 'preconditions' }
-RBChangeMethodNameTransformation >> interactionConditions [
-	"This refactoring only preserves behavior if all implementors are renamed."
-	
-	self flag: #popUp.
-	
-	^ (RBCondition withBlock:
-		[self implementors size > 1
-			ifTrue:
-				[self refactoringWarning: ('This will modify all <1p> implementors. Proceed anyway?'
-							expandMacrosWith: self implementors size)].
-		true])
-]
-
 { #category : 'support' }
 RBChangeMethodNameTransformation >> modifyImplementorParseTree: parseTree in: aClass [
 	| oldArgs |

--- a/src/Refactoring-Transformations/RBChangeMethodNameTransformation.class.st
+++ b/src/Refactoring-Transformations/RBChangeMethodNameTransformation.class.st
@@ -21,15 +21,6 @@ RBChangeMethodNameTransformation >> applicabilityPreconditions [
 
 ]
 
-{ #category : 'preconditions' }
-RBChangeMethodNameTransformation >> breakingChangePreconditions [ 
-
-	^ self implementors
-		inject: self interactionConditions 
-		into: [ :condition :each |
-			condition & (RBCondition hierarchyOf: each canUnderstand: newSelector) not; errorBlock: [] ]
-]
-
 { #category : 'support' }
 RBChangeMethodNameTransformation >> convertAllReferencesTo: aSymbol of: classes using: searchReplacer [
 	(self model allReferencesTo: aSymbol in: classes)
@@ -108,12 +99,6 @@ RBChangeMethodNameTransformation >> parseTreeRewriter [
 	rewriteRule replace: '``@object ' , oldString
 		with: '``@object ' , newString.
 	^rewriteRule
-]
-
-{ #category : 'preconditions' }
-RBChangeMethodNameTransformation >> preconditions [
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions 
 ]
 
 { #category : 'support' }

--- a/src/Refactoring-Transformations/RBExpandReferencedPoolsTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExpandReferencedPoolsTransformation.class.st
@@ -81,15 +81,14 @@ RBExpandReferencedPoolsTransformation >> movePoolVariables [
 ]
 
 { #category : 'transforming' }
+RBExpandReferencedPoolsTransformation >> prepareForExecution [
+
+	self computePoolsToMove
+]
+
+{ #category : 'transforming' }
 RBExpandReferencedPoolsTransformation >> privateTransform [
 
-	self computePoolsToMove.
-	self flag: #popUp.
-	self hasPoolsToMove
-		ifTrue:
-			[self
-				refactoringWarning: 'This method contains references to pools<n>which may need to be moved.<n>Proceed anyway?'
-						expandMacros].
 	self movePoolVariables
 ]
 

--- a/src/Refactoring-Transformations/RBPullUpVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPullUpVariableTransformation.class.st
@@ -30,21 +30,6 @@ RBPullUpVariableTransformation >> applicabilityPreconditions [
 			true] ]
 ]
 
-{ #category : 'preconditions' }
-RBPullUpVariableTransformation >> breakingChangePreconditions [ 
-
-	^ isClassVariable
-		ifTrue: [ self trueCondition ]
-		ifFalse: [ RBCondition withBlock:
-			[(self definingClass subclasses
-				anySatisfy: [:each | (each directlyDefinesInstanceVariable: variableName) not])
-				ifTrue:
-					[self
-						refactoringWarning: 'Not all subclasses have an instance variable named.<n> Do you want pull up this variable anyway?'
-								, variableName , '.'].
-			true] ]
-]
-
 { #category : 'executing' }
 RBPullUpVariableTransformation >> buildTransformations [
 
@@ -62,12 +47,6 @@ RBPullUpVariableTransformation >> buildTransformations [
 				class: className
 				classVariable: isClassVariable);
 		yourself
-]
-
-{ #category : 'preconditions' }
-RBPullUpVariableTransformation >> preconditions [
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions
 ]
 
 { #category : 'printing' }

--- a/src/Refactoring-Transformations/RBTransformation.class.st
+++ b/src/Refactoring-Transformations/RBTransformation.class.st
@@ -58,25 +58,6 @@ RBTransformation >> asRefactoring [
 	^ self yourself
 ]
 
-{ #category : 'accessing' }
-RBTransformation >> copyOptionsFrom: aDictionary [
-	| dict |
-	dict := self options.
-	dict == self class refactoringOptions
-		ifTrue: [^self options: aDictionary copy].
-	dict keysAndValuesDo:
-			[:key :value |
-			value == (self class refactoringOptions at: key)
-				ifTrue: [dict at: key put: (aDictionary at: key)]].
-	self options: dict
-]
-
-{ #category : 'accessing' }
-RBTransformation >> setOption: aSymbol toUse: aBlock [
-
-	self options at: aSymbol put: aBlock
-]
-
 { #category : 'transforming' }
 RBTransformation >> transform [
 


### PR DESCRIPTION
This PR includes a couple of small cleanups of refactorings:
- extracting breaking changes from `privateTransform`
- extracting `prepareForExecution` from `privateTransform`
- removing breaking changes from transformations
- remove interaction conditions from change name transformation
- pull up similar methods to common superclass