### PR TITLE
16436-Using-shortcut-CmdCtrl-W-on-a-window-with-multiple-tabs-closes-the-entire-window-instead-of-focused-tab

### DIFF
--- a/src/Calypso-Browser/ClyGroupWindowMorph.class.st
+++ b/src/Calypso-Browser/ClyGroupWindowMorph.class.st
@@ -41,6 +41,15 @@ ClyGroupWindowMorph >> dragTab: aSystemWindow event: anEvent in: aTabLabel [
 	anEvent hand grabMorph: aSystemWindow
 ]
 
+{ #category : 'closing' }
+ClyGroupWindowMorph >> handleCloseByShortcut [ 
+	
+	self activeWindow ifNotNil: [ :page | self removeWindow: page ].
+	
+	"Returns true to stop handling"
+	^ tabGroup pages isNotEmpty
+]
+
 { #category : 'updating' }
 ClyGroupWindowMorph >> update: aSymbol [
 	"Handle tab changes."

--- a/src/Deprecated12/SystemWindow.extension.st
+++ b/src/Deprecated12/SystemWindow.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'SystemWindow' }
+
+{ #category : '*Deprecated12' }
+SystemWindow class >> closeTopWindow [
+
+	self
+		deprecated: 'Please use #closeTopWindowByShortcut instead.'
+		transformWith: '`@receiver closeTopWindow' -> '`@receiver closeTopWindowByShortcut'.
+
+	^ self closeTopWindowByShortcut
+]

--- a/src/Morphic-Widgets-Windows/Morph.extension.st
+++ b/src/Morphic-Widgets-Windows/Morph.extension.st
@@ -51,6 +51,13 @@ Morph >> embeddedInMorphicWindowLabeled: labelString [
 ]
 
 { #category : '*Morphic-Widgets-Windows' }
+Morph >> handleCloseByShortcut [
+	
+	"Entry point, if one of the morphs inside a window want to catch the close window shortcut"
+	^ false
+]
+
+{ #category : '*Morphic-Widgets-Windows' }
 Morph >> isInSystemWindow [
 	"answer if the receiver is in a system window"
 	^ owner isMorph and:[owner isSystemWindow or:[owner isInSystemWindow]]

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -55,7 +55,7 @@ SystemWindow class >> buildShortcutsOn: aBuilder [
 	(aBuilder shortcut: #close)
 		category: #WindowShortcuts
 		default: PharoShortcuts current closeWindowShortcut
-		do: [ :target | SystemWindow closeTopWindow ]
+		do: [ :target | self closeTopWindowByShortcut ]
 		description: 'Close this window'
 ]
 
@@ -275,11 +275,11 @@ SystemWindow class >> closeBoxImage [
 ]
 
 { #category : 'top window' }
-SystemWindow class >> closeTopWindow [
+SystemWindow class >> closeTopWindowByShortcut [
 	"Try to close the top window.  It may of course decline"
 	TopWindow ifNotNil: [ :window |
 		TopWindow := nil.
-		window delete.
+		window closeByShortcut.
 	]
 ]
 
@@ -764,6 +764,15 @@ SystemWindow >> changeColor [
 
 { #category : 'open/close' }
 SystemWindow >> close [
+	^ self delete
+]
+
+{ #category : 'closing' }
+SystemWindow >> closeByShortcut [
+
+	self submorphsDo: [ :m | 
+		m handleCloseByShortcut ifTrue: [ ^ self ] ].
+
 	^ self delete
 ]
 


### PR DESCRIPTION
Fix #16436
- Adding a closeByShortcut so windows can react different
- Renaming closeTopWindow to closeTopWindowByShortcut
- Adding an entry point so submorphs can collaborate with the window
- ClyGroupWindowMorph can handle the event and remove one of the panes