### PR TITLE
15564-No-menubar-in-Mac-OS-Sonoma

### DIFF
--- a/src/OSWindow-SDL2/ObjCLibrary.class.st
+++ b/src/OSWindow-SDL2/ObjCLibrary.class.st
@@ -1,0 +1,104 @@
+"
+I am a little binding for the ObjC bridge library.
+I am just used to initialize the minimum the image inside OSX.
+"
+Class {
+	#name : 'ObjCLibrary',
+	#superclass : 'FFILibrary',
+	#category : 'OSWindow-SDL2-OSX-Specific',
+	#package : 'OSWindow-SDL2',
+	#tag : 'OSX-Specific'
+}
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> class_addMethodClass: cls selector: name implementation: imp signature: types [
+	^ self ffiCall: #(int class_addMethod(void* cls, void* name, void* imp, const char *types))
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> lookupClass: aString [
+
+	^ self ffiCall: #(void* objc_lookUpClass(char *aString))
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> lookupSelector: aString [
+
+	^ self ffiCall: #(void* sel_registerName(const char *aString))
+]
+
+{ #category : 'accessing - platform' }
+ObjCLibrary >> macLibraryName [
+
+	^ 'libobjc.dylib'
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> nsStringOf: aString [
+
+	| class selector encoded param |
+	class := self lookupClass: 'NSString'.
+	selector:= self lookupSelector: 'stringWithUTF8String:'.
+
+	encoded := aString utf8Encoded.
+	param := ByteArray new: encoded size + 1.
+	param pinInMemory.
+
+	LibC memCopy: encoded to: param size: encoded size.
+	param at: encoded size + 1 put: 0.
+
+	^ self sendMessage: selector to: class with: param
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> objc_allocateClassPairSuperclass: superclass name: name extraBytes: extraBytes [
+	
+	^ self ffiCall: #(void* objc_allocateClassPair(void* superclass, const char *name, size_t extraBytes))
+	
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> objc_registerClassPair: cls [
+	
+	self ffiCall: #(void objc_registerClassPair(void* cls))
+	
+	
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> release: aObjCObject [
+
+	| releaseSelector |
+	releaseSelector:= self lookupSelector: 'release'.
+	self sendMessage: releaseSelector to: aObjCObject
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> sendMessage: sel to: cls [
+
+	^ self ffiCall: #(void* objc_msgSend(void* cls, void* sel))
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> sendMessage: sel to: rcv with: aParam [
+
+	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam))
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> sendMessage: sel to: rcv with: aParam1 with:aParam2 with:aParam3 [
+
+	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam1, void* aParam2, void* aParam3))
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> sendMessage: sel to: rcv withInteger: aParam [
+
+	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, int aParam))
+]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> sendMessage: sel to: rcv withPointer: aParam [
+
+	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam))
+]

--- a/src/OSWindow-SDL2/ObjCLibrary.class.st
+++ b/src/OSWindow-SDL2/ObjCLibrary.class.st
@@ -102,3 +102,15 @@ ObjCLibrary >> sendMessage: sel to: rcv withPointer: aParam [
 
 	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam))
 ]
+
+{ #category : 'utilities - objectiveC' }
+ObjCLibrary >> sharedApplication [
+
+	| sel cls sharedApplication |
+
+	sel := self lookupSelector: 'sharedApplication'.
+	cls := self lookupClass: 'NSApplication'.
+	sharedApplication := self sendMessage: sel to: cls.
+
+	^ sharedApplication 
+]

--- a/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
@@ -11,9 +11,9 @@ Class {
 		'SDL2Constants',
 		'SDL2ConstantsHint'
 	],
-	#category : 'OSWindow-SDL2-Bindings',
+	#category : 'OSWindow-SDL2-Platforms',
 	#package : 'OSWindow-SDL2',
-	#tag : 'Bindings'
+	#tag : 'Platforms'
 }
 
 { #category : 'operations' }

--- a/src/OSWindow-SDL2/SDLNullPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLNullPlatform.class.st
@@ -4,9 +4,9 @@ I am the default platform. All my methods are empty or have a default implementa
 Class {
 	#name : 'SDLNullPlatform',
 	#superclass : 'SDLAbstractPlatform',
-	#category : 'OSWindow-SDL2-Bindings',
+	#category : 'OSWindow-SDL2-Platforms',
 	#package : 'OSWindow-SDL2',
-	#tag : 'Bindings'
+	#tag : 'Platforms'
 }
 
 { #category : 'operations' }

--- a/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
@@ -1,0 +1,214 @@
+"
+I am OSX specific operation that creates the menu bar and add the options to it.
+I am called by the SDL platform when starting. 
+"
+Class {
+	#name : 'SDLOSXPharoMenu',
+	#superclass : 'Object',
+	#instVars : [
+		'pharoMenu',
+		'aboutPharoItem',
+		'quitPharoItem',
+		'pharoMenuTargetClass',
+		'doAboutCallback',
+		'pharoTargetObject',
+		'doQuitCallback'
+	],
+	#classVars : [
+		'UniqueInstance'
+	],
+	#category : 'OSWindow-SDL2-Pharo-Specific',
+	#package : 'OSWindow-SDL2',
+	#tag : 'Pharo-Specific'
+}
+
+{ #category : 'instance creation' }
+SDLOSXPharoMenu class >> uniqueInstance [
+
+	^ UniqueInstance ifNil: [ UniqueInstance := self new ].
+]
+
+{ #category : 'private' }
+SDLOSXPharoMenu >> addPharoMenuOptions [
+
+	| selAddMenuItem selSetTarget selDoAbout selDoQuit selAlloc |
+	selAddMenuItem := self lookupSelector: 'addItemWithTitle:action:keyEquivalent:'.
+	selSetTarget := self lookupSelector: 'setTarget:'.
+	selDoAbout := self lookupSelector: 'doAbout'.
+	selDoQuit := self lookupSelector: 'doQuit'.
+	selAlloc := self lookupSelector: 'alloc'.
+	
+	pharoTargetObject := self sendMessage: selAlloc to: pharoMenuTargetClass.
+
+	aboutPharoItem := self
+		sendMessage: selAddMenuItem
+		to: self pharoMenu
+		with: (self nsStringOf: 'About Pharo')
+		with: selDoAbout
+		with: (self nsStringOf: '').
+
+	self sendMessage: selSetTarget to: aboutPharoItem withPointer: pharoTargetObject.
+
+	quitPharoItem := self
+		sendMessage: selAddMenuItem
+		to: self pharoMenu
+		with: (self nsStringOf: 'Quit Pharo')
+		with: selDoQuit
+		with: (self nsStringOf: 'q').
+		
+		self sendMessage: selSetTarget to: quitPharoItem withPointer: pharoTargetObject
+
+]
+
+{ #category : 'private - ffi' }
+SDLOSXPharoMenu >> class_addMethodClass: cls selector: name implementation: imp signature: types [
+	^ self ffiCall: #(int class_addMethod(void* cls, void* name, void* imp, const char *types))
+]
+
+{ #category : 'menu options' }
+SDLOSXPharoMenu >> doAbout [
+
+	UIManager default defer: [ Smalltalk aboutThisSystem ]
+]
+
+{ #category : 'private' }
+SDLOSXPharoMenu >> doGetPharoMenu [
+
+	| selSharedApplication selMainMenu selNumberOfItems selItemAtIndex selSubMenu clsNSApplication sharedApplication menu pharoMenuItem |
+
+	selSharedApplication := self lookupSelector: 'sharedApplication'.
+	selMainMenu := self lookupSelector: 'mainMenu'.
+	selNumberOfItems := self lookupSelector: 'numberOfItems'.
+	selItemAtIndex := self lookupSelector: 'itemAtIndex:'.
+	selSubMenu := self lookupSelector: 'submenu'.
+
+	clsNSApplication := self lookupClass: 'NSApplication'.
+	sharedApplication := self sendMessage: selSharedApplication to: clsNSApplication.
+
+	menu := self sendMessage: selMainMenu to: sharedApplication.
+
+	pharoMenuItem := self
+		                 sendMessage: selItemAtIndex
+		                 to: menu
+		                 withInteger: 0.
+
+	^ self sendMessage: selSubMenu to: pharoMenuItem
+]
+
+{ #category : 'menu options' }
+SDLOSXPharoMenu >> doQuit [
+
+	UIManager default defer: [WorldState quitSession] 
+]
+
+{ #category : 'private - ffi' }
+SDLOSXPharoMenu >> ffiLibraryName [
+
+	^ 'libobjc.dylib'
+]
+
+{ #category : 'api' }
+SDLOSXPharoMenu >> installInOSXWindow [
+
+	self registerPharoMenuTargetClass.
+	self addPharoMenuOptions.
+]
+
+{ #category : 'private - ffi' }
+SDLOSXPharoMenu >> lookupClass: aString [
+
+	^ self ffiCall: #(void* objc_lookUpClass(char *aString))
+]
+
+{ #category : 'private - ffi' }
+SDLOSXPharoMenu >> lookupSelector: aString [
+
+	^ self ffiCall: #(void* sel_registerName(const char *aString))
+]
+
+{ #category : 'private' }
+SDLOSXPharoMenu >> nsStringOf: aString [
+
+	| class selector encoded param |
+	class := self lookupClass: 'NSString'.
+	selector:= self lookupSelector: 'stringWithUTF8String:'.
+
+	encoded := aString utf8Encoded.
+	param := ByteArray new: encoded size + 1.
+	param pinInMemory.
+
+	LibC memCopy: encoded to: param size: encoded size.
+	param at: encoded size + 1 put: 0.
+
+	^ self sendMessage: selector to: class withPointer: param
+]
+
+{ #category : 'private - ffi' }
+SDLOSXPharoMenu >> objc_allocateClassPairSuperclass: superclass name: name extraBytes: extraBytes [
+	
+	^ self ffiCall: #(void* objc_allocateClassPair(void* superclass, const char *name, size_t extraBytes))
+	
+]
+
+{ #category : 'private - ffi' }
+SDLOSXPharoMenu >> objc_registerClassPair: cls [
+	
+	self ffiCall: #(void objc_registerClassPair(void* cls))
+	
+	
+]
+
+{ #category : 'accessing' }
+SDLOSXPharoMenu >> pharoMenu [
+	
+	^( pharoMenu isNil or: [ pharoMenu isNull ])
+		ifTrue: [ pharoMenu := self doGetPharoMenu ]
+		ifFalse: [ pharoMenu ].
+]
+
+{ #category : 'private' }
+SDLOSXPharoMenu >> registerPharoMenuTargetClass [
+	
+	| nsObjectCls |
+
+	nsObjectCls := self lookupClass: 'NSObject'.
+
+	pharoMenuTargetClass := self 
+		objc_allocateClassPairSuperclass: nsObjectCls 
+		name: 'PharoMenuTargetClass' 
+		extraBytes: 0.
+		
+	doAboutCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | self doAbout].	
+		
+	self class_addMethodClass: pharoMenuTargetClass selector: (self lookupSelector: 'doAbout') implementation: doAboutCallback  signature: 'v@:'.
+
+	doQuitCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | self doQuit].	
+
+	self class_addMethodClass: pharoMenuTargetClass selector: (self lookupSelector: 'doQuit') implementation: doQuitCallback  signature: 'v@:'.
+	
+	self objc_registerClassPair: pharoMenuTargetClass.
+]
+
+{ #category : 'private - ffi' }
+SDLOSXPharoMenu >> sendMessage: sel to: cls [
+
+	^ self ffiCall: #(void* objc_msgSend(void* cls, void* sel))
+]
+
+{ #category : 'private - ffi' }
+SDLOSXPharoMenu >> sendMessage: sel to: rcv with: aParam1 with:aParam2 with:aParam3 [
+
+	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam1, void* aParam2, void* aParam3))
+]
+
+{ #category : 'private - ffi' }
+SDLOSXPharoMenu >> sendMessage: sel to: rcv withInteger: aParam [
+
+	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, int aParam))
+]
+
+{ #category : 'private - ffi' }
+SDLOSXPharoMenu >> sendMessage: sel to: rcv withPointer: aParam [
+
+	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam))
+]

--- a/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
@@ -7,12 +7,11 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'pharoMenu',
-		'aboutPharoItem',
-		'quitPharoItem',
 		'pharoMenuTargetClass',
 		'doAboutCallback',
 		'pharoTargetObject',
-		'doQuitCallback'
+		'doQuitCallback',
+		'doPreferencesCallback'
 	],
 	#classVars : [
 		'UniqueInstance'
@@ -29,34 +28,103 @@ SDLOSXPharoMenu class >> uniqueInstance [
 ]
 
 { #category : 'private' }
-SDLOSXPharoMenu >> addPharoMenuOptions [
+SDLOSXPharoMenu >> addCallbackForSelector: aSelector withBlock: aBlock toTargetClass: aTargetClass [
 
-	| selAddMenuItem selSetTarget selDoAbout selDoQuit selRemoveAllItems |
+	| aCallback |
+
+	aCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | aBlock value ].			
+	ObjCLibrary uniqueInstance class_addMethodClass: aTargetClass selector: (ObjCLibrary uniqueInstance lookupSelector: aSelector) implementation: aCallback  signature: 'v@:'.
+
+	^ aCallback
+]
+
+{ #category : 'private' }
+SDLOSXPharoMenu >> addMenuItemTo: aNSMenu title: aTitle shortcut: aShortcut selector: aNSSelector [
+
+	| selAddMenuItem selSetTarget newItem selectorPointer |
 	selAddMenuItem := ObjCLibrary uniqueInstance lookupSelector: 'addItemWithTitle:action:keyEquivalent:'.
 	selSetTarget := ObjCLibrary uniqueInstance lookupSelector: 'setTarget:'.
+	
+	selectorPointer := aNSSelector ifNil: [ ExternalAddress null ] ifNotNil: [ aNSSelector ].
+	
+	newItem := ObjCLibrary uniqueInstance
+		sendMessage: selAddMenuItem
+		to: aNSMenu
+		with: (ObjCLibrary uniqueInstance nsStringOf: aTitle)
+		with: selectorPointer
+		with: (ObjCLibrary uniqueInstance nsStringOf: aShortcut).
+
+	selectorPointer isNull 
+		ifFalse: [ ObjCLibrary uniqueInstance sendMessage: selSetTarget to: newItem withPointer: pharoTargetObject].
+
+	^ newItem
+
+]
+
+{ #category : 'private' }
+SDLOSXPharoMenu >> addMenuItemTo: menu title: aTitle withSubMenu: aNSMenu [
+
+	| selSetSubMenu menuItem |
+	
+	selSetSubMenu := ObjCLibrary uniqueInstance lookupSelector: 'setSubmenu:'.
+	menuItem := self addMenuItemTo: menu title: aTitle shortcut: '' selector: nil.
+	
+	ObjCLibrary uniqueInstance sendMessage: selSetSubMenu to: menuItem withPointer: aNSMenu.
+
+]
+
+{ #category : 'private' }
+SDLOSXPharoMenu >> addPharoMenuOptions [
+
+	| selDoAbout selDoQuit selRemoveAllItems selDoPreferences |
 	selDoAbout := ObjCLibrary uniqueInstance lookupSelector: 'doAbout'.
 	selDoQuit := ObjCLibrary uniqueInstance lookupSelector: 'doQuit'.
+	selDoPreferences := ObjCLibrary uniqueInstance lookupSelector: 'doPreferences'.
+
 	selRemoveAllItems := ObjCLibrary uniqueInstance lookupSelector: 'removeAllItems'.
-
 	ObjCLibrary uniqueInstance sendMessage: selRemoveAllItems to: self pharoMenu.
+
+	self addMenuItemTo: self pharoMenu title: 'About Pharo' shortcut: '' selector: selDoAbout.
+	self addSeparatorTo: self pharoMenu.
+
+	self addMenuItemTo: self pharoMenu title: 'Preferences' shortcut: ',' selector: selDoPreferences.
+	self addSeparatorTo: self pharoMenu.
 	
-	aboutPharoItem := ObjCLibrary uniqueInstance
-		sendMessage: selAddMenuItem
-		to: self pharoMenu
-		with: (ObjCLibrary uniqueInstance nsStringOf: 'About Pharo')
-		with: selDoAbout
-		with: (ObjCLibrary uniqueInstance nsStringOf: '').
+	self addServicesMenuTo: self pharoMenu.
+	
+	self addMenuItemTo: self pharoMenu title: 'Quit Pharo' shortcut: 'q' selector: selDoQuit.
+]
 
-	ObjCLibrary uniqueInstance sendMessage: selSetTarget to: aboutPharoItem withPointer: pharoTargetObject.
+{ #category : 'private' }
+SDLOSXPharoMenu >> addSeparatorTo: aNSMenu [
 
-	quitPharoItem := ObjCLibrary uniqueInstance
-		sendMessage: selAddMenuItem
-		to: self pharoMenu
-		with: (ObjCLibrary uniqueInstance nsStringOf: 'Quit Pharo')
-		with: selDoQuit
-		with: (ObjCLibrary uniqueInstance nsStringOf: 'q').
-		
-		ObjCLibrary uniqueInstance sendMessage: selSetTarget to: quitPharoItem withPointer: pharoTargetObject
+	| menuItemCls selSeparatorItem selAddItem newSeparator |
+	menuItemCls := ObjCLibrary uniqueInstance lookupClass: 'NSMenuItem'.
+	selSeparatorItem := ObjCLibrary uniqueInstance lookupSelector: 'separatorItem'.
+	selAddItem := ObjCLibrary uniqueInstance lookupSelector: 'addItem:'.
+
+	newSeparator := ObjCLibrary uniqueInstance sendMessage: selSeparatorItem to: menuItemCls.
+
+	ObjCLibrary uniqueInstance sendMessage: selAddItem to: aNSMenu withPointer: newSeparator.
+
+]
+
+{ #category : 'private' }
+SDLOSXPharoMenu >> addServicesMenuTo: aNSMenu [
+
+	| selServicesMenu servicesMenu sharedApplication selSetServicesMenu |
+	selServicesMenu := ObjCLibrary uniqueInstance lookupSelector: 'servicesMenu'.
+	sharedApplication := ObjCLibrary uniqueInstance sharedApplication.
+	servicesMenu := ObjCLibrary uniqueInstance sendMessage: selServicesMenu to: sharedApplication.
+	selSetServicesMenu := ObjCLibrary uniqueInstance lookupSelector: 'setServicesMenu:'.
+
+	"If there is no Services Menu, we have to create it and register it"
+	servicesMenu isNull ifTrue: [ 
+		servicesMenu := self newNSMenu.
+		ObjCLibrary uniqueInstance sendMessage: selSetServicesMenu to: sharedApplication  withPointer: servicesMenu].
+
+	self addMenuItemTo: aNSMenu title: 'Services' withSubMenu: servicesMenu.
+	self addSeparatorTo: aNSMenu
 
 ]
 
@@ -75,15 +143,11 @@ SDLOSXPharoMenu >> allocatePharoMenuTarget [
 		objc_allocateClassPairSuperclass: nsObjectCls 
 		name: 'PharoMenuTargetClass' 
 		extraBytes: 0.
-		
-	doAboutCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | self doAbout].	
-		
-	ObjCLibrary uniqueInstance class_addMethodClass: pharoMenuTargetClass selector: (ObjCLibrary uniqueInstance lookupSelector: 'doAbout') implementation: doAboutCallback  signature: 'v@:'.
-
-	doQuitCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | self doQuit].	
-
-	ObjCLibrary uniqueInstance class_addMethodClass: pharoMenuTargetClass selector: (ObjCLibrary uniqueInstance lookupSelector: 'doQuit') implementation: doQuitCallback  signature: 'v@:'.
 	
+	doAboutCallback := self addCallbackForSelector: 'doAbout' withBlock: [ self doAbout ] toTargetClass: pharoMenuTargetClass.
+	doPreferencesCallback := self addCallbackForSelector: 'doPreferences' withBlock: [ self doPreferences ] toTargetClass: pharoMenuTargetClass.
+	doQuitCallback := self addCallbackForSelector: 'doQuit' withBlock: [ self doQuit ] toTargetClass: pharoMenuTargetClass.
+			
 	ObjCLibrary uniqueInstance objc_registerClassPair: pharoMenuTargetClass.
 	
 	pharoTargetObject := ObjCLibrary uniqueInstance sendMessage: selAlloc to: pharoMenuTargetClass.
@@ -99,36 +163,26 @@ SDLOSXPharoMenu >> doAbout [
 { #category : 'private' }
 SDLOSXPharoMenu >> doCreatePharoMenu [
 
-	| selSharedApplication selItemAtIndex clsNSApplication sharedApplication menu pharoMenuItem selSetMainMenu selSetSubMenu selAlloc selAddMenuItem clsNSMenu |
+	| selItemAtIndex mainMenu pharoMenuItem selSetMainMenu sharedApplication |
 
-	selSharedApplication := ObjCLibrary uniqueInstance lookupSelector: 'sharedApplication'.
 	selSetMainMenu := ObjCLibrary uniqueInstance lookupSelector: 'setMainMenu:'.
 	selItemAtIndex := ObjCLibrary uniqueInstance lookupSelector: 'itemAtIndex:'.
-	selSetSubMenu := ObjCLibrary uniqueInstance lookupSelector: 'setSubmenu:'.
-	selAlloc := ObjCLibrary uniqueInstance lookupSelector: 'alloc'.
-	selAddMenuItem := ObjCLibrary uniqueInstance lookupSelector: 'addItemWithTitle:action:keyEquivalent:'.
 
-	clsNSApplication := ObjCLibrary uniqueInstance lookupClass: 'NSApplication'.
-	clsNSMenu := ObjCLibrary uniqueInstance lookupClass: 'NSMenu'.
-
-	menu := ObjCLibrary uniqueInstance sendMessage: selAlloc to: clsNSMenu.
+	mainMenu := self newNSMenu.		
+	pharoMenu := self newNSMenu. 
 	
-	pharoMenuItem := ObjCLibrary uniqueInstance
-		sendMessage: selAddMenuItem
-		to: menu
-		with: (ObjCLibrary uniqueInstance nsStringOf: 'Pharo')
-		with: ExternalAddress null
-		with: (ObjCLibrary uniqueInstance nsStringOf: '').
-
-	pharoMenu := ObjCLibrary uniqueInstance sendMessage: selAlloc to: clsNSMenu. 
+	pharoMenuItem := self addMenuItemTo: mainMenu title: 'Pharo' withSubMenu: pharoMenu.
 	
-	ObjCLibrary uniqueInstance sendMessage: selSetSubMenu to: pharoMenuItem withPointer: pharoMenu.
-	
-	sharedApplication := ObjCLibrary uniqueInstance sendMessage: selSharedApplication to: clsNSApplication.
-
-	ObjCLibrary uniqueInstance sendMessage: selSetMainMenu to: sharedApplication withPointer: menu.
+	sharedApplication := ObjCLibrary uniqueInstance sharedApplication.
+	ObjCLibrary uniqueInstance sendMessage: selSetMainMenu to: sharedApplication withPointer: mainMenu.
 
 	^ pharoMenu
+]
+
+{ #category : 'menu options' }
+SDLOSXPharoMenu >> doPreferences [
+
+	UIManager default defer: [ SettingBrowser open ]
 ]
 
 { #category : 'menu options' }
@@ -142,6 +196,17 @@ SDLOSXPharoMenu >> installInOSXWindow [
 
 	self allocatePharoMenuTarget.
 	self addPharoMenuOptions.
+]
+
+{ #category : 'private' }
+SDLOSXPharoMenu >> newNSMenu [	
+
+	| selAlloc clsNSMenu |
+	selAlloc := ObjCLibrary uniqueInstance lookupSelector: 'alloc'.
+	clsNSMenu := ObjCLibrary uniqueInstance lookupClass: 'NSMenu'.
+
+	^ ObjCLibrary uniqueInstance sendMessage: selAlloc to: clsNSMenu.
+
 ]
 
 { #category : 'accessing' }

--- a/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
@@ -32,31 +32,31 @@ SDLOSXPharoMenu class >> uniqueInstance [
 SDLOSXPharoMenu >> addPharoMenuOptions [
 
 	| selAddMenuItem selSetTarget selDoAbout selDoQuit selRemoveAllItems |
-	selAddMenuItem := self lookupSelector: 'addItemWithTitle:action:keyEquivalent:'.
-	selSetTarget := self lookupSelector: 'setTarget:'.
-	selDoAbout := self lookupSelector: 'doAbout'.
-	selDoQuit := self lookupSelector: 'doQuit'.
-	selRemoveAllItems := self lookupSelector: 'removeAllItems'.
+	selAddMenuItem := ObjCLibrary uniqueInstance lookupSelector: 'addItemWithTitle:action:keyEquivalent:'.
+	selSetTarget := ObjCLibrary uniqueInstance lookupSelector: 'setTarget:'.
+	selDoAbout := ObjCLibrary uniqueInstance lookupSelector: 'doAbout'.
+	selDoQuit := ObjCLibrary uniqueInstance lookupSelector: 'doQuit'.
+	selRemoveAllItems := ObjCLibrary uniqueInstance lookupSelector: 'removeAllItems'.
 
-	self sendMessage: selRemoveAllItems to: self pharoMenu.
+	ObjCLibrary uniqueInstance sendMessage: selRemoveAllItems to: self pharoMenu.
 	
-	aboutPharoItem := self
+	aboutPharoItem := ObjCLibrary uniqueInstance
 		sendMessage: selAddMenuItem
 		to: self pharoMenu
-		with: (self nsStringOf: 'About Pharo')
+		with: (ObjCLibrary uniqueInstance nsStringOf: 'About Pharo')
 		with: selDoAbout
-		with: (self nsStringOf: '').
+		with: (ObjCLibrary uniqueInstance nsStringOf: '').
 
-	self sendMessage: selSetTarget to: aboutPharoItem withPointer: pharoTargetObject.
+	ObjCLibrary uniqueInstance sendMessage: selSetTarget to: aboutPharoItem withPointer: pharoTargetObject.
 
-	quitPharoItem := self
+	quitPharoItem := ObjCLibrary uniqueInstance
 		sendMessage: selAddMenuItem
 		to: self pharoMenu
-		with: (self nsStringOf: 'Quit Pharo')
+		with: (ObjCLibrary uniqueInstance nsStringOf: 'Quit Pharo')
 		with: selDoQuit
-		with: (self nsStringOf: 'q').
+		with: (ObjCLibrary uniqueInstance nsStringOf: 'q').
 		
-		self sendMessage: selSetTarget to: quitPharoItem withPointer: pharoTargetObject
+		ObjCLibrary uniqueInstance sendMessage: selSetTarget to: quitPharoItem withPointer: pharoTargetObject
 
 ]
 
@@ -68,31 +68,26 @@ SDLOSXPharoMenu >> allocatePharoMenuTarget [
 	(pharoTargetObject isNotNil and: [ pharoTargetObject isNull not ])
 		ifTrue: [ ^ self ].
 
-	nsObjectCls := self lookupClass: 'NSObject'.
-	selAlloc := self lookupSelector: 'alloc'.
+	nsObjectCls := ObjCLibrary uniqueInstance lookupClass: 'NSObject'.
+	selAlloc := ObjCLibrary uniqueInstance lookupSelector: 'alloc'.
 
-	pharoMenuTargetClass := self 
+	pharoMenuTargetClass := ObjCLibrary uniqueInstance 
 		objc_allocateClassPairSuperclass: nsObjectCls 
 		name: 'PharoMenuTargetClass' 
 		extraBytes: 0.
 		
 	doAboutCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | self doAbout].	
 		
-	self class_addMethodClass: pharoMenuTargetClass selector: (self lookupSelector: 'doAbout') implementation: doAboutCallback  signature: 'v@:'.
+	ObjCLibrary uniqueInstance class_addMethodClass: pharoMenuTargetClass selector: (ObjCLibrary uniqueInstance lookupSelector: 'doAbout') implementation: doAboutCallback  signature: 'v@:'.
 
 	doQuitCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | self doQuit].	
 
-	self class_addMethodClass: pharoMenuTargetClass selector: (self lookupSelector: 'doQuit') implementation: doQuitCallback  signature: 'v@:'.
+	ObjCLibrary uniqueInstance class_addMethodClass: pharoMenuTargetClass selector: (ObjCLibrary uniqueInstance lookupSelector: 'doQuit') implementation: doQuitCallback  signature: 'v@:'.
 	
-	self objc_registerClassPair: pharoMenuTargetClass.
+	ObjCLibrary uniqueInstance objc_registerClassPair: pharoMenuTargetClass.
 	
-	pharoTargetObject := self sendMessage: selAlloc to: pharoMenuTargetClass.
+	pharoTargetObject := ObjCLibrary uniqueInstance sendMessage: selAlloc to: pharoMenuTargetClass.
 
-]
-
-{ #category : 'private - ffi' }
-SDLOSXPharoMenu >> class_addMethodClass: cls selector: name implementation: imp signature: types [
-	^ self ffiCall: #(int class_addMethod(void* cls, void* name, void* imp, const char *types))
 ]
 
 { #category : 'menu options' }
@@ -106,35 +101,29 @@ SDLOSXPharoMenu >> doGetPharoMenu [
 
 	| selSharedApplication selMainMenu selNumberOfItems selItemAtIndex selSubMenu clsNSApplication sharedApplication menu pharoMenuItem |
 
-	selSharedApplication := self lookupSelector: 'sharedApplication'.
-	selMainMenu := self lookupSelector: 'mainMenu'.
-	selNumberOfItems := self lookupSelector: 'numberOfItems'.
-	selItemAtIndex := self lookupSelector: 'itemAtIndex:'.
-	selSubMenu := self lookupSelector: 'submenu'.
+	selSharedApplication := ObjCLibrary uniqueInstance lookupSelector: 'sharedApplication'.
+	selMainMenu := ObjCLibrary uniqueInstance lookupSelector: 'mainMenu'.
+	selNumberOfItems := ObjCLibrary uniqueInstance lookupSelector: 'numberOfItems'.
+	selItemAtIndex := ObjCLibrary uniqueInstance lookupSelector: 'itemAtIndex:'.
+	selSubMenu := ObjCLibrary uniqueInstance lookupSelector: 'submenu'.
 
-	clsNSApplication := self lookupClass: 'NSApplication'.
-	sharedApplication := self sendMessage: selSharedApplication to: clsNSApplication.
+	clsNSApplication := ObjCLibrary uniqueInstance lookupClass: 'NSApplication'.
+	sharedApplication := ObjCLibrary uniqueInstance sendMessage: selSharedApplication to: clsNSApplication.
 
-	menu := self sendMessage: selMainMenu to: sharedApplication.
+	menu := ObjCLibrary uniqueInstance sendMessage: selMainMenu to: sharedApplication.
 
-	pharoMenuItem := self
+	pharoMenuItem := ObjCLibrary uniqueInstance
 		                 sendMessage: selItemAtIndex
 		                 to: menu
 		                 withInteger: 0.
 
-	^ self sendMessage: selSubMenu to: pharoMenuItem
+	^ ObjCLibrary uniqueInstance sendMessage: selSubMenu to: pharoMenuItem
 ]
 
 { #category : 'menu options' }
 SDLOSXPharoMenu >> doQuit [
 
 	UIManager default defer: [WorldState quitSession] 
-]
-
-{ #category : 'private - ffi' }
-SDLOSXPharoMenu >> ffiLibraryName [
-
-	^ 'libobjc.dylib'
 ]
 
 { #category : 'api' }
@@ -144,78 +133,10 @@ SDLOSXPharoMenu >> installInOSXWindow [
 	self addPharoMenuOptions.
 ]
 
-{ #category : 'private - ffi' }
-SDLOSXPharoMenu >> lookupClass: aString [
-
-	^ self ffiCall: #(void* objc_lookUpClass(char *aString))
-]
-
-{ #category : 'private - ffi' }
-SDLOSXPharoMenu >> lookupSelector: aString [
-
-	^ self ffiCall: #(void* sel_registerName(const char *aString))
-]
-
-{ #category : 'private' }
-SDLOSXPharoMenu >> nsStringOf: aString [
-
-	| class selector encoded param |
-	class := self lookupClass: 'NSString'.
-	selector:= self lookupSelector: 'stringWithUTF8String:'.
-
-	encoded := aString utf8Encoded.
-	param := ByteArray new: encoded size + 1.
-	param pinInMemory.
-
-	LibC memCopy: encoded to: param size: encoded size.
-	param at: encoded size + 1 put: 0.
-
-	^ self sendMessage: selector to: class withPointer: param
-]
-
-{ #category : 'private - ffi' }
-SDLOSXPharoMenu >> objc_allocateClassPairSuperclass: superclass name: name extraBytes: extraBytes [
-	
-	^ self ffiCall: #(void* objc_allocateClassPair(void* superclass, const char *name, size_t extraBytes))
-	
-]
-
-{ #category : 'private - ffi' }
-SDLOSXPharoMenu >> objc_registerClassPair: cls [
-	
-	self ffiCall: #(void objc_registerClassPair(void* cls))
-	
-	
-]
-
 { #category : 'accessing' }
 SDLOSXPharoMenu >> pharoMenu [
 	
 	^( pharoMenu isNil or: [ pharoMenu isNull ])
 		ifTrue: [ pharoMenu := self doGetPharoMenu ]
 		ifFalse: [ pharoMenu ].
-]
-
-{ #category : 'private - ffi' }
-SDLOSXPharoMenu >> sendMessage: sel to: cls [
-
-	^ self ffiCall: #(void* objc_msgSend(void* cls, void* sel))
-]
-
-{ #category : 'private - ffi' }
-SDLOSXPharoMenu >> sendMessage: sel to: rcv with: aParam1 with:aParam2 with:aParam3 [
-
-	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam1, void* aParam2, void* aParam3))
-]
-
-{ #category : 'private - ffi' }
-SDLOSXPharoMenu >> sendMessage: sel to: rcv withInteger: aParam [
-
-	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, int aParam))
-]
-
-{ #category : 'private - ffi' }
-SDLOSXPharoMenu >> sendMessage: sel to: rcv withPointer: aParam [
-
-	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam))
 ]

--- a/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
@@ -31,15 +31,15 @@ SDLOSXPharoMenu class >> uniqueInstance [
 { #category : 'private' }
 SDLOSXPharoMenu >> addPharoMenuOptions [
 
-	| selAddMenuItem selSetTarget selDoAbout selDoQuit selAlloc |
+	| selAddMenuItem selSetTarget selDoAbout selDoQuit selRemoveAllItems |
 	selAddMenuItem := self lookupSelector: 'addItemWithTitle:action:keyEquivalent:'.
 	selSetTarget := self lookupSelector: 'setTarget:'.
 	selDoAbout := self lookupSelector: 'doAbout'.
 	selDoQuit := self lookupSelector: 'doQuit'.
-	selAlloc := self lookupSelector: 'alloc'.
-	
-	pharoTargetObject := self sendMessage: selAlloc to: pharoMenuTargetClass.
+	selRemoveAllItems := self lookupSelector: 'removeAllItems'.
 
+	self sendMessage: selRemoveAllItems to: self pharoMenu.
+	
 	aboutPharoItem := self
 		sendMessage: selAddMenuItem
 		to: self pharoMenu
@@ -57,6 +57,36 @@ SDLOSXPharoMenu >> addPharoMenuOptions [
 		with: (self nsStringOf: 'q').
 		
 		self sendMessage: selSetTarget to: quitPharoItem withPointer: pharoTargetObject
+
+]
+
+{ #category : 'private' }
+SDLOSXPharoMenu >> allocatePharoMenuTarget [
+	
+	| nsObjectCls selAlloc |
+
+	(pharoTargetObject isNotNil and: [ pharoTargetObject isNull not ])
+		ifTrue: [ ^ self ].
+
+	nsObjectCls := self lookupClass: 'NSObject'.
+	selAlloc := self lookupSelector: 'alloc'.
+
+	pharoMenuTargetClass := self 
+		objc_allocateClassPairSuperclass: nsObjectCls 
+		name: 'PharoMenuTargetClass' 
+		extraBytes: 0.
+		
+	doAboutCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | self doAbout].	
+		
+	self class_addMethodClass: pharoMenuTargetClass selector: (self lookupSelector: 'doAbout') implementation: doAboutCallback  signature: 'v@:'.
+
+	doQuitCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | self doQuit].	
+
+	self class_addMethodClass: pharoMenuTargetClass selector: (self lookupSelector: 'doQuit') implementation: doQuitCallback  signature: 'v@:'.
+	
+	self objc_registerClassPair: pharoMenuTargetClass.
+	
+	pharoTargetObject := self sendMessage: selAlloc to: pharoMenuTargetClass.
 
 ]
 
@@ -110,7 +140,7 @@ SDLOSXPharoMenu >> ffiLibraryName [
 { #category : 'api' }
 SDLOSXPharoMenu >> installInOSXWindow [
 
-	self registerPharoMenuTargetClass.
+	self allocatePharoMenuTarget.
 	self addPharoMenuOptions.
 ]
 
@@ -164,29 +194,6 @@ SDLOSXPharoMenu >> pharoMenu [
 	^( pharoMenu isNil or: [ pharoMenu isNull ])
 		ifTrue: [ pharoMenu := self doGetPharoMenu ]
 		ifFalse: [ pharoMenu ].
-]
-
-{ #category : 'private' }
-SDLOSXPharoMenu >> registerPharoMenuTargetClass [
-	
-	| nsObjectCls |
-
-	nsObjectCls := self lookupClass: 'NSObject'.
-
-	pharoMenuTargetClass := self 
-		objc_allocateClassPairSuperclass: nsObjectCls 
-		name: 'PharoMenuTargetClass' 
-		extraBytes: 0.
-		
-	doAboutCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | self doAbout].	
-		
-	self class_addMethodClass: pharoMenuTargetClass selector: (self lookupSelector: 'doAbout') implementation: doAboutCallback  signature: 'v@:'.
-
-	doQuitCallback := FFICallback signature: #(void (void* rcvr, void* objCSel)) block: [:rcvr :sel | self doQuit].	
-
-	self class_addMethodClass: pharoMenuTargetClass selector: (self lookupSelector: 'doQuit') implementation: doQuitCallback  signature: 'v@:'.
-	
-	self objc_registerClassPair: pharoMenuTargetClass.
 ]
 
 { #category : 'private - ffi' }

--- a/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
@@ -97,27 +97,38 @@ SDLOSXPharoMenu >> doAbout [
 ]
 
 { #category : 'private' }
-SDLOSXPharoMenu >> doGetPharoMenu [
+SDLOSXPharoMenu >> doCreatePharoMenu [
 
-	| selSharedApplication selMainMenu selNumberOfItems selItemAtIndex selSubMenu clsNSApplication sharedApplication menu pharoMenuItem |
+	| selSharedApplication selItemAtIndex clsNSApplication sharedApplication menu pharoMenuItem selSetMainMenu selSetSubMenu selAlloc selAddMenuItem clsNSMenu |
 
 	selSharedApplication := ObjCLibrary uniqueInstance lookupSelector: 'sharedApplication'.
-	selMainMenu := ObjCLibrary uniqueInstance lookupSelector: 'mainMenu'.
-	selNumberOfItems := ObjCLibrary uniqueInstance lookupSelector: 'numberOfItems'.
+	selSetMainMenu := ObjCLibrary uniqueInstance lookupSelector: 'setMainMenu:'.
 	selItemAtIndex := ObjCLibrary uniqueInstance lookupSelector: 'itemAtIndex:'.
-	selSubMenu := ObjCLibrary uniqueInstance lookupSelector: 'submenu'.
+	selSetSubMenu := ObjCLibrary uniqueInstance lookupSelector: 'setSubmenu:'.
+	selAlloc := ObjCLibrary uniqueInstance lookupSelector: 'alloc'.
+	selAddMenuItem := ObjCLibrary uniqueInstance lookupSelector: 'addItemWithTitle:action:keyEquivalent:'.
 
 	clsNSApplication := ObjCLibrary uniqueInstance lookupClass: 'NSApplication'.
+	clsNSMenu := ObjCLibrary uniqueInstance lookupClass: 'NSMenu'.
+
+	menu := ObjCLibrary uniqueInstance sendMessage: selAlloc to: clsNSMenu.
+	
+	pharoMenuItem := ObjCLibrary uniqueInstance
+		sendMessage: selAddMenuItem
+		to: menu
+		with: (ObjCLibrary uniqueInstance nsStringOf: 'Pharo')
+		with: ExternalAddress null
+		with: (ObjCLibrary uniqueInstance nsStringOf: '').
+
+	pharoMenu := ObjCLibrary uniqueInstance sendMessage: selAlloc to: clsNSMenu. 
+	
+	ObjCLibrary uniqueInstance sendMessage: selSetSubMenu to: pharoMenuItem withPointer: pharoMenu.
+	
 	sharedApplication := ObjCLibrary uniqueInstance sendMessage: selSharedApplication to: clsNSApplication.
 
-	menu := ObjCLibrary uniqueInstance sendMessage: selMainMenu to: sharedApplication.
+	ObjCLibrary uniqueInstance sendMessage: selSetMainMenu to: sharedApplication withPointer: menu.
 
-	pharoMenuItem := ObjCLibrary uniqueInstance
-		                 sendMessage: selItemAtIndex
-		                 to: menu
-		                 withInteger: 0.
-
-	^ ObjCLibrary uniqueInstance sendMessage: selSubMenu to: pharoMenuItem
+	^ pharoMenu
 ]
 
 { #category : 'menu options' }
@@ -137,6 +148,6 @@ SDLOSXPharoMenu >> installInOSXWindow [
 SDLOSXPharoMenu >> pharoMenu [
 	
 	^( pharoMenu isNil or: [ pharoMenu isNull ])
-		ifTrue: [ pharoMenu := self doGetPharoMenu ]
+		ifTrue: [ pharoMenu := self doCreatePharoMenu ]
 		ifFalse: [ pharoMenu ].
 ]

--- a/src/OSWindow-SDL2/SDLOSXPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatform.class.st
@@ -31,11 +31,9 @@ SDLOSXPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 
 { #category : 'initialization' }
 SDLOSXPlatform >> initPlatformSpecific [
-	| sel cls sharedApplication |
 
-	sel := ObjCLibrary uniqueInstance lookupSelector: 'sharedApplication'.
-	cls := ObjCLibrary uniqueInstance lookupClass: 'NSApplication'.
-	sharedApplication := ObjCLibrary uniqueInstance sendMessage: sel to: cls.
+	| sharedApplication |
+	sharedApplication := ObjCLibrary uniqueInstance sharedApplication.
 	
 	ObjCLibrary uniqueInstance sendMessage: (ObjCLibrary uniqueInstance lookupSelector: 'finishLaunching') to: sharedApplication.
 	

--- a/src/OSWindow-SDL2/SDLOSXPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatform.class.st
@@ -37,11 +37,16 @@ SDLOSXPlatform >> ffiLibraryName [
 
 { #category : 'initialization' }
 SDLOSXPlatform >> initPlatformSpecific [
-	| sel cls |
+	| sel cls sharedApplication |
 
 	sel := self lookupSelector: 'sharedApplication'.
 	cls := self lookupClass: 'NSApplication'.
-	self sendMessage: sel to: cls
+	sharedApplication := self sendMessage: sel to: cls.
+	
+	self sendMessage: (self lookupSelector: 'finishLaunching') to: sharedApplication.
+	
+	SDLOSXPharoMenu uniqueInstance installInOSXWindow.
+
 ]
 
 { #category : 'utilities - objectiveC' }

--- a/src/OSWindow-SDL2/SDLOSXPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatform.class.st
@@ -4,9 +4,9 @@ I execute specific operations on SDL for OSX
 Class {
 	#name : 'SDLOSXPlatform',
 	#superclass : 'SDLAbstractPlatform',
-	#category : 'OSWindow-SDL2-Bindings',
+	#category : 'OSWindow-SDL2-Platforms',
 	#package : 'OSWindow-SDL2',
-	#tag : 'Bindings'
+	#tag : 'Platforms'
 }
 
 { #category : 'operations' }
@@ -17,83 +17,28 @@ SDLOSXPlatform >> afterMainPharoWindowCreated: aOSSDLWindow [
 SDLOSXPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 
 	| aParam cocoaWindow wmInfo selector |
-	aParam := self nsStringOf: aString.
+	aParam := ObjCLibrary uniqueInstance nsStringOf: aString.
 
 	wmInfo := aOSSDLWindow backendWindow getWMInfo.
 	cocoaWindow := wmInfo info cocoa window.
 
-	selector := self lookupSelector: 'setTitleWithRepresentedFilename:'.
+	selector := ObjCLibrary uniqueInstance lookupSelector: 'setTitleWithRepresentedFilename:'.
 
-	self sendMessage: selector to: cocoaWindow getHandle with: aParam.
+	ObjCLibrary uniqueInstance sendMessage: selector to: cocoaWindow getHandle with: aParam.
 
-	self release: aParam
-]
-
-{ #category : 'ffi-calls' }
-SDLOSXPlatform >> ffiLibraryName [
-
-	^ 'libobjc.dylib'
+	ObjCLibrary uniqueInstance release: aParam
 ]
 
 { #category : 'initialization' }
 SDLOSXPlatform >> initPlatformSpecific [
 	| sel cls sharedApplication |
 
-	sel := self lookupSelector: 'sharedApplication'.
-	cls := self lookupClass: 'NSApplication'.
-	sharedApplication := self sendMessage: sel to: cls.
+	sel := ObjCLibrary uniqueInstance lookupSelector: 'sharedApplication'.
+	cls := ObjCLibrary uniqueInstance lookupClass: 'NSApplication'.
+	sharedApplication := ObjCLibrary uniqueInstance sendMessage: sel to: cls.
 	
-	self sendMessage: (self lookupSelector: 'finishLaunching') to: sharedApplication.
+	ObjCLibrary uniqueInstance sendMessage: (ObjCLibrary uniqueInstance lookupSelector: 'finishLaunching') to: sharedApplication.
 	
 	SDLOSXPharoMenu uniqueInstance installInOSXWindow.
 
-]
-
-{ #category : 'utilities - objectiveC' }
-SDLOSXPlatform >> lookupClass: aString [
-
-	^ self ffiCall: #(void* objc_lookUpClass(char *aString))
-]
-
-{ #category : 'utilities - objectiveC' }
-SDLOSXPlatform >> lookupSelector: aString [
-
-	^ self ffiCall: #(void* sel_registerName(const char *aString))
-]
-
-{ #category : 'utilities - objectiveC' }
-SDLOSXPlatform >> nsStringOf: aString [
-
-	| class selector encoded param |
-	class := self lookupClass: 'NSString'.
-	selector:= self lookupSelector: 'stringWithUTF8String:'.
-
-	encoded := aString utf8Encoded.
-	param := ByteArray new: encoded size + 1.
-	param pinInMemory.
-
-	LibC memCopy: encoded to: param size: encoded size.
-	param at: encoded size + 1 put: 0.
-
-	^ self sendMessage: selector to: class with: param
-]
-
-{ #category : 'utilities - objectiveC' }
-SDLOSXPlatform >> release: aObjCObject [
-
-	| releaseSelector |
-	releaseSelector:= self lookupSelector: 'release'.
-	self sendMessage: releaseSelector to: aObjCObject
-]
-
-{ #category : 'utilities - objectiveC' }
-SDLOSXPlatform >> sendMessage: sel to: cls [
-
-	^ self ffiCall: #(void* objc_msgSend(void* cls, void* sel))
-]
-
-{ #category : 'utilities - objectiveC' }
-SDLOSXPlatform >> sendMessage: sel to: rcv with: aParam [
-
-	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam))
 ]

--- a/src/OSWindow-SDL2/SDLUnixPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLUnixPlatform.class.st
@@ -5,9 +5,9 @@ I execute specific operations on SDL for Linux 64 (Unix term is used to keep OSP
 Class {
 	#name : 'SDLUnixPlatform',
 	#superclass : 'SDLAbstractPlatform',
-	#category : 'OSWindow-SDL2-Bindings',
+	#category : 'OSWindow-SDL2-Platforms',
 	#package : 'OSWindow-SDL2',
-	#tag : 'Bindings'
+	#tag : 'Platforms'
 }
 
 { #category : 'operations' }

--- a/src/OSWindow-SDL2/SDLWindowsPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLWindowsPlatform.class.st
@@ -4,9 +4,9 @@ Specific SDL initialization for Windows
 Class {
 	#name : 'SDLWindowsPlatform',
 	#superclass : 'SDLAbstractPlatform',
-	#category : 'OSWindow-SDL2-Bindings',
+	#category : 'OSWindow-SDL2-Platforms',
 	#package : 'OSWindow-SDL2',
-	#tag : 'Bindings'
+	#tag : 'Platforms'
 }
 
 { #category : 'operations' }


### PR DESCRIPTION
Fix #15564

Adding a class to generate the menubar in OSX. Just using the minimal api needed. A correct way will be to integrate the whole ObjectiveC Bridge support, but it is a lot of classes to just add two options in the menu, maybe later if we move all the menu there.