### PR TITLE
Avoid merged tags for vm download in bootstrap script

### DIFF
--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -51,9 +51,9 @@ function set_version_common() {
 	# HACK: Since this may beforehand a PR branch, I do not have all information I need. I assume I will have a tag indicating Pharo version.
 	# Note: do not use `--first-parent` here, since Jenkins is crazy and use the PR as the first parent wheras useful version information in the targeted branch.
     # Set the common env vars extracting version information. Requires that prefix and suffix are set beforehand
-    PHARO_MAJOR="$(git --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-1)"
-    PHARO_MINOR="$(git --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 2-2)"
-    PHARO_PATCH="$(git --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 3-3)"
+    PHARO_MAJOR="$(git describe --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-1)"
+    PHARO_MINOR="$(git describe --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 2-2)"
+    PHARO_PATCH="$(git describe --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 3-3)"
 
 	# This will answer "Pharo7.0-PR"
 	PHARO_NAME_PREFIX="Pharo${PHARO_MAJOR}.${PHARO_MINOR}-${PHARO_SUFFIX}"

--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -51,9 +51,9 @@ function set_version_common() {
 	# HACK: Since this may beforehand a PR branch, I do not have all information I need. I assume I will have a tag indicating Pharo version.
 	# Note: do not use `--first-parent` here, since Jenkins is crazy and use the PR as the first parent wheras useful version information in the targeted branch.
     # Set the common env vars extracting version information. Requires that prefix and suffix are set beforehand
-    PHARO_MAJOR="$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-1)"
-    PHARO_MINOR="$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 2-2)"
-    PHARO_PATCH="$(git describe --long --tags | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 3-3)"
+    PHARO_MAJOR="$(git --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-1)"
+    PHARO_MINOR="$(git --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 2-2)"
+    PHARO_PATCH="$(git --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 3-3)"
 
 	# This will answer "Pharo7.0-PR"
 	PHARO_NAME_PREFIX="Pharo${PHARO_MAJOR}.${PHARO_MINOR}-${PHARO_SUFFIX}"


### PR DESCRIPTION
As discussed in #16103, this PR changes the way the Pharo major, minor and patch version numbers are obtained from git describe command.

The update uses a similar way `git describe --tags --first-parent --abbrev=1` which prevents using merge tags. This is useful because in the replaced way, using `git describe --long --tags` could answer unexpected output - this is not starting with `v.[0-9]` and then causing the VM not being downloaded by wget.
