### PR TITLE
Change #transformBy:clippingTo:during:smoothing: on FormCanvas to use BitBlt combination rule 34 instead of 24

### DIFF
--- a/src/FormCanvas-Core/FormCanvas.class.st
+++ b/src/FormCanvas-Core/FormCanvas.class.st
@@ -703,7 +703,7 @@ FormCanvas >> transformBy: aDisplayTransform clippingTo: aClipRect during: aBloc
 		"If this is true B&W, then we need a first pass for erasure."
 		ifTrue: [1] ifFalse: [2].
 	"If my depth has alpha, do blending rather than paint"
-	rule := self depth = 32 ifTrue: [Form blend] ifFalse: [Form paint].
+	rule := self depth = 32 ifTrue: [Form blendAlphaScaled] ifFalse: [Form paint].
 	start to: 2 do:
 		[:i | "If i=1 we first make a shadow and erase it for opaque whites in B&W"
 		subCanvas := self class extent: patchRect extent depth: self depth.

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -328,7 +328,7 @@ ScalingCanvas >> applyClippingTo: clipRect during: aBlock [
 			sourceForm := Form extent: scaledClipRect extent / scale depth: 32.
 			(FormCanvas on: sourceForm) translateBy: scaledClipRect origin negated / scale during: aBlock.
 			(formCanvas warpFrom: sourceForm boundingBox innerCorners toRect: scaledClipRect)
-				combinationRule: Form blend;
+				combinationRule: Form blendAlphaScaled;
 				sourceForm: sourceForm;
 				warpBits
 		] ifFalse: [


### PR DESCRIPTION
This pull request changes `#transformBy:clippingTo:during:smoothing:` on FormCanvas and `#applyClippingTo:during:` on ScalingCanvas to use BitBlt combination rule 34 (`#blendAlphaScaled`) instead of 24 (`#blend`).

The following table compares the results of the snippet given below before and after these changes:

<table>
	<thead>
		<tr>
			<th></th>
			<th>
				Before
			</th>
			<th>
				After
			</th>
		</tr>
	</thead>
	<tbody>
		<tr>
			<th>
				1.png
			</th>
			<td>
				<img src="https://github.com/pharo-project/pharo/assets/1611248/1db33979-f954-459d-b7ca-3202492d7621">
			</td>
			<td>
				<img src="https://github.com/pharo-project/pharo/assets/1611248/4c04456f-b56d-4f14-bc2e-342da7c48e9a">
			</td>
		</tr>
		<tr>
			<th>
				2.png
			</th>
			<td>
				<img src="https://github.com/pharo-project/pharo/assets/1611248/0cd7f4a9-af65-4b93-9825-af85590c9fa5">
			</td>
			<td>
				<img src="https://github.com/pharo-project/pharo/assets/1611248/8c53fd63-a7fc-429d-bc62-0db3ffaeb676">
			</td>
		</tr>
	</tbody>
</table>

```smalltalk
{
	FormCanvas extent: 200@100.
	ScalingCanvas formCanvas: (FormCanvas extent: (200@100) * 2) scale: 2.
} withIndexDo: [ :canvas :index |
	canvas fillColor: Color white.
	{
		MorphicTransform identity.
		MorphicTransform offset: (100@100) negated angle: Float pi / 2 scale: 1.
	} do: [ :transform |
		canvas transformBy: transform clippingTo: (0@0 extent: 200@100) during: [ :transformedCanvas |
			transformedCanvas drawPolygon: { 5@95. 50@5. 95@95 }
				fillStyle: (SolidFillStyle color: Color blue translucent) ] ].
	PNGReadWriter putForm: canvas form
		onFileNamed: FileLocator imageDirectory / (index asString , '.png') ]
```