### PR TITLE
Take the selector into account in #AdditionalMethodState>>#analogousCodeTo:

### DIFF
--- a/src/Kernel-CodeModel/AdditionalMethodState.class.st
+++ b/src/Kernel-CodeModel/AdditionalMethodState.class.st
@@ -81,6 +81,7 @@ AdditionalMethodState >> analogousCodeTo: aMethodProperties [
 		[:i|
 		((self basicAt: i) analogousCodeTo: (aMethodProperties basicAt: i)) ifFalse:
 			[^false]].
+	self selector = aMethodProperties selector ifFalse: [ ^ false ].
 	^true
 ]
 

--- a/src/Kernel-Extended-Tests/AdditionalMethodStateTest.class.st
+++ b/src/Kernel-Extended-Tests/AdditionalMethodStateTest.class.st
@@ -37,6 +37,16 @@ AdditionalMethodStateTest >> testAnalogousCodeTo [
 ]
 
 { #category : 'tests' }
+AdditionalMethodStateTest >> testAnalogousCodeToTakesSelectorIntoAccount [
+	| pragma anotherAmState |
+	pragma := (Object compiledMethodAt: #at:) penultimateLiteral at: #primitive:.
+
+	anotherAmState := AdditionalMethodState selector: #at2: with: pragma copy.
+	
+	self deny: (amState analogousCodeTo: anotherAmState).
+]
+
+{ #category : 'tests' }
 AdditionalMethodStateTest >> testCopy [
 	| copy |
 	copy := amState copy.


### PR DESCRIPTION
This adds an extra check in AdditionalMethodState>>#analogousCodeTo: to explicitly take the selector into account