### PR TITLE
Changed 'Transcript show:' construct to 'self trace'

### DIFF
--- a/src/Beacon-Core/TranscriptLogger.class.st
+++ b/src/Beacon-Core/TranscriptLogger.class.st
@@ -19,5 +19,5 @@ Class {
 { #category : 'utilities' }
 TranscriptLogger >> nextPut: anAnnouncement [
 
-	Transcript crShow: anAnnouncement
+	anAnnouncement crTrace
 ]

--- a/src/DebugPoints/TranscriptBehavior.class.st
+++ b/src/DebugPoints/TranscriptBehavior.class.st
@@ -21,7 +21,7 @@ TranscriptBehavior class >> isAbstract [
 
 { #category : 'execution' }
 TranscriptBehavior >> execute [
-	Transcript show: self text.
+	self text trace.
 	^true
 ]
 

--- a/src/Refactoring-Critics-Tests/RBSmalllintTestObject.class.st
+++ b/src/Refactoring-Critics-Tests/RBSmalllintTestObject.class.st
@@ -480,7 +480,7 @@ RBSmalllintTestObject >> toDoWithIncrement [
 
 { #category : 'methods' }
 RBSmalllintTestObject >> transcriptMentioned [
-	Transcript show: 'message'
+	'message' trace
 ]
 
 { #category : 'accessing - good' }


### PR DESCRIPTION
Hello, I would like to start contributing, I have picked this [issue 15843](https://github.com/pharo-project/pharo/issues/15843), where the goal was to find usage of `Transcript show: 'message'` and change it to something like `'message' trace`.