### PR TITLE
Make #initializeFor: on TaskbarItemMorph use the FormSet for the icon

### DIFF
--- a/src/Morphic-Widgets-Taskbar/TaskbarItemMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarItemMorph.class.st
@@ -65,7 +65,7 @@ TaskbarItemMorph >> initializeFor: aTaskbar [
 	lm := self theme
 		newRowIn: aTaskbar
 		for:
-			{((self iconNamed: self model taskbarIconName) ifNil: [ ^ nil ]) asMorph.
+			{((self iconFormSetNamed: self model taskbarIconName) ifNil: [ ^ nil ]) asMorph.
 			lab}.
 	lm cellInset: 2.
 	self


### PR DESCRIPTION
This pull request makes #initializeFor: on TaskbarItemMorph use the FormSet for the icon.