### PR TITLE
Fixing issue #16291 - RBRemoveDirectAccessToVariableTransformationTest is failing

### DIFF
--- a/src/Refactoring-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -34,7 +34,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testClassVariable [
 		equals: (self parseMethod: 'addUndo: aRefactoringChange
 				undo push: aRefactoringChange.
 				undo size > self class undoSize
-					ifTrue: [ undo removeFirst ].
+					ifTrue: [ undo removeLast ].
 				redo := OrderedCollection new')
 ]
 


### PR DESCRIPTION
To fix the issue, I updated the text of the method's body in the test to match the updated method's body.
This PR fixes issue [pharo-project#16285](https://github.com/pharo-project/pharo/pull/16285)