### PR TITLE
#asUncommentedCode is deprecated, we can remove the test

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -548,14 +548,6 @@ StringTest >> testAsTime [
 ]
 
 { #category : 'tests' }
-StringTest >> testAsUncommentedCode [
-		self assert: '"abc"' asUncommentedCode equals: 'abc'.
-		self assert: '""' asUncommentedCode equals: ''.
-		self assert: '"Hello'' world"' asUncommentedCode equals: 'Hello'' world'.
-
-]
-
-{ #category : 'tests' }
 StringTest >> testAsUppercase [
 
 	self assert: ('éèàôütest' asUppercase) equals: 'ÉÈÀÔÜTEST'.


### PR DESCRIPTION
... less noise in the CI log