### PR TITLE
Make addReturn answer the receiver

### DIFF
--- a/src/AST-Core-Tests/RBProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/RBProgramNodeTest.class.st
@@ -156,7 +156,8 @@ RBProgramNodeTest >> testAddReturn [
 	| tree return existingReturn lastStatement |
 	tree := self parseExpression: '1. 2'.
 	lastStatement := tree statements last.
-	return := tree addReturn.
+	tree addReturn.
+	return := tree statements last.
 	self assert: return start equals: lastStatement start.
 	self assert: return value equals: lastStatement.
 	self assert: tree statements last equals: return.
@@ -164,7 +165,8 @@ RBProgramNodeTest >> testAddReturn [
 
 	tree := self parseExpression: '3. ^ 4'.
 	existingReturn := tree statements last.
-	return := tree addReturn.
+	tree addReturn.
+	return := tree statements last.
 	self assert: return identicalTo: existingReturn.
 	self assert: tree statements last equals: return.
 	self assert: (self parseExpression: '3. ^ 4') equals: tree

--- a/src/AST-Core/RBSequenceNode.class.st
+++ b/src/AST-Core/RBSequenceNode.class.st
@@ -163,6 +163,7 @@ RBSequenceNode >> addNodesFirst: aCollection [
 { #category : 'adding nodes' }
 RBSequenceNode >> addReturn [
 	| node |
+
 	statements isEmpty
 		ifTrue: [ ^ nil ].
 	statements last isReturn
@@ -170,7 +171,7 @@ RBSequenceNode >> addReturn [
 	node := RBReturnNode start: statements last start value: statements last.
 	statements at: statements size put: node.
 	node parent: self.
-	^ node
+
 ]
 
 { #category : 'adding nodes' }


### PR DESCRIPTION
As reported in #16166, this small PR makes `addReturn` method to answer the receiver (RBSequenceNode) instead of the last node. It also adapt the testAddReturn which was the sole user of this method return.
