### PR TITLE
Remove Monticello shortcut references

### DIFF
--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -343,11 +343,6 @@ PharoShortcuts >> openFontMenuShortcut [
 ]
 
 { #category : 'keymaps - Tools' }
-PharoShortcuts >> openMonticielloShortcut [
-	^ $o meta, $p meta
-]
-
-{ #category : 'keymaps - Tools' }
 PharoShortcuts >> openPlaygroundShortcut [
 	^ $o meta, $w meta
 ]

--- a/src/Tool-Base/ToolShortcutsCategory.class.st
+++ b/src/Tool-Base/ToolShortcutsCategory.class.st
@@ -16,15 +16,6 @@ ToolShortcutsCategory class >> isGlobalCategory [
 ]
 
 { #category : 'keymaps' }
-ToolShortcutsCategory >> openMonticelloPackageBrowser [
-
-	<shortcut>
-	^ KMKeymap
-		  shortcut: PharoShortcuts current openMonticielloShortcut
-		  action: [ self tools openMonticelloBrowser ]
-]
-
-{ #category : 'keymaps' }
 ToolShortcutsCategory >> openSettings [
 	<shortcut>
 	^ KMKeymap shortcut: PharoShortcuts current openSettingsShortcut action: [ SettingBrowser open ]

--- a/src/Tool-Registry/ToolRegistry.class.st
+++ b/src/Tool-Registry/ToolRegistry.class.st
@@ -146,8 +146,6 @@ ToolRegistry >> menuItems [
 		-
 		('Test Runner'				#openTestRunner)
 		('Process Browser' 			#openProcessBrowser)
-		-
-		('Monticello Browser'		#openMonticelloBrowser)
 	)
 ]
 
@@ -159,11 +157,6 @@ ToolRegistry >> openClassBrowser [
 { #category : 'menu' }
 ToolRegistry >> openFileList [
 	self fileList open
-]
-
-{ #category : 'menu' }
-ToolRegistry >> openMonticelloBrowser [
-	self monticelloBrowser open
 ]
 
 { #category : 'menu' }


### PR DESCRIPTION
This PR proposes a fix for #16275 removing the shortcut and references for the Monticello Browser, which is not included anymore in the image.
