### PR TITLE
Replace $r key combination in method editor pane

### DIFF
--- a/src/Calypso-SystemTools-Core/SycSuperclassImplementorsCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycSuperclassImplementorsCommand.extension.st
@@ -24,5 +24,7 @@ SycSuperclassImplementorsCommand class >> sourceCodeMenuActivation [
 SycSuperclassImplementorsCommand class >> sourceCodeShortcutActivation [
 	<classAnnotation>
 
-	^CmdShortcutActivation renamingFor: ClyMethodSourceCodeContext
+	^ CmdShortcutActivation 
+		by: $y meta
+		for: ClyMethodSourceCodeContext
 ]


### PR DESCRIPTION
As reported in #16127, this PR unbinds the "Meta + R" key combination in the method browser to the "browse superclass implementor" action. The action was re-bind as "Meta + Y".

Note that this PR does not create a new action or command to rename whatever is under (or left to) the cursor. IMO that would be better to do it in another PR because I checked and the "Meta + R" action depends of the node kind under the cursor and right now is only working for renaming temporaries.

