### PR TITLE
SycBrowseClassCommand fix for Browse to class in method editor

### DIFF
--- a/src/SystemCommands-ClassCommands/SycBrowseClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycBrowseClassCommand.class.st
@@ -22,3 +22,13 @@ SycBrowseClassCommand >> defaultMenuItemName [
 SycBrowseClassCommand >> execute [
 	targetClass browse
 ]
+
+{ #category : 'execution' }
+SycBrowseClassCommand >> prepareFullExecutionInContext: aToolContext [
+
+	| scope |
+	scope := RBBrowserEnvironment new.
+	super prepareFullExecutionInContext: aToolContext.
+	targetClass := (scope at: aToolContext selectedSourceNode name) 
+		ifNil: [ aToolContext lastSelectedClass ]
+]


### PR DESCRIPTION
As reported in #14390. 

Add `prepareFullExecutionInContext:` to SycBrowseClassCommand to jump directly to the class under cursor in the method editor from the Source Code -> Browse menu item. Fix based in the @pavel-krivanek proposal

