### PR TITLE
Protect with a mutex the transcript update

### DIFF
--- a/src/Transcript-Core/ThreadSafeTranscript.class.st
+++ b/src/Transcript-Core/ThreadSafeTranscript.class.st
@@ -177,7 +177,7 @@ ThreadSafeTranscript >> shoutAboutToStyle: aPluggableShoutMorphOrView [
 
 { #category : 'updating' }
 ThreadSafeTranscript >> stepGlobal [
-"	The superclass method Model>>step indicates a convention that might be used to interoperate
+	"	The superclass method Model>>step indicates a convention that might be used to interoperate
 	synchronously with the UI-thread.  However when multiple Transcript windows are open, their
 	PluggableTextMorphs share a single instance, from the global Transcript.  To avoid potential trouble,
 	this method should not be named #step.
@@ -188,23 +188,21 @@ ThreadSafeTranscript >> stepGlobal [
 "
 
 	"Next three lines required temporarily to initialize instance variables added to existing instance"
+
 	deferredClear ifNil: [ deferredClear := false ].
 	deferredEndEntry ifNil: [ deferredEndEntry := false ].
 	stepContents ifNil: [ stepContents := '' ].
 
-	deferredClear ifTrue:
-	[ 	deferredClear := false.
+	deferredClear ifTrue: [
+		deferredClear := false.
 		stepContents := ''.
-		self changed: #clearText.
-	].
-	deferredEndEntry ifTrue:
-	[	deferredEndEntry := false.
-		self critical:
-		[	stepContents := stream contents.
+		self critical: [ self changed: #clearText ] ].
+	deferredEndEntry ifTrue: [
+		deferredEndEntry := false.
+		self critical: [
+			stepContents := stream contents.
 			stream resetContents.
-		].
-		self changed: #appendEntry.
-	]
+			self changed: #appendEntry ] ]
 ]
 
 { #category : 'ui building' }


### PR DESCRIPTION
The transcript is not entirely thread-safe right now.
When writing in the transcript from another thread, a race condition may happen while drawing the UI and this may cause blockage of the UI.

This PR puts the drawing of the Transcript inside the preexisting mutex to avoid such race conditions.