### PR TITLE
Fix for Wrong focus in Calypso Find Class Dialog causes exception

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -605,6 +605,13 @@ FTTableMorph >> initializeSelectedIndexes [
 ]
 
 { #category : 'initialization' }
+FTTableMorph >> initializeShortcuts: aKMDispatcher [
+
+	super initializeShortcuts: aKMDispatcher.
+	aKMDispatcher attachCategory: #WindowShortcuts
+]
+
+{ #category : 'initialization' }
 FTTableMorph >> initializeWithHorizontalScrollBar [
 	horizontalScrollBar := true.
 	self initialize


### PR DESCRIPTION
This PR includes a fix for the bug reported in #16313.

The problem was the `WindowShortcuts` keymap category was missing from FTTableMorph during shortcut initialization, this bypassed the keydown event to the next handler, causing the browser window to be closed and subsequent problems in keyboard focus.
