### PR TITLE
Add missing RGGlobalVariable>>isInstanceVariable

### DIFF
--- a/src/Ring-Core/RGGlobalVariable.class.st
+++ b/src/Ring-Core/RGGlobalVariable.class.st
@@ -39,6 +39,12 @@ RGGlobalVariable >> isGlobalVariable [
 ]
 
 { #category : 'testing' }
+RGGlobalVariable >> isInstanceVariable [
+
+	^ false
+]
+
+{ #category : 'testing' }
 RGGlobalVariable >> isSuperVariable [
 
 	^ false


### PR DESCRIPTION
This methods is called in some cases by Espell but is not implemented on RGGlobalVariable.