### PR TITLE
Add override for #drawPolygon:fillStyle:borderWidth:borderColor: on ScalingCanvas to avoid conversion of the second argument to a Color

### DIFF
--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -391,6 +391,17 @@ ScalingCanvas >> drawPolygon: vertices color: aColor borderWidth: bw borderColor
 			transformedCanvas drawPolygon: vertices color: aColor borderWidth: bw borderColor: bc ]
 ]
 
+{ #category : 'drawing - polygons' }
+ScalingCanvas >> drawPolygon: vertices fillStyle: aFillStyle borderWidth: bw borderColor: bc [
+
+	aFillStyle isColor ifTrue: [
+		self drawPolygon: vertices color: aFillStyle borderWidth: bw borderColor: bc.
+		^ self ].
+	self applyClippingTo: (vertices min floor corner: vertices max floor + 1)
+		during: [ :transformedCanvas |
+			transformedCanvas drawPolygon: vertices fillStyle: aFillStyle borderWidth: bw borderColor: bc ]
+]
+
 { #category : 'drawing - text' }
 ScalingCanvas >> drawString: s from: firstIndex to: lastIndex in: boundsRect font: fontOrNil color: c [
 

--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -247,6 +247,25 @@ ScalingCanvas class >> exampleLine2 [
 							width: width color: Color blue translucent ] ] ] ]
 ]
 
+{ #category : 'examples' }
+ScalingCanvas class >> exampleRubScrolledTextMorph [
+
+	| source |
+
+	source := String streamContents: [ :stream |
+		stream nextPutAll: 'OrderedCollection new'; cr.
+		(1 to: 100) groupsOf: 5 atATimeDo: [ :numbers |
+			stream tab; nextPutAll: ('addAll: {1};' format: { numbers printString }); cr ].
+		stream tab; nextPutAll: 'yourself'; cr ].
+	^ self privateExampleWithMorph:
+		(RubScrolledTextMorph new
+			model: (RubScrolledTextModel new text: source; yourself);
+			beForSmalltalkCode;
+			withCodeSizeFeedback;
+			extent: 320@200;
+			yourself)
+]
+
 { #category : 'instance creation' }
 ScalingCanvas class >> formCanvas: formCanvas scale: scale [
 

--- a/src/System-DependenciesTests/SystemDependenciesTest.class.st
+++ b/src/System-DependenciesTests/SystemDependenciesTest.class.st
@@ -88,7 +88,7 @@ SystemDependenciesTest >> knownLocalMonticelloDependencies [
 SystemDependenciesTest >> knownMorphicCoreDependencies [
 	"ideally this list should be empty"
 
-	^ #(#'Fonts-Infrastructure' #'FreeType' #'Keymapping-KeyCombinations' #'Morphic-Base' #'Refactoring-Critics' #'Refactoring-Environment')
+	^ #(#'Fonts-Infrastructure' #'FreeType' #'Keymapping-KeyCombinations' #'Morphic-Base' #'Refactoring-Critics' #'Refactoring-Environment' #'Rubric')
 ]
 
 { #category : 'known dependencies' }


### PR DESCRIPTION
This pull request adds an override for `#drawPolygon:fillStyle:borderWidth:borderColor:` on ScalingCanvas to avoid the inherited implementation’s conversion of the second argument to a Color. In combination with the changes of pull request #16303, this fixes the drawing of a RubAdornmentDisplayer on a ScalingCanvas, an example for that is added as well.