### PR TITLE
Revert "Release all waiting processes when destroying a socket (fixes #15975)"

### DIFF
--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -465,18 +465,11 @@ Socket >> connectTo: hostAddress port: port [
 Socket >> connectTo: hostAddress port: port waitForConnectionFor: timeout [
 	"Initiate a connection to the given port at the given host
 	address. Waits until the connection is established or time outs."
-
 	self connectNonBlockingTo: hostAddress port: port.
 	self
 		waitForConnectionFor: timeout
-		ifClosed: [
-			ConnectionClosed signal: 'Connection aborted to '
-				, (NetNameResolver stringFromAddress: hostAddress) , ':'
-				, port asString ]
-		ifTimedOut: [
-			ConnectionTimedOut signal: 'Cannot connect to '
-				, (NetNameResolver stringFromAddress: hostAddress) , ':'
-				, port asString ]
+		ifTimedOut: [ConnectionTimedOut signal: 'Cannot connect to '
+					, (NetNameResolver stringFromAddress: hostAddress) , ':' , port asString]
 ]
 
 { #category : 'connection open/close' }
@@ -496,27 +489,18 @@ Socket >> dataAvailable [
 
 { #category : 'initialize - destroy' }
 Socket >> destroy [
-	"Destroy this socket. Its connection, if any, is aborted and its resources are freed.
-	Any processes waiting on the socket are freed immediately, but it is up to them to
-	recognize that the socket has been destroyed.
-	Do nothing if the socket has already been destroyed (i.e., if its socketHandle is nil)."
+	"Destroy this socket. Its connection, if any, is aborted and its resources are freed. Do nothing if the socket has already been destroyed (i.e., if its socketHandle is nil)."
 
-	socketHandle ifNotNil: [
-		| saveSemaphores |
-		self isValid ifTrue: [ self primSocketDestroy: socketHandle ].
-		socketHandle := nil.
-		Smalltalk unregisterExternalObject: semaphore.
-		Smalltalk unregisterExternalObject: readSemaphore.
-		Smalltalk unregisterExternalObject: writeSemaphore.
-		"Stash the semaphores and nil them before signaling to make sure
-		no caller gets a chance to wait on them again and block forever."
-		saveSemaphores := {
-			                  semaphore.
-			                  readSemaphore.
-			                  writeSemaphore }.
-		semaphore := readSemaphore := writeSemaphore := nil.
-		saveSemaphores do: [ :each | each signalAll ].
-		self unregister ]
+	socketHandle
+		ifNotNil: [
+			self isValid
+				ifTrue: [ self primSocketDestroy: socketHandle ].
+			Smalltalk unregisterExternalObject: semaphore.
+			Smalltalk unregisterExternalObject: readSemaphore.
+			Smalltalk unregisterExternalObject: writeSemaphore.
+			socketHandle := nil.
+			readSemaphore := writeSemaphore := semaphore := nil.
+			self unregister ]
 ]
 
 { #category : 'receiving' }
@@ -1350,7 +1334,6 @@ Socket >> retryIfWaitingForConnection: aBlock [
 				  ifTrue: [
 					  self
 						  waitForConnectionFor: Socket standardTimeout
-						  ifClosed: nil
 						  ifTimedOut: nil.
 					  aBlock value ]
 				  ifFalse: [ e pass ] ]
@@ -1546,19 +1529,15 @@ Socket >> setPort: port [
 
 { #category : 'queries' }
 Socket >> socketError [
-
-	^ socketHandle ifNotNil: [ self primSocketError: socketHandle ]
+	^self primSocketError: socketHandle
 ]
 
 { #category : 'queries' }
 Socket >> socketErrorMessage [
 
-	^ self socketError
-		  ifNil: [ 'Socket destroyed, cannot retrieve error message' ]
-		  ifNotNil: [ :err |
-			  [ OSPlatform current getErrorMessage: err ]
-				  on: Error
-				  do: [ 'Error code: ' , err printString ] ]
+	^ [ OSPlatform current getErrorMessage: self socketError ]
+		  on: Error
+		  do: [ 'Error code: ' , self socketError printString ]
 ]
 
 { #category : 'accessing' }
@@ -1590,57 +1569,40 @@ Socket >> unregister [
 { #category : 'waiting' }
 Socket >> waitForAcceptFor: timeout [
 	"Wait and accept an incoming connection. Return nil if it fails"
-
-	^ self waitForAcceptFor: timeout ifClosed: nil ifTimedOut: nil
+	^ self waitForAcceptFor: timeout ifTimedOut: [nil]
 ]
 
 { #category : 'waiting' }
-Socket >> waitForAcceptFor: timeout ifClosed: closedBlock ifTimedOut: timeoutBlock [
+Socket >> waitForAcceptFor: timeout ifTimedOut: timeoutBlock [
 	"Wait and accept an incoming connection"
-
-	self
-		waitForConnectionFor: timeout
-		ifClosed: [ ^ closedBlock value ]
-		ifTimedOut: [ ^ timeoutBlock value ].
-	^ self accept
+	self waitForConnectionFor: timeout ifTimedOut: [^timeoutBlock value].
+	^self accept
 ]
 
 { #category : 'waiting' }
 Socket >> waitForConnectionFor: timeout [
 	"Wait up until the given deadline for a connection to be established. Return true if it is established by the deadline, false if not."
 
-	^ self
-		  waitForConnectionFor: timeout
-		  ifClosed: [
-			  ConnectionClosed signal: (socketHandle
-					   ifNil: [ 'Socket destroyed while connecting' ]
-					   ifNotNil: [
-					   'Connection aborted or failed: ' , self socketErrorMessage ]) ]
-		  ifTimedOut: [
-			  ConnectionTimedOut signal:
-				  'Failed to connect in ' , timeout asString , ' seconds' ]
+	^self
+		waitForConnectionFor: timeout
+		ifTimedOut: [ConnectionTimedOut signal: 'Failed to connect in ', timeout asString, ' seconds']
 ]
 
 { #category : 'waiting' }
-Socket >> waitForConnectionFor: timeout ifClosed: closedBlock ifTimedOut: timeoutBlock [
-	"Wait up until the given deadline for a connection to be established.
-	Evaluate closedBlock if the connection is closed locally,
-	or timeoutBlock if the deadline expires.
-	
-	We should separately detect the case of a connection being refused here as well."
+Socket >> waitForConnectionFor: timeout ifTimedOut: timeoutBlock [
+	"Wait up until the given deadline for a connection to be established. Return true if it is established by the deadline, false if not."
 
-	| startTime msecsDelta msecsElapsed status |
+	| startTime msecsDelta msecsEllapsed status |
 	startTime := Time millisecondClockValue.
 	msecsDelta := (timeout * 1000) truncated.
-
-	[
 	status := self primSocketConnectionStatus: socketHandle.
-	status == WaitingForConnection and: [
-		(msecsElapsed := Time millisecondsSince: startTime) < msecsDelta ] ]
-		whileTrue: [ semaphore waitTimeoutMilliseconds: msecsDelta - msecsElapsed ].
+	[(status = WaitingForConnection) and: [(msecsEllapsed := Time millisecondsSince: startTime) < msecsDelta]]
+		whileTrue: [
+			semaphore waitTimeoutMilliseconds: msecsDelta - msecsEllapsed.
+			status := self primSocketConnectionStatus: socketHandle].
 
-	status == WaitingForConnection ifTrue: [ ^ timeoutBlock value ].
-	status == Connected ifFalse: [ ^ closedBlock value ]
+	status = Connected ifFalse: [^timeoutBlock value].
+	^ true
 ]
 
 { #category : 'waiting' }
@@ -1666,9 +1628,7 @@ Socket >> waitForDataFor: timeout [
 
 { #category : 'waiting' }
 Socket >> waitForDataFor: timeout ifClosed: closedBlock ifTimedOut: timedOutBlock [
-	"Wait for the given nr of seconds for data to arrive.
-	If it does not, execute <timedOutBlock>. If the connection
-	is closed before any data arrives, execute <closedBlock>."
+	"Wait for the given nr of seconds for data to arrive."
 
 	| startTime msecsDelta msecsElapsed |
 	startTime := Time millisecondClockValue.
@@ -1702,24 +1662,22 @@ Socket >> waitForDisconnectionFor: timeout [
 	(e.g., because he has called 'close' to send a close request to the other end)
 	before calling this method."
 
-	| startTime msecsDelta msecsElapsed status |
+	| startTime msecsDelta status |
 	startTime := Time millisecondClockValue.
 	msecsDelta := (timeout * 1000) truncated.
-
-	[
 	status := self primSocketConnectionStatus: socketHandle.
-	(status == Connected or: [ status == ThisEndClosed ]) and: [
-		(msecsElapsed := Time millisecondsSince: startTime) < msecsDelta ] ]
-		whileTrue: [
-			self discardReceivedData.
-			self readSemaphore waitTimeoutMilliseconds: msecsDelta - msecsElapsed ].
+	[((status == Connected) or: [(status == ThisEndClosed)]) and:
+	 [(Time millisecondsSince: startTime) < msecsDelta]] whileTrue: [
+		self discardReceivedData.
+		self readSemaphore waitTimeoutMilliseconds:
+			(msecsDelta - (Time millisecondsSince: startTime) max: 0).
+		status := self primSocketConnectionStatus: socketHandle].
 	^ status ~= Connected
 ]
 
 { #category : 'waiting' }
 Socket >> waitForSendDoneFor: timeout [
-	"Wait up until the given deadline for the current send operation to complete.
-	Raise an exception if the timeout expires or the connection is closed before sending finishes."
+	"Wait up until the given deadline for the current send operation to complete. Return true if it completes by the deadline, false if not."
 
 	^ self
 		  waitForSendDoneFor: timeout


### PR DESCRIPTION
Reverts pharo-project/pharo#16073

This PR is breaking the build because of a missing  `signalAll` method