### PR TITLE
Refactor various ‘worldMenu’ registration methods to use #iconName: instead of #icon:

### DIFF
--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -53,7 +53,7 @@ DrTests class >> menuCommandOn: aBuilder [
 		order: 2;
 		keyText: 'o, u';
 		help: 'Let you run and debug SUnit tests.';
-		icon: (aBuilder iconNamed: self taskbarIconName);
+		iconName: self taskbarIconName;
 		withSeparatorAfter
 ]
 

--- a/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
+++ b/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
@@ -41,7 +41,7 @@ EpUnifiedBrowserPresenter class >> worldMenuItemOn: aBuilder [
 	(aBuilder item: 'Code Changes')
 		parent: #Changes;
 		action: [ self open ];
-		icon: (aBuilder iconNamed: self taskbarIconName);
+		iconName: self taskbarIconName;
 		help: 'Browse recorded change logs during from Pharo coding sessions and replay changes.';
 		order: 1
 ]

--- a/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAWelcomePresenter.class.st
@@ -23,7 +23,7 @@ DAWelcomePresenter class >> menuCommandOn: aBuilder [
 		order: 2;
 		parent: #Packaging;
 		label: 'Dependency Analyser';
-		icon: (self iconNamed: #package);
+		iconName: #package;
 		help: 'Analyze dependencies between different packages in the image.';
 		action: [ self new open ]
 ]

--- a/src/Tool-FileList/FileList.class.st
+++ b/src/Tool-FileList/FileList.class.st
@@ -131,7 +131,7 @@ FileList class >> menuCommandOn: aBuilder [
 		order: 2;
 		action: [ self open ];
 		help: 'Browse the files present on your system.';
-		icon: (aBuilder iconNamed: self taskbarIconName)
+		iconName: self taskbarIconName
 ]
 
 { #category : 'morphic ui' }

--- a/src/Tool-ProcessBrowser/ProcessBrowser.class.st
+++ b/src/Tool-ProcessBrowser/ProcessBrowser.class.st
@@ -158,7 +158,7 @@ ProcessBrowser class >> menuCommandOn: aBuilder [
 		order: 3;
 		action:[ self open ];
 		help: 'Provides a view of all of the processes (threads) executing in Smalltalk.';
-		icon: (aBuilder iconNamed: self taskbarIconName)
+		iconName: self taskbarIconName
 ]
 
 { #category : 'process control' }

--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -103,7 +103,7 @@ PharoCommonTools class >> worldMenuOn: aBuilder [
 		iconName: #smallSystemBrowser.
 	(aBuilder item: 'Git Repositories Browser')
 		order: 1;
-		icon: (self iconNamed: #komitterSmalltalkhubRemote);
+		iconName: #komitterSmalltalkhubRemote;
 		parent: #Browsing;
 		keyText: 'o, i';
 		help:

--- a/src/Transcript-Tool/ThreadSafeTranscript.extension.st
+++ b/src/Transcript-Tool/ThreadSafeTranscript.extension.st
@@ -37,7 +37,7 @@ ThreadSafeTranscript class >> menuCommandOn: aBuilder [
 		help: 'Transcript';
 		keyText: 'o, t';
 		help: 'Window on the Transcript output stream, which is useful for writing log messages.';
-		icon: (aBuilder iconNamed: self taskbarIconName).
+		iconName: self taskbarIconName.
 	aBuilder withSeparatorAfter
 ]
 


### PR DESCRIPTION
This pull request refactors various ‘worldMenu’ registration methods to use `#iconName:` instead of `#icon:` for setting the menu item’s icon.

This is related to (but does not depend on) pull request #16201, in which #iconName: on PragmaMenuAndShortcutRegistration is changed to use the FormSet for the icon.