### PR TITLE
fix enum type initialization on structures

### DIFF
--- a/src/UnifiedFFI/FFIExternalEnumerationType.class.st
+++ b/src/UnifiedFFI/FFIExternalEnumerationType.class.st
@@ -131,7 +131,7 @@ FFIExternalEnumerationType >> readFieldAt: byteOffset [
 
 { #category : 'accessing' }
 FFIExternalEnumerationType >> representationType [
-	^ representationType
+	^ representationType ifNil: [ representationType := FFIUInt32 new ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
there are some conditions where the type is created without passing t…hrough the "default" creator in class side (who sets this value).

This happens for example when including an enumeration as part of a structure and then you build the field accessors. So, for those cases, we need a lazy initialization.