### PR TITLE
Refactor: extract method transformation build transformations

### DIFF
--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -187,24 +187,6 @@ RBParserTest >> testBinarySelectors [
 ]
 
 { #category : 'tests' }
-RBParserTest >> testBlockNodeIsUsed [
-	| tree |
-	" block node is not a used-node"
-	tree := self parserClass parseMethod:
-			'tmp [ 3+4 ]'.
-	self deny: tree body statements last isUsed.
-	" even a block node with non-local return is not *used* "
-	tree := self parserClass parseMethod:
-	      'tmp [^ 3+4 ]'.
-	self deny: tree body statements last isUsed.
-
-	"an explicit return node is *used*"
-	tree := self parserClass parseMethod:
-			'tmp ^[ 3+4 ]'.
-	self assert: tree body statements last isUsed
-]
-
-{ #category : 'tests' }
 RBParserTest >> testBlockReturnNode [
 	| tree |
 	" no explicit return"
@@ -908,6 +890,34 @@ RBParserTest >> testIsA [
 			types add: each first ].
 	self treeWithEverything nodesDo: [ :each | types do: [ :sel | ((each respondsTo: sel) and: [ each perform: sel ]) ifTrue: [ nodes remove: sel ] ] ].
 	self assertEmpty: nodes
+]
+
+{ #category : 'tests - isUsed' }
+RBParserTest >> testIsUsedWhenABlockNodeIsReturnedExpectIsUsed [
+	| tree |
+	"an explicit return node is *used*"
+	tree := self parserClass parseMethod:
+			'tmp ^[ 3+4 ]'.
+	self assert: tree body statements last isUsed
+]
+
+{ #category : 'tests - isUsed' }
+RBParserTest >> testIsUsedWhenBlockAloneExpectIsNotUsed [
+	| tree |
+	" block node is not a used-node"
+	tree := self parserClass parseMethod:
+			'tmp [ 3+4 ]'.
+	self deny: tree body statements last isUsed.
+
+]
+
+{ #category : 'tests - isUsed' }
+RBParserTest >> testIsUsedWhenNonLocalReturnExpectNotUsed [
+	| tree |
+	" even a block node with non-local return is not *used* "
+	tree := self parserClass parseMethod:
+	      'tmp [^ 3+4 ]'.
+	self deny: tree body statements last isUsed.
 ]
 
 { #category : 'foreign use of test' }

--- a/src/AST-Core-Tests/RBParserTest.class.st
+++ b/src/AST-Core-Tests/RBParserTest.class.st
@@ -912,6 +912,19 @@ RBParserTest >> testIsUsedWhenBlockAloneExpectIsNotUsed [
 ]
 
 { #category : 'tests - isUsed' }
+RBParserTest >> testIsUsedWhenInAssignmentExpectIsUsed [
+	| tree |
+	"an explicit return node is *used*"
+	tree := self parserClass parseMethod:
+			'newMethod
+			| asdf |
+	asdf := OrderedCollection new.
+	asdf add: 1.
+	^ asdf.'.
+	self assert: tree body statements first value isUsed
+]
+
+{ #category : 'tests - isUsed' }
 RBParserTest >> testIsUsedWhenNonLocalReturnExpectNotUsed [
 	| tree |
 	" even a block node with non-local return is not *used* "

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -79,9 +79,10 @@ RBExtractMethodTransformation >> applicabilityPreconditions [
 ]
 
 { #category : 'executing' }
-RBExtractMethodTransformation >> buildTransformationFor: newMethodName withRemovedTemps: tempsToRemove [
+RBExtractMethodTransformation >> buildTransformationFor: newMethodName [
 
-	| needsReturn messageSend newArguments |
+	| needsReturn messageSend newArguments tempsToRemove |
+	tempsToRemove := self calculateTemporariesToRemove.
 	needsReturn := self calculateIfReturnIsNeeded.
 	newMethod := self generateNewMethodWith: newMethodName.
 	newArguments := self calculateNewArgumentsIn: newMethodName.
@@ -126,18 +127,10 @@ RBExtractMethodTransformation >> buildTransformations [
 					   in:
 					   (self definingClass methodFor: self calculateTree selector)) ]
 		ifNil: [
-		  | tempsToRemove |
-		  tempsToRemove := self calculateTemporariesToRemove.
-
-		  ^ assignments size > 1
-			  ifTrue: [ OrderedCollection new ]
-			  ifFalse: [
-				  | newMethodName |
-				  newMethodName := self newMethodName.
-				  newMethodName ifNil: [ OrderedCollection new ].
-				  self
-					  buildTransformationFor: newMethodName
-					  withRemovedTemps: tempsToRemove ] ]
+			  | newMethodName |
+			  newMethodName := self newMethodName.
+			  newMethodName ifNil: [ ^ OrderedCollection new ].
+			  ^ self buildTransformationFor: newMethodName ]
 ]
 
 { #category : 'querying' }

--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodAndOccurrencesCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodAndOccurrencesCommand.class.st
@@ -48,7 +48,7 @@ SycExtractMethodAndOccurrencesCommand >> defaultMenuIconName [
 
 { #category : 'accessing' }
 SycExtractMethodAndOccurrencesCommand >> defaultMenuItemName [
-	^ 'Extract method and occurances'
+	^ '(R) Extract method and occurrences'
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
These are three small changes lightly related to extract method:

- Cleanup extract method transformation's `buildTransformations`
- Clean `isUsed` tests and add new test for assignment