### PR TITLE
Rename RPackage-Tests

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -75,7 +75,7 @@ BaselineOfBasicTools >> baseline: spec [
 			with: [ spec requires: #( 'Tool-Diff' 'MonticelloGUI' ) ].
 		spec package: 'System-Sources-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
 		spec package: 'System-Announcements-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
-		spec package: 'RPackage-Tests'.
+		spec package: 'Kernel-CodeModel-Tests'.
 		spec package: 'Monticello-Tests'.
 		spec package: 'MonticelloGUI-Tests'.
 		spec package: 'Network-Mail'.

--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -17,7 +17,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'Debugging-Utils-Tests';
 			package: 'NumberParser-Tests';
 			package: 'AST-Core-Tests';
-			package: 'RPackage-Tests';
+			package: 'Kernel-CodeModel-Tests';
 			package: 'Monticello-Tests';
 			"required by MonticelloMocks"package: 'System-Installers-Tests';
 			package: 'MonticelloMocks';

--- a/src/Kernel-CodeModel-Tests/PackageAndClassesTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageAndClassesTest.class.st
@@ -4,8 +4,9 @@ SUnit tests for RPackage classes synchronisation
 Class {
 	#name : 'PackageAndClassesTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'tests' }

--- a/src/Kernel-CodeModel-Tests/PackageAndMethodsTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageAndMethodsTest.class.st
@@ -4,8 +4,9 @@ SUnit tests for RPackage method synchronization
 Class {
 	#name : 'PackageAndMethodsTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'tests - extension methods' }

--- a/src/Kernel-CodeModel-Tests/PackageAndTraitOnModelTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageAndTraitOnModelTest.class.st
@@ -12,8 +12,9 @@ Class {
 		'yPackage',
 		'zPackage'
 	],
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'running' }

--- a/src/Kernel-CodeModel-Tests/PackageAndTraitsTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageAndTraitsTest.class.st
@@ -5,8 +5,9 @@ SUnit tests for Package trait synchronization
 Class {
 	#name : 'PackageAndTraitsTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'tests - operations on methods' }

--- a/src/Kernel-CodeModel-Tests/PackageAnnouncementsTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageAnnouncementsTest.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'numberOfAnnouncements'
 	],
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'running' }

--- a/src/Kernel-CodeModel-Tests/PackageObsoleteTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageObsoleteTest.class.st
@@ -7,8 +7,9 @@ Class {
 	#instVars : [
 		'notRun'
 	],
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'accessing' }

--- a/src/Kernel-CodeModel-Tests/PackageOnModelTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageOnModelTest.class.st
@@ -29,8 +29,9 @@ Class {
 		'yPackage',
 		'zPackage'
 	],
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'running' }

--- a/src/Kernel-CodeModel-Tests/PackageOrganizerTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageOrganizerTest.class.st
@@ -8,8 +8,9 @@ Therefore the new created PackageOrganizer is not registered to listen to event.
 Class {
 	#name : 'PackageOrganizerTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'utilities' }

--- a/src/Kernel-CodeModel-Tests/PackageRenameTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageRenameTest.class.st
@@ -4,8 +4,9 @@ SUnit tests on renaming packages
 Class {
 	#name : 'PackageRenameTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'tests' }

--- a/src/Kernel-CodeModel-Tests/PackageTagTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageTagTest.class.st
@@ -4,8 +4,9 @@ SUnit tests for Package tags
 Class {
 	#name : 'PackageTagTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'tests' }

--- a/src/Kernel-CodeModel-Tests/PackageTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageTest.class.st
@@ -4,8 +4,9 @@ SUnit tests for Package
 Class {
 	#name : 'PackageTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'tests - classes' }
@@ -261,7 +262,7 @@ PackageTest >> testHasProperty [
 PackageTest >> testHierarchyRoots [
 
 	| roots |
-	roots := (self packageOrganizer packageNamed: #'RPackage-Tests') hierarchyRoots.
+	roots := (self packageOrganizer packageNamed: #'Kernel-CodeModel-Tests') hierarchyRoots.
 	roots := roots collect: [ :each | each name ].
 	#( #PackageTestCase ) do: [ :each | roots includes: each ]
 ]

--- a/src/Kernel-CodeModel-Tests/PackageTestCase.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageTestCase.class.st
@@ -7,8 +7,9 @@ Class {
 	#instVars : [
 		'testEnvironment'
 	],
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'testing' }

--- a/src/Kernel-CodeModel-Tests/UndefinedPackageTagTest.class.st
+++ b/src/Kernel-CodeModel-Tests/UndefinedPackageTagTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'UndefinedPackageTagTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'tests' }

--- a/src/Kernel-CodeModel-Tests/UndefinedPackageTest.class.st
+++ b/src/Kernel-CodeModel-Tests/UndefinedPackageTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'UndefinedPackageTest',
 	#superclass : 'PackageTestCase',
-	#category : 'RPackage-Tests',
-	#package : 'RPackage-Tests'
+	#category : 'Kernel-CodeModel-Tests-Packages',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Packages'
 }
 
 { #category : 'tests' }

--- a/src/Kernel-CodeModel-Tests/package.st
+++ b/src/Kernel-CodeModel-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Kernel-CodeModel-Tests' }

--- a/src/RPackage-Tests/package.st
+++ b/src/RPackage-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'RPackage-Tests' }


### PR DESCRIPTION
Rename RPackage-Tests into Kernel-CodeModel-Tests

Now that all the code related to the code model is in a separated packages than Kernel, maybe the tests could reflect this architechture? Here is a first step.

Replace https://github.com/pharo-project/pharo/pull/15519