### PR TITLE
Update the Playground shortcut

### DIFF
--- a/src/Deprecated12/ToolShortcutsCategory.extension.st
+++ b/src/Deprecated12/ToolShortcutsCategory.extension.st
@@ -3,6 +3,6 @@ Extension { #name : 'ToolShortcutsCategory' }
 { #category : '*Deprecated12' }
 ToolShortcutsCategory >> openWorkspace [
 
-	self deprecated: 'Use #openPlayground' transformWith: '`@rcv openWorkspace' -> '`@rcv openPlayground'.
-	^ self openPlayground
+	<shortcut>
+	^ KMKeymap shortcut: $o meta, $w meta action: [ self tools workspace open ]
 ]

--- a/src/Deprecated12/ToolShortcutsCategory.extension.st
+++ b/src/Deprecated12/ToolShortcutsCategory.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'ToolShortcutsCategory' }
+
+{ #category : '*Deprecated12' }
+ToolShortcutsCategory >> openWorkspace [
+
+	self deprecated: 'Use #openPlayground' transformWith: '`@rcv openWorkspace' -> '`@rcv openPlayground'.
+	^ self openPlayground
+]

--- a/src/MenuRegistration/MenuRegistrationExample.class.st
+++ b/src/MenuRegistration/MenuRegistrationExample.class.st
@@ -24,8 +24,8 @@ MenuRegistrationExample class >> mostUsedToolsOn: aBuilder [
 			(aBuilder item: #'System browser')
 				selector: #openClassBrowser;
 				icon: (aBuilder iconNamed: Smalltalk tools browser taskbarIconName).
-			(aBuilder item: #Workspace)
-				selector: #openWorkspace;
+			(aBuilder item: #Playground)
+				selector: #openPlayground;
 				icon: (aBuilder iconNamed: Smalltalk tools workspace taskbarIconName).
 			]
 ]

--- a/src/Morphic-Base/Object.extension.st
+++ b/src/Morphic-Base/Object.extension.st
@@ -103,18 +103,18 @@ Object >> taskbarIcon [
 ]
 
 { #category : '*Morphic-Base' }
+Object class >> taskbarIconName [
+	"Answer the icon for an instance of the receiver in a task bar"
+
+	^#smallWindow
+]
+
+{ #category : '*Morphic-Base' }
 Object >> taskbarIconName [
 	"Answer the icon for the receiver in a task bar
 	or nil for the default."
 
 	^self class taskbarIconName
-]
-
-{ #category : '*Morphic-Base' }
-Object class >> taskbarIconName [
-	"Answer the icon for an instance of the receiver in a task bar"
-
-	^#smallWindow
 ]
 
 { #category : '*Morphic-Base' }

--- a/src/Morphic-Base/PluggableMenuSpec.extension.st
+++ b/src/Morphic-Base/PluggableMenuSpec.extension.st
@@ -48,7 +48,7 @@ PluggableMenuSpec class >> exampleWithSubMenu [
 	i := s add: 'Tools'.
 	sub := (self withModel: nil ).
 	sub add: 'System browser'  target: Smalltalk tools selector: #openClassBrowser argumentList: #().
-	sub add: 'Workspace'  target: Smalltalk tools selector: #openWorkspace argumentList: #().
+	sub add: 'Playground'  target: Smalltalk tools selector: #openPlayground argumentList: #().
 	i subMenu: sub.
 	s asMenuMorph popUpInWorld
 ]

--- a/src/Tool-Base/PharoShortcuts.class.st
+++ b/src/Tool-Base/PharoShortcuts.class.st
@@ -344,7 +344,7 @@ PharoShortcuts >> openFontMenuShortcut [
 
 { #category : 'keymaps - Tools' }
 PharoShortcuts >> openPlaygroundShortcut [
-	^ $o meta, $w meta
+	^ $o meta, $p meta
 ]
 
 { #category : 'keymaps - Tools' }

--- a/src/Tool-Base/ToolShortcutsCategory.class.st
+++ b/src/Tool-Base/ToolShortcutsCategory.class.st
@@ -16,6 +16,13 @@ ToolShortcutsCategory class >> isGlobalCategory [
 ]
 
 { #category : 'keymaps' }
+ToolShortcutsCategory >> openPlayground [
+
+	<shortcut>
+	^ KMKeymap shortcut: PharoShortcuts current openPlaygroundShortcut action: [ self tools workspace open ]
+]
+
+{ #category : 'keymaps' }
 ToolShortcutsCategory >> openSettings [
 	<shortcut>
 	^ KMKeymap shortcut: PharoShortcuts current openSettingsShortcut action: [ SettingBrowser open ]
@@ -46,15 +53,6 @@ ToolShortcutsCategory >> openUnitTestRunner [
 	^ KMKeymap
 		  shortcut: PharoShortcuts current openTestRunnerShortcut
 		  action: [ self tools openTestRunner ]
-]
-
-{ #category : 'keymaps' }
-ToolShortcutsCategory >> openWorkspace [
-
-	<shortcut>
-	^ KMKeymap
-		  shortcut: PharoShortcuts current openPlaygroundShortcut
-		  action: [ self tools workspace open ]
 ]
 
 { #category : 'keymaps' }

--- a/src/Tool-Registry/ToolRegistry.class.st
+++ b/src/Tool-Registry/ToolRegistry.class.st
@@ -140,7 +140,7 @@ ToolRegistry >> menuItems [
 	^#(
 		('System Browser' 			#openClassBrowser)
 		-
-		('Playground'				#openWorkspace)
+		('Playground'				#openPlayground)
 		('Transcript' 				#openTranscript)
 		('File Browser'				#openFileList)
 		-


### PR DESCRIPTION
This change updates the open playground shortcut. Until now it was cmd + o + w because the tool was called workspace in the past. We could not use the p because this was used by the monticello browser. But in Pharo 12 we removed the Monticello browser and we can now have a better shortcut cmd + o + p (Command Open Playground).

I also removed some references to the workspace to unify the image around the term "playground".

Fixes #3393