### PR TITLE
fix MethodConstantTest

### DIFF
--- a/src/Reflectivity-Tools-Tests/MethodConstantTest.class.st
+++ b/src/Reflectivity-Tools-Tests/MethodConstantTest.class.st
@@ -27,6 +27,8 @@ MethodConstantTest >> sumOfTwoConsts: firstBlock and: secondBlock [
 MethodConstantTest >> tearDown [
 	"recompile method to remove the caching"
 	(self class>>#constFromReceiverExpression) recompile.
+	(self class>>#sumOfTwoConsts:and:) recompile.
+	(self class>>#constFromBlock:) recompile.
 	super tearDown
 ]
 
@@ -55,8 +57,10 @@ MethodConstantTest >> testConstPlaceInTransformedMethod [
 	const := self constFromReceiverExpression.
 
 	transformedMethod := self class >> #constFromReceiverExpression.
+	self assert: const identicalTo: self constFromReceiverExpression.
 
-	self assert: (transformedMethod literals anySatisfy:  [ :each | each == const ])
+	self assert:
+		(transformedMethod allLiterals anySatisfy: [ :each | each == const ])
 ]
 
 { #category : 'tests' }

--- a/src/Reflectivity-Tools-Tests/MethodConstantTest.class.st
+++ b/src/Reflectivity-Tools-Tests/MethodConstantTest.class.st
@@ -65,9 +65,8 @@ MethodConstantTest >> testTwoConstsInSameMethod [
 { #category : 'tests' }
 MethodConstantTest >> testUsingConstJustInSameMethod [
 	| values |
-	self skip.	"not working for the first call: would need on stack replacement"
 	values := OrderedCollection new.
-	2 timesRepeat: [ values add: DateAndTime now asMethodConstant ].
+	2 timesRepeat: [ values add: self constFromReceiverExpression ].
 
 	self assert: values first identicalTo: values last
 ]

--- a/src/Reflectivity-Tools-Tests/MethodConstantTest.class.st
+++ b/src/Reflectivity-Tools-Tests/MethodConstantTest.class.st
@@ -23,6 +23,13 @@ MethodConstantTest >> sumOfTwoConsts: firstBlock and: secondBlock [
 	^firstBlock asMethodConstant + secondBlock asMethodConstant
 ]
 
+{ #category : 'running' }
+MethodConstantTest >> tearDown [
+	"recompile method to remove the caching"
+	(self class>>#constFromReceiverExpression) recompile.
+	super tearDown
+]
+
 { #category : 'tests' }
 MethodConstantTest >> testAPIFromBlock [
 	| constInitialResult constSecondResult |

--- a/src/Reflectivity/Object.extension.st
+++ b/src/Reflectivity/Object.extension.st
@@ -15,6 +15,7 @@ Object >> asMethodConstant [
 	constNode := thisContext sender sourceNodeExecuted.
 	link := MetaLink new
 		        metaObject: const;
+				  optionCompileOnLinkInstallation: true;
 		        control: #instead.
 	constNode link: link.
 	^ const

--- a/src/Reflectivity/Object.extension.st
+++ b/src/Reflectivity/Object.extension.st
@@ -15,7 +15,6 @@ Object >> asMethodConstant [
 	constNode := thisContext sender sourceNodeExecuted.
 	link := MetaLink new
 		        metaObject: const;
-				  optionCompileOnLinkInstallation: true;
 		        control: #instead.
 	constNode link: link.
 	^ const


### PR DESCRIPTION
On the Newtools CI we saw some odd failing tests. This PR improves the MethodConstantTest to

- clean up
- force compilation to make the testConstPlaceInTransformedMethod work on the first run