### PR TITLE
Expand the dependency analyzer roots by default

### DIFF
--- a/src/Tool-DependencyAnalyser-UI/DAPackageTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageTreePresenter.class.st
@@ -119,6 +119,7 @@ DAPackageTreePresenter >> initializePresenters [
 		children: [ :node | node buildChildren ];
 		display: [ :node | node label ];
 		displayIcon: [ :node | node icon ];
+		expandRoots; "<= We want to open the browser with the dependencies displayed to the user"
 		yourself.
 
 	buttonRefresh := self newButton


### PR DESCRIPTION
When opening the dependency analyzer we get dsiplayed a tree with the packages to analyze (often we only have one) and we can expand them to see their dependencies.

I think that it would be nice to automatically expand the roots so that we see the dependencies directly and that we do not have to do it all the time

Before

<img width="1501" alt="image" src="https://github.com/pharo-project/pharo/assets/9519971/83181c19-c45d-4f0e-bbe5-17076fdd2898">

After

<img width="1504" alt="image" src="https://github.com/pharo-project/pharo/assets/9519971/84723dbe-f056-4da1-91b1-9f7a819ecf8a">
