### PR TITLE
Provide a default String for settings without #default: sends.

### DIFF
--- a/src/System-Settings-Core/SettingDeclaration.class.st
+++ b/src/System-Settings-Core/SettingDeclaration.class.st
@@ -117,6 +117,7 @@ SettingDeclaration >> addToList: anItem [
 { #category : 'accessing' }
 SettingDeclaration >> default [
 	^ default
+		ifNil: [ default := String empty ]
 ]
 
 { #category : 'accessing' }
@@ -181,7 +182,7 @@ SettingDeclaration >> ghostHelp: aString [
 	ghostHelp := aString
 ]
 
-{ #category : 'testing' }
+{ #category : 'accessing' }
 SettingDeclaration >> hasDefault [
 	^ default ~~ UniqueObject
 ]

--- a/src/System-Settings-Core/SettingDeclaration.class.st
+++ b/src/System-Settings-Core/SettingDeclaration.class.st
@@ -182,7 +182,7 @@ SettingDeclaration >> ghostHelp: aString [
 	ghostHelp := aString
 ]
 
-{ #category : 'accessing' }
+{ #category : 'testing' }
 SettingDeclaration >> hasDefault [
 	^ default ~~ UniqueObject
 ]


### PR DESCRIPTION
This small fix prevents raising an error when a setting does not provide a `default:`. The default value for this case is an empty String, which will provide an input text.
