### PR TITLE
Remove UIManager dependencies from Compression.

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -75,6 +75,7 @@ BaselineOfBasicTools >> baseline: spec [
 			with: [ spec requires: #( 'Tool-Diff' 'MonticelloGUI' ) ].
 		spec package: 'System-Sources-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
 		spec package: 'System-Announcements-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
+		spec package: 'System-Spec'.
 		spec package: 'RPackage-Tests'.
 		spec package: 'Monticello-Tests'.
 		spec package: 'MonticelloGUI-Tests'.

--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -42,16 +42,6 @@ ZipArchive class >> compressionStored [
 ]
 
 { #category : 'file in/out' }
-ZipArchive class >> extractAllIn: aFileReferenceOrFileName [
-	"Service method to extract all contents of a zip."
-	| directory |
-	directory := (UIManager default chooseDirectoryFrom: aFileReferenceOrFileName asFileReference) ifNil: [^ self].
-	^ (self new)
-		readFrom: aFileReferenceOrFileName;
-		extractAllTo: directory
-]
-
-{ #category : 'file in/out' }
 ZipArchive class >> extractFrom: aZipFile to: aDirectory [
 
 	^ self new
@@ -148,8 +138,8 @@ ZipArchive >> extractAllTo: aDirectory [
 ZipArchive >> extractAllTo: aDirectory informing: job [
 	"Extract all elements to the given directory; notifying user via UI on progress and if existing files exist"
 
-	| job1 barValue |
-	job1 := job ifNil: [ DummySystemProgressItem new ].
+	| barValue |
+
 	barValue := 0.
 	self members select: #isDirectory thenDo: [ :entry |
 		| dir shouldUpdateInfos lastUpdate |
@@ -157,24 +147,24 @@ ZipArchive >> extractAllTo: aDirectory informing: job [
 		(shouldUpdateInfos := (Time millisecondsSince: lastUpdate) >= 100)
 			ifTrue: [
 				lastUpdate := Time millisecondClockValue.
-				job1 title: 'Creating ' , entry fileName ].
+				job title: 'Creating ' , entry fileName ].
 		dir := (entry fileName findTokens: '/')
 			       inject: aDirectory
 			       into: [ :base :part | base / part ].
 		dir ensureCreateDirectory.
 		barValue := barValue + 1.
-		shouldUpdateInfos ifTrue: [ job1 currentValue: barValue ] ].
+		shouldUpdateInfos ifTrue: [ job currentValue: barValue ] ].
 	self members reject: #isDirectory thenDo: [ :entry |
 		| shouldUpdateInfos lastUpdate |
 		lastUpdate := 0.
 		(shouldUpdateInfos := (Time millisecondsSince: lastUpdate) >= 100)
 			ifTrue: [
 				lastUpdate := Time millisecondClockValue.
-				job1 title: 'Extracting ' , entry fileName ].
+				job title: 'Extracting ' , entry fileName ].
 		entry extractInDirectory: aDirectory.
 		barValue := barValue + 1.
 		shouldUpdateInfos ifTrue: [
-			job1 currentValue: barValue.
+			job currentValue: barValue.
 			lastUpdate := Time millisecondClockValue ] ].
 	^ self
 ]
@@ -183,8 +173,8 @@ ZipArchive >> extractAllTo: aDirectory informing: job [
 ZipArchive >> extractAllTo: aDirectory informing: aBar overwrite: allOverwrite [
 	"Extract all elements to the given directory. Informs user when a file exists and set to overwrite"
 
-	| bar overwriteAll barValue |
-	bar := aBar ifNil: [ DummySystemProgressItem new ].
+	| overwriteAll barValue |
+
 	overwriteAll := allOverwrite.
 	barValue := 0.
 	self members select: #isDirectory thenDo: [ :entry |
@@ -193,24 +183,24 @@ ZipArchive >> extractAllTo: aDirectory informing: aBar overwrite: allOverwrite [
 		(shouldUpdateInfos := (Time millisecondsSince: lastUpdate) >= 100)
 			ifTrue: [
 				lastUpdate := Time millisecondClockValue.
-				bar label: 'Creating ' , entry fileName ].
+				aBar label: 'Creating ' , entry fileName ].
 		dir := (entry fileName findTokens: '/')
 			       inject: aDirectory
 			       into: [ :base :part | base / part ].
 		dir ensureCreateDirectory.
 		barValue := barValue + 1.
-		shouldUpdateInfos ifTrue: [ bar value: barValue ] ].
+		shouldUpdateInfos ifTrue: [ aBar value: barValue ] ].
 	self members reject: #isDirectory thenDo: [ :entry |
 		| shouldUpdateInfos lastUpdate |
 		lastUpdate := 0.
 		(shouldUpdateInfos := (Time millisecondsSince: lastUpdate) >= 100)
 			ifTrue: [
 				lastUpdate := Time millisecondClockValue.
-				bar label: 'Extracting ' , entry fileName ].
+				aBar label: 'Extracting ' , entry fileName ].
 		entry extractInDirectory: aDirectory.
 		barValue := barValue + 1.
 		shouldUpdateInfos ifTrue: [
-			bar value: barValue.
+			aBar value: barValue.
 			lastUpdate := Time millisecondClockValue ] ]
 ]
 

