### PR TITLE
Use new StProtocolNameChooserPresenter to replace morphic tool

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyProtocolEditorMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyProtocolEditorMorph.class.st
@@ -163,8 +163,10 @@ ClyProtocolEditorMorph >> requestProtocol [
 
 	| newProtocol priorProtocol |
 	priorProtocol := ownerTool methodProtocol ifNil: [ '' ].
-
-	newProtocol := StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter | presenter protocolName: priorProtocol ].
+	newProtocol := StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter |
+		               presenter
+			               protocolName: priorProtocol;
+			               concernedClass: ownerTool methodClass ].
 	newProtocol = priorProtocol ifTrue: [ ^ CmdCommandAborted signal ].
 
 	ownerTool methodProtocol: newProtocol

--- a/src/Calypso-SystemTools-Core/ClyProtocolEditorMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyProtocolEditorMorph.class.st
@@ -164,7 +164,7 @@ ClyProtocolEditorMorph >> requestProtocol [
 	| newProtocol priorProtocol |
 	priorProtocol := ownerTool methodProtocol ifNil: [ '' ].
 
-	newProtocol := self ownerTool context requestProtocol: 'New protocol name' suggesting: priorProtocol.
+	newProtocol := StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter | presenter protocolName: priorProtocol ].
 	newProtocol = priorProtocol ifTrue: [ ^ CmdCommandAborted signal ].
 
 	ownerTool methodProtocol: newProtocol

--- a/src/Calypso-SystemTools-FullBrowser/ClyConvertMethodGroupToProtocolCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyConvertMethodGroupToProtocolCommand.class.st
@@ -55,7 +55,7 @@ ClyConvertMethodGroupToProtocolCommand >> prepareFullExecutionInContext: aToolCo
 
 	super prepareFullExecutionInContext: aToolContext.
 
-	protocol := StProtocolNameChooserPresenter requestProtocolName
+	protocol := StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter | presenter concernedClass: aToolContext lastSelectedClass ]
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemTools-FullBrowser/ClyConvertMethodGroupToProtocolCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyConvertMethodGroupToProtocolCommand.class.st
@@ -52,9 +52,10 @@ ClyConvertMethodGroupToProtocolCommand >> execute [
 
 { #category : 'execution' }
 ClyConvertMethodGroupToProtocolCommand >> prepareFullExecutionInContext: aToolContext [
+
 	super prepareFullExecutionInContext: aToolContext.
 
-	protocol := aToolContext requestProtocol: 'New protocol name'
+	protocol := StProtocolNameChooserPresenter requestProtocolName
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemTools-FullBrowser/ClyRenameProtocolCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyRenameProtocolCommand.class.st
@@ -84,6 +84,9 @@ ClyRenameProtocolCommand >> prepareFullExecutionInContext: aToolContext [
 
 	methodGroup := aToolContext lastSelectedMethodGroup.
 
-	newName := StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter | presenter protocolName: methodGroup name ].
+	newName := StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter |
+		           presenter
+			           protocolName: methodGroup name;
+			           concernedClass: aToolContext lastSelectedClass ].
 	newName = methodGroup name ifTrue: [ CmdCommandAborted signal ]
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyRenameProtocolCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyRenameProtocolCommand.class.st
@@ -83,6 +83,7 @@ ClyRenameProtocolCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 
 	methodGroup := aToolContext lastSelectedMethodGroup.
-	newName := aToolContext requestProtocol: 'New name of protocol' suggesting: methodGroup name.
+
+	newName := StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter | presenter protocolName: methodGroup name ].
 	newName = methodGroup name ifTrue: [ CmdCommandAborted signal ]
 ]

--- a/src/Commander-Core/CmdToolContext.class.st
+++ b/src/Commander-Core/CmdToolContext.class.st
@@ -93,34 +93,6 @@ CmdToolContext >> processFailure: anException of: aCommand [
 	anException notifyUserOfCommand: aCommand
 ]
 
