### PR TITLE
[Bug]: Workaround Read-Only Mac /tmp

### DIFF
--- a/src/FileSystem-Core/MacOSResolver.class.st
+++ b/src/FileSystem-Core/MacOSResolver.class.st
@@ -48,7 +48,12 @@ MacOSResolver >> systemLibrary [
 
 { #category : 'origins' }
 MacOSResolver >> temp [
-	^ '/tmp' asFileReference
+	"On OSX, which symlinks tmp, some versions make the link only-root-writable. See https://apple.stackexchange.com/questions/257753/osx-tmp-not-writable-operation-not-permitted"
+	| tmpLinkTarget |
+	tmpLinkTarget := '/private/tmp' asFileReference.
+	^ tmpLinkTarget exists
+		ifFalse: [ '/tmp' asFileReference ]
+		ifTrue: [ tmpLinkTarget ]
 ]
 
 { #category : 'origins' }


### PR DESCRIPTION
On OSX, which symlinks tmp, some versions make the link only-root-writable. Therefore, we check to see if the link target (/private/tmp) exists and if so, reference it directly.

For more details, see https://apple.stackexchange.com/questions/257753/osx-tmp-not-writable-operation-not-permitted