### PR TITLE
Remove part of ReAsClassRule about #asClass

### DIFF
--- a/src/General-Rules-Tests/ReAsClassRuleTest.class.st
+++ b/src/General-Rules-Tests/ReAsClassRuleTest.class.st
@@ -23,7 +23,7 @@ ReAsClassRuleTest >> testRuleNotViolated [
 
 	| critiques |
 	critiques := self myCritiquesOnMethod:
-		             self class >> #testRuleWithAsClass.
+		             self class >> #testRuleNotViolated.
 	self assertEmpty: critiques 
 ]
 

--- a/src/General-Rules-Tests/ReAsClassRuleTest.class.st
+++ b/src/General-Rules-Tests/ReAsClassRuleTest.class.st
@@ -7,12 +7,6 @@ Class {
 }
 
 { #category : 'test-help' }
-ReAsClassRuleTest >> methodWithAsClass [
-
-	self class asClass
-]
-
-{ #category : 'test-help' }
 ReAsClassRuleTest >> methodWithAsClassIfAbsent [
 
 	self class asClassIfAbsent: [  ]
@@ -31,14 +25,6 @@ ReAsClassRuleTest >> testRuleNotViolated [
 	critiques := self myCritiquesOnMethod:
 		             self class >> #testRuleWithAsClass.
 	self assertEmpty: critiques 
-]
-
-{ #category : 'tests' }
-ReAsClassRuleTest >> testRuleWithAsClass [
-
-	| critiques |
-	critiques := self myCritiquesOnMethod: self class >> #methodWithAsClass.
-	self assert: critiques size equals: 1
 ]
 
 { #category : 'tests' }

--- a/src/General-Rules/ReAsClassRule.class.st
+++ b/src/General-Rules/ReAsClassRule.class.st
@@ -1,7 +1,6 @@
 "
 Do not use methods such as
 
-	#asClass
 	#asClassIfAbsent:
 	#asClassIfPresent:
 	
@@ -23,16 +22,11 @@ ReAsClassRule >> group [
 
 { #category : 'initialization' }
 ReAsClassRule >> initialize [
+
 	super initialize.
 	self
-		replace: '`@expr asClass'
-		   with: 'self class environment at: `@expr';
-
-		replace: '`@expr asClassIfAbsent: `@block'
-		with: 'self class environment at: `@expr ifAbsent: `@block';
-
-	replace: '`@expr asClassIfPresent: `@block'
-		with: 'self class environment at: `@expr ifPresent: `@block'
+		replace: '`@expr asClassIfAbsent: `@block' with: 'self class environment at: `@expr ifAbsent: `@block';
+		replace: '`@expr asClassIfPresent: `@block' with: 'self class environment at: `@expr ifPresent: `@block'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku-Tests/RenrakuTest.class.st
+++ b/src/Renraku-Tests/RenrakuTest.class.st
@@ -11,7 +11,7 @@ RenrakuTest >> testAsClassRuleTransformation [
 
 	asClassMethod := testClass >> (testClass compile:
 		'aMethodWhichSendsAsClass
-			#', self class name, ' asClass').
+			#', self class name, ' asClassIfAbsent: [ nil ]').
 
 	critique := asClassMethod critiques detect: [ :crit |
 		crit rule class = ReAsClassRule ].


### PR DESCRIPTION
#asClass ot deprecated in P12 and will be removed soon in P13. Thus we should not refer to it anymore.