### PR TITLE
Move archival of ‘*.xml’ and ‘*.fuel’ files in ‘Jenkinsfile’ to the ‘finally’ block

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,9 +34,9 @@ def runTests(architecture, prefix=''){
         unstash "bootstrap${architecture}"
         shell "bash -c 'bootstrap/scripts/run${prefix}Tests.sh ${architecture} ${env.STAGE_NAME}${prefix}'"
         junit allowEmptyResults: true, testResults: "${env.STAGE_NAME}${prefix}*.xml"
+    } finally {
         archiveArtifacts allowEmptyArchive: true, artifacts: "${env.STAGE_NAME}${prefix}*.xml", fingerprint: true
         archiveArtifacts allowEmptyArchive: true, artifacts: "*.fuel", fingerprint: true
-    } finally {
         // I am archiving the logs to check for crashes and errors.
         if(fileExists('PharoDebug.log')){
             shell "mv PharoDebug.log PharoDebug-${env.STAGE_NAME}${prefix}.log"


### PR DESCRIPTION
This pull request moves the archival of the test report `*.xml` and `*.fuel` files in ‘runTests’ in the ‘Jenkinsfile’ from the ‘try’ block to the ‘finally’ block so that any such files are still archived when the test running step fails or times out, which can help in diagnosing that problem.

The ‘junit’ step is not moved as it would presumably throw an error when there’s an incomplete `*.xml` file (that could be avoided by making HDTestReport name the file with a different extension initially and making it rename the file when completed though).