### PR TITLE
16153-AST-testIsClean-and-testHasNonLocalReturn-failing-and-more

### DIFF
--- a/src/AST-Core/RBArrayNode.class.st
+++ b/src/AST-Core/RBArrayNode.class.st
@@ -171,6 +171,14 @@ RBArrayNode >> isUsingAsReturnValue: aNode [
 	^ (statements anySatisfy: [ :each | each == aNode ]) or: [ self isUsedAsReturnValue ]
 ]
 
+{ #category : 'testing' }
+RBArrayNode >> lastIsReturn [
+
+	^ statements isEmpty
+		  ifTrue: [ false ]
+		  ifFalse: [ statements last lastIsReturn ]
+]
+
 { #category : 'accessing - token' }
 RBArrayNode >> left [
 	^ left


### PR DESCRIPTION
add back #lastIsReturn to RBArrayNode

fixes #16153 (but there are other failing tests not related to this)