### PR TITLE
Added the compare methods to all the byte array classes so they use the new primitiveCompareBytes

### DIFF
--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -44,6 +44,13 @@ ByteArray class >> readHexFrom: aString [
 	^(self new: aString size // 2) readHexFrom: aString readStream
 ]
 
+{ #category : 'comparing' }
+ByteArray >> = anotherByteArray [
+
+	<primitive: 156>
+	^ super = anotherByteArray
+]
+
 { #category : 'converting' }
 ByteArray >> asByteArray [
 	^ self

--- a/src/Collections-Native/DoubleByteArray.class.st
+++ b/src/Collections-Native/DoubleByteArray.class.st
@@ -12,6 +12,13 @@ Class {
 	#tag : 'Base'
 }
 
+{ #category : 'comparing' }
+DoubleByteArray >> = anotherByteArray [
+
+	<primitive: 156>
+	^ super = anotherByteArray
+]
+
 { #category : 'private' }
 DoubleByteArray >> atAllPut: value [
 	"Fill the receiver with the given value"

--- a/src/Collections-Native/DoubleWordArray.class.st
+++ b/src/Collections-Native/DoubleWordArray.class.st
@@ -12,6 +12,13 @@ Class {
 	#tag : 'Base'
 }
 
+{ #category : 'comparing' }
+DoubleWordArray >> = anotherByteArray [
+
+	<primitive: 156>
+	^ super = anotherByteArray
+]
+
 { #category : 'private' }
 DoubleWordArray >> atAllPut: value [
 	"Fill the receiver with the given value"

--- a/src/Collections-Strings/ByteString.class.st
+++ b/src/Collections-Strings/ByteString.class.st
@@ -95,13 +95,6 @@ ByteString class >> translate: aString from: start  to: stop  table: table [
 		aString at: i put: (table at: (aString basicAt: i) + 1) ]
 ]
 
-{ #category : 'comparing' }
-ByteString >> = anotherByteArray [
-
-	<primitive: 156>
-	^ super = anotherByteArray
-]
-
 { #category : 'converting' }
 ByteString >> asByteArray [
 

--- a/src/Collections-Strings/ByteString.class.st
+++ b/src/Collections-Strings/ByteString.class.st
@@ -95,6 +95,13 @@ ByteString class >> translate: aString from: start  to: stop  table: table [
 		aString at: i put: (table at: (aString basicAt: i) + 1) ]
 ]
 
+{ #category : 'comparing' }
+ByteString >> = anotherByteArray [
+
+	<primitive: 156>
+	^ super = anotherByteArray
+]
+
 { #category : 'converting' }
 ByteString >> asByteArray [
 


### PR DESCRIPTION
Now the classes ByteArray, DoubleByteArray, DoubleWordArray and ByteString uses the new primitiveCompareBytes when comparing them. 
 This new primitive was implemented but was never used. Now it is. This would result in a better performance (cf https://github.com/pharo-project/pharo-vm/pull/759).

The comparison methods added have the fallback to use the comparison mechanism as always in case the VM used doesn't support the primitive.