### PR TITLE
Reposition Calypso contextual class menu items

### DIFF
--- a/src/Calypso-SystemTools-Core/SycBrowseClassCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycBrowseClassCommand.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : 'SycBrowseClassCommand' }
 
 { #category : '*Calypso-SystemTools-Core' }
+SycBrowseClassCommand class >> browserContextMenuActivation [ 
+
+	^ CmdContextMenuActivation 
+		byRootGroupItemOrder: 1 
+		for: ClyClass asCalypsoItemContext 
+]
+
+{ #category : '*Calypso-SystemTools-Core' }
 SycBrowseClassCommand class >> sourceCodeMenuActivation [
 	<classAnnotation>
 

--- a/src/Calypso-SystemTools-Core/SycDeprecateClassCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycDeprecateClassCommand.extension.st
@@ -5,7 +5,7 @@ SycDeprecateClassCommand class >> browserContextMenuActivation [
 	"disabled for now, see https://github.com/pharo-project/pharo/issues/9551"
 	<classAnnotation>
 
-	^CmdContextMenuActivation byRootGroupItemOrder: 1.4 for: ClyClass asCalypsoItemContext
+	^CmdContextMenuActivation byRootGroupItemOrder: 1.3 for: ClyClass asCalypsoItemContext
 ]
 
 { #category : '*Calypso-SystemTools-Core' }

--- a/src/Calypso-SystemTools-Core/SycRenameClassCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycRenameClassCommand.extension.st
@@ -4,7 +4,9 @@ Extension { #name : 'SycRenameClassCommand' }
 SycRenameClassCommand class >> browserContextMenuActivation [
 	<classAnnotation>
 
-	^CmdContextMenuActivation byRootGroupItemOrder: 1 for: ClyClass asCalypsoItemContext
+	^CmdContextMenuActivation 
+		byRootGroupItemOrder: 1.2
+		for: ClyClass asCalypsoItemContext
 ]
 
 { #category : '*Calypso-SystemTools-Core' }


### PR DESCRIPTION
This PR changes the order of Calypso contextual class menu items to be consistent with previous Pharo versions, as reported in #16396 by @astares.
It also fixes the Deprecate class command to not overlap with the Migrate class references command which were using both 1.4 order.
