### PR TITLE
Make #reportTestCase:runBlock: on HDTestReport print the test run time on the progress log stream

### DIFF
--- a/src/JenkinsTools-Core/HDTestReport.class.st
+++ b/src/JenkinsTools-Core/HDTestReport.class.st
@@ -255,7 +255,11 @@ HDTestReport >> reportTestCase: aTestCase runBlock: aBlock [
 		lf.
 	stream nextPutAll: testLog.
 	stream tab; nextPutAll: '</testcase>'; lf.
-	progressStream nextPutAll: 'finished' ; crlf; flush
+	progressStream
+		nextPutAll: 'finished in ';
+		nextPutAll: (Duration milliSeconds: time) humanReadablePrintString;
+		crlf;
+		flush
 ]
 
 { #category : 'running' }


### PR DESCRIPTION
As suggested in a [comment on issue #15104](https://github.com/pharo-project/pharo/issues/15104#issuecomment-1972188046), this pull request make `#reportTestCase:runBlock:` on HDTestReport print the test run time on the progress log stream.