### PR TITLE
Remove VariableLayout from tests

### DIFF
--- a/src/FileSystem-Core-Tests/FileReferenceTest.class.st
+++ b/src/FileSystem-Core-Tests/FileReferenceTest.class.st
@@ -4,7 +4,6 @@ SUnit tests for file reference
 Class {
 	#name : 'FileReferenceTest',
 	#superclass : 'TestCase',
-	#type : 'variable',
 	#instVars : [
 		'filesystem'
 	],

--- a/src/FileSystem-Core-Tests/PathTest.class.st
+++ b/src/FileSystem-Core-Tests/PathTest.class.st
@@ -4,7 +4,6 @@ SUnit tests for file system paths
 Class {
 	#name : 'PathTest',
 	#superclass : 'TestCase',
-	#type : 'variable',
 	#category : 'FileSystem-Core-Tests-Base',
 	#package : 'FileSystem-Core-Tests',
 	#tag : 'Base'


### PR DESCRIPTION
FileReferenceTest and PathTest wrongfully had a VariableLayout.