### PR TITLE
Fix SDL2 class>>primCreateRGBSurfaceForCairoWidth:height:

### DIFF
--- a/src/OSWindow-SDL2/SDL2.class.st
+++ b/src/OSWindow-SDL2/SDL2.class.st
@@ -376,9 +376,19 @@ SDL2 class >> primClipboardText: text [
 
 { #category : 'cairo' }
 SDL2 class >> primCreateRGBSurfaceForCairoWidth: width height: height [
-	^ self ffiCall: #( SDL_Surface* SDL_CreateRGBSurface
-						( Uint32 0 , int width , int height , int 32 ,
-						  Uint32 16r00FF0000 , Uint32 16r0000FF00 , Uint32 16r000000FF , 0 ) )
+	"See: https://wiki.libsdl.org/SDL2/SDL_CreateRGBSurface"
+
+	^ self ffiCall: #(
+		SDL_Surface*
+		SDL_CreateRGBSurface (
+			Uint32 0,
+			int width,
+			int height,
+			int 32,
+			Uint32 16r00FF0000,
+			Uint32 16r0000FF00,
+			Uint32 16r000000FF,
+			Uint32 0 ) )
 ]
 
 { #category : 'audio' }


### PR DESCRIPTION
... an argument wasn't good for the strict mode enabled