### PR TITLE
fix Reflectivity API `#link:toAST:` for metaclasses  to fix debug points on class-side methods

### DIFF
--- a/src/DebugPoints-Tests/DebugPointTest.class.st
+++ b/src/DebugPoints-Tests/DebugPointTest.class.st
@@ -179,6 +179,15 @@ DebugPointTest >> testBreakDebugPoint [
 ]
 
 { #category : 'tests' }
+DebugPointTest >> testBreakDebugPointOnClassSideMethod [
+
+	node := (DummyTestClass class >> #dummyClassSide) ast.
+	dp := DebugPointManager installNew: BreakDebugPoint on: node.
+	self should: [ dp hitWithContext: context ] raise: Break.
+	self should: [ DummyTestClass dummyClassSide ] raise: Break
+]
+
+{ #category : 'tests' }
 DebugPointTest >> testBreakDebugPointOnClassVariableAccess [
 
 	dp := DebugPointManager

--- a/src/DebugPoints-Tests/DummyTestClass.class.st
+++ b/src/DebugPoints-Tests/DummyTestClass.class.st
@@ -15,6 +15,12 @@ Class {
 	#tag : 'Utils'
 }
 
+{ #category : 'test methods' }
+DummyTestClass class >> dummyClassSide [
+
+	^ 42
+]
+
 { #category : 'nil' }
 DummyTestClass >> classVarRead [
 

--- a/src/Reflectivity/Class.extension.st
+++ b/src/Reflectivity/Class.extension.st
@@ -13,11 +13,6 @@ Class >> isInClassHierarchyOf: aClass [
 ]
 
 { #category : '*Reflectivity' }
-Class >> link: aMetaLink toAST: aNode [
-	aNode link: aMetaLink
-]
-
-{ #category : '*Reflectivity' }
 Class >> link: aMetaLink toClassVariable: aClassVariable [
 	aClassVariable link: aMetaLink
 ]

--- a/src/Reflectivity/ClassDescription.extension.st
+++ b/src/Reflectivity/ClassDescription.extension.st
@@ -21,6 +21,11 @@ ClassDescription >> instanceVariableWriteNodes [
 ]
 
 { #category : '*Reflectivity' }
+ClassDescription >> link: aMetaLink toAST: aNode [
+	aNode link: aMetaLink
+]
+
+{ #category : '*Reflectivity' }
 ClassDescription >> sendNodes [
 	^self methods flatCollect: [ :each | each sendNodes ]
 ]


### PR DESCRIPTION
Fixes #16682 

When trying to put a debug point on a class-side method, the debug point used to be installed but it would not break.

This is because I send the message #link:toAST: that is understood by both classes and objects.

In the case of classes, the method just installed the link on the node and everything is fine.
In the case of objects, it creates the anonymous class of the object and installs the metalink in the anonymous class so that only the object is instrumented. This is used for object-centric debug point and this is fine.

However, Metaclass does NOT inherit from Class, so the method installs the link in an anonymous subclass of the metaclass, which is wrong as the node should directly be installed on the node.

As a simple solution, I just  moved up the method `#link:toAST:` from `Class` to `ClassDescription`. 
This API from Reflectivity seems to be used only by me...