### PR TITLE
Fix Bug: `OrderedDictionary>>#at:at:put:` not updating ordered keys

### DIFF
--- a/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
@@ -498,20 +498,43 @@ OrderedDictionaryTest >> testAtAtIfAbsent [
 { #category : 'tests' }
 OrderedDictionaryTest >> testAtAtIfAbsentPut [
 
-	self assert: (OrderedDictionary new 
-						at: #key1 at: #key2 ifAbsentPut: [ 33 ]; at: #key1 at: #key2) equals: 33.
-	self assert: (OrderedDictionary new 
-						at: #key1 at: #key2 put: 22; 
-						at: #key1 at: #key2 ifAbsentPut: [ 33 ]; at: #key1 at: #key2) equals: 22.
+	| dictionary |
+	dictionary := OrderedDictionary new.
+
+	self
+		assert: (dictionary
+				 at: #key1 at: #key2 ifAbsentPut: [ 33 ];
+				 at: #key1 at: #key2)
+		equals: 33.
+	dictionary keysAndValuesDo: [ :key :value |
+		self
+			assert: key equals: #key1;
+			assert: (value at: #key2) equals: 33 ].
+	self
+		assert: (dictionary
+				 at: #key1 at: #key2 put: 22;
+				 at: #key1 at: #key2 ifAbsentPut: [ 33 ];
+				 at: #key1 at: #key2)
+		equals: 22
 ]
 
 { #category : 'tests' }
 OrderedDictionaryTest >> testAtAtPut [
 
-	self assert: (OrderedDictionary new 
-						at: #key1 at: #key2 put: 22;
-						at: #key1 at: #key2 put: 23;
-						at: #key1 at: #key2 ) equals: 23.
+	| dictionary |
+	dictionary := OrderedDictionary new.
+
+	self
+		assert: (dictionary
+				 at: #key1 at: #key2 put: 22;
+				 at: #key1 at: #key2 put: 23;
+				 at: #key1 at: #key2)
+		equals: 23.
+
+	dictionary keysAndValuesDo: [ :key :value |
+		self
+			assert: key equals: #key1;
+			assert: (value at: #key2) equals: 23 ]
 ]
 
 { #category : 'tests' }

--- a/src/Collections-Sequenceable/OrderedDictionary.class.st
+++ b/src/Collections-Sequenceable/OrderedDictionary.class.st
@@ -204,8 +204,6 @@ OrderedDictionary >> at: firstKey at: secondKey ifAbsent: aZeroArgBlock [
 OrderedDictionary >> at: firstKey at: secondKey ifAbsentPut: aZeroArgBlock [
 	"Return the object stored in the second dictionary at secondKey. The second dictionary is accessed via the key firstKey. If firstKey is not defined, set a new dictionary for the second key and set the value of aZeroArgBlock execution. If firstKey is defined and not second key set the value of aZeroArgBlock execution. See NestedDictionaryTest for examples."
 
-	"Set a value at secondKey in the dictionary returned by firstKey."
-
 	^ self
 		  value: [
 		  dictionary at: firstKey at: secondKey ifAbsentPut: aZeroArgBlock ]

--- a/src/Collections-Sequenceable/OrderedDictionary.class.st
+++ b/src/Collections-Sequenceable/OrderedDictionary.class.st
@@ -204,15 +204,21 @@ OrderedDictionary >> at: firstKey at: secondKey ifAbsent: aZeroArgBlock [
 OrderedDictionary >> at: firstKey at: secondKey ifAbsentPut: aZeroArgBlock [
 	"Return the object stored in the second dictionary at secondKey. The second dictionary is accessed via the key firstKey. If firstKey is not defined, set a new dictionary for the second key and set the value of aZeroArgBlock execution. If firstKey is defined and not second key set the value of aZeroArgBlock execution. See NestedDictionaryTest for examples."
 
-	^ dictionary at: firstKey at: secondKey ifAbsentPut: aZeroArgBlock
+	"Set a value at secondKey in the dictionary returned by firstKey."
 
+	^ self
+		  value: [
+		  dictionary at: firstKey at: secondKey ifAbsentPut: aZeroArgBlock ]
+		  registeringAtOrderedKeys: firstKey
 ]
 
 { #category : 'nested dictionaries' }
 OrderedDictionary >> at: firstKey at: secondKey put: aValue [
 	"Set a value at secondKey in the dictionary returned by firstKey."
 
-	^ dictionary at: firstKey at: secondKey put: aValue
+	^ self
+		  value: [ dictionary at: firstKey at: secondKey put: aValue ]
+		  registeringAtOrderedKeys: firstKey
 ]
 
 { #category : 'accessing' }
@@ -248,16 +254,10 @@ OrderedDictionary >> at: aKey ifPresent: aPresentBlock ifAbsentPut: anAbsentBloc
 
 { #category : 'accessing' }
 OrderedDictionary >> at: aKey put: aValue [
-	| oldSize |
 
-	oldSize := dictionary size.
-	dictionary at: aKey put: aValue.
-	dictionary size > oldSize
-		ifTrue: [
-			orderedKeys size > oldSize
-				ifFalse: [self growOrderedKeys].
-			orderedKeys at: oldSize + 1 put: aKey].
-	^ aValue
+	^ self
+		  value: [ dictionary at: aKey put: aValue ]
+		  registeringAtOrderedKeys: aKey
 ]
 
 { #category : 'accessing' }
@@ -597,6 +597,21 @@ OrderedDictionary >> storeOn: aStream [
 				separatedBy: [ aStream << ';' ].
 			aStream << '; yourself' ].
 	aStream << ')'
+]
+
+{ #category : 'private' }
+OrderedDictionary >> value: aBlock registeringAtOrderedKeys: aKey [
+
+	| oldSize value |
+
+	oldSize := dictionary size.
+	value := aBlock value.
+	dictionary size > oldSize
+		ifTrue: [
+			orderedKeys size > oldSize
+				ifFalse: [self growOrderedKeys].
+			orderedKeys at: oldSize + 1 put: aKey].
+	^ value
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Fix `OrderedDictionary>>#at:at:put:` and `#at:at:ifAbsentPut:` because it was not registering the key in the `orederedKeys` collection.

So if you send later `keysAndValuesDo:` for example the key is not present, because the dictionary is inconsistent with the orderedKeys collection.

For example, running
```smalltalk
| o |
o := OrderedDictionary new at: 2 at: 3 put: 3;yourself.
o keysAndValuesDo: [ :k :v | ]
```
will raise a debugger