### PR TITLE
Remove use of ‘set -e’ from script ‘getPharoVM.sh’

### DIFF
--- a/bootstrap/scripts/getPharoVM.sh
+++ b/bootstrap/scripts/getPharoVM.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -x
-set -e
 
 if [ $# -lt 1 ]
   then


### PR DESCRIPTION
This pull request removes the use of [‘set -e’](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#set:~:text=an%20individual%20file.-,%2De,an%20exit%20status%20greater%20than%20zero%29%2C%20the%20shell%20immediately%20shall%20exit,-%2C%20as%20if%20by) (added in pull request #14764) from the shell script ‘getPharoVM.sh’ so that when the download of the VM fails, the shell no longer immediately exits but continues to the commands for retrying the download:

https://github.com/pharo-project/pharo/blob/c1b6dac4d3ea2200b5affd5f5063e75dd8eb69a5/bootstrap/scripts/getPharoVM.sh#L25-L28