### PR TITLE
Fix: extract method failing tests

### DIFF
--- a/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -140,13 +140,15 @@ RBExtractMethodTransformationTest >> testNeedsReturn [
 
 	| refactoring class |
 	model := self modelOnClasses: { RBDummyLintRuleTest }.
-	refactoring := (RBExtractMethodTransformation
+	refactoring := [(RBExtractMethodTransformation
 		                model: model
 		                extract: 'rules isEmpty ifTrue: [^self].
 						rules size == 1 ifTrue: [^rules first viewResults]'
 		                from: #openEditor
 		                to: #foo:
-		                in: #RBDummyLintRuleTest) generateChanges.
+		                in: #RBDummyLintRuleTest) generateChanges ]
+		               on: RBRefactoringWarning
+		               do: [ :ex | ex resume ].
 
 	self assert: refactoring model changes changes size equals: 2.
 

--- a/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReSemanticsOfExtractMethodTransformationTest.class.st
@@ -271,7 +271,7 @@ fromSource: 'm: arg
 withNewSelector: #extractedMethod:.
 
 	self should: [ transformation generateChanges ]
-		raise: RBRefactoringError 
+		raise: RBRefactoringWarning
 ]
 
 { #category : 'tests - failures' }
@@ -286,7 +286,7 @@ fromSource: 'm: arg
 withNewSelector: #extractedMethod:.
 
 	self should: [ transformation generateChanges ]
-		raise: RBRefactoringError 
+		raise: RBRefactoringWarning
 ]
 
 { #category : 'tests' }

--- a/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBExtractMethodTransformation.class.st
@@ -76,7 +76,12 @@ RBExtractMethodTransformation >> applicabilityPreconditions [
 	  & self preconditionOneAssignmentMaximum
 	  & self preconditionAssignmentsNotReadBeforeWritten
 	  & self preconditionSubtreeDoesNotContainsReturn
-	  & self preconditionHasSameExitPoint 
+]
+
+{ #category : 'preconditions' }
+RBExtractMethodTransformation >> breakingChangePreconditions [ 
+
+	  ^ self preconditionHasSameExitPoint 
 ]
 
 { #category : 'executing' }
@@ -227,6 +232,15 @@ RBExtractMethodTransformation >> calculateTemporaries [
 RBExtractMethodTransformation >> calculateTree [
 
 	^ parseTree ifNil: [ parseTree := self definingMethod ]
+]
+
+{ #category : 'scripting api - conditions' }
+RBExtractMethodTransformation >> checkPreconditions [
+
+	super checkPreconditions.
+	self breakingChangePreconditions check ifFalse: [
+		self refactoringWarning:
+			self breakingChangePreconditions errorString ]
 ]
 
 { #category : 'api' }


### PR DESCRIPTION
Extract method has a breaking change precondition now, because of it tests started failing since some code is applicable to be extracted but it breaks the execution flow. To fix it I've modified extract method transformation to raise warning when this scenario happened. So this is a refactoring now, not a real transformation anymore.

Extract method transformation is a refactoring now.
We need to migrate it to its package and rename.
However, this transformation does not work as well as expected, so we should wait a bit with that.