### PR TITLE
Fix testCodeCruftLeftInMethods

### DIFF
--- a/src/General-Rules-Tests/ReSmalllintTest.class.st
+++ b/src/General-Rules-Tests/ReSmalllintTest.class.st
@@ -56,9 +56,13 @@ ReSmalllintTest >> assertResult: critiques hasAllClassesInEnvironment: anEnviron
 
 { #category : 'asserting' }
 ReSmalllintTest >> assertResult: critiques hasAllMethodsInEnvironment: anEnvironment [
-	anEnvironment methodsDo: [ :method |
-		self assert: (critiques anySatisfy: [ :crit |
-			crit entity = method ]) ]
+
+	| missingMethods |
+	missingMethods := OrderedCollection new.
+	anEnvironment methodsDo: [ :method | (critiques anySatisfy: [ :crit | crit entity = method ]) ifFalse: [ missingMethods add: method ] ].
+
+	"We collect the missing methods instead of doing an assert in the previous block to give a better feedback in the CI and test failure."
+	self assertEmpty: missingMethods
 ]
 
 { #category : 'private' }
@@ -263,7 +267,7 @@ ReSmalllintTest >> testClassNotReferenced [
 
 { #category : 'tests' }
 ReSmalllintTest >> testCodeCruftLeftInMethods [
-	self ruleFor: self currentSelector plusSelectors: #(haltClassMentioned flagged transcriptMentioned #debuggingMessageSent)
+	self ruleFor: self currentSelector plusSelectors: #(haltClassMentioned flagged transcriptMentioned debuggingMessageSent)
 ]
 
 { #category : 'tests' }

--- a/src/Refactoring-Critics-Tests/RBSmalllintTestObject.class.st
+++ b/src/Refactoring-Critics-Tests/RBSmalllintTestObject.class.st
@@ -480,7 +480,9 @@ RBSmalllintTestObject >> toDoWithIncrement [
 
 { #category : 'methods' }
 RBSmalllintTestObject >> transcriptMentioned [
-	'message' trace
+	"Please keep the Transcript reference since this is used for a test."
+
+	Transcript show: 'message'
 ]
 
 { #category : 'accessing - good' }


### PR DESCRIPTION
This fixes testCodeCruftLeftInMethods that is currently failing and also improves the CI logs to list the methods that should fail the rules we are testing but that do not make it fail.

This alongside with the Roassal update should get us a green CI.