### PR TITLE
Cleanup: rename method refactoring driver to new architecture with breaking choices

### DIFF
--- a/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
+++ b/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
@@ -73,8 +73,8 @@ ReRenameMethodRefactoring >> applicabilityPreconditions [
 
 { #category : 'torevisit' }
 ReRenameMethodRefactoring >> areArgumentsPermuted [
-	
-	^ (permutation asArray = (1 to: oldSelector numArgs) asArray ) not
+
+	^ permutation asArray ~= (1 to: oldSelector numArgs) asArray
 ]
 
 { #category : 'testing' }

--- a/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
+++ b/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
@@ -68,7 +68,7 @@ ReRenameMethodRefactoring >> applicabilityPreconditions [
 		self validSelectorCondition .
 		self methodDefinedInClassCondition . 
 		self newNameDoesNotRequireRefactoringPrecondition not . 
-		self localConditions }
+		self selectorsHaveSameArity }
 ]
 
 { #category : 'torevisit' }
@@ -160,16 +160,6 @@ ReRenameMethodRefactoring >> implementorsCanBePrimitives [
 ]
 
 { #category : 'preconditions' }
-ReRenameMethodRefactoring >> localConditions [
-	"For a rename we only check for the same arity, in add parameter obviously it should be different"
-	
-	^ ReBlockCondition new 
-		block: [ self haveSelectorsSameArity ];
-		violatorErrorString: newSelector printString
-				, ' doesn''t have the same number of arguments as ', oldSelector printString
-]
-
-{ #category : 'preconditions' }
 ReRenameMethodRefactoring >> methodDefinedInClassCondition [
 
 	^ (ReDefinesSelectorsCondition new definesSelectors: {oldSelector} in: class)
@@ -212,6 +202,16 @@ ReRenameMethodRefactoring >> renameChanges [
 
 	self privateTransform.
 	^ self changes
+]
+
+{ #category : 'preconditions' }
+ReRenameMethodRefactoring >> selectorsHaveSameArity [
+	"For a rename we only check for the same arity, in add parameter obviously it should be different"
+	
+	^ ReBlockCondition new 
+		block: [ self haveSelectorsSameArity ];
+		violatorErrorString: newSelector printString
+				, ' doesn''t have the same number of arguments as ', oldSelector printString
 ]
 
 { #category : 'storing' }

--- a/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
+++ b/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
@@ -86,7 +86,7 @@ ReRenameMethodRefactoring >> areNamesTheSame [
 { #category : 'preconditions' }
 ReRenameMethodRefactoring >> breakingChangePreconditions [
 
-	^ self doesNotOverrideExistingMethodPreconditions isEmpty
+	^ self doesNotOverrideExistingMethodPreconditions
 ]
 
 { #category : 'printing' }
@@ -111,7 +111,7 @@ ReRenameMethodRefactoring >> doesNotOverrideExistingMethodPreconditions [
 			cond := (ReUpToRootDefinesMethod new class: each ; selector: newSelector).
 			cond check
 				ifTrue: [ self violations addAll: cond violators ] ].
-	^ self violations
+	^ self violations isEmpty
 	
 ]
 

--- a/src/Refactoring-UI/RERenameMethodDriver.class.st
+++ b/src/Refactoring-UI/RERenameMethodDriver.class.st
@@ -135,7 +135,7 @@ ReRenameMethodDriver >> runRefactoring [
 
 	"names are different so we should check because this is not a permutation" 
 	refactoring doesNotOverrideExistingMethodPreconditions 
-		ifNotEmpty: [ 
+		ifFalse: [ 
 			"We need to mockify it"
 			| ok |
 			ok := self application newConfirm

--- a/src/Refactoring-UI/RERenameMethodDriver.class.st
+++ b/src/Refactoring-UI/RERenameMethodDriver.class.st
@@ -16,6 +16,27 @@ Class {
 	#tag : 'Drivers'
 }
 
+{ #category : 'execution' }
+ReRenameMethodDriver >> breakingChoices [
+
+	| items |
+	items := OrderedCollection new.
+	items add: (ReRenameMethodChoice new driver: self).
+	items add: (ReRenameAndBrowseMethodOverridesChoice new driver: self).
+	items add: (ReBrowseMethodOverridesChoice new driver: self).
+	^ items
+]
+
+{ #category : 'actions' }
+ReRenameMethodDriver >> browseOverrides [
+
+	| overrides |
+	overrides := refactoring violations.
+	StMessageBrowser
+		browse: (overrides collect: [ :ref | ref realClass methodNamed: newMessage selector ])
+		asImplementorsOf: newMessage selector
+]
+
 { #category : 'private testing' }
 ReRenameMethodDriver >> canAddArgs [
 	^ false
@@ -61,6 +82,26 @@ ReRenameMethodDriver >> configureRefactoring [
 	refactoring := ReRenameMethodRefactoring new renameMethod: originalMessage selector in: class 
 ]
 
+{ #category : 'configuration' }
+ReRenameMethodDriver >> defaultSelectDialog [ 
+
+	^ SpSelectDialog new
+		    title: 'There are potential breaking changes!';
+		          label: 'Watchout potential override detected!';
+		          items: self breakingChoices;
+		          display: [ :each | each description ];
+		          displayIcon: [ :each | self iconNamed: each systemIconName ];
+		          openModal
+]
+
+{ #category : 'execution' }
+ReRenameMethodDriver >> handleBreakingChanges [
+
+	| select |
+	select := self selectDialog.
+	select ifNotNil: [ select action ]
+]
+
 { #category : 'initialization' }
 ReRenameMethodDriver >> initialize [ 
 	
@@ -86,6 +127,12 @@ ReRenameMethodDriver >> model: aModel renameMethodSignature: aMessage in: aClass
 	originalMessage := aMessage.
 	"while we could think that the class is not needed, it is because a rename should not override existing methods."
 	class := aClass
+]
+
+{ #category : 'actions' }
+ReRenameMethodDriver >> renameMethod [
+
+	self applyChanges 
 ]
 
 { #category : 'interaction' }
@@ -135,20 +182,11 @@ ReRenameMethodDriver >> runRefactoring [
 
 	"names are different so we should check because this is not a permutation" 
 	refactoring doesNotOverrideExistingMethodPreconditions 
-		ifFalse: [ 
-			"We need to mockify it"
-			| ok |
-			ok := self application newConfirm
-				 title: 'Watchout potential override detected!';
-		  	    label: (String streamContents: 
-							[:s | refactoring breakingChangeViolationMessageOn: s.
-								s nextPutAll: '. Do you want the override(s)?']);
-		  	    acceptLabel: 'Sure!';
-		  	    cancelLabel: 'No, forget it';
-		   	   openModal.
-			ok ifFalse: [ ^ self ] ].
-	self configureMessage.
-	self applyChanges.
+		ifTrue: [ 	
+			self configureMessage.
+			self applyChanges ]
+		ifFalse: [ self handleBreakingChanges ]
+
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-UI/RERenameMethodDriver.class.st
+++ b/src/Refactoring-UI/RERenameMethodDriver.class.st
@@ -128,25 +128,25 @@ ReRenameMethodDriver >> runRefactoring [
 				"We need to mockify it"
 				self application newInform
 					label: cond errorString;
-					title: 'Invalid name';
+					title: 'Invalid method name';
 					openModal ] ].
 	
-	refactoring areNamesTheSame 
-		ifFalse: [ 
-			"names are different so we should check because this is not a permutation" 
-			refactoring doesNotOverrideExistingMethodPreconditions 
-				ifNotEmpty: [ 
-				"We need to mockify it"
-				| ok |
-				ok := self application newConfirm
-					title: 'Watchout potential override detected!';
+	refactoring areNamesTheSame ifTrue: [ ^ self ].
+
+	"names are different so we should check because this is not a permutation" 
+	refactoring doesNotOverrideExistingMethodPreconditions 
+		ifNotEmpty: [ 
+			"We need to mockify it"
+			| ok |
+			ok := self application newConfirm
+				 title: 'Watchout potential override detected!';
 		  	    label: (String streamContents: 
 							[:s | refactoring breakingChangeViolationMessageOn: s.
 								s nextPutAll: '. Do you want the override(s)?']);
 		  	    acceptLabel: 'Sure!';
 		  	    cancelLabel: 'No, forget it';
 		   	   openModal.
-			ok ifFalse: [ ^ self ] ] ].
+			ok ifFalse: [ ^ self ] ].
 	self configureMessage.
 	self applyChanges.
 ]

--- a/src/Refactoring-UI/ReBrowseMethodOverridesChoice.class.st
+++ b/src/Refactoring-UI/ReBrowseMethodOverridesChoice.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'ReBrowseMethodOverridesChoice',
+	#superclass : 'ReMethodChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
+}
+
+{ #category : 'accessing' }
+ReBrowseMethodOverridesChoice >> action [
+
+	driver browseOverrides
+]
+
+{ #category : 'accessing' }
+ReBrowseMethodOverridesChoice >> description [
+
+	^ 'Browse existing methods that will be overriden BUT don''t rename'
+]

--- a/src/Refactoring-UI/ReRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveClassDriver.class.st
@@ -62,7 +62,7 @@ ReRemoveClassDriver >> configureRefactoring [
 	refactoring prepareForInteractiveMode
 ]
 
-{ #category : 'private execution' }
+{ #category : 'configuration' }
 ReRemoveClassDriver >> defaultSelectDialog [
 
 	^ SpSelectDialog new

--- a/src/Refactoring-UI/ReRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveClassDriver.class.st
@@ -127,13 +127,6 @@ ReRemoveClassDriver >> scopes: refactoringScopes classes: aColclasses [
 ]
 
 { #category : 'private execution' }
-ReRemoveClassDriver >> selectDialog [
-	
-	^ selectDialog ifNil: [ selectDialog := self defaultSelectDialog ].
-	
-]
-
-{ #category : 'private execution' }
 ReRemoveClassDriver >> setBreakingChangesPreconditions [
 	
 	haveNoReferences := refactoring preconditionHaveNoReferences.

--- a/src/Refactoring-UI/ReRenameAndBrowseMethodOverridesChoice.class.st
+++ b/src/Refactoring-UI/ReRenameAndBrowseMethodOverridesChoice.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : 'ReRenameAndBrowseMethodOverridesChoice',
+	#superclass : 'ReMethodChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
+}
+
+{ #category : 'accessing' }
+ReRenameAndBrowseMethodOverridesChoice >> action [
+
+	driver renameMethod.
+	driver browseOverrides
+]
+
+{ #category : 'accessing' }
+ReRenameAndBrowseMethodOverridesChoice >> description [
+
+	^ 'Rename method and browse existing methods that will then be overriden'
+]

--- a/src/Refactoring-UI/ReRenameMethodChoice.class.st
+++ b/src/Refactoring-UI/ReRenameMethodChoice.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'ReRenameMethodChoice',
+	#superclass : 'ReMethodChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
+}
+
+{ #category : 'accessing' }
+ReRenameMethodChoice >> action [
+
+	driver renameMethod
+]
+
+{ #category : 'accessing' }
+ReRenameMethodChoice >> description [
+
+	^ 'Rename method'
+]


### PR DESCRIPTION
Introduces some cleanups to the code, choices to:
- rename method
- browse overrides
- rename and browse overrides

This should fix: #14830 @jecisc could you please test and tell me what do you think of the new flow?