### PR TITLE
Remove #createTab from ClyBrowserToolMorph

### DIFF
--- a/src/Calypso-Browser/ClyBrowserToolMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserToolMorph.class.st
@@ -269,17 +269,6 @@ ClyBrowserToolMorph >> build [
 ]
 
 { #category : 'building' }
-ClyBrowserToolMorph >> buildAndDecorate [
-	self isBuilt ifTrue: [ ^self ] "somehow tab manager can call building process multiple times".
-	self setUpParametersFromModel.
-	self decorateContainerTab.
-	self build.
-	self buildStatusBar.
-	self applyDecorations.
-	self attachToSystem
-]
-
-{ #category : 'building' }
 ClyBrowserToolMorph >> buildPageAndDecorate [
 
 	self setUpParametersFromModel.

--- a/src/Calypso-Browser/ClyBrowserToolMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserToolMorph.class.st
@@ -338,23 +338,6 @@ ClyBrowserToolMorph >> copyForBrowserStateSnapshot [
 ]
 
 { #category : 'building' }
-ClyBrowserToolMorph >> createTab [
-	| menu |
-
-	menu := CmdMenu activatedBy: ClyBrowserTabCommandActivation.
-	menu buildInContext: context.
-
-	containerTab := TabMorph
-		label: self defaultTitle
-		icon: self defaultIcon
-		retrievingBlock: [ self buildAndDecorate ]
-		actions: menu buildBrowserTabActions.
-
-	containerTab model: self.
-	^ containerTab
-]
-
-{ #category : 'building' }
 ClyBrowserToolMorph >> decorateContainerTab [
 ]
 

--- a/src/Calypso-Browser/CmdCommand.extension.st
+++ b/src/Calypso-Browser/CmdCommand.extension.st
@@ -25,17 +25,6 @@ CmdCommand >> buildBrowserNotebookActionsUsing: aCommandActivator [
 ]
 
 { #category : '*Calypso-Browser' }
-CmdCommand >> buildBrowserTabActionsUsing: aCommandActivator [
-
-	^{
-		TabAction
-			action: [ aCommandActivator executeCommand ]
-			icon: self browserTabActionIcon
-			label: aCommandActivator commandDescription
-	}
-]
-
-{ #category : '*Calypso-Browser' }
 CmdCommand >> createTableCellButtonUsing: aCommandActivator [
 
 	| icon |

--- a/src/Calypso-Browser/CmdCommandActivator.extension.st
+++ b/src/Calypso-Browser/CmdCommandActivator.extension.st
@@ -9,14 +9,6 @@ CmdCommandActivator >> buildBrowserNotebookActions [
 ]
 
 { #category : '*Calypso-Browser' }
-CmdCommandActivator >> buildBrowserTabActions [
-
-	self canExecuteCommand ifFalse: [ ^#() ].
-
-	^command buildBrowserTabActionsUsing: self
-]
-
-{ #category : '*Calypso-Browser' }
 CmdCommandActivator >> buildBrowserToolbar: toolbarMorph [
 
 	self canExecuteCommand ifFalse: [ ^self ].

--- a/src/Calypso-Browser/CmdCommandMenuItem.extension.st
+++ b/src/Calypso-Browser/CmdCommandMenuItem.extension.st
@@ -7,12 +7,6 @@ CmdCommandMenuItem >> buildBrowserNotebookActions [
 ]
 
 { #category : '*Calypso-Browser' }
-CmdCommandMenuItem >> buildBrowserTabActions [
-
-	^activator buildBrowserTabActions
-]
-
-{ #category : '*Calypso-Browser' }
 CmdCommandMenuItem >> buildBrowserToolbar: toolbarMorph [
 
 	activator buildBrowserToolbar: toolbarMorph

--- a/src/Calypso-Browser/CmdMenu.extension.st
+++ b/src/Calypso-Browser/CmdMenu.extension.st
@@ -7,12 +7,6 @@ CmdMenu >> buildBrowserNotebookActions [
 ]
 
 { #category : '*Calypso-Browser' }
-CmdMenu >> buildBrowserTabActions [
-
-	^rootGroup buildBrowserTabActions
-]
-
-{ #category : '*Calypso-Browser' }
 CmdMenu >> buildBrowserToolbar: aToolbar [
 
 	rootGroup buildBrowserToolbar: aToolbar

--- a/src/Calypso-Browser/CmdMenuGroup.extension.st
+++ b/src/Calypso-Browser/CmdMenuGroup.extension.st
@@ -9,14 +9,6 @@ CmdMenuGroup >> buildBrowserNotebookActions [
 ]
 
 { #category : '*Calypso-Browser' }
-CmdMenuGroup >> buildBrowserTabActions [
-
-	self isActive ifFalse: [ ^#()].
-
-	^contents flatCollect: [ :each | each buildBrowserTabActions ]
-]
-
-{ #category : '*Calypso-Browser' }
 CmdMenuGroup >> buildBrowserToolbar: toolbarMorph [
 
 	self isActive ifFalse: [ ^self].


### PR DESCRIPTION
This pull request removes `#createTab` from ClyBrowserToolMorph as well implementors of some other selectors that only had senders through that method.