### PR TITLE
Fix #freshLogFromSelection: on EpUnifiedBrowserPresenter to map trigger references

### DIFF
--- a/src/Epicea/EpLog.class.st
+++ b/src/Epicea/EpLog.class.st
@@ -415,6 +415,14 @@ EpLog >> triggererReferenceOf: anEntry ifPresent: presentBlock ifAbsent: absentB
 		ifAbsent: absentBlock
 ]
 
+{ #category : 'accessing' }
+EpLog >> triggererReferenceOf: anEntry put: triggerReference [
+
+	^ anEntry tags
+		at: self class triggererReferenceKey
+		put: triggerReference
+]
+
 { #category : 'private' }
 EpLog >> updateEntriesCache [
 

--- a/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
+++ b/src/EpiceaBrowsers/EpUnifiedBrowserPresenter.class.st
@@ -51,10 +51,27 @@ EpUnifiedBrowserPresenter >> freshLogFromSelection: selection [
 	^ selection selectedItems
 		ifEmpty: [ EpLog newNull ]
 		ifNotEmpty: [ :items |
-			| entries |
+			| entries entriesPerLog entryPerOriginalReference newLog |
+			entries := OrderedCollection new.
+			entriesPerLog := IdentityDictionary new.
+			entryPerOriginalReference := Dictionary new.
 			"Needed to reverse the selected logs to have the expected order (as user)."
-			entries := items reversed flatCollect: [:each | each log entries ].
-			EpLog newWithEntries: entries ]
+			items reversed reverseDo: [ :item |
+				entries addAll: ((entriesPerLog at: item log put: item log entries)
+					do: [ :entry |
+						entryPerOriginalReference at: (item log referenceTo: entry) put: entry ];
+					yourself) ].
+			newLog := EpLog newWithEntries: entries.
+			entriesPerLog keysAndValuesDo: [ :log :logEntries |
+				logEntries do: [ :entry |
+					log triggererReferenceOf: entry
+						ifPresent: [ :originalTriggerReference |
+							log triggererReferenceOf: entry put: (entryPerOriginalReference
+								at: originalTriggerReference
+								ifPresent: [ :triggerEntry | newLog referenceTo: triggerEntry ]
+								ifAbsent: [ newLog nullReference ]) ]
+						ifAbsent: [ ] ] ].
+			newLog ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
This pull request fixes `#freshLogFromSelection:` on EpUnifiedBrowserPresenter to map the trigger references of the entries to the corresponding references in the new log.

This makes Code Changes show which changes are due to a revert of earlier changes:

<p align="center">
<img width="324" src="https://github.com/pharo-project/pharo/assets/1611248/8f8a8b43-0e84-40eb-a92b-2b63160cdc6d">
</p>

That was previously not shown:

<p align="center">
<img width="326" src="https://github.com/pharo-project/pharo/assets/1611248/b512324c-0867-43ae-9be7-af746cbe7afa">
</p>