### PR TITLE
Issue 16430 - String>> asSymbol no protected against concurrent access (alternative solution)

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -106,8 +106,8 @@ Symbol class >> initialize [
 { #category : 'symbol table' }
 Symbol class >> intern: aStringOrSymbol [
 
-	^ (self findInterned: aStringOrSymbol) ifNil: [
-		  NewSymbols add: aStringOrSymbol createSymbol ]
+	SymbolTableSemaphore singleInstance critical: [
+		^ self rawIntern: aStringOrSymbol ]
 ]
 
 { #category : 'instance creation' }
@@ -154,6 +154,13 @@ Symbol class >> possibleSelectorsFor: misspelled [
 		binary := misspelled, ':'.		"try for missing colon"
 		Symbol hasInterned: binary ifTrue: [:him | best addFirst: him]].
 	^ best
+]
+
+{ #category : 'symbol table' }
+Symbol class >> rawIntern: aStringOrSymbol [
+
+	^ (self findInterned: aStringOrSymbol) ifNil: [
+		  NewSymbols add: aStringOrSymbol createSymbol ]
 ]
 
 { #category : 'instance creation' }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -106,6 +106,8 @@ Symbol class >> initialize [
 { #category : 'symbol table' }
 Symbol class >> intern: aStringOrSymbol [
 
+	SymbolTableSemaphore enabled ifFalse: [
+		^ self rawIntern: aStringOrSymbol ].
 	SymbolTableSemaphore singleInstance critical: [
 		^ self rawIntern: aStringOrSymbol ]
 ]

--- a/src/Collections-Strings/SymbolTableSemaphore.class.st
+++ b/src/Collections-Strings/SymbolTableSemaphore.class.st
@@ -1,0 +1,19 @@
+"
+I am a semaphore to protect the NewSymbols table from concurrent access when new symbols are internalized. 
+I have a single instance 
+"
+Class {
+	#name : 'SymbolTableSemaphore',
+	#superclass : 'Semaphore',
+	#classVars : [
+		'SingleInstance'
+	],
+	#category : 'Collections-Strings-Base',
+	#package : 'Collections-Strings',
+	#tag : 'Base'
+}
+
+{ #category : 'instance creation' }
+SymbolTableSemaphore class >> singleInstance [
+	^ SingleInstance ifNil: [ SingleInstance := self forMutualExclusion ]
+]

--- a/src/Collections-Strings/SymbolTableSemaphore.class.st
+++ b/src/Collections-Strings/SymbolTableSemaphore.class.st
@@ -8,10 +8,28 @@ Class {
 	#classVars : [
 		'SingleInstance'
 	],
+	#classInstVars : [
+		'enabled'
+	],
 	#category : 'Collections-Strings-Base',
 	#package : 'Collections-Strings',
 	#tag : 'Base'
 }
+
+{ #category : 'accessing' }
+SymbolTableSemaphore class >> disable [
+	enabled := false
+]
+
+{ #category : 'accessing' }
+SymbolTableSemaphore class >> enable [
+	enabled := true
+]
+
+{ #category : 'accessing' }
+SymbolTableSemaphore class >> enabled [
+	^ enabled ifNil: [ enabled := true ]
+]
 
 { #category : 'instance creation' }
 SymbolTableSemaphore class >> singleInstance [

--- a/src/PharoBootstrap/PBAbstractImageBuilder.class.st
+++ b/src/PharoBootstrap/PBAbstractImageBuilder.class.st
@@ -364,6 +364,7 @@ PBAbstractImageBuilder >> createInitialObjects [
 			self bootstrapInterpreter evaluateCode: 'CompiledMethod initialize.'.
 
 			self log: 'Installing symbol table'.
+			self bootstrapInterpreter evaluateCode: 'SymbolTableSemaphore disable'.
 			self bootstrapInterpreter evaluateCode: 'Symbol initialize.
 	Symbol classPool at: #SymbolTable put: (WeakSet withAll: ByteSymbol allInstances)'.
 			objectSpace symbolTable: (EPInternalSymbolTable new objectSpace: objectSpace).

--- a/src/PharoBootstrap/PBAbstractImageBuilder.class.st
+++ b/src/PharoBootstrap/PBAbstractImageBuilder.class.st
@@ -715,7 +715,7 @@ PBAbstractImageBuilder >> initializeImage [
 			objectSpace installAsActiveProcess: process.
 			
 			"Enable protection of SymbolTable from concurrent access"
-			self bootstrapInterpreter evaluateCode: 'SymbolTableSemaphore enable'
+			self bootstrapInterpreter evaluateCode: 'SymbolTableSemaphore enable'.
 
 
 			self followForwardingPointers.

--- a/src/PharoBootstrap/PBAbstractImageBuilder.class.st
+++ b/src/PharoBootstrap/PBAbstractImageBuilder.class.st
@@ -713,6 +713,10 @@ PBAbstractImageBuilder >> initializeImage [
 
 			process := objectSpace createProcessWithPriority: 40 doing: 'PharoBootstrapInitialization initializeCommandLineHandlerAndErrorHandling'.
 			objectSpace installAsActiveProcess: process.
+			
+			"Enable protection of SymbolTable from concurrent access"
+			self bootstrapInterpreter evaluateCode: 'SymbolTableSemaphore enable'
+
 
 			self followForwardingPointers.
 


### PR DESCRIPTION
Proposes solution to issue https://github.com/pharo-project/pharo/issues/16430

### Summary
To prevent data races when new symbols are interned into the NewSymbols table, a semaphore is used to protect the critical code section in the method Symbol >> intern