### PR TITLE
fix ReSmallintChecker>>falsePositiveOf: contains duplicated code

### DIFF
--- a/src/Renraku/ReSmalllintChecker.class.st
+++ b/src/Renraku/ReSmalllintChecker.class.st
@@ -123,10 +123,9 @@ ReSmalllintChecker >> initialize [
 { #category : 'manifest' }
 ReSmalllintChecker >> isFalsePositive: aCritic forRuleId: ruleId versionId: versionId [
 
-	| mb |
-
-	mb := self manifestBuilderOf: aCritic.
-	^ mb ifNil: [ false ] ifNotNil: [ mb isFalsePositive: aCritic onRule: ruleId version: versionId ]
+	^ (self manifestBuilderOf: aCritic)
+		  ifNil: [ false ]
+		  ifNotNil: [ :manifestBuilder | manifestBuilder isFalsePositive: aCritic onRule: ruleId version: versionId ]
 ]
 
 { #category : 'manifest' }


### PR DESCRIPTION
in the methode ReSmallintChecker>>falsePositiveOf:,  we had a same part of code that the old code of ReSmalllintChecker>>#isFalsePositive:forRuleId:versionId:. This change delete the duplicated code and make the method more readable. #16459