### PR TITLE
Fix bug while adding a trait to a class without trait

### DIFF
--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -72,6 +72,27 @@ TraitTest >> createT3 [
 ]
 
 { #category : 'tests' }
+TraitTest >> testAddingATraitToAClassWithSubclasses [
+	"This is a regression test when adding a trait to a class without traits and with subclasses was not possible."
+
+	| c1 c2 t1 |
+	c1 := self newClass: #C1.
+	c2 := self newClass: #C2 superclass: c1 traits: {  }.
+	t1 := self newTrait: #T1.
+
+	self
+		shouldnt: [
+			self class classInstaller make: [ :aBuilder |
+				aBuilder
+					fillFor: c1;
+					traits: t1 ] ]
+		raise: Error.
+
+	self assert: (c1 includesTrait: t1).
+	self deny: (c2 includesTrait: t1)
+]
+
+{ #category : 'tests' }
 TraitTest >> testClassHavingAnInstanceVariableUsersDifferenThanUsers [
 
 	| t1 aClass |

--- a/src/Traits/Metaclass.extension.st
+++ b/src/Traits/Metaclass.extension.st
@@ -6,6 +6,13 @@ Metaclass >> baseLocalMethods [
 ]
 
 { #category : '*Traits' }
+Metaclass >> basicTraitComposition [
+	"Compatibility method to match TraitedMetaclass."
+
+	^ self traitComposition
+]
+
+{ #category : '*Traits' }
 Metaclass >> initializeBasicMethods [
 
 	"Nothing to do in the metaclass"


### PR DESCRIPTION
This fixes a bug which cause in some cases a bug when adding a trait to a class because Metaclass and TraitedMetaclass are not polymorphic on a method that was added some weeks ago.

Fixes #16471