### PR TITLE
Remove old backward compatibility code from FFILibrary

### DIFF
--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -514,7 +514,7 @@ ReleaseTest >> testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented 
 	 This test makes sure that we do not introduce new cases until we are down to one"
 
 	| knownFailures violations wantedAndValidViolations |
-	
+
 	"String streamContents: [ :aStream | aStream << '#( '.  SystemNavigation default allSentButNotImplementedSelectors do: [ :m | .aStream << '''' << m printString  << ''' ' ]. aStream << ')' ]"
 	knownFailures := #( 'AthensCCWArcSegment>>#accept:' 'AthensCWArcSegment>>#accept:' 'AthensCairoCanvas>>#visitCubicSegment:'
 	                    'AthensCairoCanvas>>#visitQuadSegment:' 'AthensCloseSegment>>#accept:' 'AthensCubicSegment>>#accept:' 'AthensEllipticalArcSegment>>#accept:'
@@ -523,16 +523,13 @@ ReleaseTest >> testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented 
 	                    'BalloonEngine>>#registerFills:' 'BalloonFillData>>#computeFill' 'ClyFullBrowserMorph>>#extendClassScopeForMethods:'
 	                    'ComplexBorderStyle>>#drawPolyPatchFrom:to:on:usingEnds:' 'ComplexBorderStyle>>#drawLineFrom:to:on:'
 	                    'Context>>#simulatePrimitive:in:receiver:arguments:' 'Context>>#doPrimitive:method:receiver:args:'
-	                    'Context>>#failPrimitiveWith:'
-	          
-'DAPackageAnalyzerDiffTreePresenter>>#buildRoots' 'DTReRunConfiguration>>#items' 'DebugSession>>#shouldDisplayContext:basedOnFilters:'
-	                    'DiskDirectoryEntry class>>#store:path:node:' 'EDEmergencyDebugger>>#resetDisplay' 'EDTest>>#prepareMethodVersionTest'
-	                    'ExternalDropHandler class>>#defaultHandler' 'FFICallbackArgumentReader>>#stackPointer' 'FFIFloat32>>#callbackReturnOn:for:'
-	                    'FFIFloatType>>#callbackReturnOn:for:' 'FFIIndirectFunctionResolution>>#resolveFunction:'
-	                    'FFILibrary>>#macLibraryName' 'FFILibrary>>#win32LibraryName' 'FileDialogWindow>>#saveForcedSelectedFile'
-	                    'FileList class>>#morphicViewOnFile:contents:fileList:' 'GLMOSWindowWorldMorph>>#delete' 'IRReconstructor>>#fixPushNilsForTemps'
-	                    'IceLibgitCommitWalk>>#shouldInclude:' 'IcePackage>>#outgoingCommits' 'IceRemote>>#upstreamForBranch:backend:'
-	                    'IceTag>>#lastCommit' 'IceTipHiedraAltComponentHistoryBrowser>>#newCommitRow:commit:'
+	                    'Context>>#failPrimitiveWith:' 'DAPackageAnalyzerDiffTreePresenter>>#buildRoots' 'DTReRunConfiguration>>#items'
+	                    'DebugSession>>#shouldDisplayContext:basedOnFilters:' 'DiskDirectoryEntry class>>#store:path:node:'
+	                    'EDEmergencyDebugger>>#resetDisplay' 'EDTest>>#prepareMethodVersionTest' 'ExternalDropHandler class>>#defaultHandler'
+	                    'FFICallbackArgumentReader>>#stackPointer' 'FFIFloat32>>#callbackReturnOn:for:' 'FFIFloatType>>#callbackReturnOn:for:'
+	                    'FFIIndirectFunctionResolution>>#resolveFunction:' 'FileDialogWindow>>#saveForcedSelectedFile' 'FileList class>>#morphicViewOnFile:contents:fileList:'
+	                    'GLMOSWindowWorldMorph>>#delete' 'IRReconstructor>>#fixPushNilsForTemps' 'IceLibgitCommitWalk>>#shouldInclude:'
+	                    'IcePackage>>#outgoingCommits' 'IceRemote>>#upstreamForBranch:backend:' 'IceTag>>#lastCommit' 'IceTipHiedraAltComponentHistoryBrowser>>#newCommitRow:commit:'
 	                    'IceTipHiedraAltHistoryBrowser>>#newCommitRow:commit:' 'IceTipHiedraAltHistoryBrowser>>#initializeCommitList'
 	                    'InstructionStream>>#interpretNext3ByteSistaV1Instruction:for:extA:extB:startPC:'
 	                    'KMDispatcher>>#spotterForKeysFor:' 'KMMetaModifier>>#printOsRepresentationOn:' 'LGitDiff>>#includesFileNamed:'
@@ -568,8 +565,8 @@ ReleaseTest >> testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented 
 	violations removeAllSuchThat: [ :violation | violation beginsWithAnyOf: #( SCI SmalltalkCI ) ].
 
 	"There is a violation that we explicitly want for rule tesing"
-	wantedAndValidViolations := #('ReSentButNotUnderstoodBySuperRuleTest>>#sampleMethod').
-	
+	wantedAndValidViolations := #( 'ReSentButNotUnderstoodBySuperRuleTest>>#sampleMethod' ).
+
 	violations removeAll: wantedAndValidViolations.
 	self assertEmpty: (violations difference: knownFailures)
 ]

--- a/src/UnifiedFFI/FFILibrary.class.st
+++ b/src/UnifiedFFI/FFILibrary.class.st
@@ -74,11 +74,8 @@ FFILibrary >> libraryName [
 
 { #category : 'accessing - platform' }
 FFILibrary >> macLibraryName [
-	"Calling by default #macModuleName for backwards compatibility.
-	The system complains that this method is not implemented as it will only exist
-	in subclasses that use the old API.
-	Please redefine #macLibraryName"
-	^ self macModuleName
+
+	^ self subclassResponsibility
 ]
 
 { #category : 'accessing - platform' }
@@ -103,30 +100,25 @@ FFILibrary >> uniqueInstance [
 
 { #category : 'accessing - platform' }
 FFILibrary >> unix32LibraryName [
-	"Use to #unixLibraryName to keep backward compatibility."
+
 	^ self unixLibraryName
 ]
 
 { #category : 'accessing - platform' }
 FFILibrary >> unix64LibraryName [
-	"Point to #unixLibraryName to keep backward compatibility."
+
 	^ self unixLibraryName
 ]
 
 { #category : 'accessing - platform' }
 FFILibrary >> unixLibraryName [
-	"Kept for backward compatibility.
-	The system complains that this method is not implemented as it will only exist
-	in subclasses that use the old API.
-	 Users should use unix32* or unix64*"
-	^ self unixModuleName
+	"Users should use unix32* or unix64*"
+
+	^ self subclassResponsibility
 ]
 
 { #category : 'accessing - platform' }
 FFILibrary >> win32LibraryName [
-	"Calling by default #win32ModuleName for backwards compatibility.
-	The system complains that this method is not implemented as it will only exist
-	in subclasses that use the old API.
-	Please redefine #win32LibraryName"
-	^ self win32ModuleName
+
+	^ self subclassResponsibility
 ]


### PR DESCRIPTION
In the past we could declare platform library name for FII via methods such as #macModuleName. But now it should override other methods and we kept the old code for backward compatibility.

This compatibility has been kept for multiple versions of Pharo. We can probably drop it now.

This also reduces the violation to testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented

Fixes #16280