### PR TITLE
Fix #visitBehaviorRepackagedChange: on EpHasImpactVisitor to send #not instead of #y

### DIFF
--- a/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
+++ b/src/EpiceaBrowsers/EpHasImpactVisitor.class.st
@@ -75,7 +75,7 @@ EpHasImpactVisitor >> visitBehaviorRepackagedChange: aBehaviorRepackagedChange [
 	classRepackaged := aBehaviorRepackagedChange behaviorAffected.
 	self
 		behaviorNamed: classRepackaged name
-		ifPresent: [ :behavior | ^ (behavior package name = classRepackaged package name and: [ behavior packageTag name = classRepackaged packageTag ]) y ].
+		ifPresent: [ :behavior | ^ (behavior package name = classRepackaged package name and: [ behavior packageTag name = classRepackaged packageTag ]) not ].
 
 	^ true
 ]


### PR DESCRIPTION
This pull request fixes `#visitBehaviorRepackagedChange:` on EpHasImpactVisitor to send `#not` instead of `#y`. 