### PR TITLE
16680-Zinc-uses-old-Announcers-API

### DIFF
--- a/src/Zinc-HTTP/ZnLogEvent.class.st
+++ b/src/Zinc-HTTP/ZnLogEvent.class.st
@@ -40,8 +40,13 @@ ZnLogEvent class >> initialize [
 
 { #category : 'convenience' }
 ZnLogEvent class >> logToTranscript [
+
 	self stopLoggingToTranscript.
-	^ self announcer when: ZnLogEvent do: [ :event | self crTrace: event ]
+
+	^ self announcer
+		  when: ZnLogEvent
+		  do: [ :event | self crTrace: event ]
+		  for: self
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Changing #when:do: to #when:do:for: in the announcers.
Fix #16680 