### PR TITLE
fixing reflectivity bug that executes a #before metalink twice if an #after metalink is installed 

### DIFF
--- a/src/Reflectivity-Tests/ReflectivityControlTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityControlTest.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : 'ReflectivityTestCase',
 	#instVars : [
 		'tag',
-		'link'
+		'link',
+		'link2'
 	],
 	#category : 'Reflectivity-Tests-Base',
 	#package : 'Reflectivity-Tests',
@@ -36,6 +37,7 @@ ReflectivityControlTest >> tagExec: aTag [
 { #category : 'running' }
 ReflectivityControlTest >> tearDown [
 	link ifNotNil: [ link uninstall ].
+	link2 ifNotNil: [ link2 uninstall ].
 	super tearDown
 ]
 
@@ -428,6 +430,41 @@ ReflectivityControlTest >> testAfterVariableNode [
 	self assert: tag equals: 'yes'.
 	self assert: (ReflectivityExamples >> #exampleGlobalRead) class equals: CompiledMethod.
 	self deny: (ReflectivityExamples >> #exampleGlobalRead) isQuick
+]
+
+{ #category : 'tests' }
+ReflectivityControlTest >> testBeforeAndAfterSend [
+
+	| sendNode collection |
+	collection := OrderedCollection new.
+	sendNode := (ReflectivityExamples >> #exampleMethod) sendNodes first.
+	self assert: sendNode isMessage.
+	link := MetaLink new
+		        metaObject: [ collection add: #before ];
+		        selector: #value;
+		        control: #before;
+		        arguments: #(  ).
+	link2 := MetaLink new
+		         metaObject: [ collection add: #after ];
+		         selector: #value;
+		         control: #after;
+		         arguments: #(  ).
+	sendNode link: link.
+	sendNode link: link2.
+
+	self assert: sendNode hasMetalinkAfter.
+	self assertEmpty: collection.
+	self
+		assert: (ReflectivityExamples >> #exampleMethod) class
+		equals: ReflectiveMethod.
+
+	self assert: ReflectivityExamples new exampleMethod equals: 5.
+	self
+		assertCollection: collection
+		equals: #( #before #after ) asOrderedCollection.
+	self
+		assert: (ReflectivityExamples >> #exampleMethod) class
+		equals: CompiledMethod
 ]
 
 { #category : 'tests - before' }

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -98,26 +98,30 @@ ReflectiveMethod >> flushCache [
 
 { #category : 'evaluation' }
 ReflectiveMethod >> generatePrimitiveWrapper [
+
 	| wrappedMethod send wrapperMethod assignmentNode |
 	wrappedMethod := self compileAST.
 
 	send := RBMessageNode
-		receiver: RBVariableNode selfNode
-		selector:  #rFwithArgs:executeMethod:
-		arguments: {RBArrayNode statements: ast arguments . (RBLiteralNode value: wrappedMethod)}.
+		        receiver: RBVariableNode selfNode
+		        selector: #rFwithArgs:executeMethod:
+		        arguments: {
+				        (RBArrayNode statements: ast arguments).
+				        (RBLiteralNode value: self compiledMethod) }.
 
 	assignmentNode := RBAssignmentNode
-		variable: (RBVariableNode named: #RFReifyValueVar)
-		value: send.
+		                  variable: (RBVariableNode named: #RFReifyValueVar)
+		                  value: send.
 
 	wrapperMethod := RBMethodNode
-		selector: ast selector
-		arguments: ast arguments
-		body: assignmentNode asSequenceNode.
+		                 selector: ast selector
+		                 arguments: ast arguments
+		                 body: assignmentNode asSequenceNode.
 
 	wrapperMethod methodClass: ast methodClass.
 	wrapperMethod propertyAt: #wrapperMethod put: true.
-	ast hasMetalink ifTrue: [wrapperMethod propertyAt: #links put: (ast propertyAt: #links)].
+	ast hasMetalink ifTrue: [
+		wrapperMethod propertyAt: #links put: (ast propertyAt: #links) ].
 	ast := wrapperMethod
 ]
 


### PR DESCRIPTION
Fixes #15283 

Done with @ValentinBourcier and @RemiDufloer 

When installing two metalinks on the same node, one metalink #before and one metalink #after, the metalink #before was executed twice.

This is because, when executing the instrumented method, it executes a reflective method via `ReflectiveMethod>>#run: aSelector with: anArray in: aReceiver`, which calls:

```Smalltalk
ReflectiveMethod>>#compileAndInstallCompiledMethod
compileAndInstallCompiledMethod
	self wrapperNeeded ifTrue: [ self generatePrimitiveWrapper ].
	self recompileAST.
	self installCompiledMethod
```

When a metalink #after is installed, the method `ReflectiveMethod>>#generatePrimitiveWrapper` is called:

```Smalltalk
generatePrimitiveWrapper
	| wrappedMethod send wrapperMethod assignmentNode |
	wrappedMethod := self compileAST.

	send := RBMessageNode
		receiver: RBVariableNode selfNode
		selector:  #rFwithArgs:executeMethod:
		arguments: {RBArrayNode statements: ast arguments . (RBLiteralNode value: wrappedMethod)}.

     ...

```

This method wraps a method inside a reflective call and this reflective call should ignore metalinks.

However, `wrappedMethod` is obtained by recompiling the AST, which generates a method that contain the #before metalink. Indeed, when inspecting `wrappedMethod`, in the screenshot below, the first 3 bytecodes come from a #before metalink:

<img width="573" alt="image" src="https://github.com/pharo-project/pharo/assets/97704417/e1442e62-5d62-49f2-8a96-df6c63bf9aeb">

So the reflective call created by the #after metalink also executes the code of the #before metalink.
As the AST is later recompiled again in `#compileAndInstallCompiledMethod`, the code of the #before metalink is also added at this moment again, resulting the #before metalink to be executed twice: once before the reflective call and once inside the reflective call.

To fix that, we just use the simple compiled method because we don't want to recompile the AST to wrap the reflective method, but we want to wrap the compiled method insted to ensure that the method without metalink is executed inside the reflective call:

```Smalltalk
generatePrimitiveWrapper
	| wrappedMethod send wrapperMethod assignmentNode |
	wrappedMethod := self compileAST.

	send := RBMessageNode
		receiver: RBVariableNode selfNode
		selector:  #rFwithArgs:executeMethod:
		arguments: {RBArrayNode statements: ast arguments . (RBLiteralNode value: self compiledCode)}.

     ...

```