### PR TITLE
16132-Caret-return-char-broken-in-Pharo-11-macOS-Keyboard-as-US-International---PC

### DIFF
--- a/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
+++ b/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
@@ -157,6 +157,16 @@ OSWindowMorphicEventHandler >> convertPosition: aPosition [
 	^ morphicWorld worldState worldRenderer convertWindowMouseEventPosition: aPosition
 ]
 
+{ #category : 'converting' }
+OSWindowMorphicEventHandler >> convertText: aString [
+
+	"I convert the string if some well-known problematic characters are found.
+	Currently I am converting the 'Modifier Letter Circumflex Accent (U+02C6) without a modifying character to the circunflex (U+005E).
+	See issue #16132'"
+	
+	^ aString copy replaceAll: (Character value: 16r02C6) with: $^.
+]
+
 { #category : 'events' }
 OSWindowMorphicEventHandler >> dispatchMorphicEvent: anEvent [
 	morphicWorld defer: [
@@ -323,6 +333,7 @@ OSWindowMorphicEventHandler >> visitTextEditingEvent: anEvent [
 { #category : 'visiting' }
 OSWindowMorphicEventHandler >> visitTextInputEvent: anEvent [
 	anEvent text ifNil: [ ^ nil ].
+	
 	(anEvent text size = 1 and: [ anEvent text first codePoint < 128 ])
 		ifTrue: [
 			| char mods |
@@ -344,7 +355,7 @@ OSWindowMorphicEventHandler >> visitTextInputEvent: anEvent [
 			^ TextInputEvent new
 				  setHand: self activeHand;
 				  setPosition: (self convertPosition: anEvent position);
-				  text: anEvent text;
+				  text: (self convertText: anEvent text);
 				  wasHandled: false ]
 ]
 


### PR DESCRIPTION
Fix #16132
We have to convert the  'Modifier Letter Circumflex Accent (U+02C6) without a modifying character to the circunflex (U+005E). Even though it is a valid entry from the user, it makes complicated as it looks like the circunflex but it is not handled as one by the parser.