### PR TITLE
Revert comment change from commit f5df5966bd73d05bc04806d2f8735baa4b1783cb

### DIFF
--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -1677,7 +1677,8 @@ Socket >> waitForDisconnectionFor: timeout [
 
 { #category : 'waiting' }
 Socket >> waitForSendDoneFor: timeout [
-	"Wait up until the given deadline for the current send operation to complete. Return true if it completes by the deadline, false if not."
+	"Wait up until the given deadline for the current send operation to complete. 
+	Raise an exception if the timeout expires or the connection is closed before sending finishes."
 
 	^ self
 		  waitForSendDoneFor: timeout


### PR DESCRIPTION
The method comment is incorrect. This was caused by an (inadvertent?) revert in commit f5df5966bd73d05bc04806d2f8735baa4b1783cb

Context: https://github.com/pharo-project/pharo/issues/16373

The issue itself is not fixed (probably needs to be fixed upstream in Zodiac to take the changes of Socket in Pharo12 into account)