### PR TITLE
Remove some users of SystemAnnoucer class>>#uniqueInstance

### DIFF
--- a/src/Kernel-CodeModel-Tests/PackageAnnouncementsTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageAnnouncementsTest.class.st
@@ -19,7 +19,7 @@ PackageAnnouncementsTest >> setUp [
 { #category : 'running' }
 PackageAnnouncementsTest >> tearDown [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
+	self class codeChangeAnnouncer unsubscribe: self.
 	super tearDown
 ]
 
@@ -58,6 +58,23 @@ PackageAnnouncementsTest >> testAddExtensionMethodHasTheRightPackage [
 
 	class compile: 'testMethod ^ #kheego' classified: '*' , yPackage name.
 	
+	self assert: numberOfAnnouncements equals: 1
+]
+
+{ #category : 'tests - classes' }
+PackageAnnouncementsTest >> testAnnouncementClassRemovedIsRaisedOnRemoveFromSystem [
+
+	| xPackage class |
+	xPackage := self ensureXPackage.
+
+	class := self newClassNamed: #NewClass in: xPackage.
+
+	self when: ClassRemoved do: [ :ann |
+		self assert: ann classRemoved originalName equals: #NewClass.
+		self assert: ann packageAffected identicalTo: xPackage ].
+
+	class removeFromSystem.
+
 	self assert: numberOfAnnouncements equals: 1
 ]
 
@@ -215,7 +232,7 @@ PackageAnnouncementsTest >> testSetPackageOfClassAnnounceClassRepackaged [
 { #category : 'running' }
 PackageAnnouncementsTest >> when: anAnnouncement do: aBlock [
 
-	SystemAnnouncer uniqueInstance
+	self class codeChangeAnnouncer
 		when: anAnnouncement
 		do: [ :ann |
 			numberOfAnnouncements := numberOfAnnouncements + 1.

--- a/src/Kernel-CodeModel-Tests/PackageObsoleteTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageObsoleteTest.class.st
@@ -4,9 +4,6 @@ SUnit tests for Package
 Class {
 	#name : 'PackageObsoleteTest',
 	#superclass : 'PackageTestCase',
-	#instVars : [
-		'notRun'
-	],
 	#category : 'Kernel-CodeModel-Tests-Packages',
 	#package : 'Kernel-CodeModel-Tests',
 	#tag : 'Packages'

--- a/src/Kernel-CodeModel-Tests/PackageObsoleteTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageObsoleteTest.class.st
@@ -12,24 +12,6 @@ Class {
 	#tag : 'Packages'
 }
 
-{ #category : 'accessing' }
-PackageObsoleteTest >> setNotRun [
-	notRun := true
-]
-
-{ #category : 'tests' }
-PackageObsoleteTest >> testAnnouncementClassRemovedIsRaisedOnRemoveFromSystem [
-
-	| foo |
-	[
-	notRun := false.
-	SystemAnnouncer uniqueInstance weak when: ClassRemoved send: #setNotRun to: self.
-	foo := self newClassNamed: #FooForTest2 in: self xPackageName.
-	self deny: notRun.
-	foo removeFromSystem.
-	self assert: notRun ] ensure: [ SystemAnnouncer uniqueInstance unsubscribe: self ]
-]
-
 { #category : 'tests' }
 PackageObsoleteTest >> testMethodPackageFromObsoleteClass [
 

--- a/src/Kernel-Tests/AbstractClassDescriptionAnnouncementTest.class.st
+++ b/src/Kernel-Tests/AbstractClassDescriptionAnnouncementTest.class.st
@@ -26,7 +26,7 @@ AbstractClassDescriptionAnnouncementTest >> tearDown [
 { #category : 'running' }
 AbstractClassDescriptionAnnouncementTest >> when: anAnnouncement do: aBlock [
 
-	SystemAnnouncer uniqueInstance
+	self class codeChangeAnnouncer
 		when: anAnnouncement
 		do: [ :ann |
 			numberOfAnnouncements := numberOfAnnouncements + 1.

--- a/src/Keymapping-Pragmas/KMPragmaKeymapBuilder.class.st
+++ b/src/Keymapping-Pragmas/KMPragmaKeymapBuilder.class.st
@@ -39,19 +39,16 @@ KMPragmaKeymapBuilder class >> pragmas [
 
 { #category : 'system-events' }
 KMPragmaKeymapBuilder class >> registerInterestToSystemAnnouncement [
+
 	<systemEventRegistration>
-	SystemAnnouncer uniqueInstance
-		unsubscribe: self.
-	SystemAnnouncer uniqueInstance weak
-		when: MethodAdded, MethodModified, MethodRemoved
-		send: #methodAnnouncementReceived:
-		to: self
+	self release.
+	self codeChangeAnnouncer weak when: MethodAdded , MethodModified , MethodRemoved send: #methodAnnouncementReceived: to: self
 ]
 
 { #category : 'instance creation' }
 KMPragmaKeymapBuilder class >> release [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self
+	self codeChangeAnnouncer unsubscribe: self
 ]
 
 { #category : 'instance creation' }

--- a/src/Monticello-Tests/MCPackageTest.class.st
+++ b/src/Monticello-Tests/MCPackageTest.class.st
@@ -38,8 +38,11 @@ MCPackageTest >> testUnload [
 MCPackageTest >> testUnloadWithAdditionalTracking [
 	"This is to test against another entity removing the extension protocol as well."
 
-	SystemAnnouncer uniqueInstance when: MethodRemoved send: #aMethodRemoved: to: self.
-	self assert: (SystemAnnouncer uniqueInstance hasSubscriber: self).
+	| announcer |
+	announcer := self class codeChangeAnnouncer.
+
+	announcer when: MethodRemoved send: #aMethodRemoved: to: self.
+	self assert: (announcer hasSubscriber: self).
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
 	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
@@ -48,6 +51,6 @@ MCPackageTest >> testUnloadWithAdditionalTracking [
 	self assert: (Object subclasses
 			 detect: [ :c | c name = #MCMockClassA ]
 			 ifNone: [  ]) isNil.
-	SystemAnnouncer uniqueInstance unsubscribe: self.
-	self deny: (SystemAnnouncer uniqueInstance hasSubscriber: self)
+	announcer unsubscribe: self.
+	self deny: (announcer hasSubscriber: self)
 ]

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -76,7 +76,7 @@ MCPackageLoader >> basicLoadDefinitions [
 	self loadClassDefinitions.
 
 	"We want to announce the addition of the methods only once all methods are loaded because the system might react to the annoucements and execute code requirement other methods from the classes we are loading."
-	SystemAnnouncer uniqueInstance delayAnnouncementsAfter: [ additions select: [ :aDefinition | aDefinition isMethodDefinition ] thenDo: [ :definition | definition load ] ].
+	self class codeChangeAnnouncer delayAnnouncementsAfter: [ additions select: [ :aDefinition | aDefinition isMethodDefinition ] thenDo: [ :definition | definition load ] ].
 
 	removals do: [ :each | each unload ] displayingProgress: 'Cleaning up...'.
 

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -200,7 +200,7 @@ MCWorkingCopy class >> registry [
 { #category : 'event registration' }
 MCWorkingCopy class >> unregisterForNotifications [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self
+	self codeChangeAnnouncer unsubscribe: self
 ]
 
 { #category : 'operations' }

--- a/src/Shift-ClassBuilder-Tests/ShClassInstallerAnnouncementsTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShClassInstallerAnnouncementsTest.class.st
@@ -20,7 +20,7 @@ ShClassInstallerAnnouncementsTest >> setUp [
 { #category : 'running' }
 ShClassInstallerAnnouncementsTest >> tearDown [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
+	self class codeChangeAnnouncer unsubscribe: self.
 	super tearDown
 ]
 
@@ -70,7 +70,7 @@ ShClassInstallerAnnouncementsTest >> testRecompilingClassUsingTraitsDoesNotAnnou
 { #category : 'protocol' }
 ShClassInstallerAnnouncementsTest >> when: anAnnouncement do: aBlock [
 
-	SystemAnnouncer uniqueInstance
+	self class codeChangeAnnouncer
 		when: anAnnouncement
 		do: [ :ann |
 			numberOfAnnouncements := numberOfAnnouncements + 1.

--- a/src/Shift-ClassBuilder/ShClassChanged.class.st
+++ b/src/Shift-ClassBuilder/ShClassChanged.class.st
@@ -12,8 +12,10 @@ Class {
 
 { #category : 'announcing' }
 ShClassChanged >> announceChanges [
-	SystemAnnouncer uniqueInstance classDefinitionChangedFrom: oldClass to: builder newClass.
-	SystemAnnouncer uniqueInstance classModificationAppliedTo: builder newClass
+
+	self class codeChangeAnnouncer
+		classDefinitionChangedFrom: oldClass to: builder newClass;
+		classModificationAppliedTo: builder newClass
 ]
 
 { #category : 'announcing' }

--- a/src/Shift-ClassBuilder/ShMetaclassChanged.class.st
+++ b/src/Shift-ClassBuilder/ShMetaclassChanged.class.st
@@ -12,8 +12,10 @@ Class {
 
 { #category : 'announcing' }
 ShMetaclassChanged >> announceChanges [
-	SystemAnnouncer uniqueInstance classDefinitionChangedFrom: oldClass class to: builder newMetaclass.
-	SystemAnnouncer uniqueInstance classModificationAppliedTo: builder newMetaclass
+
+	self class codeChangeAnnouncer
+		classDefinitionChangedFrom: oldClass class to: builder newMetaclass;
+		classModificationAppliedTo: builder newMetaclass
 ]
 
 { #category : 'accessing' }

--- a/src/Slot-Tests/SlotAnnouncementsTest.class.st
+++ b/src/Slot-Tests/SlotAnnouncementsTest.class.st
@@ -59,16 +59,13 @@ SlotAnnouncementsTest >> setUp [
 { #category : 'helpers' }
 SlotAnnouncementsTest >> subscribeOn: anAnnouncement [
 
-	SystemAnnouncer uniqueInstance weak
-		when: anAnnouncement
-		send: #add:
-		to: collectedAnnouncements
+	self class codeChangeAnnouncer weak when: anAnnouncement send: #add: to: collectedAnnouncements
 ]
 
 { #category : 'running' }
 SlotAnnouncementsTest >> tearDown [
 
-	SystemAnnouncer uniqueInstance unsubscribe: collectedAnnouncements.
+	self class codeChangeAnnouncer unsubscribe: collectedAnnouncements.
 	super tearDown
 ]
 

--- a/src/Slot-Tests/SlotClassBuilderTest.class.st
+++ b/src/Slot-Tests/SlotClassBuilderTest.class.st
@@ -88,14 +88,14 @@ SlotClassBuilderTest >> slotTestPackageName [
 SlotClassBuilderTest >> tearDown [
 	"We remove the classes that could have been created during test run"
 
-	SystemAnnouncer uniqueInstance suspendAllWhile: [
+	self class codeChangeAnnouncer suspendAllWhile: [
 		{
 			self aClassName.
 			self anotherClassName.
 			self yetAnotherClassName.
 			self yetYetAnotherClassName } do: [ :each | testingEnvironment at: each ifPresent: [ :class | class removeFromSystem ] ] ].
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
+	self class codeChangeAnnouncer unsubscribe: self.
 
 	self
 		cleanUpTrait: TOne;

--- a/src/Slot-Tests/SlotSilentTest.class.st
+++ b/src/Slot-Tests/SlotSilentTest.class.st
@@ -40,5 +40,5 @@ SlotSilentTest >> compileAccessorsFor: aSlot [
 { #category : 'running' }
 SlotSilentTest >> runCase [
 
-	SystemAnnouncer uniqueInstance suspendAllWhile: [ super runCase ]
+	self class codeChangeAnnouncer suspendAllWhile: [ super runCase ]
 ]

--- a/src/Traits-Tests/AbstractTraitsOnPreparedModelTest.class.st
+++ b/src/Traits-Tests/AbstractTraitsOnPreparedModelTest.class.st
@@ -151,7 +151,7 @@ AbstractTraitsOnPreparedModelTest >> setUp [
 	"SetUpCount := SetUpCount + 1."
 
 	super setUp.
-	SystemAnnouncer uniqueInstance suspendAllWhile:
+	self class codeChangeAnnouncer suspendAllWhile:
 			[self t1: (self newTrait: #T1
 						traits: { }).
 			self t1 comment: 'I am the trait T1'.


### PR DESCRIPTION
This is a step to remove the singleton of SystemAnnouncer to be able to have one announcer by environment/module.

I'm using the previously introduced #codeChangeAnnouncer method.

I also removed a package test to reimplement it on a class that has the responsibility for this kind of tests