### PR TITLE
16447-Dropping-window-outside-of-Pharo-window-borders-closes-the-window

### DIFF
--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1672,6 +1672,18 @@ SystemWindow >> reframePanesAdjoining: growingPane along: side to: aDisplayBox [
 	self extent: self extent
 ]
 
+{ #category : 'dropping/grabbing' }
+SystemWindow >> rejectDropMorphEvent: evt [
+
+	super rejectDropMorphEvent: evt.
+
+	self formerOwner acceptDroppingMorph: self event: evt.
+	self position: self formerPosition.
+	
+	self formerOwner: nil.
+	self formerPosition: nil.
+]
+
 { #category : 'label' }
 SystemWindow >> relabel [
 	| newLabel |


### PR DESCRIPTION
Fix #16447
When a window is rejected the drag, it should be put in the same place it was before. If we don't do that, the window is deleted.