### PR TITLE
[P12][P13] Fixing bug that raised `NodeNotFound` when an object-centric permalink was installed on a slot defined by a superclass of the object class

### DIFF
--- a/src/DebugPoints/DebugPoint.class.st
+++ b/src/DebugPoints/DebugPoint.class.st
@@ -204,19 +204,6 @@ DebugPoint >> install [
 	self target install: self link
 ]
 
-{ #category : 'API' }
-DebugPoint >> instanceVariable: aSlot accessStrategy: aSymbol [
-
-	target := DebugPointInstanceVariableTarget new
-		          instanceVariable: aSlot;
-		          accessStrategy: aSymbol;
-		          yourself.
-
-	name := 'var_{1}_{2}' format: {
-			        aSlot name.
-			        aSymbol }
-]
-
 { #category : 'accessing' }
 DebugPoint >> link [
 	^metaLink
@@ -372,6 +359,20 @@ DebugPoint >> target [
 DebugPoint >> targetClass [
 
 	^ self target targetClass
+]
+
+{ #category : 'API' }
+DebugPoint >> targetClass: aClass instanceVariable: aSlot accessStrategy: aSymbol [
+
+	target := DebugPointInstanceVariableTarget new
+					 targetClass: aClass;
+		          instanceVariable: aSlot;
+		          accessStrategy: aSymbol;
+		          yourself.
+
+	name := 'var_{1}_{2}' format: {
+			        aSlot name.
+			        aSymbol }
 ]
 
 { #category : 'scope' }

--- a/src/DebugPoints/DebugPointInstanceVariableTarget.class.st
+++ b/src/DebugPoints/DebugPointInstanceVariableTarget.class.st
@@ -7,7 +7,8 @@ Class {
 	#name : 'DebugPointInstanceVariableTarget',
 	#superclass : 'DebugPointClassTarget',
 	#instVars : [
-		'accessStrategy'
+		'accessStrategy',
+		'targetClass'
 	],
 	#category : 'DebugPoints-Implementations',
 	#package : 'DebugPoints',
@@ -110,5 +111,11 @@ DebugPointInstanceVariableTarget >> removeFromMethod: aMethod for: aDebugPoint [
 { #category : 'accessing' }
 DebugPointInstanceVariableTarget >> targetClass [
 
-	^ self instanceVariable owningClass
+	^ targetClass ifNil: [ targetClass := self instanceVariable owningClass ]
+]
+
+{ #category : 'accessing' }
+DebugPointInstanceVariableTarget >> targetClass: anObject [
+
+	^ targetClass := anObject
 ]

--- a/src/DebugPoints/DebugPointManager.class.st
+++ b/src/DebugPoints/DebugPointManager.class.st
@@ -102,6 +102,7 @@ DebugPointManager class >> installNew: aDebugPointClass forObject: anObject onVa
 	| dp instanceVariable |
 	instanceVariable := anObject class slotNamed: aSlotNameSymbol.
 	dp := aDebugPointClass new
+		      targetClass: anObject class
 		      instanceVariable: instanceVariable
 		      accessStrategy: anAccessStrategySymbol;
 		      targetInstance: anObject;
@@ -217,7 +218,8 @@ DebugPointManager class >> installNew: aDebugPointClass inClass: aClass onVariab
 	| dp instanceVariable |
 	instanceVariable := aClass lookupVar: aSlotNameSymbol.
 	dp := aDebugPointClass new
-		      instanceVariable: instanceVariable
+		      targetClass: aClass
+		      instanceVariable: instanceVariable 
 		      accessStrategy: anAccessStrategySymbol;
 		      yourself.
 

--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -142,6 +142,29 @@ LinkInstallerTest >> testLinkOnRBProgramNode [
 ]
 
 { #category : 'permalinks' }
+LinkInstallerTest >> testLinkOnSlotDefinedBySuperclassForObject [
+
+	| link obj |
+	link := MetaLink new.
+	obj := ReflectivityExamples2Subclass2 new.
+
+	link
+		installOnVariableNamed: #instVar2
+		for: obj
+		option: #read
+		instanceSpecific: true.
+	self assert: link nodes size equals: 1.
+	self assert: (link nodes allSatisfy: [ :node | node isRead ]).
+	self assert:
+		(link nodes allSatisfy: [ :node | node name = #instVar2 ]).
+	"There is a second accessing node in a brother class (ReflectivityExamples2Sublcass) and the metalink should not be installed on this node because the class is not in the class hierarchy of ReflectivityExamples2Subclass2"
+	self assert: (link nodes noneSatisfy: [ :node |
+			 node methodNode selector == #useInstVarInSubclass ]).
+	link uninstall.
+	self assert: link nodes isEmpty
+]
+
+{ #category : 'permalinks' }
 LinkInstallerTest >> testLinkOnTempVar [
 	| methodNode link variable |
 	methodNode := (ReflectivityExamples2 >> #methodWithTempVarAccess) ast.

--- a/src/Reflectivity-Tests/ReflectivityExamples2Subclass2.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples2Subclass2.class.st
@@ -1,0 +1,16 @@
+"
+Subclass for testing premalink spanning class hierarchies.
+"
+Class {
+	#name : 'ReflectivityExamples2Subclass2',
+	#superclass : 'ReflectivityExamples2',
+	#category : 'Reflectivity-Tests-Data',
+	#package : 'Reflectivity-Tests',
+	#tag : 'Data'
+}
+
+{ #category : 'examples' }
+ReflectivityExamples2Subclass2 >> usedInstVarInSubclass2 [
+
+	^ instVar2
+]

--- a/src/Reflectivity/MetaLinkInstaller.class.st
+++ b/src/Reflectivity/MetaLinkInstaller.class.st
@@ -289,13 +289,19 @@ MetaLinkInstaller >> recursiveRemoveMethodNode: methodNode fromPermaLinks: perma
 
 { #category : 'permalinks' }
 MetaLinkInstaller >> registerAndInstallPermaLink: aPermaLink forTarget: aSlotOrVar [
-	| nodes |
-	(linksRegistry canReinstallPermaLink: aPermaLink)
-		ifFalse: [ ^ self ].
+
+	| nodes targetClass |
+	(linksRegistry canReinstallPermaLink: aPermaLink) ifFalse: [ ^ self ].
 
 	linksRegistry registerPermaLink: aPermaLink.
 
-	nodes := (aSlotOrVar accessingNodesFor: aPermaLink persistenceType) asIdentitySet.
+	targetClass := aPermaLink slotOrVarClass.
+	nodes := ((aSlotOrVar accessingNodesFor: aPermaLink persistenceType)
+		          select: [ :aNode |
+			          | nodeClass |
+			          nodeClass := aNode methodNode methodClass.
+			          targetClass == nodeClass or: [
+				          targetClass inheritsFrom: nodeClass ] ]) asIdentitySet.
 	aPermaLink targetObjectOrClass link: aPermaLink link toNodes: nodes
 ]
 


### PR DESCRIPTION
Fixes #16548 

When installing an object-centric permalink on a variable slot, the method `registerAndInstallPermaLink:forTarget:` takes all nodes that access this slot and it installs the metalink on the equivalent nodes in the anonymous subclass of the object:

```Smalltalk
registerAndInstallPermaLink: aPermaLink forTarget: aSlotOrVar
	| nodes |
	(linksRegistry canReinstallPermaLink: aPermaLink)
		ifFalse: [ ^ self ].

	linksRegistry registerPermaLink: aPermaLink.

	nodes := (aSlotOrVar accessingNodesFor: aPermaLink persistenceType) asIdentitySet.
	aPermaLink targetObjectOrClass link: aPermaLink link toNodes: nodes
```

However, if the target variable slot has been defined by one of the superclasses of the object, it does not exclude the accessing nodes that are not in the object's class hierarchy (so: the nodes from methods that are in brother/cousin classes). As a result, it will try to find equivalent nodes in the anonymous subclass but these nodes do not exist so an exception `NodeNotFound` is raised.

This breaks object-centric debug points, for example

I fixed that method to only keep the accessing nodes that are in the class hierarchy of the target object.