### PR TITLE
During compilation there are redundant allocation of collections

### DIFF
--- a/src/Files/AbstractBinaryFileStream.class.st
+++ b/src/Files/AbstractBinaryFileStream.class.st
@@ -178,12 +178,19 @@ AbstractBinaryFileStream >> next: n into: aString startingAt: startIndex [
 
 { #category : 'writing' }
 AbstractBinaryFileStream >> next: amount putAll: aByteArray [
+
+	^ self next: amount putAll: aByteArray startingAt: 1
+]
+
+{ #category : 'accessing' }
+AbstractBinaryFileStream >> next: amount putAll: aByteArray startingAt: startingIndex [
+
 	forWrite
 		ifFalse: [ ^ self error: 'Cannot write a read-only file' ].
 	[ File
 		write: handle
 		from: aByteArray
-		startingAt: 1
+		startingAt: startingIndex
 		count: amount ]
 		on: PrimitiveFailed
 		do: [ (FileWriteError fileName: self name)

--- a/src/System-Sources/ChunkWriteStream.class.st
+++ b/src/System-Sources/ChunkWriteStream.class.st
@@ -38,10 +38,16 @@ ChunkWriteStream >> duplicateTerminatorMarkOn: aString [
 
 	| string start bangIndex newStringStream |
 	string := aString asString.
-	newStringStream := WriteStream on: (string species new: string size * 2).
 	start := 1.
+	bangIndex := string indexOf: self terminatorMark startingAt: start.
+	
+	"We check the bang ahead, so we can avoid two allocations of the string!"
+	(bangIndex = 0) 
+		ifTrue: [ ^ string copyWith: self terminatorMark ].
 
-	[ (bangIndex := string indexOf: self terminatorMark startingAt: start) = 0 ]
+	newStringStream := WriteStream on: (string species new: string size * 2).
+
+	[ bangIndex = 0 ]
 		whileFalse: [
 			newStringStream
 				next: bangIndex - start + 1
@@ -49,7 +55,8 @@ ChunkWriteStream >> duplicateTerminatorMarkOn: aString [
 				startingAt: start.
 
 			newStringStream nextPut: self terminatorMark. "double it"
-			start := bangIndex + 1 ].
+			start := bangIndex + 1.
+			bangIndex := string indexOf: self terminatorMark startingAt: start ].
 
 	newStringStream
 		next: string size - start + 1


### PR DESCRIPTION
- Provide an implementation of #next:putAll:startingAt: for AbstractBinaryStream
- Improve the implementation of #duplicateTerminatorMarkOn: to avoid the creation of the stream, and the copies if not needed.