### PR TITLE
Fix hierarchical implementors bug

### DIFF
--- a/src/SystemCommands-MessageCommands/SycMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycMessageCommand.class.st
@@ -56,3 +56,23 @@ SycMessageCommand >> prepareFullExecutionInContext: aToolContext [
 
 	messages := aToolContext selectedMessages
 ]
+
+{ #category : 'accessing' }
+SycMessageCommand >> selectedClass [
+	"Answer the receiver's selected <Class>"
+
+	^ self selectedMessage methodClass
+]
+
+{ #category : 'accessing' }
+SycMessageCommand >> selectedMessage [
+	"Answer a <SycMessageDescription> describing the selected message"
+
+	^ self messages anyOne
+]
+
+{ #category : 'execution' }
+SycMessageCommand >> selectedSelector [
+
+	^ self selectedMessage selector
+]

--- a/src/SystemCommands-MessageCommands/SycShowLocalSendersCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycShowLocalSendersCommand.class.st
@@ -45,23 +45,3 @@ SycShowLocalSendersCommand >> searchInTheWholeHierarchy [
 		flatCollect: [ :class |
 			(class thoroughWhichMethodsReferTo: self selectedSelector) , (class class thoroughWhichMethodsReferTo: self selectedSelector) ].
 ]
-
-{ #category : 'accessing' }
-SycShowLocalSendersCommand >> selectedClass [
-	"Answer the receiver's selected <Class>"
-
-	^ self selectedMessage methodClass
-]
-
-{ #category : 'accessing' }
-SycShowLocalSendersCommand >> selectedMessage [
-	"Answer a <SycMessageDescription> describing the selected message"
-
-	^ self messages anyOne
-]
-
-{ #category : 'execution' }
-SycShowLocalSendersCommand >> selectedSelector [
-
-	^ self selectedMessage selector
-]

--- a/src/SystemCommands-MessageCommands/SycSuperclassImplementorsCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycSuperclassImplementorsCommand.class.st
@@ -1,6 +1,7 @@
 Class {
 	#name : 'SycSuperclassImplementorsCommand',
-	#superclass : 'SycChangeMessageSignatureCommand',
+	#superclass : 'SycMessageCommand',
+	#classTraits : '{} + TraitedClass',
 	#category : 'SystemCommands-MessageCommands',
 	#package : 'SystemCommands-MessageCommands'
 }
@@ -16,21 +17,31 @@ SycSuperclassImplementorsCommand >> defaultMenuIconName [
 
 { #category : 'accessing' }
 SycSuperclassImplementorsCommand >> defaultMenuItemName [
-	^'Hierarchical implementors'
+
+	^ 'Hierarchical implementors'
 ]
 
 { #category : 'execution' }
 SycSuperclassImplementorsCommand >> execute [
 
-	| sup |
-	sup := refactoredClass withAllSuperclasses 
-		detect: [ :cl | cl includesSelector: originalMessage selector ] 
-		ifNone: [ ^ self ].
-	Smalltalk tools messageList browse: { sup >> originalMessage selector }
+	Smalltalk tools messageList browse: self searchInTheWholeHierarchy.
 ]
 
 { #category : 'execution' }
 SycSuperclassImplementorsCommand >> isComplexRefactoring [
 
 	^ false
+]
+
+{ #category : 'execution' }
+SycSuperclassImplementorsCommand >> searchInTheWholeHierarchy [
+
+	| mthImplementors |
+	mthImplementors := OrderedCollection new.
+	self selectedClass withAllSuperAndSubclasses do: [ : class | 
+		(class includesSelector: self selectedSelector) 
+			ifTrue: [ mthImplementors add: class >> self selectedSelector ].
+		(class class includesSelector: self selectedSelector)
+			ifTrue: [ mthImplementors add: class class >> self selectedSelector ] ].
+	^ mthImplementors
 ]

--- a/src/SystemCommands-MessageCommands/SycSuperclassImplementorsCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycSuperclassImplementorsCommand.class.st
@@ -1,7 +1,6 @@
 Class {
 	#name : 'SycSuperclassImplementorsCommand',
 	#superclass : 'SycMessageCommand',
-	#classTraits : '{} + TraitedClass',
 	#category : 'SystemCommands-MessageCommands',
 	#package : 'SystemCommands-MessageCommands'
 }


### PR DESCRIPTION
This PR fixes the reported issue #16117 with the following changes:

- Subclass SycSuperclassImplementorsCommand from SycMessageCommand instead of SycChangeMessageSignatureCommand since this command is only about browsing, not applying refactoring.
- Pull up useful methods to SycMessageCommand.
- Add `searchInTheWholeHierarchy` method to collect hierarchical implementors, in the class and metaclass of selected method.

Video demo of the fix:

https://github.com/pharo-project/pharo/assets/4825959/19dd3f32-e214-47ba-a851-71f9a7d5c933


