### PR TITLE
Avoid merged tags without abbrev parameter for vm download in bootstrap script

### DIFF
--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -51,9 +51,9 @@ function set_version_common() {
 	# HACK: Since this may beforehand a PR branch, I do not have all information I need. I assume I will have a tag indicating Pharo version.
 	# Note: do not use `--first-parent` here, since Jenkins is crazy and use the PR as the first parent wheras useful version information in the targeted branch.
     # Set the common env vars extracting version information. Requires that prefix and suffix are set beforehand
-    PHARO_MAJOR="$(git describe --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-1)"
-    PHARO_MINOR="$(git describe --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 2-2)"
-    PHARO_PATCH="$(git describe --tags --first-parent --abbrev=1 | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 3-3)"
+    PHARO_MAJOR="$(git describe --tags --first-parent | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 1-1)"
+    PHARO_MINOR="$(git describe --tags --first-parent | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 2-2)"
+    PHARO_PATCH="$(git describe --tags --first-parent | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 3-3)"
 
 	# This will answer "Pharo7.0-PR"
 	PHARO_NAME_PREFIX="Pharo${PHARO_MAJOR}.${PHARO_MINOR}-${PHARO_SUFFIX}"


### PR DESCRIPTION
Update to fix `"abbrev=1"` in #16121 