### PR TITLE
Change ‘./$0’ to ‘$0’ in recursive retry command in script ‘getPharoVM.sh’

### DIFF
--- a/bootstrap/scripts/getPharoVM.sh
+++ b/bootstrap/scripts/getPharoVM.sh
@@ -34,7 +34,7 @@ else
   if [ $RETRY_REMAINING -gt 0 ]
   then
     echo "Retry"
-    ./$0 $PHARO $VM $ARCHITECTURE `expr $RETRY_REMAINING - 1`
+    $0 $PHARO $VM $ARCHITECTURE `expr $RETRY_REMAINING - 1`
   else
     echo "Failed to download the VM"
   fi


### PR DESCRIPTION
This pull request changes `./$0` to `$0` in the recursive retry command in the script ‘getPharoVM.sh’. This should fix the [error seen in build 1432 of the ‘Pharo12’ Jenkins job](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/Pharo12/1432/execution/node/16/log/#:~:text=/builds/workspace/uest_and_branch_Pipeline_Pharo12/64/bootstrap/scripts/getPharoVM.sh%3A%20line%2037%3A%20.//builds/workspace/uest_and_branch_Pipeline_Pharo12/64/bootstrap/scripts/getPharoVM.sh%3A%20No%20such%20file%20or%20directory):

```
Downloading the latest pharoVM:
	http://files.pharo.org/get-files/120/pharo-vm-Linux-x86_64-latest.zip
+ '[' 56 -eq 0 ']'
+ echo 'Download failed'
Download failed
[…]
+ echo Retry
Retry
++ expr 3 - 1
+ .//builds/workspace/uest_and_branch_Pipeline_Pharo12/64/bootstrap/scripts/getPharoVM.sh 120 vmLatest 64 2
/builds/workspace/uest_and_branch_Pipeline_Pharo12/64/bootstrap/scripts/getPharoVM.sh: line 37: .//builds/workspace/uest_and_branch_Pipeline_Pharo12/64/bootstrap/scripts/getPharoVM.sh: No such file or directory
```
