### PR TITLE
Adding a Calypso class to display the Debug Points menu group in the method list context menu

### DIFF
--- a/src/Calypso-SystemPlugins-DebugPoints-Browser/SycOpenDebuggingPointsInMethodMenuCommand.class.st
+++ b/src/Calypso-SystemPlugins-DebugPoints-Browser/SycOpenDebuggingPointsInMethodMenuCommand.class.st
@@ -1,0 +1,36 @@
+"
+I define how the debugging point menu group should activate inside the calypso method view
+"
+Class {
+	#name : 'SycOpenDebuggingPointsInMethodMenuCommand',
+	#superclass : 'SycOpenMethodMenuCommand',
+	#category : 'Calypso-SystemPlugins-DebugPoints-Browser',
+	#package : 'Calypso-SystemPlugins-DebugPoints-Browser'
+}
+
+{ #category : 'activation' }
+SycOpenDebuggingPointsInMethodMenuCommand class >> methodContextMenuActivation [
+
+	<classAnnotation>
+	^ CmdContextMenuActivation
+		  byRootGroupItemOrder: 1.4
+		  for: ClyMethod asCalypsoItemContext 
+]
+
+{ #category : 'execution' }
+SycOpenDebuggingPointsInMethodMenuCommand >> activationStrategy [
+
+	^ SycDebuggingPointsMenuActivation 
+]
+
+{ #category : 'accessing' }
+SycOpenDebuggingPointsInMethodMenuCommand >> defaultMenuIconName [
+
+	^ #smallDebug 
+]
+
+{ #category : 'accessing' }
+SycOpenDebuggingPointsInMethodMenuCommand >> defaultMenuItemName [
+
+	^ 'Debug Points' 
+]


### PR DESCRIPTION
Fixes #16488 

The "Debug Points" command group was displayed everywhere in Calypso, except in the method list.

There was just a missing class to describe how it should display in the method list's context menu...

This design is so weird because it's no different than the rest of Calypso so I don't understand why this is necessary... It was a pain because it is not documented 