### PR TITLE
15965-CI-Failing-tests-on-the-CI-ReleaseTeststestThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented

### DIFF
--- a/src/Kernel-Tests/DeprecationTest.class.st
+++ b/src/Kernel-Tests/DeprecationTest.class.st
@@ -8,7 +8,7 @@ Class {
 
 { #category : 'tests' }
 DeprecationTest >> testTransformingDeprecation [
-
+	<ignoreNotImplementedSelectors: #(sendsDeprecatedMessageWithTransform)>
 	| classFactory oldRaiseWarning oldActivateTransformations |
 	classFactory := ClassFactoryForTestCase new.
 	classFactory 


### PR DESCRIPTION
fixes #15965