### PR TITLE
Fix adding slots in Ring

### DIFF
--- a/src/Ring-Core/RGPointerLayout.class.st
+++ b/src/Ring-Core/RGPointerLayout.class.st
@@ -62,9 +62,11 @@ RGPointerLayout >> isPointerLayout [
 
 { #category : 'resolving' }
 RGPointerLayout >> makeResolved [
+
 	super makeResolved.
 
-	slots := self slots do: [ :each | each markAsRingResolved]
+	"We want to ensure we have an ordered collection because we can add slocts to the model and we cannot do it if it's an array"
+	slots := self slots asOrderedCollection do: [ :each | each markAsRingResolved ]
 ]
 
 { #category : 'private - backend access' }


### PR DESCRIPTION
A problem got introduced in ring with this commit: https://github.com/pharo-project/pharo/commit/d105e1a9715e188eee8f40b7de0120e1c3229600

This commit removed an #asOrderedCollection and then we could have slots in an array. With this, it makes it impossible to add a new slot to a class or a trait. 

This change reverts this change and adds a comment about why we are having the #asOrderedCollection

This is necessary to have Moose working in P12