### PR TITLE
Make #taskbarButtonMenu: on SystemWindow and MorphicNativeWindow use the FormSet for each of the icons

### DIFF
--- a/src/Morphic-Base/MenuMorph.class.st
+++ b/src/Morphic-Base/MenuMorph.class.st
@@ -214,11 +214,17 @@ MenuMorph >> activeSubmenu: aSubmenu [
 
 { #category : 'construction' }
 MenuMorph >> add: aLabelString icon: aForm subMenu: aMenuMorph [
+
+	^ self add: aLabelString iconFormSet: (aForm ifNotNil: [ FormSet form: aForm ]) subMenu: aMenuMorph
+]
+
+{ #category : 'construction' }
+MenuMorph >> add: aLabelString iconFormSet: aFormSet subMenu: aMenuMorph [
 	"Append the given submenu with the given label."
 
 	self addToggle: aLabelString target: nil selector: nil.
 	self lastItem
-		icon: aForm;
+		iconFormSet: aFormSet;
 		subMenu: aMenuMorph.
 	^ self
 ]

--- a/src/Morphic-Base/MorphicNativeWindow.class.st
+++ b/src/Morphic-Base/MorphicNativeWindow.class.st
@@ -257,7 +257,7 @@ MorphicNativeWindow >> taskbarButtonMenu: aMenu [
 		getStateSelector: nil
 		enablementSelector: #isNotRestored.
 	menu lastItem
-		icon: theme windowMaximizeForm;
+		iconFormSet: theme windowMaximizeFormSet;
 		font: theme menuFont.
 		
 	menu
@@ -267,7 +267,7 @@ MorphicNativeWindow >> taskbarButtonMenu: aMenu [
 		getStateSelector: nil
 		enablementSelector: #isNotMinimized.
 	menu lastItem
-		icon:  theme windowMinimizeForm;
+		iconFormSet: theme windowMinimizeFormSet;
 		font: theme menuFont.
 		
 	menu
@@ -277,7 +277,7 @@ MorphicNativeWindow >> taskbarButtonMenu: aMenu [
 		getStateSelector: nil
 		enablementSelector: #canBeMaximized.
 	menu lastItem
-		icon: theme windowMaximizeForm;
+		iconFormSet: theme windowMaximizeFormSet;
 		font: theme menuFont.
 		
 	menu addLine.
@@ -285,7 +285,7 @@ MorphicNativeWindow >> taskbarButtonMenu: aMenu [
 	submenu := theme newMenuIn: self for: self.
 	menu
 		add: 'Close all'
-		icon: theme windowCloseForm
+		iconFormSet: theme windowCloseFormSet
 		subMenu: submenu.
 	submenu
 		addToggle: 'Close all' translated
@@ -318,7 +318,7 @@ MorphicNativeWindow >> taskbarButtonMenu: aMenu [
 		getStateSelector: nil
 		enablementSelector: #allowedToClose.
 	menu lastItem
-		icon: theme windowCloseForm;
+		iconFormSet: theme windowCloseFormSet;
 		font: theme menuFont.
 
 	^menu

--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -136,7 +136,7 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 		getStateSelector: nil
 		enablementSelector: #isNotRestored.
 	menu lastItem
-		icon: self theme windowMaximizeForm;
+		iconFormSet: self theme windowMaximizeFormSet;
 		font: theme menuFont.
 
 	menu
@@ -146,7 +146,7 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 		getStateSelector: nil
 		enablementSelector: #isNotMinimized.
 	menu lastItem
-		icon: self theme windowMinimizeForm;
+		iconFormSet: self theme windowMinimizeFormSet;
 		font: theme menuFont.
 
 	menu
@@ -156,7 +156,7 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 		getStateSelector: nil
 		enablementSelector: #canBeMaximized.
 	menu lastItem
-		icon: self theme windowMaximizeForm;
+		iconFormSet: self theme windowMaximizeFormSet;
 		font: theme menuFont.
 
 	menu addLine.
@@ -164,7 +164,7 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 	moveSubmenu := theme newMenuIn: self for: self.
 	menu
 		add: 'Move'
-		icon: (self iconNamed: #blank)
+		iconFormSet: (self iconFormSetNamed: #blank)
 		subMenu: moveSubmenu.
 	moveSubmenu
 		addToggle: 'Move left' translated
@@ -183,7 +183,7 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 	submenu := theme newMenuIn: self for: self.
 	menu
 		add: 'Close all'
-		icon: self theme windowCloseForm
+		iconFormSet: self theme windowCloseFormSet
 		subMenu: submenu.
 	submenu
 		addToggle: 'all windows' translated
@@ -229,7 +229,7 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 		getStateSelector: nil
 		enablementSelector: #allowedToClose.
 	menu lastItem
-		icon: self theme windowCloseForm;
+		iconFormSet: self theme windowCloseFormSet;
 		font: theme menuFont.
 
 	^menu


### PR DESCRIPTION
This pull request makes `#taskbarButtonMenu:` on SystemWindow and MorphicNativeWindow use the FormSet for each of the icons.