### PR TITLE
Refactor: preconditions of add method and migrate to new architecture

### DIFF
--- a/src/Refactoring-Core/RBAddMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBAddMethodRefactoring.class.st
@@ -55,21 +55,27 @@ RBAddMethodRefactoring class >> sourceCode: aString in: aClass withProtocol: aPr
 { #category : 'preconditions' }
 RBAddMethodRefactoring >> applicabilityPreconditions [ 
 
-	^ (RBCondition canUnderstand: transformation selector in: class) not
+	^ transformation applicabilityPreconditions 
 ]
 
 { #category : 'preconditions' }
-RBAddMethodRefactoring >> checkPreconditions [
-	"We should have same preconditions checking API for all refactorings.
-	Some of them do it like: 
-	preconditions
-	^ self applicabilityPreconditions & self breakingChangePreconditions
-	
-	and refactorings that are decorators do it like this method:
-	"
+RBAddMethodRefactoring >> breakingChangePreconditions [ 
 
-	transformation checkPreconditions.
-	super checkPreconditions 
+	^ ((RBCondition canUnderstand: transformation selector in: class) 
+		errorBlock: [ "this is here so a warning is raised until we refactor all precondition checking logic" ])
+		not
+]
+
+{ #category : 'preconditions' }
+RBAddMethodRefactoring >> preconditions [ 
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions 
+]
+
+{ #category : 'transforming' }
+RBAddMethodRefactoring >> prepareForExecution [ 
+
+	transformation prepareForExecution 
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBAddOverrideMethodTransformation.class.st
+++ b/src/Refactoring-Core/RBAddOverrideMethodTransformation.class.st
@@ -14,7 +14,9 @@ Class {
 }
 
 { #category : 'preconditions' }
-RBAddOverrideMethodTransformation >> applicabilityPreconditions [ 
+RBAddOverrideMethodTransformation >> breakingChangePreconditions [
 
-	^ (RBCondition definesSelector: transformation selector in: class) not
+	^ ((RBCondition definesSelector: transformation selector in: class)
+		errorBlock: [ "this is here so a warning is raised until we refactor all precondition checking logic" ])
+		not
 ]

--- a/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpMethodRefactoring.class.st
@@ -139,7 +139,7 @@ RBPullUpMethodRefactoring >> checkInstVarsFor: aSelector [
 								with: each
 								with: class))
 						ifTrue: [ self pushUpVariable: each ]
-						ifFalse: [ self refactoringError: 'You are about to push your method without the instance variable it uses.
+						ifFalse: [ self refactoringWarning: 'You are about to push your method without the instance variable it uses.
 						It will bring the system is an inconsistent state. But this may be what you want.
 						So do you want to push up anyway?' ] ]]
 ]

--- a/src/Refactoring-Core/RBTemporaryToInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBTemporaryToInstanceVariableRefactoring.class.st
@@ -99,15 +99,9 @@ RBTemporaryToInstanceVariableRefactoring class >> model: aRBSmalltalk class: aCl
 RBTemporaryToInstanceVariableRefactoring >> applicabilityPreconditions [ 
 	^(RBCondition definesSelector: selector in: class)
 		& (RBCondition definesInstanceVariable: temporaryVariableName asString in: class) not
-		& (RBCondition withBlock: [
-			(class allSubclasses anySatisfy:
-				[ :cls | cls definesInstanceVariable: temporaryVariableName asString ])
-			ifTrue: [ self refactoringWarning:
-				('One or more subclasses of <1p> already defines an<n>instance variable with the same name. Proceed anyway?' expandMacrosWith: class name) ].
-			true ])
-			& (RBCondition withBlock:
-						[self checkForValidTemporaryVariable.
-						true])
+		& (RBCondition withBlock:
+				[self checkForValidTemporaryVariable.
+				true])
 ]
 
 { #category : 'preconditions' }
@@ -120,7 +114,8 @@ RBTemporaryToInstanceVariableRefactoring >> breakingChangePreconditions [
 				   self refactoringWarning:
 					   ('One or more subclasses of <1p> already defines an<n>instance variable with the same name. Proceed anyway?'
 						    expandMacrosWith: class name) ].
-		   true ]) & (ReVariablesNotReadBeforeWrittenCondition new subtree: parseTree; variables: temporaryVariableName)
+			true ])
+	& (ReVariablesNotReadBeforeWrittenCondition new subtree: parseTree; variables: temporaryVariableName)
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Transformations-Tests/RBAddMethodRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBAddMethodRefactoringTest.class.st
@@ -14,24 +14,15 @@ RBAddMethodRefactoringTest >> setUp [
 ]
 
 { #category : 'failure tests' }
-RBAddMethodRefactoringTest >> testFailureExistingSelector [
-
-	self shouldFail: (RBAddMethodRefactoring
-			 sourceCode: 'printString ^super printString'
-			 in: RBBasicLintRuleTestData
-			 withProtocol: #accessing)
-]
-
-{ #category : 'failure tests' }
-RBAddMethodRefactoringTest >> testFailureModelExistingSelector [
+RBAddMethodRefactoringTest >> testWarnModelExistingSelector [
 
 	self
-		shouldFail: (RBAddMethodRefactoring
+		shouldWarn: (RBAddMethodRefactoring
 				 model: model
 				 sourceCode: 'classVarName1 ^super printString'
 				 in: (model classNamed: #Bar)
 				 withProtocol: #accessing);
-		shouldFail: (RBAddMethodRefactoring
+		shouldWarn: (RBAddMethodRefactoring
 				 model: model
 				 sourceCode: 'printString ^super printString'
 				 in: (model classNamed: #Bar)
@@ -39,7 +30,7 @@ RBAddMethodRefactoringTest >> testFailureModelExistingSelector [
 ]
 
 { #category : 'failure tests' }
-RBAddMethodRefactoringTest >> testFailureModelInheritedSelector [
+RBAddMethodRefactoringTest >> testWarnModelInheritedSelector [
 
 	| refactoring |
 	refactoring := RBAddMethodRefactoring
@@ -47,5 +38,14 @@ RBAddMethodRefactoringTest >> testFailureModelInheritedSelector [
 		               sourceCode: 'printString ^super printString'
 		               in: (model classNamed: #Bar)
 		               withProtocol: #accessing .
-	self shouldFail: refactoring
+	self shouldWarn: refactoring
+]
+
+{ #category : 'failure tests' }
+RBAddMethodRefactoringTest >> testWarnWhenSelectorAlreadyExists [
+
+	self shouldWarn: (RBAddMethodRefactoring
+			 sourceCode: 'printString ^super printString'
+			 in: RBBasicLintRuleTestData
+			 withProtocol: #accessing)
 ]

--- a/src/Refactoring-Transformations-Tests/RBPullUpMethodParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPullUpMethodParametrizedTest.class.st
@@ -72,20 +72,6 @@ RBPullUpMethodParametrizedTest >> constructor [
 ]
 
 { #category : 'failure tests' }
-RBPullUpMethodParametrizedTest >> testFailureDoesntPullUpReferencesInstVar [
-
-	| refactoring class |
-	class := model classNamed:
-		         ('RBTransformation' , 'RuleTestData1') asSymbol.
-	refactoring := self
-		               createRefactoringWithModel: model
-		               andArguments: {
-				               #( #foo ).
-				               class }.
-	[ self shouldFail: refactoring ] valueSupplyingAnswer: false
-]
-
-{ #category : 'failure tests' }
 RBPullUpMethodParametrizedTest >> testFailurePullUpClassMethod [
 
 	| class |
@@ -284,4 +270,18 @@ RBPullUpMethodParametrizedTest >> testPullUpReferencesInstVar [
 	self assert: (superClass directlyDefinesInstanceVariable: #foo).
 	self deny: (class directlyDefinesMethod: #foo).
 	self deny: (class directlyDefinesInstanceVariable: #foo)
+]
+
+{ #category : 'failure tests' }
+RBPullUpMethodParametrizedTest >> testWarnDoesntPullUpReferencesInstVar [
+
+	| refactoring class |
+	class := model classNamed:
+		         ('RBTransformation' , 'RuleTestData1') asSymbol.
+	refactoring := self
+		               createRefactoringWithModel: model
+		               andArguments: {
+				               #( #foo ).
+				               class }.
+	[ self shouldWarn: refactoring ] valueSupplyingAnswer: false
 ]

--- a/src/Refactoring-Transformations/RBAddMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddMethodTransformation.class.st
@@ -48,23 +48,33 @@ RBAddMethodTransformation class >> sourceCode: aString in: aClass withProtocol: 
 ]
 
 { #category : 'preconditions' }
-RBAddMethodTransformation >> applicabilityPreconditions [
+RBAddMethodTransformation >> applicabilityPreconditions [ 
 
-	rbMethod := self parserClass
-		parseMethod: sourceCode
-		onError: [ :string :position |
-			^ RBCondition
-				withBlock: [ self
-						refactoringError: 'The content of this method cannot be parsed.' ] ].
-	rbMethod selector
-		ifNil: [ self refactoringError: 'The method has no selector.' ].
-	^ self trueCondition
+	^ (RBCondition 
+		withBlock: [ 
+			rbMethod ifNil: [
+				self refactoringError: 'The content of this method cannot be parsed.' ]. 
+			true ])
+	& (RBCondition
+		withBlock: [ rbMethod selector ifNil: [ 
+				self refactoringError: 'The method has no selector.' ]. 
+			true])
 ]
 
 { #category : 'accessing' }
 RBAddMethodTransformation >> method [
 
 	^ rbMethod 
+]
+
+{ #category : 'transforming' }
+RBAddMethodTransformation >> prepareForExecution [
+
+	rbMethod := self parserClass
+		            parseMethod: sourceCode
+		            onError: [ :string :position |
+			            self refactoringError:
+				            'The content of this method cannot be parsed.' ]
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Transformations/RBPullUpMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPullUpMethodTransformation.class.st
@@ -119,7 +119,7 @@ RBPullUpMethodTransformation >> checkInstVarsFor: aSelector [
 								with: each
 								with: class))
 						ifTrue: [ self previousTransformations add: (self pushUpVariable: each) ]
-						ifFalse: [ self refactoringError: 'You are about to push your method without the instance variable it uses.
+						ifFalse: [ self refactoringWarning: 'You are about to push your method without the instance variable it uses.
 						It will bring the system is an inconsistent state. But this may be what you want.
 						So do you want to push up anyway?' ] ]]
 ]


### PR DESCRIPTION
- refactored add method refactoring to new architecture and fixed a bug where breaking change precondition was applicability precondition
- raise a warning when a pull up method references instance variable