### PR TITLE
Make #cascadeFor:initialExtent:world: for RealEstateAgent use integral positions when using the world’s center

### DIFF
--- a/src/Morphic-Core/RealEstateAgent.class.st
+++ b/src/Morphic-Core/RealEstateAgent.class.st
@@ -71,7 +71,7 @@ RealEstateAgent class >> cascadeFor: aView initialExtent: initialExtent world: a
 	| position allowedArea |
 	allowedArea := self maximumUsableAreaInWorld: aWorld.
 	position := aWorld currentWindow isMorph
-		ifFalse: [ aWorld center - (initialExtent / 2)]
+		ifFalse: [ aWorld center - (initialExtent // 2)]
 		ifTrue: [ aWorld currentWindow position + 20].
 	^ (position extent: initialExtent)
 		translatedAndSquishedToBeWithin: allowedArea


### PR DESCRIPTION
This pull request makes `#cascadeFor:initialExtent:world:` for RealEstateAgent divide the initial extent using integer division when using the world’s center to determine the position, so that the position uses integral numbers. Related issue: #16389.