### PR TITLE
Fix for:  UFFI/TFFI call for WebBrowser with specific URL length adds strange characters to the URL #15980

### DIFF
--- a/src/WebBrowser-Core/WBWindowsWebBrowser.class.st
+++ b/src/WebBrowser-Core/WBWindowsWebBrowser.class.st
@@ -25,9 +25,9 @@ WBWindowsWebBrowser class >> shellExecute: lpOperation file: lpFile parameters: 
 	^self ffiCall: #( 
 			FFIConstantHandle ShellExecuteA(
      				0,
-     				String* lpOperation,
-         			String* lpFile,
-     				String* lpParameters,
-     				String* lpDirectory,
+     				String lpOperation,
+         			String lpFile,
+     				String lpParameters,
+     				String lpDirectory,
         			int nShowCmd)) module: #shell32
 ]

--- a/src/WebBrowser-Core/WBWindowsWebBrowser.class.st
+++ b/src/WebBrowser-Core/WBWindowsWebBrowser.class.st
@@ -24,7 +24,7 @@ WBWindowsWebBrowser class >> shellExecute: lpOperation file: lpFile parameters: 
 	
 	^self ffiCall: #( 
 			FFIConstantHandle ShellExecuteA(
-     				0,
+     				int 0,
      				String lpOperation,
          			String lpFile,
      				String lpParameters,


### PR DESCRIPTION
Pushing to pharo 10.
Feel free to backport on pharo 11 and 12.