### PR TITLE
Feat: extract method source string api

### DIFF
--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -33,12 +33,31 @@ RBExtractMethodRefactoring class >> extract: anInterval from: aSelector in: aCla
 ]
 
 { #category : 'instance creation' }
+RBExtractMethodRefactoring class >> extractSource: aString from: aSelector in: aClass [ 
+
+	^ self new
+		extractSource: aString 
+		from: aSelector
+		in: aClass
+]
+
+{ #category : 'instance creation' }
 RBExtractMethodRefactoring class >> model: aRBSmalltalk extract: anInterval from: aSelector in: aClass [
 	^ self new
 		model: aRBSmalltalk;
 		extract: anInterval
 			from: aSelector
 			in: aClass;
+		yourself
+]
+
+{ #category : 'instance creation' }
+RBExtractMethodRefactoring class >> model: aRBSmalltalk extractSource: aString from: aSelector in: aClass [
+	^ self new
+		model: aRBSmalltalk;
+		extractSource: aString
+		from: aSelector
+		in: aClass;
 		yourself
 ]
 
@@ -227,6 +246,14 @@ RBExtractMethodRefactoring >> extractMethod [
 				onInterval: extractionInterval ]
 ]
 
+{ #category : 'instance creation' }
+RBExtractMethodRefactoring >> extractSource: aString from: aSelector in: aClass [ 
+
+	class := self classObjectFor: aClass.
+	selector := aSelector.
+	extractionInterval := self getIntervalForSource: aString
+]
+
 { #category : 'accessing' }
 RBExtractMethodRefactoring >> extractedParseTree [
 	^ extractedParseTree
@@ -240,6 +267,21 @@ RBExtractMethodRefactoring >> getExtractedSource [
 		and: [extractionInterval last between: 1 and: source size])
 			ifFalse: [self refactoringError: 'Invalid interval'].
 	^source copyFrom: extractionInterval first to: extractionInterval last
+]
+
+{ #category : 'transforming' }
+RBExtractMethodRefactoring >> getIntervalForSource: aString [
+	"I return interval where aString is situated in the `selector`"
+
+	| method expression searcher matchedNode |
+	method := class methodFor: selector.
+	expression := RBParser parseExpression: aString.
+
+	searcher := RBParseTreeSearcher new.
+	searcher matchesTree: expression do: [ :aNode :answer | aNode ].
+	matchedNode := searcher executeTree: method ast.
+	matchedNode ifNil: [ self refactoringError: 'Could not find given source in the method.' ].
+	^ matchedNode start to: matchedNode stop
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodAndOccurrencesTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodAndOccurrencesTest.class.st
@@ -1,9 +1,9 @@
 Class {
 	#name : 'RBExtractMethodAndOccurrencesTest',
 	#superclass : 'RBAbstractRefactoringTest',
-	#category : 'Refactoring-Transformations-Tests-SingleParametrized',
+	#category : 'Refactoring-Transformations-Tests-Test',
 	#package : 'Refactoring-Transformations-Tests',
-	#tag : 'SingleParametrized'
+	#tag : 'Test'
 }
 
 { #category : 'running' }

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodRefactoringTest.class.st
@@ -88,7 +88,10 @@ RBExtractMethodRefactoringTest >> testExtractMethodThatNeedsTemporaryVariable [
 { #category : 'tests' }
 RBExtractMethodRefactoringTest >> testExtractMethodToSuperclass [
 	| refactoring class |
-	refactoring := RBExtractMethodRefactoring extract: (143 to: 340) from: #checkMethod: in: RBTransformationRuleTestData.
+	refactoring := RBExtractMethodRefactoring extractSource: '(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false) ifFalse:
+		[builder compile: rewriteRule tree printString
+		in: class
+		classified: aSmalllintContext protocols]' from: #checkMethod: in: RBTransformationRuleTestData.
 	self setupMethodNameFor: refactoring toReturn: #foo:.
 	self setupExtractionClassFor: refactoring toReturn: RBFooLintRuleTestData.
 	self executeRefactoring: refactoring.

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodRefactoringTest.class.st
@@ -157,6 +157,18 @@ RBExtractMethodRefactoringTest >> testFailureExtract [
 ]
 
 { #category : 'failure tests' }
+RBExtractMethodRefactoringTest >> testFailureExtractMethodWhenGivenSourceIsNotInTheMethod [
+
+	self
+		should: [
+			RBExtractMethodRefactoring
+				extractSource: 'some source that is not from the method'
+				from: #subclassOf:overrides:
+				in: RBBasicLintRuleTestData class ]
+		raise: RBRefactoringError
+]
+
+{ #category : 'failure tests' }
 RBExtractMethodRefactoringTest >> testFailureNonExistantSelector [
 	self shouldFail: (RBExtractMethodRefactoring extract: (10 to: 20) from: #checkClass1: in: RBBasicLintRuleTestData)
 ]


### PR DESCRIPTION
Now it's possible to create an instance of extract method refactoring by adding it string of the source code you want to extract, whereas previously we had to use intervals.