### PR TITLE
FFIUnsupportedUntypedLiteral when using WebBrowser classes on Windows

### DIFF
--- a/src/WebBrowser-Core/WBWindowsWebBrowser.class.st
+++ b/src/WebBrowser-Core/WBWindowsWebBrowser.class.st
@@ -26,10 +26,10 @@ WBWindowsWebBrowser class >> shellExecute: lpOperation file: lpFile parameters: 
 
 	^ self ffiCall: #(
 			FFIConstantHandle ShellExecuteA(
-     				0, "Operation is not associated with a window"
-     				String* lpOperation,
-         			String* lpFile,
-     				String* lpParameters,
-     				String* lpDirectory,
+     				int 0, "Operation is not associated with a window"
+     				String lpOperation,
+         			String lpFile,
+     				String lpParameters,
+     				String lpDirectory,
         			int nShowCmd)) module: #shell32
 ]


### PR DESCRIPTION
- fix #16261
- fix #15980