### PR TITLE
Improving Message list morph UI

### DIFF
--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
@@ -182,7 +182,7 @@ ClyQueryBrowserMorph >> extraScopesOfSelectedItems [
 { #category : 'initialization' }
 ClyQueryBrowserMorph >> initialExtent [
 
-	^ 1450 @ 620 * self currentWorld displayScaleFactor
+	^ 1350 @ 620 * self currentWorld displayScaleFactor
 ]
 
 { #category : 'initialization' }
@@ -199,17 +199,11 @@ ClyQueryBrowserMorph >> initializeNavigationViews [
 	resultView enableFilter: ClyQueryBrowserFilter.
 	resultView allowsDeselection: false.
 	resultView mainColumn
-		width: 250;
 		displayItemPropertyBy: [:item | self classNameOf: item].
 	(resultView addColumn: #name)
-		width: 200;
 		displayItemPropertyBy: [:item | self mainNameOf: item].
 	(resultView addColumn: #package)
-		width: 150;
-		displayItemPropertyBy: [:item | self packageNameOf: item].
-	(resultView addColumn: #protocol)
-		width: 150;
-		displayItemPropertyBy: [:item | self protocolNameOf: item].
+		displayItemPropertyBy: [:item | self packageNameOf: item]
 ]
 
 { #category : 'testing' }

--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
@@ -180,6 +180,12 @@ ClyQueryBrowserMorph >> extraScopesOfSelectedItems [
 ]
 
 { #category : 'initialization' }
+ClyQueryBrowserMorph >> initialExtent [
+
+	^ 1450 @ 620 * self currentWorld displayScaleFactor
+]
+
+{ #category : 'initialization' }
 ClyQueryBrowserMorph >> initialize [
 	super initialize.
 
@@ -198,12 +204,12 @@ ClyQueryBrowserMorph >> initializeNavigationViews [
 	(resultView addColumn: #name)
 		width: 200;
 		displayItemPropertyBy: [:item | self mainNameOf: item].
-	(resultView addColumn: #protocol)
-		width: 200;
-		displayItemPropertyBy: [:item | self protocolNameOf: item].
 	(resultView addColumn: #package)
-		width: 50;
-		displayItemPropertyBy: [:item | self packageNameOf: item]
+		width: 150;
+		displayItemPropertyBy: [:item | self packageNameOf: item].
+	(resultView addColumn: #protocol)
+		width: 150;
+		displayItemPropertyBy: [:item | self protocolNameOf: item].
 ]
 
 { #category : 'testing' }

--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowserMorph.class.st
@@ -203,7 +203,9 @@ ClyQueryBrowserMorph >> initializeNavigationViews [
 	(resultView addColumn: #name)
 		displayItemPropertyBy: [:item | self mainNameOf: item].
 	(resultView addColumn: #package)
-		displayItemPropertyBy: [:item | self packageNameOf: item]
+		displayItemPropertyBy: [:item | self packageNameOf: item].
+	(resultView addColumn: #protocol)
+		displayItemPropertyBy: [:item | self protocolNameOf: item]
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
This PR changes a little the UI of the old Calypso Message Browser.

- It removes the protocol column. This is because when one browses the senders, the protocol information is most of the time not needed. And also, in the new StMessageBrowser there is not a protocol column.
- It changes the default extent to be wider.
- It now uses dynamic width instead of a fixed one.

This is the old UI:
![Capture d’écran 2024-02-05 à 16 44 07](https://github.com/pharo-project/pharo/assets/33934979/5da1d478-66d6-4066-957c-77cdc4a0a9f3)

And this is the new one:
![Capture d’écran 2024-02-05 à 16 43 21](https://github.com/pharo-project/pharo/assets/33934979/99f0eb04-6519-40e3-8ceb-fff1fdf1c82b)

