### PR TITLE
16407-RBNodes-errorNotices-creates-unneeded-empty-collections

### DIFF
--- a/src/AST-Core/RBProgramNode.class.st
+++ b/src/AST-Core/RBProgramNode.class.st
@@ -511,7 +511,14 @@ RBProgramNode >> equalTo: aNode withMapping: aDictionary [
 RBProgramNode >> errorNotices [
 	"The errors attached to the receiver"
 
-	^ self notices select: #isError
+	| notices |
+	
+	notices := self notices.
+	
+	"Optimization to avoid select in an empty collection"
+	notices ifEmpty: [ ^ #() ].
+
+	^ notices select: [ :e | e isError ]
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
Fix #16407
- Optimizing to not create an empty collection
- Using a block instead of symbols