### PR TITLE
Fix parsing twice per keystroke in Calypso

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -223,8 +223,8 @@ ClyMethodEditorToolMorph >> setUpTargetClasses [
 
 { #category : 'events handling' }
 ClyMethodEditorToolMorph >> textChanged: aTextChanged [
+
 	super textChanged: aTextChanged.
-	ast := self currentEditedAST.
 	textMorph segments copy do: #delete.
 	IconStyler new
 	   stylerClasses: {ErrorNodeStyler . SemanticMessageIconStyler . SemanticWarningIconStyler };


### PR DESCRIPTION
This PR removes an unnecessary send to `currentEditedAST` in `ClyMethodEditorToolMorph` textChanged: so we don't parse twice the current method in Calypso.

To easily check the issue, open the Transcript, go to `RBParser` and compile this method:

```smalltalk
parseMethod
	| methodNode |
	
	(String streamContents: [ : s | DateAndTime now asUTC printHMSOn: s ]) traceCr.
	methodNode := self parseMessagePattern.
	self parsePragmas.
	self addCommentsTo: methodNode.
	self parseMethodBodyInto: methodNode.
	^methodNode
```

This was discovered by @jecisc and @MarcusDenker in #15178 
