### PR TITLE
ProcessorScheduler>>#activeProcess added no instrumentation pragma

### DIFF
--- a/src/Kernel/ProcessorScheduler.class.st
+++ b/src/Kernel/ProcessorScheduler.class.st
@@ -121,7 +121,8 @@ ProcessorScheduler >> activeProcess [
 	It can be just pretending to be the active process
 	(like during the code simulation in the debugger)"
 
-	^activeProcess effectiveProcess
+	<noInstrumentation>
+	^ activeProcess effectiveProcess
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
Added `noInstrumentation` pragma to ProcessorScheduler>>#activeProcess. This is important since this method cannot be instrumented because it's used inside the instrumentation to check for meta-recursions