### PR TITLE
Announcer: Return early if there isn't any subscriber

### DIFF
--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -27,16 +27,22 @@ Class {
 Announcer >> announce: anAnnouncement [
 
 	^ self isSuspended
-		  ifFalse: [
-			  | announcement |
-			  announcement := anAnnouncement asAnnouncement.
+		ifFalse: [
+			| announcement |
+			announcement := anAnnouncement asAnnouncement.
 
-			  "If the user required to prevent the current announcement, we stop here."
-			  (self preventedAnnouncements handlesAnnouncement: announcement) ifTrue: [ ^ self ].
+			"Stop if there isn't any subscriber"
+			registry isEmpty ifTrue: [ ^ announcement ].
 
-			  registry ifNotNil: [ registry deliver: announcement ].
-			  announcement ]
-		  ifTrue: [ storedAnnouncements ifNotNil: [ storedAnnouncements add: anAnnouncement ] ]
+			"If the user required to prevent the current announcement, we stop here."
+			(self preventedAnnouncements handlesAnnouncement: announcement)
+				ifTrue: [ ^ announcement ].
+
+			registry deliver: announcement.
+			announcement ]
+		ifTrue: [
+			storedAnnouncements ifNotNil: [
+				storedAnnouncements add: anAnnouncement ] ]
 ]
 
 { #category : 'private' }

--- a/src/Announcements-Core/SubscriptionRegistry.class.st
+++ b/src/Announcements-Core/SubscriptionRegistry.class.st
@@ -73,6 +73,12 @@ SubscriptionRegistry >> initialize [
 	self reset
 ]
 
+{ #category : 'testing' }
+SubscriptionRegistry >> isEmpty [
+
+	^ subscriptions isEmpty
+]
+
 { #category : 'accessing' }
 SubscriptionRegistry >> numberOfSubscriptions [
 


### PR DESCRIPTION
Doing announcements on an empty Announcer showed a 6X speed-up on a MacBookPro 2018:

"20,785,231 iterations in 5 seconds 2 milliseconds. 4155384.046 per second"
"125,964,386 iterations in 5 seconds 1 millisecond. 25187839.632 per second"

Execute before / after the change:
```smalltalk
announcer := Announcer new.
[announcer announce: Announcement new] bench.  
```

