### PR TITLE
Refactor: extract method transformation improvements

### DIFF
--- a/src/Refactoring-Core/ReRemoveUnusedTemporaryVariableRefactoring.class.st
+++ b/src/Refactoring-Core/ReRemoveUnusedTemporaryVariableRefactoring.class.st
@@ -1,0 +1,50 @@
+"
+I am a refactoring that removes all unused temporary variables from a method.
+"
+Class {
+	#name : 'ReRemoveUnusedTemporaryVariableRefactoring',
+	#superclass : 'RBRefactoring',
+	#instVars : [
+		'selector',
+		'class',
+		'parseTree'
+	],
+	#category : 'Refactoring-Core-Refactorings',
+	#package : 'Refactoring-Core',
+	#tag : 'Refactorings'
+}
+
+{ #category : 'instance creation' }
+ReRemoveUnusedTemporaryVariableRefactoring class >> model: aRBNamespace inMethod: aSelector inClass: className [ 
+	
+	^ self new
+		model: aRBNamespace;
+		inMethod: aSelector
+		inClass: className
+]
+
+{ #category : 'initialization' }
+ReRemoveUnusedTemporaryVariableRefactoring >> inMethod: aSelector inClass: className [
+
+	selector := aSelector asSymbol.
+	class := self model classNamed: className
+]
+
+{ #category : 'transforming' }
+ReRemoveUnusedTemporaryVariableRefactoring >> prepareForExecution [ 
+
+	parseTree := class parseTreeForSelector: selector
+]
+
+{ #category : 'transforming' }
+ReRemoveUnusedTemporaryVariableRefactoring >> privateTransform [
+
+	| unusedTemps |
+	unusedTemps := parseTree allTemporaryVariables reject: [ :temp | parseTree references: temp ].
+	unusedTemps do: [ :temp |
+		(RBRemoveTemporaryVariableTransformation
+			model: self model
+			variable: temp
+			inMethod: selector
+			inClass: class) generateChanges ]
+]

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -128,7 +128,7 @@ RBExtractMethodTransformationTest >> testFailureWhenTemporaryReadBeforeWritten [
 			temp := bar * bar.'
 				 from: #foo
 				 to: #foobar
-				 in: class) generateChanges ]
+				 in: class name) generateChanges ]
 		raise: RBRefactoringError
 ]
 
@@ -187,7 +187,7 @@ RBExtractMethodTransformationTest >> testTransform [
 							temp := bar * bar.
 							Transcript show: temp printString; cr'
 		                   from: #foo
-		                   to: #foobar
+		                   to: #extractedMethod
 		                   in: self changeMockClass name) generateChanges.
 
 	self assert: transformation model changes changes size equals: 4.
