### PR TITLE
fixes #16315 dependency browser layout feels wrong

### DIFF
--- a/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
@@ -31,7 +31,7 @@ DADependencyTreePresenter class >> defaultLayout [
 		add: ( SpBoxLayout newHorizontal
 					add: #textPackageField;
 					add: #buttonBrowseCycles;
-					add: #buttonRefresh;
+					add: #buttonRefresh expand: false;
 					add: #buttonDefault;
 					yourself)
 			expand: false;

--- a/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
@@ -231,7 +231,8 @@ DADependencyTreePresenter >> initializeButtons [
 		label: 'Open the graph'.
 	buttonReverseAnalysis := self newButton
 		help: 'Reverse the analysis : set the dependent packages as root packages';
-		label: 'Reverse the analysis'.
+		label: 'Reverse the analysis';
+		icon: (self iconNamed: #refresh).
 	buttonSave := self newButton
 		help: 'Serialize the current object relation graph dependencies';
 		label: 'Save current analysis'.

--- a/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
@@ -4,7 +4,6 @@ A PDPackageAnalyzerTreeModel shows all dependent packages from a set of packages
 Class {
 	#name : 'DADependencyTreePresenter',
 	#superclass : 'DAPackageTreePresenter',
-	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'systemCycles',
 		'packageLabel',

--- a/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DADependencyTreePresenter.class.st
@@ -4,6 +4,7 @@ A PDPackageAnalyzerTreeModel shows all dependent packages from a set of packages
 Class {
 	#name : 'DADependencyTreePresenter',
 	#superclass : 'DAPackageTreePresenter',
+	#classTraits : '{} + TraitedClass',
 	#instVars : [
 		'systemCycles',
 		'packageLabel',
@@ -17,7 +18,8 @@ Class {
 		'buttonReverseAnalysis',
 		'buttonSave',
 		'buttonMakeDiff',
-		'relationGraph'
+		'relationGraph',
+		'actionBar'
 	],
 	#category : 'Tool-DependencyAnalyser-UI-Core',
 	#package : 'Tool-DependencyAnalyser-UI',
@@ -28,21 +30,14 @@ Class {
 DADependencyTreePresenter class >> defaultLayout [
 	<spec: #default>
 	^ SpBoxLayout newVertical
-		add: ( SpBoxLayout newHorizontal
-					add: #textPackageField;
-					add: #buttonBrowseCycles;
-					add: #buttonRefresh expand: false;
-					add: #buttonDefault;
+		add: (SpBoxLayout newHorizontal
+					add: #textPackageField expand: true;
+					add: #buttonDefault expand: false;
 					yourself)
 			expand: false;
 		add: #packageLabel expand: false;
 		add: #tree;
-		add: (SpBoxLayout newHorizontal
-				add: #buttonAddPackage;
-				add: #buttonRemovePackage;
-				add: #buttonReverseAnalysis;
-				yourself)
-			expand: false;
+		add: #actionBar expand: false;
 		yourself
 ]
 
@@ -212,32 +207,41 @@ DADependencyTreePresenter >> filter: aString [
 
 { #category : 'initialization' }
 DADependencyTreePresenter >> initializeButtons [
+
+	buttonRefresh
+		icon: (self iconNamed: #glamorousRefresh);
+		label: ''.
 	buttonBrowseCycles := self newButton
 		help: 'Find all the cycles where the package is in the system';
-		label: 'Find cycles'.
+		icon: (self iconNamed: #objects).
 	buttonDefault := self newButton
-		help: 'Back to the default settings';
-		label: 'Default settings'.
+		help: 'Restore default settings';
+		label: 'Reset'.
 	buttonAddPackage := self newButton
-		help: 'Add package to the current analysis';
-		label: 'Add packages';
+		help: 'Add packages to the current analysis';
 		icon: (self iconNamed: #add).
 	buttonRemovePackage := self newButton
-		help: 'Remove package to the current analysis';
-		label: 'Remove packages';
+		help: 'Remove packages to the current analysis';
 		icon: (self iconNamed: #remove).
 	buttonGenerateGraphViz := self newButton
 		help: 'Open the graph in world';
 		label: 'Open the graph'.
 	buttonReverseAnalysis := self newButton
 		help: 'Reverse the analysis : set the dependent packages as root packages';
-		label: 'Reverse the analysis';
 		icon: (self iconNamed: #refresh).
 	buttonSave := self newButton
 		help: 'Serialize the current object relation graph dependencies';
 		label: 'Save current analysis'.
 	buttonMakeDiff := self newButton
-		label: 'Make diff'
+		label: 'Make diff'.
+	
+	actionBar := self newActionBar
+		add: buttonAddPackage;
+		add: buttonRemovePackage;
+		addLast: buttonRefresh;
+		addLast: buttonReverseAnalysis;
+		addLast: buttonBrowseCycles;
+		yourself.
 ]
 
 { #category : 'initialization' }

--- a/src/Tool-DependencyAnalyser-UI/DAPackageTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageTreePresenter.class.st
@@ -118,9 +118,8 @@ DAPackageTreePresenter >> initializePresenters [
 		yourself.
 
 	buttonRefresh := self newButton
-		icon: (self iconNamed: #refreshIcon);
-		help: 'Refresh the TreePresenter';
-		label: 'Refresh';
+		icon: (self iconNamed: #glamorousRefresh);
+		help: 'Refresh the list of analysed packages.';
 		yourself.
 
 	browser := Smalltalk tools browser onDefaultEnvironment

--- a/src/Tool-DependencyAnalyser-UI/DAPackageTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageTreePresenter.class.st
@@ -119,7 +119,8 @@ DAPackageTreePresenter >> initializePresenters [
 
 	buttonRefresh := self newButton
 		icon: (self iconNamed: #glamorousRefresh);
-		help: 'Refresh the list of analysed packages.';
+		label: 'Refresh';
+		help: 'Refresh the list of analyzed packages';
 		yourself.
 
 	browser := Smalltalk tools browser onDefaultEnvironment


### PR DESCRIPTION
This PR proposes a fix for issue #16315. It changes the UI to provide the widgets with their respective space. For this some of the buttons are moved into an SpActionBarPresenter.

See the screenshot below for the new look.
![16315-new-ui](https://github.com/pharo-project/pharo/assets/29785597/b6c92dca-bdd0-4f1b-81c6-7300002ac45f)
