### PR TITLE
add rule to avoid that TestCase rely on Initialize

### DIFF
--- a/src/General-Rules-Tests/ReUseSetUpRuleTest.class.st
+++ b/src/General-Rules-Tests/ReUseSetUpRuleTest.class.st
@@ -21,8 +21,7 @@ ReUseSetUpRuleTest >> testRuleNotViolated [
 
 	| critiques |
 	self class compile: 'setUp'.
-	critiques := self myCritiquesOnClass: self class.
-	self assertEmpty: critiques.
-	[ "code of the test" ] ensure: [
+	[ critiques := self myCritiquesOnClass: self class.
+	self assertEmpty: critiques ] ensure: [
 		(self class >> #setUp) removeFromSystem ]
 ]

--- a/src/General-Rules-Tests/ReUseSetUpRuleTest.class.st
+++ b/src/General-Rules-Tests/ReUseSetUpRuleTest.class.st
@@ -11,9 +11,8 @@ ReUseSetUpRuleTest >> testRule [
 
 	| critiques |
 	self class compile: 'initialize' classified: 'initialization'.
-	critiques := self myCritiquesOnMethod: self class >> #initialize.
-	self assert: critiques size equals: 1.
-	[ "code of the test" ] ensure: [
+	[ critiques := self myCritiquesOnMethod: self class >> #initialize.
+	self assert: critiques size equals: 1 ] ensure: [
 		(self class >> #initialize) removeFromSystem ]
 ]
 

--- a/src/General-Rules-Tests/ReUseSetUpRuleTest.class.st
+++ b/src/General-Rules-Tests/ReUseSetUpRuleTest.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : 'ReUseSetUpRuleTest',
+	#superclass : 'ReAbstractRuleTestCase',
+	#category : 'General-Rules-Tests-Migrated',
+	#package : 'General-Rules-Tests',
+	#tag : 'Migrated'
+}
+
+{ #category : 'initialization' }
+ReUseSetUpRuleTest >> initialize [ 
+]
+
+{ #category : 'tests' }
+ReUseSetUpRuleTest >> testRule [
+
+	| critiques |
+	self class compile: 'initialize'.
+	critiques := self myCritiquesOnClass: self class.
+	self assert: critiques size equals: 1.
+	[ "code of the test" ] ensure: [ (self class >> #initialize) removeFromSystem ]
+]
+
+{ #category : 'tests' }
+ReUseSetUpRuleTest >> testRuleNotViolated [ 
+
+	| critiques |
+	self class compile: 'setUp'.
+	critiques := self myCritiquesOnClass: self class.
+	self assertEmpty: critiques.
+	[ "code of the test" ] ensure: [ (self class >> #setUp) removeFromSystem ]
+]

--- a/src/General-Rules-Tests/ReUseSetUpRuleTest.class.st
+++ b/src/General-Rules-Tests/ReUseSetUpRuleTest.class.st
@@ -6,26 +6,24 @@ Class {
 	#tag : 'Migrated'
 }
 
-{ #category : 'initialization' }
-ReUseSetUpRuleTest >> initialize [ 
-]
-
 { #category : 'tests' }
 ReUseSetUpRuleTest >> testRule [
 
 	| critiques |
-	self class compile: 'initialize'.
-	critiques := self myCritiquesOnClass: self class.
+	self class compile: 'initialize' classified: 'initialization'.
+	critiques := self myCritiquesOnMethod: self class >> #initialize.
 	self assert: critiques size equals: 1.
-	[ "code of the test" ] ensure: [ (self class >> #initialize) removeFromSystem ]
+	[ "code of the test" ] ensure: [
+		(self class >> #initialize) removeFromSystem ]
 ]
 
 { #category : 'tests' }
-ReUseSetUpRuleTest >> testRuleNotViolated [ 
+ReUseSetUpRuleTest >> testRuleNotViolated [
 
 	| critiques |
 	self class compile: 'setUp'.
 	critiques := self myCritiquesOnClass: self class.
 	self assertEmpty: critiques.
-	[ "code of the test" ] ensure: [ (self class >> #setUp) removeFromSystem ]
+	[ "code of the test" ] ensure: [
+		(self class >> #setUp) removeFromSystem ]
 ]

--- a/src/General-Rules/ReUseSetUpRule.class.st
+++ b/src/General-Rules/ReUseSetUpRule.class.st
@@ -3,16 +3,11 @@ this smell arise when we use initialize instead of setUp in a TestCase
 "
 Class {
 	#name : 'ReUseSetUpRule',
-	#superclass : 'ReAbstractRule',
+	#superclass : 'ReNodeRewriteRule',
 	#category : 'General-Rules-Migrated',
 	#package : 'General-Rules',
 	#tag : 'Migrated'
 }
-
-{ #category : 'testing - interest' }
-ReUseSetUpRule class >> checksClass [ 
-	^ true
-]
 
 { #category : 'manifest' }
 ReUseSetUpRule class >> uniqueIdentifierName [
@@ -21,23 +16,21 @@ ReUseSetUpRule class >> uniqueIdentifierName [
 	^ 'UseSetUpRule'
 ]
 
-{ #category : 'running' }
-ReUseSetUpRule >> basicCheck: aClass [
-	
-	aClass isTestCase ifFalse: [ ^ false ].
-	^ aClass selectors includes: #initialize
-]
-
 { #category : 'accessing' }
 ReUseSetUpRule >> group [
 
 	^ 'Design Flaws'
 ]
 
-{ #category : 'testing' }
-ReUseSetUpRule >> isRewriteRule [
+{ #category : 'initialization' }
+ReUseSetUpRule >> initialize [
 
-	^ true
+	super initialize.
+	self
+		addMatchingMethod:
+		'initialize |`@temps| super initialize. `.@statements'
+		rewriteTo: 'setUp |`@temps| super setUp. `.@statements'.
+	self addMatchingMethod: 'initialize' rewriteTo: 'setUp'
 ]
 
 { #category : 'accessing' }
@@ -47,7 +40,13 @@ ReUseSetUpRule >> name [
 ]
 
 { #category : 'accessing' }
-ReUseSetUpRule >> severity [ 
+ReUseSetUpRule >> severity [
 
-	^ #error
+	^ #error 
+]
+
+{ #category : 'testing' }
+ReUseSetUpRule >> shouldCheckMethod: aMethod [ 
+
+	^ aMethod selector = #initialize and: [ aMethod methodClass isTestCase ]
 ]

--- a/src/General-Rules/ReUseSetUpRule.class.st
+++ b/src/General-Rules/ReUseSetUpRule.class.st
@@ -1,0 +1,53 @@
+"
+this smell arise when we use initialize instead of setUp in a TestCase
+"
+Class {
+	#name : 'ReUseSetUpRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'General-Rules-Migrated',
+	#package : 'General-Rules',
+	#tag : 'Migrated'
+}
+
+{ #category : 'testing - interest' }
+ReUseSetUpRule class >> checksClass [ 
+	^ true
+]
+
+{ #category : 'manifest' }
+ReUseSetUpRule class >> uniqueIdentifierName [
+	"This number should be unique and should change only when the rule completely change semantics"
+
+	^ 'UseSetUpRule'
+]
+
+{ #category : 'running' }
+ReUseSetUpRule >> basicCheck: aClass [
+	
+	aClass isTestCase ifFalse: [ ^ false ].
+	^ aClass selectors includes: #initialize
+]
+
+{ #category : 'accessing' }
+ReUseSetUpRule >> group [
+
+	^ 'Design Flaws'
+]
+
+{ #category : 'testing' }
+ReUseSetUpRule >> isRewriteRule [
+
+	^ true
+]
+
+{ #category : 'accessing' }
+ReUseSetUpRule >> name [
+
+	^ 'Uses setUp instead of initialize for Test class.'
+]
+
+{ #category : 'accessing' }
+ReUseSetUpRule >> severity [ 
+
+	^ #error
+]


### PR DESCRIPTION
This pull request proposes a rule to validate that users do not use initialize but setUp.
#5792 