-{ #category : 'user requests' }
-CmdToolContext >> requestProtocol: queryTitle [
-	^self requestProtocol: queryTitle suggesting: ''
-]
-
-{ #category : 'user requests' }
-CmdToolContext >> requestProtocol: queryTitle suggesting: suggestedTag [
-	| knownTags ui selectedTag |
-	knownTags := (SystemNavigation default allExistingProtocolsFor: true)
-		reject: [ :each | each beginsWith: '*' ].
-	knownTags := knownTags asSortedCollection: [ :a :b | a asLowercase < b asLowercase ].
-	ui := ListDialogWindow new
-		getList: [ :r | knownTags select: [ :e | r search: e ] ];
-		displayBlock: [ :e | e ];
-		initialAnswer: suggestedTag;
-		acceptNewEntry: true;
-		title: queryTitle;
-		yourself.
-	ui defaultFocusMorph contentMorph selectAll.
-	selectedTag := ui chooseFromOwner: tool.
-	selectedTag isEmptyOrNil ifTrue: [ CmdCommandAborted signal].
-	(selectedTag beginsWith: '*') ifTrue: [
-		self inform: 'Star is forbidden for protocol name. You can specify package in method editor using status bar checkbox'.
-		^CmdCommandAborted signal].
-
-	^selectedTag asSymbol
-]
-
 { #category : 'accessing' }
 CmdToolContext >> tool [
 	^ tool

--- a/src/SystemCommands-ClassCommands/SycAddNewProtocolCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycAddNewProtocolCommand.class.st
@@ -44,9 +44,10 @@ SycAddNewProtocolCommand >> execute [
 
 { #category : 'execution' }
 SycAddNewProtocolCommand >> prepareFullExecutionInContext: aToolContext [
+
 	super prepareFullExecutionInContext: aToolContext.
 
-	protocol := aToolContext requestProtocol: 'New protocol name'.
+	protocol := StProtocolNameChooserPresenter requestProtocolName.
 
 	targetClass := self requestClassInContext: aToolContext.
 	targetClass := aToolContext currentMetaLevelOf: targetClass

--- a/src/SystemCommands-ClassCommands/SycAddNewProtocolCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycAddNewProtocolCommand.class.st
@@ -47,7 +47,7 @@ SycAddNewProtocolCommand >> prepareFullExecutionInContext: aToolContext [
 
 	super prepareFullExecutionInContext: aToolContext.
 
-	protocol := StProtocolNameChooserPresenter requestProtocolName.
+	protocol := StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter | presenter concernedClass: aToolContext lastSelectedClass ].
 
 	targetClass := self requestClassInContext: aToolContext.
 	targetClass := aToolContext currentMetaLevelOf: targetClass

--- a/src/SystemCommands-MethodCommands/SycClassifyMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycClassifyMethodCommand.class.st
@@ -45,7 +45,7 @@ SycClassifyMethodCommand >> prepareFullExecutionInContext: aToolContext [
 
 	super prepareFullExecutionInContext: aToolContext.
 
-	protocol := StProtocolNameChooserPresenter requestProtocolName
+	protocol := StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter | presenter concernedClass: aToolContext lastSelectedClass ]
 ]
 
 { #category : 'accessing' }

--- a/src/SystemCommands-MethodCommands/SycClassifyMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycClassifyMethodCommand.class.st
@@ -42,9 +42,10 @@ SycClassifyMethodCommand >> execute [
 
 { #category : 'execution' }
 SycClassifyMethodCommand >> prepareFullExecutionInContext: aToolContext [
+
 	super prepareFullExecutionInContext: aToolContext.
 
-	protocol := aToolContext requestProtocol: 'New protocol name'
+	protocol := StProtocolNameChooserPresenter requestProtocolName
 ]
 
 { #category : 'accessing' }

--- a/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
@@ -28,5 +28,7 @@ SycMethodRepackagingCommand >> classifyMethod: aMethod [
 { #category : 'categories' }
 SycMethodRepackagingCommand >> newProtocolFor: aMethod [
 
-	^ self asCommandActivator context requestProtocol: 'New protocol name for: ' , aMethod name suggesting: (MethodClassifier suggestProtocolFor: aMethod)
+	^ StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter :dialog |
+		  dialog title: 'New protocol name for: ' , aMethod name.
+		  presenter protocolName: (MethodClassifier suggestProtocolFor: aMethod) ]
 ]

--- a/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodRepackagingCommand.class.st
@@ -30,5 +30,7 @@ SycMethodRepackagingCommand >> newProtocolFor: aMethod [
 
 	^ StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter :dialog |
 		  dialog title: 'New protocol name for: ' , aMethod name.
-		  presenter protocolName: (MethodClassifier suggestProtocolFor: aMethod) ]
+		  presenter
+			  protocolName: (MethodClassifier suggestProtocolFor: aMethod);
+			  concernedClass: aMethod methodClass ]
 ]


### PR DESCRIPTION
I did a PR in NewTools in order to introduce a ProtocolNameChooserPresenter done in Spec.

https://github.com/pharo-spec/NewTools/pull/759

This PR removes the Morphic version that was implemented in Commander and uses the new presenter

Changes compared to the old UI:
- No more browse button to browse UndefinedObject
- Protocols suggested are sorted by occurrences ==> I hope this helps to keep consistency in the protocol names 
- On class side we now suggest protocols from class side

Fixes #16412