### PR TITLE
Use #setUp instead of #initialize for test cases

### DIFF
--- a/src/SUnit-Tests/FailingTearDownTest.class.st
+++ b/src/SUnit-Tests/FailingTearDownTest.class.st
@@ -31,7 +31,7 @@ FailingTearDownTest >> isClean [
 	^ assignedVariableToTestCleanup isNil
 ]
 
-{ #category : 'initialization' }
+{ #category : 'running' }
 FailingTearDownTest >> setUp [
 
 	super setUp.

--- a/src/SUnit-Tests/FailingTearDownTest.class.st
+++ b/src/SUnit-Tests/FailingTearDownTest.class.st
@@ -25,17 +25,17 @@ FailingTearDownTest >> failTearDown [
 	shouldFailTearDown := true
 ]
 
-{ #category : 'initialization' }
-FailingTearDownTest >> initialize [
-
-	super initialize.
-	shouldFailTearDown := false
-]
-
 { #category : 'running' }
 FailingTearDownTest >> isClean [
 
 	^ assignedVariableToTestCleanup isNil
+]
+
+{ #category : 'initialization' }
+FailingTearDownTest >> setUp [
+
+	super setUp.
+	shouldFailTearDown := false
 ]
 
 { #category : 'running' }

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
@@ -11,7 +11,7 @@ Class {
 	#package : 'Tools-CodeNavigation-Tests'
 }
 
-{ #category : 'initialization' }
+{ #category : 'running' }
 CNSelectorExtractorTest >> setUp [
 
 	selectorExtractor := CNSelectorExtractor new

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
@@ -4,7 +4,7 @@ A CNSelectorExtractorTest is a test class for testing the behavior of CNSelector
 Class {
 	#name : 'CNSelectorExtractorTest',
 	#superclass : 'TestCase',
-	#classVars : [
+	#instVars : [
 		'selectorExtractor'
 	],
 	#category : 'Tools-CodeNavigation-Tests',
@@ -12,7 +12,7 @@ Class {
 }
 
 { #category : 'initialization' }
-CNSelectorExtractorTest >> initialize [
+CNSelectorExtractorTest >> setUp [
 
 	selectorExtractor := CNSelectorExtractor new
 ]

--- a/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
+++ b/src/Tools-CodeNavigation-Tests/CNSelectorExtractorTest.class.st
@@ -13,7 +13,7 @@ Class {
 
 { #category : 'running' }
 CNSelectorExtractorTest >> setUp [
-
+	super setUp.
 	selectorExtractor := CNSelectorExtractor new
 ]
 


### PR DESCRIPTION
Subclasses of TestCase should prioritize #setUp over #initialize because SUnit nils out some ivar and it can cause problems while relaunching some tests.

I also converted a sharedVariable to an instance variable because it did not make sense to me to have a shared variable.