### PR TITLE
16321-Method-with-an-highlighted-warning-or-error-is-kept-when-deleting-the-offending-text

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -228,7 +228,7 @@ ClyMethodEditorToolMorph >> textChanged: aTextChanged [
 	textMorph segments copy do: #delete.
 	IconStyler new
 	   stylerClasses: {ErrorNodeStyler . SemanticMessageIconStyler . SemanticWarningIconStyler };
-		styleText: textModel withAst: ast.
+		styleText: textModel withAst: self currentEditedAST.
 	^ ast
 ]
 


### PR DESCRIPTION
Fix #16321
When styling the text when it changed we need to use the currrentEditedAST.