### PR TITLE
Deprecate #newMethod:header: with rewritting to #basicNew:header:

### DIFF
--- a/src/Kernel-CodeModel/CompiledCode.class.st
+++ b/src/Kernel-CodeModel/CompiledCode.class.st
@@ -130,6 +130,10 @@ CompiledCode class >> newMethod: numberOfBytes header: headerWord [
 	 Essential. See Object documentation whatIsAPrimitive."
 
 	<primitive: 79 error: ec>
+	self 
+		deprecated: 'Use #basicNew:header: instead.' 
+		transformWith: '`@rcv newMethod: `@numberOfBytes header: `@headerWord' -> '`@rcv basicNew: `@numberOfBytes header: `@headerWord'.
+	
 	ec == #'insufficient object memory' ifTrue:
 		[^self handleFailingNew: numberOfBytes header: headerWord].
 	^self primitiveFailed

--- a/src/Kernel-CodeModel/CompiledCode.class.st
+++ b/src/Kernel-CodeModel/CompiledCode.class.st
@@ -121,22 +121,12 @@ CompiledCode class >> newFrom: aCompiledMethod [
 
 { #category : 'instance creation' }
 CompiledCode class >> newMethod: numberOfBytes header: headerWord [
-	"Primitive. Answer an instance of me. The number of literals (and other
-	 information) is specified by the headerWord (see my class comment).
-	 The first argument specifies the number of fields for bytecodes in the
-	 method. Fail if either argument is not a SmallInteger, or if numberOfBytes
-	 is negative, or if memory is low. Once the header of a method is set by
-	 this primitive, it cannot be changed to change the number of literals.
-	 Essential. See Object documentation whatIsAPrimitive."
 
-	<primitive: 79 error: ec>
 	self 
 		deprecated: 'Use #basicNew:header: instead.' 
 		transformWith: '`@rcv newMethod: `@numberOfBytes header: `@headerWord' -> '`@rcv basicNew: `@numberOfBytes header: `@headerWord'.
 	
-	ec == #'insufficient object memory' ifTrue:
-		[^self handleFailingNew: numberOfBytes header: headerWord].
-	^self primitiveFailed
+	^ self basicNew: numberOfBytes header: headerWord
 ]
 
 { #category : 'comparing' }


### PR DESCRIPTION
Related to #15625. 