### PR TITLE
Test for semantics of extract method transformation and additional code supporting it

### DIFF
--- a/src/AST-Core-Tests/RBProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/RBProgramNodeTest.class.st
@@ -644,6 +644,195 @@ RBProgramNodeTest >> testHasProperty [
 	self assert: (self node hasProperty: #foo)
 ]
 
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenBlockWithoutReturnExpectTrue [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							[ 2 ]'.
+	statement := ast body statements last.
+	self assert: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenMessageWithReturnBlockExpectFalse [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							instVar at: #foo ifAbsentPut: [ ^ 2 ]'.
+	statement := ast body statements last.
+	self deny: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenMessageWithoutReturnBlockExpectTrue [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							instVar at: #foo ifAbsentPut: [ 2 ]'.
+	statement := ast body statements last.
+	self assert: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenReturnNodeExpectTrue [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							^ 2'.
+	statement := ast body statements last.
+	self assert: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenReturnNodeWithAssignmentExpectTrue [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							^ a := 3'.
+	statement := ast body statements last.
+	self assert: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenReturnNodeWithMessageSendExpectTrue [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							^ self foo: 2'.
+	statement := ast body statements last.
+	self assert: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenReturnWithBlockAndSequenceWithNestedBlockWithoutReturnExpectTrue [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							^ [ self foo: [ :a | a + 1 ]. ^ 2 ]'.
+	statement := ast body statements last.
+	self assert: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenReturnWithBlockWithoutReturnExpectTrue [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							^ [ 2 ]'.
+	statement := ast body statements last.
+	self assert: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenReturnWithEmptyBlockExpectTrue [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							^ [ ]'.
+	statement := ast body statements last.
+	self assert: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenReturnWithMessageWithReturnBlockExpectTrue [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							^ instVar at: #foo ifAbsentPut: [ ^ 2 ]'.
+	statement := ast body statements last.
+	self assert: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenReturnWithMessageWithoutReturnBlockExpecTrue [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							^ instVar at: #foo ifAbsentPut: [ 2 ]'.
+	statement := ast body statements last.
+	self assert: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenReturnWithWhileFalseBlockWithReturnExpectFalse [
+
+	| ast statement |
+	ast := RBParser parseMethod: 'a1
+							[ ^ false ] whileFalse: [ true ]'.
+	statement := ast body statements last.
+	self deny: statement hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenSequenceWithLastReturnAndNonLocalReturnExpectTrue [
+
+	| ast sequence |
+	ast := RBParser parseMethod: 'a1
+							self foo.
+							instVar := true ifFalse: [ ^ 1 ].
+							instVar isOdd ifTrue: [ instVar := instVar + 1 ].
+							^ self end'.
+	sequence := RBSequenceNode statements: ast body statements allButFirst.
+	sequence parent: ast body.
+	self assert: sequence hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenSequenceWithLastReturnExpectTrue [
+
+	| ast sequence |
+	ast := RBParser parseMethod: 'a1
+							self foo.
+							instVar := true ifFalse: [ 1 ].
+							^ 2'.
+	sequence := RBSequenceNode statements: ast body statements allButFirst.
+	sequence parent: ast body.
+	self assert: sequence hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenSequenceWithoutAnyReturnsExpectTrue [
+
+	| ast sequence |
+	ast := RBParser parseMethod: 'a1
+							self foo.
+							instVar := true ifFalse: [ 1 ]
+							self end'.
+	sequence := RBSequenceNode statements: ast body statements allButFirst.
+	sequence parent: ast body.
+	self assert: sequence hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenSequenceWithoutLastReturnAndMultipleNonLocalReturnExpectFalse [
+
+	| ast sequence |
+	ast := RBParser parseMethod: 'a1
+							self foo.
+							[  instVar isOdd ifTrue: [ ^ 2 ]. 
+								instVar := instVar + 1] 
+								whileTrue: [ instVar < 10 ].
+							instVar := true ifFalse: [ ^ 1 ].
+							self end'.
+	sequence := RBSequenceNode statements: ast body statements allButLast.
+	sequence parent: ast body.
+	self deny: sequence hasSameExitPoint 
+]
+
+{ #category : 'tests - hasSameExitPoint' }
+RBProgramNodeTest >> testHasSameExitPointWhenSequenceWithoutLastReturnAndNonLocalReturnExpectFalse [
+
+	| ast sequence |
+	ast := RBParser parseMethod: 'a1
+							self foo.
+							instVar := true ifFalse: [ ^ 1 ]
+							self end'.
+	sequence := RBSequenceNode statements: ast body statements allButFirst.
+	sequence parent: ast body.
+	self deny: sequence hasSameExitPoint 
+]
+
 { #category : 'tests - isEssential' }
 RBProgramNodeTest >> testIsEssentialWhenFirstMessageInACascadeExpectFalse [
 

--- a/src/AST-Core-Tests/RBProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/RBProgramNodeTest.class.st
@@ -1094,13 +1094,13 @@ RBProgramNodeTest >> testIsUsedAsReturnValueWhenNodeIsAssignmentVariableExpectFa
 ]
 
 { #category : 'tests - isUsedAsReturnValue' }
-RBProgramNodeTest >> testIsUsedAsReturnValueWhenNodeIsLastInBlockExpectTrue [
+RBProgramNodeTest >> testIsUsedAsReturnValueWhenNodeIsLastInBlockExpectFalse [
 
 	| ast statement |
 	ast := RBParser parseMethod: 'a1
 	               [ self foo. self bar ]'.
 	statement := ast body statements first body statements second.
-	self assert: statement isUsedAsReturnValue 
+	self deny: statement isUsedAsReturnValue 
 ]
 
 { #category : 'tests - isUsedAsReturnValue' }

--- a/src/AST-Core-Tests/RBReturnNodeAdderVisitorTest.class.st
+++ b/src/AST-Core-Tests/RBReturnNodeAdderVisitorTest.class.st
@@ -1,0 +1,114 @@
+Class {
+	#name : 'RBReturnNodeAdderVisitorTest',
+	#superclass : 'RBParseTreeTest',
+	#category : 'AST-Core-Tests-Visitors',
+	#package : 'AST-Core-Tests',
+	#tag : 'Visitors'
+}
+
+{ #category : 'tests' }
+RBReturnNodeAdderVisitorTest >> testAddReturnWhenArrayExpectReturnAdded [
+
+	| expression visitor result expect |
+	expression := RBParser parseExpression: '{ x . ''a'' . #a }'.
+	visitor := RBReturnNodeAdderVisitor new.
+	result := visitor visit: expression.
+	
+	expect := RBParser parseExpression: '^ { x . ''a'' . #a }'.
+	self assert: result equals: expect
+]
+
+{ #category : 'tests' }
+RBReturnNodeAdderVisitorTest >> testAddReturnWhenAssignmentExpectReturnAdded [
+
+	| expression visitor result expect |
+	expression := RBParser parseExpression: 'a := self foo'.
+	visitor := RBReturnNodeAdderVisitor new.
+	result := visitor visit: expression.
+	
+	expect := RBParser parseExpression: '^ a := self foo'.
+	self assert: result equals: expect
+]
+
+{ #category : 'tests' }
+RBReturnNodeAdderVisitorTest >> testAddReturnWhenBlockExpectReturnAdded [
+
+	| expression visitor result expect |
+	expression := RBParser parseExpression: '[ a := self foo ]'.
+	visitor := RBReturnNodeAdderVisitor new.
+	result := visitor visit: expression.
+	
+	expect := RBParser parseExpression: '^ [ a := self foo ]'.
+	self assert: result equals: expect
+]
+
+{ #category : 'tests' }
+RBReturnNodeAdderVisitorTest >> testAddReturnWhenCascadeMessageExpectReturnAdded [
+
+	| expression visitor result expect |
+	expression := RBParser parseExpression: 'self foo; bar; end'.
+	visitor := RBReturnNodeAdderVisitor new.
+	result := visitor visit: expression.
+	
+	expect := RBParser parseExpression: '^ self foo; bar; end'.
+	self assert: result equals: expect
+]
+
+{ #category : 'tests' }
+RBReturnNodeAdderVisitorTest >> testAddReturnWhenLiteralExpectReturnAdded [
+
+	| expression visitor result expect |
+	expression := RBParser parseExpression: '1'.
+	visitor := RBReturnNodeAdderVisitor new.
+	result := visitor visit: expression.
+	
+	expect := RBParser parseExpression: '^ 1'.
+	self assert: result equals: expect
+]
+
+{ #category : 'tests' }
+RBReturnNodeAdderVisitorTest >> testAddReturnWhenMessageSendExpectReturnAdded [
+
+	| expression visitor result expect |
+	expression := RBParser parseExpression: 'self foo'.
+	visitor := RBReturnNodeAdderVisitor new.
+	result := visitor visit: expression.
+	
+	expect := RBParser parseExpression: '^ self foo'.
+	self assert: result equals: expect
+]
+
+{ #category : 'tests' }
+RBReturnNodeAdderVisitorTest >> testAddReturnWhenReturnNodeExpectNoChanges [
+
+	| expression visitor result |
+	expression := RBParser parseExpression: '^ 2'.
+	visitor := RBReturnNodeAdderVisitor new.
+	result := visitor visit: expression.
+	
+	self assert: expression equals: result
+]
+
+{ #category : 'tests' }
+RBReturnNodeAdderVisitorTest >> testAddReturnWhenSequenceExpectReturnAdded [
+
+	| expression visitor result expect |
+	expression := RBParser parseExpression: 'self foo. self bar'.
+	visitor := RBReturnNodeAdderVisitor new.
+	result := visitor visit: expression.
+	
+	expect := RBParser parseExpression: 'self foo. ^ self bar'.
+	self assert: result equals: expect
+]
+
+{ #category : 'tests' }
+RBReturnNodeAdderVisitorTest >> testAddReturnWhenVariableExpectReturnAdded [
+
+	| expression visitor result expect |
+	expression := RBParser parseExpression: 'x'.
+	visitor := RBReturnNodeAdderVisitor new.
+	result := visitor visit: expression.
+	
+	expect := RBParser parseExpression: '^ x'.
+	self assert: result equals: expect
+]

--- a/src/AST-Core/RBArrayNode.class.st
+++ b/src/AST-Core/RBArrayNode.class.st
@@ -128,6 +128,12 @@ RBArrayNode >> equalTo: anObject withMapping: aDictionary [
 	^ true
 ]
 
+{ #category : 'testing' }
+RBArrayNode >> hasBlock [
+
+	^ statements anySatisfy: [ :stm | stm hasBlock ]
+]
+
 { #category : 'comparing' }
 RBArrayNode >> hash [
 	^ self hashForCollection: self statements

--- a/src/AST-Core/RBAssignmentNode.class.st
+++ b/src/AST-Core/RBAssignmentNode.class.st
@@ -101,6 +101,12 @@ RBAssignmentNode >> hasBlock [
 	^ value hasBlock 
 ]
 
+{ #category : 'testing' }
+RBAssignmentNode >> hasSameExitPoint: aBoolean [ 
+
+	^ value hasSameExitPoint: aBoolean
+]
+
 { #category : 'comparing' }
 RBAssignmentNode >> hash [
 	^self variable hash bitXor: self value hash

--- a/src/AST-Core/RBAssignmentNode.class.st
+++ b/src/AST-Core/RBAssignmentNode.class.st
@@ -95,6 +95,12 @@ RBAssignmentNode >> equalTo: anObject withMapping: aDictionary [
 				and: [self value equalTo: anObject value withMapping: aDictionary]]
 ]
 
+{ #category : 'testing' }
+RBAssignmentNode >> hasBlock [
+
+	^ value hasBlock 
+]
+
 { #category : 'comparing' }
 RBAssignmentNode >> hash [
 	^self variable hash bitXor: self value hash

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -230,6 +230,18 @@ RBBlockNode >> hasBlockReturn [
 ]
 
 { #category : 'testing' }
+RBBlockNode >> hasSameExitPoint [
+
+	^ body hasSameExitPoint 
+]
+
+{ #category : 'testing' }
+RBBlockNode >> hasSameExitPoint: aBoolean [ 
+
+	^ body hasSameExitPoint: aBoolean 
+]
+
+{ #category : 'testing' }
 RBBlockNode >> hasTemporaries [
 
 	^ self temporaries isNotEmpty

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -217,6 +217,9 @@ RBBlockNode >> hasArguments [
 
 { #category : 'testing' }
 RBBlockNode >> hasBlockReturn [
+
+	self deprecated: 'This method is deprecated, don''t use it. Use on your own responsibility.'.
+
 	^ self body lastIsReturn
 ]
 

--- a/src/AST-Core/RBBlockNode.class.st
+++ b/src/AST-Core/RBBlockNode.class.st
@@ -216,6 +216,12 @@ RBBlockNode >> hasArguments [
 ]
 
 { #category : 'testing' }
+RBBlockNode >> hasBlock [
+
+	^ true
+]
+
+{ #category : 'testing' }
 RBBlockNode >> hasBlockReturn [
 
 	self deprecated: 'This method is deprecated, don''t use it. Use on your own responsibility.'.

--- a/src/AST-Core/RBCascadeNode.class.st
+++ b/src/AST-Core/RBCascadeNode.class.st
@@ -78,6 +78,13 @@ RBCascadeNode >> equalTo: anObject withMapping: aDictionary [
 	^true
 ]
 
+{ #category : 'testing' }
+RBCascadeNode >> hasBlock [
+
+	"They all have same receiver so we only check with the first one."
+	^ messages first hasBlock
+]
+
 { #category : 'comparing' }
 RBCascadeNode >> hash [
 	^ self hashForCollection: self messages

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -149,6 +149,13 @@ RBMessageNode >> hasBlock [
 	^ receiver hasBlock | (arguments anySatisfy: [ :arg | arg hasBlock ])
 ]
 
+{ #category : 'testing' }
+RBMessageNode >> hasSameExitPoint: aBoolean [
+
+	^ (receiver hasSameExitPoint: aBoolean )
+	& (arguments allSatisfy: [ :arg | arg hasSameExitPoint: aBoolean ])
+]
+
 { #category : 'comparing' }
 RBMessageNode >> hash [
 	^ (self receiver hash bitXor: self selector hash) bitXor: (self hashForCollection: self arguments)

--- a/src/AST-Core/RBMessageNode.class.st
+++ b/src/AST-Core/RBMessageNode.class.st
@@ -143,6 +143,12 @@ RBMessageNode >> equalTo: anObject withMapping: aDictionary [
 	^true
 ]
 
+{ #category : 'testing' }
+RBMessageNode >> hasBlock [
+
+	^ receiver hasBlock | (arguments anySatisfy: [ :arg | arg hasBlock ])
+]
+
 { #category : 'comparing' }
 RBMessageNode >> hash [
 	^ (self receiver hash bitXor: self selector hash) bitXor: (self hashForCollection: self arguments)

--- a/src/AST-Core/RBMethodNode.class.st
+++ b/src/AST-Core/RBMethodNode.class.st
@@ -347,6 +347,12 @@ RBMethodNode >> hasArguments [
 ]
 
 { #category : 'testing' }
+RBMethodNode >> hasBlock [
+
+	^ body hasBlock 
+]
+
+{ #category : 'testing' }
 RBMethodNode >> hasPragmaNamed: aSymbol [
 	self pragmaNamed: aSymbol ifAbsent: [ ^ false ].
 	^ true

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -558,6 +558,12 @@ RBProgramNode >> getCommentsFor: anInterval [
 ]
 
 { #category : 'testing' }
+RBProgramNode >> hasBlock [
+
+	^ false
+]
+
+{ #category : 'testing' }
 RBProgramNode >> hasComments [
 	"Answer whether the receiver as comments"
 

--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -592,6 +592,18 @@ RBProgramNode >> hasProperty: aKey [
 	^ properties isNotNil and: [ properties includesKey: aKey ]
 ]
 
+{ #category : 'testing' }
+RBProgramNode >> hasSameExitPoint [
+
+	^ self hasSameExitPoint: false
+]
+
+{ #category : 'testing' }
+RBProgramNode >> hasSameExitPoint: aBoolean [ 
+
+	^ true
+]
+
 { #category : 'comparing' }
 RBProgramNode >> hashForCollection: aCollection [
 	^ aCollection isEmpty ifTrue: [ 0 ] ifFalse: [ aCollection first hash ]

--- a/src/AST-Core/RBReturnNode.class.st
+++ b/src/AST-Core/RBReturnNode.class.st
@@ -75,6 +75,18 @@ RBReturnNode >> hasBlock [
 	^ value hasBlock 
 ]
 
+{ #category : 'testing' }
+RBReturnNode >> hasSameExitPoint [
+
+	^ true
+]
+
+{ #category : 'testing' }
+RBReturnNode >> hasSameExitPoint: aBoolean [
+
+	^ value hasSameExitPoint: aBoolean 
+]
+
 { #category : 'comparing' }
 RBReturnNode >> hash [
 	^self value hash

--- a/src/AST-Core/RBReturnNode.class.st
+++ b/src/AST-Core/RBReturnNode.class.st
@@ -69,6 +69,12 @@ RBReturnNode >> equalTo: anObject withMapping: aDictionary [
 		and: [self value equalTo: anObject value withMapping: aDictionary]
 ]
 
+{ #category : 'testing' }
+RBReturnNode >> hasBlock [
+
+	^ value hasBlock 
+]
+
 { #category : 'comparing' }
 RBReturnNode >> hash [
 	^self value hash

--- a/src/AST-Core/RBReturnNodeAdderVisitor.class.st
+++ b/src/AST-Core/RBReturnNodeAdderVisitor.class.st
@@ -1,0 +1,66 @@
+"
+I am a visitor that wraps a node in a return node. If the node is sequence it will wrap the last statement in a return.
+"
+Class {
+	#name : 'RBReturnNodeAdderVisitor',
+	#superclass : 'RBProgramNodeVisitor',
+	#category : 'AST-Core-Visitors',
+	#package : 'AST-Core',
+	#tag : 'Visitors'
+}
+
+{ #category : 'visiting' }
+RBReturnNodeAdderVisitor >> visitArrayNode: aNode [
+
+	^ RBReturnNode value: aNode
+]
+
+{ #category : 'visiting' }
+RBReturnNodeAdderVisitor >> visitAssignmentNode: aNode [
+
+	^ RBReturnNode value: aNode
+]
+
+{ #category : 'visiting' }
+RBReturnNodeAdderVisitor >> visitBlockNode: aNode [
+
+	^ RBReturnNode value: aNode
+]
+
+{ #category : 'visiting' }
+RBReturnNodeAdderVisitor >> visitCascadeNode: aNode [
+
+	^ RBReturnNode value: aNode
+]
+
+{ #category : 'visiting' }
+RBReturnNodeAdderVisitor >> visitLiteralNode: aNode [
+
+	^ RBReturnNode value: aNode
+]
+
+{ #category : 'visiting' }
+RBReturnNodeAdderVisitor >> visitMessageNode: aNode [
+
+	^ RBReturnNode value: aNode
+]
+
+{ #category : 'visiting' }
+RBReturnNodeAdderVisitor >> visitReturnNode: aNode [
+
+	^ aNode
+]
+
+{ #category : 'visiting' }
+RBReturnNodeAdderVisitor >> visitSequenceNode: aNode [
+
+	"Add return returns the newly added return node, but nobody uses it"
+	aNode addReturn.
+	^ aNode 
+]
+
+{ #category : 'visiting' }
+RBReturnNodeAdderVisitor >> visitVariableNode: aNode [
+
+	^ RBReturnNode value: aNode
+]

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -283,6 +283,12 @@ RBSequenceNode >> equalTo: anObject withMapping: aDictionary [
 ]
 
 { #category : 'testing' }
+RBSequenceNode >> hasBlock [
+
+	^ statements anySatisfy: [ :stm | stm hasBlock ]
+]
+
+{ #category : 'testing' }
 RBSequenceNode >> hasNonLocalReturn [
 	"check if there is a non-local return anywhere
 	Note: returns in a method itself are local returns"

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -298,6 +298,24 @@ RBSequenceNode >> hasNonLocalReturn [
 ]
 
 { #category : 'testing' }
+RBSequenceNode >> hasSameExitPoint [
+
+	statements last isReturn ifTrue: [ ^ true ].
+	^ self hasSameExitPoint: false
+]
+
+{ #category : 'testing' }
+RBSequenceNode >> hasSameExitPoint: aBoolean [ 
+
+	| statementsWithBlocks |
+	aBoolean ifTrue: [ ^ true ].
+	statements ifEmpty: [ ^ true ].
+	statementsWithBlocks := statements select: [ :stm | stm hasBlock ].
+	^ (statements last isReturn not and: [
+		statementsWithBlocks allSatisfy: [ :stm | stm hasSameExitPoint: false ] ]).
+]
+
+{ #category : 'testing' }
 RBSequenceNode >> hasTemporaries [
 
 	^ temporaries isNotEmpty

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -98,6 +98,8 @@ RBExtractMethodRefactoring >> checkReturn [
 	needsReturn := self placeholderNode isUsedAsReturnValue.
 	extractedParseTree containsReturn ifFalse: [^self].
 	extractedParseTree lastIsReturn ifTrue: [^self].
+	"Since we have a return that is not last in the extracted tree,
+	extraction is only possible if the modified method's last statement is being extracted"
 	(modifiedParseTree isLast: self placeholderNode)
 		ifFalse:
 			[self refactoringError: 'Couldn''t extract code since it contains a return.'].

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -82,6 +82,56 @@ self
 ]
 
 { #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testExtractClassFromAssignmentExpectExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'ReClassForTesting' 
+fromSource: 'm 
+		| temp |
+		temp := ReClassForTesting'
+withNewSelector: #extractedMethod.
+	transformation generateChanges.
+	
+self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					^ ReClassForTesting').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm 
+				| temp | 
+				temp := self extractedMethod')
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testExtractSequenceEndingWithReturnExpectExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'self bar. ^ self end.' 
+fromSource: 'm 
+		self foo.
+		self bar.
+		^ self end'
+withNewSelector: #extractedMethod.
+	transformation generateChanges.
+	
+self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					self bar. 
+					^ self end').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm 
+				self foo. 
+				^ self extractedMethod')
+]
+
+{ #category : 'tests' }
 ReSemanticsOfExtractMethodTransformationTest >> testMiddleExpressionsOfASequenceGotExtracted [
 
 	| transformation |

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -36,7 +36,7 @@ ReSemanticsOfExtractMethodTransformationTest >> setUp [
 	class := model classNamed: 'ReClassForTesting'
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'tests' }
 ReSemanticsOfExtractMethodTransformationTest >> testMiddleExpressionsOfASequenceGotExtracted [
 
 	| transformation |
@@ -58,7 +58,7 @@ self
 		equals: (self parseMethod: 'm self foo. self extractedMethod. self end')
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'tests' }
 ReSemanticsOfExtractMethodTransformationTest >> testTwoLastExpressionsOfASequenceGotExtracted [
 
 	| transformation |

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -32,6 +32,7 @@ ReSemanticsOfExtractMethodTransformationTest >> setUp [
 		aBuilder
 			superclass: Object;
 			name: #ReClassForTesting;
+			slots: { #instVar };
 			package: 'Refactoring-DataForTesting'].
 	class := model classNamed: 'ReClassForTesting'
 ]

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -37,6 +37,50 @@ ReSemanticsOfExtractMethodTransformationTest >> setUp [
 ]
 
 { #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testBeginningExpressionsOfASequenceGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'self foo. self bar.' 
+fromSource: 'm 
+		self foo.
+		self bar.
+		self end'
+withNewSelector: #extractedMethod.
+	transformation generateChanges.
+	
+self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod self foo. self bar.').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm self extractedMethod. self end')
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testCompleteSequenceGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'self foo. self bar. self end' 
+fromSource: 'm 
+		self foo.
+		self bar.
+		self end'
+withNewSelector: #extractedMethod.
+	transformation generateChanges.
+	
+self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod self foo. self bar. self end').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm self extractedMethod')
+]
+
+{ #category : 'tests' }
 ReSemanticsOfExtractMethodTransformationTest >> testMiddleExpressionsOfASequenceGotExtracted [
 
 	| transformation |

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -83,7 +83,7 @@ RBExtractMethodTransformation >> buildTransformationFor: newMethodName [
 
 	| needsReturn messageSend newArguments tempsToRemove |
 	tempsToRemove := self calculateTemporariesToRemove.
-	needsReturn := self calculateIfReturnIsNeeded.
+	needsReturn := self calculateIfReturnIsNeededInCaller.
 	newMethod := self generateNewMethodWith: newMethodName.
 	newArguments := self calculateNewArgumentsIn: newMethodName.
 	messageSend := self
@@ -171,7 +171,7 @@ RBExtractMethodTransformation >> calculateAssignments [
 ]
 
 { #category : 'querying' }
-RBExtractMethodTransformation >> calculateIfReturnIsNeeded [
+RBExtractMethodTransformation >> calculateIfReturnIsNeededInCaller [
 
 	| searcher |
 	searcher := self parseTreeSearcher.


### PR DESCRIPTION
This PR introduces a couple of changes:

- few new tests for extract method transformation
- small cleanup of transformation
- deprecate `hasBlockReturn`
- fix failing test for `isUsedAsReturnValue`
- new method in AST `hasSameExitPoint` needed for validating extract method refactoring selection
- visitor for wrapping/adding a node with a return node

The PR might be big, but most of the changes are tests for visitor and transformation and the visitor itself.