### PR TITLE
Make ScalingCanvas avoid converting a Form in a FormSet for lookup in the FormMapping

### DIFF
--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -376,13 +376,7 @@ ScalingCanvas >> depth [
 { #category : 'drawing - images' }
 ScalingCanvas >> drawFormSet: formSet at: point [
 
-	| form scaledForm |
-
-	form := formSet asForm.
-	scaledForm := (scale = 2 and: [ FormMapping includesKey: form ])
-		ifTrue: [ FormMapping at: form ]
-		ifFalse: [ formSet asFormAtScale: scale ].
-	formCanvas drawImage: scaledForm at: point * scale
+	formCanvas drawImage: (self scaledFormForFormSet: formSet) at: point * scale
 ]
 
 { #category : 'drawing - polygons' }
@@ -586,6 +580,17 @@ ScalingCanvas >> scalePolygon: vertices [
 		point truncated * scale ]
 ]
 
+{ #category : 'private' }
+ScalingCanvas >> scaledFormForFormSet: formSet [
+
+	| form |
+
+	form := formSet asForm.
+	^ (scale = 2 and: [ FormMapping includesKey: form ])
+		ifTrue: [ FormMapping at: form ]
+		ifFalse: [ formSet asFormAtScale: scale ]
+]
+
 { #category : 'accessing' }
 ScalingCanvas >> shadowColor [
 
@@ -644,11 +649,5 @@ ScalingCanvas >> translateBy: delta during: aBlock [
 { #category : 'drawing - images' }
 ScalingCanvas >> translucentFormSet: formSet at: point [
 
-	| form scaledForm |
-
-	form := formSet asForm.
-	scaledForm := (scale = 2 and: [ FormMapping includesKey: form ])
-		ifTrue: [ FormMapping at: form ]
-		ifFalse: [ formSet asFormAtScale: scale ].
-	formCanvas translucentImage: scaledForm at: point * scale
+	formCanvas translucentImage: (self scaledFormForFormSet: formSet) at: point * scale
 ]

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -583,12 +583,10 @@ ScalingCanvas >> scalePolygon: vertices [
 { #category : 'private' }
 ScalingCanvas >> scaledFormForFormSet: formSet [
 
-	| form |
-
-	form := formSet asForm.
-	^ (scale = 2 and: [ FormMapping includesKey: form ])
-		ifTrue: [ FormMapping at: form ]
-		ifFalse: [ formSet asFormAtScale: scale ]
+	scale = 2 ifTrue: [
+		formSet mappableFormForScalingCanvas ifNotNil: [ :mappableForm |
+			FormMapping at: mappableForm ifPresent: [ :mappedForm | ^ mappedForm ] ] ].
+	^ formSet asFormAtScale: scale
 ]
 
 { #category : 'accessing' }

--- a/src/Graphics-Display Objects/FormSet.class.st
+++ b/src/Graphics-Display Objects/FormSet.class.st
@@ -93,6 +93,14 @@ FormSet >> initializeWithExtent: initialExtent depth: initialDepth forms: initia
 	forms := initialForms.
 ]
 
+{ #category : 'converting' }
+FormSet >> mappableFormForScalingCanvas [
+
+	forms detect: [ :form | form extent = extent ]
+		ifFound: [ :form | form depth = depth ifTrue: [ ^ form ] ].
+	^ nil
+]
+
 { #category : 'copying' }
 FormSet >> veryDeepCopyWith: deepCopier [
 	"Return self.  I am immutable in the Morphic world.  Do not record me."


### PR DESCRIPTION
This pull request makes ScalingCanvas avoid converting a Form in a FormSet for lookup in the FormMapping. This is related to [Roassal pull request #56](https://github.com/pharo-graphics/Roassal/pull/56), in which a FormSet is used which causes such a conversion for the lookup, avoiding that makes drawing faster and improves animation fluency.