### PR TITLE
ZnHeaders does not understand isNotEmpty

### DIFF
--- a/src/Zinc-HTTP/ManifestZincHTTP.class.st
+++ b/src/Zinc-HTTP/ManifestZincHTTP.class.st
@@ -1,0 +1,17 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestZincHTTP',
+	#superclass : 'PackageManifest',
+	#category : 'Zinc-HTTP-Manifest',
+	#package : 'Zinc-HTTP',
+	#tag : 'Manifest'
+}
+
+{ #category : 'code-critics' }
+ManifestZincHTTP class >> ruleNotEliminationRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGMethodDefinition #(#ZnMimePart #hasHeaders #false)) #'2024-03-23T16:05:34.582387+01:00') )
+]

--- a/src/Zinc-HTTP/ZnMimePart.class.st
+++ b/src/Zinc-HTTP/ZnMimePart.class.st
@@ -196,7 +196,7 @@ ZnMimePart >> hasEntity [
 { #category : 'testing' }
 ZnMimePart >> hasHeaders [
 
-	^ headers isNotNil and: [ self headers isNotEmpty ]
+	^ headers isNotNil and: [ self headers isEmpty not ]
 ]
 
 { #category : 'comparing' }


### PR DESCRIPTION
Revert change made in commit 031182ec9ea9912a9d5bed6cf47a633dd07e766a because ZnHeaders does not understand #isNotEmpty.

Fixes issue #16338 