### PR TITLE
Fix: remove extract method transformation from UI

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodAndOccurrencesCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodAndOccurrencesCommand.class.st
@@ -24,7 +24,7 @@ SycExtractMethodAndOccurrencesCommand class >> canBeExecutedInContext: aSourceCo
 SycExtractMethodAndOccurrencesCommand class >> methodEditorShortcutActivation [
 	<classAnnotation>
 
-	^CmdShortcutActivation by: $e meta, $m meta, $o meta for: ClySourceCodeContext
+	^CmdShortcutActivation by: $e meta, $m meta for: ClySourceCodeContext
 ]
 
 { #category : 'converting' }
@@ -48,7 +48,7 @@ SycExtractMethodAndOccurrencesCommand >> defaultMenuIconName [
 
 { #category : 'accessing' }
 SycExtractMethodAndOccurrencesCommand >> defaultMenuItemName [
-	^ '(R) Extract method and occurrences'
+	^ '(R) Extract method'
 ]
 
 { #category : 'execution' }

--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -16,8 +16,8 @@ Class {
 { #category : 'testing' }
 SycExtractMethodCommand class >> canBeExecutedInContext: aSourceCodeContext [
 
-	^ (super canBeExecutedInContext: aSourceCodeContext) and: [
-		  aSourceCodeContext isMethodSelected not ]
+	^ false. "(super canBeExecutedInContext: aSourceCodeContext) and: [
+		  aSourceCodeContext isMethodSelected not ]"
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
This removes extract method transformation for the UI menu. We have refactoring implementation that is exposed and works better than this one. This closes: #16248
Besides this fix, extract method refactoring has new shortcut, that makes it easier to execute.