### PR TITLE
Reduce references to Undeclared global variable

### DIFF
--- a/src/Hermes/HEInstaller.class.st
+++ b/src/Hermes/HEInstaller.class.st
@@ -155,7 +155,7 @@ HEInstaller >> existingTrait: aHETrait [
 HEInstaller >> initialize [
 
 	environment := self class environment.
-	originalUndeclareds := Undeclared copy.
+	originalUndeclareds := self class undeclaredRegistry copy.
 	"We need to set it at the initialization and we cannot ask this later during the building because it will cause trouble if the class we are building is Trait."
 	hasTraits := Smalltalk globals hasClassNamed: #Trait
 ]
@@ -204,7 +204,7 @@ HEInstaller >> messageMethod: aHEMethod alreadyExistsIn: aClass [
 { #category : 'reporting undeclared' }
 HEInstaller >> newUndeclaredVariables [
 	"Return the collection of undeclared variables created during this installation"
-	^ Undeclared associations reject: [ :asoc |
+	^ self class undeclaredRegistry associations reject: [ :asoc |
 		  originalUndeclareds associations includes: asoc ]
 ]
 
@@ -272,5 +272,5 @@ HEInstaller >> validateNoNewUndeclared [
 	self reportNewUndeclareds: self newUndeclaredVariables.
 	
 	SystemNotification signal: ('[Hermes] Remaining Undeclared variables in the system: '
-		, Undeclared keys printString)
+		, self class undeclaredRegistry keys printString)
 ]

--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -203,21 +203,21 @@ Class >> basicDeclareClassVariable: aClassVariable [
 	This method was extracted from existing users and it keeps known issues (therefore a flag):
 	- When a class of a variable is changed we must recompile using methods because new variable can implement specific compilation logic (method bytecode can become different).
 	- Undeclared case requires much more clever logic. Now in that case the class variable will be shared between all classes previously referencing undeclared variable despite on the fact that they do no see a class variables from other classes"
+
 	self flag: #todo.
 
 	classPool ifNil: [ classPool := Dictionary new ].
 	aClassVariable owningClass: self.
 
-	self classPool associationAt: aClassVariable name ifPresent:  [:existingVar |
-		(existingVar class == aClassVariable class) ifTrue: [^self].
+	self classPool associationAt: aClassVariable name ifPresent: [ :existingVar |
+		existingVar class == aClassVariable class ifTrue: [ ^ self ].
 		"need to take care to migrate existing variables to new global if class if different"
 		aClassVariable write: existingVar read.
 		self classPool removeKey: existingVar name ].
 	"Pick up any refs in Undeclared"
-	Undeclared associationAt: aClassVariable name ifPresent:  [:existingVar |
-		Undeclared removeKey: existingVar name.
-		existingVar becomeForward: aClassVariable
-	].
+	self undeclaredRegistry associationAt: aClassVariable name ifPresent: [ :existingVar |
+		self undeclaredRegistry removeKey: existingVar name.
+		existingVar becomeForward: aClassVariable ].
 	self classPool add: aClassVariable
 ]
 
@@ -842,7 +842,7 @@ Class >> removeClassVariable: aClassVariable [
 	aClassVariable isReferenced ifTrue: [
 			NewUndeclaredWarning signal: aClassVariable name in: self name.
 			"NOTE: we add ClassVariable to Undeclared, we need to update to UndeclaredVariable"
-			Undeclared add: aClassVariable ].
+			self undeclaredRegistry add: aClassVariable ].
 		
 	self classPool removeKey: aClassVariable key.
 	self classPool ifEmpty: [ self classPool: nil ].
@@ -870,9 +870,9 @@ Class >> removeFromSystem: logged [
 
 	"we add the class to Undeclared so that if references still exist, they will  be automatically fixed if this class is loaded again. We do not check if references exist as it is too slow"
 	
-	(Undeclared includesKey: self name) ifFalse: [
+	(self undeclaredRegistry includesKey: self name) ifFalse: [
 		self environment associationAt: self name ifPresent: [  
-			Undeclared add: ((self environment associationAt: self name) primitiveChangeClassTo: UndeclaredVariable new)]].
+			self undeclaredRegistry add: ((self environment associationAt: self name) primitiveChangeClassTo: UndeclaredVariable new)]].
 	
 	self environment forgetClass: self.
 
@@ -948,9 +948,9 @@ Class >> rename: aString [
 		ifTrue: [^ self error: newName , ' already exists'].
 	self setName: newName.
 	self environment renameClass: self from: oldName.
-	(Undeclared includesKey: newName)
+	(self undeclaredRegistry includesKey: newName)
 		ifTrue: [self inform: 'There are references to, ' , aString printString , '
-from Undeclared. Check them after this change.']
+from the undeclared registry. Check them after this change.']
 ]
 
 { #category : 'private' }
@@ -1067,6 +1067,13 @@ Class >> superclass: aClass methodDictionary: mDict format: fmt [
 	"Basic initialization of the receiver"
 	super superclass: aClass methodDictionary: mDict format: fmt.
 	self subclasses: nil
+]
+
+{ #category : 'accessing' }
+Class >> undeclaredRegistry [
+	"The undeclared registry is a registry of all the undeclared classes in the environment of the class. An undeclared class is a class that is not part of the environment but that is referenced or subclassed."
+
+	^ self environment undeclaredRegistry
 ]
 
 { #category : 'initialization' }

--- a/src/PharoBootstrap/RGGlobalVariable.extension.st
+++ b/src/PharoBootstrap/RGGlobalVariable.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'RGGlobalVariable' }
+
+{ #category : '*PharoBootstrap' }
+RGGlobalVariable >> isInstanceVariable [
+	"This method is missing in Pharo < 13 so we add it as an extension. When the bootstrap will happen in Pharo 13+ we can remove this method"
+	^ false
+]

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -123,8 +123,8 @@ ClassFactoryForTestCase >> delete: aBehavior [
 			createdSilently remove: aBehavior.
 			aBehavior removeFromSystemUnlogged ]
 		ifFalse: [ aBehavior removeFromSystem ].
-	"We know that we can remove the key from Undeclared, as it was added by #removeFromSystem"
-	Undeclared removeKey: name ifAbsent: [ "might be an anonymous class" ]
+	"We know that we can remove the key from the undeclared registry, as it was added by #removeFromSystem"
+	self class undeclaredRegistry removeKey: name ifAbsent: [ "might be an anonymous class" ]
 ]
 
 { #category : 'cleaning' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -318,7 +318,7 @@ SmalltalkImage >> classOrTraitNamed: aString [
 { #category : 'housekeeping' }
 SmalltalkImage >> cleanOutUndeclared [
 	| unreferenced |
-	unreferenced := Undeclared keys asSet.
+	unreferenced := self environment undeclaredRegistry keys asSet.
 	self systemNavigation allBehaviorsDo: [ :class |
 		class methodsDo: [ :method |
 			method withAllNestedLiteralsDo: [ :lit |
@@ -326,9 +326,9 @@ SmalltalkImage >> cleanOutUndeclared [
 					unreferenced
 						remove: lit key
 						ifAbsent: [ "Sanity check--a binding with more than one reference may already be gone from the unreferenced set, but should be present in Undeclared itself"
-							Undeclared at: lit key ] ] ] ] ].
+							self environment undeclaredRegistry at: lit key ] ] ] ] ].
 
-	unreferenced do: [ :key | Undeclared removeKey: key ]
+	unreferenced do: [ :key | self environment undeclaredRegistry removeKey: key ]
 ]
 
 { #category : 'cleanup' }

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -108,14 +108,14 @@ SystemDictionary >> at: aKey put: anObject [
 	references to undeclared variables."
 	| index assoc |
 	aKey isSymbol ifFalse: [ self error: 'Only symbols are accepted as keys in SystemDictionary' ].
-	((self includesKey: aKey) not and: [ Undeclared includesKey: aKey ]) ifTrue: [
+	((self includesKey: aKey) not and: [ self undeclaredRegistry includesKey: aKey ]) ifTrue: [
  			| undeclared |
- 			undeclared := Undeclared associationAt: aKey.
+ 			undeclared := self undeclaredRegistry associationAt: aKey.
  			"Undeclared variables record using methods in a property, remove. Boostrap might have used Associations"
  			(undeclared class == UndeclaredVariable) ifTrue: [undeclared removeProperty: #registeredMethods ifAbsent: [ ]]. 
  			"and change class to be Global" 
  			self add: (undeclared primitiveChangeClassTo: GlobalVariable new).
- 			Undeclared removeKey: aKey].
+ 			self undeclaredRegistry removeKey: aKey].
  	"code of super at:put:, not using Associations but GlobalVariable"
  	index := self findElementOrNil: aKey.
  	assoc := array at: index.
@@ -453,6 +453,13 @@ SystemDictionary >> traitNames [
 			  ifPresent: [ :global |
 			  global isTrait and: [ global isObsolete not ] ]
 			  ifAbsent: [ false ] ]
+]
+
+{ #category : 'accessing' }
+SystemDictionary >> undeclaredRegistry [
+	"For now we are referencing a global variable of the default environment of Pharo. But in the future each environments should have their undeclared registry, else we have memory leaks of the environments."
+
+	^ Undeclared
 ]
 
 { #category : 'copying' }

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -334,7 +334,7 @@ SystemNavigation >> browseUndeclaredReferences [
 	"
 
 	Smalltalk image cleanOutUndeclared.
-	Undeclared associations do: [:binding |
+	self class undeclaredRegistry associations do: [:binding |
 		self
 			browseMessageList: (self allReferencesTo: binding )
 			name: 'References to Undeclared: ', binding key printString ]


### PR DESCRIPTION
## Context 

Currently, it is not possible to have clean new environments or modules because some part of Pharo are still managed via global variables or singletons. One example is the management of undeclares that is done via the global variable `Undeclared`. 

I plan to remove this global variable and to replace it by a design where we have one undeclared registry by environment. Like this, environments will be independants. 

## Done in this PR

Here is a first step. I introduced an #undeclaredRegistry accessor on environments and classes. They are currently returning the value of the global but they will help to reduce the references to this global.  I also started using those accessors to reduce drastically the references to this global variable.

## Future step

- The only references to the globals that are still in the image are in UndeclaredVariable. A next step will be to make the undeclared variables know their environment in order to remove the usage of the global.
- Remove the references in the bootstrap scripts
- Remove the global variable (or deprecate it)