### PR TITLE
Fix `RBCompositeRefactoryChange>>#defineClass:` argument name

### DIFF
--- a/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st
+++ b/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st
@@ -140,9 +140,9 @@ RBCompositeRefactoryChange >> compile: source in: class classified: aProtocol [
 ]
 
 { #category : 'refactory - changes' }
-RBCompositeRefactoryChange >> defineClass: aString [
+RBCompositeRefactoryChange >> defineClass: definition [
 
-	^ self addChange: (changeFactory addClassDefinition: aString)
+	^ self addChange: (changeFactory addClassDefinition: definition)
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
This PR aims to improve the readability of the argument of https://github.com/pharo-project/pharo/blob/Pharo13/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st#L143 based on its real expected value, and other variable of linked methods such as `RBRefactoryChangeFactory>>#addClassDefinition:`


fix #16592 