### PR TITLE
Simplify Calypso packaging

### DIFF
--- a/src/BaselineOfCalypso/BaselineOfCalypso.class.st
+++ b/src/BaselineOfCalypso/BaselineOfCalypso.class.st
@@ -169,10 +169,6 @@ BaselineOfCalypso >> baseline: spec [
 						   #'Calypso-SystemTools-Core' ) ];
 			package: #'Calypso-SystemPlugins-ClassScripts-Queries'
 			with: [ spec requires: #( #'Calypso-SystemQueries' ) ];
-			package: #'Calypso-SystemPlugins-ClassScripts-Queries-Tests'
-			with: [
-				spec requires:
-						#( #'Calypso-SystemQueries-Tests' #'Calypso-SystemPlugins-ClassScripts-Queries' ) ];
 			package: #'Calypso-SystemPlugins-ClassScripts-Browser' with: [
 				spec requires: #( #'Calypso-SystemPlugins-ClassScripts-Queries'
 						   #'Calypso-SystemTools-Core' ) ];
@@ -255,8 +251,7 @@ BaselineOfCalypso >> baseline: spec [
 				   #'Calypso-SystemPlugins-SUnit-Queries-Tests'
 				   #'Calypso-SystemPlugins-Undeclared-Queries-Tests'
 				   #'Calypso-SystemPlugins-FFI-Queries-Tests'
-				   #'Calypso-SystemPlugins-Flags-Queries-Tests'
-				   #'Calypso-SystemPlugins-ClassScripts-Queries-Tests' );
+				   #'Calypso-SystemPlugins-Flags-Queries-Tests' );
 			group: 'Tests'
 			with:
 				#( 'MinimalEnvironmentTests' #'Calypso-SystemTools-FullBrowser-Tests'

--- a/src/Calypso-SystemPlugins-ClassScripts-Queries-Tests/ClySubclassWithInheritedScripts.class.st
+++ b/src/Calypso-SystemPlugins-ClassScripts-Queries-Tests/ClySubclassWithInheritedScripts.class.st
@@ -1,9 +1,0 @@
-"
-I am example class which inherits scripts from superclass
-"
-Class {
-	#name : 'ClySubclassWithInheritedScripts',
-	#superclass : 'ClyClassWithScripts',
-	#category : 'Calypso-SystemPlugins-ClassScripts-Queries-Tests',
-	#package : 'Calypso-SystemPlugins-ClassScripts-Queries-Tests'
-}

--- a/src/Calypso-SystemPlugins-ClassScripts-Queries-Tests/package.st
+++ b/src/Calypso-SystemPlugins-ClassScripts-Queries-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'Calypso-SystemPlugins-ClassScripts-Queries-Tests' }

--- a/src/Calypso-SystemPlugins-ClassScripts-Queries/ClyClassScriptsExample.class.st
+++ b/src/Calypso-SystemPlugins-ClassScripts-Queries/ClyClassScriptsExample.class.st
@@ -1,21 +1,21 @@
 "
-I am example class which includes all kind of scripts.
+I am example class which includes all kind of scripts. such as class initalization, <example>, <sampleInstance>, <script>, <script:>...
 Look at the class side
 "
 Class {
-	#name : 'ClyClassWithScripts',
+	#name : 'ClyClassScriptsExample',
 	#superclass : 'Object',
-	#category : 'Calypso-SystemPlugins-ClassScripts-Queries-Tests',
-	#package : 'Calypso-SystemPlugins-ClassScripts-Queries-Tests'
+	#category : 'Calypso-SystemPlugins-ClassScripts-Queries',
+	#package : 'Calypso-SystemPlugins-ClassScripts-Queries'
 }
 
 { #category : 'class initialization' }
-ClyClassWithScripts class >> initialize [
+ClyClassScriptsExample class >> initialize [
 	self inform: 'it is class initialization example from ', self name
 ]
 
 { #category : 'methods with examples' }
-ClyClassWithScripts class >> methodWithExample [
+ClyClassScriptsExample class >> methodWithExample [
 	<example>
 	self inform: 'it is example string from ', self name.
 
@@ -23,24 +23,30 @@ ClyClassWithScripts class >> methodWithExample [
 ]
 
 { #category : 'methods with samples' }
-ClyClassWithScripts class >> methodWithSample [
+ClyClassScriptsExample class >> methodWithSample [
 	<sampleInstance>
 
 	^'it is string sample instance from ', self name
 ]
 
 { #category : 'methods with scripts' }
-ClyClassWithScripts class >> methodWithScript [
+ClyClassScriptsExample class >> methodWithScript [
 	<script>
 	self inform: 'It is example method with script from ', self name
 ]
 
 { #category : 'methods with scripts' }
-ClyClassWithScripts class >> methodWithScriptWithArgument [
+ClyClassScriptsExample class >> methodWithScriptWithArgument [
 	<script: 'self inform: ''It is example method with script with argument from '', self name'>
 ]
 
 { #category : 'methods with script' }
-ClyClassWithScripts >> instSideMethodWithScriptWithArgument [
+ClyClassScriptsExample >> instSideMethodWithScriptWithArgument [
 	<script: 'self inform: ''It is example inst side method with script with argument from '', self name'>
+]
+
+{ #category : 'see class side' }
+ClyClassScriptsExample >> seeClassSide [
+
+	
 ]


### PR DESCRIPTION
This PR removes the package Calypso-SystemPlugins-ClassScripts-Queries-Tests because it did not contains any tests but only examples. 

One of the two example class is useless and got removed. I moved the only example class remaining in Calypso-SystemPlugins-ClassScripts-Queries and I gave it a more explicit name to make sure developers understand it is examples.