### PR TITLE
MCWorkingCopy class>>#infoFromDictionary:cache: sends a deprecated method

### DIFF
--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -121,7 +121,7 @@ MCWorkingCopy class >> infoFromDictionary: aDictionary cache: cache [
 			name: (aDictionary at: #name ifAbsent: [''])
 			id: (UUID fromString: id)
 			message: (aDictionary at: #message ifAbsent: [''])
-			date: ([Date fromString: (aDictionary at: #date)] onErrorDo: [nil])
+			date: ([Date readFrom: (aDictionary at: #date) pattern: 'yyyy-mm-dd' ] onErrorDo: [nil])
 			time: ([Time fromString: (aDictionary at: #time)] onErrorDo: [nil])
 			ancestors: (self ancestorsFromArray: (aDictionary at: #ancestors ifAbsent: []) cache: cache)
 			stepChildren: (self ancestorsFromArray: (aDictionary at: #stepChildren ifAbsent: []) cache: cache)]


### PR DESCRIPTION


This PR fixes it, use the same pattern as MczInstaller>>#extractInfoFrom: