### PR TITLE
Fix for: UFFI/TFFI call for WebBrowser with specific URL length adds strange characters to the URL #15980

### DIFF
--- a/src/WebBrowser-Core/WBWindowsWebBrowser.class.st
+++ b/src/WebBrowser-Core/WBWindowsWebBrowser.class.st
@@ -24,10 +24,10 @@ WBWindowsWebBrowser class >> shellExecute: lpOperation file: lpFile parameters: 
 
 	^ self ffiCall: #(
 			FFIConstantHandle ShellExecuteA(
-     				0, "Operation is not associated with a window"
-     				String* lpOperation,
-         			String* lpFile,
-     				String* lpParameters,
-     				String* lpDirectory,
+     				int 0, "Operation is not associated with a window"
+     				String lpOperation,
+         			String lpFile,
+     				String lpParameters,
+     				String lpDirectory,
         			int nShowCmd)) module: #shell32
 ]


### PR DESCRIPTION
This is a backport to Pharo 11 of the solution proposed by @VincentBlondeau for Pharo 10 in [PR#16253](https://github.com/pharo-project/pharo/pull/16253)