### PR TITLE
16204-RubPluggableTextFieldMorph-does-not-open-drop-list

### DIFF
--- a/src/Polymorph-Widgets/EntryCompletion.class.st
+++ b/src/Polymorph-Widgets/EntryCompletion.class.st
@@ -169,7 +169,8 @@ EntryCompletion >> openChooserWith: aToken from: aFieldMorph [
 		chooser requestor: aFieldMorph.
 		chooser position:
 			aFieldMorph bottomLeft + (aFieldMorph borderWidth @ 0).
-		chooser forcesHeight: 0 - (chooser boundsInWorld topLeft y + 2).
+		chooser boundsInWorld bottomLeft y > chooser allowedArea bottom
+				ifTrue: [ chooser forcesHeight: chooser allowedArea bottom - (chooser boundsInWorld topLeft y + 2) ].
 		chooser open ].
 	^ chooser
 ]

--- a/src/Polymorph-Widgets/IdentifierChooserMorph.class.st
+++ b/src/Polymorph-Widgets/IdentifierChooserMorph.class.st
@@ -102,7 +102,7 @@ IdentifierChooserMorph >> activate: evt [
 	"Backstop."
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 IdentifierChooserMorph >> allowedArea [
 	
 	^ RealEstateAgent maximumUsableAreaInWorld: self currentWorld

--- a/src/Polymorph-Widgets/IdentifierChooserMorph.class.st
+++ b/src/Polymorph-Widgets/IdentifierChooserMorph.class.st
@@ -102,6 +102,12 @@ IdentifierChooserMorph >> activate: evt [
 	"Backstop."
 ]
 
+{ #category : 'as yet unclassified' }
+IdentifierChooserMorph >> allowedArea [
+	
+	^ RealEstateAgent maximumUsableAreaInWorld: self currentWorld
+]
+
 { #category : 'accessing' }
 IdentifierChooserMorph >> baseColor [
 	^ baseColor ifNil: [baseColor := self defaultBaseColor]


### PR DESCRIPTION
We need to implement the allowed area delegating to the RealStateAgent so it uses the information of the size of the world.
Fix #16204