### PR TITLE
Fix: PullUpClassVar was not checking breaking change preconditions

### DIFF
--- a/src/Refactoring-Core/RBPullUpClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPullUpClassVariableRefactoring.class.st
@@ -32,6 +32,12 @@ RBPullUpClassVariableRefactoring >> breakingChangePreconditions [
 		  true ]
 ]
 
+{ #category : 'preconditions' }
+RBPullUpClassVariableRefactoring >> preconditions [
+
+	^ self applicabilityPreconditions & self breakingChangePreconditions
+]
+
 { #category : 'transforming' }
 RBPullUpClassVariableRefactoring >> privateTransform [
 


### PR DESCRIPTION
It was only checking applicability, so user wouldn't be warned when breaking changes fail.