### PR TITLE
[Bug]: Date>>#addMonths: should Respect Offset

### DIFF
--- a/src/System-Time-Tests/DateTest.class.st
+++ b/src/System-Time-Tests/DateTest.class.st
@@ -82,8 +82,11 @@ DateTest >> testAddDays [
 { #category : 'tests' }
 DateTest >> testAddMonths [
 
+	| dateOutOfTimeZone |
 	self assert: (january23rd2004 addMonths: 0) equals: (Date readFrom: '23-1-2004' pattern: 'd-m-y').
 	self assert: (january23rd2004 addMonths: 1) equals: (Date readFrom: '23-2-2004' pattern: 'd-m-y').
+	dateOutOfTimeZone := january23rd2004 offset: (january23rd2004 offset + 1 hour).
+	self assert: (dateOutOfTimeZone addMonths: 1) offset equals: dateOutOfTimeZone offset.
 	self assert: (january23rd2004 addMonths: 12) equals: (Date readFrom: '23-1-2005' pattern: 'd-m-y')
 ]
 

--- a/src/System-Time/ChronologyConstants.class.st
+++ b/src/System-Time/ChronologyConstants.class.st
@@ -7,6 +7,7 @@ Class {
 	#classVars : [
 		'DayNames',
 		'DaysInMonth',
+		'Epoch',
 		'HoursInDay',
 		'MicrosecondsInDay',
 		'MinutesInHour',
@@ -16,8 +17,7 @@ Class {
 		'NanosInSecond',
 		'SecondsInDay',
 		'SecondsInHour',
-		'SecondsInMinute',
-		'Epoch'
+		'SecondsInMinute'
 	],
 	#category : 'System-Time',
 	#package : 'System-Time'

--- a/src/System-Time/Date.class.st
+++ b/src/System-Time/Date.class.st
@@ -303,7 +303,7 @@ Date >> addMonths: monthCount [
 	month := self monthIndex + monthCount - 1 \\ 12 + 1.
 	maxDaysInMonth := Month daysInMonth: month forYear: year.
 	day := self dayOfMonth min: maxDaysInMonth.
-	^ Date year: year month: month day: day
+	^ (Date year: year month: month day: day) translateTo: self offset
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
- Returned Date should have same offset as receiver, but currently has local offset.
- Includes test that was failing, but now passes.