### PR TITLE
Add exact commit and tag information in recorded metacello directives

### DIFF
--- a/src/Metacello-Core/MetacelloMonticelloLoader.class.st
+++ b/src/Metacello-Core/MetacelloMonticelloLoader.class.st
@@ -107,7 +107,7 @@ MetacelloMonticelloLoader >> lookupProjectClassNamed: aString [
 	^ Smalltalk at: aString asSymbol ifAbsent: [ nil ]
 ]
 
-{ #category : 'repositories' }
+{ #category : 'repository-resolution' }
 MetacelloMonticelloLoader >> repositoriesFrom: aMetacelloMVRepositorySpecs [
 
 	aMetacelloMVRepositorySpecs size = 1 ifTrue: [
@@ -116,4 +116,16 @@ MetacelloMonticelloLoader >> repositoriesFrom: aMetacelloMVRepositorySpecs [
 	^ MetacelloRepositoryGroup onRepositories:
 		  (aMetacelloMVRepositorySpecs collect: [ :aSpec |
 			   aSpec createRepository ])
+]
+
+{ #category : 'repository-resolution' }
+MetacelloMonticelloLoader >> resolveRepositorySpecs: aCollection [
+	"Return a resolved repository spec with a concrete commit id or tag"
+
+	| repository |
+	repository := self repositoriesFrom: aCollection.
+	aCollection first resolvedReference:
+		repository repositoryDescription , '('
+		, repository repositoryVersionString , ')'.
+	^ aCollection
 ]

--- a/src/Metacello-Core/MetacelloMonticelloLoader.class.st
+++ b/src/Metacello-Core/MetacelloMonticelloLoader.class.st
@@ -58,7 +58,7 @@ MetacelloMonticelloLoader >> loadAtomicPackageDirectives: packageDirectives [
 	packageDirectives do: [ :e |
 		MetacelloNotification signal:
 			'Loaded -> ' , e packageName , ' --- '
-			, e repositorySpecs first description ]
+			, e repositorySpecs first fullDescription ]
 ]
 
 { #category : 'loading' }

--- a/src/Metacello-Core/MetacelloPackageLoadDirective.class.st
+++ b/src/Metacello-Core/MetacelloPackageLoadDirective.class.st
@@ -37,7 +37,7 @@ MetacelloPackageLoadDirective >> hash [
 { #category : 'printing' }
 MetacelloPackageLoadDirective >> label [
 
-	^ spec name , ' -- ', repositorySpecs first description
+	^ spec name , ' -- ', repositorySpecs first fullDescription
 ]
 
 { #category : 'enumerating' }

--- a/src/Metacello-Core/MetacelloRecordTarget.class.st
+++ b/src/Metacello-Core/MetacelloRecordTarget.class.st
@@ -159,7 +159,7 @@ MetacelloRecordTarget >> visitVersionSpecChildren: aSpec [
 	aSpec resolveToLoadableSpecs: required map: packages.
 	
 	oldCurrentRepositorySpecs := currentRepositorySpecs.
-	currentRepositorySpecs := aSpec repositorySpecs.
+	currentRepositorySpecs := engine loader resolveRepositorySpecs: aSpec repositorySpecs.
 	packages := aSpec packageSpecsInLoadOrderForMap: packages.
 	
 	["Iterate the internals of the version spec"

--- a/src/Metacello-Core/MetacelloRepositorySpec.class.st
+++ b/src/Metacello-Core/MetacelloRepositorySpec.class.st
@@ -5,7 +5,8 @@ Class {
 		'description',
 		'username',
 		'password',
-		'type'
+		'type',
+		'resolvedReference'
 	],
 	#category : 'Metacello-Core-Specs',
 	#package : 'Metacello-Core',
@@ -70,6 +71,12 @@ MetacelloRepositorySpec >> description: aString [
 	description := aString
 ]
 
+{ #category : 'printing' }
+MetacelloRepositorySpec >> fullDescription [
+
+	^ resolvedReference ifNil: [ 'unresolved' ]
+]
+
 { #category : 'mc support' }
 MetacelloRepositorySpec >> hasNoLoadConflicts: aMetacelloRepositorySpec [
 
@@ -128,6 +135,12 @@ MetacelloRepositorySpec >> removeFromMetacelloRepositories: aMetacelloRepositori
 			name: self name;
 			spec: self;
 			yourself)
+]
+
+{ #category : 'accessing' }
+MetacelloRepositorySpec >> resolvedReference: aString [ 
+	
+	resolvedReference := aString
 ]
 
 { #category : 'querying' }


### PR DESCRIPTION
This PR adds commit and tag information in recorded metacello directives.
It is the best I can do at recording the downloaded versions from metacello without touching iceberg 🙂
I think I managed to do this without breaking any filetree/tonel support (without iceberg)

The rationale behind this is to be able to track exactly what was loaded for the following scenarios:
 - dependencies on floating branches
 - CI builds

The new record output looks like follows.
It's a bit verbose but it's useful.
Two things to notice from the example:
- that here I'm loading master from XMLParserHTML, yet metacello tells me exactly what it loaded
also.
- other dependencies are based on tags. The output provides all tags in addition of the commit SHAs.

This could be improved in the future with a short/lessverbose print. This would require touching iceberg a bit to access short commitishes from metacello integration. 

```
linear load : baseline [BaselineOfOrderPreservingDictionary]
    load : Collections-BitmapCharacterSet -- git@github.com:pharo-contributions/BitmapCharacterSet.git[1.2.7, 1.2.x](9400f95e97d61e575989162c8514dd8268b06980)
    load : Collections-OrderPreservingDictionary -- git@github.com:pharo-contributions/OrderPreservingDictionary.git[1.5.0, 1.5.x](480ff3d62be2722d4a5da8f2a074085dc9e38988)
    load : XML-Parser -- git@github.com:pharo-contributions/XML-XMLParser.git[3.5.0, 3.5.x](0effb9130748e417844886b3cb5992644757b206)
    load : Collections-BitmapCharacterSet-Tests -- git@github.com:pharo-contributions/BitmapCharacterSet.git[1.2.7, 1.2.x](9400f95e97d61e575989162c8514dd8268b06980)
(480ff3d62be2722d4a5da8f2a074085dc9e38988)
    load : XML-Parser-Tests -- git@github.com:pharo-contributions/XML-XMLParser.git[3.5.0, 3.5.x](0effb9130748e417844886b3cb5992644757b206)
    load : XML-Parser-Tests-Conformance -- git@github.com:pharo-contributions/XML-XMLParser.git[3.5.0, 3.5.x](0effb9130748e417844886b3cb5992644757b206)
    load : Collections-OrderPreservingDictionary-GTExtensions -- git@github.com:pharo-contributions/OrderPreservingDictionary.git[1.5.0, 1.5.x](480ff3d62be2722d4a5da8f2a074085dc9e38988)
    load : XML-Parser-GTExtensions -- git@github.com:pharo-contributions/XML-XMLParser.git[3.5.0, 3.5.x](0effb9130748e417844886b3cb5992644757b206)
    load : XML-ParserHTML-Core -- git@github.com:pharo-contributions/XML-XMLParserHTML.git[master](df3caea136ef358484287c7ee273fa10c3901aaa)
    load : XML-ParserHTML-Tests -- git@github.com:pharo-contributions/XML-XMLParserHTML.git[master](df3caea136ef358484287c7ee273fa10c3901aaa)
```