### PR TITLE
Fix: use new API for getting the package name in CopyClassRegexRefactoring

### DIFF
--- a/src/Refactoring-Core/RBClassRegexRefactoring.class.st
+++ b/src/Refactoring-Core/RBClassRegexRefactoring.class.st
@@ -70,7 +70,7 @@ RBClassRegexRefactoring >> duplicate: aClass name: aSymbol deep: aBoolean [
 		aBuilder
 			superclassName: superclassName;
 			name: aSymbol;
-			package: aClass package name ].
+			package: aClass packageName ].
 	aBoolean ifTrue: [
 		(class := self model classNamed: aSymbol) ifNil: [ ^ self ].
 		self copyFrom: aClass to: class.


### PR DESCRIPTION
This fixes: https://github.com/pharo-project/pharo/issues/11519#issuecomment-1966948654