### PR TITLE
Fixing reflectivity tests that can randomly fail because of unstable and unpredictable tests generating methods

### DIFF
--- a/src/Reflectivity-Tests/LinkInstallerTest.class.st
+++ b/src/Reflectivity-Tests/LinkInstallerTest.class.st
@@ -32,6 +32,7 @@ LinkInstallerTest >> setUp [
 { #category : 'running' }
 LinkInstallerTest >> tearDown [
 	ReflectivityExamples2 new removeModifiedMethodWithInstVarAccess.
+	ReflectivityExamples2 new removeNewMethodWithInstVarAccess.
 	ReflectivityExamples new removeTemporaryMethods.
 	super tearDown
 ]
@@ -475,8 +476,7 @@ LinkInstallerTest >> testPermaLinkNotInstalledOnObjectIfExistsInClass [
 	link installOnVariableNamed: #instVar for: obj option: #all instanceSpecific: true.
 	self assert: link nodes size equals: 8.
 
-	link uninstall.
-	ReflectivityExamples2 new removeNewMethodWithInstVarAccess
+	link uninstall
 ]
 
 { #category : 'links - updating' }
@@ -751,8 +751,7 @@ LinkInstallerTest >> testSlotOrVarLinksAddedAfterMethodAddition [
 
 	|methodNode link|
 	methodNode := (ReflectivityExamples2 >> #methodWithInstVarAccess) ast.
-	ReflectivityExamples2 new removeNewMethodWithInstVarAccess.
-
+	
 	link := MetaLink new.
 	link installOnVariableNamed: #instVar for: ReflectivityExamples2 option: #all instanceSpecific: false.
 
@@ -771,8 +770,7 @@ LinkInstallerTest >> testSlotOrVarLinksAddedAfterMethodAdditionForObject [
 
 	methodNode := (ReflectivityExamples2 >> #methodWithInstVarAccess) ast.
 	obj := ReflectivityExamples2 new.
-	ReflectivityExamples2 new removeNewMethodWithInstVarAccess.
-
+	
 	link := MetaLink new.
 	link installOnVariableNamed: #instVar for: obj option: #all instanceSpecific: true.
 
@@ -787,7 +785,7 @@ LinkInstallerTest >> testSlotOrVarLinksAddedAfterMethodAdditionForObject [
 { #category : 'permalinks' }
 LinkInstallerTest >> testSlotOrVarLinksRemainAfterMethodModification [
 	|methodNode link|
-
+   ReflectivityExamples2 new generateNewMethodWithInstVarAccess.
 	ReflectivityExamples2 new resetModifiedMethodWithInstVarAccess.
 	methodNode := (ReflectivityExamples2 >> #modifiedMethodWithInstVarAccess) ast.
 
@@ -808,6 +806,7 @@ LinkInstallerTest >> testSlotOrVarLinksRemainAfterMethodModificationForObject [
 	|methodNode link obj|
 
 	obj := ReflectivityExamples2 new.
+	ReflectivityExamples2 new generateNewMethodWithInstVarAccess.
 	ReflectivityExamples2 new resetModifiedMethodWithInstVarAccess.
 	methodNode := (ReflectivityExamples2 >> #modifiedMethodWithInstVarAccess) ast.
 

--- a/src/Reflectivity-Tests/ReflectivityExamples2.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExamples2.class.st
@@ -83,13 +83,6 @@ ReflectivityExamples2 >> modifyMethodWithInstVarAccess [
 	instVar > 5 ifTrue:[^ instVar raisedTo: 2]'
 ]
 
-{ #category : 'example' }
-ReflectivityExamples2 >> newMethodWithInstVarAccess [
-	instVar := 5.
-	instVar := 6.
-	instVar > 5 ifTrue:[^ instVar raisedTo: 2]
-]
-
 { #category : 'removing' }
 ReflectivityExamples2 >> removeModifiedMethodWithInstVarAccess [
 	self class removeSelector: #modifiedMethodWithInstVarAccess


### PR DESCRIPTION
We have this problem sometimes on the NewTools builds.
This is due to methods generated for reflectivity tests, but not systematically removed.
Depending on the test order some reflectivity tests may therefore fail.

This fixes it.