### PR TITLE
Minor improvement in TF test class

### DIFF
--- a/src/ThreadedFFI-UFFI-Tests/TFTestLibraryUsingSameThreadRunner.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFTestLibraryUsingSameThreadRunner.class.st
@@ -21,7 +21,7 @@ TFTestLibraryUsingSameThreadRunner >> macLibraryName [
 ]
 
 { #category : 'accessing - platform' }
-TFTestLibraryUsingSameThreadRunner >> unixModuleName [
+TFTestLibraryUsingSameThreadRunner >> unix64LibraryName [
 
 	^ 'libTestLibrary.so'
 ]


### PR DESCRIPTION
Rename unixModuleName as unix64LibraryName

Superclass definition is:

FFILibrary>>
unixLibraryName
	"Kept for backward compatibility.
	The system complains that this method is not implemented as it will only exist
	in subclasses that use the old API.
	 Users should use unix32* or unix64*"
	^ self unixModuleName

and:

unixLibraryName
	"Kept for backward compatibility.
	The system complains that this method is not implemented as it will only exist
	in subclasses that use the old API.
	 Users should use unix32* or unix64*"
	^ self unix64LibraryName