### PR TITLE
Change #getTempPath:buffer: on WinPlatform to use ‘GetTempPathW’ instead of ‘GetTempPath2W’

### DIFF
--- a/src/System-OSEnvironments-Tests/OSEnvironmentTest.class.st
+++ b/src/System-OSEnvironments-Tests/OSEnvironmentTest.class.st
@@ -109,9 +109,11 @@ OSEnvironmentTest >> testSettingEnvValueDuringRevertsValueAfterDuringBlock [
 	envName := self envNameForTest.
 	self instance setEnv: envName value: 'Before'.
 	expected := 'After'.
-	self instance setEnv: envName value: expected during: [  ].
+	self instance setEnv: envName value: expected during: [
+		actual := self instance at: envName.
+		self assert: actual equals: expected ].
 	actual := self instance at: envName.
-	self assert: actual equals: expected
+	self assert: actual equals: 'Before'
 ]
 
 { #category : 'tests' }

--- a/src/System-OSEnvironments/OSEnvironment.class.st
+++ b/src/System-OSEnvironments/OSEnvironment.class.st
@@ -262,7 +262,7 @@ OSEnvironment >> setEnv: nameString value: valueString during: aBlock [
 	aBlock value ] ensure: [
 		oldValue
 			ifNil: [ self removeKey: nameString ]
-			ifNotNil: [ self setEnv: nameString value: valueString ] ]
+			ifNotNil: [ self setEnv: nameString value: oldValue ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/System-OSEnvironments/Win32Environment.class.st
+++ b/src/System-OSEnvironments/Win32Environment.class.st
@@ -121,7 +121,7 @@ Win32Environment >> keysAndValuesDo: aBlock [
 { #category : 'private' }
 Win32Environment >> removeEnvironmentVariable: nameString [
 
-	 ^ self ffiCall: #( int SetEnvironmentVariableW ( Win32WideString nameString, 0 ) )
+	 ^ self ffiCall: #( int SetEnvironmentVariableW ( Win32WideString nameString, Win32WideString 0 ) )
 ]
 
 { #category : 'accessing' }

--- a/src/System-Platforms-Tests/WinPlatformTest.class.st
+++ b/src/System-Platforms-Tests/WinPlatformTest.class.st
@@ -19,5 +19,7 @@ WinPlatformTest >> testGetTempPathFromTMP [
 	OSEnvironment current at: 'TMP' put: expected.
 	actual := OSPlatform current getTempPath.
 	self assert: actual equals: expected ] ensure: [
-		value ifNotNil: [ OSEnvironment current at: 'TMP' put: value ] ]
+		value
+			ifNil: [ OSEnvironment current removeKey: 'TMP' ]
+			ifNotNil: [ OSEnvironment current at: 'TMP' put: value ] ]
 ]

--- a/src/System-Platforms/WinPlatform.class.st
+++ b/src/System-Platforms/WinPlatform.class.st
@@ -86,7 +86,7 @@ WinPlatform >> getTempPath [
 { #category : 'file paths' }
 WinPlatform >> getTempPath: bufferLength buffer: buffer [
 
-    self ffiCall: #(long GetTempPath2W(long bufferLength,
+    self ffiCall: #(long GetTempPathW(long bufferLength,
                             void*  buffer))
 ]
 


### PR DESCRIPTION
This pull request changes `#getTempPath:buffer:` on WinPlatform to use ‘GetTempPathW’ instead of ‘GetTempPath2W’ for compatibility with versions of Windows older than ‘Windows 10 Build 20348’ or ‘Windows Server Build 20348’.

See the [‘Requirements’ for ‘GetTempPathW’](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw#requirements), the [‘Requirements’ for ‘GetTempPath2W’](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2w#requirements) and my [earlier comment in pull request #13777](https://github.com/pharo-project/pharo/pull/13777#issuecomment-2016488515).

The [documentation for ‘GetTempPath2W’](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2w) indicates it is equivalent to ‘GetTempPathW’ for non-SYSTEM processes: “When calling this function from a process running as SYSTEM it will return the path C:\Windows\SystemTemp, which is inaccessible to non-SYSTEM processes. For non-SYSTEM processes, GetTempPath2 will behave the same as GetTempPath.” As for how ‘GetTempPath2’ is related to ‘GetTempPath2W’: “The fileapi.h header defines GetTempPath2 as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant. […] For more information, see [Conventions for Function Prototypes](https://learn.microsoft.com/en-us/windows/win32/intl/conventions-for-function-prototypes).”