### PR TITLE
Enhance ReCodeCruftLeftInMethodsRule

### DIFF
--- a/src/General-Rules-Tests/ReCodeCruftLeftInMethodsRuleTest.class.st
+++ b/src/General-Rules-Tests/ReCodeCruftLeftInMethodsRuleTest.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : 'ReCodeCruftLeftInMethodsRuleTest',
+	#superclass : 'ReAbstractRuleTestCase',
+	#category : 'General-Rules-Tests-Migrated',
+	#package : 'General-Rules-Tests',
+	#tag : 'Migrated'
+}
+
+{ #category : 'tests' }
+ReCodeCruftLeftInMethodsRuleTest >> testRule [
+
+	| critiques |
+	self class compile: 'method self halt' classified: 'test-helper'.
+	[
+	critiques := self myCritiquesOnMethod: self class >> #method.
+	self assert: critiques size equals: 1 ] ensure: [
+		(self class >> #method) removeFromSystem ]
+]
+
+{ #category : 'tests' }
+ReCodeCruftLeftInMethodsRuleTest >> testRuleNotViolated [
+
+	| critiques |
+	self class
+		compile: 'method  <debuggerCompleteToSender> self halt'
+		classified: 'test-helper'.
+	[
+	critiques := self critiguesFor: ReCodeCruftLeftInMethodsRule onMethod: self class >> #method.
+	self assertEmpty: critiques ] ensure: [
+		(self class >> #method) removeFromSystem ]
+]

--- a/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
+++ b/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
@@ -121,3 +121,12 @@ ReCodeCruftLeftInMethodsRule >> rationale [
 ReCodeCruftLeftInMethodsRule >> severity [
 	^ #error
 ]
+
+{ #category : 'testing' }
+ReCodeCruftLeftInMethodsRule >> shouldCheckMethod: aMethod [
+
+	(aMethod hasPragmaNamed: #debuggerCompleteToSender)
+	| (aMethod hasPragmaNamed: #haltOrBreakpointForTesting) ifTrue: [
+		^ false ].
+	^ true
+]

--- a/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
+++ b/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
@@ -125,8 +125,6 @@ ReCodeCruftLeftInMethodsRule >> severity [
 { #category : 'testing' }
 ReCodeCruftLeftInMethodsRule >> shouldCheckMethod: aMethod [
 
-	(aMethod hasPragmaNamed: #debuggerCompleteToSender)
-	| (aMethod hasPragmaNamed: #haltOrBreakpointForTesting) ifTrue: [
-		^ false ].
+	(#(#debuggerCompleteToSender #haltOrBreakpointForTesting) anySatifsy: [ :selector |  aMethod hasPragmaNamed: selector ]) ifTrue: [ ^ false ].
 	^ true
 ]

--- a/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
+++ b/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
@@ -125,6 +125,6 @@ ReCodeCruftLeftInMethodsRule >> severity [
 { #category : 'testing' }
 ReCodeCruftLeftInMethodsRule >> shouldCheckMethod: aMethod [
 
-	(#(#debuggerCompleteToSender #haltOrBreakpointForTesting) anySatifsy: [ :selector |  aMethod hasPragmaNamed: selector ]) ifTrue: [ ^ false ].
+	(#(#debuggerCompleteToSender #haltOrBreakpointForTesting) anySatisfy: [ :selector |  aMethod hasPragmaNamed: selector ]) ifTrue: [ ^ false ].
 	^ true
 ]


### PR DESCRIPTION
this pull request propose an improvement for the rule ReCodeCruftLeftInMethodsRule to take pragmas #haltOrBreakpointForTesting or #debuggerCompleteToSender into account. #14250