### PR TITLE
Fixes issue: RB - Undo refactoring sometimes not only undo the last changes of refactoring #8103

### DIFF
--- a/src/Refactoring-Changes-Tests/RBRefactoringChangeManagerTest.class.st
+++ b/src/Refactoring-Changes-Tests/RBRefactoringChangeManagerTest.class.st
@@ -13,6 +13,13 @@ RBRefactoringChangeManagerTest >> newMockChange [
 	^ RBRefactoringChangeMock new
 ]
 
+{ #category : 'running' }
+RBRefactoringChangeManagerTest >> setUp [
+	super setUp.
+	RBRefactoryChangeManager nuke.
+	manager := RBRefactoryChangeManager instance
+]
+
 { #category : 'tests' }
 RBRefactoringChangeManagerTest >> testAddUndoAddsTheChangeToTheUndoStackAndEmptiesTheRedoCollection [
 

--- a/src/Refactoring-Changes-Tests/RBRefactoringChangeManagerTest.class.st
+++ b/src/Refactoring-Changes-Tests/RBRefactoringChangeManagerTest.class.st
@@ -1,13 +1,127 @@
 Class {
 	#name : 'RBRefactoringChangeManagerTest',
 	#superclass : 'TestCase',
+	#instVars : [
+		'manager'
+	],
 	#category : 'Refactoring-Changes-Tests',
 	#package : 'Refactoring-Changes-Tests'
 }
 
+{ #category : 'private' }
+RBRefactoringChangeManagerTest >> newMockChange [
+	^ RBRefactoringChangeMock new
+]
+
+{ #category : 'tests' }
+RBRefactoringChangeManagerTest >> testAddUndoAddsTheChangeToTheUndoStackAndEmptiesTheRedoCollection [
+
+	| change |
+	change := self newMockChange.
+	manager addUndo: change.
+
+	self assert: manager undoChange equals: change
+]
+
+{ #category : 'tests' }
+RBRefactoringChangeManagerTest >> testAddUndoWhenTheUndoStackIsFullCorrectlyPutsTheChangeAtTheStackTop [
+
+	| change undoSize |
+	undoSize := RBRefactoryChangeManager undoSize.
+	"Fill the undo stack to the top"
+	1 to: undoSize do: [ :i | manager addUndo: self newMockChange ].
+	"Put an extra element to the undo stack"
+	change := self newMockChange.
+	manager addUndo: change.
+
+	self assert: manager undoChange equals: change
+]
+
 { #category : 'tests' }
 RBRefactoringChangeManagerTest >> testChangeFactoryIsCorrectlyInitialized [
 
-	RBRefactoryChangeManager nuke.
 	self assert: RBRefactoryChangeManager changeFactory isNotNil
+]
+
+{ #category : 'tests' }
+RBRefactoringChangeManagerTest >> testRedoOperationExecutesTheCorrectChange [
+
+	| change1 change2 |
+	change1 := self newMockChange.
+	change2 := self newMockChange.
+	
+	manager addUndo: change1.
+	manager addUndo: change2.
+	manager undoOperation.
+	manager undoOperation.
+	
+	self assert: manager redoChange equals: change1.
+	manager redoOperation.
+	self assert: manager redoChange equals: change2.
+	manager redoOperation.
+	self deny: manager hasRedoableOperations. 
+]
+
+{ #category : 'tests' }
+RBRefactoringChangeManagerTest >> testRedoingAndUndoingAnOperationExecutesTheCorrectChange [
+
+	| change1 change2 |
+	change1 := self newMockChange.
+	change2 := self newMockChange.
+	
+	manager addUndo: change1.
+	manager addUndo: change2.
+	manager undoOperation.
+	manager undoOperation.
+	
+	self assert: manager redoChange equals: change1.
+	manager redoOperation.
+	self assert: manager redoChange equals: change2.
+	manager undoOperation.
+	self assert: manager redoChange equals: change1
+]
+
+{ #category : 'tests' }
+RBRefactoringChangeManagerTest >> testUndoOperationAddsTheChangeToTheRedoCollection [
+
+	| change |
+	change := self newMockChange.
+	manager addUndo: change.
+
+	self deny: manager hasRedoableOperations.
+
+	manager undoOperation.
+
+	self assert: manager hasRedoableOperations.
+	self assert: manager redoChange equals: change
+]
+
+{ #category : 'tests' }
+RBRefactoringChangeManagerTest >> testUndoOperationAddsTheChangeToTheRedoCollectionInTheCorrectOrder [
+
+	| change1 change2 |
+	change1 := self newMockChange.
+	change2 := self newMockChange.
+	manager addUndo: change1.
+	manager addUndo: change2.
+	
+	self deny: manager hasRedoableOperations.
+	
+	manager undoOperation.
+	self assert: manager redoChange equals: change2.
+	
+	manager undoOperation.
+	self assert: manager redoChange equals: change1
+]
+
+{ #category : 'tests' }
+RBRefactoringChangeManagerTest >> testUndoOperationWhenTheUndoStackIsEmptyPreservesTheUndoStackAndTheRedoCollectionEmpty [
+
+	"Ensure that the undo stack and the redo collection are empty"
+	self deny: manager hasUndoableOperations.
+	self deny: manager hasRedoableOperations.
+	manager undoOperation.
+	"Both should remain empty"
+	self deny: manager hasUndoableOperations.
+	self deny: manager hasRedoableOperations
 ]

--- a/src/Refactoring-Changes-Tests/RBRefactoringChangeMock.class.st
+++ b/src/Refactoring-Changes-Tests/RBRefactoringChangeMock.class.st
@@ -3,7 +3,7 @@ This class is used to test refactoring changes.
 "
 Class {
 	#name : 'RBRefactoringChangeMock',
-	#superclass : 'Object',
+	#superclass : 'RBRefactoryChange',
 	#instVars : [
 		'instVar'
 	],
@@ -30,6 +30,12 @@ RBRefactoringChangeMock >> accessAll [
 	^ instVar + SharedVar 
 ]
 
+{ #category : 'private' }
+RBRefactoringChangeMock >> executeNotifying: aBlock [
+	"I'm a mock, I do nothing"
+	^ self
+]
+
 { #category : 'initialization' }
 RBRefactoringChangeMock >> initialize [
 
@@ -41,4 +47,10 @@ RBRefactoringChangeMock >> initialize [
 RBRefactoringChangeMock >> one [
 
 	^ 1
+]
+
+{ #category : 'accessing' }
+RBRefactoringChangeMock >> renameChangesForClass: oldClassName to: newClassName [
+	"I'm a mock, I do nothing"
+	^ self
 ]

--- a/src/Refactoring-Changes-Tests/RBRefactoringChangeTest.class.st
+++ b/src/Refactoring-Changes-Tests/RBRefactoringChangeTest.class.st
@@ -380,7 +380,7 @@ RBRefactoringChangeTest >> testPerformChangeClass [
 		self assert: change changeClass superclass equals: self class.
 		self assertEmpty: change changeClass instVarNames.
 		self assertEmpty: change changeClass classVarNames ].
-	self assert: change changeClass superclass equals: Object.
+	self assert: change changeClass superclass equals: RBRefactoryChange.
 	self denyEmpty: change changeClass instVarNames.
 	self denyEmpty: change changeClass classVarNames.
 	self assert: change definedClass equals: self changeMockClass

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -124,9 +124,13 @@ RBRefactoryChangeManager class >> unload [
 
 { #category : 'public access' }
 RBRefactoryChangeManager >> addUndo: aRefactoringChange [
+	
 	undo push: aRefactoringChange.
 	undo size > UndoSize
-		ifTrue: [ undo removeFirst ].
+		ifTrue: [ 
+			"Remove the element at the bottom of the stack"
+			undo removeLast 
+		].
 	redo := OrderedCollection new
 ]
 
@@ -243,7 +247,8 @@ RBRefactoryChangeManager >> undoOperation [
 	undo ifEmpty: [ ^ self ].
 	self ignoreChangesWhile: [
 		| change |
-		change := undo removeLast.
+		"Retrieve the element at the top"
+		change := self undoChange.
 		redo add: change execute ]
 ]
 


### PR DESCRIPTION
This PR replicates the solution proposed by @VincentBlondeau in [PR#15800](https://github.com/pharo-project/pharo/pull/15800).
In addition it creates tests for the `RefactoryChangeManager` where its behavior related to undo and redo operations is checked.

This should fix [pharo-issue#8103](https://github.com/pharo-project/pharo/issues/8103)