### PR TITLE
Fix Refactorings should have help menus to explain their actions

### DIFF
--- a/src/Calypso-Browser/ClyBrowserCommand.class.st
+++ b/src/Calypso-Browser/ClyBrowserCommand.class.st
@@ -30,6 +30,13 @@ ClyBrowserCommand >> browser: anObject [
 	browser := anObject
 ]
 
+{ #category : 'accessing' }
+ClyBrowserCommand >> description [
+	"Answer a <String> describing the receiver, useful for instance in menu items pop-ups"
+
+	^ self class comment.
+]
+
 { #category : 'private' }
 ClyBrowserCommand >> morphicUIManager [
 

--- a/src/Calypso-SystemPlugins-FileOut-Browser/ClyFileOutCommand.class.st
+++ b/src/Calypso-SystemPlugins-FileOut-Browser/ClyFileOutCommand.class.st
@@ -34,6 +34,12 @@ ClyFileOutCommand >> defaultMenuItemName [
 	^'File Out'
 ]
 
+{ #category : 'accessing' }
+ClyFileOutCommand >> description [
+
+	^ 'Requests to save a textual version of the selected class to a new file in chunk format and .st extension. Instance and class side methods are both saved'
+]
+
 { #category : 'execution' }
 ClyFileOutCommand >> execute [
 

--- a/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateClassCommand.class.st
+++ b/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateClassCommand.class.st
@@ -1,3 +1,6 @@
+"
+Provide a class definition to create a new class in the selected package.
+"
 Class {
 	#name : 'ClyCreateClassCommand',
 	#superclass : 'ClyBrowserCommand',

--- a/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTestCaseCommand.class.st
+++ b/src/Calypso-SystemPlugins-Traits-Browser/ClyCreateTestCaseCommand.class.st
@@ -1,3 +1,6 @@
+"
+Generate New Test Class: Automatically create a test class for the selected class, to include test methods and setup/teardown stubs.
+"
 Class {
 	#name : 'ClyCreateTestCaseCommand',
 	#superclass : 'ClyBrowserCommand',

--- a/src/Calypso-SystemTools-QueryBrowser/ClyShowTraitUsersCommand.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyShowTraitUsersCommand.class.st
@@ -1,3 +1,6 @@
+"
+Retrieves the selected class traits.
+"
 Class {
 	#name : 'ClyShowTraitUsersCommand',
 	#superclass : 'SycClassCommand',

--- a/src/SystemCommands-ClassCommands/SycClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycClassCommand.class.st
@@ -44,6 +44,13 @@ SycClassCommand >> classes: anObject [
 	classes := anObject
 ]
 
+{ #category : 'accessing' }
+SycClassCommand >> description [
+	"Answer a <String> describing the receiver, useful for instance in menu items pop-ups"
+
+	^ self class comment.
+]
+
 { #category : 'activation - drag and drop' }
 SycClassCommand >> prepareExecutionInDragContext: aToolContext [
 	super prepareExecutionInDragContext: aToolContext.

--- a/src/SystemCommands-ClassCommands/SycDuplicateClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycDuplicateClassCommand.class.st
@@ -11,7 +11,7 @@ Internal Representation and Key Implementation Points.
 "
 Class {
 	#name : 'SycDuplicateClassCommand',
-	#superclass : 'CmdCommand',
+	#superclass : 'SycClassCommand',
 	#instVars : [
 		'originalClass',
 		'newClassName',
@@ -20,11 +20,6 @@ Class {
 	#category : 'SystemCommands-ClassCommands',
 	#package : 'SystemCommands-ClassCommands'
 }
-
-{ #category : 'testing' }
-SycDuplicateClassCommand class >> canBeExecutedInContext: aToolContext [
-	^aToolContext isClassSelected
-]
 
 { #category : 'execution' }
 SycDuplicateClassCommand >> applyResultInContext: aToolContext [

--- a/src/SystemCommands-ClassCommands/SycGenerateEqualAndHashCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycGenerateEqualAndHashCommand.class.st
@@ -1,3 +1,7 @@
+"
+Generate Equals and Hash Methods: Automatically create `=` and `hash` methods for the selected class, ensuring proper object comparison
+
+"
 Class {
 	#name : 'SycGenerateEqualAndHashCommand',
 	#superclass : 'SycSingleClassCommand',

--- a/src/SystemCommands-ClassCommands/SycGeneratePrintOnCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycGeneratePrintOnCommand.class.st
@@ -1,3 +1,6 @@
+"
+Generate the `printOn:` method for the selected class, to distinguish instances of the selected class by printing a description.
+"
 Class {
 	#name : 'SycGeneratePrintOnCommand',
 	#superclass : 'SycSingleClassCommand',

--- a/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
@@ -1,3 +1,6 @@
+"
+Remove Class Refactoring: Safely delete a selected class, ensuring no references are left behind, and preview changes before applying.
+"
 Class {
 	#name : 'SycRemoveClassCommand',
 	#superclass : 'SycClassCommand',

--- a/src/SystemCommands-ClassCommands/SycRenameClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRenameClassCommand.class.st
@@ -1,3 +1,7 @@
+"
+Rename Class Refactoring: Change the name of a selected class, update all references, and preview changes before applying.
+
+"
 Class {
 	#name : 'SycRenameClassCommand',
 	#superclass : 'SycSingleClassCommand',

--- a/src/SystemCommands-ClassCommands/SycSingleClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycSingleClassCommand.class.st
@@ -28,6 +28,13 @@ SycSingleClassCommand class >> isAbstract [
 	^self = SycSingleClassCommand
 ]
 
+{ #category : 'accessing' }
+SycSingleClassCommand >> description [
+	"Answer a <String> describing the receiver, useful for instance in menu items pop-ups"
+
+	^ self class comment.
+]
+
 { #category : 'execution' }
 SycSingleClassCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.

--- a/src/SystemCommands-RefactoringSupport/SycCmCommand.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycCmCommand.class.st
@@ -55,6 +55,13 @@ SycCmCommand class >> addMenuItemsTo: menuMorph onContext: context [
 	^ menuMorph
 ]
 
+{ #category : 'default' }
+SycCmCommand class >> defaultDescription [
+	"Answer a <String> describing the receiver, useful for instance in menu items pop-ups"
+
+	^ self comment
+]
+
 { #category : 'execution' }
 SycCmCommand >> applyCommandResult [
 ]


### PR DESCRIPTION
This PR fixes the issue #16410 implementing the suggested changes as @Ducasse proposed:

Use the class comments to describe class menu items pop-up help text.
Make SycDuplicateClassCommand subclass of SycClassCommand so we can reuse `description` and remove duplicated `canBeExecutedInContext:`
Add missing class comments for 
- Rename class
- Remove class
- Duplicate class
- New class
- New test class
- Generate equal and hash
- Generate print o
- File out
- Show trait users
