### PR TITLE
fixes #16610: Cleanup: simple typo in Crown class comment

### DIFF
--- a/src/Coverage/Crown.class.st
+++ b/src/Coverage/Crown.class.st
@@ -1,5 +1,5 @@
 "
-I represent an not fully visided selector in a core result.
+I represent an not fully visited selector in a core result.
 
 For a given `selector`, I associate callers that are call sites (`RBSendNode`) in covered methods to callees that are uncovered methods (`CompiledMethod`).
 "


### PR DESCRIPTION
Fixes simple typo in Class comment of Crown class