### PR TITLE
Add setting to set the world renderer canvas scale factor automatically

### DIFF
--- a/src/OSWindow-Core/OSNullFormRenderer.class.st
+++ b/src/OSWindow-Core/OSNullFormRenderer.class.st
@@ -13,6 +13,12 @@ Class {
 OSNullFormRenderer >> newExtent: anExtent [
 ]
 
+{ #category : 'accessing' }
+OSNullFormRenderer >> outputExtent [
+
+	^ 0@0
+]
+
 { #category : 'updating screen' }
 OSNullFormRenderer >> updateAll [
 	"Do nothing"

--- a/src/OSWindow-Core/OSWindowFormRenderer.class.st
+++ b/src/OSWindow-Core/OSWindowFormRenderer.class.st
@@ -63,6 +63,12 @@ OSWindowFormRenderer >> newExtent: newExtent [
 ]
 
 { #category : 'accessing' }
+OSWindowFormRenderer >> outputExtent [
+
+	self subclassResponsibility
+]
+
+{ #category : 'accessing' }
 OSWindowFormRenderer >> pixelExtent [
 	^ form ifNotNil: [ form extent ] ifNil: [ 1@1 ]
 ]

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -12,12 +12,25 @@ Class {
 		'previousFrameRenderingTime'
 	],
 	#classInstVars : [
-		'canvasScaleFactor'
+		'canvasScaleFactor',
+		'autoSetCanvasScaleFactor'
 	],
 	#category : 'OSWindow-Core-Morphic',
 	#package : 'OSWindow-Core',
 	#tag : 'Morphic'
 }
+
+{ #category : 'accessing' }
+OSWorldRenderer class >> autoSetCanvasScaleFactor [
+
+	^ autoSetCanvasScaleFactor ifNil: [ autoSetCanvasScaleFactor := false ]
+]
+
+{ #category : 'accessing' }
+OSWorldRenderer class >> autoSetCanvasScaleFactor: boolean [
+
+	autoSetCanvasScaleFactor := boolean
+]
 
 { #category : 'accessing' }
 OSWorldRenderer class >> canvasScaleFactor [
@@ -62,7 +75,11 @@ OSWorldRenderer class >> settingsOn: aBuilder [
 				label: 'Canvas scale factor';
 				target: self;
 				domainValues: (1 to: 5);
-				default: 1 ]
+				default: 1.
+			(aBuilder setting: #autoSetCanvasScaleFactor)
+				label: 'Set canvas scale factor automatically';
+				target: self;
+				default: false ]
 ]
 
 { #category : 'accessing' }
@@ -101,6 +118,9 @@ OSWorldRenderer >> checkForNewScreenSize [
 	 skip the check. "
 	windowRenderer := self osWindowRenderer.
 	windowRenderer ifNil: [ ^ self ].
+
+	(world == World and: [ self class autoSetCanvasScaleFactor ]) ifTrue: [
+		self class canvasScaleFactor: (windowRenderer outputExtent / self windowExtent) min * self screenScaleFactor ].
 
 	(display isNil or: [ display extent = self actualDisplaySize and: [ world worldState realWindowExtent = self actualScreenSize ] ])
 		ifTrue: [ ^ self ].

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -54,12 +54,15 @@ OSWorldRenderer class >> settingsOn: aBuilder [
 
 	<systemsettings>
 
-	(aBuilder pickOne: #canvasScaleFactor)
+	(aBuilder group: #canvasScaleFactorGroup)
 		parent: #appearance;
-		label: 'Canvas scale factor for OSWorldRenderer';
-		target: self;
-		domainValues: (1 to: 5);
-		default: 1
+		label: 'World renderer canvas scaling';
+		with: [
+			(aBuilder pickOne: #canvasScaleFactor)
+				label: 'Canvas scale factor';
+				target: self;
+				domainValues: (1 to: 5);
+				default: 1 ]
 ]
 
 { #category : 'accessing' }

--- a/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
@@ -71,6 +71,12 @@ OSSDL2FormRenderer >> initialize [
 	mutex := Mutex new
 ]
 
+{ #category : 'accessing' }
+OSSDL2FormRenderer >> outputExtent [
+
+	^ renderer outputExtent
+]
+
 { #category : 'private' }
 OSSDL2FormRenderer >> primitiveUpdateRectangle: rectangle externalForm: externalForm [
 


### PR DESCRIPTION
This pull request adds a setting to let the World’s OSWorldRenderer set the class’s #canvasScaleFactor automatically when performing #checkForNewScreenSize. On Macs with two displays, one of which is a ‘Retina display’ and one which is not, enabling the setting should make the canvas scale factor be changed automatically from 2 to 1 when moving the Pharo window from the ‘Retina display’ to the other one and vice-versa, as described in issue #16046. This, and the effect on Windows and Linux, may however need some further testing. The setting is by default disabled.

<p align="center">
<img width="487" src="https://github.com/pharo-project/pharo/assets/1611248/ffc8b748-704e-4a30-94cb-b72aa8f6c45b">
</p>