### PR TITLE
Move group metadate of rules class side

### DIFF
--- a/src/General-Rules/FloatReferencesRule.class.st
+++ b/src/General-Rules/FloatReferencesRule.class.st
@@ -9,15 +9,15 @@ Class {
 	#tag : 'Base'
 }
 
+{ #category : 'accessing' }
+FloatReferencesRule class >> group [
+	^ 'Bugs'
+]
+
 { #category : 'running' }
 FloatReferencesRule >> basicCheck: node [
 	node isGlobalVariable ifFalse: [ ^ false ].
 	^(self systemClassNames includes: node name)
-]
-
-{ #category : 'accessing' }
-FloatReferencesRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/OverridesDeprecatedMethodRule.class.st
+++ b/src/General-Rules/OverridesDeprecatedMethodRule.class.st
@@ -17,6 +17,11 @@ OverridesDeprecatedMethodRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+OverridesDeprecatedMethodRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 OverridesDeprecatedMethodRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -28,11 +33,6 @@ OverridesDeprecatedMethodRule >> basicCheck: aMethod [
 	aMethod isDeprecated ifTrue: [ ^ false ].
 
 	^ aMethod overriddenMethods anySatisfy: #isDeprecated
-]
-
-{ #category : 'accessing' }
-OverridesDeprecatedMethodRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReAddRemoveDependentsRule.class.st
+++ b/src/General-Rules/ReAddRemoveDependentsRule.class.st
@@ -15,6 +15,11 @@ ReAddRemoveDependentsRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReAddRemoveDependentsRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReAddRemoveDependentsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,11 +38,6 @@ ReAddRemoveDependentsRule >> basicCheck: aClass [
 				addSends := addSends + (messages count: [ :each | each selector == #addDependent:]).
 				removeSends := removeSends + (messages count: [ :each | each selector == #removeDependent:])].
 	^ addSends > removeSends
-]
-
-{ #category : 'accessing' }
-ReAddRemoveDependentsRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReAllAnyNoneSatisfyRule.class.st
+++ b/src/General-Rules/ReAllAnyNoneSatisfyRule.class.st
@@ -24,15 +24,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAllAnyNoneSatisfyRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReAllAnyNoneSatisfyRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AllAnyNoneSatisfyRule'
-]
-
-{ #category : 'accessing' }
-ReAllAnyNoneSatisfyRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReAsClassRule.class.st
+++ b/src/General-Rules/ReAsClassRule.class.st
@@ -15,7 +15,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReAsClassRule >> group [
+ReAsClassRule class >> group [
 
 	^ 'Design Flaws'
 ]

--- a/src/General-Rules/ReAsOrderedCollectionNotNeededRule.class.st
+++ b/src/General-Rules/ReAsOrderedCollectionNotNeededRule.class.st
@@ -11,15 +11,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAsOrderedCollectionNotNeededRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReAsOrderedCollectionNotNeededRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AsOrderedCollectionNotNeededRule'
-]
-
-{ #category : 'accessing' }
-ReAsOrderedCollectionNotNeededRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReAssertWithBooleanEqualtiyRule.class.st
+++ b/src/General-Rules/ReAssertWithBooleanEqualtiyRule.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReAssertWithBooleanEqualtiyRule >> group [ 
+ReAssertWithBooleanEqualtiyRule class >> group [ 
 
 	^ 'Optimization'
 ]

--- a/src/General-Rules/ReAssignmentInBlockRule.class.st
+++ b/src/General-Rules/ReAssignmentInBlockRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAssignmentInBlockRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReAssignmentInBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AssignmentInBlockRule'
-]
-
-{ #category : 'accessing' }
-ReAssignmentInBlockRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReAssignmentInIfTrueRule.class.st
+++ b/src/General-Rules/ReAssignmentInIfTrueRule.class.st
@@ -18,15 +18,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAssignmentInIfTrueRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReAssignmentInIfTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AssignmentInIfTrueRule'
-]
-
-{ #category : 'accessing' }
-ReAssignmentInIfTrueRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReAssignmentWithoutEffectRule.class.st
+++ b/src/General-Rules/ReAssignmentWithoutEffectRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAssignmentWithoutEffectRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReAssignmentWithoutEffectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AssignmentWithoutEffectRule'
-]
-
-{ #category : 'accessing' }
-ReAssignmentWithoutEffectRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReAtIfAbsentRule.class.st
+++ b/src/General-Rules/ReAtIfAbsentRule.class.st
@@ -12,15 +12,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAtIfAbsentRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReAtIfAbsentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AtIfAbsentRule'
-]
-
-{ #category : 'accessing' }
-ReAtIfAbsentRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReBadMessageRule.class.st
+++ b/src/General-Rules/ReBadMessageRule.class.st
@@ -12,6 +12,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReBadMessageRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReBadMessageRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -29,11 +34,6 @@ ReBadMessageRule >> basicCheck: aNode [
 	"In tests using these messages (like isKindOf:) is no problem"
 	aNode methodNode methodClass ifNotNil: [ :class | class isTestCase ifTrue: [ ^false ]].
 	^ self badSelectors includes: aNode selector
-]
-
-{ #category : 'accessing' }
-ReBadMessageRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReBaselineProperlyPackagedRule.class.st
+++ b/src/General-Rules/ReBaselineProperlyPackagedRule.class.st
@@ -17,6 +17,11 @@ ReBaselineProperlyPackagedRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReBaselineProperlyPackagedRule class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'manifest' }
 ReBaselineProperlyPackagedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -31,11 +36,6 @@ ReBaselineProperlyPackagedRule >> basicCheck: aClass [
 	 
 	^(aClass name beginsWith: 'BaselineOf') 
 		and: [ aClass package name ~= aClass name ]
-]
-
-{ #category : 'accessing' }
-ReBaselineProperlyPackagedRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReBaselineWithProperSuperclassRule.class.st
+++ b/src/General-Rules/ReBaselineWithProperSuperclassRule.class.st
@@ -15,6 +15,12 @@ ReBaselineWithProperSuperclassRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReBaselineWithProperSuperclassRule class >> group [
+
+	^ 'Design Flaws'
+]
+
 { #category : 'manifest' }
 ReBaselineWithProperSuperclassRule class >> uniqueIdentifierName [ 
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -31,12 +37,6 @@ ReBaselineWithProperSuperclassRule >> basicCheck: aClass [
 	^(aClass name beginsWith: 'BaselineOf') 
 		and: [ (aClass inheritsFrom: BaselineOf) not ]
  
-]
-
-{ #category : 'accessing' }
-ReBaselineWithProperSuperclassRule >> group [
-
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReBetweenAndRule.class.st
+++ b/src/General-Rules/ReBetweenAndRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReBetweenAndRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReBetweenAndRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'BetweenAndRule'
-]
-
-{ #category : 'accessing' }
-ReBetweenAndRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReBooleanPrecedenceRule.class.st
+++ b/src/General-Rules/ReBooleanPrecedenceRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReBooleanPrecedenceRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReBooleanPrecedenceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'BooleanPrecedenceRule'
-]
-
-{ #category : 'accessing' }
-ReBooleanPrecedenceRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReCascadedNextPutAllsRule.class.st
+++ b/src/General-Rules/ReCascadedNextPutAllsRule.class.st
@@ -19,15 +19,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCascadedNextPutAllsRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReCascadedNextPutAllsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'CascadedNextPutAllsRule'
-]
-
-{ #category : 'accessing' }
-ReCascadedNextPutAllsRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReClassNameInSelectorRule.class.st
+++ b/src/General-Rules/ReClassNameInSelectorRule.class.st
@@ -17,6 +17,11 @@ ReClassNameInSelectorRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReClassNameInSelectorRule class >> group [
+	^ 'Style'
+]
+
+{ #category : 'accessing' }
 ReClassNameInSelectorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -48,11 +53,6 @@ ReClassNameInSelectorRule >> critiqueFor: aMethod withInterval: anInterval [
 			entity: aMethod
 			interval: anInterval)
 		by: self
-]
-
-{ #category : 'accessing' }
-ReClassNameInSelectorRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassNotCategorizedRule.class.st
+++ b/src/General-Rules/ReClassNotCategorizedRule.class.st
@@ -18,6 +18,11 @@ ReClassNotCategorizedRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReClassNotCategorizedRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReClassNotCategorizedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReClassNotCategorizedRule >> basicCheck: aClass [
 	aClass isMeta ifTrue: [ ^ false ].
 
 	^ aClass packageTag isRoot and: [ aClass package tags size > 1 ]
-]
-
-{ #category : 'accessing' }
-ReClassNotCategorizedRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassNotReferencedRule.class.st
+++ b/src/General-Rules/ReClassNotReferencedRule.class.st
@@ -15,6 +15,11 @@ ReClassNotReferencedRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReClassNotReferencedRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReClassNotReferencedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -24,11 +29,6 @@ ReClassNotReferencedRule class >> uniqueIdentifierName [
 { #category : 'enumerating' }
 ReClassNotReferencedRule >> basicCheck: aClass [
 	^ aClass isUsed not
-]
-
-{ #category : 'accessing' }
-ReClassNotReferencedRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassVariableCapitalizationRule.class.st
+++ b/src/General-Rules/ReClassVariableCapitalizationRule.class.st
@@ -14,6 +14,11 @@ ReClassVariableCapitalizationRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReClassVariableCapitalizationRule class >> group [
+	^ 'Style'
+]
+
 { #category : 'running' }
 ReClassVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlock [
 	aClass isMeta ifTrue: [ ^ self ].
@@ -43,11 +48,6 @@ ReClassVariableCapitalizationRule >> critiqueFor: aClass about: aVarName [
 				in: aClass).
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReClassVariableCapitalizationRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassVariableNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReClassVariableNeitherReadNorWrittenRule.class.st
@@ -16,6 +16,11 @@ ReClassVariableNeitherReadNorWrittenRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReClassVariableNeitherReadNorWrittenRule class >> group [
+	^ 'Clean Code'
+]
+
 { #category : 'running' }
 ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -24,11 +29,6 @@ ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriti
 			variable definingClass pragmas anySatisfy: [ :pragma |
 				pragma selector = #ignoreUnusedClassVariables: and: [ (pragma argumentAt: 1) includes: variable name ] ] ]
 		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
-]
-
-{ #category : 'accessing' }
-ReClassVariableNeitherReadNorWrittenRule >> group [
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassVariablesShadowingRule.class.st
+++ b/src/General-Rules/ReClassVariablesShadowingRule.class.st
@@ -15,17 +15,17 @@ ReClassVariablesShadowingRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReClassVariablesShadowingRule class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'running' }
 ReClassVariablesShadowingRule >> check: aClass forCritiquesDo: aCriticBlock [
 
 	aClass definedVariables
 		select: [ :variable | variable isShadowing ]
 		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
-]
-
-{ #category : 'accessing' }
-ReClassVariablesShadowingRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
+++ b/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCodeCruftLeftInMethodsRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReCodeCruftLeftInMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -49,11 +54,6 @@ ReCodeCruftLeftInMethodsRule >> debuggingPatterns [
 ReCodeCruftLeftInMethodsRule >> debuggingSelectors [
 
 	^ Object allSelectorsInProtocol: 'flagging'
-]
-
-{ #category : 'accessing' }
-ReCodeCruftLeftInMethodsRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReCollectSelectNotUsedRule.class.st
+++ b/src/General-Rules/ReCollectSelectNotUsedRule.class.st
@@ -12,6 +12,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCollectSelectNotUsedRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReCollectSelectNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -23,11 +28,6 @@ ReCollectSelectNotUsedRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^ false ].
 	(#(#select: #collect: #reject:) includes: aNode selector) ifFalse: [ ^ false ].
 	^ aNode isUsedAsReturnValue not
-]
-
-{ #category : 'accessing' }
-ReCollectSelectNotUsedRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReCollectionAtCollectionSizeRule.class.st
+++ b/src/General-Rules/ReCollectionAtCollectionSizeRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCollectionAtCollectionSizeRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReCollectionAtCollectionSizeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ReCollectionAtCollectionSizeRule'
-]
-
-{ #category : 'accessing' }
-ReCollectionAtCollectionSizeRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReCollectionCopyEmptyRule.class.st
+++ b/src/General-Rules/ReCollectionCopyEmptyRule.class.st
@@ -15,6 +15,11 @@ ReCollectionCopyEmptyRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReCollectionCopyEmptyRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReCollectionCopyEmptyRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -24,11 +29,6 @@ ReCollectionCopyEmptyRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReCollectionCopyEmptyRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: Collection) and: [ aClass isVariable and: [ (aClass includesSelector: #copyEmpty) not and: [ aClass instVarNames isNotEmpty ] ] ]
-]
-
-{ #category : 'accessing' }
-ReCollectionCopyEmptyRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReCollectionMessagesToExternalObjectRule.class.st
+++ b/src/General-Rules/ReCollectionMessagesToExternalObjectRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCollectionMessagesToExternalObjectRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReCollectionMessagesToExternalObjectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -27,11 +32,6 @@ ReCollectionMessagesToExternalObjectRule >> afterCheck: aNode mappings: mappingD
 	collectionOwner isVariable ifFalse: [ ^ true ].
 	"ignore for all global vars and self and super"
 	^ (aNode scope lookupVar: collectionOwner name) scope ~= Smalltalk globals
-]
-
-{ #category : 'accessing' }
-ReCollectionMessagesToExternalObjectRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReCollectionProtocolRule.class.st
+++ b/src/General-Rules/ReCollectionProtocolRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCollectionProtocolRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReCollectionProtocolRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'CollectionProtocolRule'
-]
-
-{ #category : 'accessing' }
-ReCollectionProtocolRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReDeadBlockRule.class.st
+++ b/src/General-Rules/ReDeadBlockRule.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReDeadBlockRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReDeadBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -20,11 +25,6 @@ ReDeadBlockRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReDeadBlockRule >> basicCheck: node [
 	^ node isBlock and: [ node isUsedAsReturnValue not ]
-]
-
-{ #category : 'accessing' }
-ReDeadBlockRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDefineBasicCheckRule.class.st
+++ b/src/General-Rules/ReDefineBasicCheckRule.class.st
@@ -18,6 +18,11 @@ ReDefineBasicCheckRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReDefineBasicCheckRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
 { #category : 'running' }
 ReDefineBasicCheckRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: RBLintRule) and: [ aClass isVisible and: [ (aClass lookupSelector: #basicCheck:) isSubclassResponsibility ] ]
@@ -30,11 +35,6 @@ ReDefineBasicCheckRule >> critiqueFor: aClass [
 		by: self
 		class: aClass
 		selector: #basicCheck:) beShouldBeImplemented
-]
-
-{ #category : 'accessing' }
-ReDefineBasicCheckRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDefineEntityComplianceCheckRule.class.st
+++ b/src/General-Rules/ReDefineEntityComplianceCheckRule.class.st
@@ -14,6 +14,11 @@ ReDefineEntityComplianceCheckRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReDefineEntityComplianceCheckRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
 { #category : 'running' }
 ReDefineEntityComplianceCheckRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: RBLintRule) and: [ aClass isVisible and: [ self complianceMethods noneSatisfy: [ :method | aClass perform: method ] ] ]
@@ -23,11 +28,6 @@ ReDefineEntityComplianceCheckRule >> basicCheck: aClass [
 ReDefineEntityComplianceCheckRule >> complianceMethods [
 
 	^ #(checksMethod checksClass checksPackage)
-]
-
-{ #category : 'accessing' }
-ReDefineEntityComplianceCheckRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDefinesEqualNotHashRule.class.st
+++ b/src/General-Rules/ReDefinesEqualNotHashRule.class.st
@@ -25,6 +25,11 @@ ReDefinesEqualNotHashRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReDefinesEqualNotHashRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReDefinesEqualNotHashRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -34,11 +39,6 @@ ReDefinesEqualNotHashRule class >> uniqueIdentifierName [
 { #category : 'enumerating' }
 ReDefinesEqualNotHashRule >> basicCheck: aClass [
 	^ (aClass includesSelector: #=) and: [ (aClass includesSelector: #hash) not ]
-]
-
-{ #category : 'accessing' }
-ReDefinesEqualNotHashRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDeprecateWithFirstCharacterDownshiftedRule.class.st
+++ b/src/General-Rules/ReDeprecateWithFirstCharacterDownshiftedRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReDeprecateWithFirstCharacterDownshiftedRule class >> group [
+	^ 'Style'
+]
+
+{ #category : 'accessing' }
 ReDeprecateWithFirstCharacterDownshiftedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'FirstCharacterDownShifted'
-]
-
-{ #category : 'accessing' }
-ReDeprecateWithFirstCharacterDownshiftedRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReDetectContainsRule.class.st
+++ b/src/General-Rules/ReDetectContainsRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReDetectContainsRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReDetectContainsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DetectContainsRule'
-]
-
-{ #category : 'accessing' }
-ReDetectContainsRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReDetectIfNoneRule.class.st
+++ b/src/General-Rules/ReDetectIfNoneRule.class.st
@@ -21,15 +21,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReDetectIfNoneRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReDetectIfNoneRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DetectIfNoneRule'
-]
-
-{ #category : 'accessing' }
-ReDetectIfNoneRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReDoNotSendSuperInitializeInClassSideRule.class.st
+++ b/src/General-Rules/ReDoNotSendSuperInitializeInClassSideRule.class.st
@@ -20,15 +20,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReDoNotSendSuperInitializeInClassSideRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReDoNotSendSuperInitializeInClassSideRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DoNotSendSuperInitializeInClassSideRule'
-]
-
-{ #category : 'accessing' }
-ReDoNotSendSuperInitializeInClassSideRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReEmptyExceptionHandlerRule.class.st
+++ b/src/General-Rules/ReEmptyExceptionHandlerRule.class.st
@@ -16,6 +16,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReEmptyExceptionHandlerRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReEmptyExceptionHandlerRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,11 +38,6 @@ ReEmptyExceptionHandlerRule >> afterCheck: aNode mappings: mappingDict [
 	(class includesBehavior: Notification) ifTrue: [ ^false ].
 
 	^ true
-]
-
-{ #category : 'accessing' }
-ReEmptyExceptionHandlerRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReEqualNilRule.class.st
+++ b/src/General-Rules/ReEqualNilRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReEqualNilRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReEqualNilRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'EqualNilRule'
-]
-
-{ #category : 'accessing' }
-ReEqualNilRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReEqualNotUsedRule.class.st
+++ b/src/General-Rules/ReEqualNotUsedRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReEqualNotUsedRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReEqualNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -19,11 +24,6 @@ ReEqualNotUsedRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReEqualNotUsedRule >> basicCheck: node [
 	^ node isMessage and: [ node isUsedAsReturnValue not and: [ #(#= #== #~= #~~ #< #> #<= #>=) includes: node selector ] ]
-]
-
-{ #category : 'accessing' }
-ReEqualNotUsedRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReEqualsTrueRule.class.st
+++ b/src/General-Rules/ReEqualsTrueRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReEqualsTrueRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReEqualsTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -24,11 +29,6 @@ ReEqualsTrueRule >> basicCheck: aNode [
 	(parent := aNode parent) ifNil: [ ^ false ].
 	parent isMessage ifFalse: [ ^ false ].
 	^ #(#= #== #~= #~~) includes: parent selector
-]
-
-{ #category : 'accessing' }
-ReEqualsTrueRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReEquivalentSuperclassMethodsRule.class.st
+++ b/src/General-Rules/ReEquivalentSuperclassMethodsRule.class.st
@@ -17,6 +17,11 @@ ReEquivalentSuperclassMethodsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReEquivalentSuperclassMethodsRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReEquivalentSuperclassMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -31,11 +36,6 @@ ReEquivalentSuperclassMethodsRule >> basicCheck: aMethod [
 	^ aMethod overriddenMethod
 		  ifNotNil: [ :overridenMethod | aMethod equivalentTo: overridenMethod ]
 		  ifNil: [ false ]
-]
-
-{ #category : 'accessing' }
-ReEquivalentSuperclassMethodsRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExcessiveArgumentsRule.class.st
+++ b/src/General-Rules/ReExcessiveArgumentsRule.class.st
@@ -19,6 +19,11 @@ ReExcessiveArgumentsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReExcessiveArgumentsRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReExcessiveArgumentsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReExcessiveArgumentsRule >> basicCheck: aMethod [
 	aMethod isFFIMethod ifTrue: [ ^false ].
 
 	^ aMethod numArgs >= self argumentsCount
-]
-
-{ #category : 'accessing' }
-ReExcessiveArgumentsRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExcessiveInheritanceRule.class.st
+++ b/src/General-Rules/ReExcessiveInheritanceRule.class.st
@@ -23,6 +23,11 @@ ReExcessiveInheritanceRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReExcessiveInheritanceRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReExcessiveInheritanceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -34,11 +39,6 @@ ReExcessiveInheritanceRule >> basicCheck: aClass [
 	aClass isMeta ifTrue: [ ^ false ].
 
 	^ aClass allSuperclasses size >= self inheritanceDepth
-]
-
-{ #category : 'accessing' }
-ReExcessiveInheritanceRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReExcessiveMethodsRule.class.st
+++ b/src/General-Rules/ReExcessiveMethodsRule.class.st
@@ -21,6 +21,11 @@ ReExcessiveMethodsRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReExcessiveMethodsRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReExcessiveMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReExcessiveMethodsRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReExcessiveMethodsRule >> basicCheck: aClass [
 	^ aClass selectors size >= self methodsCount
-]
-
-{ #category : 'accessing' }
-ReExcessiveMethodsRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReExcessiveVariablesRule.class.st
+++ b/src/General-Rules/ReExcessiveVariablesRule.class.st
@@ -17,6 +17,11 @@ ReExcessiveVariablesRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReExcessiveVariablesRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReExcessiveVariablesRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -28,11 +33,6 @@ ReExcessiveVariablesRule >> basicCheck: aClass [
 	^ aClass instVarNames size >= self variablesCount or: [
 		"Shared pools are just there to define vars, so it is ok for them to have a lot"
 		(aClass instanceSide isPool not) and: [aClass classVarNames size >= self variablesCount ]]
-]
-
-{ #category : 'accessing' }
-ReExcessiveVariablesRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExplicitRequirementMethodsRule.class.st
+++ b/src/General-Rules/ReExplicitRequirementMethodsRule.class.st
@@ -15,6 +15,11 @@ ReExplicitRequirementMethodsRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReExplicitRequirementMethodsRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReExplicitRequirementMethodsRule class >> uniqueIdentifierName [
 
 	^ 'ExplicitRequirementMethodsRule'
@@ -40,11 +45,6 @@ ReExplicitRequirementMethodsRule >> check: aClass forCritiquesDo: aCritiqueBlock
 					((self critiqueFor: aClass)
 						tinyHint: method selector;
 						yourself) ]
-]
-
-{ #category : 'accessing' }
-ReExplicitRequirementMethodsRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExtraBlockRule.class.st
+++ b/src/General-Rules/ReExtraBlockRule.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReExtraBlockRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReExtraBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -31,11 +36,6 @@ ReExtraBlockRule >> blockEvaluatingMessages [
 	value: value:value: value:value:value: value:value:value:value:
 	cull: cull:cull: cull:cull:cull: cull:cull:cull:cull:
 	#valueWithArguments: valueWithPossibleArgs: valueWithPossibleArgument)
-]
-
-{ #category : 'accessing' }
-ReExtraBlockRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReFileBlocksRule.class.st
+++ b/src/General-Rules/ReFileBlocksRule.class.st
@@ -26,15 +26,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReFileBlocksRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReFileBlocksRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'FileBlocksRule'
-]
-
-{ #category : 'accessing' }
-ReFileBlocksRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReFloatEqualityComparisonRule.class.st
+++ b/src/General-Rules/ReFloatEqualityComparisonRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReFloatEqualityComparisonRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReFloatEqualityComparisonRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -19,11 +24,6 @@ ReFloatEqualityComparisonRule class >> uniqueIdentifierName [
 { #category : 'hooks' }
 ReFloatEqualityComparisonRule >> afterCheck: aNode mappings: mappingDict [
 	^ (mappingDict at: '`#floatLiteral') value isFloat
-]
-
-{ #category : 'accessing' }
-ReFloatEqualityComparisonRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReGlobalVariablesUsageRule.class.st
+++ b/src/General-Rules/ReGlobalVariablesUsageRule.class.st
@@ -16,6 +16,11 @@ ReGlobalVariablesUsageRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReGlobalVariablesUsageRule class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'running' }
 ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	aMethod ast allChildren
@@ -28,11 +33,6 @@ ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				createTrivialCritiqueOn: aMethod
 				intervalOf: node
 				hint: node name) ]
-]
-
-{ #category : 'running' }
-ReGlobalVariablesUsageRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'testing' }

--- a/src/General-Rules/ReGuardClauseRule.class.st
+++ b/src/General-Rules/ReGuardClauseRule.class.st
@@ -27,7 +27,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReGuardClauseRule >> group [
+ReGuardClauseRule class >> group [
 	^ 'Coding Idiom Violation'
 ]
 

--- a/src/General-Rules/ReIfNotNilDoRule.class.st
+++ b/src/General-Rules/ReIfNotNilDoRule.class.st
@@ -10,14 +10,14 @@ Class {
 }
 
 { #category : 'accessing' }
-ReIfNotNilDoRule class >> uniqueIdentifierName [
-
-	^ 'RuleIfNotNilDo'
+ReIfNotNilDoRule class >> group [
+	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }
-ReIfNotNilDoRule >> group [
-	^ 'Coding Idiom Violation'
+ReIfNotNilDoRule class >> uniqueIdentifierName [
+
+	^ 'RuleIfNotNilDo'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReIfTrueIfFalseUselessRule.class.st
+++ b/src/General-Rules/ReIfTrueIfFalseUselessRule.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReIfTrueIfFalseUselessRule >> group [
+ReIfTrueIfFalseUselessRule class >> group [
 
 	^ 'Design Flaws'
 ]

--- a/src/General-Rules/ReImplementedNotSentRule.class.st
+++ b/src/General-Rules/ReImplementedNotSentRule.class.st
@@ -57,6 +57,11 @@ ReImplementedNotSentRule class >> enabled: aBoolean [
 		ifFalse: [ self unsubscribe ]
 ]
 
+{ #category : 'accessing' }
+ReImplementedNotSentRule class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'class initialization' }
 ReImplementedNotSentRule class >> initialize [
 	"we do not want to register if the rule is disabled"
@@ -135,11 +140,6 @@ ReImplementedNotSentRule >> basicCheck: aMethod [
 						  occurrencesToFind := occurrencesToFind - 1.
 						  false ] ]
 			  ifFalse: [ false ] ]
-]
-
-{ #category : 'accessing' }
-ReImplementedNotSentRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/General-Rules/ReInconsistentMethodClassificationRule.class.st
@@ -17,6 +17,11 @@ ReInconsistentMethodClassificationRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReInconsistentMethodClassificationRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReInconsistentMethodClassificationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -44,11 +49,6 @@ ReInconsistentMethodClassificationRule >> critiqueFor: aMethod [
 
 	^ (ReRefactoringCritique withAnchor: (self anchorFor: aMethod) by: self) refactoring:
 		  (RBMethodProtocolTransformation protocol: { aMethod overriddenMethod protocolName } inMethod: aMethod selector inClass: aMethod methodClass name)
-]
-
-{ #category : 'accessing' }
-ReInconsistentMethodClassificationRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReInstVarInSubclassesRule.class.st
+++ b/src/General-Rules/ReInstVarInSubclassesRule.class.st
@@ -17,6 +17,11 @@ ReInstVarInSubclassesRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReInstVarInSubclassesRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReInstVarInSubclassesRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -50,11 +55,6 @@ ReInstVarInSubclassesRule >> critiqueFor: aClass [
 	^ ReRefactoringCritique
 			withAnchor: (self anchorFor: aClass)
 			by: self
-]
-
-{ #category : 'accessing' }
-ReInstVarInSubclassesRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReInstanceVariableCapitalizationRule.class.st
+++ b/src/General-Rules/ReInstanceVariableCapitalizationRule.class.st
@@ -14,6 +14,11 @@ ReInstanceVariableCapitalizationRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReInstanceVariableCapitalizationRule class >> group [
+	^ 'Style'
+]
+
 { #category : 'running' }
 ReInstanceVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -41,11 +46,6 @@ ReInstanceVariableCapitalizationRule >> critiqueFor: aClass about: aVarName [
 				in: aClass).
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReInstanceVariableCapitalizationRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReIsNilAndConditionalRule.class.st
+++ b/src/General-Rules/ReIsNilAndConditionalRule.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReIsNilAndConditionalRule >> group [
+ReIsNilAndConditionalRule class >> group [
 
 	^ 'Coding Idiom Violation'
 ]

--- a/src/General-Rules/ReIsNotNilAndConditionalRule.class.st
+++ b/src/General-Rules/ReIsNotNilAndConditionalRule.class.st
@@ -11,7 +11,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReIsNotNilAndConditionalRule >> group [
+ReIsNotNilAndConditionalRule class >> group [
 
 	^ 'Coding Idiom Violation'
 ]

--- a/src/General-Rules/ReIvarNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReIvarNeitherReadNorWrittenRule.class.st
@@ -16,6 +16,11 @@ ReIvarNeitherReadNorWrittenRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReIvarNeitherReadNorWrittenRule class >> group [
+	^ 'Clean Code'
+]
+
 { #category : 'running' }
 ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -24,11 +29,6 @@ ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 			slot isReferenced or: [
 				slot definingClass pragmas anySatisfy: [ :pragma | pragma selector = #ignoreUnusedVariables: and: [ (pragma argumentAt: 1) includes: slot name ] ] ] ]
 		thenDo: [ :slot | aCriticBlock cull: (self critiqueFor: aClass about: slot name) ]
-]
-
-{ #category : 'accessing' }
-ReIvarNeitherReadNorWrittenRule >> group [
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReJustSendsSuperRule.class.st
+++ b/src/General-Rules/ReJustSendsSuperRule.class.st
@@ -18,6 +18,11 @@ ReJustSendsSuperRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReJustSendsSuperRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReJustSendsSuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,11 +38,6 @@ ReJustSendsSuperRule >> basicCheck: aMethod [
 	aMethod pragmas ifNotEmpty: [ ^ false ].
 
 	^ matcher executeMethod: aMethod ast initialAnswer: false
-]
-
-{ #category : 'accessing' }
-ReJustSendsSuperRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReKeysDoRule.class.st
+++ b/src/General-Rules/ReKeysDoRule.class.st
@@ -17,15 +17,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReKeysDoRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReKeysDoRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'keysDoRule'
-]
-
-{ #category : 'accessing' }
-ReKeysDoRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReLiteralArrayCharactersRule.class.st
+++ b/src/General-Rules/ReLiteralArrayCharactersRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReLiteralArrayCharactersRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReLiteralArrayCharactersRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -21,11 +26,6 @@ ReLiteralArrayCharactersRule >> basicCheck: aNode [
 	aNode isLiteralArray ifFalse: [ ^ false ].
 	aNode value ifEmpty: [ ^ false ].
 	^ aNode value allSatisfy: #isCharacter
-]
-
-{ #category : 'accessing' }
-ReLiteralArrayCharactersRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReLiteralArrayContainsCommaRule.class.st
+++ b/src/General-Rules/ReLiteralArrayContainsCommaRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReLiteralArrayContainsCommaRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReLiteralArrayContainsCommaRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -26,11 +31,6 @@ ReLiteralArrayContainsCommaRule >> basicCheck: aNode [
 		 FFICompilerPlugin ffiCalloutSelectors includes: aNode parent parent selector ]) ifTrue: [ ^ false ].
 
 	^ aNode value includes: #,
-]
-
-{ #category : 'accessing' }
-ReLiteralArrayContainsCommaRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReLocalMethodsSameThanTraitRule.class.st
+++ b/src/General-Rules/ReLocalMethodsSameThanTraitRule.class.st
@@ -15,6 +15,11 @@ ReLocalMethodsSameThanTraitRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReLocalMethodsSameThanTraitRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReLocalMethodsSameThanTraitRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -35,11 +40,6 @@ ReLocalMethodsSameThanTraitRule >> check: aClass forCritiquesDo: aCriticBlock [
 		thenDo: [ :duplicatedMethod |
 			aCriticBlock cull:
 				(ReRemoveMethodCritique for: aClass selector: duplicatedMethod selector by: self) ]
-]
-
-{ #category : 'accessing' }
-ReLocalMethodsSameThanTraitRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReLongMethodsRule.class.st
+++ b/src/General-Rules/ReLongMethodsRule.class.st
@@ -23,6 +23,11 @@ ReLongMethodsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReLongMethodsRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReLongMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,11 +47,6 @@ ReLongMethodsRule >> basicCheck: aMethod [
 				ifTrue: [ numberOfStatements := numberOfStatements + node statements size.
 					numberOfStatements >= self longMethodSize ifTrue: [ ^ true ] ] ].
 	^ false
-]
-
-{ #category : 'accessing' }
-ReLongMethodsRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReMethodHasSyntaxErrorRule.class.st
+++ b/src/General-Rules/ReMethodHasSyntaxErrorRule.class.st
@@ -15,6 +15,11 @@ ReMethodHasSyntaxErrorRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReMethodHasSyntaxErrorRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -24,11 +29,6 @@ ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReMethodHasSyntaxErrorRule >> basicCheck: aMethod [
 	^aMethod isFaulty
-]
-
-{ #category : 'accessing' }
-ReMethodHasSyntaxErrorRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMethodSelectorKeywordCasingRule.class.st
+++ b/src/General-Rules/ReMethodSelectorKeywordCasingRule.class.st
@@ -15,6 +15,12 @@ ReMethodSelectorKeywordCasingRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReMethodSelectorKeywordCasingRule class >> group [
+
+	^ 'Design Flaws'
+]
+
 { #category : 'manifest' }
 ReMethodSelectorKeywordCasingRule class >> uniqueIdentifierName [
 	"The return value hould be unique and should change only when the rule completely change semantics"
@@ -28,12 +34,6 @@ ReMethodSelectorKeywordCasingRule >> basicCheck: aMethod [
 	^ aMethod selector isKeyword and: [
 		  (aMethod selector asString substrings: #( $: )) anySatisfy: [
 			  :each | each first isUppercase ] ]
-]
-
-{ #category : 'accessing' }
-ReMethodSelectorKeywordCasingRule >> group [
-
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMethodSignaturePeriodRule.class.st
+++ b/src/General-Rules/ReMethodSignaturePeriodRule.class.st
@@ -14,6 +14,11 @@ ReMethodSignaturePeriodRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReMethodSignaturePeriodRule class >> group [
+	^ 'Potential Bugs'
+]
+
 { #category : 'running' }
 ReMethodSignaturePeriodRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
@@ -26,11 +31,6 @@ ReMethodSignaturePeriodRule >> check: aMethod forCritiquesDo: aCriticBlock [
 						  entity: aMethod
 						  interval: (1 to: firstLine size))
 				 by: self) ]
-]
-
-{ #category : 'accessing' }
-ReMethodSignaturePeriodRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMethodSourceContainsLinefeedsRule.class.st
+++ b/src/General-Rules/ReMethodSourceContainsLinefeedsRule.class.st
@@ -15,6 +15,11 @@ ReMethodSourceContainsLinefeedsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReMethodSourceContainsLinefeedsRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReMethodSourceContainsLinefeedsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,11 +38,6 @@ ReMethodSourceContainsLinefeedsRule >> check: aMethod forCritiquesDo: aCriticBlo
 				interval: lfInterval)
 			by: self
 			hint: 'lf') ]
-]
-
-{ #category : 'accessing' }
-ReMethodSourceContainsLinefeedsRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMinMaxRule.class.st
+++ b/src/General-Rules/ReMinMaxRule.class.st
@@ -24,15 +24,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReMinMaxRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReMinMaxRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'MinMaxRule'
-]
-
-{ #category : 'accessing' }
-ReMinMaxRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReMissingSubclassResponsibilityRule.class.st
+++ b/src/General-Rules/ReMissingSubclassResponsibilityRule.class.st
@@ -15,6 +15,11 @@ ReMissingSubclassResponsibilityRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReMissingSubclassResponsibilityRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReMissingSubclassResponsibilityRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -45,11 +50,6 @@ ReMissingSubclassResponsibilityRule >> check: aClass forCritiquesDo: aCritiqueBl
 				thenDo: [ :critic |
 					aCritiqueBlock cull: critic ].
 				^ self ] ]
-]
-
-{ #category : 'accessing' }
-ReMissingSubclassResponsibilityRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMissingSuperSendsRule.class.st
+++ b/src/General-Rules/ReMissingSuperSendsRule.class.st
@@ -17,6 +17,12 @@ ReMissingSuperSendsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReMissingSuperSendsRule class >> group [
+
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReMissingSuperSendsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -41,12 +47,6 @@ ReMissingSuperSendsRule >> basicCheck: aMethod [
 
 	superMethod isReturnSelf ifTrue: [ ^ false ].
 	^ (superMethod sendsSelector: #subclassResponsibility) not
-]
-
-{ #category : 'accessing' }
-ReMissingSuperSendsRule >> group [
-
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReModifiesCollectionRule.class.st
+++ b/src/General-Rules/ReModifiesCollectionRule.class.st
@@ -18,6 +18,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReModifiesCollectionRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReModifiesCollectionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -29,11 +34,6 @@ ReModifiesCollectionRule >> afterCheck: aNode mappings: mappingDict [
 	^ self
 		modifiesCollection: (mappingDict at: '`@collection')
 		inAnyStatement: (mappingDict at: '`@.Statements')
-]
-
-{ #category : 'accessing' }
-ReModifiesCollectionRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReMultiplePeriodsTerminatingStatementRule.class.st
+++ b/src/General-Rules/ReMultiplePeriodsTerminatingStatementRule.class.st
@@ -15,6 +15,11 @@ ReMultiplePeriodsTerminatingStatementRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReMultiplePeriodsTerminatingStatementRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReMultiplePeriodsTerminatingStatementRule class >> uniqueIdentifierName [
 
 	^ 'MultiplePeriodsTerminatingStatementRule'
@@ -26,11 +31,6 @@ ReMultiplePeriodsTerminatingStatementRule >> check: aMethod forCritiquesDo: aCri
 	aMethod ast nodesDo: [ :node |
 		node isSequence and: [
 			self periodPairs: node critiqueBlock: aCriticBlock in: aMethod ] ]
-]
-
-{ #category : 'accessing' }
-ReMultiplePeriodsTerminatingStatementRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNilBranchRule.class.st
+++ b/src/General-Rules/ReNilBranchRule.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReNilBranchRule >> group [
+ReNilBranchRule class >> group [
 
 	^ 'Design Flaws'
 ]

--- a/src/General-Rules/ReNoClassCommentRule.class.st
+++ b/src/General-Rules/ReNoClassCommentRule.class.st
@@ -15,6 +15,11 @@ ReNoClassCommentRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReNoClassCommentRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReNoClassCommentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ ReNoClassCommentRule class >> uniqueIdentifierName [
 ReNoClassCommentRule >> basicCheck: aClass [
 	(aClass isMeta or: [ aClass isTestCase ]) ifTrue: [ ^ false ].
 	^ aClass hasComment not
-]
-
-{ #category : 'accessing' }
-ReNoClassCommentRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNoSpaceAroundProtocolRule.class.st
+++ b/src/General-Rules/ReNoSpaceAroundProtocolRule.class.st
@@ -18,6 +18,12 @@ ReNoSpaceAroundProtocolRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReNoSpaceAroundProtocolRule class >> group [
+
+	^ 'Coding Idiom Violation'
+]
+
 { #category : 'manifest' }
 ReNoSpaceAroundProtocolRule class >> uniqueIdentifierName [
 
@@ -43,12 +49,6 @@ ReNoSpaceAroundProtocolRule >> critiqueFor: aMethod [
 			   protocol: { proposedProtocol }
 			   inMethod: aMethod selector
 			   inClass: aMethod methodClass name asSymbol)
-]
-
-{ #category : 'accessing' }
-ReNoSpaceAroundProtocolRule >> group [
-
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNoUnusedInstanceVariableRule.class.st
+++ b/src/General-Rules/ReNoUnusedInstanceVariableRule.class.st
@@ -13,6 +13,12 @@ ReNoUnusedInstanceVariableRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReNoUnusedInstanceVariableRule class >> group [
+
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReNoUnusedInstanceVariableRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,12 +48,6 @@ ReNoUnusedInstanceVariableRule >> critiqueFor: aClass about: aVarName [
 
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReNoUnusedInstanceVariableRule >> group [
-
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNotEliminationRule.class.st
+++ b/src/General-Rules/ReNotEliminationRule.class.st
@@ -31,15 +31,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReNotEliminationRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReNotEliminationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'NotEliminationRule'
-]
-
-{ #category : 'accessing' }
-ReNotEliminationRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReNotEqualityOperatorsRule.class.st
+++ b/src/General-Rules/ReNotEqualityOperatorsRule.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReNotEqualityOperatorsRule >> group [
+ReNotEqualityOperatorsRule class >> group [
 	^ 'Bugs'
 ]
 

--- a/src/General-Rules/ReNotOptimizedIfNilRule.class.st
+++ b/src/General-Rules/ReNotOptimizedIfNilRule.class.st
@@ -15,17 +15,17 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReNotOptimizedIfNilRule class >> group [
+	^ 'Optimization'
+]
+
 { #category : 'running' }
 ReNotOptimizedIfNilRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isMessage ifFalse: [  ^ self ].
 	(#(ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil:) includes: aNode selector) ifFalse: [^ self].
 	aNode isInlineIfNil ifFalse: [
 		aBlock cull: (self critiqueFor: aNode) ]
-]
-
-{ #category : 'accessing' }
-ReNotOptimizedIfNilRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNotOptimizedIfRule.class.st
+++ b/src/General-Rules/ReNotOptimizedIfRule.class.st
@@ -13,17 +13,17 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReNotOptimizedIfRule class >> group [
+	^ 'Optimization'
+]
+
 { #category : 'running' }
 ReNotOptimizedIfRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isMessage ifFalse: [  ^ self ].
 	(#(ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue:) includes: aNode selector) ifFalse: [^ self].
 	aNode isInlineIf ifFalse: [
 		aBlock cull: (self critiqueFor: aNode) ]
-]
-
-{ #category : 'accessing' }
-ReNotOptimizedIfRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReOverridesSpecialMessageRule.class.st
+++ b/src/General-Rules/ReOverridesSpecialMessageRule.class.st
@@ -15,6 +15,11 @@ ReOverridesSpecialMessageRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReOverridesSpecialMessageRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReOverridesSpecialMessageRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReOverridesSpecialMessageRule >> check: aClass forCritiquesDo: aCriticBlock [
 { #category : 'private' }
 ReOverridesSpecialMessageRule >> classShouldNotOverride [
 	^ #( #== #~~ #class #basicAt: #basicAt:put: #basicSize #identityHash )
-]
-
-{ #category : 'accessing' }
-ReOverridesSpecialMessageRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReOverridingExtentsionMethod.class.st
+++ b/src/General-Rules/ReOverridingExtentsionMethod.class.st
@@ -9,6 +9,11 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReOverridingExtentsionMethod class >> group [
+	^ 'Potential Bugs'
+]
+
 { #category : 'running' }
 ReOverridingExtentsionMethod >> basicCheck: aMethod [
   ^ aMethod isExtension and: [
@@ -23,11 +28,6 @@ ReOverridingExtentsionMethod >> basicCheck: aMethod [
           "We allow extensions from the same package to override, so that
           hierarchies can be extended with overriding functionality."
           superMethod package ~= aMethod package ] ] ]
-]
-
-{ #category : 'accessing' }
-ReOverridingExtentsionMethod >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/RePlatformDependentUserInteractionRule.class.st
+++ b/src/General-Rules/RePlatformDependentUserInteractionRule.class.st
@@ -12,15 +12,15 @@ Class {
 }
 
 { #category : 'accessing' }
+RePlatformDependentUserInteractionRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 RePlatformDependentUserInteractionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'PlatformDependentUserInteractionRule'
-]
-
-{ #category : 'accessing' }
-RePlatformDependentUserInteractionRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/RePointRule.class.st
+++ b/src/General-Rules/RePointRule.class.st
@@ -13,6 +13,12 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+RePointRule class >> group [
+
+	^ 'Optimization'
+]
+
 { #category : 'manifest' }
 RePointRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -27,12 +33,6 @@ RePointRule >> basicCheck: aNode [
 	aNode receiver isMessage ifTrue: [ ^ false ].
 	aNode isSelfSend ifTrue: [ ^ false ].
 	^ (#( #x:y: ) includes: aNode selector ) and: [ aNode receiver name == Point name  ]
-]
-
-{ #category : 'accessing' }
-RePointRule >> group [
-
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/RePrecedenceRule.class.st
+++ b/src/General-Rules/RePrecedenceRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+RePrecedenceRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 RePrecedenceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ RePrecedenceRule >> basicCheck: aNode [
 	leftOperand isMessage ifFalse: [ ^ false ].
 	leftOperand hasParentheses ifTrue: [ ^ false ].
 	^ #(#+ #-) includes: leftOperand selector
-]
-
-{ #category : 'accessing' }
-RePrecedenceRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReReferencesObsoleteClassRule.class.st
+++ b/src/General-Rules/ReReferencesObsoleteClassRule.class.st
@@ -10,6 +10,11 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReReferencesObsoleteClassRule class >> group [
+	^ 'Bugs'
+]
+
 { #category : 'helpers' }
 ReReferencesObsoleteClassRule >> basicCheck: aNode [
  	^ aNode isGlobalVariable
@@ -22,11 +27,6 @@ ReReferencesObsoleteClassRule >> critiqueFor: aNode [
 	^ (super critiqueFor: aNode)
 		  tinyHint: aNode name;
 		  yourself
-]
-
-{ #category : 'accessing' }
-ReReferencesObsoleteClassRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReRefersToClassRule.class.st
+++ b/src/General-Rules/ReRefersToClassRule.class.st
@@ -16,6 +16,11 @@ ReRefersToClassRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReRefersToClassRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReRefersToClassRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReRefersToClassRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
 	problemLiterals do: [ :literal |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: literal hint:literal name )]
-]
-
-{ #category : 'accessing' }
-ReRefersToClassRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReReturnInEnsureRule.class.st
+++ b/src/General-Rules/ReReturnInEnsureRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReReturnInEnsureRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReReturnInEnsureRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -20,11 +25,6 @@ ReReturnInEnsureRule class >> uniqueIdentifierName [
 ReReturnInEnsureRule >> afterCheck: aNode mappings: mappingDict [
 	^ (mappingDict at: '`@.Stmts')
 		anySatisfy: #containsReturn
-]
-
-{ #category : 'accessing' }
-ReReturnInEnsureRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReReturnsBooleanAndOtherRule.class.st
+++ b/src/General-Rules/ReReturnsBooleanAndOtherRule.class.st
@@ -15,6 +15,11 @@ ReReturnsBooleanAndOtherRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReReturnsBooleanAndOtherRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReReturnsBooleanAndOtherRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -54,11 +59,6 @@ ReReturnsBooleanAndOtherRule >> checkIfNodeIsBool: node [
 ReReturnsBooleanAndOtherRule >> checkIfNodeIsNotBool: node [
 	^ node isSelfVariable or:
 		[ node isLiteralNode and: [ (#(true false) includes: node value) not ] ]
-]
-
-{ #category : 'accessing' }
-ReReturnsBooleanAndOtherRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReReturnsIfTrueRule.class.st
+++ b/src/General-Rules/ReReturnsIfTrueRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReReturnsIfTrueRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReReturnsIfTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ReturnsIfTrueRule'
-]
-
-{ #category : 'accessing' }
-ReReturnsIfTrueRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSearchingLiteralRule.class.st
+++ b/src/General-Rules/ReSearchingLiteralRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSearchingLiteralRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReSearchingLiteralRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -21,11 +26,6 @@ ReSearchingLiteralRule >> afterCheck: aNode mappings: mappingDict [
 	^ self
 		isSearchingLiteralExpression: aNode
 		for: (mappingDict at: '``@object')
-]
-
-{ #category : 'accessing' }
-ReSearchingLiteralRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSelfSentNotImplementedRule.class.st
+++ b/src/General-Rules/ReSelfSentNotImplementedRule.class.st
@@ -15,6 +15,11 @@ ReSelfSentNotImplementedRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReSelfSentNotImplementedRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSelfSentNotImplementedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -35,11 +40,6 @@ ReSelfSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	
 	problemSends do: [ :msgSend |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: msgSend hint: msgSend selector asString)]
-]
-
-{ #category : 'accessing' }
-ReSelfSentNotImplementedRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSendsDifferentSuperRule.class.st
+++ b/src/General-Rules/ReSendsDifferentSuperRule.class.st
@@ -22,6 +22,11 @@ ReSendsDifferentSuperRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReSendsDifferentSuperRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReSendsDifferentSuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -31,11 +36,6 @@ ReSendsDifferentSuperRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReSendsDifferentSuperRule >> basicCheck: aMethod [
 	^ aMethod superMessages anySatisfy: [ :message | message ~= aMethod selector ]
-]
-
-{ #category : 'accessing' }
-ReSendsDifferentSuperRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSendsMethodDictRule.class.st
+++ b/src/General-Rules/ReSendsMethodDictRule.class.st
@@ -15,6 +15,11 @@ ReSendsMethodDictRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReSendsMethodDictRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSendsMethodDictRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -27,11 +32,6 @@ ReSendsMethodDictRule >> basicCheck: aMethod [
 	({Behavior . ClassDescription . Class. Metaclass. TraitedMetaclass. MetaclassForTraits} includes: aMethod methodClass)
 		ifTrue: [ ^ false ].
 	^(aMethod refersToLiteral: #methodDict) and: [aMethod messages includes: #methodDict]
-]
-
-{ #category : 'accessing' }
-ReSendsMethodDictRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSendsUnknownMessageToGlobalRule.class.st
+++ b/src/General-Rules/ReSendsUnknownMessageToGlobalRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSendsUnknownMessageToGlobalRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSendsUnknownMessageToGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -27,11 +32,6 @@ ReSendsUnknownMessageToGlobalRule >> basicCheck: aNode [
 	"if we know that the selector does not exist, we ignore"
 	(aNode methodNode compiledMethod allIgnoredNotImplementedSelectors includes: aNode selector) ifTrue: [ ^false ].
 	^ (aNode receiver variable value respondsTo: aNode selector) not
-]
-
-{ #category : 'accessing' }
-ReSendsUnknownMessageToGlobalRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSentButNotUnderstoodBySuperRule.class.st
+++ b/src/General-Rules/ReSentButNotUnderstoodBySuperRule.class.st
@@ -16,6 +16,12 @@ ReSentButNotUnderstoodBySuperRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReSentButNotUnderstoodBySuperRule class >> group [
+
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSentButNotUnderstoodBySuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -38,12 +44,6 @@ ReSentButNotUnderstoodBySuperRule >> check: aMethod forCritiquesDo: aCriticBlock
 				 createTrivialCritiqueOn: aMethod
 				 intervalOf: msgSend
 				 hint: msgSend selector asString) ]
-]
-
-{ #category : 'accessing' }
-ReSentButNotUnderstoodBySuperRule >> group [
-
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSentNotImplementedRule.class.st
+++ b/src/General-Rules/ReSentNotImplementedRule.class.st
@@ -15,6 +15,11 @@ ReSentNotImplementedRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReSentNotImplementedRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSentNotImplementedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				 createTrivialCritiqueOn: aMethod
 				 intervalOf: msgSend
 				 hint: msgSend selector asString) ]
-]
-
-{ #category : 'accessing' }
-ReSentNotImplementedRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReShouldntRaiseErrorRule.class.st
+++ b/src/General-Rules/ReShouldntRaiseErrorRule.class.st
@@ -41,15 +41,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReShouldntRaiseErrorRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReShouldntRaiseErrorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ShouldntRaiseErrorRule'
-]
-
-{ #category : 'accessing' }
-ReShouldntRaiseErrorRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSizeCheckRule.class.st
+++ b/src/General-Rules/ReSizeCheckRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSizeCheckRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReSizeCheckRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -23,11 +28,6 @@ ReSizeCheckRule >> genericPatternForSelector: aSymbol [
 			stream space; nextPutAll: value.
 			aSymbol last = $:
 				ifTrue: [ stream space; nextPutAll: '`@object'; print: index ] ] ]
-]
-
-{ #category : 'accessing' }
-ReSizeCheckRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSmalltalkGlobalsRule.class.st
+++ b/src/General-Rules/ReSmalltalkGlobalsRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSmalltalkGlobalsRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReSmalltalkGlobalsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^ 'SmalltalkGlobalsRule'
-]
-
-{ #category : 'accessing' }
-ReSmalltalkGlobalsRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReStatementsAfterReturnConditionalRule.class.st
+++ b/src/General-Rules/ReStatementsAfterReturnConditionalRule.class.st
@@ -16,6 +16,12 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReStatementsAfterReturnConditionalRule class >> group [
+
+	^ 'Potential Bugs'
+]
+
 { #category : 'running' }
 ReStatementsAfterReturnConditionalRule >> basicCheck: aNode [
 
@@ -24,12 +30,6 @@ ReStatementsAfterReturnConditionalRule >> basicCheck: aNode [
 	aNode arguments do: [ :arg |
 		(arg isBlock and: [ arg statements last isReturn ]) ifFalse: [ ^ false ] ].
 	^ aNode ~= aNode methodNode statements last
-]
-
-{ #category : 'accessing' }
-ReStatementsAfterReturnConditionalRule >> group [
-
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReStringConcatenationRule.class.st
+++ b/src/General-Rules/ReStringConcatenationRule.class.st
@@ -26,6 +26,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReStringConcatenationRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReStringConcatenationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -43,11 +48,6 @@ ReStringConcatenationRule >> afterCheck: aNode mappings: mappingDict [
 			^ self performsConcatenation: arg2 ]).
 
 	^ false
-]
-
-{ #category : 'accessing' }
-ReStringConcatenationRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSubclassResponsibilityNotDefinedRule.class.st
+++ b/src/General-Rules/ReSubclassResponsibilityNotDefinedRule.class.st
@@ -15,6 +15,11 @@ ReSubclassResponsibilityNotDefinedRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReSubclassResponsibilityNotDefinedRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSubclassResponsibilityNotDefinedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -36,11 +41,6 @@ ReSubclassResponsibilityNotDefinedRule >> check: aClass forCritiquesDo: aCriticB
 						selector: method selector)
 						beShouldBeImplemented;
 						yourself ] ]) ]
-]
-
-{ #category : 'accessing' }
-ReSubclassResponsibilityNotDefinedRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSuperSendsNewRule.class.st
+++ b/src/General-Rules/ReSuperSendsNewRule.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSuperSendsNewRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSuperSendsNewRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -20,11 +25,6 @@ ReSuperSendsNewRule class >> uniqueIdentifierName [
 { #category : 'hooks' }
 ReSuperSendsNewRule >> afterCheck: aNode mappings: mappingDict [
 	^ aNode methodNode methodClass isMeta
-]
-
-{ #category : 'accessing' }
-ReSuperSendsNewRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSuperSendsRule.class.st
+++ b/src/General-Rules/ReSuperSendsRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSuperSendsRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReSuperSendsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SuperSendsRule'
-]
-
-{ #category : 'accessing' }
-ReSuperSendsRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSuperWithoutSend.class.st
+++ b/src/General-Rules/ReSuperWithoutSend.class.st
@@ -14,6 +14,11 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReSuperWithoutSend class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'running' }
 ReSuperWithoutSend >> basicCheck: aNode [
 	aNode isVariable ifFalse: [ ^ false ].
@@ -23,11 +28,6 @@ ReSuperWithoutSend >> basicCheck: aNode [
 		^aNode parent receiver ~= aNode
 	].
 	^true
-]
-
-{ #category : 'accessing' }
-ReSuperWithoutSend >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTempVarOverridesInstVarRule.class.st
+++ b/src/General-Rules/ReTempVarOverridesInstVarRule.class.st
@@ -15,6 +15,11 @@ ReTempVarOverridesInstVarRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReTempVarOverridesInstVarRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReTempVarOverridesInstVarRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,11 +47,6 @@ ReTempVarOverridesInstVarRule >> critiqueFor: aMethod about: aVarNode [
 		by: self)
 		tinyHint: aVarNode name;
 		yourself
-]
-
-{ #category : 'accessing' }
-ReTempVarOverridesInstVarRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTemporaryNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReTemporaryNeitherReadNorWrittenRule.class.st
@@ -9,17 +9,17 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReTemporaryNeitherReadNorWrittenRule class >> group [
+	^ 'Optimization'
+]
+
 { #category : 'running' }
 ReTemporaryNeitherReadNorWrittenRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isTempVariable ifFalse: [ ^ self ].
 	aNode isDefinition ifFalse: [ ^ self ].
 	aNode variable isReferenced ifFalse: [
 		aBlock cull: (self critiqueFor: aNode) ]
-]
-
-{ #category : 'accessing' }
-ReTemporaryNeitherReadNorWrittenRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTemporaryVariableCapitalizationRule.class.st
+++ b/src/General-Rules/ReTemporaryVariableCapitalizationRule.class.st
@@ -9,6 +9,11 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReTemporaryVariableCapitalizationRule class >> group [
+	^ 'Style'
+]
+
 { #category : 'running' }
 ReTemporaryVariableCapitalizationRule >> basicCheck: aNode [
 	aNode isLocalVariable ifFalse: [ ^false ].
@@ -34,11 +39,6 @@ ReTemporaryVariableCapitalizationRule >> critiqueFor: aNode [
 				selector: aNode methodNode selector).
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReTemporaryVariableCapitalizationRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTempsReadBeforeWrittenRule.class.st
+++ b/src/General-Rules/ReTempsReadBeforeWrittenRule.class.st
@@ -27,6 +27,11 @@ ReTempsReadBeforeWrittenRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReTempsReadBeforeWrittenRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReTempsReadBeforeWrittenRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -51,11 +56,6 @@ ReTempsReadBeforeWrittenRule >> findReadsBeforeWrittenTemporariesIn: aMethod [
 
 	^ (RBReadBeforeWrittenTester variablesReadBeforeWrittenIn:
 		   aMethod ast) array select: #isNotNil
-]
-
-{ #category : 'accessing' }
-ReTempsReadBeforeWrittenRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTestCaseShouldNotUseInitializeRule.class.st
+++ b/src/General-Rules/ReTestCaseShouldNotUseInitializeRule.class.st
@@ -19,6 +19,11 @@ ReTestCaseShouldNotUseInitializeRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReTestCaseShouldNotUseInitializeRule class >> group [
+	^ 'Clean Code'
+]
+
+{ #category : 'accessing' }
 ReTestCaseShouldNotUseInitializeRule >> basicCheck: aClass [
 
 	| alteredVariables expectedVariables |
@@ -36,11 +41,6 @@ ReTestCaseShouldNotUseInitializeRule >> basicCheck: aClass [
 	expectedVariables := aClass new instanceVariablesToKeep.
 
 	^ alteredVariables anySatisfy: [ :e | (expectedVariables includes: e name) not ]
-]
-
-{ #category : 'accessing' }
-ReTestCaseShouldNotUseInitializeRule >> group [
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReThemeAPIUpdateRule.class.st
+++ b/src/General-Rules/ReThemeAPIUpdateRule.class.st
@@ -11,15 +11,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReThemeAPIUpdateRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReThemeAPIUpdateRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ThemeAPIUpdateRule'
-]
-
-{ #category : 'accessing' }
-ReThemeAPIUpdateRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReThreeElementPointRule.class.st
+++ b/src/General-Rules/ReThreeElementPointRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReThreeElementPointRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReThreeElementPointRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -47,11 +52,6 @@ ReThreeElementPointRule >> findSuspiciousParentFor: aNode ifNone: alternativeBlo
 	^ self
 		findSuspiciousParentFor: tentativeNode
 		ifNone: alternativeBlock
-]
-
-{ #category : 'accessing' }
-ReThreeElementPointRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReToDoCollectRule.class.st
+++ b/src/General-Rules/ReToDoCollectRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReToDoCollectRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReToDoCollectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ToDoCollectRule'
-]
-
-{ #category : 'accessing' }
-ReToDoCollectRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReToDoWithIncrementRule.class.st
+++ b/src/General-Rules/ReToDoWithIncrementRule.class.st
@@ -13,15 +13,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReToDoWithIncrementRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReToDoWithIncrementRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ToDoWithIncrementRule'
-]
-
-{ #category : 'accessing' }
-ReToDoWithIncrementRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReTrueFalseDuplicationRule.class.st
+++ b/src/General-Rules/ReTrueFalseDuplicationRule.class.st
@@ -21,6 +21,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReTrueFalseDuplicationRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReTrueFalseDuplicationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReTrueFalseDuplicationRule >> afterCheck: aNode mappings: mappingDict [
 
 	"the first statement is duplicated"
 	^ true
-]
-
-{ #category : 'accessing' }
-ReTrueFalseDuplicationRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUnaryAccessingMethodWithoutReturnRule.class.st
+++ b/src/General-Rules/ReUnaryAccessingMethodWithoutReturnRule.class.st
@@ -15,6 +15,11 @@ ReUnaryAccessingMethodWithoutReturnRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUnaryAccessingMethodWithoutReturnRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReUnaryAccessingMethodWithoutReturnRule class >> uniqueIdentifierName [
 
 	^ 'UnaryAccessingMethodWithoutReturnRule'
@@ -26,11 +31,6 @@ ReUnaryAccessingMethodWithoutReturnRule >> basicCheck: aMethod [
 	(aMethod numArgs > 0 or: [ aMethod isAbstract ]) ifTrue: [ ^ false ].
 	(aMethod protocolName beginsWith: 'accessing') ifFalse: [ ^ false ].
 	^ aMethod ast allChildren noneSatisfy: [ :each | each isReturn ]
-]
-
-{ #category : 'accessing' }
-ReUnaryAccessingMethodWithoutReturnRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnclassifiedMethodsRule.class.st
+++ b/src/General-Rules/ReUnclassifiedMethodsRule.class.st
@@ -15,6 +15,11 @@ ReUnclassifiedMethodsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUnclassifiedMethodsRule class >> group [
+	^ 'Style'
+]
+
+{ #category : 'accessing' }
 ReUnclassifiedMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ ReUnclassifiedMethodsRule class >> uniqueIdentifierName [
 ReUnclassifiedMethodsRule >> basicCheck: aMethod [
 
 	^ aMethod isClassified not
-]
-
-{ #category : 'accessing' }
-ReUnclassifiedMethodsRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUncommonMessageSendRule.class.st
+++ b/src/General-Rules/ReUncommonMessageSendRule.class.st
@@ -17,6 +17,11 @@ ReUncommonMessageSendRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUncommonMessageSendRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReUncommonMessageSendRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -38,11 +43,6 @@ ReUncommonMessageSendRule >> check: aMethod forCritiquesDo: aCriticBlock [
 ReUncommonMessageSendRule >> commonLiterals [
 
 	^ #(#self #super #thisContext #true #false #nil)
-]
-
-{ #category : 'accessing' }
-ReUncommonMessageSendRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnconditionalRecursionRule.class.st
+++ b/src/General-Rules/ReUnconditionalRecursionRule.class.st
@@ -16,6 +16,11 @@ ReUnconditionalRecursionRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUnconditionalRecursionRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReUnconditionalRecursionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ ReUnconditionalRecursionRule class >> uniqueIdentifierName [
 { #category : 'hooks' }
 ReUnconditionalRecursionRule >> afterCheck: aNode mappings: mappingDict [
 	^ (mappingDict at: '`@.before') noneSatisfy: #containsReturn
-]
-
-{ #category : 'accessing' }
-ReUnconditionalRecursionRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUndeclaredVariableRule.class.st
+++ b/src/General-Rules/ReUndeclaredVariableRule.class.st
@@ -9,6 +9,11 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReUndeclaredVariableRule class >> group [
+	^ 'Bugs'
+]
+
 { #category : 'running' }
 ReUndeclaredVariableRule >> basicCheck: aNode [
 	^ aNode isVariable and: [ aNode isUndeclaredVariable ]
@@ -19,11 +24,6 @@ ReUndeclaredVariableRule >> critiqueFor: aNode [
 	^ (super critiqueFor: aNode)
 		tinyHint: aNode name;
 		yourself
-]
-
-{ #category : 'accessing' }
-ReUndeclaredVariableRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnnecessaryAssignmentRule.class.st
+++ b/src/General-Rules/ReUnnecessaryAssignmentRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUnnecessaryAssignmentRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReUnnecessaryAssignmentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -21,11 +26,6 @@ ReUnnecessaryAssignmentRule >> basicCheck: aNode [
 	aNode isReturn ifFalse: [ ^ false ].
 	aNode isAssignment ifFalse: [ ^ false ].
 	^ (aNode whoDefines: aNode variable name) isNotNil
-]
-
-{ #category : 'accessing' }
-ReUnnecessaryAssignmentRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnoptimizedAndOrRule.class.st
+++ b/src/General-Rules/ReUnoptimizedAndOrRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUnoptimizedAndOrRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReUnoptimizedAndOrRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnoptimizedAndOrRule'
-]
-
-{ #category : 'accessing' }
-ReUnoptimizedAndOrRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUnoptimizedToDoRule.class.st
+++ b/src/General-Rules/ReUnoptimizedToDoRule.class.st
@@ -16,15 +16,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUnoptimizedToDoRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReUnoptimizedToDoRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnoptimizedToDoRule'
-]
-
-{ #category : 'accessing' }
-ReUnoptimizedToDoRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUnpackagedCodeRule.class.st
+++ b/src/General-Rules/ReUnpackagedCodeRule.class.st
@@ -20,6 +20,11 @@ ReUnpackagedCodeRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUnpackagedCodeRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReUnpackagedCodeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReUnpackagedCodeRule class >> uniqueIdentifierName [
 ReUnpackagedCodeRule >> basicCheck: anEntity [
 
 	^ anEntity package isNotNil and: [ anEntity package isUndefined ]
-]
-
-{ #category : 'accessing' }
-ReUnpackagedCodeRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnwindBlocksRule.class.st
+++ b/src/General-Rules/ReUnwindBlocksRule.class.st
@@ -23,15 +23,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUnwindBlocksRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReUnwindBlocksRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnwindBlocksRule'
-]
-
-{ #category : 'accessing' }
-ReUnwindBlocksRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUseIsEmptyNotSizeRule.class.st
+++ b/src/General-Rules/ReUseIsEmptyNotSizeRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUseIsEmptyNotSizeRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReUseIsEmptyNotSizeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ConsistencyCheckRule'
-]
-
-{ #category : 'accessing' }
-ReUseIsEmptyNotSizeRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUseSetUpRule.class.st
+++ b/src/General-Rules/ReUseSetUpRule.class.st
@@ -9,17 +9,17 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReUseSetUpRule class >> group [
+
+	^ 'Design Flaws'
+]
+
 { #category : 'manifest' }
 ReUseSetUpRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^ 'UseSetUpRule'
-]
-
-{ #category : 'accessing' }
-ReUseSetUpRule >> group [
-
-	^ 'Design Flaws'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUsesAddRule.class.st
+++ b/src/General-Rules/ReUsesAddRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUsesAddRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReUsesAddRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -19,11 +24,6 @@ ReUsesAddRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReUsesAddRule >> basicCheck: node [
 	^ node isMessage and: [ (#(#add: #addAll:) includes: node selector) and: [ node isEssential ] ]
-]
-
-{ #category : 'accessing' }
-ReUsesAddRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUsesTrueRule.class.st
+++ b/src/General-Rules/ReUsesTrueRule.class.st
@@ -17,6 +17,11 @@ ReUsesTrueRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUsesTrueRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReUsesTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReUsesTrueRule >> check: aMethod forCritiquesDo: aCriticBlock [
 			                 aNode isGlobalVariable and: [ #( True False ) includes: aNode name ] ].
 	problemUsages do: [ :ref |
 		aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: ref hint: ref name asString)]
-]
-
-{ #category : 'accessing' }
-ReUsesTrueRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUsesWorldGlobalRule.class.st
+++ b/src/General-Rules/ReUsesWorldGlobalRule.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUsesWorldGlobalRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReUsesWorldGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -20,11 +25,6 @@ ReUsesWorldGlobalRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReUsesWorldGlobalRule >> basicCheck: aNode [
 	^ aNode isGlobalVariable and: [ #(#World #ActiveWorld) includes: aNode name ]
-]
-
-{ #category : 'accessing' }
-ReUsesWorldGlobalRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReVariableAssignedLiteralRule.class.st
+++ b/src/General-Rules/ReVariableAssignedLiteralRule.class.st
@@ -15,6 +15,11 @@ ReVariableAssignedLiteralRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReVariableAssignedLiteralRule class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'running' }
 ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -26,11 +31,6 @@ ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 		assignmentNodes size = 1 ifFalse: [ ^ self ].
 		assignmentNodes first value isLiteralNode ifTrue: [
 			aCriticBlock cull: (self critiqueFor: aClass about: variable name) ] ]
-]
-
-{ #category : 'accessing' }
-ReVariableAssignedLiteralRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReVariableReferencedOnceRule.class.st
+++ b/src/General-Rules/ReVariableReferencedOnceRule.class.st
@@ -15,6 +15,11 @@ ReVariableReferencedOnceRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReVariableReferencedOnceRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReVariableReferencedOnceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReVariableReferencedOnceRule >> check: aClass forCritiquesDo: aCriticBlock [
 		  (RBReadBeforeWrittenTester
 				  isVariable: slot name
 				  writtenBeforeReadIn: usingMethods first ast) ifTrue: [aCriticBlock cull: (self critiqueFor: aClass about: slot  name)   ]]
-]
-
-{ #category : 'accessing' }
-ReVariableReferencedOnceRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReWhileTrueRule.class.st
+++ b/src/General-Rules/ReWhileTrueRule.class.st
@@ -20,15 +20,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReWhileTrueRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReWhileTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'WhileTrueRule'
-]
-
-{ #category : 'accessing' }
-ReWhileTrueRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReYourselfNotUsedRule.class.st
+++ b/src/General-Rules/ReYourselfNotUsedRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReYourselfNotUsedRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReYourselfNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -21,11 +26,6 @@ ReYourselfNotUsedRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^ false ].
 	aNode selector = #yourself ifFalse: [ ^ false ].
 	^ aNode isUsedAsReturnValue not
-]
-
-{ #category : 'accessing' }
-ReYourselfNotUsedRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/SendsDeprecatedMethodToGlobalRule.class.st
+++ b/src/General-Rules/SendsDeprecatedMethodToGlobalRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+SendsDeprecatedMethodToGlobalRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 SendsDeprecatedMethodToGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ SendsDeprecatedMethodToGlobalRule >> basicCheck: aNode [
 	^value class classAndMethodFor: aNode selector
 		do: [ :class :method | method isDeprecated ]
 		ifAbsent: [ false ]
-]
-
-{ #category : 'accessing' }
-SendsDeprecatedMethodToGlobalRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReAbstractRule.class.st
+++ b/src/Renraku/ReAbstractRule.class.st
@@ -84,6 +84,15 @@ ReAbstractRule class >> enabledSettingID [
 	^ (self name, '_enabled') asSymbol
 ]
 
+{ #category : 'accessing' }
+ReAbstractRule class >> group [
+
+	(self selectors includes: #group) ifTrue: [
+		self deprecated: 'The method #group of rules should be implemented on the class side in Pharo 13+ and not in instance sice.'.
+		^ self new group ].
+	^ 'Unclassified rules'
+]
+
 { #category : 'manifest' }
 ReAbstractRule class >> identifierMinorVersionNumber [
 	"This number identifies the version of the rule definition. Each time the rule is updated and its changes invalidates previous false positives identification (and as such should be reassessed by developers) the number should be increased."
@@ -239,8 +248,7 @@ ReAbstractRule >> critiqueFor: aClass about: aVarName [
 
 { #category : 'accessing' }
 ReAbstractRule >> group [
-
-	^ 'Unclassified rules'
+	^ self class group
 ]
 
 { #category : 'testing' }

--- a/src/Renraku/ReCompactSourceCodeRule.class.st
+++ b/src/Renraku/ReCompactSourceCodeRule.class.st
@@ -45,6 +45,12 @@ ReCompactSourceCodeRule class >> criticizeFinalDotInMethodBody: aBoolean [
 	CriticizeFinalDotInMethodBody := aBoolean
 ]
 
+{ #category : 'accessing' }
+ReCompactSourceCodeRule class >> group [
+
+	^ 'Clean Code'
+]
+
 { #category : 'class initialization' }
 ReCompactSourceCodeRule class >> initialize [
 
@@ -67,12 +73,6 @@ ReCompactSourceCodeRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				ReCompactSourceCodeCritic
 					for: aMethod
 					by: self)  ]
-]
-
-{ #category : 'accessing' }
-ReCompactSourceCodeRule >> group [
-
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReEndTrueFalseRule.class.st
+++ b/src/Renraku/ReEndTrueFalseRule.class.st
@@ -21,6 +21,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReEndTrueFalseRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReEndTrueFalseRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -36,11 +41,6 @@ ReEndTrueFalseRule >> afterCheck: aNode mappings: mappingDict [
 			statement := aNode arguments first body statements last.
 			( statement isVariable and: [ statement = aNode arguments last body statements last ] ) not]
 		ifNotNil: [ true ]
-]
-
-{ #category : 'accessing' }
-ReEndTrueFalseRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/Renraku/ReGuardingClauseRule.class.st
+++ b/src/Renraku/ReGuardingClauseRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReGuardingClauseRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReGuardingClauseRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'GuardingClauseRule'
-]
-
-{ #category : 'accessing' }
-ReGuardingClauseRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/Renraku/ReNoNilAssignationInInitializeRule.class.st
+++ b/src/Renraku/ReNoNilAssignationInInitializeRule.class.st
@@ -14,6 +14,12 @@ ReNoNilAssignationInInitializeRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReNoNilAssignationInInitializeRule class >> group [
+
+	^ 'Style'
+]
+
 { #category : 'running' }
 ReNoNilAssignationInInitializeRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| problemAssigments|
@@ -24,12 +30,6 @@ ReNoNilAssignationInInitializeRule >> check: aMethod forCritiquesDo: aCriticBloc
 	problemAssigments do: [ :assignment |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: assignment hint: 'nil').
 		 ]
-]
-
-{ #category : 'accessing' }
-ReNoNilAssignationInInitializeRule >> group [
-
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReNoPrintStringInPrintOnRule.class.st
+++ b/src/Renraku/ReNoPrintStringInPrintOnRule.class.st
@@ -16,6 +16,11 @@ ReNoPrintStringInPrintOnRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReNoPrintStringInPrintOnRule class >> group [
+	^ 'Optimization'
+]
+
 { #category : 'class initialization' }
 ReNoPrintStringInPrintOnRule class >> initialize [
     ReRuleManager cleanUp
@@ -33,11 +38,6 @@ ReNoPrintStringInPrintOnRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				createTrivialCritiqueOn: aMethod
 				intervalOf: msgSend
 				hint: msgSend selector asString )]
-]
-
-{ #category : 'accessing' }
-ReNoPrintStringInPrintOnRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/RePackageManifestShouldBePackagedInManifestTagRule.class.st
+++ b/src/Renraku/RePackageManifestShouldBePackagedInManifestTagRule.class.st
@@ -12,16 +12,16 @@ RePackageManifestShouldBePackagedInManifestTagRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+RePackageManifestShouldBePackagedInManifestTagRule class >> group [
+
+	^ 'Coding Idiom Violation'
+]
+
 { #category : 'running' }
 RePackageManifestShouldBePackagedInManifestTagRule >> basicCheck: aClass [
 
 	^ (aClass inheritsFrom: PackageManifest) and: [ ((aClass package classesTaggedWith: 'Manifest') includes: aClass) not ]
-]
-
-{ #category : 'accessing' }
-RePackageManifestShouldBePackagedInManifestTagRule >> group [
-
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReProperMethodProtocolNameRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameRule.class.st
@@ -34,6 +34,12 @@ ReProperMethodProtocolNameRule class >> goodMethodProtocolName [
 	^self protocolIdiom key
 ]
 
+{ #category : 'accessing' }
+ReProperMethodProtocolNameRule class >> group [
+
+	^ 'Coding Idiom Violation'
+]
+
 { #category : 'testing' }
 ReProperMethodProtocolNameRule class >> isAbstract [
 
@@ -75,12 +81,6 @@ ReProperMethodProtocolNameRule >> critiqueFor: aMethod [
 			   protocol: { proposedProtocol }
 			   inMethod: aMethod selector
 			   inClass: aMethod methodClass name)
-]
-
-{ #category : 'accessing' }
-ReProperMethodProtocolNameRule >> group [
-
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReProperMethodProtocolRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolRule.class.st
@@ -27,6 +27,12 @@ ReProperMethodProtocolRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReProperMethodProtocolRule class >> group [
+
+	^ 'Clean Code'
+]
+
 { #category : 'testing' }
 ReProperMethodProtocolRule class >> isAbstract [
 
@@ -60,12 +66,6 @@ ReProperMethodProtocolRule >> critiqueFor: aMethod [
 			   protocol: self protocolName
 			   inMethod: methodSymbol
 			   inClass: classSymbol)
-]
-
-{ #category : 'accessing' }
-ReProperMethodProtocolRule >> group [
-
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReReturnMethodRule.class.st
+++ b/src/Renraku/ReReturnMethodRule.class.st
@@ -17,17 +17,17 @@ ReReturnMethodRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReReturnMethodRule class >> group [
+
+	^ 'Bugs'
+]
+
 { #category : 'running' }
 ReReturnMethodRule >> basicCheck: aMethod [
 	(aMethod overriddenMethods anySatisfy: [ :method | method hasPragmaNamed: #shouldReturn ]) ifFalse: [ ^ false ].
 
 	^ aMethod ast lastIsReturn not
-]
-
-{ #category : 'accessing' }
-ReReturnMethodRule >> group [
-
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReThemeAccessRule.class.st
+++ b/src/Renraku/ReThemeAccessRule.class.st
@@ -14,6 +14,11 @@ ReThemeAccessRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReThemeAccessRule class >> group [
+	^ 'API Hints'
+]
+
 { #category : 'class initialization' }
 ReThemeAccessRule class >> initialize [
    " ReRuleManager cleanUp "
@@ -34,11 +39,6 @@ ReThemeAccessRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				createTrivialCritiqueOn: aMethod
 				intervalOf: msgSend
 				hint: msgSend selector asString) ]
-]
-
-{ #category : 'running' }
-ReThemeAccessRule >> group [
-	^ 'API Hints'
 ]
 
 { #category : 'running' }

--- a/src/SUnit-Rules/ReAssertEqualSignIntoAssertEqualsRule.class.st
+++ b/src/SUnit-Rules/ReAssertEqualSignIntoAssertEqualsRule.class.st
@@ -12,6 +12,12 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAssertEqualSignIntoAssertEqualsRule class >> group [
+
+	^ 'SUnit'
+]
+
+{ #category : 'accessing' }
 ReAssertEqualSignIntoAssertEqualsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 

--- a/src/SUnit-Rules/ReShouldSendSuperInitializeAsFirstMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperInitializeAsFirstMessage.class.st
@@ -19,6 +19,12 @@ ReShouldSendSuperInitializeAsFirstMessage class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReShouldSendSuperInitializeAsFirstMessage class >> group [
+
+	^ 'Clean Code'
+]
+
 { #category : 'utilities' }
 ReShouldSendSuperInitializeAsFirstMessage class >> parseTreeSearcher [
 
@@ -45,12 +51,6 @@ ReShouldSendSuperInitializeAsFirstMessage class >> superInitializeNotCalledFirst
 ReShouldSendSuperInitializeAsFirstMessage >> basicCheck: aMethod [
 
 	^ (aMethod isClassSide not) and: [ aMethod selector = #initialize and: [ self class superInitializeNotCalledFirstIn: aMethod ] ]
-]
-
-{ #category : 'accessing' }
-ReShouldSendSuperInitializeAsFirstMessage >> group [
-
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/SUnit-Rules/ReShouldSendSuperSetUpAsFirstMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperSetUpAsFirstMessage.class.st
@@ -17,6 +17,12 @@ ReShouldSendSuperSetUpAsFirstMessage class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReShouldSendSuperSetUpAsFirstMessage class >> group [
+
+	^ 'SUnit'
+]
+
 { #category : 'utilities' }
 ReShouldSendSuperSetUpAsFirstMessage class >> parseTreeSearcher [
 

--- a/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
@@ -17,6 +17,12 @@ ReShouldSendSuperTearDownAsLastMessage class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReShouldSendSuperTearDownAsLastMessage class >> group [
+
+	^ 'SUnit'
+]
+
 { #category : 'utilities' }
 ReShouldSendSuperTearDownAsLastMessage class >> parseTreeSearcher [
 

--- a/src/SUnit-Rules/ReShouldTransformedIntoAssertRule.class.st
+++ b/src/SUnit-Rules/ReShouldTransformedIntoAssertRule.class.st
@@ -12,6 +12,12 @@ Class {
 }
 
 { #category : 'accessing' }
+ReShouldTransformedIntoAssertRule class >> group [
+
+	^ 'SUnit'
+]
+
+{ #category : 'accessing' }
 ReShouldTransformedIntoAssertRule class >> uniqueIdentifierName [
 
 	^'ShouldTransformedIntoAssert'

--- a/src/SUnit-Rules/ReTestClassNameShouldEndWithTestRule.class.st
+++ b/src/SUnit-Rules/ReTestClassNameShouldEndWithTestRule.class.st
@@ -17,6 +17,12 @@ ReTestClassNameShouldEndWithTestRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReTestClassNameShouldEndWithTestRule class >> group [
+
+	^ 'SUnit'
+]
+
 { #category : 'running' }
 ReTestClassNameShouldEndWithTestRule >> basicCheck: aClass [
 	| suffixes |

--- a/src/SUnit-Rules/ReTestClassNameShouldNotEndWithTests.class.st
+++ b/src/SUnit-Rules/ReTestClassNameShouldNotEndWithTests.class.st
@@ -17,6 +17,12 @@ ReTestClassNameShouldNotEndWithTests class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReTestClassNameShouldNotEndWithTests class >> group [
+
+	^ 'SUnit'
+]
+
 { #category : 'running' }
 ReTestClassNameShouldNotEndWithTests >> basicCheck: aClass [
 

--- a/src/SUnit-Rules/ReTestClassNotInPackageWithTestEndingNameRule.class.st
+++ b/src/SUnit-Rules/ReTestClassNotInPackageWithTestEndingNameRule.class.st
@@ -17,6 +17,12 @@ ReTestClassNotInPackageWithTestEndingNameRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReTestClassNotInPackageWithTestEndingNameRule class >> group [
+
+	^ 'SUnit'
+]
+
 { #category : 'running' }
 ReTestClassNotInPackageWithTestEndingNameRule >> basicCheck: aClass [
 

--- a/src/Specific-Rules/PharoBootstrapRule.class.st
+++ b/src/Specific-Rules/PharoBootstrapRule.class.st
@@ -17,6 +17,12 @@ PharoBootstrapRule class >> checksPackage [
 	^ true
 ]
 
+{ #category : 'accessing' }
+PharoBootstrapRule class >> group [
+
+	^ 'Architectural'
+]
+
 { #category : 'running' }
 PharoBootstrapRule >> basicCheck: aPackage [
 
@@ -42,12 +48,6 @@ PharoBootstrapRule >> critiqueFor: aPackage [
 { #category : 'private' }
 PharoBootstrapRule >> dependencyChecker [
 	^ (DependencyChecker ifNil: [ DADependencyChecker ]) new
-]
-
-{ #category : 'accessing' }
-PharoBootstrapRule >> group [
-
-	^ 'Architectural'
 ]
 
 { #category : 'accessing' }

--- a/src/Specific-Rules/RbScriptingSetBeforeModel.class.st
+++ b/src/Specific-Rules/RbScriptingSetBeforeModel.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-RbScriptingSetBeforeModel >> group [
+RbScriptingSetBeforeModel class >> group [
 	^ 'Rubric'
 ]
 

--- a/src/Specific-Rules/ReIconHardcodedMessageRule.class.st
+++ b/src/Specific-Rules/ReIconHardcodedMessageRule.class.st
@@ -16,7 +16,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReIconHardcodedMessageRule >> group [
+ReIconHardcodedMessageRule class >> group [
 
 	^ 'API Change'
 ]

--- a/src/Specific-Rules/SettingDontTranslateDescriptionRule.class.st
+++ b/src/Specific-Rules/SettingDontTranslateDescriptionRule.class.st
@@ -9,6 +9,12 @@ Class {
 	#tag : 'System-Settings'
 }
 
+{ #category : 'accessing' }
+SettingDontTranslateDescriptionRule class >> group [
+
+	^ 'API Hints'
+]
+
 { #category : 'running' }
 SettingDontTranslateDescriptionRule >> basicCheck: aNode [
 	^ aNode methodNode ifNil: [ false ] ifNotNil: [ :methNode | self checkPreconditionOn: methNode ]
@@ -19,12 +25,6 @@ SettingDontTranslateDescriptionRule >> checkPreconditionOn: aMethodNode [
 
 	^ aMethodNode pragmas anySatisfy: [ :p |
 		p selector = #systemsettings ]
-]
-
-{ #category : 'accessing' }
-SettingDontTranslateDescriptionRule >> group [
-
-	^ 'API Hints'
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
This change moves the method #group of rules from the instance side to the class side. This is a metadata that will not change for any instance of the rule so it makes sense to have it class side. It will be useful for Angel to implement some features. Currently, if we want the group of a rule we need to create a new instance and this takes some times because of the initializations of the rules. This change will make it uch faster to know the group of a rule for which we do not have an instance.

There is a temporary hack to deprecate the instance side group method that could still be here for rule existing outside pharo to let them move the group on the class side without breaking the tools that will use the new class side method