--- a/src/System-Spec/Archive.extension.st
+++ b/src/System-Spec/Archive.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : 'Archive' }
+
+{ #category : '*System-Spec' }
+Archive class >> application [
+
+	^ StPharoApplication current
+]
+
+{ #category : '*System-Spec' }
+Archive class >> openDirectoryDialog [
+	"Answer a new instance of <StOpenDirectoryDialog>"
+
+	^ self application openDirectoryDialog
+]

--- a/src/System-Spec/GZipReadStream.extension.st
+++ b/src/System-Spec/GZipReadStream.extension.st
@@ -1,0 +1,27 @@
+Extension { #name : 'GZipReadStream' }
+
+{ #category : '*System-Spec' }
+GZipReadStream class >> openWithContents: contentsString label: titleString [
+	"Open a text viewer on contentsString and window label titleString"
+
+	SpTextPresenter new
+		text: contentsString;
+		open;
+		withWindowDo: [ : w | 
+			w 
+				title: titleString;
+				extent: 600 @ 800 ]
+]
+
+{ #category : '*System-Spec' }
+GZipReadStream class >> viewContents: fullFileName [
+	"Open the decompressed contents of the .gz file with the given name."
+
+	| file |
+	(file := fullFileName asFileReference) binaryReadStreamDo: [ :aStream | 
+		self with: aStream do: [ :aGzStream | 
+			self 
+				openWithContents: aGzStream upToEnd 
+				label: 'Decompressed contents of: ' , file basename ] ]
+
+]

--- a/src/System-Spec/StPharoApplication.extension.st
+++ b/src/System-Spec/StPharoApplication.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'StPharoApplication' }
+
+{ #category : '*System-Spec' }
+StPharoApplication >> openDirectoryDialog [
+	
+	^ StOpenDirectoryDialog new
+]

--- a/src/System-Spec/ZipArchive.extension.st
+++ b/src/System-Spec/ZipArchive.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : 'ZipArchive' }
+
+{ #category : '*System-Spec' }
+ZipArchive class >> extractAllIn: aFileReferenceOrFileName [
+	"Service method to extract all contents of a zip.
+	Example: 
+		ZipArchive extractAllIn: 'my_file.zip' 
+		"
+	| directory |
+
+	directory := (self openDirectoryDialog
+		currentDirectory: FileSystem workingDirectory;
+		openModal) ifNil: [ ^ self ].
+
+	^ self new
+		readFrom: aFileReferenceOrFileName;
+		extractAllTo: directory
+]

--- a/src/System-Spec/package.st
+++ b/src/System-Spec/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'System-Spec' }


### PR DESCRIPTION
This PR is a continuation of the work started in #15865 (auto-closed because of conflicts (?))
The summary of changes are:

- Moved utility methods to new package System-Spec.
- Add utility methods as extension to Compression classes.
- Use `openDirectoryDialog`.
- Updated Baseline to load System-Spec.

Probably more changes are needed, but let's see the CI first.
