### PR TITLE
Change #pharoItemsOn: for WorldState and #menuCommandOn: for ProfStef to use the icon #smallPharo

### DIFF
--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -174,7 +174,7 @@ WorldState class >> pharoItemsOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #Pharo)
 		label: 'Pharo';
-		icon: ((self iconNamed: #pharo) scaledToSize: (16 @ 16) scaledByDisplayScaleFactor);
+		iconName: #smallPharo;
 		order: 0;
 		with: [
 			(aBuilder group: #Saving)

--- a/src/ProfStef-Core/ProfStef.class.st
+++ b/src/ProfStef-Core/ProfStef.class.st
@@ -131,7 +131,7 @@ ProfStef class >> menuCommandOn: aBuilder [
 		parent: #PharoHelp;
 		order: 3;
 		action: [ self openPharoZenWorkspace ];
-		icon: ((self iconNamed: #pharo) scaledToSize: (16@16) scaledByDisplayScaleFactor);
+		iconName: #smallPharo;
 		help: 'Pharo values.'
 ]
 


### PR DESCRIPTION
This pull request changes `#pharoItemsOn:` for WorldState and `#menuCommandOn:` for ProfStef to use the icon `#smallPharo` instead of scaling the icon `#pharo`.

This requires merging [pharo-icon-packs pull request #12](https://github.com/pharo-project/pharo-icon-packs/pull/12) first.