### PR TITLE
Fix a small bug with FFI calls when passing 'NULL'  as argument to the C function

### DIFF
--- a/src/UnifiedFFI/FFIStrictResolutionMode.class.st
+++ b/src/UnifiedFFI/FFIStrictResolutionMode.class.st
@@ -26,10 +26,8 @@ FFIStrictResolutionMode >> resolveUndeclaredTypeForArgument: aFFIValueArgument w
 	 	 There is no ambiguity.
 	"
 	
-	(aFFIValueArgument value isNil
-		or: [aFFIValueArgument value = 'nil'
-			or: [ aFFIValueArgument value = 'NULL' ]])
-				ifTrue: [ ^ (aResolver resolveType: #'void *') ].
+	(#(nil 'nil' 'NULL') includes: aFFIValueArgument value)
+		 ifTrue: [ ^ (aResolver resolveType: #'void *') ].
 				
 	aFFIValueArgument value == #self ifTrue: [
 		| externalType |

--- a/src/UnifiedFFI/FFIStrictResolutionMode.class.st
+++ b/src/UnifiedFFI/FFIStrictResolutionMode.class.st
@@ -18,10 +18,19 @@ FFIStrictResolutionMode >> isStrict [
 { #category : 'resolution' }
 FFIStrictResolutionMode >> resolveUndeclaredTypeForArgument: aFFIValueArgument withResolver: aResolver [
 
-	"Make strict all declarations except those using self.
+	"Make strict all declarations except those using self and NULL.
 	This is safe because:
 	 - We can infer self from the current class
-	 - the only implementor of prepareAsSelfFromCalloutDeclaration are those classes representing pointers"
+	 - the only implementor of prepareAsSelfFromCalloutDeclaration are those classes representing pointers
+	 - NULL can only be of one specific type: void*
+	 	 There is no ambiguity.
+	"
+	
+	(aFFIValueArgument value isNil
+		or: [aFFIValueArgument value = 'nil'
+			or: [ aFFIValueArgument value = 'NULL' ]])
+				ifTrue: [ ^ (aResolver resolveType: #'void *') ].
+				
 	aFFIValueArgument value == #self ifTrue: [
 		| externalType |
 		externalType := aResolver requestor asExternalTypeOn: aResolver.


### PR DESCRIPTION
Now it can infer its type correctly as 'void*'