### PR TITLE
Remove CharacterTable

### DIFF
--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -13,7 +13,6 @@ Class {
 	#type : 'immediate',
 	#classVars : [
 		'CharSet',
-		'CharacterTable',
 		'DigitValues'
 	],
 	#category : 'Kernel-BasicObjects',
@@ -467,7 +466,6 @@ Character >> hexDigitValue [
 
 { #category : 'initialization' }
 Character >> initialize [
-		<ignoreUnusedClassVariables: #( CharacterTable )>
 		super initialize.
 ]
 

--- a/src/PharoBootstrap/PBAbstractImageBuilder.class.st
+++ b/src/PharoBootstrap/PBAbstractImageBuilder.class.st
@@ -342,9 +342,6 @@ PBAbstractImageBuilder >> createInitialObjects [
 
 			self log: 'Initializing Character Table'.
 			self bootstrapInterpreter evaluateCode: 'Character initialize.'.
-			characterTable := EPInternalCharacterTable new objectSpace: objectSpace.
-			objectSpace backend characterTable: ((self classNamed: #Character) classPool at: #CharacterTable).
-			objectSpace characterTable: characterTable.
 
 			self log: 'Initializing String Ascii and CaseInsensitive Table'.
 			self bootstrapInterpreter evaluateCode: '| asciiOrder caseInsesitiveOrder |
@@ -681,7 +678,6 @@ PBAbstractImageBuilder >> initializeBootstrapEnvironment [
 	We will later replace them by real ones."
 	objectSpace := EPObjectSpace new.
 	objectSpace backend: espellBackend.
-	objectSpace characterTable: (EPExternalCharacterTable new objectSpace: objectSpace; yourself).
 	objectSpace symbolTable: (EPExternalSymbolTable new objectSpace: objectSpace; yourself).
 	
 	classLoader createJustStubs.


### PR DESCRIPTION
The character table is not used anymore in Spur.

Fixes #5275

If this gets integrated we could probably remove two classes from Espell also