### PR TITLE
Issue 16430 - String>> asSymbol no protected against concurrent access

### DIFF
--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -52,7 +52,7 @@ if [ ! -e "${BOOTSTRAP_DOWNLOADS}/vmBootstrap/pharo" ]; then
 fi 
 
 if [ ! -e "${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip" ]; then
-	download_to https://github.com/guillep/PharoBootstrap/releases/download/v1.7.8/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip
+	download_to https://github.com/carolahp/PharoBootstrap/releases/download/symbolTableDatarace/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip
 fi 
 
 # checking for PharoV60.sources

--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -52,6 +52,7 @@ if [ ! -e "${BOOTSTRAP_DOWNLOADS}/vmBootstrap/pharo" ]; then
 fi 
 
 if [ ! -e "${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip" ]; then
+	# This link must be updated after the PharoBootstrap repo has been updated
 	download_to https://github.com/carolahp/PharoBootstrap/releases/download/symbolTableDt1/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip 
 fi 
 

--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -52,7 +52,7 @@ if [ ! -e "${BOOTSTRAP_DOWNLOADS}/vmBootstrap/pharo" ]; then
 fi 
 
 if [ ! -e "${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip" ]; then
-	download_to https://github.com/carolahp/PharoBootstrap/releases/download/symbolTableDt/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip
+	download_to https://github.com/carolahp/PharoBootstrap/releases/download/symbolTableDt/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip 
 fi 
 
 # checking for PharoV60.sources

--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -52,7 +52,7 @@ if [ ! -e "${BOOTSTRAP_DOWNLOADS}/vmBootstrap/pharo" ]; then
 fi 
 
 if [ ! -e "${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip" ]; then
-	download_to https://github.com/carolahp/PharoBootstrap/releases/download/symbolTableDatarace/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip
+	download_to https://github.com/carolahp/PharoBootstrap/releases/download/symbolTableDt/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip
 fi 
 
 # checking for PharoV60.sources

--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -52,7 +52,7 @@ if [ ! -e "${BOOTSTRAP_DOWNLOADS}/vmBootstrap/pharo" ]; then
 fi 
 
 if [ ! -e "${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip" ]; then
-	download_to https://github.com/carolahp/PharoBootstrap/releases/download/symbolTableDt/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip 
+	download_to https://github.com/carolahp/PharoBootstrap/releases/download/symbolTableDt1/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip 
 fi 
 
 # checking for PharoV60.sources

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -107,11 +107,11 @@ Symbol class >> initialize [
 { #category : 'symbol table' }
 Symbol class >> intern: aStringOrSymbol [
 
-	| found |
+	| internedSymbol |
 	self symbolTableSemaphore critical: [
-		found := (self findInterned: aStringOrSymbol) ifNil: [
+		internedSymbol := (self findInterned: aStringOrSymbol) ifNil: [
 			         NewSymbols add: aStringOrSymbol createSymbol ] ].
-	^ found
+	^ internedSymbol
 ]
 
 { #category : 'instance creation' }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -109,8 +109,7 @@ Symbol class >> intern: aStringOrSymbol [
 
 	| internedSymbol |
 	self symbolTableSemaphore critical: [
-		internedSymbol := (self findInterned: aStringOrSymbol) ifNil: [
-			         NewSymbols add: aStringOrSymbol createSymbol ] ].
+		internedSymbol := self rawIntern: aStringOrSymbol ].
 	^ internedSymbol
 ]
 
@@ -158,6 +157,13 @@ Symbol class >> possibleSelectorsFor: misspelled [
 		binary := misspelled, ':'.		"try for missing colon"
 		Symbol hasInterned: binary ifTrue: [:him | best addFirst: him]].
 	^ best
+]
+
+{ #category : 'symbol table' }
+Symbol class >> rawIntern: aStringOrSymbol [
+
+	^ (self findInterned: aStringOrSymbol) ifNil: [
+		  NewSymbols add: aStringOrSymbol createSymbol ]
 ]
 
 { #category : 'instance creation' }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -32,7 +32,8 @@ Class {
 	#classVars : [
 		'NewSymbols',
 		'SelectorTable',
-		'SymbolTable'
+		'SymbolTable',
+		'SymbolTableSemaphore'
 	],
 	#category : 'Collections-Strings-Base',
 	#package : 'Collections-Strings',
@@ -106,8 +107,11 @@ Symbol class >> initialize [
 { #category : 'symbol table' }
 Symbol class >> intern: aStringOrSymbol [
 
-	^ (self findInterned: aStringOrSymbol) ifNil: [
-		  NewSymbols add: aStringOrSymbol createSymbol ]
+	| found |
+	self symbolTableSemaphore critical: [
+		found := (self findInterned: aStringOrSymbol) ifNil: [
+			         NewSymbols add: aStringOrSymbol createSymbol ] ].
+	^ found
 ]
 
 { #category : 'instance creation' }
@@ -229,6 +233,13 @@ Symbol class >> shutDown: aboutToQuit [
 { #category : 'accessing' }
 Symbol class >> streamSpecies [
 	^ String
+]
+
+{ #category : 'accessing' }
+Symbol class >> symbolTableSemaphore [
+
+	^ SymbolTableSemaphore ifNil: [
+		  ^ SymbolTableSemaphore := Semaphore forMutualExclusion ]
 ]
 
 { #category : 'symbol table' }


### PR DESCRIPTION
Proposes solution to issue #16430 

### Summary 
To prevent data races when new symbols are interned into the NewSymbols table, a semaphore (stored as a class variable in the Symbol class) is used to protect the critical code in the method Symbol >> intern

### Dependencies
To fix failures during the bootstrap process due to changes in this PR, espell had to be modified. This PR must be merged only after changes in espell and in PharoBootstrap have been introduced. 
Once tests are passing, the corresponding PR will be created


### Tests
No new tests were added since reproducing dataraces is not straightforward
