### PR TITLE
16057-Cleanup-use-cascaded-nextPutAll-in-LocaleIDstoreOn 

### DIFF
--- a/src/System-Localization/LocaleID.class.st
+++ b/src/System-Localization/LocaleID.class.st
@@ -133,9 +133,13 @@ LocaleID >> printOn: stream [
 
 { #category : 'printing' }
 LocaleID >> storeOn: aStream [
-	aStream nextPut: $(.
-	aStream nextPutAll: self class name.
-	aStream nextPutAll: ' isoString: '.
-	aStream nextPutAll: '''' , self printString , ''''.
-	aStream nextPut: $)
+
+	aStream
+		nextPut: $(;
+		nextPutAll: self class name;
+		nextPutAll: ' isoString: ';
+		nextPut: $';
+		nextPutAll: self printString;
+		nextPut: $';
+		nextPut: $)
 ]


### PR DESCRIPTION
use cascade, fixes #16057