### PR TITLE
16423-Scrolling-always-acts-as-if-macOS-option-Use-inertia-when-scrolling-is-turned-off

### DIFF
--- a/src/OSWindow-SDL2/ObjCLibrary.class.st
+++ b/src/OSWindow-SDL2/ObjCLibrary.class.st
@@ -86,6 +86,12 @@ ObjCLibrary >> sendMessage: sel to: rcv with: aParam [
 ]
 
 { #category : 'utilities - objectiveC' }
+ObjCLibrary >> sendMessage: sel to: rcv with: aParam1 with:aParam2 [
+
+	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam1, void* aParam2))
+]
+
+{ #category : 'utilities - objectiveC' }
 ObjCLibrary >> sendMessage: sel to: rcv with: aParam1 with:aParam2 with:aParam3 [
 
 	^ self ffiCall: #(void* objc_msgSend(void* rcv, void* sel, void* aParam1, void* aParam2, void* aParam3))

--- a/src/OSWindow-SDL2/SDLOSXPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatform.class.st
@@ -29,6 +29,33 @@ SDLOSXPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 	ObjCLibrary uniqueInstance release: aParam
 ]
 
+{ #category : 'private - initialization' }
+SDLOSXPlatform >> allowTouchpadInertia [
+
+	| nsUserDefaultsClass standardUserDefaultsSel standardUserDefaults key setBoolForKeySel |
+	nsUserDefaultsClass := ObjCLibrary uniqueInstance lookupClass: 'NSUserDefaults'.
+
+	standardUserDefaultsSel := ObjCLibrary uniqueInstance
+		                           lookupSelector: 'standardUserDefaults'.
+
+	standardUserDefaults := ObjCLibrary uniqueInstance
+		                        sendMessage: standardUserDefaultsSel
+		                        to: nsUserDefaultsClass.
+
+	key := ObjCLibrary uniqueInstance nsStringOf: 'AppleMomentumScrollSupported'.
+
+	setBoolForKeySel := ObjCLibrary uniqueInstance lookupSelector:
+		                    'setBool:forKey:'.
+
+	ObjCLibrary uniqueInstance
+		sendMessage: setBoolForKeySel
+		to: standardUserDefaults
+		with: (ExternalAddress fromAddress: 1)
+		with: key.
+		
+	ObjCLibrary uniqueInstance release: key.
+]
+
 { #category : 'initialization' }
 SDLOSXPlatform >> initPlatformSpecific [
 
@@ -38,5 +65,7 @@ SDLOSXPlatform >> initPlatformSpecific [
 	ObjCLibrary uniqueInstance sendMessage: (ObjCLibrary uniqueInstance lookupSelector: 'finishLaunching') to: sharedApplication.
 	
 	SDLOSXPharoMenu uniqueInstance installInOSXWindow.
+	
+	self allowTouchpadInertia.
 
 ]


### PR DESCRIPTION
Fix #16423
- Supporting trackpad inertia in OSX