### PR TITLE
New pass at removing SystemAnnouncer references

### DIFF
--- a/src/ClassAnnotation/ClassAnnotationRegistry.class.st
+++ b/src/ClassAnnotation/ClassAnnotationRegistry.class.st
@@ -127,11 +127,11 @@ ClassAnnotationRegistry class >> doesMethodDefineAnnotation: aMethod [
 { #category : 'system changes' }
 ClassAnnotationRegistry class >> ensureSystemSubscription [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
+	self codeChangeAnnouncer unsubscribe: self.
 
-	SystemAnnouncer uniqueInstance weak
-		when: ClassRemoved, ClassAdded, ClassModificationApplied send: #handleClassChanged: to: self;
-		when: MethodRemoved, MethodAdded, MethodModified send: #handleMethodChange: to: self;
+	self codeChangeAnnouncer weak
+		when: ClassRemoved , ClassAdded , ClassModificationApplied send: #handleClassChanged: to: self;
+		when: MethodRemoved , MethodAdded , MethodModified send: #handleMethodChange: to: self;
 		when: MethodModified send: #handleOldMethodChange: to: self
 ]
 
@@ -157,9 +157,9 @@ ClassAnnotationRegistry class >> handleOldMethodChange: aMethodModified [
 
 { #category : 'class initialization' }
 ClassAnnotationRegistry class >> reset [
-	<script>
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
+	<script>
+	self codeChangeAnnouncer unsubscribe: self.
 	default := nil
 ]
 

--- a/src/DebugPoints-Tests/DebugPointObserverTest.class.st
+++ b/src/DebugPoints-Tests/DebugPointObserverTest.class.st
@@ -26,7 +26,7 @@ DebugPointObserverTest >> setUp [
 DebugPointObserverTest >> tearDown [
 
 	dp ifNotNil: [ dp remove ].
-	SystemAnnouncer uniqueInstance unsubscribe: observer.
+	self class codeSupportAnnouncer unsubscribe: observer.
 
 	super tearDown
 ]
@@ -34,100 +34,69 @@ DebugPointObserverTest >> tearDown [
 { #category : 'tests' }
 DebugPointObserverTest >> testNotifyDebugPointAdded [
 
-	SystemAnnouncer uniqueInstance
-		when: DebugPointAdded
-		send: #update:
-		to: observer.
+	self class codeSupportAnnouncer when: DebugPointAdded send: #update: to: observer.
 	dp := DebugPointManager installNew: DebugPoint on: node.
 	self assert: observer tag class equals: DebugPointAdded.
 	self assert: observer tag debugPoint identicalTo: dp.
-	self
-		assertCollection: observer tag nodes
-		equals: { (DummyTestClass >> #id:) ast } asSet
+	self assertCollection: observer tag nodes equals: { (DummyTestClass >> #id:) ast } asSet
 ]
 
 { #category : 'tests' }
 DebugPointObserverTest >> testNotifyDebugPointChanged [
 
 	dp := DebugPointManager installNew: DebugPoint on: node.
-	SystemAnnouncer uniqueInstance
-		when: DebugPointChanged
-		send: #update:
-		to: observer.
+	self class codeSupportAnnouncer when: DebugPointChanged send: #update: to: observer.
 
 	dp addBehavior: OnceBehavior new.
 
 	self assert: observer tag class equals: DebugPointChanged.
 	self assert: observer tag debugPoint identicalTo: dp.
-	self
-		assertCollection: observer tag nodes
-		equals: { (DummyTestClass >> #id:) ast } asSet.
+	self assertCollection: observer tag nodes equals: { (DummyTestClass >> #id:) ast } asSet.
 
 	observer tag: nil.
 	dp removeBehavior: OnceBehavior.
 
 	self assert: observer tag class equals: DebugPointChanged.
 	self assert: observer tag debugPoint identicalTo: dp.
-	self
-		assertCollection: observer tag nodes
-		equals: { (DummyTestClass >> #id:) ast } asSet
+	self assertCollection: observer tag nodes equals: { (DummyTestClass >> #id:) ast } asSet
 ]
 
 { #category : 'tests' }
 DebugPointObserverTest >> testNotifyDebugPointHit [
 
-	SystemAnnouncer uniqueInstance
-		when: DebugPointHit
-		send: #update:
-		to: observer.
+	self class codeSupportAnnouncer when: DebugPointHit send: #update: to: observer.
 	dp := DebugPointManager installNew: DebugPoint on: node.
 
 	DummyTestClass new id: 2.
 
 	self assert: observer tag class equals: DebugPointHit.
 	self assert: observer tag debugPoint identicalTo: dp.
-	self
-		assertCollection: observer tag nodes
-		equals: { (DummyTestClass >> #id:) ast } asSet
+	self assertCollection: observer tag nodes equals: { (DummyTestClass >> #id:) ast } asSet
 ]
 
 { #category : 'tests' }
 DebugPointObserverTest >> testNotifyDebugPointRemoved [
 
 	dp := DebugPointManager installNew: DebugPoint on: node.
-	SystemAnnouncer uniqueInstance
-		when: DebugPointRemoved
-		send: #update:
-		to: observer.
+	self class codeSupportAnnouncer when: DebugPointRemoved send: #update: to: observer.
 	dp remove.
 	self assert: observer tag class equals: DebugPointRemoved.
 	self assert: observer tag debugPoint identicalTo: dp.
-	self
-		assertCollection: observer tag nodes
-		equals: { (DummyTestClass >> #id:) ast } asSet
+	self assertCollection: observer tag nodes equals: { (DummyTestClass >> #id:) ast } asSet
 ]
 
 { #category : 'tests' }
 DebugPointObserverTest >> testNotifyVariableDebugPointHit [
 
 	| obj |
-	SystemAnnouncer uniqueInstance
-		when: DebugPointHit
-		send: #update:
-		to: observer.
-	dp := DebugPointManager
-		      installNew: DebugPoint
-		      inClass: DummyTestClass
-		      onVariableAccessNamed: #id.
+	self class codeSupportAnnouncer when: DebugPointHit send: #update: to: observer.
+	dp := DebugPointManager installNew: DebugPoint inClass: DummyTestClass onVariableAccessNamed: #id.
 
 	obj := DummyTestClass new.
 
 	self assert: observer tag class equals: VariableDebugPointHit.
 	self assert: observer tag debugPoint identicalTo: dp.
-	self
-		assertCollection: observer tag nodes
-		equals:
-		{ (DummyTestClass >> #initialize) ast statements second } asSet.
+	self assertCollection: observer tag nodes equals: { (DummyTestClass >> #initialize) ast statements second } asSet.
 	self assert: observer tag variableValue equals: nil.
 
 	observer tag: nil.
@@ -135,9 +104,7 @@ DebugPointObserverTest >> testNotifyVariableDebugPointHit [
 
 	self assert: observer tag class equals: VariableDebugPointHit.
 	self assert: observer tag debugPoint identicalTo: dp.
-	self
-		assertCollection: observer tag nodes
-		equals: { (DummyTestClass >> #id) ast statements first value } asSet.
+	self assertCollection: observer tag nodes equals: { (DummyTestClass >> #id) ast statements first value } asSet.
 	self assert: observer tag variableValue equals: 0.
 
 	observer tag: nil.
@@ -145,10 +112,7 @@ DebugPointObserverTest >> testNotifyVariableDebugPointHit [
 
 	self assert: observer tag class equals: VariableDebugPointHit.
 	self assert: observer tag debugPoint identicalTo: dp.
-	self
-		assertCollection: observer tag nodes
-		equals:
-		{ (DummyTestClass >> #id:) ast statements first value } asSet.
+	self assertCollection: observer tag nodes equals: { (DummyTestClass >> #id:) ast statements first value } asSet.
 	self assert: observer tag variableValue equals: 0.
 
 	observer tag: nil.
@@ -156,8 +120,6 @@ DebugPointObserverTest >> testNotifyVariableDebugPointHit [
 
 	self assert: observer tag class equals: VariableDebugPointHit.
 	self assert: observer tag debugPoint identicalTo: dp.
-	self
-		assertCollection: observer tag nodes
-		equals: { (DummyTestClass >> #id) ast statements first value } asSet.
+	self assertCollection: observer tag nodes equals: { (DummyTestClass >> #id) ast statements first value } asSet.
 	self assert: observer tag variableValue equals: 2
 ]

--- a/src/DebugPoints/DebugPointManager.class.st
+++ b/src/DebugPoints/DebugPointManager.class.st
@@ -323,53 +323,44 @@ DebugPointManager class >> installNew: aDebugPointClass on: aNode withBehaviors:
 DebugPointManager class >> notifyDebugPointAdded: aDebugPoint [
 
 	| announcement |
-	announcement := DebugPointAdded 
-		on: aDebugPoint
-		nodes: aDebugPoint link nodes.
-	SystemAnnouncer uniqueInstance announce: announcement
+	announcement := DebugPointAdded on: aDebugPoint nodes: aDebugPoint link nodes.
+	self codeSupportAnnouncer announce: announcement
 ]
 
 { #category : 'announcements' }
 DebugPointManager class >> notifyDebugPointChanged: aDebugPoint [
-	
+
 	| announcement |
-	announcement := DebugPointChanged
-		on: aDebugPoint
-		nodes: aDebugPoint link nodes.
-	SystemAnnouncer uniqueInstance announce: announcement
+	announcement := DebugPointChanged on: aDebugPoint nodes: aDebugPoint link nodes.
+	self codeSupportAnnouncer announce: announcement
 ]
 
 { #category : 'announcements' }
 DebugPointManager class >> notifyDebugPointHit: aDebugPoint inContext: aContext [
 
 	| announcement |
-	announcement := aDebugPoint
-		                hitAnnouncementOn: aDebugPoint
-		                inContext: aContext.
-	SystemAnnouncer uniqueInstance announce: announcement
+	announcement := aDebugPoint hitAnnouncementOn: aDebugPoint inContext: aContext.
+	self codeSupportAnnouncer announce: announcement
 ]
 
 { #category : 'announcements' }
 DebugPointManager class >> notifyDebugPointRemoved: aDebugPoint fromNodes: nodes [
 	"nodes have to be seperate because they will be removed from the debugpoint before this method is called"
+
 	| announcement |
-	announcement := DebugPointRemoved
-		on: aDebugPoint 
-		nodes: nodes.
-	SystemAnnouncer uniqueInstance announce: announcement.
-
-		
-
+	announcement := DebugPointRemoved on: aDebugPoint nodes: nodes.
+	self codeSupportAnnouncer announce: announcement
 ]
 
 { #category : 'announcements - registration' }
 DebugPointManager class >> registerInterestToSystemAnnouncement [
-	<systemEventRegistration>
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
-	SystemAnnouncer uniqueInstance weak when: MethodRemoved send: #handleMethodRemoved: to: self.
-	SystemAnnouncer uniqueInstance weak when: MethodModified send: #handleMethodModified: to: self.
-	SystemAnnouncer uniqueInstance weak when: ClassRemoved send: #handleClassRemoved: to: self
+	<systemEventRegistration>
+	self codeChangeAnnouncer unsubscribe: self.
+	self codeChangeAnnouncer weak
+		when: MethodRemoved send: #handleMethodRemoved: to: self;
+		when: MethodModified send: #handleMethodModified: to: self;
+		when: ClassRemoved send: #handleClassRemoved: to: self
 ]
 
 { #category : 'removing' }

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -539,7 +539,7 @@ EpMonitor >> subscribeToSystemAnnouncer [
 { #category : 'private' }
 EpMonitor >> systemAnnouncer [
 
-	^ SystemAnnouncer uniqueInstance
+	^ self class codeChangeAnnouncer
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReImplementedNotSentRule.class.st
+++ b/src/General-Rules/ReImplementedNotSentRule.class.st
@@ -92,11 +92,12 @@ ReImplementedNotSentRule class >> shutDown [
 
 { #category : 'announcement' }
 ReImplementedNotSentRule class >> subscribe [
+
 	<systemEventRegistration>
 	self unsubscribe.
 
-	SystemAnnouncer uniqueInstance weak
-		when: MethodAdded    send: #methodAdded: to: self;
+	self codeChangeAnnouncer weak
+		when: MethodAdded send: #methodAdded: to: self;
 		when: MethodModified send: #methodModified: to: self
 ]
 
@@ -110,7 +111,7 @@ ReImplementedNotSentRule class >> uniqueIdentifierName [
 { #category : 'announcement' }
 ReImplementedNotSentRule class >> unsubscribe [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self
+	self codeChangeAnnouncer unsubscribe: self
 ]
 
 { #category : 'running' }

--- a/src/Kernel-Tests/AbstractClassDescriptionAnnouncementTest.class.st
+++ b/src/Kernel-Tests/AbstractClassDescriptionAnnouncementTest.class.st
@@ -19,7 +19,7 @@ AbstractClassDescriptionAnnouncementTest >> setUp [
 { #category : 'running' }
 AbstractClassDescriptionAnnouncementTest >> tearDown [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
+	self class codeChangeAnnouncer unsubscribe: self.
 	super tearDown
 ]
 

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -78,11 +78,13 @@ ReflectiveMethod >> decreaseLinkCount [
 
 { #category : 'invalidate' }
 ReflectiveMethod >> destroyTwin [
-	(ast hasProperty: #wrapperMethod) ifTrue: [  ast :=  compiledMethod parseTree].
+
+	(ast hasProperty: #wrapperMethod) ifTrue: [ ast := compiledMethod parseTree ].
 	self recompileAST.
 	self installCompiledMethod.
 	compiledMethod reflectiveMethod: nil.
-	SystemAnnouncer uniqueInstance unsubscribe: self
+	self class codeSupportAnnouncer unsubscribe: self.
+	self class codeChangeAnnouncer unsubscribe: self
 ]
 
 { #category : 'forwarding' }

--- a/src/Renraku/ReRuleManager.class.st
+++ b/src/Renraku/ReRuleManager.class.st
@@ -208,17 +208,15 @@ ReRuleManager class >> setDefaultProfile [
 
 { #category : 'event subscriptions' }
 ReRuleManager class >> subscribe [
+
 	<systemEventRegistration>
 	self unsubscribe.
 
-	SystemAnnouncer uniqueInstance weak
-		when: ClassAdded   send: #classAddedOrRemoved: to: self;
+	self codeChangeAnnouncer weak
+		when: ClassAdded send: #classAddedOrRemoved: to: self;
 		when: ClassRemoved send: #classAddedOrRemoved: to: self.
 
-	ReSystemAnnouncer uniqueInstance weak
-		when: ReCritiqueBanned
-		send: #critiqueBanned:
-		to: self
+	ReSystemAnnouncer uniqueInstance weak when: ReCritiqueBanned send: #critiqueBanned: to: self
 ]
 
 { #category : 'instance creation' }
@@ -236,7 +234,7 @@ ReRuleManager class >> unload [
 { #category : 'event subscriptions' }
 ReRuleManager class >> unsubscribe [
 
-	SystemAnnouncer uniqueInstance unsubscribe: self.
+	self codeChangeAnnouncer unsubscribe: self.
 	ReSystemAnnouncer uniqueInstance unsubscribe: self
 ]
 

--- a/src/Ring-Definitions-Core-Tests/RGMethodDefinitionTest.class.st
+++ b/src/Ring-Definitions-Core-Tests/RGMethodDefinitionTest.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : 'running' }
 RGMethodDefinitionTest >> runCase [
 
-	SystemAnnouncer uniqueInstance suspendAllWhile: [ super runCase ]
+	self class codeChangeAnnouncer suspendAllWhile: [ super runCase ]
 ]
 
 { #category : 'running' }

--- a/src/System-Support-Tests/SystemNavigationTest.class.st
+++ b/src/System-Support-Tests/SystemNavigationTest.class.st
@@ -7,8 +7,7 @@ Class {
 	#name : 'SystemNavigationTest',
 	#superclass : 'TestCase',
 	#instVars : [
-		'classFactory',
-		'oldSystemAnnouncer'
+		'classFactory'
 	],
 	#category : 'System-Support-Tests-Image',
 	#package : 'System-Support-Tests',
@@ -27,12 +26,16 @@ SystemNavigationTest >> createClassFactory [
 	^ ClassFactoryForTestCase environment: self systemNavigationToTest environment
 ]
 
+{ #category : 'private' }
+SystemNavigationTest >> performTest [
+
+	self class codeChangeAnnouncer suspendAllWhile: [ ^ super performTest ]
+]
+
 { #category : 'running' }
 SystemNavigationTest >> setUp [
 
 	super setUp.
-	oldSystemAnnouncer := SystemAnnouncer uniqueInstance.
-	SystemAnnouncer announcer: nil.
 	classFactory := self createClassFactory
 ]
 
@@ -46,7 +49,6 @@ SystemNavigationTest >> systemNavigationToTest [
 SystemNavigationTest >> tearDown [
 
 	self classFactory cleanUp.
-	SystemAnnouncer announcer: oldSystemAnnouncer.
 	super tearDown
 ]
 

--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -206,7 +206,7 @@ TaAbstractComposition >> copyMethod: aSelector into: aClass replacing: replacing
 	newMethod sourcePointer: aCompiledMethod sourcePointer.
 
 	"This step should not announce anything in the system."
-	SystemAnnouncer uniqueInstance suspendAllWhile: [ aClass classify: aSelector under: aCompiledMethod protocolName ].
+	self class codeChangeAnnouncer suspendAllWhile: [ aClass classify: aSelector under: aCompiledMethod protocolName ].
 
 	aClass addSelectorSilently: aSelector withMethod: newMethod.
 


### PR DESCRIPTION
This change is a new step at reducing the references to SystemAnnouncer class>>#uniqueInstance references in order to remove the singleton in the future.