@@ -197,11 +197,11 @@ RBExtractMethodTransformationTest >> testTransform [
 		assert: (class parseTreeForSelector: #foo)
 		equals: (self parseMethod: 'foo
 													| temp |
-													temp := self foobar.
+													temp := self extractedMethod.
 													^temp * temp').
 	self
-		assert: (class parseTreeForSelector: #foobar)
-		equals: (self parseMethod: 'foobar
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod
 													| temp bar |
 													bar := 5.
 													temp := bar * bar.
@@ -295,7 +295,7 @@ RBExtractMethodTransformationTest >> testWithTemporariesSelected [
 		                extract: '| temp | temp := 5. temp * temp'
 		                from: #foo
 		                to: #foobar
-		                in: class) generateChanges.
+		                in: class name) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 4.
 	self
@@ -329,7 +329,7 @@ RBExtractMethodTransformationTest >> testWithTemporaryAssigned [
 			Transcript show: temp printString; cr.'
 		                from: #foo
 		                to: #foobar
-		                in: class) generateChanges.
+		                in: class name) generateChanges.
 
 	self assert: refactoring model changes changes size equals: 4.
 	self

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -161,7 +161,7 @@ RBExtractMethodTransformationTest >> testNeedsReturn [
 		assert: (class parseTreeForSelector: #foo:)
 		equals: (self parseMethod: 'foo: rules
 				rules isEmpty ifTrue: [^self].
-				rules size == 1 ifTrue: [^rules first viewResults]')
+				^ rules size == 1 ifTrue: [^rules first viewResults]')
 ]
 
 { #category : 'tests' }
@@ -240,7 +240,7 @@ RBExtractMethodTransformationTest >> testWhenTemporaryVariableBecomesArgumentOfE
 					nameStream nextPutAll: self name;
 								nextPutAll: '' (''.
 					self problemCount printOn: nameStream.
-					nameStream nextPut: $).')
+					^ nameStream nextPut: $).')
 ]
 
 { #category : 'tests' }
@@ -273,7 +273,7 @@ RBExtractMethodTransformationTest >> testWithArgument [
 	self
 		assert: (class parseTreeForSelector: #foo:)
 		equals: (self parseMethod: 'foo: aSmalllintContext
-					(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
+					^ (RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 						ifFalse:
 							[builder compile: rewriteRule tree printString
 										in: class

--- a/src/Refactoring-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveTemporaryVariableTransformationTest.class.st
@@ -6,7 +6,7 @@ Class {
 	#tag : 'Test'
 }
 
-{ #category : 'tests' }
+{ #category : 'tests - failures' }
 RBRemoveTemporaryVariableTransformationTest >> testClassDoesNotExist [
 
 	self shouldFail: (RBRemoveTemporaryVariableTransformation
@@ -15,45 +15,13 @@ RBRemoveTemporaryVariableTransformationTest >> testClassDoesNotExist [
 			 inClass: #RBTemporaryVariableTransformationTest)
 ]
 
-{ #category : 'tests' }
+{ #category : 'tests - failures' }
 RBRemoveTemporaryVariableTransformationTest >> testMethodDoesNotExist [
 
 	self shouldFail: (RBRemoveTemporaryVariableTransformation
 			 variable: 'temp'
 			 inMethod: #foofoo
 			 inClass: #RBRemoveTemporaryVariableTransformationTest)
-]
-
-{ #category : 'tests' }
-RBRemoveTemporaryVariableTransformationTest >> testRefactoring [
-
-	| refactoring class |
-	refactoring := (RBAddMethodTransformation
-		                sourceCode: 'foo
-										| temp bar |
-										bar := 5.
-										temp := bar * bar.
-										Transcript show: temp printString; cr.
-										^temp * temp'
-		                in: #RBRemoveTemporaryVariableTransformationTest
-		                withProtocol: #accessing ) generateChanges.
-
-	refactoring := (RBRemoveTemporaryVariableTransformation
-		                model: refactoring model
-		                variable: 'temp'
-		                inMethod: #foo
-		                inClass:
-		                #RBRemoveTemporaryVariableTransformationTest)
-		               generateChanges.
-
-	self assert: refactoring model changes changes size equals: 2.
-
-	class := refactoring model classNamed:
-		         #RBRemoveTemporaryVariableTransformationTest.
-	self assert: (class directlyDefinesMethod: #foo).
-	self
-		assert: (class parseTreeForSelector: #foo) temporaries size
-		equals: 1
 ]
 
 { #category : 'tests' }
@@ -80,13 +48,13 @@ RBRemoveTemporaryVariableTransformationTest >> testTransform [
 	self assert: transformation model changes changes size equals: 2.
 
 	class := transformation model classNamed: self changeMockClass name.
-	self assert: (class directlyDefinesMethod: #one).
+	self assert: (class directlyDefinesMethod: #foo).
 	self
 		assert: (class parseTreeForSelector: #foo) temporaries size
 		equals: 1
 ]
 
-{ #category : 'tests' }
+{ #category : 'tests - failures' }
 RBRemoveTemporaryVariableTransformationTest >> testVariableDoesNotExist [
 
 	self shouldFail: (RBRemoveTemporaryVariableTransformation

--- a/src/Refactoring-Transformations-Tests/ReRemoveUnusedTemporaryVariableRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReRemoveUnusedTemporaryVariableRefactoringTest.class.st
@@ -1,0 +1,83 @@
+Class {
+	#name : 'ReRemoveUnusedTemporaryVariableRefactoringTest',
+	#superclass : 'RBAbstractTransformationTest',
+	#instVars : [
+		'class'
+	],
+	#category : 'Refactoring-Transformations-Tests-Test',
+	#package : 'Refactoring-Transformations-Tests',
+	#tag : 'Test'
+}
+
+{ #category : 'running' }
+ReRemoveUnusedTemporaryVariableRefactoringTest >> setUp [
+
+	| package |
+	super setUp.
+	package := RBPackageEnvironment packageName: 'Refactoring-DataForTesting'.
+	model := RBNamespace onEnvironment: package.
+	model defineClass: [ :aBuilder | 
+		aBuilder
+			superclass: Object;
+			name: #ReClassForTesting;
+			slots: { #instVar };
+			package: 'Refactoring-DataForTesting'].
+	class := model classNamed: 'ReClassForTesting'
+]
+
+{ #category : 'tests' }
+ReRemoveUnusedTemporaryVariableRefactoringTest >> testRemoveUnusedTempsWhenAllUnusedTempsExpectAllTempsRemoved [
+
+	| source refactoring parseTree |
+	source := 'm
+	| one two |
+	^ 1'.
+	class compile: source classified: '#test data'.
+	
+	refactoring := ReRemoveUnusedTemporaryVariableRefactoring model: model inMethod: #m inClass: class name.
+	refactoring generateChanges.
+	
+	parseTree := class parseTreeForSelector: #m.
+	
+	self assert: parseTree allTemporaryVariables size equals: 0.
+	self
+		assert: parseTree
+		equals: (self parseMethod: 'm ^ 1')
+]
+
+{ #category : 'tests' }
+ReRemoveUnusedTemporaryVariableRefactoringTest >> testRemoveUnusedTempsWhenNoUnusedTempsExpectNothingIsRemoved [
+
+	| source refactoring parseTree |
+	source := 'm
+	| one two |
+	one := 1.
+	two := 2.
+	^ one + two'.
+	class compile: source classified: '#test data'.
+	
+	refactoring := ReRemoveUnusedTemporaryVariableRefactoring model: model inMethod: #m inClass: class name.
+	refactoring generateChanges.
+	
+	parseTree := class parseTreeForSelector: #m.
+	
+	self assert: parseTree allTemporaryVariables size equals: 2
+]
+
+{ #category : 'tests' }
+ReRemoveUnusedTemporaryVariableRefactoringTest >> testRemoveUnusedTempsWhenOneUnusedTempsExpectTempIsRemoved [
+
+	| source refactoring parseTree |
+	source := 'm
+	| one two |
+	one := 1.
+	^ one'.
+	class compile: source classified: '#test data'.
+	
+	refactoring := ReRemoveUnusedTemporaryVariableRefactoring model: model inMethod: #m inClass: class name.
+	refactoring generateChanges.
+	
+	parseTree := class parseTreeForSelector: #m.
+	
+	self assert: parseTree allTemporaryVariables size equals: 1
+]

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -155,6 +155,51 @@ self
 ]
 
 { #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testMultipleTempAssignmentWithReferencesAfterExtractedCodeExpectFailure [
+
+	| transformation |
+	transformation := self 
+extractSource: 'a := 2. b := self foo: 8.' 
+fromSource: 'm 
+		| a b |
+		a := 2.
+		b := self foo: 8.
+		^ a + b'
+withNewSelector: #extractedMethod.
+
+	self should: [ transformation generateChanges ]
+		raise: RBRefactoringError
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testMultipleTempAssignmentWithoutReferencesAfterExtractedCodeExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'a := 2. b := self foo: 8.' 
+fromSource: 'm 
+		| a b |
+		a := 2.
+		b := self foo: 8.
+		self end'
+withNewSelector: #extractedMethod.
+	transformation generateChanges.
+	
+self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					| a b |
+					a := 2. 
+					^ b := self foo: 8').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm
+				self extractedMethod.
+				self end')
+]
+
+{ #category : 'tests' }
 ReSemanticsOfExtractMethodTransformationTest >> testTempAssignmentAndReferenceAfterExtractedCodeExpectGotExtracted [
 
 	| transformation |

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -155,6 +155,88 @@ self
 ]
 
 { #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testTempAssignmentAndReferenceAfterExtractedCodeExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'a := 2. self foo: a.' 
+fromSource: 'm 
+		| a |
+		a := 2.
+		self foo: a.
+		self end: a'
+withNewSelector: #extractedMethod.
+	transformation generateChanges.
+	
+self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					| a |
+					a := 2. 
+					self foo: a.
+					^ a').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm
+				| a |
+				a := self extractedMethod.
+				self end: a')
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testTempAssignmentAndReferenceExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'a := 2. self foo: a' 
+fromSource: 'm 
+		| a |
+		a := 2.
+		self foo: a'
+withNewSelector: #extractedMethod.
+	transformation generateChanges.
+	
+self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					| a |
+					a := 2. 
+					^ self foo: a').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm
+				self extractedMethod')
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testTempAssignmentAndReturnWithTempReferenceExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'a := 2. ^ self foo: a.' 
+fromSource: 'm 
+		| a |
+		a := 2.
+		^ self foo: a'
+withNewSelector: #extractedMethod.
+	transformation generateChanges.
+	
+self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					| a |
+					a := 2. 
+					^ self foo: a').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm
+				^ self extractedMethod')
+]
+
+{ #category : 'tests' }
 ReSemanticsOfExtractMethodTransformationTest >> testTwoLastExpressionsOfASequenceGotExtracted [
 
 	| transformation |

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -155,6 +155,37 @@ self
 ]
 
 { #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testMultipleTempAssignmentWithOneReferencedAfterExtractedCodeExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'a := 2. b := self foo: 8.' 
+fromSource: 'm 
+		| a b |
+		a := 2.
+		b := self foo: 8.
+		^ a'
+withNewSelector: #extractedMethod.
+
+	transformation generateChanges.
+
+	self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					| a b |
+					a := 2. 
+					b := self foo: 8.
+					^ a').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm
+				| a |
+				a := self extractedMethod.
+				^ a')
+]
+
+{ #category : 'tests - failures' }
 ReSemanticsOfExtractMethodTransformationTest >> testMultipleTempAssignmentWithReferencesAfterExtractedCodeExpectFailure [
 
 	| transformation |

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -15,10 +15,11 @@ ReSemanticsOfExtractMethodTransformationTest >> extractSource: sourceToExtract f
 	class compile: source classified: '#test data'.
 
 	^ RBExtractMethodTransformation new
+		  model: model;
 		  extractSource: sourceToExtract
 		  fromMethodSource: source
 		  to: newSelector
-		  in: class
+		  in: class name
 ]
 
 { #category : 'set up' }

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -22,7 +22,7 @@ ReSemanticsOfExtractMethodTransformationTest >> extractSource: sourceToExtract f
 		  in: class name
 ]
 
-{ #category : 'set up' }
+{ #category : 'running' }
 ReSemanticsOfExtractMethodTransformationTest >> setUp [
 
 	| package |
@@ -234,6 +234,28 @@ self
 		equals: (self parseMethod: 'm 
 				self foo. 
 				^ self extractedMethod')
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testExtractSuperExpectExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'super' 
+fromSource: 'm 
+		^ super someMethod'
+withNewSelector: #extractedMethod.
+	transformation generateChanges.
+	
+self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					^ super').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm 
+				^ self extractedMethod someMethod')
 ]
 
 { #category : 'tests' }

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -33,9 +33,67 @@ ReSemanticsOfExtractMethodTransformationTest >> setUp [
 		aBuilder
 			superclass: Object;
 			name: #ReClassForTesting;
-			slots: { #instVar };
+			slots: { #instVar . #instVar2 };
 			package: 'Refactoring-DataForTesting'].
 	class := model classNamed: 'ReClassForTesting'
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testArgumentIsNotUsedInExtractedCodeExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'a := instVar + 1' 
+fromSource: 'm: arg
+		| a |
+		a := instVar + 1.
+		^ a'
+withNewSelector: #extractedMethod.
+
+	transformation generateChanges.
+
+	self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					| a |
+					a := instVar + 1.
+					^ a').
+		
+	self 
+		assert: (class parseTreeForSelector: #m:)
+		equals: (self parseMethod: 'm: arg
+				| a |
+				a := self extractedMethod.
+				^ a')
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testArgumentUsedInExtractedCodeExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'a := arg + 1' 
+fromSource: 'm: arg
+		| a |
+		a := arg + 1.
+		^ a'
+withNewSelector: #extractedMethod:.
+
+	transformation generateChanges.
+
+	self 
+		assert: (class parseTreeForSelector: #extractedMethod:)
+		equals: (self parseMethod: 'extractedMethod: arg 
+					| a |
+					a := arg + 1.
+					^ a').
+		
+	self 
+		assert: (class parseTreeForSelector: #m:)
+		equals: (self parseMethod: 'm: arg
+				| a |
+				a := self extractedMethod: arg.
+				^ a')
 ]
 
 { #category : 'tests' }
@@ -107,6 +165,52 @@ self
 ]
 
 { #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testExtractClassFromMessageExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'RBParser' 
+fromSource: 'm
+		instVar := RBParser parseMethod: foo'
+withNewSelector: #extractedMethod.
+
+	transformation generateChanges.
+
+	self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					^ RBParser').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm
+				instVar := self extractedMethod parseMethod: foo')
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testExtractLiteralExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: '42' 
+fromSource: 'm
+		instVar := 42'
+withNewSelector: #extractedMethod.
+
+	transformation generateChanges.
+
+	self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					^ 42').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm
+				instVar := self extractedMethod')
+]
+
+{ #category : 'tests' }
 ReSemanticsOfExtractMethodTransformationTest >> testExtractSequenceEndingWithReturnExpectExtracted [
 
 	| transformation |
@@ -133,6 +237,58 @@ self
 ]
 
 { #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testInstanceVariableIsAssignedInExtractedCodeExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'instVar := instVar + 1' 
+fromSource: 'm
+		instVar := instVar + 1'
+withNewSelector: #extractedMethod.
+
+	transformation generateChanges.
+
+	self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					^ instVar := instVar + 1').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm
+				self extractedMethod')
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testInstanceVariableIsUsedInExtractedCodeExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'a := instVar + 1' 
+fromSource: 'm
+		| a |
+		a := instVar + 1.
+		^ a'
+withNewSelector: #extractedMethod.
+
+	transformation generateChanges.
+
+	self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					| a |
+					a := instVar + 1.
+					^ a').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm
+				| a |
+				a := self extractedMethod.
+				^ a')
+]
+
+{ #category : 'tests' }
 ReSemanticsOfExtractMethodTransformationTest >> testMiddleExpressionsOfASequenceGotExtracted [
 
 	| transformation |
@@ -152,6 +308,31 @@ self
 	self 
 		assert: (class parseTreeForSelector: #m)
 		equals: (self parseMethod: 'm self foo. self extractedMethod. self end')
+]
+
+{ #category : 'tests' }
+ReSemanticsOfExtractMethodTransformationTest >> testMultipleInstanceVariableAssignmentsInExtractedCodeExpectGotExtracted [
+
+	| transformation |
+	transformation := self 
+extractSource: 'instVar := instVar + 1. instVar2 := instVar2 + instVar' 
+fromSource: 'm
+		instVar := instVar + 1.
+		instVar2 := instVar2 + instVar'
+withNewSelector: #extractedMethod.
+
+	transformation generateChanges.
+
+	self 
+		assert: (class parseTreeForSelector: #extractedMethod)
+		equals: (self parseMethod: 'extractedMethod 
+					instVar := instVar + 1.
+					^ instVar2 := instVar2 + instVar').
+		
+	self 
+		assert: (class parseTreeForSelector: #m)
+		equals: (self parseMethod: 'm
+				self extractedMethod')
 ]
 
 { #category : 'tests' }

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -52,7 +52,7 @@ withNewSelector: #extractedMethod.
 	
 self 
 		assert: (class parseTreeForSelector: #extractedMethod)
-		equals: (self parseMethod: 'extractedMethod self foo. self bar.').
+		equals: (self parseMethod: 'extractedMethod self foo. ^ self bar.').
 		
 	self 
 		assert: (class parseTreeForSelector: #m)
@@ -74,7 +74,7 @@ withNewSelector: #extractedMethod.
 	
 self 
 		assert: (class parseTreeForSelector: #extractedMethod)
-		equals: (self parseMethod: 'extractedMethod self foo. self bar. self end').
+		equals: (self parseMethod: 'extractedMethod self foo. self bar. ^ self end').
 		
 	self 
 		assert: (class parseTreeForSelector: #m)
@@ -146,7 +146,7 @@ withNewSelector: #extractedMethod.
 	
 self 
 		assert: (class parseTreeForSelector: #extractedMethod)
-		equals: (self parseMethod: 'extractedMethod self bar.').
+		equals: (self parseMethod: 'extractedMethod ^ self bar.').
 		
 	self 
 		assert: (class parseTreeForSelector: #m)
@@ -170,7 +170,7 @@ self
 		assert: (class parseTreeForSelector: #extractedMethod)
 		equals: (self parseMethod: 'extractedMethod 
 					self bar. 
-					self end').
+					^ self end').
 		
 	self 
 		assert: (class parseTreeForSelector: #m)

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -258,6 +258,37 @@ self
 				^ self extractedMethod someMethod')
 ]
 
+{ #category : 'tests - failures' }
+ReSemanticsOfExtractMethodTransformationTest >> testExtractedCodeHasMoreThanOneExitPointExpectFailure [
+
+	| transformation |
+	transformation := self 
+extractSource: 'arg ifOdd: [ ^ false ]. arg ifEven: [ ^ true ].' 
+fromSource: 'm: arg
+		arg ifOdd: [ ^ false ].
+		arg ifEven: [ ^ true ].
+		self calculateOn: arg'
+withNewSelector: #extractedMethod:.
+
+	self should: [ transformation generateChanges ]
+		raise: RBRefactoringError 
+]
+
+{ #category : 'tests - failures' }
+ReSemanticsOfExtractMethodTransformationTest >> testExtractedCodeHasTwoExitPointExpectFailure [
+
+	| transformation |
+	transformation := self 
+extractSource: 'arg ifOdd: [ ^ false ]' 
+fromSource: 'm: arg
+		arg ifOdd: [ ^ false ].
+		self calculateOn: arg'
+withNewSelector: #extractedMethod:.
+
+	self should: [ transformation generateChanges ]
+		raise: RBRefactoringError 
+]
+
 { #category : 'tests' }
 ReSemanticsOfExtractMethodTransformationTest >> testInstanceVariableIsAssignedInExtractedCodeExpectGotExtracted [
 

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -45,25 +45,25 @@ RBExtractMethodTransformation class >> allMethodsInHierarchyOf: aRBClass [
 ]
 
 { #category : 'api' }
-RBExtractMethodTransformation class >> extract: aString from: aSelector to: aNewSelector in: aClass [
+RBExtractMethodTransformation class >> extract: aString from: aSelector to: aNewSelector in: aClassName [
 
 	^ self new
 		extract: aString
 		from: aSelector
 		to: aNewSelector
-		in: aClass;
+		in: aClassName;
 		yourself
 ]
 
 { #category : 'api' }
-RBExtractMethodTransformation class >> model: aRBModel extract: aString from: aSelector to: aNewSelector in: aClass [
+RBExtractMethodTransformation class >> model: aRBModel extract: aString from: aSelector to: aNewSelector in: aClassName [
 
 	^ self new
 		model: aRBModel;
 		extract: aString
 		from: aSelector
 		to: aNewSelector
-		in: aClass;
+		in: aClassName;
 		yourself
 ]
 
@@ -244,7 +244,7 @@ RBExtractMethodTransformation >> calculateTree [
 { #category : 'api' }
 RBExtractMethodTransformation >> extract: aString from: aSelector to: aNewSelector in: aClassName [
 
-	class := aClassName.
+	class := self model classNamed: aClassName.
 	selector := aSelector.
 	newSelector := aNewSelector.
 	sourceCode := aString
@@ -253,7 +253,7 @@ RBExtractMethodTransformation >> extract: aString from: aSelector to: aNewSelect
 { #category : 'api' }
 RBExtractMethodTransformation >> extractSource: aString fromMethodSource: source to: aNewSelector in: aClassName [
 
-	class := aClassName.
+	class := self model classNamed: aClassName.
 	parseTree := RBParser parseMethod: source. 
 	selector := parseTree selector.
 	newSelector := aNewSelector.

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -76,6 +76,7 @@ RBExtractMethodTransformation >> applicabilityPreconditions [
 	  & self preconditionOneAssignmentMaximum
 	  & self preconditionAssignmentsNotReadBeforeWritten
 	  & self preconditionSubtreeDoesNotContainsReturn
+	  & self preconditionHasSameExitPoint 
 ]
 
 { #category : 'executing' }
@@ -357,6 +358,14 @@ RBExtractMethodTransformation >> preconditionAssignmentsNotReadBeforeWritten [
 	assignments isEmptyOrNil ifTrue: [ ^ self trueCondition ].
 
 	^ ReVariablesNotReadBeforeWrittenCondition new subtree: subtree; variables: assignments
+]
+
+{ #category : 'preconditions' }
+RBExtractMethodTransformation >> preconditionHasSameExitPoint [
+
+	^ RBCondition
+		withBlock: [ subtree hasSameExitPoint ]
+		errorString: 'You cannot extract guard clauses and other expressions that directly impact the methods execution flow.'
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -81,8 +81,7 @@ RBExtractMethodTransformation >> applicabilityPreconditions [
 { #category : 'executing' }
 RBExtractMethodTransformation >> buildTransformationFor: newMethodName [
 
-	| needsReturn messageSend newArguments tempsToRemove |
-	tempsToRemove := self calculateTemporariesToRemove.
+	| needsReturn messageSend newArguments |
 	needsReturn := self calculateIfReturnIsNeededInCaller.
 	newMethod := self generateNewMethodWith: newMethodName.
 	newArguments := self calculateNewArgumentsIn: newMethodName.
@@ -103,12 +102,10 @@ RBExtractMethodTransformation >> buildTransformationFor: newMethodName [
 				   to: messageSend
 				   inMethod: selector
 				   inClass: class);
-		  addAll: (tempsToRemove collect: [ :temporary |
-					   RBRemoveTemporaryVariableTransformation
-						   model: self model
-						   variable: temporary
-						   inMethod: selector
-						   inClass: class ]);
+		  add: (ReRemoveUnusedTemporaryVariableRefactoring
+				   model: self model
+				   inMethod: selector
+				   inClass: class name);
 		  yourself
 ]
 
@@ -223,16 +220,6 @@ RBExtractMethodTransformation >> calculateTemporaries [
 		accesses := allVariables select: [ :each | subtree references: each ].
 
 		temporaries := accesses select: [ :each | subtree assigns: each ] ]
-]
-
-{ #category : 'querying' }
-RBExtractMethodTransformation >> calculateTemporariesToRemove [
-	"returns a collection of variables that should be removed from the original method"
-
-	| newParseTree |
-	newParseTree := parseTree copy removeSubtree: subtree.
-	^ newParseTree allDefinedVariables
-		reject: [ :var | newParseTree references: var ]
 ]
 
 { #category : 'querying' }

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -297,10 +297,12 @@ RBExtractMethodTransformation >> generateNewMethodWith: aMethodName [
 	((parseTree parentOfSubtree: subtree) isUsingAsReturnValue: subtree)
 		ifTrue: [ newMethodNode addReturn ].
 
-	assignments size = 1 ifTrue: [
+	assignments size = 1 
+		ifTrue: [
 		newMethodNode addNode:
 			(RBReturnNode value:
-			(RBVariableNode named: assignments first asString)) ].
+			(RBVariableNode named: assignments first asString)) ]
+		ifFalse: [RBReturnNodeAdderVisitor new visit: newMethodNode ].
 
 	^ newMethodNode
 ]


### PR DESCRIPTION
This PR introduces several improvements for extract method transformation:

- you cannot extract code with guard clauses anymore (these extracts would break the execution flow and not preserve behavior. in the future we should migrate these to breaking change preconditions)
- fix bug when tree with return statement couldn't be removed with `removeTree:`
- create new refactoring `Remove unused temporary variables` and use it in extract method
- all extract method API takes class name as input now
- bunch of semantics tests