### PR TITLE
Deprecate RPackageSet

### DIFF
--- a/src/Deprecated13/ManifestDeprecated13.class.st
+++ b/src/Deprecated13/ManifestDeprecated13.class.st
@@ -5,9 +5,9 @@ I will be removed in Pharo 14
 Class {
 	#name : 'ManifestDeprecated13',
 	#superclass : 'PackageManifest',
-	#category : 'Deprecated13',
+	#category : 'Deprecated13-Manifest',
 	#package : 'Deprecated13',
-	#tag: 'Manifest'
+	#tag : 'Manifest'
 }
 
 { #category : 'testing' }

--- a/src/Deprecated13/RPackageSet.class.st
+++ b/src/Deprecated13/RPackageSet.class.st
@@ -18,9 +18,8 @@ Class {
 		'cacheActive',
 		'cachePackages'
 	],
-	#category : 'Kernel-CodeModel-Packages',
-	#package : 'Kernel-CodeModel',
-	#tag : 'Packages'
+	#category : 'Deprecated13',
+	#package : 'Deprecated13'
 }
 
 { #category : 'private' }
@@ -51,6 +50,13 @@ RPackageSet class >> cachePackages [
 { #category : 'testing' }
 RPackageSet class >> isCacheActive [
 	^ cacheActive ifNil: [ cacheActive := false ]
+]
+
+{ #category : 'testing' }
+RPackageSet class >> isDeprecated [
+	"RPackageSet was an optimization done when RPackage implementation was slow. Now it has been revised and it is better to just have a collection of packages and do standard operations of them such as #collect: or #do: or #select:"
+
+	^ true
 ]
 
 { #category : 'instance creation' }

--- a/src/Monticello/MCVersionLoader.class.st
+++ b/src/Monticello/MCVersionLoader.class.st
@@ -128,13 +128,14 @@ MCVersionLoader >> initialize [
 
 { #category : 'loading' }
 MCVersionLoader >> load [
-	RPackageSet withCacheDo: [   
-		| version |
-		version := versions first. 
-		[ self ensurePackage: version package.
-		  self loadWithNameLike: version info name ] asJob
-				title: 'Loading ', version info name asString;
-				run ]
+
+	| version |
+	version := versions first.
+	[
+	self ensurePackage: version package.
+	self loadWithNameLike: version info name ] asJob
+		title: 'Loading ' , version info name asString;
+		run
 ]
 
 { #category : 'loading' }


### PR DESCRIPTION
RPackageSet was an optimization done when RPackage implementation was slow. Now it has been revised and it is better to just have a collection of packages and do standard operations of them such as #collect: or #do: or #select: