### PR TITLE
Fix String method causing multiple problems

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -765,31 +765,6 @@ String >> asTime [
 ]
 
 { #category : 'converting' }
-String >> asUncommentedCode [
-	"this string represents a commented code, let's uncomment it"
-	
-	"'""abc""' asUncommentedCode >>> 'abc'"
-	
-	^ String streamContents:  [ :str |
-
-		|doubleQuoteAlreadyFound|
-		doubleQuoteAlreadyFound := false.
-
-		self withoutQuoting do: [ :char |
-			char = $"
-				ifTrue: [
-					doubleQuoteAlreadyFound 	ifTrue: [
-							str nextPut: $" ].
-					doubleQuoteAlreadyFound := doubleQuoteAlreadyFound not.
-				]
-				ifFalse: [
-					str nextPut: char
-				]
-		 ]
-	]
-]
-
-{ #category : 'converting' }
 String >> asUnsignedInteger [
 	"Returns the first integer it can find or nil."
 	| start stream |

--- a/src/Deprecated12/String.extension.st
+++ b/src/Deprecated12/String.extension.st
@@ -1,6 +1,33 @@
 Extension { #name : 'String' }
 
 { #category : '*Deprecated12' }
+String >> asUncommentedCode [
+	"This string represents a commented code, let''s uncomment it.   
+	''""""abc""""'' asUncommentedCode.
+		"
+
+	self deprecated: 'This method will be removed in the future version of Pharo because the implementation does not seem to have use cases or there are too few.'.
+	
+	^ String streamContents:  [ :str |
+
+		|doubleQuoteAlreadyFound|
+		doubleQuoteAlreadyFound := false.
+
+		self withoutQuoting do: [ :char |
+			char = $"
+				ifTrue: [
+					doubleQuoteAlreadyFound 	ifTrue: [
+							str nextPut: $" ].
+					doubleQuoteAlreadyFound := doubleQuoteAlreadyFound not.
+				]
+				ifFalse: [
+					str nextPut: char
+				]
+		 ]
+	]
+]
+
+{ #category : '*Deprecated12' }
 String class >> crlfcrlf [
 
 	self


### PR DESCRIPTION
This PR combines a previous PR (#16047 closed to avoid merging conflicts). The method was not used and it was deprecated.
Fix an invalid comment format causing a test `RBFormatterTest>>testCoreSystem` to fail in builds >= 1318 (this is reported in #16078)
