### PR TITLE
missing stroke paint method

### DIFF
--- a/src/Athens-Cairo/AthensCairoStrokePaint.class.st
+++ b/src/Athens-Cairo/AthensCairoStrokePaint.class.st
@@ -81,6 +81,11 @@ AthensCairoStrokePaint >> joinRound [
 	joinStyle := CAIRO_LINE_JOIN_ROUND
 ]
 
+{ #category : 'drawing' }
+AthensCairoStrokePaint >> loadOnCairoCanvas: aCanvas [
+
+]
+
 { #category : 'private' }
 AthensCairoStrokePaint >> prepareForDrawingOn: aCanvas [
 


### PR DESCRIPTION
Some (dummy) example to reproduce the issue:
```smalltalk
RSBox new
       extent: 240 @ 130;
       paint: (AthensCairoStrokePaint new fillPaint: (AthensCairoStrokePaint new fillPaint:  Color red)).
```` 

fixes #5360