### PR TITLE
Fix #magnifyBy:smoothing: on OSSDL2ExternalForm

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2ExternalForm.class.st
+++ b/src/OSWindow-SDL2/OSSDL2ExternalForm.class.st
@@ -46,6 +46,16 @@ OSSDL2ExternalForm >> destroySurface [
 	]
 ]
 
+{ #category : 'scaling, rotation' }
+OSSDL2ExternalForm >> magnifyBy: scale smoothing: cellSize [
+
+	| form |
+	
+	form := Form extent: self extent depth: self depth.
+	form getCanvas image: self at: 0@0 sourceRect: self boundingBox rule: 34.
+	^ form magnifyBy: scale smoothing: cellSize
+]
+
 { #category : 'old - ffi backend support' }
 OSSDL2ExternalForm >> oldPrimCreateManualSurfaceWidth: aWidth height: aHeight rowPitch: rowPitch depth: aDepth isMSB: isMSB [
 	<primitive: 'primitiveCreateManualSurface' module: 'SqueakFFIPrims'>


### PR DESCRIPTION
This pull request fixes `#magnifyBy:smoothing:` on OSSDL2ExternalForm so that the following example no longer signals an error (“Bad BitBlt arg […]”):

```smalltalk
(OSSDL2ExternalForm extent: 10@10 depth: 32)
	allocateSpace;
	fillColor: Color blue;
	scaledToSize: 20@20
```

Like in pull request #14922, the fix is an override that first draws the OSSDL2ExternalForm on a Form with the same extent through a FormCanvas and then delegates the `#magnifyBy:smoothing:` message to that Form.