### PR TITLE
test for ReAsClassRule +  AbstractRuleTest base on the node

### DIFF
--- a/src/General-Rules-Tests/ReAbstractRuleTestCase.class.st
+++ b/src/General-Rules-Tests/ReAbstractRuleTestCase.class.st
@@ -23,11 +23,8 @@ ReAbstractRuleTestCase >> critiguesFor: ruleClass onMethod: method [
 
 { #category : 'utilities' }
 ReAbstractRuleTestCase >> myCritiques [
-	| critiques |
-	critiques := OrderedCollection new.
-	self subjectUnderTest  new
-		check: (self class >> #sampleMethod ) forCritiquesDo:[:critique | critiques add: critique].
-	^critiques
+
+	^ self myCritiquesOnMethod: self class >> #sampleMethod
 ]
 
 { #category : 'utilities' }
@@ -41,11 +38,25 @@ ReAbstractRuleTestCase >> myCritiquesOnClass: aClass [
 
 { #category : 'utilities' }
 ReAbstractRuleTestCase >> myCritiquesOnMethod: method [
-	| critiques |
+
+	| critiques rule |
 	critiques := OrderedCollection new.
-	self subjectUnderTest  new
-		check: method forCritiquesDo:[:critique | critiques add: critique].
-	^critiques
+	rule := self subjectUnderTest new.
+	self subjectUnderTest checksNode
+		ifTrue: [
+			| ast |
+			ast := method ast.
+			"for rewrite rules, we run every rule on a copy of the ast"
+			rule isRewriteRule ifTrue: [ ast := ast copy ].
+			ast nodesDo: [ :node |
+				rule
+					check: node
+					forCritiquesDo: [ :critique | critiques add: critique ] ] ]
+		ifFalse: [
+			rule
+				check: method
+				forCritiquesDo: [ :critique | critiques add: critique ] ].
+	^ critiques
 ]
 
 { #category : 'utilities' }

--- a/src/General-Rules-Tests/ReAsClassRuleTest.class.st
+++ b/src/General-Rules-Tests/ReAsClassRuleTest.class.st
@@ -1,0 +1,59 @@
+Class {
+	#name : 'ReAsClassRuleTest',
+	#superclass : 'ReAbstractRuleTestCase',
+	#category : 'General-Rules-Tests-Migrated',
+	#package : 'General-Rules-Tests',
+	#tag : 'Migrated'
+}
+
+{ #category : 'test-help' }
+ReAsClassRuleTest >> methodWithAsClass [
+
+	self class asClass
+]
+
+{ #category : 'test-help' }
+ReAsClassRuleTest >> methodWithAsClassIfAbsent [
+
+	self class asClassIfAbsent: [  ]
+]
+
+{ #category : 'test-help' }
+ReAsClassRuleTest >> methodWithAsClassIfPresent [
+
+	 self class asClassIfPresent: [  ]
+]
+
+{ #category : 'tests' }
+ReAsClassRuleTest >> testRuleNotViolated [
+
+	| critiques |
+	critiques := self myCritiquesOnMethod:
+		             self class >> #testRuleWithAsClass.
+	self assertEmpty: critiques 
+]
+
+{ #category : 'tests' }
+ReAsClassRuleTest >> testRuleWithAsClass [
+
+	| critiques |
+	critiques := self myCritiquesOnMethod: self class >> #methodWithAsClass.
+	self assert: critiques size equals: 1
+]
+
+{ #category : 'tests' }
+ReAsClassRuleTest >> testRuleWithAsClassIfAbsent [
+
+	| critiques |
+	critiques := self myCritiquesOnMethod: 
+		             self class >> #methodWithAsClassIfPresent.
+	self assert: critiques size equals: 1
+]
+
+{ #category : 'tests' }
+ReAsClassRuleTest >> testRuleWithAsClassIfPresent [
+
+	| critiques |
+	critiques := self myCritiquesOnMethod: self class >> #methodWithAsClassIfAbsent.
+	self assert: critiques size equals: 1
+]


### PR DESCRIPTION
this commit propose a transformation for ReAbstractRuleTest>>mycritiques and ReAbstractRuleTest>>myCritiquesOnMethod to allow that ReAbstractRuleTest can to base on the node and give the possibility to test rules which base Nodes