### PR TITLE
Fix Generate Equals and Hash DNU

### DIFF
--- a/src/SystemCommands-ClassCommands/SycGenerateEqualAndHashCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycGenerateEqualAndHashCommand.class.st
@@ -8,6 +8,15 @@ Class {
 	#package : 'SystemCommands-ClassCommands'
 }
 
+{ #category : 'testing' }
+SycGenerateEqualAndHashCommand class >> canBeExecutedInContext: aToolContext [
+	"Show the receiver if the last selected class has instance variables" 
+
+	^ (super canBeExecutedInContext: aToolContext) and: [ 
+		aToolContext lastSelectedClass instanceVariables notEmpty ]
+
+]
+
 { #category : 'execution' }
 SycGenerateEqualAndHashCommand >> asRefactorings [
 
@@ -32,11 +41,15 @@ SycGenerateEqualAndHashCommand >> execute [
 
 { #category : 'execution' }
 SycGenerateEqualAndHashCommand >> prepareFullExecutionInContext: aToolContext [
-	super prepareFullExecutionInContext: aToolContext.
 
+	super prepareFullExecutionInContext: aToolContext.
 	variables := aToolContext
 		requestMultipleVariables: 'Choose variables for equality'
-		from: {targetClass}
+		from: { targetClass }.
+	variables
+		ifEmpty: [ 
+			self inform: 'Please select variables for equality'.
+			CmdCommandAborted signal ]
 ]
 
 { #category : 'factory method' }


### PR DESCRIPTION
This PR tries to fix the issue reported in #16360.
The modifications involve:

- Show the generate equal and hash menu entry if the selected class has instance variables.
- Inform and Abort the operation if no variable is selected and Ok is clicked.

## Class without instance variables
<img width="814" alt="Screenshot 2024-03-29 at 23 44 37" src="https://github.com/pharo-project/pharo/assets/4825959/5702474c-cff7-49e2-a1bc-3d51c9574420">

## Class with instance variable
<img width="939" alt="Screenshot 2024-03-29 at 23 44 57" src="https://github.com/pharo-project/pharo/assets/4825959/8dc91955-22de-48fb-a0cb-136dd3c2a5e6">
