### PR TITLE
Do not suggest trait when deprecating a class

### DIFF
--- a/src/Refactoring-UI/RBDeprecateClassDriver.class.st
+++ b/src/Refactoring-UI/RBDeprecateClassDriver.class.st
@@ -80,12 +80,10 @@ RBDeprecateClassDriver >> requestClassToMigrateReferencesTo [
 
 	newClassName := SpSelectDialog new
 		                title: 'Class to migrate ' , className;
-		                label:
-			                'The new class that will be used to migrate all references of the old class to it.';
-		                items: Smalltalk allClassesAndTraits;
+		                label: 'The new class that will be used to migrate all references of the old class to it.';
+		                items: self class environment allClasses; "This should probably check in the environment of the class to deprecate but I don't know how to get it here"
 		                display: [ :each | each name ];
-		                displayIcon: [ :each |
-			                self iconNamed: each systemIconName ];
+		                displayIcon: [ :each | self iconNamed: each systemIconName ];
 		                openModal.
 	^ newClassName name
 ]


### PR DESCRIPTION
If we deprecate a class and we select a trait to replace the references, a bug is produced. While it might make sense in some cases to replace a class by a trait, it's something that we do not do often so I propose to just remove the traits from the suggestions for this refactoring.

The alternative would be to update Ring to finish the implementation of the V2 of traits because we are currently in a bastard state of having both V1 and V2 representation but inly using V1 in the system. But that's a bigger change that requires a lot more time.

Fixes #16368