### PR TITLE
Refactor MenuItemMorph, PluggableMenuItemSpec and PragmaMenuAndShortcutRegistrationItem to support use of a FormSet and apply that to CmdCommand

### DIFF
--- a/src/Athens-Morphic/MenuItemMorph.extension.st
+++ b/src/Athens-Morphic/MenuItemMorph.extension.st
@@ -20,9 +20,9 @@ MenuItemMorph >> drawIconAndLabelOnAthensCanvas: anAthensCanvas [
 MenuItemMorph >> drawIconOnAthensCanvas: anAthensCanvas [
 	self hasIcon
 		ifFalse: [ ^ self ].
-	anAthensCanvas setPaint: self iconForm.
-	anAthensCanvas drawShape: (0 @ 0 extent: self iconForm extent).
-	anAthensCanvas pathTransform translateX: self iconForm width + 2 Y: 0
+	anAthensCanvas setPaint: self toggledIconFormSet asForm.
+	anAthensCanvas drawShape: (0 @ 0 extent: self toggledIconFormSet extent).
+	anAthensCanvas pathTransform translateX: self toggledIconFormSet width + 2 Y: 0
 ]
 
 { #category : '*Athens-Morphic' }

--- a/src/Calypso-Browser/CmdCommand.extension.st
+++ b/src/Calypso-Browser/CmdCommand.extension.st
@@ -84,8 +84,8 @@ CmdCommand >> decorateToolbarItem: aBrowserToolbarItem [
 	self description ifNotNil: [ :d |
 		aBrowserToolbarItem setBalloonText: d ].
 
-	self defaultMenuIcon ifNotNil: [:icon |
-		aBrowserToolbarItem addIcon: icon asMorph]
+	self defaultMenuIconFormSet ifNotNil: [:iconFormSet |
+		aBrowserToolbarItem addIcon: iconFormSet asMorph]
 ]
 
 { #category : '*Calypso-Browser' }

--- a/src/Calypso-SystemPlugins-ClassScripts-Browser/ClyRunClassScriptCommand.class.st
+++ b/src/Calypso-SystemPlugins-ClassScripts-Browser/ClyRunClassScriptCommand.class.st
@@ -35,13 +35,8 @@ ClyRunClassScriptCommand class >> methodTableIconActivation [
 ]
 
 { #category : 'accessing' }
-ClyRunClassScriptCommand >> defaultMenuIcon [
-	^Smalltalk ui iconNamed: script iconName
-]
-
-{ #category : 'accessing' }
 ClyRunClassScriptCommand >> defaultMenuIconName [
-	^#scriptManager
+	^ script iconName
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyDebugTestCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyDebugTestCommand.class.st
@@ -23,8 +23,8 @@ ClyDebugTestCommand class >> fullBrowserTableIconActivation [
 ]
 
 { #category : 'execution' }
-ClyDebugTestCommand >> defaultMenuIcon [
-	^Smalltalk ui iconNamed: #smallDebug
+ClyDebugTestCommand >> defaultMenuIconName [
+	^ #smallDebug
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyDebugTestSetupCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyDebugTestSetupCommand.class.st
@@ -23,8 +23,8 @@ ClyDebugTestSetupCommand class >> fullBrowserTableIconActivation [
 ]
 
 { #category : 'execution' }
-ClyDebugTestSetupCommand >> defaultMenuIcon [
-	^Smalltalk ui iconNamed: #smallDebug
+ClyDebugTestSetupCommand >> defaultMenuIconName [
+	^ #smallDebug
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromMethodsCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyRunTestsFromMethodsCommand.class.st
@@ -24,15 +24,15 @@ ClyRunTestsFromMethodsCommand class >> contextClass [
 ]
 
 { #category : 'execution' }
-ClyRunTestsFromMethodsCommand >> defaultMenuIcon [
+ClyRunTestsFromMethodsCommand >> defaultMenuIconName [
 
 	| fullResult |
 	fullResult := self testResult.
 	runTestCases do: [ :each |
 		fullResult concreteResultOf: runTestCases first ifPresent: [:testResult |
-			^testResult createIcon ]].
+			^testResult iconName ]].
 
-	^fullResult createIcon
+	^fullResult iconName
 ]
 
 { #category : 'execution' }

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestCommand.class.st
@@ -25,9 +25,9 @@ ClyTestCommand >> applyResultInContext: aToolContext [
 ]
 
 { #category : 'context menu support' }
-ClyTestCommand >> defaultMenuIcon [
+ClyTestCommand >> defaultMenuIconName [
 
-	^self testResult createIcon
+	^self testResult iconName
 ]
 
 { #category : 'execution' }

--- a/src/Calypso-SystemPlugins-SUnit-Queries/ClyTestResultProperty.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Queries/ClyTestResultProperty.class.st
@@ -89,15 +89,7 @@ ClyTestResultProperty >> brokenCount [
 { #category : 'presentation' }
 ClyTestResultProperty >> createIcon [
 
-	allCount = 0 ifTrue: [ ^ self iconNamed: #testNotRun ].
-	allCount = successCount
-		ifTrue: [ ^ self iconNamed: #testGreen ].
-	errorCount = 0 & (failureCount > 0)
-		ifTrue: [ ^ self iconNamed: #testYellow ].
-	errorCount > 0
-		ifTrue: [ ^ self iconNamed: #testRed].
-
-	^ self iconNamed: #testNotRun
+	^ self iconNamed: self iconName
 ]
 
 { #category : 'accessing' }
@@ -123,6 +115,20 @@ ClyTestResultProperty >> failureCount: anObject [
 { #category : 'testing' }
 ClyTestResultProperty >> hasBrokenTests [
 	^failureCount > 0 | (errorCount > 0)
+]
+
+{ #category : 'presentation' }
+ClyTestResultProperty >> iconName [
+
+	allCount = 0 ifTrue: [ ^ #testNotRun ].
+	allCount = successCount
+		ifTrue: [ ^ #testGreen ].
+	errorCount = 0 & (failureCount > 0)
+		ifTrue: [ ^ #testYellow ].
+	errorCount > 0
+		ifTrue: [ ^ #testRed].
+
+	^ #testNotRun
 ]
 
 { #category : 'initialization' }

--- a/src/Commander-Activators-ContextMenu/CmdCommand.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdCommand.extension.st
@@ -41,8 +41,8 @@ CmdCommand >> registerContextMenuItemsFor: aCommandItem withBuilder: aBuilder [
 { #category : '*Commander-Activators-ContextMenu' }
 CmdCommand >> setUpIconForMenuItem: aMenuItemMorph [
 
-	self defaultMenuIcon ifNotNil: [:icon |
-		aMenuItemMorph icon: icon ]
+	self defaultMenuIconFormSet ifNotNil: [:iconFormSet |
+		aMenuItemMorph iconFormSet: iconFormSet ]
 ]
 
 { #category : '*Commander-Activators-ContextMenu' }

--- a/src/Commander-Activators-ContextMenu/CmdCommand.extension.st
+++ b/src/Commander-Activators-ContextMenu/CmdCommand.extension.st
@@ -39,10 +39,10 @@ CmdCommand >> registerContextMenuItemsFor: aCommandItem withBuilder: aBuilder [
 ]
 
 { #category : '*Commander-Activators-ContextMenu' }
-CmdCommand >> setUpIconForMenuItem: aMenuItemMorph [
+CmdCommand >> setUpIconForMenuItem: menuItem [
 
 	self defaultMenuIconFormSet ifNotNil: [:iconFormSet |
-		aMenuItemMorph iconFormSet: iconFormSet ]
+		menuItem iconFormSet: iconFormSet ]
 ]
 
 { #category : '*Commander-Activators-ContextMenu' }

--- a/src/Commander-Core/CmdCommand.class.st
+++ b/src/Commander-Core/CmdCommand.class.st
@@ -140,11 +140,17 @@ CmdCommand >> asCommandActivator [
 
 { #category : 'accessing' }
 CmdCommand >> defaultMenuIcon [
+
+	^ self defaultMenuIconFormSet ifNotNil: [ :formSet | formSet asForm ]
+]
+
+{ #category : 'accessing' }
+CmdCommand >> defaultMenuIconFormSet [
 	"By default the result is nil which is not really nice
 	but it is already expected by many tools.	So it is easy to allow nil.
 	For simple cases users should implement class side method #defaultMenuIconName"
 	^self defaultMenuIconName ifNotNil: [ :iconName |
-		Smalltalk ui iconNamed: iconName ]
+		Smalltalk ui iconFormSetNamed: iconName ]
 ]
 
 { #category : 'accessing' }

--- a/src/MenuRegistration/MenuRegistration.class.st
+++ b/src/MenuRegistration/MenuRegistration.class.st
@@ -299,6 +299,12 @@ MenuRegistration >> icon: aForm [
 	self spec icon: aForm
 ]
 
+{ #category : 'spec accessing' }
+MenuRegistration >> iconFormSet: aFormSet [
+	"set the icon that is shown in the menu"
+	self spec iconFormSet: aFormSet
+]
+
 { #category : 'initialization' }
 MenuRegistration >> initialize [
 	super initialize.

--- a/src/MenuRegistration/PluggableMenuItemSpec.class.st
+++ b/src/MenuRegistration/PluggableMenuItemSpec.class.st
@@ -12,7 +12,7 @@ Class {
 		'enabled',
 		'separator',
 		'subMenu',
-		'icon',
+		'iconFormSet',
 		'enabledBlock',
 		'keyText',
 		'help',
@@ -93,12 +93,22 @@ PluggableMenuItemSpec >> help: aSymbol [
 
 { #category : 'accessing' }
 PluggableMenuItemSpec >> icon [
-	^ icon
+	^ self iconFormSet ifNotNil: [ :formSet | formSet asForm ]
 ]
 
 { #category : 'accessing' }
 PluggableMenuItemSpec >> icon: aForm [
-	 icon := aForm
+	self iconFormSet: (aForm ifNotNil: [ FormSet form: aForm ])
+]
+
+{ #category : 'accessing' }
+PluggableMenuItemSpec >> iconFormSet [
+	^ iconFormSet
+]
+
+{ #category : 'accessing' }
+PluggableMenuItemSpec >> iconFormSet: aFormSet [
+	iconFormSet := aFormSet
 ]
 
 { #category : 'accessing' }

--- a/src/MenuRegistration/PragmaMenuAndShortcutRegistration.class.st
+++ b/src/MenuRegistration/PragmaMenuAndShortcutRegistration.class.st
@@ -171,11 +171,17 @@ PragmaMenuAndShortcutRegistration >> icon: anIcon [
 ]
 
 { #category : 'menu protocol' }
+PragmaMenuAndShortcutRegistration >> iconFormSet: aFormSet [
+
+	self currentItem iconFormSet: aFormSet
+]
+
+{ #category : 'menu protocol' }
 PragmaMenuAndShortcutRegistration >> iconName: aSymbol [
 	"instead of forcing clients to refer to an icon builder such Smalltalk ui icons
 	this message encapsulates it inside the builder itself. When removing uses of Smalltalk ui icons it avoid to force to subclass class with menu to inherit from Model."
 
-	self icon: (Smalltalk ui icons iconNamed: aSymbol)
+	self iconFormSet: (Smalltalk ui icons iconFormSetNamed: aSymbol)
 ]
 
 { #category : 'initialization' }

--- a/src/MenuRegistration/PragmaMenuAndShortcutRegistrationItem.class.st
+++ b/src/MenuRegistration/PragmaMenuAndShortcutRegistrationItem.class.st
@@ -13,6 +13,7 @@ Class {
 		'label',
 		'help',
 		'icon',
+		'iconFormSet',
 		'selector',
 		'arguments',
 		'withSeparatorAfter',
@@ -132,13 +133,25 @@ PragmaMenuAndShortcutRegistrationItem >> help: aString [
 { #category : 'accessing' }
 PragmaMenuAndShortcutRegistrationItem >> icon [
 
-	^ icon
+	^ self iconFormSet ifNotNil: [ :formSet | formSet asForm ]
 ]
 
 { #category : 'menu protocol' }
-PragmaMenuAndShortcutRegistrationItem >> icon: anIcon [
+PragmaMenuAndShortcutRegistrationItem >> icon: aForm [
 
-	icon := anIcon
+	self iconFormSet: (aForm ifNotNil: [ FormSet form: aForm ])
+]
+
+{ #category : 'menu protocol' }
+PragmaMenuAndShortcutRegistrationItem >> iconFormSet [
+
+	^ iconFormSet
+]
+
+{ #category : 'menu protocol' }
+PragmaMenuAndShortcutRegistrationItem >> iconFormSet: aFormSet [
+
+	iconFormSet := aFormSet
 ]
 
 { #category : 'initialization' }

--- a/src/MenuRegistration/PragmaMenuAndShortcutRegistrationItem.class.st
+++ b/src/MenuRegistration/PragmaMenuAndShortcutRegistrationItem.class.st
@@ -12,7 +12,6 @@ Class {
 		'enabledBlock',
 		'label',
 		'help',
-		'icon',
 		'iconFormSet',
 		'selector',
 		'arguments',

--- a/src/MenuRegistration/PragmaMenuBuilder.class.st
+++ b/src/MenuRegistration/PragmaMenuBuilder.class.st
@@ -198,7 +198,7 @@ PragmaMenuBuilder >> interpretRegistration: aRegistration [
 			node
 				keyText: item keyText;
 				help: item help;
-				icon: item icon;
+				iconFormSet: item iconFormSet;
 				order: item order;
 				parent: item parent.
 			item enabled

--- a/src/Morphic-Base/MenuItemMorph.class.st
+++ b/src/Morphic-Base/MenuItemMorph.class.st
@@ -10,7 +10,7 @@ Instance variables:
 	target 		<Object>		The target of the associated action.
 	selector 		<Symbol>	The associated action.
 	arguments 	<Array>		The arguments for the associated action.
-	icon		<Form | nil>	An optional icon form to be displayed to my left.
+	iconFormSet	<FormSet | nil>	An optional icon form set to be displayed to my left.
 
 
 "
@@ -24,7 +24,7 @@ Class {
 		'target',
 		'selector',
 		'arguments',
-		'icon',
+		'iconFormSet',
 		'keyText'
 	],
 	#classVars : [
@@ -334,7 +334,7 @@ MenuItemMorph >> handlesMouseOverDragging: evt [
 { #category : 'accessing' }
 MenuItemMorph >> hasIcon [
 	"Answer whether the receiver has an icon."
-	^ icon isNotNil
+	^ iconFormSet isNotNil
 ]
 
 { #category : 'accessing' }
@@ -364,14 +364,26 @@ MenuItemMorph >> hasSubMenu: aMenuMorph [
 
 { #category : 'accessing' }
 MenuItemMorph >> icon [
-	"answer the receiver's icon"
-	^ icon
+
+	^ self iconFormSet ifNotNil: [ :formSet | formSet asForm ]
 ]
 
 { #category : 'accessing' }
 MenuItemMorph >> icon: aForm [
-	"change the the receiver's icon"
-	icon := aForm
+
+	self iconFormSet: (aForm ifNotNil: [ FormSet form: aForm ])
+]
+
+{ #category : 'accessing' }
+MenuItemMorph >> iconFormSet [
+	"answer the receiver's icon form set"
+	^ iconFormSet
+]
+
+{ #category : 'accessing' }
+MenuItemMorph >> iconFormSet: aFormSet [
+	"change the the receiver's icon form set"
+	iconFormSet := aFormSet
 ]
 
 { #category : 'initialization' }
@@ -685,9 +697,13 @@ MenuItemMorph >> themeChanged [
 { #category : 'private' }
 MenuItemMorph >> toggledIconFormSet [
 	"private - answer the form set to be used as the icon"
+	| baseIconFormSet |
+	baseIconFormSet := self iconFormSet.
 	^ isEnabled
-		ifTrue: [FormSet form: self icon]
-		ifFalse: [FormSet form: self icon asGrayScale]
+		ifTrue: [ baseIconFormSet ]
+		ifFalse: [
+			FormSet extent: baseIconFormSet extent depth: 8
+				forms: (baseIconFormSet forms collect: [ :form | form asGrayScale ]) ]
 ]
 
 { #category : 'private' }
@@ -715,7 +731,7 @@ MenuItemMorph >> veryDeepInner: deepCopier [
 	isEnabled := isEnabled veryDeepCopyWith: deepCopier.
 	subMenu := subMenu veryDeepCopyWith: deepCopier.
 	isSelected := isSelected veryDeepCopyWith: deepCopier.
-	icon := icon veryDeepCopyWith: deepCopier.
+	iconFormSet := iconFormSet veryDeepCopyWith: deepCopier.
 	"target := target.		Weakly copied"
 	"selector := selector.		a Symbol"
 	arguments := arguments

--- a/src/Morphic-Base/MenuItemMorph.class.st
+++ b/src/Morphic-Base/MenuItemMorph.class.st
@@ -244,11 +244,11 @@ MenuItemMorph >> doButtonAction [
 
 { #category : 'drawing' }
 MenuItemMorph >> drawIconOn: aCanvas [
-	| iconForm |
+	| toggledIconFormSet |
 	self hasIcon ifFalse: [ ^ self ].
 
-	iconForm := self iconForm.
-	aCanvas translucentImage: iconForm at: bounds left @ (self top + ((self height - iconForm height) // 2))
+	toggledIconFormSet := self toggledIconFormSet.
+	aCanvas translucentFormSet: toggledIconFormSet at: bounds left @ (self top + ((self height - toggledIconFormSet height) // 2))
 ]
 
 { #category : 'drawing' }
@@ -374,14 +374,6 @@ MenuItemMorph >> icon: aForm [
 	icon := aForm
 ]
 
-{ #category : 'private' }
-MenuItemMorph >> iconForm [
-	"private - answer the form to be used as the icon"
-	^ isEnabled
-		ifTrue: [self icon]
-		ifFalse: [self icon asGrayScale]
-]
-
 { #category : 'initialization' }
 MenuItemMorph >> initialize [
 	"initialize the state of the receiver"
@@ -485,9 +477,9 @@ MenuItemMorph >> leftArrow [
 MenuItemMorph >> menuStringBounds [
 	| stringBounds |
 	stringBounds := bounds.
-	self hasIcon ifTrue: [ | iconForm |
-		iconForm := self iconForm.
-		stringBounds := stringBounds left: stringBounds left + iconForm width + 2 ].
+	self hasIcon ifTrue: [ | toggledIconFormSet |
+		toggledIconFormSet := self toggledIconFormSet.
+		stringBounds := stringBounds left: stringBounds left + toggledIconFormSet width + 2 ].
 	self hasMarker ifTrue: [
 		stringBounds := stringBounds left: stringBounds left + self submorphBounds width + 8 ].
 	^ stringBounds top: (stringBounds top + stringBounds bottom - self fontToUse height) // 2
@@ -688,6 +680,14 @@ MenuItemMorph >> themeChanged [
 
 	super themeChanged.
 	self subMenu ifNotNil:[ :m | m themeChanged ]
+]
+
+{ #category : 'private' }
+MenuItemMorph >> toggledIconFormSet [
+	"private - answer the form set to be used as the icon"
+	^ isEnabled
+		ifTrue: [FormSet form: self icon]
+		ifFalse: [FormSet form: self icon asGrayScale]
 ]
 
 { #category : 'private' }

--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -1047,7 +1047,7 @@ MenuMorph >> maxItemsIconWidth [
 
 	^ self menuItems inject: 0 into: [ :maxWidth :menuItemMorph |
 		menuItemMorph hasIcon
-			ifTrue: [ maxWidth max: menuItemMorph iconForm width ]
+			ifTrue: [ maxWidth max: menuItemMorph toggledIconFormSet width ]
 			ifFalse: [ maxWidth ] ]
 ]
 

--- a/src/Morphic-Base/PluggableMenuItemSpec.extension.st
+++ b/src/Morphic-Base/PluggableMenuItemSpec.extension.st
@@ -9,7 +9,7 @@ PluggableMenuItemSpec >> asMenuItemMorphFrom: parentMenu isLast: aBoolean [
 	"here checked can be nil, true, false"
 	checked ifNotNil: [ lbl := self hasCheckBox -> lbl ].
 	it contents: lbl.
-	it icon: self icon.
+	it iconFormSet: self iconFormSet.
 	it keyText: self keyText.
 	it isEnabled: self enabled.
 	it balloonText: self help.

--- a/src/Morphic-Base/ToggleMenuItemMorph.class.st
+++ b/src/Morphic-Base/ToggleMenuItemMorph.class.st
@@ -171,23 +171,23 @@ ToggleMenuItemMorph >> getStateSelector: anObject [
 ]
 
 { #category : 'accessing' }
-ToggleMenuItemMorph >> icon [
-	"Answer the receiver's icon. Handle legacy case
+ToggleMenuItemMorph >> iconFormSet [
+	"Answer the receiver's icon form set. Handle legacy case
 	of wording-based mechanism."
 
 	|state|
-	self getStateSelector ifNil: [^super icon].
+	self getStateSelector ifNil: [^super iconFormSet].
 	state := (MessageSend receiver: self target selector: self getStateSelector)
 		valueWithEnoughArguments: self arguments .
 	self flag: #pharoFixMe.
 	(state isKindOf: Association)
-		ifTrue: [^ state key ifTrue: [self onImage] ifFalse: [self offImage]]
+		ifTrue: [^ state key ifTrue: [FormSet form: self onImage] ifFalse: [FormSet form: self offImage]]
 		ifFalse: [
 	(state = true or: [state isString and: [(state beginsWith: '<yes>') or: [state beginsWith: '<on>']]])
-		ifTrue: [^self onImage].
+		ifTrue: [^FormSet form: self onImage].
 	(state = false or: [state isString and: [(state beginsWith: '<no>') or: [state beginsWith: '<off>']]])
-		ifTrue: [^self offImage]].
-	^super icon
+		ifTrue: [^FormSet form: self offImage]].
+	^super iconFormSet
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Base/ToggleMenuItemMorph.class.st
+++ b/src/Morphic-Base/ToggleMenuItemMorph.class.st
@@ -51,9 +51,8 @@ ToggleMenuItemMorph >> basicDrawOn: aCanvas [
 			fillRectangle: self bounds
 			fillStyle: self selectionFillStyle
 			borderStyle: self selectionBorderStyle].
-	self hasIcon ifTrue: [ |iconForm|
-		iconForm := self icon.
-		self drawIcon: iconForm on: aCanvas in: stringBounds ].
+	self hasIcon ifTrue: [
+		self drawIcon: self iconFormSet on: aCanvas in: stringBounds ].
 	maxItemsIconWidth := self owner maxItemsIconWidth.
 	maxItemsIconWidth > 0 ifTrue: [
 		stringBounds := stringBounds left: stringBounds left + maxItemsIconWidth + (2*self displayScaleFactor) ].
@@ -68,20 +67,24 @@ ToggleMenuItemMorph >> basicDrawOn: aCanvas [
 ]
 
 { #category : 'private - drawing' }
-ToggleMenuItemMorph >> drawIcon: aForm on: aCanvas in: aRectangle [
+ToggleMenuItemMorph >> drawIcon: aFormSet on: aCanvas in: aRectangle [
 	"Draw the icon on the canvas within the given bounds."
 
-	|iconForm|
-	self isEnabled
-		ifTrue: [iconForm := aForm]
-		ifFalse: [iconForm := Form extent: aForm extent depth: 32.
-				iconForm fillColor: (Color white alpha: 0.003922).
-				(iconForm getCanvas asAlphaBlendingCanvas: 0.5)
-					drawImage: aForm
-					at: 0@0].
+	| toggledIconFormSet |
+	toggledIconFormSet := self isEnabled
+		ifTrue: [ aFormSet ]
+		ifFalse: [
+			| baseIconForm toggledIconForm |
+			baseIconForm := aFormSet asFormAtScale: aCanvas scale.
+			toggledIconForm := Form extent: baseIconForm extent depth: 32.
+			toggledIconForm fillColor: (Color white alpha: 0.003922).
+			(toggledIconForm getCanvas asAlphaBlendingCanvas: 0.5)
+				drawImage: baseIconForm
+				at: 0@0.
+			FormSet extent: aFormSet extent depth: 32 forms: { toggledIconForm } ].
 	aCanvas
-		translucentImage: iconForm
-		at: aRectangle topLeft + (0@(aRectangle height - iconForm height // 2))
+		translucentFormSet: toggledIconFormSet
+		at: aRectangle topLeft + (0@(aRectangle height - toggledIconFormSet height // 2))
 ]
 
 { #category : 'private - drawing' }
@@ -108,7 +111,7 @@ ToggleMenuItemMorph >> drawSubMenuMarker: aForm on: aCanvas in: aRectangle [
 
 	|markerRect|
 	markerRect := aRectangle topRight + ((aForm width * self displayScaleFactor) negated @ (aRectangle height - (aForm height * self displayScaleFactor) // 2)) extent: aForm extent * self displayScaleFactor.
-	self drawIcon: aForm scaledByDisplayScaleFactor on: aCanvas in: markerRect
+	self drawIcon: (FormSet form: aForm scaledByDisplayScaleFactor) on: aCanvas in: markerRect
 ]
 
 { #category : 'private - drawing' }

--- a/src/Morphic-Base/UpdatingMenuItemMorph.class.st
+++ b/src/Morphic-Base/UpdatingMenuItemMorph.class.st
@@ -41,10 +41,11 @@ UpdatingMenuItemMorph >> contents [
 ]
 
 { #category : 'accessing' }
-UpdatingMenuItemMorph >> icon [
+UpdatingMenuItemMorph >> iconFormSet [
 
 	^ (target perform: iconSelector)
-		ifNil: [ super icon ]
+		ifNotNil: [ :form | FormSet form: form ]
+		ifNil: [ super iconFormSet ]
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Widgets-Extra/DockingBarToggleMenuItemMorph.class.st
+++ b/src/Morphic-Widgets-Extra/DockingBarToggleMenuItemMorph.class.st
@@ -58,10 +58,10 @@ DockingBarToggleMenuItemMorph >> drawOn: aCanvas [
 	stringBounds := bounds.
 	stringBounds := stringBounds left: stringBounds left + 4.
 	self hasIcon
-		ifTrue: [ | iconForm |
-			iconForm := self iconForm.
-			aCanvas translucentImage: iconForm at: stringBounds left @ (self top + ((self height - iconForm height) // 2)).
-			stringBounds := stringBounds left: stringBounds left + iconForm width + 2 ].
+		ifTrue: [ | toggledIconFormSet |
+			toggledIconFormSet := self toggledIconFormSet.
+			aCanvas translucentFormSet: toggledIconFormSet at: stringBounds left @ (self top + ((self height - toggledIconFormSet height) // 2)).
+			stringBounds := stringBounds left: stringBounds left + toggledIconFormSet width + 2 ].
 	self hasMarker ifTrue: [ stringBounds := stringBounds left: stringBounds left + self submorphBounds width + 8 ].
 	stringBounds := stringBounds top: (stringBounds top + stringBounds bottom - self fontToUse height) // 2.
 	aCanvas

--- a/src/Morphic-Widgets-Extra/DockingBarToggleMenuItemMorph.class.st
+++ b/src/Morphic-Widgets-Extra/DockingBarToggleMenuItemMorph.class.st
@@ -84,7 +84,7 @@ DockingBarToggleMenuItemMorph >> drawSubMenuMarker: aForm on: aCanvas in: aRecta
 	|markerRect|
 	markerRect := aRectangle topRight + (aForm width negated @ (aRectangle height - aForm height // 2)) extent: aForm extent.
 	markerRect translateBy: -4@1.
-	self drawIcon: aForm on: aCanvas in: markerRect
+	self drawIcon: (FormSet form: aForm) on: aCanvas in: markerRect
 ]
 
 { #category : 'events' }

--- a/src/Morphic-Widgets-Menubar/MenubarItemMorph.class.st
+++ b/src/Morphic-Widgets-Menubar/MenubarItemMorph.class.st
@@ -14,14 +14,14 @@ Class {
 
 { #category : 'drawing' }
 MenubarItemMorph >> drawIconOn: aCanvas [
-	| iconForm x y |
+	| toggledIconFormSet x y |
 	self hasIcon ifFalse: [ ^ self ].
 
-	iconForm := self iconForm.
-	x := (self menuStringBounds left - iconForm width - 5 ).
-	y := (self top + ((self height - iconForm height) // 2)).
+	toggledIconFormSet := self toggledIconFormSet.
+	x := (self menuStringBounds left - toggledIconFormSet width - 5 ).
+	y := (self top + ((self height - toggledIconFormSet height) // 2)).
 
-	aCanvas translucentImage: iconForm at: x @ y
+	aCanvas translucentFormSet: toggledIconFormSet at: x @ y
 ]
 
 { #category : 'drawing' }


### PR DESCRIPTION
This pull request refactors MenuItemMorph to support use of a FormSet for the icon and applies that to the CmdCommand hierarchy. In the CmdCommand hierarchy, the overrides of `#defaultMenuIcon` are refactored to override `#defaultMenuIconName` instead.