### PR TITLE
16495-Wrong-source-for-CompiledBlocks-due-to-incorrect-bytecode-to-AST-nodes-mapping

### DIFF
--- a/src/Kernel-CodeModel-Tests/UndeclaredVariableTest.class.st
+++ b/src/Kernel-CodeModel-Tests/UndeclaredVariableTest.class.st
@@ -1,0 +1,88 @@
+Class {
+	#name : 'UndeclaredVariableTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'createdClasses'
+	],
+	#category : 'Kernel-CodeModel-Tests-UndeclaredVariables',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'UndeclaredVariables'
+}
+
+{ #category : 'instance creation' }
+UndeclaredVariableTest >> newClass: aName [
+
+	^ createdClasses add: (self class classInstaller make: [ :aClassBuilder |
+		  aClassBuilder
+			  name: aName;
+			  package: self class package name ]).
+]
+
+{ #category : 'running' }
+UndeclaredVariableTest >> setUp [ 
+
+	super setUp.
+	createdClasses := OrderedCollection new.
+]
+
+{ #category : 'running' }
+UndeclaredVariableTest >> tearDown [ 
+
+	createdClasses reversed do: [ :aClass | aClass removeFromSystem ]. 
+	super tearDown.
+
+]
+
+{ #category : 'tests' }
+UndeclaredVariableTest >> testUsingDeclaredVariableCompilesUsingVariable [
+
+	| class1 |
+	
+	class1 := self newClass: #TestClass1.
+	self newClass: #TestClass2.
+
+	class1 compile: 'm 
+	  ^ TestClass2'.
+	
+	self deny: ((class1 >> #m) literals includes: #runtimeUndeclaredReadInContext:)
+]
+
+{ #category : 'tests' }
+UndeclaredVariableTest >> testUsingUndeclaredVariableCompilesMessageSendToVariable [
+
+	| class1 |
+	
+	class1 := self newClass: #TestClass1.
+	class1 compile: 'm 
+	  ^ TestClass2'.
+	
+	self assert: ((class1 >> #m) literals includes: #runtimeUndeclaredReadInContext:)
+]
+
+{ #category : 'tests' }
+UndeclaredVariableTest >> testUsingUndeclaredVariableInABlockIsRecompiledWhenDefiningTheUndeclaredVariable [
+
+	| class1 |
+	
+	class1 := self newClass: #TestClass1.
+	class1 compile: 'm 
+	  ^ [TestClass2]'.
+
+	self newClass: #TestClass2.
+		
+	self deny: (((class1 >> #m) literalAt: 1) literals includes: #runtimeUndeclaredReadInContext:)
+]
+
+{ #category : 'tests' }
+UndeclaredVariableTest >> testUsingUndeclaredVariableIsRecompiledWhenDefiningTheUndeclaredVariable [
+
+	| class1 |
+	
+	class1 := self newClass: #TestClass1.
+	class1 compile: 'm 
+	  ^ TestClass2'.
+
+	self newClass: #TestClass2.
+		
+	self deny: ((class1 >> #m) literals includes: #runtimeUndeclaredReadInContext:)
+]

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -106,13 +106,17 @@ SystemDictionary >> allTraitsDo: aBlock [
 SystemDictionary >> at: aKey put: anObject [
 	"Override from Dictionary to check Undeclared and fix up
 	references to undeclared variables."
-	| index assoc |
+	| index assoc registeredMethods |
 	aKey isSymbol ifFalse: [ self error: 'Only symbols are accepted as keys in SystemDictionary' ].
+
+	registeredMethods := #().
+
 	((self includesKey: aKey) not and: [ self undeclaredRegistry includesKey: aKey ]) ifTrue: [
  			| undeclared |
  			undeclared := self undeclaredRegistry associationAt: aKey.
  			"Undeclared variables record using methods in a property, remove. Boostrap might have used Associations"
- 			(undeclared class == UndeclaredVariable) ifTrue: [undeclared removeProperty: #registeredMethods ifAbsent: [ ]]. 
+ 			(undeclared class == UndeclaredVariable) ifTrue: [
+				registeredMethods := undeclared removeProperty: #registeredMethods ifAbsent: [ #() ]]. 
  			"and change class to be Global" 
  			self add: (undeclared primitiveChangeClassTo: GlobalVariable new).
  			self undeclaredRegistry removeKey: aKey].
@@ -122,6 +126,9 @@ SystemDictionary >> at: aKey put: anObject [
  	assoc
  		ifNil: [self atNewIndex: index put: (GlobalVariable key: aKey value: anObject). self flushClassNameCache]
  		ifNotNil: [assoc value: anObject].
+		
+	registeredMethods do: [ :aMethod | aMethod isInstalled ifTrue: [aMethod recompile] ].		
+
  	^ anObject
 ]
 


### PR DESCRIPTION
Fix #16495
When removing an undeclared variable we recompile the methods that are accessing through a message send.
It is a WIP. We need to refactor the code as it is quite ugly to have everything in #at:put: