### PR TITLE
Exclude some commands from virtual method groups on Calypso

### DIFF
--- a/src/Calypso-SystemQueries/ClyExternalPackageMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyExternalPackageMethodGroup.class.st
@@ -17,6 +17,12 @@ Class {
 }
 
 { #category : 'testing' }
+ClyExternalPackageMethodGroup class >> isBasedOnExtensions [
+
+	^ true
+]
+
+{ #category : 'testing' }
 ClyExternalPackageMethodGroup class >> isEditableGroup [
 	^true
 ]

--- a/src/Calypso-SystemQueries/ClyMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyMethodGroup.class.st
@@ -57,6 +57,12 @@ ClyMethodGroup class >> decorateBrowserItem: aBrowserItem by: anEnvironmentPlugi
 ]
 
 { #category : 'testing' }
+ClyMethodGroup class >> isBasedOnExtensions [
+
+	^ false
+]
+
+{ #category : 'testing' }
 ClyMethodGroup class >> isBasedOnProtocol [
 	^false
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyConvertMethodGroupToProtocolCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyConvertMethodGroupToProtocolCommand.class.st
@@ -20,7 +20,8 @@ Class {
 
 { #category : 'testing' }
 ClyConvertMethodGroupToProtocolCommand class >> canBeExecutedInContext: aToolContext [
-	^aToolContext isProtocolSelected not
+
+	^ aToolContext isExtensionMethodGroupSelected
 ]
 
 { #category : 'activation' }

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserContext.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowserContext.class.st
@@ -26,6 +26,14 @@ ClyFullBrowserContext >> currentMetaLevelOf: aClass [
 ]
 
 { #category : 'selection-method groups' }
+ClyFullBrowserContext >> isExtensionMethodGroupSelected [
+
+	self isMethodGroupSelected ifFalse: [ ^ false ].
+
+	^ self selectedMethodGroupClass isBasedOnExtensions
+]
+
+{ #category : 'selection-method groups' }
 ClyFullBrowserContext >> isMethodGroupSelected [
 	^self selectedMethodGroupItems notEmpty
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyMoveMethodGroupsToPackageCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyMoveMethodGroupsToPackageCommand.class.st
@@ -17,6 +17,12 @@ Class {
 	#tag : 'Commands-MethodGroups'
 }
 
+{ #category : 'testing' }
+ClyMoveMethodGroupsToPackageCommand class >> canBeExecutedInContext: aToolContext [
+
+	^ aToolContext isProtocolSelected
+]
+
 { #category : 'activation' }
 ClyMoveMethodGroupsToPackageCommand class >> fullBrowserContextMenuActivation [
 	<classAnnotation>


### PR DESCRIPTION
The commands 'Convert to protocol' and 'Convert to extension' were applyable on too many elements in Calypso.

I propose to be able to convert to protocol only extensions and to be able to convert to extensions only method groups based on real protocols.

Fixes #16369