### PR TITLE
remaining morphic dialogs: aligning the default option to right

### DIFF
--- a/src/Morphic-Widgets-Windows/DialogWindowMorph.class.st
+++ b/src/Morphic-Widgets-Windows/DialogWindowMorph.class.st
@@ -281,7 +281,10 @@ DialogWindowMorph >> newButtonRow [
 DialogWindowMorph >> newButtons [
 	"Answer new buttons as appropriate."
 
-	^{self newOKButton isDefault: true. self newCancelButton}
+	^ {
+		self newCancelButton.
+		self newOKButton isDefault: true 
+	}
 ]
 
 { #category : 'actions' }

--- a/src/Polymorph-Widgets/CustomQuestionDialogWindow.class.st
+++ b/src/Polymorph-Widgets/CustomQuestionDialogWindow.class.st
@@ -86,7 +86,11 @@ CustomQuestionDialogWindow >> initialize [
 CustomQuestionDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 
-	^{self yesButton. self noButton. self cancelButton}
+	^{
+		self cancelButton.
+		self noButton.
+		self yesButton isDefault: true 
+	}
 ]
 
 { #category : 'accessing' }

--- a/src/Polymorph-Widgets/ListDialogWindow.class.st
+++ b/src/Polymorph-Widgets/ListDialogWindow.class.st
@@ -280,7 +280,11 @@ ListDialogWindow >> listKeystrokeUp [
 ListDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 
-	^{self newOKButton isDefault: true. self buildBrowseButton. self newCancelButton}
+	^ { 
+		self buildBrowseButton. 
+		self newCancelButton.
+		self newOKButton isDefault: true
+	}
 ]
 
 { #category : 'actions' }

--- a/src/Polymorph-Widgets/MessageDialogWindow.class.st
+++ b/src/Polymorph-Widgets/MessageDialogWindow.class.st
@@ -84,7 +84,7 @@ MessageDialogWindow >> minimumWidth [
 MessageDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 
-	^{self newOKButton isDefault: true}
+	^ { self newOKButton isDefault: true }
 ]
 
 { #category : 'actions' }

--- a/src/Polymorph-Widgets/PluggableDialogWindow.class.st
+++ b/src/Polymorph-Widgets/PluggableDialogWindow.class.st
@@ -82,15 +82,14 @@ PluggableDialogWindow >> initialize [
 	"Initialize the receiver."
 
 	super initialize.
-	self
-		buttons: super newButtons
+	self buttons: super newButtons
 ]
 
 { #category : 'actions' }
 PluggableDialogWindow >> newButtons [
 	"Answer  the plugged buttons."
 
-	^self buttons
+	^ self buttons
 ]
 
 { #category : 'actions' }
@@ -115,7 +114,9 @@ PluggableDialogWindow >> useDefaultOKButton [
 	"Set the buttons to be just an OK button.
 	Only effective before the model is set."
 
-	self buttons: {self newOKButton isDefault: true}
+	self buttons: {
+		self newOKButton isDefault: true
+	}
 ]
 
 { #category : 'actions' }
@@ -131,5 +132,8 @@ PluggableDialogWindow >> useOKDefaultCancelButton [
 	"Set the buttons to be an OK button and a default cancel button.
 	Only effective before the model is set."
 
-	self buttons: {self newOKButton. self newCancelButton isDefault: true}
+	self buttons: {
+		self newOKButton. 
+		self newCancelButton isDefault: true 
+	}
 ]

--- a/src/Polymorph-Widgets/PopupChoiceDialogWindow.class.st
+++ b/src/Polymorph-Widgets/PopupChoiceDialogWindow.class.st
@@ -239,7 +239,10 @@ PopupChoiceDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 
 	self filterMorph: self newFilterEntry.
-	^{self filterMorph. self newCancelButton}
+	^{ 
+		self filterMorph. 
+		self newCancelButton
+	}
 ]
 
 { #category : 'actions' }

--- a/src/Polymorph-Widgets/PopupChoiceOrRequestDialogWindow.class.st
+++ b/src/Polymorph-Widgets/PopupChoiceOrRequestDialogWindow.class.st
@@ -44,10 +44,11 @@ PopupChoiceOrRequestDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 	self filterMorph: self newFilterEntry.
 	self okButton: self newOKButton.
-	^Array
-		with: self filterMorph
-		with: self okButton
-		with: self newCancelButton
+	^ {
+		self filterMorph.
+		self newCancelButton.
+		self okButton isDefault: true 
+	}
 ]
 
 { #category : 'accessing' }

--- a/src/Polymorph-Widgets/ProceedDialogWindow.class.st
+++ b/src/Polymorph-Widgets/ProceedDialogWindow.class.st
@@ -46,7 +46,10 @@ ProceedDialogWindow >> keyStroke: evt [
 ProceedDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 
-	^{self newOKButton. self newCancelButton isDefault: true}
+	^ {
+		self newCancelButton. 
+		self newOKButton isDefault: true
+	}
 ]
 
 { #category : 'accessing' }

--- a/src/Polymorph-Widgets/QuestionDialogWindow.class.st
+++ b/src/Polymorph-Widgets/QuestionDialogWindow.class.st
@@ -30,7 +30,11 @@ QuestionDialogWindow >> answer: anObject [
 QuestionDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 
-	^{self newYesButton. self newNoButton. self newCancelButton isDefault: true}
+	^ {
+		self newCancelButton.
+		self newNoButton. 
+		self newYesButton isDefault: true 
+	}
 ]
 
 { #category : 'accessing' }

--- a/src/Polymorph-Widgets/QuestionWithoutCancelDialogWindow.class.st
+++ b/src/Polymorph-Widgets/QuestionWithoutCancelDialogWindow.class.st
@@ -26,5 +26,8 @@ QuestionWithoutCancelDialogWindow >> escapePressed [
 QuestionWithoutCancelDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 
-	^{self newYesButton isDefault: true. self newNoButton}
+	^ {
+		self newNoButton.
+		self newYesButton isDefault: true
+	}
 ]

--- a/src/Polymorph-Widgets/TextEditorDialogWindow.class.st
+++ b/src/Polymorph-Widgets/TextEditorDialogWindow.class.st
@@ -86,7 +86,10 @@ TextEditorDialogWindow >> initialize [
 TextEditorDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 
-	^{self newOKButton. self newCancelButton}
+	^{
+		self newCancelButton.
+		self newOKButton isDefault: true
+	}
 ]
 
 { #category : 'actions' }

--- a/src/Polymorph-Widgets/TextEntryDialogWindow.class.st
+++ b/src/Polymorph-Widgets/TextEntryDialogWindow.class.st
@@ -44,7 +44,10 @@ TextEntryDialogWindow >> minimumWidth [
 TextEntryDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 
-	^{self newOKButton isDefault: true. self newCancelButton}
+	^ {
+		self newCancelButton.
+		self newOKButton isDefault: true
+	}
 ]
 
 { #category : 'creation' }

--- a/src/Rubric/RubFindReplaceDialogWindow.class.st
+++ b/src/Rubric/RubFindReplaceDialogWindow.class.st
@@ -184,7 +184,12 @@ RubFindReplaceDialogWindow >> maxPreviousListSize [
 RubFindReplaceDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."
 
-	^{self newFindButton isDefault: true. self newReplaceButton. self newReplaceAllButton. self newCancelButton}
+	^ {
+	self newFindButton. 
+	self newReplaceButton. 
+	self newReplaceAllButton. 
+	self newCancelButton isDefault: true
+	}
 ]
 
 { #category : 'user-interface' }


### PR DESCRIPTION
This is to finish the compatibility adjustment of dialog options: all positive options are default and aligned as last button option. This may be just a setting in the future: once we finish moving all dialogs to spec :)

Still uncertain if the positive (which in some cases is destructive) option needs to be there, that will cause some problems to people (thinking on muscular memory) :/