### PR TITLE
15841-ZeroDivide-when-selecting-idea11-icons

### DIFF
--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -375,12 +375,20 @@ ThemeIcons >> loadIconsFromUrl [
 
 { #category : 'loading' }
 ThemeIcons >> loadIconsFromUrlUsingScale: newScale [
-	| newIconsPerScale zipArchive |
+	| newIconsPerScale zipArchive zipContent |
 
 	newIconsPerScale := Dictionary new.
 	zipArchive := self downloadFromUrl.
 
-	((FileSystem zip: zipArchive) open workingDirectory allChildrenMatching: 'png-scale*') do: [ :directory |
+	zipContent := (FileSystem zip: zipArchive) open workingDirectory.
+
+	"If it has the old icon pack structure we handle as they don't have multiple sizes"
+	(zipContent allChildrenMatching: 'icons') 
+		ifNotEmpty: [ 
+			scale := 1.
+			^ self loadIconsOldIconSetsFrom: zipContent ].
+
+	(zipContent allChildrenMatching: 'png-scale*') do: [ :directory |
 		| newIcons |
 		newIconsPerScale
 			at: (Float readFrom: (directory basename copyFrom: 10 to: directory basename size))
@@ -396,6 +404,25 @@ ThemeIcons >> loadIconsFromUrlUsingScale: newScale [
 		icons at: #notFound ifAbsentPut: [ Color red iconOrThumbnailOfSize: 16 * iconsScale ] ].
 	iconsPerScale := newIconsPerScale.
 	scale := newScale
+]
+
+{ #category : 'loading' }
+ThemeIcons >> loadIconsOldIconSetsFrom: zipContent [ 
+
+	| newIcons |
+	newIcons := IdentityDictionary new.
+	
+	(zipContent allChildrenMatching: '*.png')
+		reject: [ :each | each base beginsWith: '.' ]
+		thenDo: [ :each | 
+			[ newIcons 	
+				at: each base asSymbol
+				put: (self readPNGFrom: each) ]
+			on: Error do: [ :e | self crTrace: each fullName, ' not a PNG, skipping.'  ]].
+
+	iconsPerScale := Dictionary new
+	   at: 1.0 put: newIcons;
+	   yourself
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Fix #15841
- Detecting when we are loading an icon set that does not have multiple scales per image.