### PR TITLE
Restore fileIn button in File Browser

### DIFF
--- a/src/System-FileRegistry/FileList.extension.st
+++ b/src/System-FileRegistry/FileList.extension.st
@@ -1,0 +1,47 @@
+Extension { #name : 'FileList' }
+
+{ #category : '*System-FileRegistry' }
+FileList class >> fileInto: fullName [
+	"File in all of the contents of the currently selected file"
+	
+	fullName ifNil: [ ^ self ].
+	fullName asFileReference readStreamDo: [ :readStream |
+		CodeImporter evaluateReadStream: readStream ].
+	self inform: fullName asString , ' was filed in'.
+]
+
+{ #category : '*System-FileRegistry' }
+FileList class >> fileReaderServicesForFile: fullName suffix: suffix [
+	<fileService>
+
+	^ (self sourceFileSuffixes includes: suffix)
+		ifTrue: [ self services ]
+		ifFalse: [ #() ]
+]
+
+{ #category : '*System-FileRegistry' }
+FileList class >> serviceFileIn [
+	"Answer a service for installing a file into a new change set"
+
+	^ SimpleServiceEntry
+		provider: self
+		label: 'Install into the image'
+		selector: #fileInto:
+		description: 'Install the file as a body of code in the image: file-in the selected file into it'
+		buttonLabel: 'Install'
+]
+
+{ #category : '*System-FileRegistry' }
+FileList class >> services [
+	"Answer potential file services associated with this class"
+
+	^ { 
+		self serviceFileIn
+		}
+]
+
+{ #category : '*System-FileRegistry' }
+FileList class >> sourceFileSuffixes [
+
+	^#('st' 'cs')
+]

--- a/src/Tool-ExternalBrowser/ExternalBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalBrowser.class.st
@@ -1,16 +1,17 @@
 "
 Browser the current image:
 
-	ExternalBrowser openOn: Smalltalk image.
+`ExternalBrowser openOn: Smalltalk image.`
 
 Browse a FileOut
 
-	| internalStream |
-	internalStream := (String new: 1000) writeStream.
-	SystemOrganization 
-		fileOutCategory: 'Tool-ExternalBrowser'
-		on: internalStream.
-	ExternalBrowser browseStream: internalStream contents readStream.
+```
+| pkgName |
+
+pkgName := 'Tool-ExternalBrowser'.
+pkgName asPackage fileOut.
+ExternalBrowser browseStream: (pkgName , '.st') asFileReference readStream.
+```
 "
 Class {
 	#name : 'ExternalBrowser',


### PR DESCRIPTION
- Restored the older serviceFileIntoNewChangeSet in ChangeSet class in serviceFileIn, since we're removing code related with change sets.
- Related code for file in button now is in FileList class side, and belongs to System-FileRegistry package.
- Updated class comment
