### PR TITLE
14700-Shortcut-text-is-not-displayed-correctly-on-a-Mac

### DIFF
--- a/src/Morphic-Base/BalloonMorph.class.st
+++ b/src/Morphic-Base/BalloonMorph.class.st
@@ -77,11 +77,15 @@ BalloonMorph class >> getTextMorph: aStringOrMorph for: balloonOwner [
 	| m text |
 	aStringOrMorph isMorph
 		ifTrue: [m := aStringOrMorph]
-		ifFalse: [balloonOwner balloonFont
+		ifFalse: [
+			balloonOwner balloonFont
 				ifNil: [text := aStringOrMorph]
-				ifNotNil: [text := Text
+				ifNotNil: [text := 
+					aStringOrMorph isText 
+						ifTrue: [ aStringOrMorph ]
+						ifFalse: [Text
 								string: aStringOrMorph
-								attribute: (TextFontReference toFont: balloonOwner balloonFont)].
+								attribute: (TextFontReference toFont: balloonOwner balloonFont)]].
 			m := (TextMorph new contents: text) centered; color: UITheme current balloonTextColor].
 	m setToAdhereToEdge: #adjustedCenter.
 	^ m

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -103,18 +103,18 @@ Object >> taskbarIcon [
 ]
 
 { #category : '*Morphic-Base' }
+Object class >> taskbarIconName [
+	"Answer the icon for an instance of the receiver in a task bar"
+
+	^#smallWindow
+]
+
+{ #category : '*Morphic-Base' }
 Object >> taskbarIconName [
 	"Answer the icon for the receiver in a task bar
 	or nil for the default."
 
 	^self class taskbarIconName
-]
-
-{ #category : '*Morphic-Base' }
-Object class >> taskbarIconName [
-	"Answer the icon for an instance of the receiver in a task bar"
-
-	^#smallWindow
 ]
 
 { #category : '*Morphic-Base' }

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -1186,7 +1186,7 @@ Morph >> balloonText [
 	a Viewer"
 
 	^ extension ifNotNil: [:ext | ext balloonText ifNotNil: [:text |
-				text asString withNoLineLongerThan: self theme settings maxBalloonHelpLineLength]]
+				text withNoLineLongerThan: self theme settings maxBalloonHelpLineLength]]
 ]
 
 { #category : 'theme' }
@@ -5450,7 +5450,7 @@ Morph >> setBalloonText: stringOrText maxLineLength: aLength [
 	"Set receiver's balloon help text. Pass nil to remove the help."
 	(extension isNil and: [stringOrText isNil]) ifTrue: [^ self].
 	self assureExtension balloonText:
-		(stringOrText ifNotNil: [stringOrText asString withNoLineLongerThan: aLength])
+		(stringOrText ifNotNil: [stringOrText withNoLineLongerThan: aLength])
 ]
 
 { #category : 'accessing' }

--- a/src/Text-Core/Text.class.st
+++ b/src/Text-Core/Text.class.st
@@ -584,3 +584,33 @@ Text >> withInternalLineEndings [
 	(newText asString includes: Character lf) ifFalse: [ ^newText ].
 	^newText copyReplaceAll: String lf with: String cr
 ]
+
+{ #category : 'converting' }
+Text >> withNoLineLongerThan: aNumber [
+
+	"Answer a string with the same content as receiver, but rewrapped so that no line has more characters than the given number"
+
+	(aNumber isNumber not or: [ aNumber < 1 ]) ifTrue: [self error: 'too narrow'].
+	^self species
+		new: self size * (aNumber + 1) // aNumber "provision for supplementary line breaks"
+		streamContents: [ :stream |
+			self string lineIndicesDo: [ :start :endWithoutDelimiters :end |
+				| pastEnd lineStart |
+				pastEnd := endWithoutDelimiters + 1.
+				"eliminate spaces at beginning of line"
+				lineStart := (self indexOfAnyOf: CharacterSet separators complement startingAt: start ifAbsent: [pastEnd]) min: pastEnd.
+				[| lineStop lineEnd spacePosition |
+				lineEnd := lineStop  := lineStart + aNumber min: pastEnd.
+				spacePosition := lineStart.
+				[spacePosition < lineStop] whileTrue: [
+					spacePosition := self indexOfAnyOf: CharacterSet separators startingAt: spacePosition + 1 ifAbsent: [pastEnd].
+					spacePosition <= lineStop ifTrue: [lineEnd := spacePosition].
+				].
+				"split before space or before lineStop if no space"
+				stream nextPutAll: (self copyFrom: lineStart to: lineEnd - 1).
+				"eliminate spaces at beginning of next line"
+				lineStart := self indexOfAnyOf: CharacterSet separators complement startingAt: lineEnd ifAbsent: [pastEnd].
+				lineStart <= endWithoutDelimiters ]
+					whileTrue: [stream cr].
+				stream nextPutAll: (self copyFrom: pastEnd to: end) ] ].
+]


### PR DESCRIPTION
Fix #14700

- Ballon Help should support to have a text that we are providing.

Related with 
- https://github.com/pharo-spec/NewTools/pull/720
- https://github.com/pharo-spec/Spec/pull/1529