### PR TITLE
Refactoring of the RefactoryChange manager

### DIFF
--- a/src/NautilusRefactoring/StChangesBrowserPresenter.class.st
+++ b/src/NautilusRefactoring/StChangesBrowserPresenter.class.st
@@ -25,8 +25,7 @@ StChangesBrowserPresenter >> accept [
 
 	self okToChange ifFalse: [ ^ self ].
 
-	[ self pickedChanges do: [ :change |
-			RBRefactoryChangeManager instance performChange: change ] ] asJob
+	[ RBRefactoryChangeManager instance performChanges: self pickedChanges ] asJob
 		title: 'Refactoring';
 		run
 ]

--- a/src/NautilusRefactoring/StRewriteRuleChangesBrowserPresenter.class.st
+++ b/src/NautilusRefactoring/StRewriteRuleChangesBrowserPresenter.class.st
@@ -43,6 +43,12 @@ StRewriteRuleChangesBrowserPresenter class >> defaultLayout [
 		yourself
 ]
 
+{ #category : 'testing' }
+StRewriteRuleChangesBrowserPresenter class >> isDeprecated [ 
+
+	^ true
+]
+
 { #category : 'actions' }
 StRewriteRuleChangesBrowserPresenter >> accept [
 	self okToChange

--- a/src/NautilusRefactoring/StRewriteRuleChangesBrowserPresenter.class.st
+++ b/src/NautilusRefactoring/StRewriteRuleChangesBrowserPresenter.class.st
@@ -54,7 +54,7 @@ StRewriteRuleChangesBrowserPresenter >> accept [
 	self okToChange
 		ifFalse: [ ^ self ].
 	self selectedChanges isEmptyOrNil ifTrue: [ ^self ].
-	[ self selectedChanges do: [ :change | RBRefactoryChangeManager instance performChange: change ] ] asJob
+	[ RBRefactoryChangeManager instance performChanges: self selectedChanges ] asJob
 		title: 'Refactoring';
 		run.
 	self window delete

--- a/src/Refactoring-Changes-Tests/RBRefactoringChangeManagerPerformChangesTest.class.st
+++ b/src/Refactoring-Changes-Tests/RBRefactoringChangeManagerPerformChangesTest.class.st
@@ -11,7 +11,7 @@ Class {
 { #category : 'instance creation' }
 RBRefactoringChangeManagerPerformChangesTest >> listOfMockChangesWithSize: aNumber [
 
-	^ (1 to: aNumber) collect: [ :i | RBRefactoringChangeMock new ]
+	^ (1 to: aNumber) collect: [ :i | RBRefactoringChangeMock new name: i asString ]
 ]
 
 { #category : 'instance creation' }
@@ -38,4 +38,28 @@ RBRefactoringChangeManagerPerformChangesTest >> testPerformChanges [
 	manager undoLastRefactoring.
 	
 	self deny: manager hasUndoableOperations
+]
+
+{ #category : 'tests' }
+RBRefactoringChangeManagerPerformChangesTest >> testPerformChangesWhenChangesBiggerThanUndoSizeExpectCorrectChangesUndone [
+
+	| changes undoneChanges |
+	changes := self listOfMockChangesWithSize: manager class undoSize + 1.
+	manager performChanges: changes.
+	
+	undoneChanges := manager undoLastRefactoring.
+	
+	self assertCollection: undoneChanges first changes asArray equals: changes reversed asArray
+]
+
+{ #category : 'tests' }
+RBRefactoringChangeManagerPerformChangesTest >> testPerformChangesWhenChangesSmallerThanUndoSizeExpectCorrectChangesUndone [
+
+	| changes undoneChanges |
+	changes := self listOfMockChangesWithSize: 5.
+	manager performChanges: changes.
+	
+	undoneChanges := manager undoLastRefactoring.
+	
+	self assertCollection: undoneChanges first changes asArray equals: changes reversed asArray
 ]

--- a/src/Refactoring-Changes-Tests/RBRefactoringChangeManagerPerformChangesTest.class.st
+++ b/src/Refactoring-Changes-Tests/RBRefactoringChangeManagerPerformChangesTest.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : 'RBRefactoringChangeManagerPerformChangesTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'manager'
+	],
+	#category : 'Refactoring-Changes-Tests',
+	#package : 'Refactoring-Changes-Tests'
+}
+
+{ #category : 'instance creation' }
+RBRefactoringChangeManagerPerformChangesTest >> listOfMockChangesWithSize: aNumber [
+
+	^ (1 to: aNumber) collect: [ :i | RBRefactoringChangeMock new ]
+]
+
+{ #category : 'instance creation' }
+RBRefactoringChangeManagerPerformChangesTest >> newMockChange [
+
+	^ RBRefactoringChangeMock new
+]
+
+{ #category : 'running' }
+RBRefactoringChangeManagerPerformChangesTest >> setUp [
+
+	super setUp.
+	RBRefactoryChangeManager nuke.
+	manager := RBRefactoryChangeManager instance
+]
+
+{ #category : 'tests' }
+RBRefactoringChangeManagerPerformChangesTest >> testPerformChanges [
+
+	| changes |
+	changes := self listOfMockChangesWithSize: 5.
+	manager performChanges: changes.
+	
+	manager undoLastRefactoring.
+	
+	self deny: manager hasUndoableOperations
+]

--- a/src/Refactoring-Changes-Tests/RBRefactoringChangeMock.class.st
+++ b/src/Refactoring-Changes-Tests/RBRefactoringChangeMock.class.st
@@ -49,6 +49,16 @@ RBRefactoringChangeMock >> one [
 	^ 1
 ]
 
+{ #category : 'printing' }
+RBRefactoringChangeMock >> printOn: aStream [
+	"Generate a string representation of the receiver based on its instance variables."
+
+	super printOn: aStream.
+	aStream
+		nextPutAll: ' name: ';
+		print: name
+]
+
 { #category : 'accessing' }
 RBRefactoringChangeMock >> renameChangesForClass: oldClassName to: newClassName [
 	"I'm a mock, I do nothing"

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -216,6 +216,16 @@ RBRefactoryChangeManager >> performChange: aRefactoringChange [
 ]
 
 { #category : 'public access' }
+RBRefactoryChangeManager >> performChanges: aRefactoringChangesList [
+	
+	self ignoreChangesWhile: [ 
+		aRefactoringChangesList do: [ :change |
+		 self addUndo: change execute.
+		 self addUndoPointer: self class nextCounter ]
+	]
+]
+
+{ #category : 'public access' }
 RBRefactoryChangeManager >> redoChange [
 	^ redo last
 ]

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -195,8 +195,12 @@ RBRefactoryChangeManager >> lastUndoPointer [
 
 { #category : 'public access' }
 RBRefactoryChangeManager >> performChange: aRefactoringChange [
-	
-	self ignoreChangesWhile: [ self addUndo: aRefactoringChange execute ]
+
+	self
+		deprecated: 'Use `performCompositeChange:` if you have CompositeChange or use `performChanges:` if you have a list of changes instead of current one'
+		transformWith: '`@rec performChange: `@arg' -> '`@rec performCompositeChange: `@arg'.
+
+	self performCompositeChange: aRefactoringChange.
 ]
 
 { #category : 'public access' }

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -248,7 +248,8 @@ RBRefactoryChangeManager >> undoLastRefactoring [
 	list := OrderedCollection new.
 	limit := manager lastUndoPointer .
 	1 to: limit do:[ :i | list add: manager undoChange ].
-	list do: [ :e | e execute ]
+	list do: [ :e | e execute ].
+	^ list
 	 ] asJob
 		title: 'Refactoring';
 		run]

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -214,6 +214,14 @@ RBRefactoryChangeManager >> performChanges: aRefactoringChangesList [
 ]
 
 { #category : 'public access' }
+RBRefactoryChangeManager >> performCompositeChange: aCompositeChange [
+
+	self ignoreChangesWhile: [
+		self addUndo: aCompositeChange execute.
+		self addUndoPointer: self class nextCounter ]
+]
+
+{ #category : 'public access' }
 RBRefactoryChangeManager >> redoChange [
 	^ redo last
 ]

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -53,7 +53,7 @@ RBRefactoryChangeManager class >> instance [
 RBRefactoryChangeManager class >> menuCommandOn: aBuilder [
 	<worldMenu>
 	(aBuilder item: #'Undo last refactoring')
-				action: [self undoLastRefactoring];
+				action: [self instance undoLastRefactoring];
 				parent: #Refactoring;
 				help: 'Undo last refactoring';
 				order: 10;
@@ -86,22 +86,6 @@ RBRefactoryChangeManager class >> nuke [
 RBRefactoryChangeManager class >> resetCounter [
 
 	Counter := nil
-]
-
-{ #category : 'menu' }
-RBRefactoryChangeManager class >> undoLastRefactoring [
-	| manager |
-	manager := RBRefactoryChangeManager instance.
-	manager undoPointers ifNotEmpty: [
-	[ |limit list|
-	list := OrderedCollection new.
-	limit := manager lastUndoPointer .
-	1 to: limit do:[ :i | list add: manager undoChange ].
-	list do: [ :e | e execute ]
-	 ] asJob
-		title: 'Refactoring';
-		run]
-	ifEmpty: [ self inform: 'There aren''t refactorings to undo.'  ]
 ]
 
 { #category : 'class initialization' }
@@ -249,6 +233,22 @@ RBRefactoryChangeManager >> release [
 RBRefactoryChangeManager >> undoChange [
 
 	^ undo pop
+]
+
+{ #category : 'menu' }
+RBRefactoryChangeManager >> undoLastRefactoring [
+	| manager |
+	manager := RBRefactoryChangeManager instance.
+	manager undoPointers ifNotEmpty: [
+	[ |limit list|
+	list := OrderedCollection new.
+	limit := manager lastUndoPointer .
+	1 to: limit do:[ :i | list add: manager undoChange ].
+	list do: [ :e | e execute ]
+	 ] asJob
+		title: 'Refactoring';
+		run]
+	ifEmpty: [ self inform: 'There aren''t refactorings to undo.'  ]
 ]
 
 { #category : 'public access' }

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -88,6 +88,14 @@ RBRefactoryChangeManager class >> resetCounter [
 	Counter := nil
 ]
 
+{ #category : 'menu' }
+RBRefactoryChangeManager class >> undoLastRefactoring [
+
+	self deprecated: 'Use instance side method instead'
+		transformWith: '`@rec undoLastRefactoring' -> '`@rec instance undoLastRefactoring'.
+	^ self instance undoLastRefactoring 
+]
+
 { #category : 'class initialization' }
 RBRefactoryChangeManager class >> undoSize [
 

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -201,12 +201,16 @@ RBRefactoryChangeManager >> performChange: aRefactoringChange [
 
 { #category : 'public access' }
 RBRefactoryChangeManager >> performChanges: aRefactoringChangesList [
-	
-	self ignoreChangesWhile: [ 
-		aRefactoringChangesList do: [ :change |
-		 self addUndo: change execute.
-		 self addUndoPointer: self class nextCounter ]
-	]
+
+	| compositeChange |
+	aRefactoringChangesList ifEmpty: [ ^ self ].
+	compositeChange := RBCompositeRefactoryChange new.
+	compositeChange onSystemDictionary:
+		aRefactoringChangesList first onSystemDictionary.
+	compositeChange changes: aRefactoringChangesList.
+	self ignoreChangesWhile: [
+		self addUndo: compositeChange execute.
+		self addUndoPointer: self class nextCounter ]
 ]
 
 { #category : 'public access' }

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -253,13 +253,12 @@ RBRefactoryChangeManager >> undoChange [
 
 { #category : 'menu' }
 RBRefactoryChangeManager >> undoLastRefactoring [
-	| manager |
-	manager := RBRefactoryChangeManager instance.
-	manager undoPointers ifNotEmpty: [
+
+	self undoPointers ifNotEmpty: [
 	[ |limit list|
 	list := OrderedCollection new.
-	limit := manager lastUndoPointer .
-	1 to: limit do:[ :i | list add: manager undoChange ].
+	limit := self lastUndoPointer .
+	1 to: limit do:[ :i | list add: self undoChange ].
 	list do: [ :e | e execute ].
 	^ list
 	 ] asJob

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -212,9 +212,7 @@ RBRefactoryChangeManager >> performChanges: aRefactoringChangesList [
 	compositeChange onSystemDictionary:
 		aRefactoringChangesList first onSystemDictionary.
 	compositeChange changes: aRefactoringChangesList.
-	self ignoreChangesWhile: [
-		self addUndo: compositeChange execute.
-		self addUndoPointer: self class nextCounter ]
+	self performCompositeChange: compositeChange
 ]
 
 { #category : 'public access' }
@@ -256,11 +254,11 @@ RBRefactoryChangeManager >> undoLastRefactoring [
 
 	self undoPointers ifNotEmpty: [
 	[ |limit list|
-	list := OrderedCollection new.
-	limit := self lastUndoPointer .
-	1 to: limit do:[ :i | list add: self undoChange ].
-	list do: [ :e | e execute ].
-	^ list
+		list := OrderedCollection new.
+		limit := self lastUndoPointer .
+		1 to: limit do:[ :i | list add: self undoChange ].
+		list do: [ :e | e execute ].
+		^ list
 	 ] asJob
 		title: 'Refactoring';
 		run]

--- a/src/Refactoring-Core/RBAbstractTransformation.class.st
+++ b/src/Refactoring-Core/RBAbstractTransformation.class.st
@@ -327,8 +327,7 @@ RBAbstractTransformation >> performChanges: aCompositeChange [
 	"Perform the changes contained in a composite change"
 	
 	RBRefactoryChangeManager instance
-		performChange: aCompositeChange;
-		addUndoPointer: RBRefactoryChangeManager nextCounter
+		performCompositeChange: aCompositeChange
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBMethodProtocolTransformationTest.class.st
@@ -34,7 +34,7 @@ RBMethodProtocolTransformationTest >> testRefactoring [
 		                protocol: 'empty protocol 2'
 		                inMethod: #someMethod
 		                inClass: #RBDummyEmptyClass) generateChanges.
-	RBRefactoryChangeManager instance performChange: refactoring changes.
+	refactoring performChanges.
 
 	self deny:
 		(RBDummyEmptyClass protocolNamed: 'empty protocol 2') isEmpty.
@@ -43,7 +43,7 @@ RBMethodProtocolTransformationTest >> testRefactoring [
 		                protocol: 'empty protocol 1'
 		                inMethod: #someMethod
 		                inClass: #RBDummyEmptyClass) generateChanges.
-	RBRefactoryChangeManager instance performChange: refactoring changes.
+	refactoring performChanges.
 
 	self deny: (RBDummyEmptyClass hasProtocol: 'empty protocol 2')
 ]
@@ -58,8 +58,7 @@ RBMethodProtocolTransformationTest >> testTransform [
 		                   protocol: 'empty protocol 2'
 		                   inMethod: #someMethod
 		                   inClass: #RBDummyEmptyClass) generateChanges.
-	RBRefactoryChangeManager instance performChange:
-		transformation changes.
+	transformation performChanges.
 
 	self deny:
 		(RBDummyEmptyClass protocolNamed: 'empty protocol 2') isEmpty.
@@ -68,7 +67,6 @@ RBMethodProtocolTransformationTest >> testTransform [
 		                   protocol: 'empty protocol 1'
 		                   inMethod: #someMethod
 		                   inClass: #RBDummyEmptyClass) generateChanges.
-	RBRefactoryChangeManager instance performChange:
-		transformation changes.
+	transformation performChanges.
 	self deny: (RBDummyEmptyClass hasProtocol: 'empty protocol 2')
 ]

--- a/src/Refactoring-Transformations-Tests/RBRemoveProtocolTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveProtocolTransformationTest.class.st
@@ -13,7 +13,7 @@ RBRemoveProtocolTransformationTest >> testRefactoring [
 	refactoring := (RBAddProtocolTransformation
 		                protocol: 'transforming'
 		                inClass: #RBDummyEmptyClass) generateChanges.
-	RBRefactoryChangeManager instance performChange: refactoring changes.
+	refactoring performChanges.
 
 	refactoring := (RBRemoveProtocolTransformation
 		                protocol: 'transforming'

--- a/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
@@ -205,18 +205,16 @@ StRefactoringPreviewPresenter >> initializeWindow: aWindowPresenter [
 ]
 
 { #category : 'action' }
-StRefactoringPreviewPresenter >> performChanges [ 
+StRefactoringPreviewPresenter >> performChanges [
 	"the following behavior should not be kept in the UI. 
 	It should be moved to the driver or the refactoring itself because the driver is a model of interaction.
 	May be this should be in the refactoring."
-	
-	[
-	selectedChanges do: [ :change |
-			RBRefactoryChangeManager instance
-				performChange: change;
-				addUndoPointer: RBRefactoryChangeManager nextCounter ] ] asJob
+
+	[ RBRefactoryChangeManager instance
+			performChanges: selectedChanges ]
+		asJob
 		title: 'Refactoring';
-		run.
+		run
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku-Tests/ReProperMethodProtocolRuleTest.class.st
+++ b/src/Renraku-Tests/ReProperMethodProtocolRuleTest.class.st
@@ -83,7 +83,7 @@ ReProperMethodProtocolRuleTest >> testAutomatedFix [
 
 	critiques := self defaultTestClass new check: method.
 	refactoring := critiques first refactoring generateChanges.
-	RBRefactoryChangeManager instance performChange: refactoring changes.
+	refactoring performChanges.
 
 	self assert: method protocolName equals: self properProtocolName asSymbol
 ]

--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
@@ -59,10 +59,8 @@ SycRefactoringPreviewPresenter class >> title [
 SycRefactoringPreviewPresenter >> accept [
 	self okToChange ifFalse: [ ^ self ].
 	
-	[ self pickedChanges do: [ :change |
-		RBRefactoryChangeManager instance
-			performChange: change;
-			addUndoPointer: (RBRefactoryChangeManager nextCounter) ] ] asJob
+	[ RBRefactoryChangeManager instance
+			performChanges: self pickedChanges ] asJob
 		title: 'Refactoring';
 		run
 ]


### PR DESCRIPTION
This PR introduces:
- new API for the manager with deprecation of the old api
- fixing previous behavior (changes could get lost if you were doing a bigger refactoring)

Now all changes in undo stack are composite, so no more partial undos.
New API is:
- `performChanges:` with a list of changes to perform
- `performCompositeChange:` with a composite change to perform