### PR TITLE
Move rules matadatas to class side

### DIFF
--- a/src/General-Rules-Tests/ReSmalllintTest.class.st
+++ b/src/General-Rules-Tests/ReSmalllintTest.class.st
@@ -33,18 +33,11 @@ ReSmalllintTest >> assertEnvironment: anEnvironment hasAllMethodsOfTheResult: cr
 
 { #category : 'private' }
 ReSmalllintTest >> assertIsValidRule: aRule [
-	self
-		assert: (aRule name isString and: [ aRule name notEmpty ])
-		description: 'Missing rule name'.
-	self
-		assert: (aRule group isString and: [ aRule group notEmpty ])
-		description: 'Missing group name'.
-	self
-		assert: (aRule rationale isString and: [ aRule rationale notEmpty ])
-		description: 'Missing rationale'.
-	self
-		assert: (#(error warning information) includes: aRule severity)
-		description: 'Invalid severity'
+
+	self assert: (aRule name isString and: [ aRule name isNotEmpty ]) description: 'Missing rule name'.
+	self assert: (aRule group isString and: [ aRule group isNotEmpty ]) description: 'Missing group name'.
+	self assert: (aRule rationale isString and: [ aRule rationale isNotEmpty ]) description: 'Missing rationale'.
+	self assert: (#( error warning information ) includes: aRule severity) description: 'Invalid severity'
 ]
 
 { #category : 'asserting' }

--- a/src/General-Rules/FloatReferencesRule.class.st
+++ b/src/General-Rules/FloatReferencesRule.class.st
@@ -9,15 +9,15 @@ Class {
 	#tag : 'Base'
 }
 
+{ #category : 'accessing' }
+FloatReferencesRule class >> group [
+	^ 'Bugs'
+]
+
 { #category : 'running' }
 FloatReferencesRule >> basicCheck: node [
 	node isGlobalVariable ifFalse: [ ^ false ].
 	^(self systemClassNames includes: node name)
-]
-
-{ #category : 'accessing' }
-FloatReferencesRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/FloatReferencesRule.class.st
+++ b/src/General-Rules/FloatReferencesRule.class.st
@@ -14,16 +14,15 @@ FloatReferencesRule class >> group [
 	^ 'Bugs'
 ]
 
+{ #category : 'accessing' }
+FloatReferencesRule class >> ruleName [
+	^ 'Access to a system class'
+]
+
 { #category : 'running' }
 FloatReferencesRule >> basicCheck: node [
 	node isGlobalVariable ifFalse: [ ^ false ].
 	^(self systemClassNames includes: node name)
-]
-
-{ #category : 'accessing' }
-FloatReferencesRule >> name [
-
-	^ 'Access to a system class'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/FloatReferencesRule.class.st
+++ b/src/General-Rules/FloatReferencesRule.class.st
@@ -15,8 +15,21 @@ FloatReferencesRule class >> group [
 ]
 
 { #category : 'accessing' }
+FloatReferencesRule class >> rationale [
+
+	^ 'You should not reference ' , (self systemClassNames joinUsing: Character space)
+	  , ' as they are there for system purpose and should not be referenced directly.'
+]
+
+{ #category : 'accessing' }
 FloatReferencesRule class >> ruleName [
 	^ 'Access to a system class'
+]
+
+{ #category : 'running' }
+FloatReferencesRule class >> systemClassNames [
+
+	^ #(BoxedFloat64 SmallFloat64)
 ]
 
 { #category : 'running' }
@@ -25,16 +38,7 @@ FloatReferencesRule >> basicCheck: node [
 	^(self systemClassNames includes: node name)
 ]
 
-{ #category : 'accessing' }
-FloatReferencesRule >> rationale [
-
-	^ 'You should not reference ',
-		(self systemClassNames joinUsing: Character space),
-		' as they are there for system purpose and should not be referenced directly.'
-]
-
 { #category : 'running' }
 FloatReferencesRule >> systemClassNames [
-
-	^ #(BoxedFloat64 SmallFloat64)
+	^ self class systemClassNames
 ]

--- a/src/General-Rules/OverridesDeprecatedMethodRule.class.st
+++ b/src/General-Rules/OverridesDeprecatedMethodRule.class.st
@@ -22,6 +22,11 @@ OverridesDeprecatedMethodRule class >> group [
 ]
 
 { #category : 'accessing' }
+OverridesDeprecatedMethodRule class >> ruleName [
+	^ 'Overrides a deprecated method'
+]
+
+{ #category : 'accessing' }
 OverridesDeprecatedMethodRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,9 +38,4 @@ OverridesDeprecatedMethodRule >> basicCheck: aMethod [
 	aMethod isDeprecated ifTrue: [ ^ false ].
 
 	^ aMethod overriddenMethods anySatisfy: #isDeprecated
-]
-
-{ #category : 'accessing' }
-OverridesDeprecatedMethodRule >> name [
-	^ 'Overrides a deprecated method'
 ]

--- a/src/General-Rules/OverridesDeprecatedMethodRule.class.st
+++ b/src/General-Rules/OverridesDeprecatedMethodRule.class.st
@@ -17,6 +17,11 @@ OverridesDeprecatedMethodRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+OverridesDeprecatedMethodRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 OverridesDeprecatedMethodRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -28,11 +33,6 @@ OverridesDeprecatedMethodRule >> basicCheck: aMethod [
 	aMethod isDeprecated ifTrue: [ ^ false ].
 
 	^ aMethod overriddenMethods anySatisfy: #isDeprecated
-]
-
-{ #category : 'accessing' }
-OverridesDeprecatedMethodRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReAddRemoveDependentsRule.class.st
+++ b/src/General-Rules/ReAddRemoveDependentsRule.class.st
@@ -20,6 +20,11 @@ ReAddRemoveDependentsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReAddRemoveDependentsRule class >> ruleName [
+	^ 'Number of addDependent: messages > removeDependent:'
+]
+
+{ #category : 'accessing' }
 ReAddRemoveDependentsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -38,9 +43,4 @@ ReAddRemoveDependentsRule >> basicCheck: aClass [
 				addSends := addSends + (messages count: [ :each | each selector == #addDependent:]).
 				removeSends := removeSends + (messages count: [ :each | each selector == #removeDependent:])].
 	^ addSends > removeSends
-]
-
-{ #category : 'accessing' }
-ReAddRemoveDependentsRule >> name [
-	^ 'Number of addDependent: messages > removeDependent:'
 ]

--- a/src/General-Rules/ReAddRemoveDependentsRule.class.st
+++ b/src/General-Rules/ReAddRemoveDependentsRule.class.st
@@ -15,6 +15,11 @@ ReAddRemoveDependentsRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReAddRemoveDependentsRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReAddRemoveDependentsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,11 +38,6 @@ ReAddRemoveDependentsRule >> basicCheck: aClass [
 				addSends := addSends + (messages count: [ :each | each selector == #addDependent:]).
 				removeSends := removeSends + (messages count: [ :each | each selector == #removeDependent:])].
 	^ addSends > removeSends
-]
-
-{ #category : 'accessing' }
-ReAddRemoveDependentsRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReAllAnyNoneSatisfyRule.class.st
+++ b/src/General-Rules/ReAllAnyNoneSatisfyRule.class.st
@@ -29,6 +29,11 @@ ReAllAnyNoneSatisfyRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReAllAnyNoneSatisfyRule class >> rationale [
+	^ 'Replace ad-hoc implementations (using explicit logic based on do:) of allSatisfy:, anySatisfy: and noneSatisfy: by the adequate calls to #allSatisfy:, #anySatisfy: or #noneSatisfy:. '
+]
+
+{ #category : 'accessing' }
 ReAllAnyNoneSatisfyRule class >> ruleName [
 	^ 'Replace with #allSatisfy:, #anySatisfy: or #noneSatisfy:'
 ]
@@ -98,9 +103,4 @@ ReAllAnyNoneSatisfyRule >> initialize [
 				| `@blocktemps |
 				`@.blockstatements.
 				`@condition ]'
-]
-
-{ #category : 'accessing' }
-ReAllAnyNoneSatisfyRule >> rationale [
-	^ 'Replace ad-hoc implementations (using explicit logic based on do:) of allSatisfy:, anySatisfy: and noneSatisfy: by the adequate calls to #allSatisfy:, #anySatisfy: or #noneSatisfy:. '
 ]

--- a/src/General-Rules/ReAllAnyNoneSatisfyRule.class.st
+++ b/src/General-Rules/ReAllAnyNoneSatisfyRule.class.st
@@ -29,6 +29,11 @@ ReAllAnyNoneSatisfyRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReAllAnyNoneSatisfyRule class >> ruleName [
+	^ 'Replace with #allSatisfy:, #anySatisfy: or #noneSatisfy:'
+]
+
+{ #category : 'accessing' }
 ReAllAnyNoneSatisfyRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -93,11 +98,6 @@ ReAllAnyNoneSatisfyRule >> initialize [
 				| `@blocktemps |
 				`@.blockstatements.
 				`@condition ]'
-]
-
-{ #category : 'accessing' }
-ReAllAnyNoneSatisfyRule >> name [
-	^ 'Replace with #allSatisfy:, #anySatisfy: or #noneSatisfy:'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReAllAnyNoneSatisfyRule.class.st
+++ b/src/General-Rules/ReAllAnyNoneSatisfyRule.class.st
@@ -24,15 +24,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAllAnyNoneSatisfyRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReAllAnyNoneSatisfyRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AllAnyNoneSatisfyRule'
-]
-
-{ #category : 'accessing' }
-ReAllAnyNoneSatisfyRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReAsClassRule.class.st
+++ b/src/General-Rules/ReAsClassRule.class.st
@@ -15,7 +15,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReAsClassRule >> group [
+ReAsClassRule class >> group [
 
 	^ 'Design Flaws'
 ]

--- a/src/General-Rules/ReAsClassRule.class.st
+++ b/src/General-Rules/ReAsClassRule.class.st
@@ -25,6 +25,12 @@ ReAsClassRule class >> ruleName [
 	^ 'Do not use #asClass & similar'
 ]
 
+{ #category : 'accessing' }
+ReAsClassRule class >> severity [
+
+	^ #error
+]
+
 { #category : 'initialization' }
 ReAsClassRule >> initialize [
 
@@ -32,10 +38,4 @@ ReAsClassRule >> initialize [
 	self
 		replace: '`@expr asClassIfAbsent: `@block' with: 'self class environment at: `@expr ifAbsent: `@block';
 		replace: '`@expr asClassIfPresent: `@block' with: 'self class environment at: `@expr ifPresent: `@block'
-]
-
-{ #category : 'accessing' }
-ReAsClassRule >> severity [
-
-	^ #error
 ]

--- a/src/General-Rules/ReAsClassRule.class.st
+++ b/src/General-Rules/ReAsClassRule.class.st
@@ -20,6 +20,11 @@ ReAsClassRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReAsClassRule class >> ruleName [
+	^ 'Do not use #asClass & similar'
+]
+
 { #category : 'initialization' }
 ReAsClassRule >> initialize [
 
@@ -27,12 +32,6 @@ ReAsClassRule >> initialize [
 	self
 		replace: '`@expr asClassIfAbsent: `@block' with: 'self class environment at: `@expr ifAbsent: `@block';
 		replace: '`@expr asClassIfPresent: `@block' with: 'self class environment at: `@expr ifPresent: `@block'
-]
-
-{ #category : 'accessing' }
-ReAsClassRule >> name [
-
-	^ 'Do not use #asClass & similar'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReAsOrderedCollectionNotNeededRule.class.st
+++ b/src/General-Rules/ReAsOrderedCollectionNotNeededRule.class.st
@@ -11,15 +11,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAsOrderedCollectionNotNeededRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReAsOrderedCollectionNotNeededRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AsOrderedCollectionNotNeededRule'
-]
-
-{ #category : 'accessing' }
-ReAsOrderedCollectionNotNeededRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReAsOrderedCollectionNotNeededRule.class.st
+++ b/src/General-Rules/ReAsOrderedCollectionNotNeededRule.class.st
@@ -16,6 +16,11 @@ ReAsOrderedCollectionNotNeededRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReAsOrderedCollectionNotNeededRule class >> ruleName [
+	^ '#asOrderedCollection/#asArray not needed'
+]
+
+{ #category : 'accessing' }
 ReAsOrderedCollectionNotNeededRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -32,9 +37,4 @@ ReAsOrderedCollectionNotNeededRule >> initialize [
 					| baseString |
 					baseString := '``@receiver ' , collectionMessage , ' ``@arg '.
 					self replace: baseString , conversionMessage with: baseString ] ]
-]
-
-{ #category : 'accessing' }
-ReAsOrderedCollectionNotNeededRule >> name [
-	^ '#asOrderedCollection/#asArray not needed'
 ]

--- a/src/General-Rules/ReAssertWithBooleanEqualtiyRule.class.st
+++ b/src/General-Rules/ReAssertWithBooleanEqualtiyRule.class.st
@@ -15,6 +15,11 @@ ReAssertWithBooleanEqualtiyRule class >> group [
 	^ 'Optimization'
 ]
 
+{ #category : 'accessing' }
+ReAssertWithBooleanEqualtiyRule class >> ruleName [
+	^ 'use deny: instead of assert:equals:'
+]
+
 { #category : 'initialization' }
 ReAssertWithBooleanEqualtiyRule >> initialize [
 
@@ -36,10 +41,4 @@ ReAssertWithBooleanEqualtiyRule >> initialize [
 		with: 'self assert: `@expr';
 		replace: 'self deny: `@expr identicalTo: true'
 		with: 'self deny: `@expr'
-]
-
-{ #category : 'accessing' }
-ReAssertWithBooleanEqualtiyRule >> name [
-
-	^ 'use deny: instead of assert:equals:'
 ]

--- a/src/General-Rules/ReAssertWithBooleanEqualtiyRule.class.st
+++ b/src/General-Rules/ReAssertWithBooleanEqualtiyRule.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReAssertWithBooleanEqualtiyRule >> group [ 
+ReAssertWithBooleanEqualtiyRule class >> group [ 
 
 	^ 'Optimization'
 ]

--- a/src/General-Rules/ReAssignmentInBlockRule.class.st
+++ b/src/General-Rules/ReAssignmentInBlockRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAssignmentInBlockRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReAssignmentInBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AssignmentInBlockRule'
-]
-
-{ #category : 'accessing' }
-ReAssignmentInBlockRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReAssignmentInBlockRule.class.st
+++ b/src/General-Rules/ReAssignmentInBlockRule.class.st
@@ -15,6 +15,11 @@ ReAssignmentInBlockRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReAssignmentInBlockRule class >> ruleName [
+	^ 'Unnecessary assignment or return in block'
+]
+
+{ #category : 'accessing' }
 ReAssignmentInBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -31,9 +36,4 @@ ReAssignmentInBlockRule >> initialize [
 			'[| `@temps | `@.Statements. ^`@object] ensure: `@block'
 			'[| `@temps | `@.Statements. `var := `@object] ifCurtailed: `@block'
 			'[| `@temps | `@.Statements. ^`@object] ifCurtailed: `@block' )
-]
-
-{ #category : 'accessing' }
-ReAssignmentInBlockRule >> name [
-	^ 'Unnecessary assignment or return in block'
 ]

--- a/src/General-Rules/ReAssignmentInIfTrueRule.class.st
+++ b/src/General-Rules/ReAssignmentInIfTrueRule.class.st
@@ -18,15 +18,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAssignmentInIfTrueRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReAssignmentInIfTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AssignmentInIfTrueRule'
-]
-
-{ #category : 'accessing' }
-ReAssignmentInIfTrueRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReAssignmentInIfTrueRule.class.st
+++ b/src/General-Rules/ReAssignmentInIfTrueRule.class.st
@@ -23,6 +23,11 @@ ReAssignmentInIfTrueRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReAssignmentInIfTrueRule class >> ruleName [
+	^ 'Move variable assignment outside of single statement ifTrue:ifFalse: blocks'
+]
+
+{ #category : 'accessing' }
 ReAssignmentInIfTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReAssignmentInIfTrueRule >> initialize [
 		with: '`variable := ``@Boolean ifTrue: [``@true] ifFalse: [``@false]';
 		replace: '``@Boolean ifFalse: [`variable := ``@true] ifTrue: [`variable := ``@false]'
 		with: '`variable := ``@Boolean ifFalse: [``@true] ifTrue: [``@false]'
-]
-
-{ #category : 'accessing' }
-ReAssignmentInIfTrueRule >> name [
-	^ 'Move variable assignment outside of single statement ifTrue:ifFalse: blocks'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReAssignmentInIfTrueRule.class.st
+++ b/src/General-Rules/ReAssignmentInIfTrueRule.class.st
@@ -23,6 +23,11 @@ ReAssignmentInIfTrueRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReAssignmentInIfTrueRule class >> rationale [
+	^ 'Moving assignments outside blocks leads to shorter and more efficient code.'
+]
+
+{ #category : 'accessing' }
 ReAssignmentInIfTrueRule class >> ruleName [
 	^ 'Move variable assignment outside of single statement ifTrue:ifFalse: blocks'
 ]
@@ -42,9 +47,4 @@ ReAssignmentInIfTrueRule >> initialize [
 		with: '`variable := ``@Boolean ifTrue: [``@true] ifFalse: [``@false]';
 		replace: '``@Boolean ifFalse: [`variable := ``@true] ifTrue: [`variable := ``@false]'
 		with: '`variable := ``@Boolean ifFalse: [``@true] ifTrue: [``@false]'
-]
-
-{ #category : 'accessing' }
-ReAssignmentInIfTrueRule >> rationale [
-	^ 'Moving assignments outside blocks leads to shorter and more efficient code.'
 ]

--- a/src/General-Rules/ReAssignmentWithoutEffectRule.class.st
+++ b/src/General-Rules/ReAssignmentWithoutEffectRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAssignmentWithoutEffectRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReAssignmentWithoutEffectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AssignmentWithoutEffectRule'
-]
-
-{ #category : 'accessing' }
-ReAssignmentWithoutEffectRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReAssignmentWithoutEffectRule.class.st
+++ b/src/General-Rules/ReAssignmentWithoutEffectRule.class.st
@@ -20,6 +20,11 @@ ReAssignmentWithoutEffectRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReAssignmentWithoutEffectRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReAssignmentWithoutEffectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,9 +35,4 @@ ReAssignmentWithoutEffectRule class >> uniqueIdentifierName [
 ReAssignmentWithoutEffectRule >> initialize [
 	super initialize.
 	self  replace: 	'`var := `var' with: ''
-]
-
-{ #category : 'accessing' }
-ReAssignmentWithoutEffectRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReAssignmentWithoutEffectRule.class.st
+++ b/src/General-Rules/ReAssignmentWithoutEffectRule.class.st
@@ -15,6 +15,11 @@ ReAssignmentWithoutEffectRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReAssignmentWithoutEffectRule class >> ruleName [
+	^ 'Assignment has no effect'
+]
+
+{ #category : 'accessing' }
 ReAssignmentWithoutEffectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ ReAssignmentWithoutEffectRule class >> uniqueIdentifierName [
 ReAssignmentWithoutEffectRule >> initialize [
 	super initialize.
 	self  replace: 	'`var := `var' with: ''
-]
-
-{ #category : 'accessing' }
-ReAssignmentWithoutEffectRule >> name [
-	^ 'Assignment has no effect'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReAtIfAbsentRule.class.st
+++ b/src/General-Rules/ReAtIfAbsentRule.class.st
@@ -17,6 +17,11 @@ ReAtIfAbsentRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReAtIfAbsentRule class >> ruleName [
+	^ 'at:ifAbsent: -> at:ifAbsentPut:'
+]
+
+{ #category : 'accessing' }
 ReAtIfAbsentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -46,9 +51,4 @@ ReAtIfAbsentRule >> initialize [
 					ifAbsentPut: [| `@temps |
 							``@.Statements.
 							``@object]'
-]
-
-{ #category : 'accessing' }
-ReAtIfAbsentRule >> name [
-	^ 'at:ifAbsent: -> at:ifAbsentPut:'
 ]

--- a/src/General-Rules/ReAtIfAbsentRule.class.st
+++ b/src/General-Rules/ReAtIfAbsentRule.class.st
@@ -12,15 +12,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAtIfAbsentRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReAtIfAbsentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'AtIfAbsentRule'
-]
-
-{ #category : 'accessing' }
-ReAtIfAbsentRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReBadMessageRule.class.st
+++ b/src/General-Rules/ReBadMessageRule.class.st
@@ -17,6 +17,11 @@ ReBadMessageRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReBadMessageRule class >> rationale [
+	^ 'Check methods that send messages that perform low level things.'
+]
+
+{ #category : 'accessing' }
 ReBadMessageRule class >> ruleName [
 	^ 'Sends "questionable" message'
 ]
@@ -39,9 +44,4 @@ ReBadMessageRule >> basicCheck: aNode [
 	"In tests using these messages (like isKindOf:) is no problem"
 	aNode methodNode methodClass ifNotNil: [ :class | class isTestCase ifTrue: [ ^false ]].
 	^ self badSelectors includes: aNode selector
-]
-
-{ #category : 'accessing' }
-ReBadMessageRule >> rationale [
-	^ 'Check methods that send messages that perform low level things.'
 ]

--- a/src/General-Rules/ReBadMessageRule.class.st
+++ b/src/General-Rules/ReBadMessageRule.class.st
@@ -12,6 +12,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReBadMessageRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReBadMessageRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -29,11 +34,6 @@ ReBadMessageRule >> basicCheck: aNode [
 	"In tests using these messages (like isKindOf:) is no problem"
 	aNode methodNode methodClass ifNotNil: [ :class | class isTestCase ifTrue: [ ^false ]].
 	^ self badSelectors includes: aNode selector
-]
-
-{ #category : 'accessing' }
-ReBadMessageRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReBadMessageRule.class.st
+++ b/src/General-Rules/ReBadMessageRule.class.st
@@ -17,6 +17,11 @@ ReBadMessageRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReBadMessageRule class >> ruleName [
+	^ 'Sends "questionable" message'
+]
+
+{ #category : 'accessing' }
 ReBadMessageRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -34,11 +39,6 @@ ReBadMessageRule >> basicCheck: aNode [
 	"In tests using these messages (like isKindOf:) is no problem"
 	aNode methodNode methodClass ifNotNil: [ :class | class isTestCase ifTrue: [ ^false ]].
 	^ self badSelectors includes: aNode selector
-]
-
-{ #category : 'accessing' }
-ReBadMessageRule >> name [
-	^ 'Sends "questionable" message'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReBaselineProperlyPackagedRule.class.st
+++ b/src/General-Rules/ReBaselineProperlyPackagedRule.class.st
@@ -17,6 +17,11 @@ ReBaselineProperlyPackagedRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReBaselineProperlyPackagedRule class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'manifest' }
 ReBaselineProperlyPackagedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -31,11 +36,6 @@ ReBaselineProperlyPackagedRule >> basicCheck: aClass [
 	 
 	^(aClass name beginsWith: 'BaselineOf') 
 		and: [ aClass package name ~= aClass name ]
-]
-
-{ #category : 'accessing' }
-ReBaselineProperlyPackagedRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReBaselineProperlyPackagedRule.class.st
+++ b/src/General-Rules/ReBaselineProperlyPackagedRule.class.st
@@ -27,6 +27,11 @@ ReBaselineProperlyPackagedRule class >> ruleName [
 	^ 'Baseline class not properly packaged in a package with the same name'
 ]
 
+{ #category : 'accessing' }
+ReBaselineProperlyPackagedRule class >> severity [
+	^ #information
+]
+
 { #category : 'manifest' }
 ReBaselineProperlyPackagedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -41,9 +46,4 @@ ReBaselineProperlyPackagedRule >> basicCheck: aClass [
 	 
 	^(aClass name beginsWith: 'BaselineOf') 
 		and: [ aClass package name ~= aClass name ]
-]
-
-{ #category : 'accessing' }
-ReBaselineProperlyPackagedRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReBaselineProperlyPackagedRule.class.st
+++ b/src/General-Rules/ReBaselineProperlyPackagedRule.class.st
@@ -22,6 +22,11 @@ ReBaselineProperlyPackagedRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReBaselineProperlyPackagedRule class >> ruleName [
+	^ 'Baseline class not properly packaged in a package with the same name'
+]
+
 { #category : 'manifest' }
 ReBaselineProperlyPackagedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -36,11 +41,6 @@ ReBaselineProperlyPackagedRule >> basicCheck: aClass [
 	 
 	^(aClass name beginsWith: 'BaselineOf') 
 		and: [ aClass package name ~= aClass name ]
-]
-
-{ #category : 'accessing' }
-ReBaselineProperlyPackagedRule >> name [
-	^ 'Baseline class not properly packaged in a package with the same name'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReBaselineWithProperSuperclassRule.class.st
+++ b/src/General-Rules/ReBaselineWithProperSuperclassRule.class.st
@@ -26,6 +26,12 @@ ReBaselineWithProperSuperclassRule class >> ruleName [
 	^ 'Custom Baseline class should be a subclass of predefined class BaselineOf'
 ]
 
+{ #category : 'accessing' }
+ReBaselineWithProperSuperclassRule class >> severity [
+
+	^ #information
+]
+
 { #category : 'manifest' }
 ReBaselineWithProperSuperclassRule class >> uniqueIdentifierName [ 
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -42,10 +48,4 @@ ReBaselineWithProperSuperclassRule >> basicCheck: aClass [
 	^(aClass name beginsWith: 'BaselineOf') 
 		and: [ (aClass inheritsFrom: BaselineOf) not ]
  
-]
-
-{ #category : 'accessing' }
-ReBaselineWithProperSuperclassRule >> severity [
-
-	^ #information
 ]

--- a/src/General-Rules/ReBaselineWithProperSuperclassRule.class.st
+++ b/src/General-Rules/ReBaselineWithProperSuperclassRule.class.st
@@ -15,6 +15,12 @@ ReBaselineWithProperSuperclassRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReBaselineWithProperSuperclassRule class >> group [
+
+	^ 'Design Flaws'
+]
+
 { #category : 'manifest' }
 ReBaselineWithProperSuperclassRule class >> uniqueIdentifierName [ 
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -31,12 +37,6 @@ ReBaselineWithProperSuperclassRule >> basicCheck: aClass [
 	^(aClass name beginsWith: 'BaselineOf') 
 		and: [ (aClass inheritsFrom: BaselineOf) not ]
  
-]
-
-{ #category : 'accessing' }
-ReBaselineWithProperSuperclassRule >> group [
-
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReBaselineWithProperSuperclassRule.class.st
+++ b/src/General-Rules/ReBaselineWithProperSuperclassRule.class.st
@@ -21,6 +21,11 @@ ReBaselineWithProperSuperclassRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReBaselineWithProperSuperclassRule class >> ruleName [
+	^ 'Custom Baseline class should be a subclass of predefined class BaselineOf'
+]
+
 { #category : 'manifest' }
 ReBaselineWithProperSuperclassRule class >> uniqueIdentifierName [ 
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -36,13 +41,6 @@ ReBaselineWithProperSuperclassRule >> basicCheck: aClass [
 	
 	^(aClass name beginsWith: 'BaselineOf') 
 		and: [ (aClass inheritsFrom: BaselineOf) not ]
- 
-]
-
-{ #category : 'accessing' }
-ReBaselineWithProperSuperclassRule >> name [
-
-	^ 'Custom Baseline class should be a subclass of predefined class BaselineOf'
  
 ]
 

--- a/src/General-Rules/ReBetweenAndRule.class.st
+++ b/src/General-Rules/ReBetweenAndRule.class.st
@@ -15,6 +15,11 @@ ReBetweenAndRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReBetweenAndRule class >> ruleName [
+	^ '"a >= b and: [a <= c]" -> "a between: b and: c"'
+]
+
+{ #category : 'accessing' }
 ReBetweenAndRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -41,9 +46,4 @@ ReBetweenAndRule >> initialize [
 		replace: '``@a <= ``@c & (``@b <= ``@a)' with: '``@a between: ``@b and: ``@c';
 		replace: '``@c >= ``@a and: [``@b <= ``@a]' with: '``@a between: ``@b and: ``@c';
 		replace: '``@c >= ``@a & (``@b <= ``@a)' with: '``@a between: ``@b and: ``@c'
-]
-
-{ #category : 'accessing' }
-ReBetweenAndRule >> name [
-	^ '"a >= b and: [a <= c]" -> "a between: b and: c"'
 ]

--- a/src/General-Rules/ReBetweenAndRule.class.st
+++ b/src/General-Rules/ReBetweenAndRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReBetweenAndRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReBetweenAndRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'BetweenAndRule'
-]
-
-{ #category : 'accessing' }
-ReBetweenAndRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReBooleanPrecedenceRule.class.st
+++ b/src/General-Rules/ReBooleanPrecedenceRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReBooleanPrecedenceRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReBooleanPrecedenceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'BooleanPrecedenceRule'
-]
-
-{ #category : 'accessing' }
-ReBooleanPrecedenceRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReBooleanPrecedenceRule.class.st
+++ b/src/General-Rules/ReBooleanPrecedenceRule.class.st
@@ -20,6 +20,11 @@ ReBooleanPrecedenceRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReBooleanPrecedenceRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReBooleanPrecedenceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -38,9 +43,4 @@ ReBooleanPrecedenceRule >> initialize [
 			'`@object1 | `@object2 ~~ `@object3'
 			'`@object1 & `@object2 ~= `@object3'
 			'`@object1 & `@object2 ~~ `@object3' )
-]
-
-{ #category : 'accessing' }
-ReBooleanPrecedenceRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReBooleanPrecedenceRule.class.st
+++ b/src/General-Rules/ReBooleanPrecedenceRule.class.st
@@ -15,6 +15,11 @@ ReBooleanPrecedenceRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReBooleanPrecedenceRule class >> ruleName [
+	^ 'Uses A | B = C instead of A | (B = C)'
+]
+
+{ #category : 'accessing' }
 ReBooleanPrecedenceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,11 +38,6 @@ ReBooleanPrecedenceRule >> initialize [
 			'`@object1 | `@object2 ~~ `@object3'
 			'`@object1 & `@object2 ~= `@object3'
 			'`@object1 & `@object2 ~~ `@object3' )
-]
-
-{ #category : 'accessing' }
-ReBooleanPrecedenceRule >> name [
-	^ 'Uses A | B = C instead of A | (B = C)'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReCascadedNextPutAllsRule.class.st
+++ b/src/General-Rules/ReCascadedNextPutAllsRule.class.st
@@ -24,6 +24,11 @@ ReCascadedNextPutAllsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReCascadedNextPutAllsRule class >> ruleName [
+	^ 'Use cascaded nextPutAll:''s instead of #, in #nextPutAll:'
+]
+
+{ #category : 'accessing' }
 ReCascadedNextPutAllsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -36,11 +41,6 @@ ReCascadedNextPutAllsRule >> initialize [
 	self
 		replace: '``@rcvr nextPutAll: ``@object1 , ``@object2' with: '``@rcvr nextPutAll: ``@object1; nextPutAll: ``@object2';
 		replace: '``@rcvr show: ``@object1 , ``@object2' with: '``@rcvr show: ``@object1; show: ``@object2'
-]
-
-{ #category : 'accessing' }
-ReCascadedNextPutAllsRule >> name [
-	^ 'Use cascaded nextPutAll:''s instead of #, in #nextPutAll:'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReCascadedNextPutAllsRule.class.st
+++ b/src/General-Rules/ReCascadedNextPutAllsRule.class.st
@@ -19,15 +19,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCascadedNextPutAllsRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReCascadedNextPutAllsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'CascadedNextPutAllsRule'
-]
-
-{ #category : 'accessing' }
-ReCascadedNextPutAllsRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReCascadedNextPutAllsRule.class.st
+++ b/src/General-Rules/ReCascadedNextPutAllsRule.class.st
@@ -24,6 +24,11 @@ ReCascadedNextPutAllsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReCascadedNextPutAllsRule class >> rationale [
+	^ 'Use cascaded nextPutAll:''s instead of #, in #nextPutAll:.'
+]
+
+{ #category : 'accessing' }
 ReCascadedNextPutAllsRule class >> ruleName [
 	^ 'Use cascaded nextPutAll:''s instead of #, in #nextPutAll:'
 ]
@@ -41,9 +46,4 @@ ReCascadedNextPutAllsRule >> initialize [
 	self
 		replace: '``@rcvr nextPutAll: ``@object1 , ``@object2' with: '``@rcvr nextPutAll: ``@object1; nextPutAll: ``@object2';
 		replace: '``@rcvr show: ``@object1 , ``@object2' with: '``@rcvr show: ``@object1; show: ``@object2'
-]
-
-{ #category : 'accessing' }
-ReCascadedNextPutAllsRule >> rationale [
-	^ 'Use cascaded nextPutAll:''s instead of #, in #nextPutAll:.'
 ]

--- a/src/General-Rules/ReClassNameInSelectorRule.class.st
+++ b/src/General-Rules/ReClassNameInSelectorRule.class.st
@@ -22,6 +22,11 @@ ReClassNameInSelectorRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReClassNameInSelectorRule class >> ruleName [
+	^ 'Redundant class name in selector'
+]
+
+{ #category : 'accessing' }
 ReClassNameInSelectorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -53,11 +58,6 @@ ReClassNameInSelectorRule >> critiqueFor: aMethod withInterval: anInterval [
 			entity: aMethod
 			interval: anInterval)
 		by: self
-]
-
-{ #category : 'accessing' }
-ReClassNameInSelectorRule >> name [
-	^ 'Redundant class name in selector'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassNameInSelectorRule.class.st
+++ b/src/General-Rules/ReClassNameInSelectorRule.class.st
@@ -22,6 +22,11 @@ ReClassNameInSelectorRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReClassNameInSelectorRule class >> rationale [
+	^ 'Checks for the class name in a selector. This is redundant since to call the you must already refer to the class name. For example, openHierarchyBrowserFrom: is a redundant name for HierarchyBrowser. Avoiding selector including class name gives a chance to have more polymorphic methods.'
+]
+
+{ #category : 'accessing' }
 ReClassNameInSelectorRule class >> ruleName [
 	^ 'Redundant class name in selector'
 ]
@@ -58,9 +63,4 @@ ReClassNameInSelectorRule >> critiqueFor: aMethod withInterval: anInterval [
 			entity: aMethod
 			interval: anInterval)
 		by: self
-]
-
-{ #category : 'accessing' }
-ReClassNameInSelectorRule >> rationale [
-	^ 'Checks for the class name in a selector. This is redundant since to call the you must already refer to the class name. For example, openHierarchyBrowserFrom: is a redundant name for HierarchyBrowser. Avoiding selector including class name gives a chance to have more polymorphic methods.'
 ]

--- a/src/General-Rules/ReClassNameInSelectorRule.class.st
+++ b/src/General-Rules/ReClassNameInSelectorRule.class.st
@@ -17,6 +17,11 @@ ReClassNameInSelectorRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReClassNameInSelectorRule class >> group [
+	^ 'Style'
+]
+
+{ #category : 'accessing' }
 ReClassNameInSelectorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -48,11 +53,6 @@ ReClassNameInSelectorRule >> critiqueFor: aMethod withInterval: anInterval [
 			entity: aMethod
 			interval: anInterval)
 		by: self
-]
-
-{ #category : 'accessing' }
-ReClassNameInSelectorRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassNotCategorizedRule.class.st
+++ b/src/General-Rules/ReClassNotCategorizedRule.class.st
@@ -33,6 +33,12 @@ ReClassNotCategorizedRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReClassNotCategorizedRule class >> severity [
+
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReClassNotCategorizedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -45,10 +51,4 @@ ReClassNotCategorizedRule >> basicCheck: aClass [
 	aClass isMeta ifTrue: [ ^ false ].
 
 	^ aClass packageTag isRoot and: [ aClass package tags size > 1 ]
-]
-
-{ #category : 'accessing' }
-ReClassNotCategorizedRule >> severity [
-
-	^ #information
 ]

--- a/src/General-Rules/ReClassNotCategorizedRule.class.st
+++ b/src/General-Rules/ReClassNotCategorizedRule.class.st
@@ -23,6 +23,11 @@ ReClassNotCategorizedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReClassNotCategorizedRule class >> rationale [
+	^ 'Classes should be categorized with a tag if other class tags exist in the package. Use "Base" as default if you can not provide a better name.'
+]
+
+{ #category : 'accessing' }
 ReClassNotCategorizedRule class >> ruleName [
 	^ 'Uncategorized class - missing class tag'
 ]
@@ -40,11 +45,6 @@ ReClassNotCategorizedRule >> basicCheck: aClass [
 	aClass isMeta ifTrue: [ ^ false ].
 
 	^ aClass packageTag isRoot and: [ aClass package tags size > 1 ]
-]
-
-{ #category : 'accessing' }
-ReClassNotCategorizedRule >> rationale [
-	^ 'Classes should be categorized with a tag if other class tags exist in the package. Use "Base" as default if you can not provide a better name.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassNotCategorizedRule.class.st
+++ b/src/General-Rules/ReClassNotCategorizedRule.class.st
@@ -23,6 +23,11 @@ ReClassNotCategorizedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReClassNotCategorizedRule class >> ruleName [
+	^ 'Uncategorized class - missing class tag'
+]
+
+{ #category : 'accessing' }
 ReClassNotCategorizedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -35,12 +40,6 @@ ReClassNotCategorizedRule >> basicCheck: aClass [
 	aClass isMeta ifTrue: [ ^ false ].
 
 	^ aClass packageTag isRoot and: [ aClass package tags size > 1 ]
-]
-
-{ #category : 'accessing' }
-ReClassNotCategorizedRule >> name [
-
-	^ 'Uncategorized class - missing class tag'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassNotCategorizedRule.class.st
+++ b/src/General-Rules/ReClassNotCategorizedRule.class.st
@@ -18,6 +18,11 @@ ReClassNotCategorizedRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReClassNotCategorizedRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReClassNotCategorizedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReClassNotCategorizedRule >> basicCheck: aClass [
 	aClass isMeta ifTrue: [ ^ false ].
 
 	^ aClass packageTag isRoot and: [ aClass package tags size > 1 ]
-]
-
-{ #category : 'accessing' }
-ReClassNotCategorizedRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassNotReferencedRule.class.st
+++ b/src/General-Rules/ReClassNotReferencedRule.class.st
@@ -15,6 +15,11 @@ ReClassNotReferencedRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReClassNotReferencedRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReClassNotReferencedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -24,11 +29,6 @@ ReClassNotReferencedRule class >> uniqueIdentifierName [
 { #category : 'enumerating' }
 ReClassNotReferencedRule >> basicCheck: aClass [
 	^ aClass isUsed not
-]
-
-{ #category : 'accessing' }
-ReClassNotReferencedRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassNotReferencedRule.class.st
+++ b/src/General-Rules/ReClassNotReferencedRule.class.st
@@ -30,6 +30,11 @@ ReClassNotReferencedRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReClassNotReferencedRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReClassNotReferencedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -39,9 +44,4 @@ ReClassNotReferencedRule class >> uniqueIdentifierName [
 { #category : 'enumerating' }
 ReClassNotReferencedRule >> basicCheck: aClass [
 	^ aClass isUsed not
-]
-
-{ #category : 'accessing' }
-ReClassNotReferencedRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReClassNotReferencedRule.class.st
+++ b/src/General-Rules/ReClassNotReferencedRule.class.st
@@ -20,6 +20,11 @@ ReClassNotReferencedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReClassNotReferencedRule class >> ruleName [
+	^ 'Class not referenced'
+]
+
+{ #category : 'accessing' }
 ReClassNotReferencedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -29,11 +34,6 @@ ReClassNotReferencedRule class >> uniqueIdentifierName [
 { #category : 'enumerating' }
 ReClassNotReferencedRule >> basicCheck: aClass [
 	^ aClass isUsed not
-]
-
-{ #category : 'accessing' }
-ReClassNotReferencedRule >> name [
-	^ 'Class not referenced'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassNotReferencedRule.class.st
+++ b/src/General-Rules/ReClassNotReferencedRule.class.st
@@ -20,6 +20,11 @@ ReClassNotReferencedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReClassNotReferencedRule class >> rationale [
+	^ 'Check if a class is referenced either directly or indirectly by a symbol. If a class is not referenced, it can be removed.'
+]
+
+{ #category : 'accessing' }
 ReClassNotReferencedRule class >> ruleName [
 	^ 'Class not referenced'
 ]
@@ -34,11 +39,6 @@ ReClassNotReferencedRule class >> uniqueIdentifierName [
 { #category : 'enumerating' }
 ReClassNotReferencedRule >> basicCheck: aClass [
 	^ aClass isUsed not
-]
-
-{ #category : 'accessing' }
-ReClassNotReferencedRule >> rationale [
-	^ 'Check if a class is referenced either directly or indirectly by a symbol. If a class is not referenced, it can be removed.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassVariableCapitalizationRule.class.st
+++ b/src/General-Rules/ReClassVariableCapitalizationRule.class.st
@@ -14,6 +14,11 @@ ReClassVariableCapitalizationRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReClassVariableCapitalizationRule class >> group [
+	^ 'Style'
+]
+
 { #category : 'running' }
 ReClassVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlock [
 	aClass isMeta ifTrue: [ ^ self ].
@@ -43,11 +48,6 @@ ReClassVariableCapitalizationRule >> critiqueFor: aClass about: aVarName [
 				in: aClass).
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReClassVariableCapitalizationRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassVariableCapitalizationRule.class.st
+++ b/src/General-Rules/ReClassVariableCapitalizationRule.class.st
@@ -19,6 +19,11 @@ ReClassVariableCapitalizationRule class >> group [
 	^ 'Style'
 ]
 
+{ #category : 'accessing' }
+ReClassVariableCapitalizationRule class >> ruleName [
+	^ 'Class (or pool) variable not capitalized'
+]
+
 { #category : 'running' }
 ReClassVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlock [
 	aClass isMeta ifTrue: [ ^ self ].
@@ -48,9 +53,4 @@ ReClassVariableCapitalizationRule >> critiqueFor: aClass about: aVarName [
 				in: aClass).
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReClassVariableCapitalizationRule >> name [
-	^ 'Class (or pool) variable not capitalized'
 ]

--- a/src/General-Rules/ReClassVariableNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReClassVariableNeitherReadNorWrittenRule.class.st
@@ -16,6 +16,11 @@ ReClassVariableNeitherReadNorWrittenRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReClassVariableNeitherReadNorWrittenRule class >> group [
+	^ 'Clean Code'
+]
+
 { #category : 'running' }
 ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -24,11 +29,6 @@ ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriti
 			variable definingClass pragmas anySatisfy: [ :pragma |
 				pragma selector = #ignoreUnusedClassVariables: and: [ (pragma argumentAt: 1) includes: variable name ] ] ]
 		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
-]
-
-{ #category : 'accessing' }
-ReClassVariableNeitherReadNorWrittenRule >> group [
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassVariableNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReClassVariableNeitherReadNorWrittenRule.class.st
@@ -21,6 +21,11 @@ ReClassVariableNeitherReadNorWrittenRule class >> group [
 	^ 'Clean Code'
 ]
 
+{ #category : 'accessing' }
+ReClassVariableNeitherReadNorWrittenRule class >> ruleName [
+	^ 'Class variable not read or not written'
+]
+
 { #category : 'running' }
 ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -29,12 +34,6 @@ ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriti
 			variable definingClass pragmas anySatisfy: [ :pragma |
 				pragma selector = #ignoreUnusedClassVariables: and: [ (pragma argumentAt: 1) includes: variable name ] ] ]
 		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
-]
-
-{ #category : 'accessing' }
-ReClassVariableNeitherReadNorWrittenRule >> name [
-
-	^ 'Class variable not read or not written'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassVariableNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReClassVariableNeitherReadNorWrittenRule.class.st
@@ -26,6 +26,11 @@ ReClassVariableNeitherReadNorWrittenRule class >> ruleName [
 	^ 'Class variable not read or not written'
 ]
 
+{ #category : 'accessing' }
+ReClassVariableNeitherReadNorWrittenRule class >> severity [
+	^ #information
+]
+
 { #category : 'running' }
 ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -34,11 +39,6 @@ ReClassVariableNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriti
 			variable definingClass pragmas anySatisfy: [ :pragma |
 				pragma selector = #ignoreUnusedClassVariables: and: [ (pragma argumentAt: 1) includes: variable name ] ] ]
 		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
-]
-
-{ #category : 'accessing' }
-ReClassVariableNeitherReadNorWrittenRule >> severity [
-	^ #information
 ]
 
 { #category : 'running' }

--- a/src/General-Rules/ReClassVariablesShadowingRule.class.st
+++ b/src/General-Rules/ReClassVariablesShadowingRule.class.st
@@ -15,17 +15,17 @@ ReClassVariablesShadowingRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReClassVariablesShadowingRule class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'running' }
 ReClassVariablesShadowingRule >> check: aClass forCritiquesDo: aCriticBlock [
 
 	aClass definedVariables
 		select: [ :variable | variable isShadowing ]
 		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
-]
-
-{ #category : 'accessing' }
-ReClassVariablesShadowingRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReClassVariablesShadowingRule.class.st
+++ b/src/General-Rules/ReClassVariablesShadowingRule.class.st
@@ -20,15 +20,15 @@ ReClassVariablesShadowingRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReClassVariablesShadowingRule class >> ruleName [
+	^ 'Variable shadows a global variable'
+]
+
 { #category : 'running' }
 ReClassVariablesShadowingRule >> check: aClass forCritiquesDo: aCriticBlock [
 
 	aClass definedVariables
 		select: [ :variable | variable isShadowing ]
 		thenDo: [ :variable | aCriticBlock cull: (self critiqueFor: aClass about: variable name) ]
-]
-
-{ #category : 'accessing' }
-ReClassVariablesShadowingRule >> name [
-	^ 'Variable shadows a global variable'
 ]

--- a/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
+++ b/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
@@ -15,6 +15,11 @@ ReCodeCruftLeftInMethodsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReCodeCruftLeftInMethodsRule class >> rationale [
+	^ 'Breakpoints, logging statements, etc. should not be left in production code.'
+]
+
+{ #category : 'accessing' }
 ReCodeCruftLeftInMethodsRule class >> ruleName [
 	^ 'Debugging code left in methods'
 ]
@@ -110,11 +115,6 @@ ReCodeCruftLeftInMethodsRule >> patternForKeywordSelector: selector [
 { #category : 'private' }
 ReCodeCruftLeftInMethodsRule >> patterns [
 	^ self debuggingPatterns, self haltPatterns
-]
-
-{ #category : 'accessing' }
-ReCodeCruftLeftInMethodsRule >> rationale [
-	^ 'Breakpoints, logging statements, etc. should not be left in production code.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
+++ b/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCodeCruftLeftInMethodsRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReCodeCruftLeftInMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -49,11 +54,6 @@ ReCodeCruftLeftInMethodsRule >> debuggingPatterns [
 ReCodeCruftLeftInMethodsRule >> debuggingSelectors [
 
 	^ Object allSelectorsInProtocol: 'flagging'
-]
-
-{ #category : 'accessing' }
-ReCodeCruftLeftInMethodsRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
+++ b/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
@@ -15,6 +15,11 @@ ReCodeCruftLeftInMethodsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReCodeCruftLeftInMethodsRule class >> ruleName [
+	^ 'Debugging code left in methods'
+]
+
+{ #category : 'accessing' }
 ReCodeCruftLeftInMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -76,11 +81,6 @@ ReCodeCruftLeftInMethodsRule >> haltSelectors [
 ReCodeCruftLeftInMethodsRule >> initialize [
 	super initialize.
 	self patterns do: [ :halt | self addRuleRemoving: halt ]
-]
-
-{ #category : 'accessing' }
-ReCodeCruftLeftInMethodsRule >> name [
-	^ 'Debugging code left in methods'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
+++ b/src/General-Rules/ReCodeCruftLeftInMethodsRule.class.st
@@ -25,6 +25,11 @@ ReCodeCruftLeftInMethodsRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReCodeCruftLeftInMethodsRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReCodeCruftLeftInMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -115,9 +120,4 @@ ReCodeCruftLeftInMethodsRule >> patternForKeywordSelector: selector [
 { #category : 'private' }
 ReCodeCruftLeftInMethodsRule >> patterns [
 	^ self debuggingPatterns, self haltPatterns
-]
-
-{ #category : 'accessing' }
-ReCodeCruftLeftInMethodsRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReCollectSelectNotUsedRule.class.st
+++ b/src/General-Rules/ReCollectSelectNotUsedRule.class.st
@@ -17,6 +17,11 @@ ReCollectSelectNotUsedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReCollectSelectNotUsedRule class >> ruleName [
+	^ 'Doesn''t use the result of a collect:/select:'
+]
+
+{ #category : 'accessing' }
 ReCollectSelectNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -28,9 +33,4 @@ ReCollectSelectNotUsedRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^ false ].
 	(#(#select: #collect: #reject:) includes: aNode selector) ifFalse: [ ^ false ].
 	^ aNode isUsedAsReturnValue not
-]
-
-{ #category : 'accessing' }
-ReCollectSelectNotUsedRule >> name [
-	^ 'Doesn''t use the result of a collect:/select:'
 ]

--- a/src/General-Rules/ReCollectSelectNotUsedRule.class.st
+++ b/src/General-Rules/ReCollectSelectNotUsedRule.class.st
@@ -12,6 +12,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCollectSelectNotUsedRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReCollectSelectNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -23,11 +28,6 @@ ReCollectSelectNotUsedRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^ false ].
 	(#(#select: #collect: #reject:) includes: aNode selector) ifFalse: [ ^ false ].
 	^ aNode isUsedAsReturnValue not
-]
-
-{ #category : 'accessing' }
-ReCollectSelectNotUsedRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReCollectionAtCollectionSizeRule.class.st
+++ b/src/General-Rules/ReCollectionAtCollectionSizeRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCollectionAtCollectionSizeRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReCollectionAtCollectionSizeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ReCollectionAtCollectionSizeRule'
-]
-
-{ #category : 'accessing' }
-ReCollectionAtCollectionSizeRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReCollectionAtCollectionSizeRule.class.st
+++ b/src/General-Rules/ReCollectionAtCollectionSizeRule.class.st
@@ -15,6 +15,11 @@ ReCollectionAtCollectionSizeRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReCollectionAtCollectionSizeRule class >> ruleName [
+	^ 'Uses "collection at: collection size" instead of "collection last"'
+]
+
+{ #category : 'accessing' }
 ReCollectionAtCollectionSizeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,9 +30,4 @@ ReCollectionAtCollectionSizeRule class >> uniqueIdentifierName [
 ReCollectionAtCollectionSizeRule >> initialize [
 	super initialize.
 	self  matchesAny: #('`@collection at: `@collection size')
-]
-
-{ #category : 'accessing' }
-ReCollectionAtCollectionSizeRule >> name [
-	^ 'Uses "collection at: collection size" instead of "collection last"'
 ]

--- a/src/General-Rules/ReCollectionCopyEmptyRule.class.st
+++ b/src/General-Rules/ReCollectionCopyEmptyRule.class.st
@@ -20,6 +20,11 @@ ReCollectionCopyEmptyRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReCollectionCopyEmptyRule class >> ruleName [
+	^ 'Subclass of collection that has instance variable but doesn''t define copyEmpty'
+]
+
+{ #category : 'accessing' }
 ReCollectionCopyEmptyRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -29,9 +34,4 @@ ReCollectionCopyEmptyRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReCollectionCopyEmptyRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: Collection) and: [ aClass isVariable and: [ (aClass includesSelector: #copyEmpty) not and: [ aClass instVarNames isNotEmpty ] ] ]
-]
-
-{ #category : 'accessing' }
-ReCollectionCopyEmptyRule >> name [
-	^ 'Subclass of collection that has instance variable but doesn''t define copyEmpty'
 ]

--- a/src/General-Rules/ReCollectionCopyEmptyRule.class.st
+++ b/src/General-Rules/ReCollectionCopyEmptyRule.class.st
@@ -15,6 +15,11 @@ ReCollectionCopyEmptyRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReCollectionCopyEmptyRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReCollectionCopyEmptyRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -24,11 +29,6 @@ ReCollectionCopyEmptyRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReCollectionCopyEmptyRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: Collection) and: [ aClass isVariable and: [ (aClass includesSelector: #copyEmpty) not and: [ aClass instVarNames isNotEmpty ] ] ]
-]
-
-{ #category : 'accessing' }
-ReCollectionCopyEmptyRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReCollectionMessagesToExternalObjectRule.class.st
+++ b/src/General-Rules/ReCollectionMessagesToExternalObjectRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCollectionMessagesToExternalObjectRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReCollectionMessagesToExternalObjectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -27,11 +32,6 @@ ReCollectionMessagesToExternalObjectRule >> afterCheck: aNode mappings: mappingD
 	collectionOwner isVariable ifFalse: [ ^ true ].
 	"ignore for all global vars and self and super"
 	^ (aNode scope lookupVar: collectionOwner name) scope ~= Smalltalk globals
-]
-
-{ #category : 'accessing' }
-ReCollectionMessagesToExternalObjectRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReCollectionMessagesToExternalObjectRule.class.st
+++ b/src/General-Rules/ReCollectionMessagesToExternalObjectRule.class.st
@@ -15,6 +15,11 @@ ReCollectionMessagesToExternalObjectRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReCollectionMessagesToExternalObjectRule class >> ruleName [
+	^ 'Sends add:/remove: to external collection'
+]
+
+{ #category : 'accessing' }
 ReCollectionMessagesToExternalObjectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -43,9 +48,4 @@ ReCollectionMessagesToExternalObjectRule >> initialize [
 		'(`@collectionOwner `@collectionGetter: `@args) addAll:       `@arg'
 		'(`@collectionOwner `@collectionGetter: `@args) removeAll: `@arg'
 		)
-]
-
-{ #category : 'accessing' }
-ReCollectionMessagesToExternalObjectRule >> name [
-	^ 'Sends add:/remove: to external collection'
 ]

--- a/src/General-Rules/ReCollectionProtocolRule.class.st
+++ b/src/General-Rules/ReCollectionProtocolRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReCollectionProtocolRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReCollectionProtocolRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'CollectionProtocolRule'
-]
-
-{ #category : 'accessing' }
-ReCollectionProtocolRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReCollectionProtocolRule.class.st
+++ b/src/General-Rules/ReCollectionProtocolRule.class.st
@@ -15,6 +15,11 @@ ReCollectionProtocolRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReCollectionProtocolRule class >> ruleName [
+	^ 'Uses do: instead of collect: or select:''s'
+]
+
+{ #category : 'accessing' }
 ReCollectionProtocolRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,9 +47,4 @@ ReCollectionProtocolRule >> initialize [
 					`@object add: `each.
 					`@.BlockStatements2].
 			`@.Statements2]' )
-]
-
-{ #category : 'accessing' }
-ReCollectionProtocolRule >> name [
-	^ 'Uses do: instead of collect: or select:''s'
 ]

--- a/src/General-Rules/ReDeadBlockRule.class.st
+++ b/src/General-Rules/ReDeadBlockRule.class.st
@@ -16,6 +16,12 @@ ReDeadBlockRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReDeadBlockRule class >> rationale [
+	^ 'Dead Block. The block is not assigned, not returned and no message is send to it.
+Often this is a left over from using blocks to comment out code.'
+]
+
+{ #category : 'accessing' }
 ReDeadBlockRule class >> ruleName [
 	^ 'Dead Block'
 ]
@@ -30,12 +36,6 @@ ReDeadBlockRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReDeadBlockRule >> basicCheck: node [
 	^ node isBlock and: [ node isUsedAsReturnValue not ]
-]
-
-{ #category : 'accessing' }
-ReDeadBlockRule >> rationale [
-	^ 'Dead Block. The block is not assigned, not returned and no message is send to it.
-Often this is a left over from using blocks to comment out code.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDeadBlockRule.class.st
+++ b/src/General-Rules/ReDeadBlockRule.class.st
@@ -27,6 +27,11 @@ ReDeadBlockRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReDeadBlockRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReDeadBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -36,9 +41,4 @@ ReDeadBlockRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReDeadBlockRule >> basicCheck: node [
 	^ node isBlock and: [ node isUsedAsReturnValue not ]
-]
-
-{ #category : 'accessing' }
-ReDeadBlockRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReDeadBlockRule.class.st
+++ b/src/General-Rules/ReDeadBlockRule.class.st
@@ -16,6 +16,11 @@ ReDeadBlockRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReDeadBlockRule class >> ruleName [
+	^ 'Dead Block'
+]
+
+{ #category : 'accessing' }
 ReDeadBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ ReDeadBlockRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReDeadBlockRule >> basicCheck: node [
 	^ node isBlock and: [ node isUsedAsReturnValue not ]
-]
-
-{ #category : 'accessing' }
-ReDeadBlockRule >> name [
-	^ 'Dead Block'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDeadBlockRule.class.st
+++ b/src/General-Rules/ReDeadBlockRule.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReDeadBlockRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReDeadBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -20,11 +25,6 @@ ReDeadBlockRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReDeadBlockRule >> basicCheck: node [
 	^ node isBlock and: [ node isUsedAsReturnValue not ]
-]
-
-{ #category : 'accessing' }
-ReDeadBlockRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDefineBasicCheckRule.class.st
+++ b/src/General-Rules/ReDefineBasicCheckRule.class.st
@@ -18,6 +18,11 @@ ReDefineBasicCheckRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReDefineBasicCheckRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
 { #category : 'running' }
 ReDefineBasicCheckRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: RBLintRule) and: [ aClass isVisible and: [ (aClass lookupSelector: #basicCheck:) isSubclassResponsibility ] ]
@@ -30,11 +35,6 @@ ReDefineBasicCheckRule >> critiqueFor: aClass [
 		by: self
 		class: aClass
 		selector: #basicCheck:) beShouldBeImplemented
-]
-
-{ #category : 'accessing' }
-ReDefineBasicCheckRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDefineBasicCheckRule.class.st
+++ b/src/General-Rules/ReDefineBasicCheckRule.class.st
@@ -23,6 +23,11 @@ ReDefineBasicCheckRule class >> group [
 	^ 'Coding Idiom Violation'
 ]
 
+{ #category : 'accessing' }
+ReDefineBasicCheckRule class >> ruleName [
+	^ 'Rule does not define #basicCheck:'
+]
+
 { #category : 'running' }
 ReDefineBasicCheckRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: RBLintRule) and: [ aClass isVisible and: [ (aClass lookupSelector: #basicCheck:) isSubclassResponsibility ] ]
@@ -35,9 +40,4 @@ ReDefineBasicCheckRule >> critiqueFor: aClass [
 		by: self
 		class: aClass
 		selector: #basicCheck:) beShouldBeImplemented
-]
-
-{ #category : 'accessing' }
-ReDefineBasicCheckRule >> name [
-	^ 'Rule does not define #basicCheck:'
 ]

--- a/src/General-Rules/ReDefineEntityComplianceCheckRule.class.st
+++ b/src/General-Rules/ReDefineEntityComplianceCheckRule.class.st
@@ -14,9 +14,22 @@ ReDefineEntityComplianceCheckRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'properties' }
+ReDefineEntityComplianceCheckRule class >> complianceMethods [
+
+	^ #(checksMethod checksClass checksPackage)
+]
+
 { #category : 'accessing' }
 ReDefineEntityComplianceCheckRule class >> group [
 	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
+ReDefineEntityComplianceCheckRule class >> rationale [
+
+	^ 'You should override on the CLASS SIDE at least one of #' , (self complianceMethods joinUsing: ', #')
+	  , ' methods to return true and so indicate which entities can be checked by your rule.'
 ]
 
 { #category : 'accessing' }
@@ -31,14 +44,5 @@ ReDefineEntityComplianceCheckRule >> basicCheck: aClass [
 
 { #category : 'properties' }
 ReDefineEntityComplianceCheckRule >> complianceMethods [
-
-	^ #(checksMethod checksClass checksPackage)
-]
-
-{ #category : 'accessing' }
-ReDefineEntityComplianceCheckRule >> rationale [
-
-	^ 'You should override on the CLASS SIDE at least one of #',
-	  (self complianceMethods joinUsing: ', #'),
-	  ' methods to return true and so indicate which entities can be checked by your rule.'
+	^ self class complianceMethods
 ]

--- a/src/General-Rules/ReDefineEntityComplianceCheckRule.class.st
+++ b/src/General-Rules/ReDefineEntityComplianceCheckRule.class.st
@@ -14,6 +14,11 @@ ReDefineEntityComplianceCheckRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReDefineEntityComplianceCheckRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
 { #category : 'running' }
 ReDefineEntityComplianceCheckRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: RBLintRule) and: [ aClass isVisible and: [ self complianceMethods noneSatisfy: [ :method | aClass perform: method ] ] ]
@@ -23,11 +28,6 @@ ReDefineEntityComplianceCheckRule >> basicCheck: aClass [
 ReDefineEntityComplianceCheckRule >> complianceMethods [
 
 	^ #(checksMethod checksClass checksPackage)
-]
-
-{ #category : 'accessing' }
-ReDefineEntityComplianceCheckRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDefineEntityComplianceCheckRule.class.st
+++ b/src/General-Rules/ReDefineEntityComplianceCheckRule.class.st
@@ -19,6 +19,11 @@ ReDefineEntityComplianceCheckRule class >> group [
 	^ 'Coding Idiom Violation'
 ]
 
+{ #category : 'accessing' }
+ReDefineEntityComplianceCheckRule class >> ruleName [
+	^ 'Rule does not define entity compliance'
+]
+
 { #category : 'running' }
 ReDefineEntityComplianceCheckRule >> basicCheck: aClass [
 	^ (aClass inheritsFrom: RBLintRule) and: [ aClass isVisible and: [ self complianceMethods noneSatisfy: [ :method | aClass perform: method ] ] ]
@@ -28,11 +33,6 @@ ReDefineEntityComplianceCheckRule >> basicCheck: aClass [
 ReDefineEntityComplianceCheckRule >> complianceMethods [
 
 	^ #(checksMethod checksClass checksPackage)
-]
-
-{ #category : 'accessing' }
-ReDefineEntityComplianceCheckRule >> name [
-	^ 'Rule does not define entity compliance'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDefinesEqualNotHashRule.class.st
+++ b/src/General-Rules/ReDefinesEqualNotHashRule.class.st
@@ -30,6 +30,11 @@ ReDefinesEqualNotHashRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReDefinesEqualNotHashRule class >> ruleName [
+	^ 'Defines = but not hash'
+]
+
+{ #category : 'accessing' }
 ReDefinesEqualNotHashRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -39,9 +44,4 @@ ReDefinesEqualNotHashRule class >> uniqueIdentifierName [
 { #category : 'enumerating' }
 ReDefinesEqualNotHashRule >> basicCheck: aClass [
 	^ (aClass includesSelector: #=) and: [ (aClass includesSelector: #hash) not ]
-]
-
-{ #category : 'accessing' }
-ReDefinesEqualNotHashRule >> name [
-	^ 'Defines = but not hash'
 ]

--- a/src/General-Rules/ReDefinesEqualNotHashRule.class.st
+++ b/src/General-Rules/ReDefinesEqualNotHashRule.class.st
@@ -25,6 +25,11 @@ ReDefinesEqualNotHashRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReDefinesEqualNotHashRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReDefinesEqualNotHashRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -34,11 +39,6 @@ ReDefinesEqualNotHashRule class >> uniqueIdentifierName [
 { #category : 'enumerating' }
 ReDefinesEqualNotHashRule >> basicCheck: aClass [
 	^ (aClass includesSelector: #=) and: [ (aClass includesSelector: #hash) not ]
-]
-
-{ #category : 'accessing' }
-ReDefinesEqualNotHashRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDeprecateWithFirstCharacterDownshiftedRule.class.st
+++ b/src/General-Rules/ReDeprecateWithFirstCharacterDownshiftedRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReDeprecateWithFirstCharacterDownshiftedRule class >> group [
+	^ 'Style'
+]
+
+{ #category : 'accessing' }
 ReDeprecateWithFirstCharacterDownshiftedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'FirstCharacterDownShifted'
-]
-
-{ #category : 'accessing' }
-ReDeprecateWithFirstCharacterDownshiftedRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReDeprecateWithFirstCharacterDownshiftedRule.class.st
+++ b/src/General-Rules/ReDeprecateWithFirstCharacterDownshiftedRule.class.st
@@ -15,6 +15,11 @@ ReDeprecateWithFirstCharacterDownshiftedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReDeprecateWithFirstCharacterDownshiftedRule class >> ruleName [
+	^ 'Use uncapitalized instead of withFirstCharacterDownshifted'
+]
+
+{ #category : 'accessing' }
 ReDeprecateWithFirstCharacterDownshiftedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -26,9 +31,4 @@ ReDeprecateWithFirstCharacterDownshiftedRule >> initialize [
 	super initialize.
 	self
 		replace: '``@object withFirstCharacterDownshifted' with: '``@object uncapitalized'
-]
-
-{ #category : 'accessing' }
-ReDeprecateWithFirstCharacterDownshiftedRule >> name [
-	^ 'Use uncapitalized instead of withFirstCharacterDownshifted'
 ]

--- a/src/General-Rules/ReDetectContainsRule.class.st
+++ b/src/General-Rules/ReDetectContainsRule.class.st
@@ -15,6 +15,11 @@ ReDetectContainsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReDetectContainsRule class >> ruleName [
+	^ 'Uses do: instead of contains: or detect:''s'
+]
+
+{ #category : 'accessing' }
 ReDetectContainsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -49,9 +54,4 @@ ReDetectContainsRule >> initialize [
 				`@.Statements1.
 				`@condition ifTrue: [| `@BlockTemps | `@.BlockStatements1.  ^false].
 				`@.Statements2]' )
-]
-
-{ #category : 'accessing' }
-ReDetectContainsRule >> name [
-	^ 'Uses do: instead of contains: or detect:''s'
 ]

--- a/src/General-Rules/ReDetectContainsRule.class.st
+++ b/src/General-Rules/ReDetectContainsRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReDetectContainsRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReDetectContainsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DetectContainsRule'
-]
-
-{ #category : 'accessing' }
-ReDetectContainsRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReDetectIfNoneRule.class.st
+++ b/src/General-Rules/ReDetectIfNoneRule.class.st
@@ -26,6 +26,11 @@ ReDetectIfNoneRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReDetectIfNoneRule class >> ruleName [
+	^ '#detect:ifNone: or #contains: -> #anySatisfy:'
+]
+
+{ #category : 'accessing' }
 ReDetectIfNoneRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -56,11 +61,6 @@ ReDetectIfNoneRule >> initialize [
 
 		replace: '(``@collection detect: [:`each | | `@temps | ``@.Statements] ifNone: [nil]) ~~ nil'
 		with: '``@collection anySatisfy: [:`each | | `@temps | ``@.Statements]'
-]
-
-{ #category : 'accessing' }
-ReDetectIfNoneRule >> name [
-	^ '#detect:ifNone: or #contains: -> #anySatisfy:'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReDetectIfNoneRule.class.st
+++ b/src/General-Rules/ReDetectIfNoneRule.class.st
@@ -21,15 +21,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReDetectIfNoneRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReDetectIfNoneRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DetectIfNoneRule'
-]
-
-{ #category : 'accessing' }
-ReDetectIfNoneRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReDetectIfNoneRule.class.st
+++ b/src/General-Rules/ReDetectIfNoneRule.class.st
@@ -26,6 +26,11 @@ ReDetectIfNoneRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReDetectIfNoneRule class >> rationale [
+	^ 'Replaces detect:ifNone: and contains: by anySatisfy:'
+]
+
+{ #category : 'accessing' }
 ReDetectIfNoneRule class >> ruleName [
 	^ '#detect:ifNone: or #contains: -> #anySatisfy:'
 ]
@@ -61,9 +66,4 @@ ReDetectIfNoneRule >> initialize [
 
 		replace: '(``@collection detect: [:`each | | `@temps | ``@.Statements] ifNone: [nil]) ~~ nil'
 		with: '``@collection anySatisfy: [:`each | | `@temps | ``@.Statements]'
-]
-
-{ #category : 'accessing' }
-ReDetectIfNoneRule >> rationale [
-	^ 'Replaces detect:ifNone: and contains: by anySatisfy:'
 ]

--- a/src/General-Rules/ReDoNotSendSuperInitializeInClassSideRule.class.st
+++ b/src/General-Rules/ReDoNotSendSuperInitializeInClassSideRule.class.st
@@ -20,15 +20,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReDoNotSendSuperInitializeInClassSideRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReDoNotSendSuperInitializeInClassSideRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'DoNotSendSuperInitializeInClassSideRule'
-]
-
-{ #category : 'accessing' }
-ReDoNotSendSuperInitializeInClassSideRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReDoNotSendSuperInitializeInClassSideRule.class.st
+++ b/src/General-Rules/ReDoNotSendSuperInitializeInClassSideRule.class.st
@@ -25,6 +25,11 @@ ReDoNotSendSuperInitializeInClassSideRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReDoNotSendSuperInitializeInClassSideRule class >> ruleName [
+	^ 'Class-side #initialize should not send "super initialize".'
+]
+
+{ #category : 'accessing' }
 ReDoNotSendSuperInitializeInClassSideRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReDoNotSendSuperInitializeInClassSideRule >> initialize [
 	self
 		replace: 'super initialize'
 		with: ''
-]
-
-{ #category : 'accessing' }
-ReDoNotSendSuperInitializeInClassSideRule >> name [
-	^ 'Class-side #initialize should not send "super initialize".'
 ]
 
 { #category : 'testing' }

--- a/src/General-Rules/ReEmptyExceptionHandlerRule.class.st
+++ b/src/General-Rules/ReEmptyExceptionHandlerRule.class.st
@@ -21,6 +21,11 @@ ReEmptyExceptionHandlerRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReEmptyExceptionHandlerRule class >> ruleName [
+	^ 'Empty exception handler'
+]
+
+{ #category : 'accessing' }
 ReEmptyExceptionHandlerRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -47,9 +52,4 @@ ReEmptyExceptionHandlerRule >> initialize [
 		'`@block
 			on: `exception
 			do: [ :`@err | | `@temps | ]'
-]
-
-{ #category : 'accessing' }
-ReEmptyExceptionHandlerRule >> name [
-	^ 'Empty exception handler'
 ]

--- a/src/General-Rules/ReEmptyExceptionHandlerRule.class.st
+++ b/src/General-Rules/ReEmptyExceptionHandlerRule.class.st
@@ -16,6 +16,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReEmptyExceptionHandlerRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReEmptyExceptionHandlerRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,11 +38,6 @@ ReEmptyExceptionHandlerRule >> afterCheck: aNode mappings: mappingDict [
 	(class includesBehavior: Notification) ifTrue: [ ^false ].
 
 	^ true
-]
-
-{ #category : 'accessing' }
-ReEmptyExceptionHandlerRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReEqualNilRule.class.st
+++ b/src/General-Rules/ReEqualNilRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReEqualNilRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReEqualNilRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'EqualNilRule'
-]
-
-{ #category : 'accessing' }
-ReEqualNilRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReEqualNilRule.class.st
+++ b/src/General-Rules/ReEqualNilRule.class.st
@@ -15,6 +15,11 @@ ReEqualNilRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReEqualNilRule class >> ruleName [
+	^ '= nil -> isNil AND ~= nil -> isNotNil'
+]
+
+{ #category : 'accessing' }
 ReEqualNilRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -29,9 +34,4 @@ ReEqualNilRule >> initialize [
 		replace: '``@object == nil' with: '``@object isNil';
 		replace: '``@object ~= nil' with: '``@object isNotNil';
 		replace: '``@object ~~ nil' with: '``@object isNotNil'
-]
-
-{ #category : 'accessing' }
-ReEqualNilRule >> name [
-	^ '= nil -> isNil AND ~= nil -> isNotNil'
 ]

--- a/src/General-Rules/ReEqualNotUsedRule.class.st
+++ b/src/General-Rules/ReEqualNotUsedRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReEqualNotUsedRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReEqualNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -19,11 +24,6 @@ ReEqualNotUsedRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReEqualNotUsedRule >> basicCheck: node [
 	^ node isMessage and: [ node isUsedAsReturnValue not and: [ #(#= #== #~= #~~ #< #> #<= #>=) includes: node selector ] ]
-]
-
-{ #category : 'accessing' }
-ReEqualNotUsedRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReEqualNotUsedRule.class.st
+++ b/src/General-Rules/ReEqualNotUsedRule.class.st
@@ -15,6 +15,11 @@ ReEqualNotUsedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReEqualNotUsedRule class >> ruleName [
+	^ 'Doesn''t use the result of a =, ~=, etc.'
+]
+
+{ #category : 'accessing' }
 ReEqualNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -24,9 +29,4 @@ ReEqualNotUsedRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReEqualNotUsedRule >> basicCheck: node [
 	^ node isMessage and: [ node isUsedAsReturnValue not and: [ #(#= #== #~= #~~ #< #> #<= #>=) includes: node selector ] ]
-]
-
-{ #category : 'accessing' }
-ReEqualNotUsedRule >> name [
-	^ 'Doesn''t use the result of a =, ~=, etc.'
 ]

--- a/src/General-Rules/ReEqualsTrueRule.class.st
+++ b/src/General-Rules/ReEqualsTrueRule.class.st
@@ -15,6 +15,11 @@ ReEqualsTrueRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReEqualsTrueRule class >> ruleName [
+	^ 'Unnecessary "= true"'
+]
+
+{ #category : 'accessing' }
 ReEqualsTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -29,11 +34,6 @@ ReEqualsTrueRule >> basicCheck: aNode [
 	(parent := aNode parent) ifNil: [ ^ false ].
 	parent isMessage ifFalse: [ ^ false ].
 	^ #(#= #== #~= #~~) includes: parent selector
-]
-
-{ #category : 'accessing' }
-ReEqualsTrueRule >> name [
-	^ 'Unnecessary "= true"'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReEqualsTrueRule.class.st
+++ b/src/General-Rules/ReEqualsTrueRule.class.st
@@ -20,6 +20,11 @@ ReEqualsTrueRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReEqualsTrueRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReEqualsTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -34,9 +39,4 @@ ReEqualsTrueRule >> basicCheck: aNode [
 	(parent := aNode parent) ifNil: [ ^ false ].
 	parent isMessage ifFalse: [ ^ false ].
 	^ #(#= #== #~= #~~) includes: parent selector
-]
-
-{ #category : 'accessing' }
-ReEqualsTrueRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReEqualsTrueRule.class.st
+++ b/src/General-Rules/ReEqualsTrueRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReEqualsTrueRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReEqualsTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -24,11 +29,6 @@ ReEqualsTrueRule >> basicCheck: aNode [
 	(parent := aNode parent) ifNil: [ ^ false ].
 	parent isMessage ifFalse: [ ^ false ].
 	^ #(#= #== #~= #~~) includes: parent selector
-]
-
-{ #category : 'accessing' }
-ReEqualsTrueRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReEquivalentSuperclassMethodsRule.class.st
+++ b/src/General-Rules/ReEquivalentSuperclassMethodsRule.class.st
@@ -22,6 +22,11 @@ ReEquivalentSuperclassMethodsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReEquivalentSuperclassMethodsRule class >> rationale [
+	^ 'Check for methods that are equivalent to their superclass methods.'
+]
+
+{ #category : 'accessing' }
 ReEquivalentSuperclassMethodsRule class >> ruleName [
 	^ 'Methods equivalently defined in superclass'
 ]
@@ -48,9 +53,4 @@ ReEquivalentSuperclassMethodsRule >> ignoredSelectors [
 	"These methods are often overridden for compatilbity with other platforms."
 
 	^ #(new initialize)
-]
-
-{ #category : 'accessing' }
-ReEquivalentSuperclassMethodsRule >> rationale [
-	^ 'Check for methods that are equivalent to their superclass methods.'
 ]

--- a/src/General-Rules/ReEquivalentSuperclassMethodsRule.class.st
+++ b/src/General-Rules/ReEquivalentSuperclassMethodsRule.class.st
@@ -17,6 +17,11 @@ ReEquivalentSuperclassMethodsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReEquivalentSuperclassMethodsRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReEquivalentSuperclassMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -31,11 +36,6 @@ ReEquivalentSuperclassMethodsRule >> basicCheck: aMethod [
 	^ aMethod overriddenMethod
 		  ifNotNil: [ :overridenMethod | aMethod equivalentTo: overridenMethod ]
 		  ifNil: [ false ]
-]
-
-{ #category : 'accessing' }
-ReEquivalentSuperclassMethodsRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReEquivalentSuperclassMethodsRule.class.st
+++ b/src/General-Rules/ReEquivalentSuperclassMethodsRule.class.st
@@ -22,6 +22,11 @@ ReEquivalentSuperclassMethodsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReEquivalentSuperclassMethodsRule class >> ruleName [
+	^ 'Methods equivalently defined in superclass'
+]
+
+{ #category : 'accessing' }
 ReEquivalentSuperclassMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -43,11 +48,6 @@ ReEquivalentSuperclassMethodsRule >> ignoredSelectors [
 	"These methods are often overridden for compatilbity with other platforms."
 
 	^ #(new initialize)
-]
-
-{ #category : 'accessing' }
-ReEquivalentSuperclassMethodsRule >> name [
-	^ 'Methods equivalently defined in superclass'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExcessiveArgumentsRule.class.st
+++ b/src/General-Rules/ReExcessiveArgumentsRule.class.st
@@ -24,6 +24,11 @@ ReExcessiveArgumentsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReExcessiveArgumentsRule class >> rationale [
+	^ 'Long argument lists (five or more) can indicate that a new object should be created to wrap the numerous parameters.'
+]
+
+{ #category : 'accessing' }
 ReExcessiveArgumentsRule class >> ruleName [
 	^ 'Excessive number of arguments'
 ]
@@ -47,9 +52,4 @@ ReExcessiveArgumentsRule >> basicCheck: aMethod [
 	aMethod isFFIMethod ifTrue: [ ^false ].
 
 	^ aMethod numArgs >= self argumentsCount
-]
-
-{ #category : 'accessing' }
-ReExcessiveArgumentsRule >> rationale [
-	^ 'Long argument lists (five or more) can indicate that a new object should be created to wrap the numerous parameters.'
 ]

--- a/src/General-Rules/ReExcessiveArgumentsRule.class.st
+++ b/src/General-Rules/ReExcessiveArgumentsRule.class.st
@@ -19,6 +19,11 @@ ReExcessiveArgumentsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReExcessiveArgumentsRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReExcessiveArgumentsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReExcessiveArgumentsRule >> basicCheck: aMethod [
 	aMethod isFFIMethod ifTrue: [ ^false ].
 
 	^ aMethod numArgs >= self argumentsCount
-]
-
-{ #category : 'accessing' }
-ReExcessiveArgumentsRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExcessiveArgumentsRule.class.st
+++ b/src/General-Rules/ReExcessiveArgumentsRule.class.st
@@ -24,6 +24,11 @@ ReExcessiveArgumentsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReExcessiveArgumentsRule class >> ruleName [
+	^ 'Excessive number of arguments'
+]
+
+{ #category : 'accessing' }
 ReExcessiveArgumentsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,11 +47,6 @@ ReExcessiveArgumentsRule >> basicCheck: aMethod [
 	aMethod isFFIMethod ifTrue: [ ^false ].
 
 	^ aMethod numArgs >= self argumentsCount
-]
-
-{ #category : 'accessing' }
-ReExcessiveArgumentsRule >> name [
-	^ 'Excessive number of arguments'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExcessiveInheritanceRule.class.st
+++ b/src/General-Rules/ReExcessiveInheritanceRule.class.st
@@ -23,6 +23,11 @@ ReExcessiveInheritanceRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReExcessiveInheritanceRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReExcessiveInheritanceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -34,11 +39,6 @@ ReExcessiveInheritanceRule >> basicCheck: aClass [
 	aClass isMeta ifTrue: [ ^ false ].
 
 	^ aClass allSuperclasses size >= self inheritanceDepth
-]
-
-{ #category : 'accessing' }
-ReExcessiveInheritanceRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReExcessiveInheritanceRule.class.st
+++ b/src/General-Rules/ReExcessiveInheritanceRule.class.st
@@ -28,6 +28,11 @@ ReExcessiveInheritanceRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReExcessiveInheritanceRule class >> ruleName [
+	^ 'Excessive inheritance depth'
+]
+
+{ #category : 'accessing' }
 ReExcessiveInheritanceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -44,11 +49,6 @@ ReExcessiveInheritanceRule >> basicCheck: aClass [
 { #category : 'private' }
 ReExcessiveInheritanceRule >> inheritanceDepth [
 	^ 10
-]
-
-{ #category : 'accessing' }
-ReExcessiveInheritanceRule >> name [
-	^ 'Excessive inheritance depth'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExcessiveInheritanceRule.class.st
+++ b/src/General-Rules/ReExcessiveInheritanceRule.class.st
@@ -28,6 +28,11 @@ ReExcessiveInheritanceRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReExcessiveInheritanceRule class >> rationale [
+	^ 'Deep inheritance (10+ depth) is usually a sign of a design flaw.'
+]
+
+{ #category : 'accessing' }
 ReExcessiveInheritanceRule class >> ruleName [
 	^ 'Excessive inheritance depth'
 ]
@@ -49,9 +54,4 @@ ReExcessiveInheritanceRule >> basicCheck: aClass [
 { #category : 'private' }
 ReExcessiveInheritanceRule >> inheritanceDepth [
 	^ 10
-]
-
-{ #category : 'accessing' }
-ReExcessiveInheritanceRule >> rationale [
-	^ 'Deep inheritance (10+ depth) is usually a sign of a design flaw.'
 ]

--- a/src/General-Rules/ReExcessiveMethodsRule.class.st
+++ b/src/General-Rules/ReExcessiveMethodsRule.class.st
@@ -21,6 +21,11 @@ ReExcessiveMethodsRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReExcessiveMethodsRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReExcessiveMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReExcessiveMethodsRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReExcessiveMethodsRule >> basicCheck: aClass [
 	^ aClass selectors size >= self methodsCount
-]
-
-{ #category : 'accessing' }
-ReExcessiveMethodsRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReExcessiveMethodsRule.class.st
+++ b/src/General-Rules/ReExcessiveMethodsRule.class.st
@@ -26,6 +26,11 @@ ReExcessiveMethodsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReExcessiveMethodsRule class >> ruleName [
+	^ 'Excessive number of methods'
+]
+
+{ #category : 'accessing' }
 ReExcessiveMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -40,11 +45,6 @@ ReExcessiveMethodsRule >> basicCheck: aClass [
 { #category : 'private' }
 ReExcessiveMethodsRule >> methodsCount [
 	^ 60
-]
-
-{ #category : 'accessing' }
-ReExcessiveMethodsRule >> name [
-	^ 'Excessive number of methods'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExcessiveMethodsRule.class.st
+++ b/src/General-Rules/ReExcessiveMethodsRule.class.st
@@ -26,6 +26,11 @@ ReExcessiveMethodsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReExcessiveMethodsRule class >> rationale [
+	^ 'Large classes are indications that the class may be trying to do too much.'
+]
+
+{ #category : 'accessing' }
 ReExcessiveMethodsRule class >> ruleName [
 	^ 'Excessive number of methods'
 ]
@@ -45,9 +50,4 @@ ReExcessiveMethodsRule >> basicCheck: aClass [
 { #category : 'private' }
 ReExcessiveMethodsRule >> methodsCount [
 	^ 60
-]
-
-{ #category : 'accessing' }
-ReExcessiveMethodsRule >> rationale [
-	^ 'Large classes are indications that the class may be trying to do too much.'
 ]

--- a/src/General-Rules/ReExcessiveVariablesRule.class.st
+++ b/src/General-Rules/ReExcessiveVariablesRule.class.st
@@ -22,6 +22,11 @@ ReExcessiveVariablesRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReExcessiveVariablesRule class >> ruleName [
+	^ 'Excessive number of variables'
+]
+
+{ #category : 'accessing' }
 ReExcessiveVariablesRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,11 +38,6 @@ ReExcessiveVariablesRule >> basicCheck: aClass [
 	^ aClass instVarNames size >= self variablesCount or: [
 		"Shared pools are just there to define vars, so it is ok for them to have a lot"
 		(aClass instanceSide isPool not) and: [aClass classVarNames size >= self variablesCount ]]
-]
-
-{ #category : 'accessing' }
-ReExcessiveVariablesRule >> name [
-	^ 'Excessive number of variables'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExcessiveVariablesRule.class.st
+++ b/src/General-Rules/ReExcessiveVariablesRule.class.st
@@ -22,6 +22,11 @@ ReExcessiveVariablesRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReExcessiveVariablesRule class >> rationale [
+	^ 'Classes that have too many instance variables (10+) could be redesigned to have fewer fields, possibly through some nested object grouping.'
+]
+
+{ #category : 'accessing' }
 ReExcessiveVariablesRule class >> ruleName [
 	^ 'Excessive number of variables'
 ]
@@ -38,11 +43,6 @@ ReExcessiveVariablesRule >> basicCheck: aClass [
 	^ aClass instVarNames size >= self variablesCount or: [
 		"Shared pools are just there to define vars, so it is ok for them to have a lot"
 		(aClass instanceSide isPool not) and: [aClass classVarNames size >= self variablesCount ]]
-]
-
-{ #category : 'accessing' }
-ReExcessiveVariablesRule >> rationale [
-	^ 'Classes that have too many instance variables (10+) could be redesigned to have fewer fields, possibly through some nested object grouping.'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReExcessiveVariablesRule.class.st
+++ b/src/General-Rules/ReExcessiveVariablesRule.class.st
@@ -17,6 +17,11 @@ ReExcessiveVariablesRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReExcessiveVariablesRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReExcessiveVariablesRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -28,11 +33,6 @@ ReExcessiveVariablesRule >> basicCheck: aClass [
 	^ aClass instVarNames size >= self variablesCount or: [
 		"Shared pools are just there to define vars, so it is ok for them to have a lot"
 		(aClass instanceSide isPool not) and: [aClass classVarNames size >= self variablesCount ]]
-]
-
-{ #category : 'accessing' }
-ReExcessiveVariablesRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExplicitRequirementMethodsRule.class.st
+++ b/src/General-Rules/ReExplicitRequirementMethodsRule.class.st
@@ -15,6 +15,11 @@ ReExplicitRequirementMethodsRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReExplicitRequirementMethodsRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReExplicitRequirementMethodsRule class >> uniqueIdentifierName [
 
 	^ 'ExplicitRequirementMethodsRule'
@@ -40,11 +45,6 @@ ReExplicitRequirementMethodsRule >> check: aClass forCritiquesDo: aCritiqueBlock
 					((self critiqueFor: aClass)
 						tinyHint: method selector;
 						yourself) ]
-]
-
-{ #category : 'accessing' }
-ReExplicitRequirementMethodsRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExplicitRequirementMethodsRule.class.st
+++ b/src/General-Rules/ReExplicitRequirementMethodsRule.class.st
@@ -20,6 +20,11 @@ ReExplicitRequirementMethodsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReExplicitRequirementMethodsRule class >> ruleName [
+	^ 'Explicit requirement methods'
+]
+
+{ #category : 'accessing' }
 ReExplicitRequirementMethodsRule class >> uniqueIdentifierName [
 
 	^ 'ExplicitRequirementMethodsRule'
@@ -45,9 +50,4 @@ ReExplicitRequirementMethodsRule >> check: aClass forCritiquesDo: aCritiqueBlock
 					((self critiqueFor: aClass)
 						tinyHint: method selector;
 						yourself) ]
-]
-
-{ #category : 'accessing' }
-ReExplicitRequirementMethodsRule >> name [
-	^ 'Explicit requirement methods'
 ]

--- a/src/General-Rules/ReExtraBlockRule.class.st
+++ b/src/General-Rules/ReExtraBlockRule.class.st
@@ -21,6 +21,11 @@ ReExtraBlockRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReExtraBlockRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReExtraBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -41,9 +46,4 @@ ReExtraBlockRule >> blockEvaluatingMessages [
 	value: value:value: value:value:value: value:value:value:value:
 	cull: cull:cull: cull:cull:cull: cull:cull:cull:cull:
 	#valueWithArguments: valueWithPossibleArgs: valueWithPossibleArgument)
-]
-
-{ #category : 'accessing' }
-ReExtraBlockRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReExtraBlockRule.class.st
+++ b/src/General-Rules/ReExtraBlockRule.class.st
@@ -16,6 +16,11 @@ ReExtraBlockRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReExtraBlockRule class >> ruleName [
+	^ 'Block immediately evaluated'
+]
+
+{ #category : 'accessing' }
 ReExtraBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -36,11 +41,6 @@ ReExtraBlockRule >> blockEvaluatingMessages [
 	value: value:value: value:value:value: value:value:value:value:
 	cull: cull:cull: cull:cull:cull: cull:cull:cull:cull:
 	#valueWithArguments: valueWithPossibleArgs: valueWithPossibleArgument)
-]
-
-{ #category : 'accessing' }
-ReExtraBlockRule >> name [
-	^ 'Block immediately evaluated'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReExtraBlockRule.class.st
+++ b/src/General-Rules/ReExtraBlockRule.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReExtraBlockRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReExtraBlockRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -31,11 +36,6 @@ ReExtraBlockRule >> blockEvaluatingMessages [
 	value: value:value: value:value:value: value:value:value:value:
 	cull: cull:cull: cull:cull:cull: cull:cull:cull:cull:
 	#valueWithArguments: valueWithPossibleArgs: valueWithPossibleArgument)
-]
-
-{ #category : 'accessing' }
-ReExtraBlockRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReFileBlocksRule.class.st
+++ b/src/General-Rules/ReFileBlocksRule.class.st
@@ -26,15 +26,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReFileBlocksRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReFileBlocksRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'FileBlocksRule'
-]
-
-{ #category : 'accessing' }
-ReFileBlocksRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReFileBlocksRule.class.st
+++ b/src/General-Rules/ReFileBlocksRule.class.st
@@ -31,6 +31,11 @@ ReFileBlocksRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReFileBlocksRule class >> rationale [
+	^ 'Checks assignment to a variable that is the first statement inside the value block that is also used in the unwind block.'
+]
+
+{ #category : 'accessing' }
 ReFileBlocksRule class >> ruleName [
 	^ 'Assignment inside unwind blocks should be outside.'
 ]
@@ -56,9 +61,4 @@ ReFileBlocksRule >> initialize [
 				`@.statements]
 						ifCurtailed:
 							[`var `@messages: `@args]' )
-]
-
-{ #category : 'accessing' }
-ReFileBlocksRule >> rationale [
-	^ 'Checks assignment to a variable that is the first statement inside the value block that is also used in the unwind block.'
 ]

--- a/src/General-Rules/ReFileBlocksRule.class.st
+++ b/src/General-Rules/ReFileBlocksRule.class.st
@@ -31,6 +31,11 @@ ReFileBlocksRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReFileBlocksRule class >> ruleName [
+	^ 'Assignment inside unwind blocks should be outside.'
+]
+
+{ #category : 'accessing' }
 ReFileBlocksRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -51,11 +56,6 @@ ReFileBlocksRule >> initialize [
 				`@.statements]
 						ifCurtailed:
 							[`var `@messages: `@args]' )
-]
-
-{ #category : 'accessing' }
-ReFileBlocksRule >> name [
-	^ 'Assignment inside unwind blocks should be outside.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReFloatEqualityComparisonRule.class.st
+++ b/src/General-Rules/ReFloatEqualityComparisonRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReFloatEqualityComparisonRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReFloatEqualityComparisonRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -19,11 +24,6 @@ ReFloatEqualityComparisonRule class >> uniqueIdentifierName [
 { #category : 'hooks' }
 ReFloatEqualityComparisonRule >> afterCheck: aNode mappings: mappingDict [
 	^ (mappingDict at: '`#floatLiteral') value isFloat
-]
-
-{ #category : 'accessing' }
-ReFloatEqualityComparisonRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReFloatEqualityComparisonRule.class.st
+++ b/src/General-Rules/ReFloatEqualityComparisonRule.class.st
@@ -15,6 +15,11 @@ ReFloatEqualityComparisonRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReFloatEqualityComparisonRule class >> ruleName [
+	^ 'Float equality comparison'
+]
+
+{ #category : 'accessing' }
 ReFloatEqualityComparisonRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -34,9 +39,4 @@ ReFloatEqualityComparisonRule >> initialize [
 			'`#floatLiteral ~= `@expr'
 			'`@expr = `#floatLiteral'
 			'`@expr ~= `#floatLiteral' )
-]
-
-{ #category : 'accessing' }
-ReFloatEqualityComparisonRule >> name [
-	^ 'Float equality comparison'
 ]

--- a/src/General-Rules/ReGlobalVariablesUsageRule.class.st
+++ b/src/General-Rules/ReGlobalVariablesUsageRule.class.st
@@ -21,6 +21,11 @@ ReGlobalVariablesUsageRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReGlobalVariablesUsageRule class >> ruleName [
+	^ 'Global variable usage'
+]
+
 { #category : 'running' }
 ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	aMethod ast allChildren
@@ -49,11 +54,6 @@ ReGlobalVariablesUsageRule >> isKnownGlobal: aString [
 			Undeclared
 			World
 		) includes: aString
-]
-
-{ #category : 'accessing' }
-ReGlobalVariablesUsageRule >> name [
-	^ 'Global variable usage'
 ]
 
 { #category : 'running' }

--- a/src/General-Rules/ReGlobalVariablesUsageRule.class.st
+++ b/src/General-Rules/ReGlobalVariablesUsageRule.class.st
@@ -22,6 +22,23 @@ ReGlobalVariablesUsageRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReGlobalVariablesUsageRule class >> rationale [
+	^ 'http://wiki.c2.com/?GlobalVariablesAreBad
+
+	Why Global Variables Should Be Avoided When Unnecessary
+
+    Non-locality -- Source code is easiest to understand when the scope of its individual elements are limited. Global variables can be read or modified by any part of the program, making it difficult to remember or reason about every possible use.
+    No Access Control or Constraint Checking -- A global variable can be get or set by any part of the program, and any rules regarding its use can be easily broken or forgotten. (In other words, get/set accessors are generally preferable over direct data access, and this is even more so for global data.) By extension, the lack of access control greatly hinders achieving security in situations where you may wish to run untrusted code (such as working with 3rd party plugins).
+    Implicit coupling -- A program with many global variables often has tight couplings between some of those variables, and couplings between variables and functions. Grouping coupled items into cohesive units usually leads to better programs.
+    Concurrency issues -- if globals can be accessed by multiple threads of execution, synchronization is necessary (and too-often neglected). When dynamically linking modules with globals, the composed system might not be thread-safe even if the two independent modules tested in dozens of different contexts were safe.
+    Namespace pollution -- Global names are available everywhere. You may unknowingly end up using a global when you think you are using a local (by misspelling or forgetting to declare the local) or vice versa. Also, if you ever have to link together modules that have the same global variable names, if you are lucky, you will get linking errors. If you are unlucky, the linker will simply treat all uses of the same name as the same object.
+    Memory allocation issues -- Some environments have memory allocation schemes that make allocation of globals tricky. This is especially true in languages where "constructors" have side-effects other than allocation (because, in that case, you can express unsafe situations where two globals mutually depend on one another). Also, when dynamically linking modules, it can be unclear whether different libraries have their own instances of globals or whether the globals are shared.
+    Testing and Confinement - source that utilizes globals is somewhat more difficult to test because one cannot readily set up a ''clean'' environment between runs. More generally, source that utilizes global services of any sort (e.g. reading and writing files or databases) that aren''t explicitly provided to that source is difficult to test for the same reason. For communicating systems, the ability to test system invariants may require running more than one ''copy'' of a system simultaneously, which is greatly hindered by any use of shared services - including global memory - that are not provided for sharing as part of the test.
+
+	'
+]
+
+{ #category : 'accessing' }
 ReGlobalVariablesUsageRule class >> ruleName [
 	^ 'Global variable usage'
 ]
@@ -54,21 +71,4 @@ ReGlobalVariablesUsageRule >> isKnownGlobal: aString [
 			Undeclared
 			World
 		) includes: aString
-]
-
-{ #category : 'running' }
-ReGlobalVariablesUsageRule >> rationale [
-	^ 'http://wiki.c2.com/?GlobalVariablesAreBad
-
-	Why Global Variables Should Be Avoided When Unnecessary
-
-    Non-locality -- Source code is easiest to understand when the scope of its individual elements are limited. Global variables can be read or modified by any part of the program, making it difficult to remember or reason about every possible use.
-    No Access Control or Constraint Checking -- A global variable can be get or set by any part of the program, and any rules regarding its use can be easily broken or forgotten. (In other words, get/set accessors are generally preferable over direct data access, and this is even more so for global data.) By extension, the lack of access control greatly hinders achieving security in situations where you may wish to run untrusted code (such as working with 3rd party plugins).
-    Implicit coupling -- A program with many global variables often has tight couplings between some of those variables, and couplings between variables and functions. Grouping coupled items into cohesive units usually leads to better programs.
-    Concurrency issues -- if globals can be accessed by multiple threads of execution, synchronization is necessary (and too-often neglected). When dynamically linking modules with globals, the composed system might not be thread-safe even if the two independent modules tested in dozens of different contexts were safe.
-    Namespace pollution -- Global names are available everywhere. You may unknowingly end up using a global when you think you are using a local (by misspelling or forgetting to declare the local) or vice versa. Also, if you ever have to link together modules that have the same global variable names, if you are lucky, you will get linking errors. If you are unlucky, the linker will simply treat all uses of the same name as the same object.
-    Memory allocation issues -- Some environments have memory allocation schemes that make allocation of globals tricky. This is especially true in languages where "constructors" have side-effects other than allocation (because, in that case, you can express unsafe situations where two globals mutually depend on one another). Also, when dynamically linking modules, it can be unclear whether different libraries have their own instances of globals or whether the globals are shared.
-    Testing and Confinement - source that utilizes globals is somewhat more difficult to test because one cannot readily set up a ''clean'' environment between runs. More generally, source that utilizes global services of any sort (e.g. reading and writing files or databases) that aren''t explicitly provided to that source is difficult to test for the same reason. For communicating systems, the ability to test system invariants may require running more than one ''copy'' of a system simultaneously, which is greatly hindered by any use of shared services - including global memory - that are not provided for sharing as part of the test.
-
-	'
 ]

--- a/src/General-Rules/ReGlobalVariablesUsageRule.class.st
+++ b/src/General-Rules/ReGlobalVariablesUsageRule.class.st
@@ -16,6 +16,11 @@ ReGlobalVariablesUsageRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReGlobalVariablesUsageRule class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'running' }
 ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	aMethod ast allChildren
@@ -28,11 +33,6 @@ ReGlobalVariablesUsageRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				createTrivialCritiqueOn: aMethod
 				intervalOf: node
 				hint: node name) ]
-]
-
-{ #category : 'running' }
-ReGlobalVariablesUsageRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'testing' }

--- a/src/General-Rules/ReGuardClauseRule.class.st
+++ b/src/General-Rules/ReGuardClauseRule.class.st
@@ -27,7 +27,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReGuardClauseRule >> group [
+ReGuardClauseRule class >> group [
 	^ 'Coding Idiom Violation'
 ]
 

--- a/src/General-Rules/ReGuardClauseRule.class.st
+++ b/src/General-Rules/ReGuardClauseRule.class.st
@@ -31,6 +31,11 @@ ReGuardClauseRule class >> group [
 	^ 'Coding Idiom Violation'
 ]
 
+{ #category : 'accessing' }
+ReGuardClauseRule class >> ruleName [
+	^ 'Replace single branch conditional with guard clause'
+]
+
 { #category : 'initialization' }
 ReGuardClauseRule >> initialize [
 	super initialize.
@@ -57,9 +62,4 @@ ReGuardClauseRule >> initialize [
 					`.Statement1.
 					`.Statement2.
 					`@.Statements1'
-]
-
-{ #category : 'accessing' }
-ReGuardClauseRule >> name [
-	^ 'Replace single branch conditional with guard clause'
 ]

--- a/src/General-Rules/ReIfNotNilDoRule.class.st
+++ b/src/General-Rules/ReIfNotNilDoRule.class.st
@@ -15,6 +15,11 @@ ReIfNotNilDoRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReIfNotNilDoRule class >> ruleName [
+	^ 'Use "ifNotNil:" not "ifNotNilDo:"'
+]
+
+{ #category : 'accessing' }
 ReIfNotNilDoRule class >> uniqueIdentifierName [
 
 	^ 'RuleIfNotNilDo'
@@ -30,9 +35,4 @@ ReIfNotNilDoRule >> initialize [
 			with: '`@receiver ifNotNil: `@statements1 ifNil: `@statements2';
 		replace: '`@receiver ifNil: `@statements1 ifNotNilDo: `@statements2'
 			with: '`@receiver ifNil: `@statements1 ifNotNil: `@statements2'
-]
-
-{ #category : 'accessing' }
-ReIfNotNilDoRule >> name [
-	^ 'Use "ifNotNil:" not "ifNotNilDo:"'
 ]

--- a/src/General-Rules/ReIfNotNilDoRule.class.st
+++ b/src/General-Rules/ReIfNotNilDoRule.class.st
@@ -10,14 +10,14 @@ Class {
 }
 
 { #category : 'accessing' }
-ReIfNotNilDoRule class >> uniqueIdentifierName [
-
-	^ 'RuleIfNotNilDo'
+ReIfNotNilDoRule class >> group [
+	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }
-ReIfNotNilDoRule >> group [
-	^ 'Coding Idiom Violation'
+ReIfNotNilDoRule class >> uniqueIdentifierName [
+
+	^ 'RuleIfNotNilDo'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReIfTrueIfFalseUselessRule.class.st
+++ b/src/General-Rules/ReIfTrueIfFalseUselessRule.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReIfTrueIfFalseUselessRule >> group [
+ReIfTrueIfFalseUselessRule class >> group [
 
 	^ 'Design Flaws'
 ]

--- a/src/General-Rules/ReIfTrueIfFalseUselessRule.class.st
+++ b/src/General-Rules/ReIfTrueIfFalseUselessRule.class.st
@@ -15,6 +15,11 @@ ReIfTrueIfFalseUselessRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReIfTrueIfFalseUselessRule class >> ruleName [
+	^ 'useless ifTrue:ifFalse:'
+]
+
 { #category : 'initialization' }
 ReIfTrueIfFalseUselessRule >> initialize [
 
@@ -24,10 +29,4 @@ ReIfTrueIfFalseUselessRule >> initialize [
 		with: '^ (`@condition)';
 		replace: ' (`@condition) ifFalse: [ ^ false ] ifTrue: [ ^ true ] '
 		with: '^ (`@condition)'
-]
-
-{ #category : 'accessing' }
-ReIfTrueIfFalseUselessRule >> name [ 
-
-^ 'useless ifTrue:ifFalse:'
 ]

--- a/src/General-Rules/ReImplementedNotSentRule.class.st
+++ b/src/General-Rules/ReImplementedNotSentRule.class.st
@@ -90,6 +90,11 @@ ReImplementedNotSentRule class >> reset [
 	allMessages := nil
 ]
 
+{ #category : 'accessing' }
+ReImplementedNotSentRule class >> ruleName [
+	^ 'Methods implemented but not sent'
+]
+
 { #category : 'cleanup' }
 ReImplementedNotSentRule class >> shutDown [
 	self reset
@@ -140,11 +145,6 @@ ReImplementedNotSentRule >> basicCheck: aMethod [
 						  occurrencesToFind := occurrencesToFind - 1.
 						  false ] ]
 			  ifFalse: [ false ] ]
-]
-
-{ #category : 'accessing' }
-ReImplementedNotSentRule >> name [
-	^ 'Methods implemented but not sent'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReImplementedNotSentRule.class.st
+++ b/src/General-Rules/ReImplementedNotSentRule.class.st
@@ -57,6 +57,11 @@ ReImplementedNotSentRule class >> enabled: aBoolean [
 		ifFalse: [ self unsubscribe ]
 ]
 
+{ #category : 'accessing' }
+ReImplementedNotSentRule class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'class initialization' }
 ReImplementedNotSentRule class >> initialize [
 	"we do not want to register if the rule is disabled"
@@ -135,11 +140,6 @@ ReImplementedNotSentRule >> basicCheck: aMethod [
 						  occurrencesToFind := occurrencesToFind - 1.
 						  false ] ]
 			  ifFalse: [ false ] ]
-]
-
-{ #category : 'accessing' }
-ReImplementedNotSentRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReImplementedNotSentRule.class.st
+++ b/src/General-Rules/ReImplementedNotSentRule.class.st
@@ -95,6 +95,11 @@ ReImplementedNotSentRule class >> ruleName [
 	^ 'Methods implemented but not sent'
 ]
 
+{ #category : 'accessing' }
+ReImplementedNotSentRule class >> severity [
+	^ #information
+]
+
 { #category : 'cleanup' }
 ReImplementedNotSentRule class >> shutDown [
 	self reset
@@ -145,9 +150,4 @@ ReImplementedNotSentRule >> basicCheck: aMethod [
 						  occurrencesToFind := occurrencesToFind - 1.
 						  false ] ]
 			  ifFalse: [ false ] ]
-]
-
-{ #category : 'accessing' }
-ReImplementedNotSentRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/General-Rules/ReInconsistentMethodClassificationRule.class.st
@@ -17,6 +17,11 @@ ReInconsistentMethodClassificationRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReInconsistentMethodClassificationRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReInconsistentMethodClassificationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -44,11 +49,6 @@ ReInconsistentMethodClassificationRule >> critiqueFor: aMethod [
 
 	^ (ReRefactoringCritique withAnchor: (self anchorFor: aMethod) by: self) refactoring:
 		  (RBMethodProtocolTransformation protocol: { aMethod overriddenMethod protocolName } inMethod: aMethod selector inClass: aMethod methodClass name)
-]
-
-{ #category : 'accessing' }
-ReInconsistentMethodClassificationRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/General-Rules/ReInconsistentMethodClassificationRule.class.st
@@ -27,6 +27,11 @@ ReInconsistentMethodClassificationRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReInconsistentMethodClassificationRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReInconsistentMethodClassificationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -54,9 +59,4 @@ ReInconsistentMethodClassificationRule >> critiqueFor: aMethod [
 
 	^ (ReRefactoringCritique withAnchor: (self anchorFor: aMethod) by: self) refactoring:
 		  (RBMethodProtocolTransformation protocol: { aMethod overriddenMethod protocolName } inMethod: aMethod selector inClass: aMethod methodClass name)
-]
-
-{ #category : 'accessing' }
-ReInconsistentMethodClassificationRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReInconsistentMethodClassificationRule.class.st
+++ b/src/General-Rules/ReInconsistentMethodClassificationRule.class.st
@@ -22,6 +22,11 @@ ReInconsistentMethodClassificationRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReInconsistentMethodClassificationRule class >> ruleName [
+	^ 'Inconsistent method classification'
+]
+
+{ #category : 'accessing' }
 ReInconsistentMethodClassificationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -49,11 +54,6 @@ ReInconsistentMethodClassificationRule >> critiqueFor: aMethod [
 
 	^ (ReRefactoringCritique withAnchor: (self anchorFor: aMethod) by: self) refactoring:
 		  (RBMethodProtocolTransformation protocol: { aMethod overriddenMethod protocolName } inMethod: aMethod selector inClass: aMethod methodClass name)
-]
-
-{ #category : 'accessing' }
-ReInconsistentMethodClassificationRule >> name [
-	^ 'Inconsistent method classification'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReInstVarInSubclassesRule.class.st
+++ b/src/General-Rules/ReInstVarInSubclassesRule.class.st
@@ -22,6 +22,11 @@ ReInstVarInSubclassesRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReInstVarInSubclassesRule class >> ruleName [
+	^ 'Same instance variable defined in ALL subclasses'
+]
+
+{ #category : 'accessing' }
 ReInstVarInSubclassesRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -55,11 +60,6 @@ ReInstVarInSubclassesRule >> critiqueFor: aClass [
 	^ ReRefactoringCritique
 			withAnchor: (self anchorFor: aClass)
 			by: self
-]
-
-{ #category : 'accessing' }
-ReInstVarInSubclassesRule >> name [
-	^ 'Same instance variable defined in ALL subclasses'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReInstVarInSubclassesRule.class.st
+++ b/src/General-Rules/ReInstVarInSubclassesRule.class.st
@@ -32,6 +32,11 @@ ReInstVarInSubclassesRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReInstVarInSubclassesRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReInstVarInSubclassesRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -65,9 +70,4 @@ ReInstVarInSubclassesRule >> critiqueFor: aClass [
 	^ ReRefactoringCritique
 			withAnchor: (self anchorFor: aClass)
 			by: self
-]
-
-{ #category : 'accessing' }
-ReInstVarInSubclassesRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReInstVarInSubclassesRule.class.st
+++ b/src/General-Rules/ReInstVarInSubclassesRule.class.st
@@ -22,6 +22,11 @@ ReInstVarInSubclassesRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReInstVarInSubclassesRule class >> rationale [
+	^ 'All subclasses of this class define the same variable. Most likely this variable should be pulled up to the superclass.'
+]
+
+{ #category : 'accessing' }
 ReInstVarInSubclassesRule class >> ruleName [
 	^ 'Same instance variable defined in ALL subclasses'
 ]
@@ -60,11 +65,6 @@ ReInstVarInSubclassesRule >> critiqueFor: aClass [
 	^ ReRefactoringCritique
 			withAnchor: (self anchorFor: aClass)
 			by: self
-]
-
-{ #category : 'accessing' }
-ReInstVarInSubclassesRule >> rationale [
-	^ 'All subclasses of this class define the same variable. Most likely this variable should be pulled up to the superclass.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReInstVarInSubclassesRule.class.st
+++ b/src/General-Rules/ReInstVarInSubclassesRule.class.st
@@ -17,6 +17,11 @@ ReInstVarInSubclassesRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReInstVarInSubclassesRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReInstVarInSubclassesRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -50,11 +55,6 @@ ReInstVarInSubclassesRule >> critiqueFor: aClass [
 	^ ReRefactoringCritique
 			withAnchor: (self anchorFor: aClass)
 			by: self
-]
-
-{ #category : 'accessing' }
-ReInstVarInSubclassesRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReInstanceVariableCapitalizationRule.class.st
+++ b/src/General-Rules/ReInstanceVariableCapitalizationRule.class.st
@@ -19,6 +19,11 @@ ReInstanceVariableCapitalizationRule class >> group [
 	^ 'Style'
 ]
 
+{ #category : 'accessing' }
+ReInstanceVariableCapitalizationRule class >> ruleName [
+	^ 'Instance variable capitalized'
+]
+
 { #category : 'running' }
 ReInstanceVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -46,9 +51,4 @@ ReInstanceVariableCapitalizationRule >> critiqueFor: aClass about: aVarName [
 				in: aClass).
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReInstanceVariableCapitalizationRule >> name [
-	^ 'Instance variable capitalized'
 ]

--- a/src/General-Rules/ReInstanceVariableCapitalizationRule.class.st
+++ b/src/General-Rules/ReInstanceVariableCapitalizationRule.class.st
@@ -14,6 +14,11 @@ ReInstanceVariableCapitalizationRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReInstanceVariableCapitalizationRule class >> group [
+	^ 'Style'
+]
+
 { #category : 'running' }
 ReInstanceVariableCapitalizationRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -41,11 +46,6 @@ ReInstanceVariableCapitalizationRule >> critiqueFor: aClass about: aVarName [
 				in: aClass).
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReInstanceVariableCapitalizationRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReIsNilAndConditionalRule.class.st
+++ b/src/General-Rules/ReIsNilAndConditionalRule.class.st
@@ -15,6 +15,11 @@ ReIsNilAndConditionalRule class >> group [
 	^ 'Coding Idiom Violation'
 ]
 
+{ #category : 'accessing' }
+ReIsNilAndConditionalRule class >> ruleName [
+	^ 'Sends isNil and a conditional check instead of using #ifNil: #ifNotNil: or #ifNil:ifNotNil:'
+]
+
 { #category : 'initialization' }
 ReIsNilAndConditionalRule >> initialize [
 
@@ -26,12 +31,6 @@ ReIsNilAndConditionalRule >> initialize [
 			with: '``@receiver ifNil: ``@nilBlock ifNotNil: ``@notNilBlock';
 		replace: '``@receiver isNil ifFalse: ``@notNilBlock ifTrue: ``@nilBlock'
 			with: '``@receiver ifNil: ``@nilBlock ifNotNil: ``@notNilBlock'
-]
-
-{ #category : 'accessing' }
-ReIsNilAndConditionalRule >> name [
-
-	^ 'Sends isNil and a conditional check instead of using #ifNil: #ifNotNil: or #ifNil:ifNotNil:'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReIsNilAndConditionalRule.class.st
+++ b/src/General-Rules/ReIsNilAndConditionalRule.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReIsNilAndConditionalRule >> group [
+ReIsNilAndConditionalRule class >> group [
 
 	^ 'Coding Idiom Violation'
 ]

--- a/src/General-Rules/ReIsNilAndConditionalRule.class.st
+++ b/src/General-Rules/ReIsNilAndConditionalRule.class.st
@@ -16,6 +16,13 @@ ReIsNilAndConditionalRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReIsNilAndConditionalRule class >> rationale [
+
+	^ 'Using specific conditional methods leads to shorter code and helps in avoiding unneeded temporary variables.<n><n>Replaces<n><t>isNil ifTrue: ~~> ifNil:<n><t>isNil ifFalse: ~~> ifNotNil:<n><t>isNil ifTrue:ifFalse ~~> ifNil:ifNotNil:'
+		expandMacros
+]
+
+{ #category : 'accessing' }
 ReIsNilAndConditionalRule class >> ruleName [
 	^ 'Sends isNil and a conditional check instead of using #ifNil: #ifNotNil: or #ifNil:ifNotNil:'
 ]
@@ -31,11 +38,4 @@ ReIsNilAndConditionalRule >> initialize [
 			with: '``@receiver ifNil: ``@nilBlock ifNotNil: ``@notNilBlock';
 		replace: '``@receiver isNil ifFalse: ``@notNilBlock ifTrue: ``@nilBlock'
 			with: '``@receiver ifNil: ``@nilBlock ifNotNil: ``@notNilBlock'
-]
-
-{ #category : 'accessing' }
-ReIsNilAndConditionalRule >> rationale [
-
-	^ 'Using specific conditional methods leads to shorter code and helps in avoiding unneeded temporary variables.<n><n>Replaces<n><t>isNil ifTrue: ~~> ifNil:<n><t>isNil ifFalse: ~~> ifNotNil:<n><t>isNil ifTrue:ifFalse ~~> ifNil:ifNotNil:'
-		expandMacros
 ]

--- a/src/General-Rules/ReIsNotNilAndConditionalRule.class.st
+++ b/src/General-Rules/ReIsNotNilAndConditionalRule.class.st
@@ -11,7 +11,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReIsNotNilAndConditionalRule >> group [
+ReIsNotNilAndConditionalRule class >> group [
 
 	^ 'Coding Idiom Violation'
 ]

--- a/src/General-Rules/ReIsNotNilAndConditionalRule.class.st
+++ b/src/General-Rules/ReIsNotNilAndConditionalRule.class.st
@@ -16,6 +16,11 @@ ReIsNotNilAndConditionalRule class >> group [
 	^ 'Coding Idiom Violation'
 ]
 
+{ #category : 'accessing' }
+ReIsNotNilAndConditionalRule class >> ruleName [
+	^ 'Sends isNotNil / notNil and a conditional check instead of using #ifNil: #ifNotNil: or #ifNil:ifNotNil:'
+]
+
 { #category : 'initialization' }
 ReIsNotNilAndConditionalRule >> initialize [
 
@@ -34,12 +39,6 @@ ReIsNotNilAndConditionalRule >> initialize [
 			with: '``@receiver ifNotNil: ``@nilBlock ifNil: ``@notNilBlock';
 		replace: '``@receiver notNil ifFalse: ``@notNilBlock ifTrue: ``@nilBlock'
 			with: '``@receiver ifNotNil: ``@nilBlock ifNil: ``@notNilBlock'
-]
-
-{ #category : 'accessing' }
-ReIsNotNilAndConditionalRule >> name [
-
-	^ 'Sends isNotNil / notNil and a conditional check instead of using #ifNil: #ifNotNil: or #ifNil:ifNotNil:'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReIsNotNilAndConditionalRule.class.st
+++ b/src/General-Rules/ReIsNotNilAndConditionalRule.class.st
@@ -17,6 +17,13 @@ ReIsNotNilAndConditionalRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReIsNotNilAndConditionalRule class >> rationale [
+
+	^ 'Using specific conditional methods leads to shorter code and helps in avoiding unneeded temporary variables.<n><n>Replaces<n><t>isNotNil ifTrue: ~~> ifNotNil:<n><t>isNotNil ifFalse: ~~> ifNil:<n><t>isNotNil ifTrue:ifFalse ~~> ifNotNil:ifNil:'
+		expandMacros
+]
+
+{ #category : 'accessing' }
 ReIsNotNilAndConditionalRule class >> ruleName [
 	^ 'Sends isNotNil / notNil and a conditional check instead of using #ifNil: #ifNotNil: or #ifNil:ifNotNil:'
 ]
@@ -39,11 +46,4 @@ ReIsNotNilAndConditionalRule >> initialize [
 			with: '``@receiver ifNotNil: ``@nilBlock ifNil: ``@notNilBlock';
 		replace: '``@receiver notNil ifFalse: ``@notNilBlock ifTrue: ``@nilBlock'
 			with: '``@receiver ifNotNil: ``@nilBlock ifNil: ``@notNilBlock'
-]
-
-{ #category : 'accessing' }
-ReIsNotNilAndConditionalRule >> rationale [
-
-	^ 'Using specific conditional methods leads to shorter code and helps in avoiding unneeded temporary variables.<n><n>Replaces<n><t>isNotNil ifTrue: ~~> ifNotNil:<n><t>isNotNil ifFalse: ~~> ifNil:<n><t>isNotNil ifTrue:ifFalse ~~> ifNotNil:ifNil:'
-		expandMacros
 ]

--- a/src/General-Rules/ReIvarNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReIvarNeitherReadNorWrittenRule.class.st
@@ -21,6 +21,11 @@ ReIvarNeitherReadNorWrittenRule class >> group [
 	^ 'Clean Code'
 ]
 
+{ #category : 'accessing' }
+ReIvarNeitherReadNorWrittenRule class >> ruleName [
+	^ 'Instance variable not read or not written'
+]
+
 { #category : 'running' }
 ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -29,12 +34,6 @@ ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 			slot isReferenced or: [
 				slot definingClass pragmas anySatisfy: [ :pragma | pragma selector = #ignoreUnusedVariables: and: [ (pragma argumentAt: 1) includes: slot name ] ] ] ]
 		thenDo: [ :slot | aCriticBlock cull: (self critiqueFor: aClass about: slot name) ]
-]
-
-{ #category : 'accessing' }
-ReIvarNeitherReadNorWrittenRule >> name [
-
-	^ 'Instance variable not read or not written'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReIvarNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReIvarNeitherReadNorWrittenRule.class.st
@@ -16,6 +16,11 @@ ReIvarNeitherReadNorWrittenRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReIvarNeitherReadNorWrittenRule class >> group [
+	^ 'Clean Code'
+]
+
 { #category : 'running' }
 ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -24,11 +29,6 @@ ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 			slot isReferenced or: [
 				slot definingClass pragmas anySatisfy: [ :pragma | pragma selector = #ignoreUnusedVariables: and: [ (pragma argumentAt: 1) includes: slot name ] ] ] ]
 		thenDo: [ :slot | aCriticBlock cull: (self critiqueFor: aClass about: slot name) ]
-]
-
-{ #category : 'accessing' }
-ReIvarNeitherReadNorWrittenRule >> group [
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReIvarNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReIvarNeitherReadNorWrittenRule.class.st
@@ -26,6 +26,11 @@ ReIvarNeitherReadNorWrittenRule class >> ruleName [
 	^ 'Instance variable not read or not written'
 ]
 
+{ #category : 'accessing' }
+ReIvarNeitherReadNorWrittenRule class >> severity [
+	^ #information
+]
+
 { #category : 'running' }
 ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -34,9 +39,4 @@ ReIvarNeitherReadNorWrittenRule >> check: aClass forCritiquesDo: aCriticBlock [
 			slot isReferenced or: [
 				slot definingClass pragmas anySatisfy: [ :pragma | pragma selector = #ignoreUnusedVariables: and: [ (pragma argumentAt: 1) includes: slot name ] ] ] ]
 		thenDo: [ :slot | aCriticBlock cull: (self critiqueFor: aClass about: slot name) ]
-]
-
-{ #category : 'accessing' }
-ReIvarNeitherReadNorWrittenRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReJustSendsSuperRule.class.st
+++ b/src/General-Rules/ReJustSendsSuperRule.class.st
@@ -18,6 +18,11 @@ ReJustSendsSuperRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReJustSendsSuperRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReJustSendsSuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,11 +38,6 @@ ReJustSendsSuperRule >> basicCheck: aMethod [
 	aMethod pragmas ifNotEmpty: [ ^ false ].
 
 	^ matcher executeMethod: aMethod ast initialAnswer: false
-]
-
-{ #category : 'accessing' }
-ReJustSendsSuperRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReJustSendsSuperRule.class.st
+++ b/src/General-Rules/ReJustSendsSuperRule.class.st
@@ -33,6 +33,11 @@ ReJustSendsSuperRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReJustSendsSuperRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReJustSendsSuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -54,9 +59,4 @@ ReJustSendsSuperRule >> basicCheck: aMethod [
 ReJustSendsSuperRule >> initialize [
 	super initialize.
 	matcher := RBParseTreeSearcher justSendsSuper
-]
-
-{ #category : 'accessing' }
-ReJustSendsSuperRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReJustSendsSuperRule.class.st
+++ b/src/General-Rules/ReJustSendsSuperRule.class.st
@@ -23,6 +23,11 @@ ReJustSendsSuperRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReJustSendsSuperRule class >> rationale [
+	^ 'Check for methods that just forward the message to its superclass.'
+]
+
+{ #category : 'accessing' }
 ReJustSendsSuperRule class >> ruleName [
 	^ 'Method just sends super message'
 ]
@@ -49,11 +54,6 @@ ReJustSendsSuperRule >> basicCheck: aMethod [
 ReJustSendsSuperRule >> initialize [
 	super initialize.
 	matcher := RBParseTreeSearcher justSendsSuper
-]
-
-{ #category : 'accessing' }
-ReJustSendsSuperRule >> rationale [
-	^ 'Check for methods that just forward the message to its superclass.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReJustSendsSuperRule.class.st
+++ b/src/General-Rules/ReJustSendsSuperRule.class.st
@@ -23,6 +23,11 @@ ReJustSendsSuperRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReJustSendsSuperRule class >> ruleName [
+	^ 'Method just sends super message'
+]
+
+{ #category : 'accessing' }
 ReJustSendsSuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -44,11 +49,6 @@ ReJustSendsSuperRule >> basicCheck: aMethod [
 ReJustSendsSuperRule >> initialize [
 	super initialize.
 	matcher := RBParseTreeSearcher justSendsSuper
-]
-
-{ #category : 'accessing' }
-ReJustSendsSuperRule >> name [
-	^ 'Method just sends super message'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReKeysDoRule.class.st
+++ b/src/General-Rules/ReKeysDoRule.class.st
@@ -22,6 +22,11 @@ ReKeysDoRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReKeysDoRule class >> ruleName [
+	^ 'keys do: -> keysDo: and valuesDo:'
+]
+
+{ #category : 'accessing' }
 ReKeysDoRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -34,11 +39,6 @@ ReKeysDoRule >> initialize [
 	self
 		replace: '``@object keys do: ``@block' with: '``@object keysDo: ``@block';
 		replace: '``@object values do: ``@block' with: '``@object valuesDo: ``@block'
-]
-
-{ #category : 'accessing' }
-ReKeysDoRule >> name [
-	^ 'keys do: -> keysDo: and valuesDo:'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReKeysDoRule.class.st
+++ b/src/General-Rules/ReKeysDoRule.class.st
@@ -17,15 +17,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReKeysDoRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReKeysDoRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'keysDoRule'
-]
-
-{ #category : 'accessing' }
-ReKeysDoRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReKeysDoRule.class.st
+++ b/src/General-Rules/ReKeysDoRule.class.st
@@ -22,6 +22,11 @@ ReKeysDoRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReKeysDoRule class >> rationale [
+	^ 'The use of keysDo:/valuesDo: means one intermediate collection created less'
+]
+
+{ #category : 'accessing' }
 ReKeysDoRule class >> ruleName [
 	^ 'keys do: -> keysDo: and valuesDo:'
 ]
@@ -39,9 +44,4 @@ ReKeysDoRule >> initialize [
 	self
 		replace: '``@object keys do: ``@block' with: '``@object keysDo: ``@block';
 		replace: '``@object values do: ``@block' with: '``@object valuesDo: ``@block'
-]
-
-{ #category : 'accessing' }
-ReKeysDoRule >> rationale [
-	^ 'The use of keysDo:/valuesDo: means one intermediate collection created less'
 ]

--- a/src/General-Rules/ReLiteralArrayCharactersRule.class.st
+++ b/src/General-Rules/ReLiteralArrayCharactersRule.class.st
@@ -15,6 +15,11 @@ ReLiteralArrayCharactersRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReLiteralArrayCharactersRule class >> ruleName [
+	^ 'Literal array contains only characters'
+]
+
+{ #category : 'accessing' }
 ReLiteralArrayCharactersRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -26,9 +31,4 @@ ReLiteralArrayCharactersRule >> basicCheck: aNode [
 	aNode isLiteralArray ifFalse: [ ^ false ].
 	aNode value ifEmpty: [ ^ false ].
 	^ aNode value allSatisfy: #isCharacter
-]
-
-{ #category : 'accessing' }
-ReLiteralArrayCharactersRule >> name [
-	^ 'Literal array contains only characters'
 ]

--- a/src/General-Rules/ReLiteralArrayCharactersRule.class.st
+++ b/src/General-Rules/ReLiteralArrayCharactersRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReLiteralArrayCharactersRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReLiteralArrayCharactersRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -21,11 +26,6 @@ ReLiteralArrayCharactersRule >> basicCheck: aNode [
 	aNode isLiteralArray ifFalse: [ ^ false ].
 	aNode value ifEmpty: [ ^ false ].
 	^ aNode value allSatisfy: #isCharacter
-]
-
-{ #category : 'accessing' }
-ReLiteralArrayCharactersRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReLiteralArrayContainsCommaRule.class.st
+++ b/src/General-Rules/ReLiteralArrayContainsCommaRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReLiteralArrayContainsCommaRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReLiteralArrayContainsCommaRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -26,11 +31,6 @@ ReLiteralArrayContainsCommaRule >> basicCheck: aNode [
 		 FFICompilerPlugin ffiCalloutSelectors includes: aNode parent parent selector ]) ifTrue: [ ^ false ].
 
 	^ aNode value includes: #,
-]
-
-{ #category : 'accessing' }
-ReLiteralArrayContainsCommaRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReLiteralArrayContainsCommaRule.class.st
+++ b/src/General-Rules/ReLiteralArrayContainsCommaRule.class.st
@@ -15,6 +15,11 @@ ReLiteralArrayContainsCommaRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReLiteralArrayContainsCommaRule class >> ruleName [
+	^ 'Literal array contains a #,'
+]
+
+{ #category : 'accessing' }
 ReLiteralArrayContainsCommaRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -31,9 +36,4 @@ ReLiteralArrayContainsCommaRule >> basicCheck: aNode [
 		 FFICompilerPlugin ffiCalloutSelectors includes: aNode parent parent selector ]) ifTrue: [ ^ false ].
 
 	^ aNode value includes: #,
-]
-
-{ #category : 'accessing' }
-ReLiteralArrayContainsCommaRule >> name [
-	^ 'Literal array contains a #,'
 ]

--- a/src/General-Rules/ReLocalMethodsSameThanTraitRule.class.st
+++ b/src/General-Rules/ReLocalMethodsSameThanTraitRule.class.st
@@ -20,6 +20,11 @@ ReLocalMethodsSameThanTraitRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReLocalMethodsSameThanTraitRule class >> ruleName [
+	^ 'Repeated methods in the trait composition'
+]
+
+{ #category : 'accessing' }
 ReLocalMethodsSameThanTraitRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -40,9 +45,4 @@ ReLocalMethodsSameThanTraitRule >> check: aClass forCritiquesDo: aCriticBlock [
 		thenDo: [ :duplicatedMethod |
 			aCriticBlock cull:
 				(ReRemoveMethodCritique for: aClass selector: duplicatedMethod selector by: self) ]
-]
-
-{ #category : 'accessing' }
-ReLocalMethodsSameThanTraitRule >> name [
-	^ 'Repeated methods in the trait composition'
 ]

--- a/src/General-Rules/ReLocalMethodsSameThanTraitRule.class.st
+++ b/src/General-Rules/ReLocalMethodsSameThanTraitRule.class.st
@@ -15,6 +15,11 @@ ReLocalMethodsSameThanTraitRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReLocalMethodsSameThanTraitRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReLocalMethodsSameThanTraitRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -35,11 +40,6 @@ ReLocalMethodsSameThanTraitRule >> check: aClass forCritiquesDo: aCriticBlock [
 		thenDo: [ :duplicatedMethod |
 			aCriticBlock cull:
 				(ReRemoveMethodCritique for: aClass selector: duplicatedMethod selector by: self) ]
-]
-
-{ #category : 'accessing' }
-ReLocalMethodsSameThanTraitRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReLongMethodsRule.class.st
+++ b/src/General-Rules/ReLongMethodsRule.class.st
@@ -28,6 +28,20 @@ ReLongMethodsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReLongMethodsRule class >> rationale [
+	^ 'This smell arises when a long method is found (with {1} or more statements). Note that, it counts statements, not lines. Long methods should often be split into several smaller ones.
+
+Long methods should often be split into several smaller ones. When you start to need an empty line to separate groups of statements, this is an indication that you should probably define a new method.
+
+Do not forget that methods are points of extension in an object-oriented language. It means that each time you define a method, a subclass may override and extend it while taking advantage and reusing the calling context of your method. This is the basis for the Hook and Template Design Pattern and central to good object-oriented design. So keep your methods short.
+
+Use the extract method refactoring, which even checks whether the method you are extracting already exists in the class.
+
+The defined number of statements can be edited in #longMethodSize. In the future such rule should hold state and not be based on method redefinition for its customization. '
+	format: { self longMethodSize }
+]
+
+{ #category : 'accessing' }
 ReLongMethodsRule class >> ruleName [
 	^ 'Long methods'
 ]
@@ -57,18 +71,4 @@ ReLongMethodsRule >> basicCheck: aMethod [
 { #category : 'private' }
 ReLongMethodsRule >> longMethodSize [
 	^ 20
-]
-
-{ #category : 'accessing' }
-ReLongMethodsRule >> rationale [
-	^ 'This smell arises when a long method is found (with {1} or more statements). Note that, it counts statements, not lines. Long methods should often be split into several smaller ones.
-
-Long methods should often be split into several smaller ones. When you start to need an empty line to separate groups of statements, this is an indication that you should probably define a new method.
-
-Do not forget that methods are points of extension in an object-oriented language. It means that each time you define a method, a subclass may override and extend it while taking advantage and reusing the calling context of your method. This is the basis for the Hook and Template Design Pattern and central to good object-oriented design. So keep your methods short.
-
-Use the extract method refactoring, which even checks whether the method you are extracting already exists in the class.
-
-The defined number of statements can be edited in #longMethodSize. In the future such rule should hold state and not be based on method redefinition for its customization. '
-	format: { self longMethodSize }
 ]

--- a/src/General-Rules/ReLongMethodsRule.class.st
+++ b/src/General-Rules/ReLongMethodsRule.class.st
@@ -27,6 +27,11 @@ ReLongMethodsRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'private' }
+ReLongMethodsRule class >> longMethodSize [
+	^ 20
+]
+
 { #category : 'accessing' }
 ReLongMethodsRule class >> rationale [
 	^ 'This smell arises when a long method is found (with {1} or more statements). Note that, it counts statements, not lines. Long methods should often be split into several smaller ones.
@@ -70,5 +75,5 @@ ReLongMethodsRule >> basicCheck: aMethod [
 
 { #category : 'private' }
 ReLongMethodsRule >> longMethodSize [
-	^ 20
+	^ self class longMethodSize
 ]

--- a/src/General-Rules/ReLongMethodsRule.class.st
+++ b/src/General-Rules/ReLongMethodsRule.class.st
@@ -28,6 +28,11 @@ ReLongMethodsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReLongMethodsRule class >> ruleName [
+	^ 'Long methods'
+]
+
+{ #category : 'accessing' }
 ReLongMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -52,11 +57,6 @@ ReLongMethodsRule >> basicCheck: aMethod [
 { #category : 'private' }
 ReLongMethodsRule >> longMethodSize [
 	^ 20
-]
-
-{ #category : 'accessing' }
-ReLongMethodsRule >> name [
-	^ 'Long methods'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReLongMethodsRule.class.st
+++ b/src/General-Rules/ReLongMethodsRule.class.st
@@ -23,6 +23,11 @@ ReLongMethodsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReLongMethodsRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReLongMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,11 +47,6 @@ ReLongMethodsRule >> basicCheck: aMethod [
 				ifTrue: [ numberOfStatements := numberOfStatements + node statements size.
 					numberOfStatements >= self longMethodSize ifTrue: [ ^ true ] ] ].
 	^ false
-]
-
-{ #category : 'accessing' }
-ReLongMethodsRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReMethodHasSyntaxErrorRule.class.st
+++ b/src/General-Rules/ReMethodHasSyntaxErrorRule.class.st
@@ -15,6 +15,11 @@ ReMethodHasSyntaxErrorRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReMethodHasSyntaxErrorRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -24,11 +29,6 @@ ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReMethodHasSyntaxErrorRule >> basicCheck: aMethod [
 	^aMethod isFaulty
-]
-
-{ #category : 'accessing' }
-ReMethodHasSyntaxErrorRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMethodHasSyntaxErrorRule.class.st
+++ b/src/General-Rules/ReMethodHasSyntaxErrorRule.class.st
@@ -20,6 +20,11 @@ ReMethodHasSyntaxErrorRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReMethodHasSyntaxErrorRule class >> ruleName [
+	^ 'Method source has syntax errors'
+]
+
+{ #category : 'accessing' }
 ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -29,11 +34,6 @@ ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReMethodHasSyntaxErrorRule >> basicCheck: aMethod [
 	^aMethod isFaulty
-]
-
-{ #category : 'accessing' }
-ReMethodHasSyntaxErrorRule >> name [
-	^ 'Method source has syntax errors'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMethodHasSyntaxErrorRule.class.st
+++ b/src/General-Rules/ReMethodHasSyntaxErrorRule.class.st
@@ -25,6 +25,11 @@ ReMethodHasSyntaxErrorRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReMethodHasSyntaxErrorRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -34,9 +39,4 @@ ReMethodHasSyntaxErrorRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReMethodHasSyntaxErrorRule >> basicCheck: aMethod [
 	^aMethod isFaulty
-]
-
-{ #category : 'accessing' }
-ReMethodHasSyntaxErrorRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReMethodSelectorKeywordCasingRule.class.st
+++ b/src/General-Rules/ReMethodSelectorKeywordCasingRule.class.st
@@ -15,6 +15,12 @@ ReMethodSelectorKeywordCasingRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReMethodSelectorKeywordCasingRule class >> group [
+
+	^ 'Design Flaws'
+]
+
 { #category : 'manifest' }
 ReMethodSelectorKeywordCasingRule class >> uniqueIdentifierName [
 	"The return value hould be unique and should change only when the rule completely change semantics"
@@ -28,12 +34,6 @@ ReMethodSelectorKeywordCasingRule >> basicCheck: aMethod [
 	^ aMethod selector isKeyword and: [
 		  (aMethod selector asString substrings: #( $: )) anySatisfy: [
 			  :each | each first isUppercase ] ]
-]
-
-{ #category : 'accessing' }
-ReMethodSelectorKeywordCasingRule >> group [
-
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMethodSelectorKeywordCasingRule.class.st
+++ b/src/General-Rules/ReMethodSelectorKeywordCasingRule.class.st
@@ -21,6 +21,11 @@ ReMethodSelectorKeywordCasingRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReMethodSelectorKeywordCasingRule class >> ruleName [
+	^ 'Keyword selector has wrong casing (camel case required)'
+]
+
 { #category : 'manifest' }
 ReMethodSelectorKeywordCasingRule class >> uniqueIdentifierName [
 	"The return value hould be unique and should change only when the rule completely change semantics"
@@ -34,10 +39,4 @@ ReMethodSelectorKeywordCasingRule >> basicCheck: aMethod [
 	^ aMethod selector isKeyword and: [
 		  (aMethod selector asString substrings: #( $: )) anySatisfy: [
 			  :each | each first isUppercase ] ]
-]
-
-{ #category : 'accessing' }
-ReMethodSelectorKeywordCasingRule >> name [
-
-	^ 'Keyword selector has wrong casing (camel case required)'
 ]

--- a/src/General-Rules/ReMethodSignaturePeriodRule.class.st
+++ b/src/General-Rules/ReMethodSignaturePeriodRule.class.st
@@ -14,6 +14,11 @@ ReMethodSignaturePeriodRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReMethodSignaturePeriodRule class >> group [
+	^ 'Potential Bugs'
+]
+
 { #category : 'running' }
 ReMethodSignaturePeriodRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
@@ -26,11 +31,6 @@ ReMethodSignaturePeriodRule >> check: aMethod forCritiquesDo: aCriticBlock [
 						  entity: aMethod
 						  interval: (1 to: firstLine size))
 				 by: self) ]
-]
-
-{ #category : 'accessing' }
-ReMethodSignaturePeriodRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMethodSignaturePeriodRule.class.st
+++ b/src/General-Rules/ReMethodSignaturePeriodRule.class.st
@@ -19,6 +19,11 @@ ReMethodSignaturePeriodRule class >> group [
 	^ 'Potential Bugs'
 ]
 
+{ #category : 'accessing' }
+ReMethodSignaturePeriodRule class >> ruleName [
+	^ 'Method signature has terminating period'
+]
+
 { #category : 'running' }
 ReMethodSignaturePeriodRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
@@ -31,9 +36,4 @@ ReMethodSignaturePeriodRule >> check: aMethod forCritiquesDo: aCriticBlock [
 						  entity: aMethod
 						  interval: (1 to: firstLine size))
 				 by: self) ]
-]
-
-{ #category : 'accessing' }
-ReMethodSignaturePeriodRule >> name [
-	^ 'Method signature has terminating period'
 ]

--- a/src/General-Rules/ReMethodSourceContainsLinefeedsRule.class.st
+++ b/src/General-Rules/ReMethodSourceContainsLinefeedsRule.class.st
@@ -15,6 +15,11 @@ ReMethodSourceContainsLinefeedsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReMethodSourceContainsLinefeedsRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReMethodSourceContainsLinefeedsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,11 +38,6 @@ ReMethodSourceContainsLinefeedsRule >> check: aMethod forCritiquesDo: aCriticBlo
 				interval: lfInterval)
 			by: self
 			hint: 'lf') ]
-]
-
-{ #category : 'accessing' }
-ReMethodSourceContainsLinefeedsRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMethodSourceContainsLinefeedsRule.class.st
+++ b/src/General-Rules/ReMethodSourceContainsLinefeedsRule.class.st
@@ -20,6 +20,11 @@ ReMethodSourceContainsLinefeedsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReMethodSourceContainsLinefeedsRule class >> ruleName [
+	^ 'Method source contains linefeeds'
+]
+
+{ #category : 'accessing' }
 ReMethodSourceContainsLinefeedsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -38,11 +43,6 @@ ReMethodSourceContainsLinefeedsRule >> check: aMethod forCritiquesDo: aCriticBlo
 				interval: lfInterval)
 			by: self
 			hint: 'lf') ]
-]
-
-{ #category : 'accessing' }
-ReMethodSourceContainsLinefeedsRule >> name [
-	^ 'Method source contains linefeeds'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMethodSourceContainsLinefeedsRule.class.st
+++ b/src/General-Rules/ReMethodSourceContainsLinefeedsRule.class.st
@@ -25,6 +25,11 @@ ReMethodSourceContainsLinefeedsRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReMethodSourceContainsLinefeedsRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReMethodSourceContainsLinefeedsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -43,9 +48,4 @@ ReMethodSourceContainsLinefeedsRule >> check: aMethod forCritiquesDo: aCriticBlo
 				interval: lfInterval)
 			by: self
 			hint: 'lf') ]
-]
-
-{ #category : 'accessing' }
-ReMethodSourceContainsLinefeedsRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReMinMaxRule.class.st
+++ b/src/General-Rules/ReMinMaxRule.class.st
@@ -29,6 +29,11 @@ ReMinMaxRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReMinMaxRule class >> ruleName [
+	^ 'Rewrite ifTrue:ifFalse: using min:/max:'
+]
+
+{ #category : 'accessing' }
 ReMinMaxRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -63,11 +68,6 @@ ReMinMaxRule >> initialize [
 		replace: '``@b >= `a ifTrue: [`a := ``@b]' with: '`a := `a max: ``@b';
 		replace: '``@b > `a ifFalse: [`a := ``@b]' with: '`a := `a min: ``@b';
 		replace: '``@b >= `a ifFalse: [`a := ``@b]' with: '`a := `a min: ``@b'
-]
-
-{ #category : 'accessing' }
-ReMinMaxRule >> name [
-	^ 'Rewrite ifTrue:ifFalse: using min:/max:'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMinMaxRule.class.st
+++ b/src/General-Rules/ReMinMaxRule.class.st
@@ -29,6 +29,11 @@ ReMinMaxRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReMinMaxRule class >> rationale [
+	^ 'The use of the messages #min: and #max: improves code readability and avoids heavily nested conditionals.'
+]
+
+{ #category : 'accessing' }
 ReMinMaxRule class >> ruleName [
 	^ 'Rewrite ifTrue:ifFalse: using min:/max:'
 ]
@@ -68,9 +73,4 @@ ReMinMaxRule >> initialize [
 		replace: '``@b >= `a ifTrue: [`a := ``@b]' with: '`a := `a max: ``@b';
 		replace: '``@b > `a ifFalse: [`a := ``@b]' with: '`a := `a min: ``@b';
 		replace: '``@b >= `a ifFalse: [`a := ``@b]' with: '`a := `a min: ``@b'
-]
-
-{ #category : 'accessing' }
-ReMinMaxRule >> rationale [
-	^ 'The use of the messages #min: and #max: improves code readability and avoids heavily nested conditionals.'
 ]

--- a/src/General-Rules/ReMinMaxRule.class.st
+++ b/src/General-Rules/ReMinMaxRule.class.st
@@ -24,15 +24,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReMinMaxRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReMinMaxRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'MinMaxRule'
-]
-
-{ #category : 'accessing' }
-ReMinMaxRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReMissingSubclassResponsibilityRule.class.st
+++ b/src/General-Rules/ReMissingSubclassResponsibilityRule.class.st
@@ -15,6 +15,11 @@ ReMissingSubclassResponsibilityRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReMissingSubclassResponsibilityRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReMissingSubclassResponsibilityRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -45,11 +50,6 @@ ReMissingSubclassResponsibilityRule >> check: aClass forCritiquesDo: aCritiqueBl
 				thenDo: [ :critic |
 					aCritiqueBlock cull: critic ].
 				^ self ] ]
-]
-
-{ #category : 'accessing' }
-ReMissingSubclassResponsibilityRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMissingSubclassResponsibilityRule.class.st
+++ b/src/General-Rules/ReMissingSubclassResponsibilityRule.class.st
@@ -20,6 +20,11 @@ ReMissingSubclassResponsibilityRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReMissingSubclassResponsibilityRule class >> ruleName [
+	^ 'Method defined in all subclasses, but not in superclass'
+]
+
+{ #category : 'accessing' }
 ReMissingSubclassResponsibilityRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -50,9 +55,4 @@ ReMissingSubclassResponsibilityRule >> check: aClass forCritiquesDo: aCritiqueBl
 				thenDo: [ :critic |
 					aCritiqueBlock cull: critic ].
 				^ self ] ]
-]
-
-{ #category : 'accessing' }
-ReMissingSubclassResponsibilityRule >> name [
-	^ 'Method defined in all subclasses, but not in superclass'
 ]

--- a/src/General-Rules/ReMissingSuperSendsRule.class.st
+++ b/src/General-Rules/ReMissingSuperSendsRule.class.st
@@ -17,6 +17,12 @@ ReMissingSuperSendsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReMissingSuperSendsRule class >> group [
+
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReMissingSuperSendsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -41,12 +47,6 @@ ReMissingSuperSendsRule >> basicCheck: aMethod [
 
 	superMethod isReturnSelf ifTrue: [ ^ false ].
 	^ (superMethod sendsSelector: #subclassResponsibility) not
-]
-
-{ #category : 'accessing' }
-ReMissingSuperSendsRule >> group [
-
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReMissingSuperSendsRule.class.st
+++ b/src/General-Rules/ReMissingSuperSendsRule.class.st
@@ -23,6 +23,11 @@ ReMissingSuperSendsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReMissingSuperSendsRule class >> ruleName [
+	^ 'Missing super sends in selected methods.'
+]
+
+{ #category : 'accessing' }
 ReMissingSuperSendsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -54,10 +59,4 @@ ReMissingSuperSendsRule >> methodsRequiringSuper [
 
 	^ #( #release #postCopy #postBuildWith: #preBuildWith: #postOpenWith:
 	     #noticeOfWindowClose: #initialize )
-]
-
-{ #category : 'accessing' }
-ReMissingSuperSendsRule >> name [
-
-	^ 'Missing super sends in selected methods.'
 ]

--- a/src/General-Rules/ReModifiesCollectionRule.class.st
+++ b/src/General-Rules/ReModifiesCollectionRule.class.st
@@ -18,6 +18,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReModifiesCollectionRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReModifiesCollectionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -29,11 +34,6 @@ ReModifiesCollectionRule >> afterCheck: aNode mappings: mappingDict [
 	^ self
 		modifiesCollection: (mappingDict at: '`@collection')
 		inAnyStatement: (mappingDict at: '`@.Statements')
-]
-
-{ #category : 'accessing' }
-ReModifiesCollectionRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReModifiesCollectionRule.class.st
+++ b/src/General-Rules/ReModifiesCollectionRule.class.st
@@ -23,6 +23,11 @@ ReModifiesCollectionRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReModifiesCollectionRule class >> ruleName [
+	^ 'Modifies collection while iterating over it'
+]
+
+{ #category : 'accessing' }
 ReModifiesCollectionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -55,11 +60,6 @@ ReModifiesCollectionRule >> modifiesCollection: aCollectionNode inAnyStatement: 
 			node = aCollectionNode ifTrue: [ ^ true ] ] ].
 
 	^ false
-]
-
-{ #category : 'accessing' }
-ReModifiesCollectionRule >> name [
-	^ 'Modifies collection while iterating over it'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReModifiesCollectionRule.class.st
+++ b/src/General-Rules/ReModifiesCollectionRule.class.st
@@ -23,6 +23,12 @@ ReModifiesCollectionRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReModifiesCollectionRule class >> rationale [
+
+	^ 'Checks for remove:''s of elements inside of collection iteration methods such as do:. '
+]
+
+{ #category : 'accessing' }
 ReModifiesCollectionRule class >> ruleName [
 	^ 'Modifies collection while iterating over it'
 ]
@@ -60,10 +66,4 @@ ReModifiesCollectionRule >> modifiesCollection: aCollectionNode inAnyStatement: 
 			node = aCollectionNode ifTrue: [ ^ true ] ] ].
 
 	^ false
-]
-
-{ #category : 'accessing' }
-ReModifiesCollectionRule >> rationale [
-
-	^ 'Checks for remove:''s of elements inside of collection iteration methods such as do:. '
 ]

--- a/src/General-Rules/ReMultiplePeriodsTerminatingStatementRule.class.st
+++ b/src/General-Rules/ReMultiplePeriodsTerminatingStatementRule.class.st
@@ -20,6 +20,11 @@ ReMultiplePeriodsTerminatingStatementRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReMultiplePeriodsTerminatingStatementRule class >> ruleName [
+	^ 'Multiple periods terminating the same statement'
+]
+
+{ #category : 'accessing' }
 ReMultiplePeriodsTerminatingStatementRule class >> uniqueIdentifierName [
 
 	^ 'MultiplePeriodsTerminatingStatementRule'
@@ -31,11 +36,6 @@ ReMultiplePeriodsTerminatingStatementRule >> check: aMethod forCritiquesDo: aCri
 	aMethod ast nodesDo: [ :node |
 		node isSequence and: [
 			self periodPairs: node critiqueBlock: aCriticBlock in: aMethod ] ]
-]
-
-{ #category : 'accessing' }
-ReMultiplePeriodsTerminatingStatementRule >> name [
-	^ 'Multiple periods terminating the same statement'
 ]
 
 { #category : 'running' }

--- a/src/General-Rules/ReMultiplePeriodsTerminatingStatementRule.class.st
+++ b/src/General-Rules/ReMultiplePeriodsTerminatingStatementRule.class.st
@@ -15,6 +15,11 @@ ReMultiplePeriodsTerminatingStatementRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReMultiplePeriodsTerminatingStatementRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReMultiplePeriodsTerminatingStatementRule class >> uniqueIdentifierName [
 
 	^ 'MultiplePeriodsTerminatingStatementRule'
@@ -26,11 +31,6 @@ ReMultiplePeriodsTerminatingStatementRule >> check: aMethod forCritiquesDo: aCri
 	aMethod ast nodesDo: [ :node |
 		node isSequence and: [
 			self periodPairs: node critiqueBlock: aCriticBlock in: aMethod ] ]
-]
-
-{ #category : 'accessing' }
-ReMultiplePeriodsTerminatingStatementRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNilBranchRule.class.st
+++ b/src/General-Rules/ReNilBranchRule.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReNilBranchRule >> group [
+ReNilBranchRule class >> group [
 
 	^ 'Design Flaws'
 ]

--- a/src/General-Rules/ReNilBranchRule.class.st
+++ b/src/General-Rules/ReNilBranchRule.class.st
@@ -15,6 +15,11 @@ ReNilBranchRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReNilBranchRule class >> ruleName [
+	^ 'branch nil is useless'
+]
+
 { #category : 'initialization' }
 ReNilBranchRule >> initialize [
 
@@ -23,10 +28,4 @@ ReNilBranchRule >> initialize [
 		with: '`@condition ifTrue: [ `@.statements]';
 		replace: '`@condition ifFalse: [ `@.statements] ifTrue: [ nil ]'
 		with: '`@condition ifFalse: [ `@.statements]'
-]
-
-{ #category : 'accessing' }
-ReNilBranchRule >> name [ 
-
-	^ 'branch nil is useless'
 ]

--- a/src/General-Rules/ReNoClassCommentRule.class.st
+++ b/src/General-Rules/ReNoClassCommentRule.class.st
@@ -15,6 +15,11 @@ ReNoClassCommentRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReNoClassCommentRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReNoClassCommentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ ReNoClassCommentRule class >> uniqueIdentifierName [
 ReNoClassCommentRule >> basicCheck: aClass [
 	(aClass isMeta or: [ aClass isTestCase ]) ifTrue: [ ^ false ].
 	^ aClass hasComment not
-]
-
-{ #category : 'accessing' }
-ReNoClassCommentRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNoClassCommentRule.class.st
+++ b/src/General-Rules/ReNoClassCommentRule.class.st
@@ -20,6 +20,11 @@ ReNoClassCommentRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReNoClassCommentRule class >> ruleName [
+	^ 'No class comment'
+]
+
+{ #category : 'accessing' }
 ReNoClassCommentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReNoClassCommentRule class >> uniqueIdentifierName [
 ReNoClassCommentRule >> basicCheck: aClass [
 	(aClass isMeta or: [ aClass isTestCase ]) ifTrue: [ ^ false ].
 	^ aClass hasComment not
-]
-
-{ #category : 'accessing' }
-ReNoClassCommentRule >> name [
-	^ 'No class comment'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNoClassCommentRule.class.st
+++ b/src/General-Rules/ReNoClassCommentRule.class.st
@@ -20,6 +20,11 @@ ReNoClassCommentRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReNoClassCommentRule class >> rationale [
+	^ 'Classes should have comments to explain their purpose, collaborations with other classes, and optionally provide examples of use.'
+]
+
+{ #category : 'accessing' }
 ReNoClassCommentRule class >> ruleName [
 	^ 'No class comment'
 ]
@@ -35,9 +40,4 @@ ReNoClassCommentRule class >> uniqueIdentifierName [
 ReNoClassCommentRule >> basicCheck: aClass [
 	(aClass isMeta or: [ aClass isTestCase ]) ifTrue: [ ^ false ].
 	^ aClass hasComment not
-]
-
-{ #category : 'accessing' }
-ReNoClassCommentRule >> rationale [
-	^ 'Classes should have comments to explain their purpose, collaborations with other classes, and optionally provide examples of use.'
 ]

--- a/src/General-Rules/ReNoSpaceAroundProtocolRule.class.st
+++ b/src/General-Rules/ReNoSpaceAroundProtocolRule.class.st
@@ -18,6 +18,12 @@ ReNoSpaceAroundProtocolRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReNoSpaceAroundProtocolRule class >> group [
+
+	^ 'Coding Idiom Violation'
+]
+
 { #category : 'manifest' }
 ReNoSpaceAroundProtocolRule class >> uniqueIdentifierName [
 
@@ -43,12 +49,6 @@ ReNoSpaceAroundProtocolRule >> critiqueFor: aMethod [
 			   protocol: { proposedProtocol }
 			   inMethod: aMethod selector
 			   inClass: aMethod methodClass name asSymbol)
-]
-
-{ #category : 'accessing' }
-ReNoSpaceAroundProtocolRule >> group [
-
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNoSpaceAroundProtocolRule.class.st
+++ b/src/General-Rules/ReNoSpaceAroundProtocolRule.class.st
@@ -26,7 +26,8 @@ ReNoSpaceAroundProtocolRule class >> group [
 
 { #category : 'accessing' }
 ReNoSpaceAroundProtocolRule class >> ruleName [
-	^ 'Protocol named "{1}" should be trimmed (includes space at start or end)' format: { protocolName }
+
+	^ 'Protocol should be trimmed (includes space at start or end)'
 ]
 
 { #category : 'manifest' }

--- a/src/General-Rules/ReNoSpaceAroundProtocolRule.class.st
+++ b/src/General-Rules/ReNoSpaceAroundProtocolRule.class.st
@@ -24,6 +24,11 @@ ReNoSpaceAroundProtocolRule class >> group [
 	^ 'Coding Idiom Violation'
 ]
 
+{ #category : 'accessing' }
+ReNoSpaceAroundProtocolRule class >> ruleName [
+	^ 'Protocol named "{1}" should be trimmed (includes space at start or end)' format: { protocolName }
+]
+
 { #category : 'manifest' }
 ReNoSpaceAroundProtocolRule class >> uniqueIdentifierName [
 
@@ -49,10 +54,4 @@ ReNoSpaceAroundProtocolRule >> critiqueFor: aMethod [
 			   protocol: { proposedProtocol }
 			   inMethod: aMethod selector
 			   inClass: aMethod methodClass name asSymbol)
-]
-
-{ #category : 'accessing' }
-ReNoSpaceAroundProtocolRule >> name [
-
-	^ 'Protocol named "{1}" should be trimmed (includes space at start or end)' format: { protocolName }
 ]

--- a/src/General-Rules/ReNoUnusedInstanceVariableRule.class.st
+++ b/src/General-Rules/ReNoUnusedInstanceVariableRule.class.st
@@ -19,6 +19,11 @@ ReNoUnusedInstanceVariableRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReNoUnusedInstanceVariableRule class >> ruleName [
+	^ 'Unused instance variable'
+]
+
+{ #category : 'accessing' }
 ReNoUnusedInstanceVariableRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -48,12 +53,6 @@ ReNoUnusedInstanceVariableRule >> critiqueFor: aClass about: aVarName [
 
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReNoUnusedInstanceVariableRule >> name [
-
-	^ 'Unused instance variable'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNoUnusedInstanceVariableRule.class.st
+++ b/src/General-Rules/ReNoUnusedInstanceVariableRule.class.st
@@ -13,6 +13,12 @@ ReNoUnusedInstanceVariableRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReNoUnusedInstanceVariableRule class >> group [
+
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReNoUnusedInstanceVariableRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,12 +48,6 @@ ReNoUnusedInstanceVariableRule >> critiqueFor: aClass about: aVarName [
 
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReNoUnusedInstanceVariableRule >> group [
-
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNoUnusedInstanceVariableRule.class.st
+++ b/src/General-Rules/ReNoUnusedInstanceVariableRule.class.st
@@ -19,6 +19,11 @@ ReNoUnusedInstanceVariableRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReNoUnusedInstanceVariableRule class >> rationale [
+	^ 'Classes should have instance variables that are actually used - instance variables without a reference should be removed.'
+]
+
+{ #category : 'accessing' }
 ReNoUnusedInstanceVariableRule class >> ruleName [
 	^ 'Unused instance variable'
 ]
@@ -53,9 +58,4 @@ ReNoUnusedInstanceVariableRule >> critiqueFor: aClass about: aVarName [
 
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReNoUnusedInstanceVariableRule >> rationale [
-	^ 'Classes should have instance variables that are actually used - instance variables without a reference should be removed.'
 ]

--- a/src/General-Rules/ReNotEliminationRule.class.st
+++ b/src/General-Rules/ReNotEliminationRule.class.st
@@ -31,15 +31,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReNotEliminationRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReNotEliminationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'NotEliminationRule'
-]
-
-{ #category : 'accessing' }
-ReNotEliminationRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReNotEliminationRule.class.st
+++ b/src/General-Rules/ReNotEliminationRule.class.st
@@ -36,6 +36,11 @@ ReNotEliminationRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReNotEliminationRule class >> rationale [
+	^ 'Eliminate unnecessary not''s in relation of conditionals'
+]
+
+{ #category : 'accessing' }
 ReNotEliminationRule class >> ruleName [
 	^ 'Eliminate unnecessary not''s'
 ]
@@ -75,9 +80,4 @@ ReNotEliminationRule >> initialize [
 		replace: '(``@a ~~ ``@b) not' with: '``@a == ``@b';
 		replace: '(``@a >= ``@b) not' with: '``@a < ``@b';
 		replace: '(``@a > ``@b) not' with: '``@a <= ``@b'
-]
-
-{ #category : 'accessing' }
-ReNotEliminationRule >> rationale [
-	^ 'Eliminate unnecessary not''s in relation of conditionals'
 ]

--- a/src/General-Rules/ReNotEliminationRule.class.st
+++ b/src/General-Rules/ReNotEliminationRule.class.st
@@ -36,6 +36,11 @@ ReNotEliminationRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReNotEliminationRule class >> ruleName [
+	^ 'Eliminate unnecessary not''s'
+]
+
+{ #category : 'accessing' }
 ReNotEliminationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -70,11 +75,6 @@ ReNotEliminationRule >> initialize [
 		replace: '(``@a ~~ ``@b) not' with: '``@a == ``@b';
 		replace: '(``@a >= ``@b) not' with: '``@a < ``@b';
 		replace: '(``@a > ``@b) not' with: '``@a <= ``@b'
-]
-
-{ #category : 'accessing' }
-ReNotEliminationRule >> name [
-	^ 'Eliminate unnecessary not''s'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNotEqualityOperatorsRule.class.st
+++ b/src/General-Rules/ReNotEqualityOperatorsRule.class.st
@@ -19,6 +19,11 @@ ReNotEqualityOperatorsRule class >> ruleName [
 	^ 'Use the correct non-equality operators'
 ]
 
+{ #category : 'accessing' }
+ReNotEqualityOperatorsRule class >> severity [
+	^#error
+]
+
 { #category : 'initialization' }
 ReNotEqualityOperatorsRule >> initialize [
 	super initialize.
@@ -26,9 +31,4 @@ ReNotEqualityOperatorsRule >> initialize [
 		replace: '``@a != ``@b' with: '``@a ~= ``@b';
 		replace: '``@a <> ``@b' with: '``@a ~= ``@b';
 		replace: '``@a !== ``@b' with: '``@a ~~ ``@b'
-]
-
-{ #category : 'accessing' }
-ReNotEqualityOperatorsRule >> severity [
-	^#error
 ]

--- a/src/General-Rules/ReNotEqualityOperatorsRule.class.st
+++ b/src/General-Rules/ReNotEqualityOperatorsRule.class.st
@@ -14,6 +14,11 @@ ReNotEqualityOperatorsRule class >> group [
 	^ 'Bugs'
 ]
 
+{ #category : 'accessing' }
+ReNotEqualityOperatorsRule class >> ruleName [
+	^ 'Use the correct non-equality operators'
+]
+
 { #category : 'initialization' }
 ReNotEqualityOperatorsRule >> initialize [
 	super initialize.
@@ -21,11 +26,6 @@ ReNotEqualityOperatorsRule >> initialize [
 		replace: '``@a != ``@b' with: '``@a ~= ``@b';
 		replace: '``@a <> ``@b' with: '``@a ~= ``@b';
 		replace: '``@a !== ``@b' with: '``@a ~~ ``@b'
-]
-
-{ #category : 'accessing' }
-ReNotEqualityOperatorsRule >> name [
-	^ 'Use the correct non-equality operators'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNotEqualityOperatorsRule.class.st
+++ b/src/General-Rules/ReNotEqualityOperatorsRule.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReNotEqualityOperatorsRule >> group [
+ReNotEqualityOperatorsRule class >> group [
 	^ 'Bugs'
 ]
 

--- a/src/General-Rules/ReNotOptimizedIfNilRule.class.st
+++ b/src/General-Rules/ReNotOptimizedIfNilRule.class.st
@@ -15,17 +15,17 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReNotOptimizedIfNilRule class >> group [
+	^ 'Optimization'
+]
+
 { #category : 'running' }
 ReNotOptimizedIfNilRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isMessage ifFalse: [  ^ self ].
 	(#(ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil:) includes: aNode selector) ifFalse: [^ self].
 	aNode isInlineIfNil ifFalse: [
 		aBlock cull: (self critiqueFor: aNode) ]
-]
-
-{ #category : 'accessing' }
-ReNotOptimizedIfNilRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReNotOptimizedIfNilRule.class.st
+++ b/src/General-Rules/ReNotOptimizedIfNilRule.class.st
@@ -20,15 +20,15 @@ ReNotOptimizedIfNilRule class >> group [
 	^ 'Optimization'
 ]
 
+{ #category : 'accessing' }
+ReNotOptimizedIfNilRule class >> ruleName [
+	^ 'ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil: is used in a way that it can not be optimized'
+]
+
 { #category : 'running' }
 ReNotOptimizedIfNilRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isMessage ifFalse: [  ^ self ].
 	(#(ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil:) includes: aNode selector) ifFalse: [^ self].
 	aNode isInlineIfNil ifFalse: [
 		aBlock cull: (self critiqueFor: aNode) ]
-]
-
-{ #category : 'accessing' }
-ReNotOptimizedIfNilRule >> name [
-	^ 'ifNil: ifNotNil: ifNil:ifNotNil: ifNotNil:ifNil: is used in a way that it can not be optimized'
 ]

--- a/src/General-Rules/ReNotOptimizedIfRule.class.st
+++ b/src/General-Rules/ReNotOptimizedIfRule.class.st
@@ -18,15 +18,15 @@ ReNotOptimizedIfRule class >> group [
 	^ 'Optimization'
 ]
 
+{ #category : 'accessing' }
+ReNotOptimizedIfRule class >> ruleName [
+	^ 'ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue: is used in a way that it can not be optimized'
+]
+
 { #category : 'running' }
 ReNotOptimizedIfRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isMessage ifFalse: [  ^ self ].
 	(#(ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue:) includes: aNode selector) ifFalse: [^ self].
 	aNode isInlineIf ifFalse: [
 		aBlock cull: (self critiqueFor: aNode) ]
-]
-
-{ #category : 'accessing' }
-ReNotOptimizedIfRule >> name [
-	^ 'ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue: is used in a way that it can not be optimized'
 ]

--- a/src/General-Rules/ReNotOptimizedIfRule.class.st
+++ b/src/General-Rules/ReNotOptimizedIfRule.class.st
@@ -13,17 +13,17 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReNotOptimizedIfRule class >> group [
+	^ 'Optimization'
+]
+
 { #category : 'running' }
 ReNotOptimizedIfRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isMessage ifFalse: [  ^ self ].
 	(#(ifTrue: ifFalse: ifTrue:ifFalse: ifFalse:ifTrue:) includes: aNode selector) ifFalse: [^ self].
 	aNode isInlineIf ifFalse: [
 		aBlock cull: (self critiqueFor: aNode) ]
-]
-
-{ #category : 'accessing' }
-ReNotOptimizedIfRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReOverridesSpecialMessageRule.class.st
+++ b/src/General-Rules/ReOverridesSpecialMessageRule.class.st
@@ -20,6 +20,11 @@ ReOverridesSpecialMessageRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReOverridesSpecialMessageRule class >> ruleName [
+	^ 'Overrides a "special" message'
+]
+
+{ #category : 'accessing' }
 ReOverridesSpecialMessageRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -47,11 +52,6 @@ ReOverridesSpecialMessageRule >> classShouldNotOverride [
 { #category : 'private' }
 ReOverridesSpecialMessageRule >> metaclassShouldNotOverride [
 	^ #( #basicNew #basicNew #class #comment #name )
-]
-
-{ #category : 'accessing' }
-ReOverridesSpecialMessageRule >> name [
-	^ 'Overrides a "special" message'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReOverridesSpecialMessageRule.class.st
+++ b/src/General-Rules/ReOverridesSpecialMessageRule.class.st
@@ -14,9 +14,27 @@ ReOverridesSpecialMessageRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'private' }
+ReOverridesSpecialMessageRule class >> classShouldNotOverride [
+	^ #( #== #~~ #class #basicAt: #basicAt:put: #basicSize #identityHash )
+]
+
 { #category : 'accessing' }
 ReOverridesSpecialMessageRule class >> group [
 	^ 'Bugs'
+]
+
+{ #category : 'private' }
+ReOverridesSpecialMessageRule class >> metaclassShouldNotOverride [
+	^ #( #basicNew #basicNew #class #comment #name )
+]
+
+{ #category : 'accessing' }
+ReOverridesSpecialMessageRule class >> rationale [
+
+	^ 'Checks that a class does not override a message that is essential to the base system. For example, if you override the #class method from object, you are likely to crash your image.
+In the class the messages we should not override are: ' , (', ' join: self classShouldNotOverride) , '.
+In the class side the messages we should not override are: ' , (', ' join: self metaclassShouldNotOverride) , '.'
 ]
 
 { #category : 'accessing' }
@@ -46,20 +64,12 @@ ReOverridesSpecialMessageRule >> check: aClass forCritiquesDo: aCriticBlock [
 
 { #category : 'private' }
 ReOverridesSpecialMessageRule >> classShouldNotOverride [
-	^ #( #== #~~ #class #basicAt: #basicAt:put: #basicSize #identityHash )
+	^ self class classShouldNotOverride
 ]
 
 { #category : 'private' }
 ReOverridesSpecialMessageRule >> metaclassShouldNotOverride [
-	^ #( #basicNew #basicNew #class #comment #name )
-]
-
-{ #category : 'accessing' }
-ReOverridesSpecialMessageRule >> rationale [
-
-	^ 'Checks that a class does not override a message that is essential to the base system. For example, if you override the #class method from object, you are likely to crash your image.
-In the class the messages we should not override are: ',  (', ' join: (self classShouldNotOverride) ),'.
-In the class side the messages we should not override are: ',  (', ' join: (self metaclassShouldNotOverride) ),'.'
+	^ self class metaclassShouldNotOverride
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReOverridesSpecialMessageRule.class.st
+++ b/src/General-Rules/ReOverridesSpecialMessageRule.class.st
@@ -43,6 +43,11 @@ ReOverridesSpecialMessageRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReOverridesSpecialMessageRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReOverridesSpecialMessageRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -70,9 +75,4 @@ ReOverridesSpecialMessageRule >> classShouldNotOverride [
 { #category : 'private' }
 ReOverridesSpecialMessageRule >> metaclassShouldNotOverride [
 	^ self class metaclassShouldNotOverride
-]
-
-{ #category : 'accessing' }
-ReOverridesSpecialMessageRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReOverridesSpecialMessageRule.class.st
+++ b/src/General-Rules/ReOverridesSpecialMessageRule.class.st
@@ -15,6 +15,11 @@ ReOverridesSpecialMessageRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReOverridesSpecialMessageRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReOverridesSpecialMessageRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReOverridesSpecialMessageRule >> check: aClass forCritiquesDo: aCriticBlock [
 { #category : 'private' }
 ReOverridesSpecialMessageRule >> classShouldNotOverride [
 	^ #( #== #~~ #class #basicAt: #basicAt:put: #basicSize #identityHash )
-]
-
-{ #category : 'accessing' }
-ReOverridesSpecialMessageRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReOverridingExtentsionMethod.class.st
+++ b/src/General-Rules/ReOverridingExtentsionMethod.class.st
@@ -14,6 +14,11 @@ ReOverridingExtentsionMethod class >> group [
 	^ 'Potential Bugs'
 ]
 
+{ #category : 'accessing' }
+ReOverridingExtentsionMethod class >> ruleName [
+	^ 'An extension method overrides another method'
+]
+
 { #category : 'running' }
 ReOverridingExtentsionMethod >> basicCheck: aMethod [
   ^ aMethod isExtension and: [
@@ -28,12 +33,6 @@ ReOverridingExtentsionMethod >> basicCheck: aMethod [
           "We allow extensions from the same package to override, so that
           hierarchies can be extended with overriding functionality."
           superMethod package ~= aMethod package ] ] ]
-]
-
-{ #category : 'accessing' }
-ReOverridingExtentsionMethod >> name [
-
-	^ 'An extension method overrides another method'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReOverridingExtentsionMethod.class.st
+++ b/src/General-Rules/ReOverridingExtentsionMethod.class.st
@@ -9,6 +9,11 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReOverridingExtentsionMethod class >> group [
+	^ 'Potential Bugs'
+]
+
 { #category : 'running' }
 ReOverridingExtentsionMethod >> basicCheck: aMethod [
   ^ aMethod isExtension and: [
@@ -23,11 +28,6 @@ ReOverridingExtentsionMethod >> basicCheck: aMethod [
           "We allow extensions from the same package to override, so that
           hierarchies can be extended with overriding functionality."
           superMethod package ~= aMethod package ] ] ]
-]
-
-{ #category : 'accessing' }
-ReOverridingExtentsionMethod >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/RePlatformDependentUserInteractionRule.class.st
+++ b/src/General-Rules/RePlatformDependentUserInteractionRule.class.st
@@ -27,6 +27,11 @@ RePlatformDependentUserInteractionRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+RePlatformDependentUserInteractionRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 RePlatformDependentUserInteractionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -48,9 +53,4 @@ RePlatformDependentUserInteractionRule >> initialize [
 			'PopUpMenu labels: `@object1'
 			'PopUpMenu withCaption: `@object1 chooseFrom: `@object2'
 			 )
-]
-
-{ #category : 'accessing' }
-RePlatformDependentUserInteractionRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/RePlatformDependentUserInteractionRule.class.st
+++ b/src/General-Rules/RePlatformDependentUserInteractionRule.class.st
@@ -17,6 +17,11 @@ RePlatformDependentUserInteractionRule class >> group [
 ]
 
 { #category : 'accessing' }
+RePlatformDependentUserInteractionRule class >> rationale [
+	^ 'Check the methods that  use platform dependent user interactions.'
+]
+
+{ #category : 'accessing' }
 RePlatformDependentUserInteractionRule class >> ruleName [
 	^ 'Platform dependent user interaction'
 ]
@@ -43,11 +48,6 @@ RePlatformDependentUserInteractionRule >> initialize [
 			'PopUpMenu labels: `@object1'
 			'PopUpMenu withCaption: `@object1 chooseFrom: `@object2'
 			 )
-]
-
-{ #category : 'accessing' }
-RePlatformDependentUserInteractionRule >> rationale [
-	^ 'Check the methods that  use platform dependent user interactions.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/RePlatformDependentUserInteractionRule.class.st
+++ b/src/General-Rules/RePlatformDependentUserInteractionRule.class.st
@@ -12,15 +12,15 @@ Class {
 }
 
 { #category : 'accessing' }
+RePlatformDependentUserInteractionRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 RePlatformDependentUserInteractionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'PlatformDependentUserInteractionRule'
-]
-
-{ #category : 'accessing' }
-RePlatformDependentUserInteractionRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/RePlatformDependentUserInteractionRule.class.st
+++ b/src/General-Rules/RePlatformDependentUserInteractionRule.class.st
@@ -17,6 +17,11 @@ RePlatformDependentUserInteractionRule class >> group [
 ]
 
 { #category : 'accessing' }
+RePlatformDependentUserInteractionRule class >> ruleName [
+	^ 'Platform dependent user interaction'
+]
+
+{ #category : 'accessing' }
 RePlatformDependentUserInteractionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -38,11 +43,6 @@ RePlatformDependentUserInteractionRule >> initialize [
 			'PopUpMenu labels: `@object1'
 			'PopUpMenu withCaption: `@object1 chooseFrom: `@object2'
 			 )
-]
-
-{ #category : 'accessing' }
-RePlatformDependentUserInteractionRule >> name [
-	^ 'Platform dependent user interaction'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/RePointRule.class.st
+++ b/src/General-Rules/RePointRule.class.st
@@ -20,6 +20,12 @@ RePointRule class >> group [
 ]
 
 { #category : 'accessing' }
+RePointRule class >> rationale [ 
+
+	^ 'it''s much faster to use x@y than Point x:x y:y' 
+]
+
+{ #category : 'accessing' }
 RePointRule class >> ruleName [
 	^ 'prefer to use x@y instead of Point x: x y: y'
 ]
@@ -38,10 +44,4 @@ RePointRule >> basicCheck: aNode [
 	aNode receiver isMessage ifTrue: [ ^ false ].
 	aNode isSelfSend ifTrue: [ ^ false ].
 	^ (#( #x:y: ) includes: aNode selector ) and: [ aNode receiver name == Point name  ]
-]
-
-{ #category : 'accessing' }
-RePointRule >> rationale [ 
-
-	^ 'it''s much faster to use x@y than Point x:x y:y' 
 ]

--- a/src/General-Rules/RePointRule.class.st
+++ b/src/General-Rules/RePointRule.class.st
@@ -19,6 +19,11 @@ RePointRule class >> group [
 	^ 'Optimization'
 ]
 
+{ #category : 'accessing' }
+RePointRule class >> ruleName [
+	^ 'prefer to use x@y instead of Point x: x y: y'
+]
+
 { #category : 'manifest' }
 RePointRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -33,12 +38,6 @@ RePointRule >> basicCheck: aNode [
 	aNode receiver isMessage ifTrue: [ ^ false ].
 	aNode isSelfSend ifTrue: [ ^ false ].
 	^ (#( #x:y: ) includes: aNode selector ) and: [ aNode receiver name == Point name  ]
-]
-
-{ #category : 'accessing' }
-RePointRule >> name [
-
-	^ 'prefer to use x@y instead of Point x: x y: y'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/RePointRule.class.st
+++ b/src/General-Rules/RePointRule.class.st
@@ -13,6 +13,12 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+RePointRule class >> group [
+
+	^ 'Optimization'
+]
+
 { #category : 'manifest' }
 RePointRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -27,12 +33,6 @@ RePointRule >> basicCheck: aNode [
 	aNode receiver isMessage ifTrue: [ ^ false ].
 	aNode isSelfSend ifTrue: [ ^ false ].
 	^ (#( #x:y: ) includes: aNode selector ) and: [ aNode receiver name == Point name  ]
-]
-
-{ #category : 'accessing' }
-RePointRule >> group [
-
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/RePrecedenceRule.class.st
+++ b/src/General-Rules/RePrecedenceRule.class.st
@@ -15,6 +15,11 @@ RePrecedenceRule class >> group [
 ]
 
 { #category : 'accessing' }
+RePrecedenceRule class >> ruleName [
+	^ 'Inspect instances of "A + B * C" might be "A + (B * C)"'
+]
+
+{ #category : 'accessing' }
 RePrecedenceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,9 +35,4 @@ RePrecedenceRule >> basicCheck: aNode [
 	leftOperand isMessage ifFalse: [ ^ false ].
 	leftOperand hasParentheses ifTrue: [ ^ false ].
 	^ #(#+ #-) includes: leftOperand selector
-]
-
-{ #category : 'accessing' }
-RePrecedenceRule >> name [
-	^ 'Inspect instances of "A + B * C" might be "A + (B * C)"'
 ]

--- a/src/General-Rules/RePrecedenceRule.class.st
+++ b/src/General-Rules/RePrecedenceRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+RePrecedenceRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 RePrecedenceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ RePrecedenceRule >> basicCheck: aNode [
 	leftOperand isMessage ifFalse: [ ^ false ].
 	leftOperand hasParentheses ifTrue: [ ^ false ].
 	^ #(#+ #-) includes: leftOperand selector
-]
-
-{ #category : 'accessing' }
-RePrecedenceRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReReferencesObsoleteClassRule.class.st
+++ b/src/General-Rules/ReReferencesObsoleteClassRule.class.st
@@ -20,6 +20,11 @@ ReReferencesObsoleteClassRule class >> ruleName [
 	^ 'References an obsolete class'
 ]
 
+{ #category : 'accessing' }
+ReReferencesObsoleteClassRule class >> severity [
+	^ #error
+]
+
 { #category : 'helpers' }
 ReReferencesObsoleteClassRule >> basicCheck: aNode [
  	^ aNode isGlobalVariable
@@ -32,9 +37,4 @@ ReReferencesObsoleteClassRule >> critiqueFor: aNode [
 	^ (super critiqueFor: aNode)
 		  tinyHint: aNode name;
 		  yourself
-]
-
-{ #category : 'accessing' }
-ReReferencesObsoleteClassRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReReferencesObsoleteClassRule.class.st
+++ b/src/General-Rules/ReReferencesObsoleteClassRule.class.st
@@ -10,6 +10,11 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReReferencesObsoleteClassRule class >> group [
+	^ 'Bugs'
+]
+
 { #category : 'helpers' }
 ReReferencesObsoleteClassRule >> basicCheck: aNode [
  	^ aNode isGlobalVariable
@@ -22,11 +27,6 @@ ReReferencesObsoleteClassRule >> critiqueFor: aNode [
 	^ (super critiqueFor: aNode)
 		  tinyHint: aNode name;
 		  yourself
-]
-
-{ #category : 'accessing' }
-ReReferencesObsoleteClassRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReReferencesObsoleteClassRule.class.st
+++ b/src/General-Rules/ReReferencesObsoleteClassRule.class.st
@@ -15,6 +15,11 @@ ReReferencesObsoleteClassRule class >> group [
 	^ 'Bugs'
 ]
 
+{ #category : 'accessing' }
+ReReferencesObsoleteClassRule class >> ruleName [
+	^ 'References an obsolete class'
+]
+
 { #category : 'helpers' }
 ReReferencesObsoleteClassRule >> basicCheck: aNode [
  	^ aNode isGlobalVariable
@@ -27,11 +32,6 @@ ReReferencesObsoleteClassRule >> critiqueFor: aNode [
 	^ (super critiqueFor: aNode)
 		  tinyHint: aNode name;
 		  yourself
-]
-
-{ #category : 'accessing' }
-ReReferencesObsoleteClassRule >> name [
-	^ 'References an obsolete class'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReRefersToClassRule.class.st
+++ b/src/General-Rules/ReRefersToClassRule.class.st
@@ -21,6 +21,11 @@ ReRefersToClassRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReRefersToClassRule class >> rationale [
+	^ 'Checks for direct reference to classes themselves.'
+]
+
+{ #category : 'accessing' }
 ReRefersToClassRule class >> ruleName [
 	^ 'Refers to class name instead of "self class"'
 ]
@@ -47,9 +52,4 @@ ReRefersToClassRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
 	problemLiterals do: [ :literal |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: literal hint:literal name )]
-]
-
-{ #category : 'accessing' }
-ReRefersToClassRule >> rationale [
-	^ 'Checks for direct reference to classes themselves.'
 ]

--- a/src/General-Rules/ReRefersToClassRule.class.st
+++ b/src/General-Rules/ReRefersToClassRule.class.st
@@ -21,6 +21,11 @@ ReRefersToClassRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReRefersToClassRule class >> ruleName [
+	^ 'Refers to class name instead of "self class"'
+]
+
+{ #category : 'accessing' }
 ReRefersToClassRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,11 +47,6 @@ ReRefersToClassRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
 	problemLiterals do: [ :literal |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: literal hint:literal name )]
-]
-
-{ #category : 'accessing' }
-ReRefersToClassRule >> name [
-	^ 'Refers to class name instead of "self class"'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReRefersToClassRule.class.st
+++ b/src/General-Rules/ReRefersToClassRule.class.st
@@ -16,6 +16,11 @@ ReRefersToClassRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReRefersToClassRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReRefersToClassRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReRefersToClassRule >> check: aMethod forCritiquesDo: aCriticBlock [
 
 	problemLiterals do: [ :literal |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: literal hint:literal name )]
-]
-
-{ #category : 'accessing' }
-ReRefersToClassRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReReturnInEnsureRule.class.st
+++ b/src/General-Rules/ReReturnInEnsureRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReReturnInEnsureRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReReturnInEnsureRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -20,11 +25,6 @@ ReReturnInEnsureRule class >> uniqueIdentifierName [
 ReReturnInEnsureRule >> afterCheck: aNode mappings: mappingDict [
 	^ (mappingDict at: '`@.Stmts')
 		anySatisfy: #containsReturn
-]
-
-{ #category : 'accessing' }
-ReReturnInEnsureRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReReturnInEnsureRule.class.st
+++ b/src/General-Rules/ReReturnInEnsureRule.class.st
@@ -15,6 +15,11 @@ ReReturnInEnsureRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReReturnInEnsureRule class >> ruleName [
+	^ 'Contains a return in an ensure: block'
+]
+
+{ #category : 'accessing' }
 ReReturnInEnsureRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -33,9 +38,4 @@ ReReturnInEnsureRule >> initialize [
 	self matchesAny: #(
 		'`@rcv ensure: [| `@temps | `@.Stmts]'
 		'`@rcv ifCurtailed: [| `@temps | `@.Stmts]')
-]
-
-{ #category : 'accessing' }
-ReReturnInEnsureRule >> name [
-	^ 'Contains a return in an ensure: block'
 ]

--- a/src/General-Rules/ReReturnsBooleanAndOtherRule.class.st
+++ b/src/General-Rules/ReReturnsBooleanAndOtherRule.class.st
@@ -20,6 +20,11 @@ ReReturnsBooleanAndOtherRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReReturnsBooleanAndOtherRule class >> ruleName [
+	^ 'Returns a boolean and non boolean'
+]
+
+{ #category : 'accessing' }
 ReReturnsBooleanAndOtherRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -59,9 +64,4 @@ ReReturnsBooleanAndOtherRule >> checkIfNodeIsBool: node [
 ReReturnsBooleanAndOtherRule >> checkIfNodeIsNotBool: node [
 	^ node isSelfVariable or:
 		[ node isLiteralNode and: [ (#(true false) includes: node value) not ] ]
-]
-
-{ #category : 'accessing' }
-ReReturnsBooleanAndOtherRule >> name [
-	^ 'Returns a boolean and non boolean'
 ]

--- a/src/General-Rules/ReReturnsBooleanAndOtherRule.class.st
+++ b/src/General-Rules/ReReturnsBooleanAndOtherRule.class.st
@@ -15,6 +15,11 @@ ReReturnsBooleanAndOtherRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReReturnsBooleanAndOtherRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReReturnsBooleanAndOtherRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -54,11 +59,6 @@ ReReturnsBooleanAndOtherRule >> checkIfNodeIsBool: node [
 ReReturnsBooleanAndOtherRule >> checkIfNodeIsNotBool: node [
 	^ node isSelfVariable or:
 		[ node isLiteralNode and: [ (#(true false) includes: node value) not ] ]
-]
-
-{ #category : 'accessing' }
-ReReturnsBooleanAndOtherRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReReturnsIfTrueRule.class.st
+++ b/src/General-Rules/ReReturnsIfTrueRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReReturnsIfTrueRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReReturnsIfTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ReturnsIfTrueRule'
-]
-
-{ #category : 'accessing' }
-ReReturnsIfTrueRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReReturnsIfTrueRule.class.st
+++ b/src/General-Rules/ReReturnsIfTrueRule.class.st
@@ -15,6 +15,11 @@ ReReturnsIfTrueRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReReturnsIfTrueRule class >> ruleName [
+	^ 'Returns value of ifTrue:/ifFalse: without ifFalse:/ifTrue: block'
+]
+
+{ #category : 'accessing' }
 ReReturnsIfTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -27,9 +32,4 @@ ReReturnsIfTrueRule >> initialize [
 	self matchesAny: #(
 			'^`@condition ifTrue: [| `@temps | `@.statements]'
 			'^`@condition ifFalse: [| `@temps | `@.statements]' )
-]
-
-{ #category : 'accessing' }
-ReReturnsIfTrueRule >> name [
-	^ 'Returns value of ifTrue:/ifFalse: without ifFalse:/ifTrue: block'
 ]

--- a/src/General-Rules/ReSearchingLiteralRule.class.st
+++ b/src/General-Rules/ReSearchingLiteralRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSearchingLiteralRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReSearchingLiteralRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -21,11 +26,6 @@ ReSearchingLiteralRule >> afterCheck: aNode mappings: mappingDict [
 	^ self
 		isSearchingLiteralExpression: aNode
 		for: (mappingDict at: '``@object')
-]
-
-{ #category : 'accessing' }
-ReSearchingLiteralRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSearchingLiteralRule.class.st
+++ b/src/General-Rules/ReSearchingLiteralRule.class.st
@@ -15,6 +15,11 @@ ReSearchingLiteralRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSearchingLiteralRule class >> ruleName [
+	^ 'Uses or instead of a searching literal'
+]
+
+{ #category : 'accessing' }
 ReSearchingLiteralRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -67,9 +72,4 @@ ReSearchingLiteralRule >> isSearchingLiteralExpression: aSearchingNode for: anOb
 		for: anObjectNode) and:
 				[self isSearchingLiteralExpression: argument body statements first
 					for: anObjectNode]
-]
-
-{ #category : 'accessing' }
-ReSearchingLiteralRule >> name [
-	^ 'Uses or instead of a searching literal'
 ]

--- a/src/General-Rules/ReSelfSentNotImplementedRule.class.st
+++ b/src/General-Rules/ReSelfSentNotImplementedRule.class.st
@@ -30,6 +30,11 @@ ReSelfSentNotImplementedRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReSelfSentNotImplementedRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReSelfSentNotImplementedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -50,9 +55,4 @@ ReSelfSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	
 	problemSends do: [ :msgSend |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: msgSend hint: msgSend selector asString)]
-]
-
-{ #category : 'accessing' }
-ReSelfSentNotImplementedRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReSelfSentNotImplementedRule.class.st
+++ b/src/General-Rules/ReSelfSentNotImplementedRule.class.st
@@ -20,6 +20,11 @@ ReSelfSentNotImplementedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSelfSentNotImplementedRule class >> rationale [
+	^ 'Checks if messages sent to self or super exist in the hierarchy, since these can be statically typed. Reported methods will certainly cause a doesNotUnderstand: message when they are executed.'
+]
+
+{ #category : 'accessing' }
 ReSelfSentNotImplementedRule class >> ruleName [
 	^ 'Super and Self Messages sent but not implemented'
 ]
@@ -45,11 +50,6 @@ ReSelfSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	
 	problemSends do: [ :msgSend |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: msgSend hint: msgSend selector asString)]
-]
-
-{ #category : 'accessing' }
-ReSelfSentNotImplementedRule >> rationale [
-	^ 'Checks if messages sent to self or super exist in the hierarchy, since these can be statically typed. Reported methods will certainly cause a doesNotUnderstand: message when they are executed.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSelfSentNotImplementedRule.class.st
+++ b/src/General-Rules/ReSelfSentNotImplementedRule.class.st
@@ -15,6 +15,11 @@ ReSelfSentNotImplementedRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReSelfSentNotImplementedRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSelfSentNotImplementedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -35,11 +40,6 @@ ReSelfSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	
 	problemSends do: [ :msgSend |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: msgSend hint: msgSend selector asString)]
-]
-
-{ #category : 'accessing' }
-ReSelfSentNotImplementedRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSelfSentNotImplementedRule.class.st
+++ b/src/General-Rules/ReSelfSentNotImplementedRule.class.st
@@ -20,6 +20,11 @@ ReSelfSentNotImplementedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSelfSentNotImplementedRule class >> ruleName [
+	^ 'Super and Self Messages sent but not implemented'
+]
+
+{ #category : 'accessing' }
 ReSelfSentNotImplementedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -40,11 +45,6 @@ ReSelfSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	
 	problemSends do: [ :msgSend |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: msgSend hint: msgSend selector asString)]
-]
-
-{ #category : 'accessing' }
-ReSelfSentNotImplementedRule >> name [
-	^ 'Super and Self Messages sent but not implemented'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSendsDifferentSuperRule.class.st
+++ b/src/General-Rules/ReSendsDifferentSuperRule.class.st
@@ -22,6 +22,11 @@ ReSendsDifferentSuperRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReSendsDifferentSuperRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReSendsDifferentSuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -31,11 +36,6 @@ ReSendsDifferentSuperRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReSendsDifferentSuperRule >> basicCheck: aMethod [
 	^ aMethod superMessages anySatisfy: [ :message | message ~= aMethod selector ]
-]
-
-{ #category : 'accessing' }
-ReSendsDifferentSuperRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSendsDifferentSuperRule.class.st
+++ b/src/General-Rules/ReSendsDifferentSuperRule.class.st
@@ -27,6 +27,11 @@ ReSendsDifferentSuperRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSendsDifferentSuperRule class >> rationale [
+	^ 'Checks for methods whose source sends a different super message.'
+]
+
+{ #category : 'accessing' }
 ReSendsDifferentSuperRule class >> ruleName [
 	^ 'Sends different super message'
 ]
@@ -41,9 +46,4 @@ ReSendsDifferentSuperRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReSendsDifferentSuperRule >> basicCheck: aMethod [
 	^ aMethod superMessages anySatisfy: [ :message | message ~= aMethod selector ]
-]
-
-{ #category : 'accessing' }
-ReSendsDifferentSuperRule >> rationale [
-	^ 'Checks for methods whose source sends a different super message.'
 ]

--- a/src/General-Rules/ReSendsDifferentSuperRule.class.st
+++ b/src/General-Rules/ReSendsDifferentSuperRule.class.st
@@ -27,6 +27,11 @@ ReSendsDifferentSuperRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSendsDifferentSuperRule class >> ruleName [
+	^ 'Sends different super message'
+]
+
+{ #category : 'accessing' }
 ReSendsDifferentSuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -36,11 +41,6 @@ ReSendsDifferentSuperRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReSendsDifferentSuperRule >> basicCheck: aMethod [
 	^ aMethod superMessages anySatisfy: [ :message | message ~= aMethod selector ]
-]
-
-{ #category : 'accessing' }
-ReSendsDifferentSuperRule >> name [
-	^ 'Sends different super message'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSendsMethodDictRule.class.st
+++ b/src/General-Rules/ReSendsMethodDictRule.class.st
@@ -15,6 +15,11 @@ ReSendsMethodDictRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReSendsMethodDictRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSendsMethodDictRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -27,11 +32,6 @@ ReSendsMethodDictRule >> basicCheck: aMethod [
 	({Behavior . ClassDescription . Class. Metaclass. TraitedMetaclass. MetaclassForTraits} includes: aMethod methodClass)
 		ifTrue: [ ^ false ].
 	^(aMethod refersToLiteral: #methodDict) and: [aMethod messages includes: #methodDict]
-]
-
-{ #category : 'accessing' }
-ReSendsMethodDictRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSendsMethodDictRule.class.st
+++ b/src/General-Rules/ReSendsMethodDictRule.class.st
@@ -30,6 +30,11 @@ ReSendsMethodDictRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReSendsMethodDictRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReSendsMethodDictRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,9 +47,4 @@ ReSendsMethodDictRule >> basicCheck: aMethod [
 	({Behavior . ClassDescription . Class. Metaclass. TraitedMetaclass. MetaclassForTraits} includes: aMethod methodClass)
 		ifTrue: [ ^ false ].
 	^(aMethod refersToLiteral: #methodDict) and: [aMethod messages includes: #methodDict]
-]
-
-{ #category : 'accessing' }
-ReSendsMethodDictRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReSendsMethodDictRule.class.st
+++ b/src/General-Rules/ReSendsMethodDictRule.class.st
@@ -20,6 +20,11 @@ ReSendsMethodDictRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSendsMethodDictRule class >> ruleName [
+	^ 'No direct access of methodDict'
+]
+
+{ #category : 'accessing' }
 ReSendsMethodDictRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -32,11 +37,6 @@ ReSendsMethodDictRule >> basicCheck: aMethod [
 	({Behavior . ClassDescription . Class. Metaclass. TraitedMetaclass. MetaclassForTraits} includes: aMethod methodClass)
 		ifTrue: [ ^ false ].
 	^(aMethod refersToLiteral: #methodDict) and: [aMethod messages includes: #methodDict]
-]
-
-{ #category : 'accessing' }
-ReSendsMethodDictRule >> name [
-	^ 'No direct access of methodDict'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSendsMethodDictRule.class.st
+++ b/src/General-Rules/ReSendsMethodDictRule.class.st
@@ -20,6 +20,11 @@ ReSendsMethodDictRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSendsMethodDictRule class >> rationale [
+	^ 'Nobody should directly access the method dictionary. It is purely an implementation artefact that we use one dictionary and it might change in the future'
+]
+
+{ #category : 'accessing' }
 ReSendsMethodDictRule class >> ruleName [
 	^ 'No direct access of methodDict'
 ]
@@ -37,11 +42,6 @@ ReSendsMethodDictRule >> basicCheck: aMethod [
 	({Behavior . ClassDescription . Class. Metaclass. TraitedMetaclass. MetaclassForTraits} includes: aMethod methodClass)
 		ifTrue: [ ^ false ].
 	^(aMethod refersToLiteral: #methodDict) and: [aMethod messages includes: #methodDict]
-]
-
-{ #category : 'accessing' }
-ReSendsMethodDictRule >> rationale [
-	^ 'Nobody should directly access the method dictionary. It is purely an implementation artefact that we use one dictionary and it might change in the future'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSendsUnknownMessageToGlobalRule.class.st
+++ b/src/General-Rules/ReSendsUnknownMessageToGlobalRule.class.st
@@ -20,6 +20,11 @@ ReSendsUnknownMessageToGlobalRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReSendsUnknownMessageToGlobalRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReSendsUnknownMessageToGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,9 +42,4 @@ ReSendsUnknownMessageToGlobalRule >> basicCheck: aNode [
 	"if we know that the selector does not exist, we ignore"
 	(aNode methodNode compiledMethod allIgnoredNotImplementedSelectors includes: aNode selector) ifTrue: [ ^false ].
 	^ (aNode receiver variable value respondsTo: aNode selector) not
-]
-
-{ #category : 'accessing' }
-ReSendsUnknownMessageToGlobalRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReSendsUnknownMessageToGlobalRule.class.st
+++ b/src/General-Rules/ReSendsUnknownMessageToGlobalRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSendsUnknownMessageToGlobalRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSendsUnknownMessageToGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -27,11 +32,6 @@ ReSendsUnknownMessageToGlobalRule >> basicCheck: aNode [
 	"if we know that the selector does not exist, we ignore"
 	(aNode methodNode compiledMethod allIgnoredNotImplementedSelectors includes: aNode selector) ifTrue: [ ^false ].
 	^ (aNode receiver variable value respondsTo: aNode selector) not
-]
-
-{ #category : 'accessing' }
-ReSendsUnknownMessageToGlobalRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSendsUnknownMessageToGlobalRule.class.st
+++ b/src/General-Rules/ReSendsUnknownMessageToGlobalRule.class.st
@@ -15,6 +15,11 @@ ReSendsUnknownMessageToGlobalRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSendsUnknownMessageToGlobalRule class >> ruleName [
+	^ 'Sends unknown message to global'
+]
+
+{ #category : 'accessing' }
 ReSendsUnknownMessageToGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -32,11 +37,6 @@ ReSendsUnknownMessageToGlobalRule >> basicCheck: aNode [
 	"if we know that the selector does not exist, we ignore"
 	(aNode methodNode compiledMethod allIgnoredNotImplementedSelectors includes: aNode selector) ifTrue: [ ^false ].
 	^ (aNode receiver variable value respondsTo: aNode selector) not
-]
-
-{ #category : 'accessing' }
-ReSendsUnknownMessageToGlobalRule >> name [
-	^ 'Sends unknown message to global'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSentButNotUnderstoodBySuperRule.class.st
+++ b/src/General-Rules/ReSentButNotUnderstoodBySuperRule.class.st
@@ -33,6 +33,12 @@ ReSentButNotUnderstoodBySuperRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReSentButNotUnderstoodBySuperRule class >> severity [
+
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReSentButNotUnderstoodBySuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -55,10 +61,4 @@ ReSentButNotUnderstoodBySuperRule >> check: aMethod forCritiquesDo: aCriticBlock
 				 createTrivialCritiqueOn: aMethod
 				 intervalOf: msgSend
 				 hint: msgSend selector asString) ]
-]
-
-{ #category : 'accessing' }
-ReSentButNotUnderstoodBySuperRule >> severity [
-
-	^ #error
 ]

--- a/src/General-Rules/ReSentButNotUnderstoodBySuperRule.class.st
+++ b/src/General-Rules/ReSentButNotUnderstoodBySuperRule.class.st
@@ -22,6 +22,12 @@ ReSentButNotUnderstoodBySuperRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSentButNotUnderstoodBySuperRule class >> rationale [
+
+	^ 'Checks for messages that are sent by a method to super, but no superclass implements such a message. Reported methods will certainly cause a doesNotUnderstand: message when they are executed.'
+]
+
+{ #category : 'accessing' }
 ReSentButNotUnderstoodBySuperRule class >> ruleName [
 	^ 'Messages sent that super can not understand'
 ]
@@ -49,12 +55,6 @@ ReSentButNotUnderstoodBySuperRule >> check: aMethod forCritiquesDo: aCriticBlock
 				 createTrivialCritiqueOn: aMethod
 				 intervalOf: msgSend
 				 hint: msgSend selector asString) ]
-]
-
-{ #category : 'accessing' }
-ReSentButNotUnderstoodBySuperRule >> rationale [
-
-	^ 'Checks for messages that are sent by a method to super, but no superclass implements such a message. Reported methods will certainly cause a doesNotUnderstand: message when they are executed.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSentButNotUnderstoodBySuperRule.class.st
+++ b/src/General-Rules/ReSentButNotUnderstoodBySuperRule.class.st
@@ -16,6 +16,12 @@ ReSentButNotUnderstoodBySuperRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReSentButNotUnderstoodBySuperRule class >> group [
+
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSentButNotUnderstoodBySuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -38,12 +44,6 @@ ReSentButNotUnderstoodBySuperRule >> check: aMethod forCritiquesDo: aCriticBlock
 				 createTrivialCritiqueOn: aMethod
 				 intervalOf: msgSend
 				 hint: msgSend selector asString) ]
-]
-
-{ #category : 'accessing' }
-ReSentButNotUnderstoodBySuperRule >> group [
-
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSentButNotUnderstoodBySuperRule.class.st
+++ b/src/General-Rules/ReSentButNotUnderstoodBySuperRule.class.st
@@ -22,6 +22,11 @@ ReSentButNotUnderstoodBySuperRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSentButNotUnderstoodBySuperRule class >> ruleName [
+	^ 'Messages sent that super can not understand'
+]
+
+{ #category : 'accessing' }
 ReSentButNotUnderstoodBySuperRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -44,12 +49,6 @@ ReSentButNotUnderstoodBySuperRule >> check: aMethod forCritiquesDo: aCriticBlock
 				 createTrivialCritiqueOn: aMethod
 				 intervalOf: msgSend
 				 hint: msgSend selector asString) ]
-]
-
-{ #category : 'accessing' }
-ReSentButNotUnderstoodBySuperRule >> name [
-
-	^ 'Messages sent that super can not understand'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSentNotImplementedRule.class.st
+++ b/src/General-Rules/ReSentNotImplementedRule.class.st
@@ -15,6 +15,11 @@ ReSentNotImplementedRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReSentNotImplementedRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSentNotImplementedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				 createTrivialCritiqueOn: aMethod
 				 intervalOf: msgSend
 				 hint: msgSend selector asString) ]
-]
-
-{ #category : 'accessing' }
-ReSentNotImplementedRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSentNotImplementedRule.class.st
+++ b/src/General-Rules/ReSentNotImplementedRule.class.st
@@ -20,6 +20,11 @@ ReSentNotImplementedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSentNotImplementedRule class >> ruleName [
+	^ 'Messages sent but not implemented'
+]
+
+{ #category : 'accessing' }
 ReSentNotImplementedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,11 +47,6 @@ ReSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				 createTrivialCritiqueOn: aMethod
 				 intervalOf: msgSend
 				 hint: msgSend selector asString) ]
-]
-
-{ #category : 'accessing' }
-ReSentNotImplementedRule >> name [
-	^ 'Messages sent but not implemented'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSentNotImplementedRule.class.st
+++ b/src/General-Rules/ReSentNotImplementedRule.class.st
@@ -30,6 +30,11 @@ ReSentNotImplementedRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReSentNotImplementedRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReSentNotImplementedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -52,9 +57,4 @@ ReSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				 createTrivialCritiqueOn: aMethod
 				 intervalOf: msgSend
 				 hint: msgSend selector asString) ]
-]
-
-{ #category : 'accessing' }
-ReSentNotImplementedRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReSentNotImplementedRule.class.st
+++ b/src/General-Rules/ReSentNotImplementedRule.class.st
@@ -20,6 +20,11 @@ ReSentNotImplementedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSentNotImplementedRule class >> rationale [
+	^ 'Checks for messages that are sent by a method, but no class in the system implements such a message. Reported methods will certainly cause a doesNotUnderstand: message when they are executed.'
+]
+
+{ #category : 'accessing' }
 ReSentNotImplementedRule class >> ruleName [
 	^ 'Messages sent but not implemented'
 ]
@@ -47,11 +52,6 @@ ReSentNotImplementedRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				 createTrivialCritiqueOn: aMethod
 				 intervalOf: msgSend
 				 hint: msgSend selector asString) ]
-]
-
-{ #category : 'accessing' }
-ReSentNotImplementedRule >> rationale [
-	^ 'Checks for messages that are sent by a method, but no class in the system implements such a message. Reported methods will certainly cause a doesNotUnderstand: message when they are executed.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReShouldntRaiseErrorRule.class.st
+++ b/src/General-Rules/ReShouldntRaiseErrorRule.class.st
@@ -46,6 +46,11 @@ ReShouldntRaiseErrorRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReShouldntRaiseErrorRule class >> rationale [
+	^ 'Replaces `shouldnt: [ ... ] raise: Error` with  `[ ... ]`'
+]
+
+{ #category : 'accessing' }
 ReShouldntRaiseErrorRule class >> ruleName [
 	^ 'Do not use  `shouldnt: [ ... ] raise: Error` '
 ]
@@ -63,9 +68,4 @@ ReShouldntRaiseErrorRule >> initialize [
 	self
 		replace: 'self shouldnt: [ `@statements ] raise: Error' with: '`@statements';
 		replace: 'self shouldnt: [ `@statements ] raise: Exception' with: '`@statements'
-]
-
-{ #category : 'accessing' }
-ReShouldntRaiseErrorRule >> rationale [
-	^ 'Replaces `shouldnt: [ ... ] raise: Error` with  `[ ... ]`'
 ]

--- a/src/General-Rules/ReShouldntRaiseErrorRule.class.st
+++ b/src/General-Rules/ReShouldntRaiseErrorRule.class.st
@@ -41,15 +41,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReShouldntRaiseErrorRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReShouldntRaiseErrorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ShouldntRaiseErrorRule'
-]
-
-{ #category : 'accessing' }
-ReShouldntRaiseErrorRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReShouldntRaiseErrorRule.class.st
+++ b/src/General-Rules/ReShouldntRaiseErrorRule.class.st
@@ -46,6 +46,11 @@ ReShouldntRaiseErrorRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReShouldntRaiseErrorRule class >> ruleName [
+	^ 'Do not use  `shouldnt: [ ... ] raise: Error` '
+]
+
+{ #category : 'accessing' }
 ReShouldntRaiseErrorRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -58,11 +63,6 @@ ReShouldntRaiseErrorRule >> initialize [
 	self
 		replace: 'self shouldnt: [ `@statements ] raise: Error' with: '`@statements';
 		replace: 'self shouldnt: [ `@statements ] raise: Exception' with: '`@statements'
-]
-
-{ #category : 'accessing' }
-ReShouldntRaiseErrorRule >> name [
-	^ 'Do not use  `shouldnt: [ ... ] raise: Error` '
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSizeCheckRule.class.st
+++ b/src/General-Rules/ReSizeCheckRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSizeCheckRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReSizeCheckRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -23,11 +28,6 @@ ReSizeCheckRule >> genericPatternForSelector: aSymbol [
 			stream space; nextPutAll: value.
 			aSymbol last = $:
 				ifTrue: [ stream space; nextPutAll: '`@object'; print: index ] ] ]
-]
-
-{ #category : 'accessing' }
-ReSizeCheckRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSizeCheckRule.class.st
+++ b/src/General-Rules/ReSizeCheckRule.class.st
@@ -15,6 +15,11 @@ ReSizeCheckRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSizeCheckRule class >> ruleName [
+	^ 'Unnecessary size check'
+]
+
+{ #category : 'accessing' }
 ReSizeCheckRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -44,11 +49,6 @@ ReSizeCheckRule >> initialize [
 	patterns addAll: (self selectors
 		collect: [ :each | '`@object size = 0 ifFalse: [`@object' , (self genericPatternForSelector: each) , '. `@.Statements2]' ]).
 	self matchesAny: patterns
-]
-
-{ #category : 'accessing' }
-ReSizeCheckRule >> name [
-	^ 'Unnecessary size check'
 ]
 
 { #category : 'private' }

--- a/src/General-Rules/ReSmalltalkGlobalsRule.class.st
+++ b/src/General-Rules/ReSmalltalkGlobalsRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSmalltalkGlobalsRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReSmalltalkGlobalsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^ 'SmalltalkGlobalsRule'
-]
-
-{ #category : 'accessing' }
-ReSmalltalkGlobalsRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSmalltalkGlobalsRule.class.st
+++ b/src/General-Rules/ReSmalltalkGlobalsRule.class.st
@@ -15,6 +15,11 @@ ReSmalltalkGlobalsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSmalltalkGlobalsRule class >> ruleName [
+	^ 'Use "Smalltalk globals" instead of "Smalltalk"'
+]
+
+{ #category : 'accessing' }
 ReSmalltalkGlobalsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,9 +42,4 @@ ReSmalltalkGlobalsRule >> initialize [
 			with: 'Smalltalk globals flushClassNameCache';
 		replace: 'Smalltalk includesKey: `@statements'
 			with: 'Smalltalk globals includesKey: `@statements'
-]
-
-{ #category : 'accessing' }
-ReSmalltalkGlobalsRule >> name [
-	^ 'Use "Smalltalk globals" instead of "Smalltalk"'
 ]

--- a/src/General-Rules/ReStatementsAfterReturnConditionalRule.class.st
+++ b/src/General-Rules/ReStatementsAfterReturnConditionalRule.class.st
@@ -16,6 +16,12 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReStatementsAfterReturnConditionalRule class >> group [
+
+	^ 'Potential Bugs'
+]
+
 { #category : 'running' }
 ReStatementsAfterReturnConditionalRule >> basicCheck: aNode [
 
@@ -24,12 +30,6 @@ ReStatementsAfterReturnConditionalRule >> basicCheck: aNode [
 	aNode arguments do: [ :arg |
 		(arg isBlock and: [ arg statements last isReturn ]) ifFalse: [ ^ false ] ].
 	^ aNode ~= aNode methodNode statements last
-]
-
-{ #category : 'accessing' }
-ReStatementsAfterReturnConditionalRule >> group [
-
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReStatementsAfterReturnConditionalRule.class.st
+++ b/src/General-Rules/ReStatementsAfterReturnConditionalRule.class.st
@@ -22,6 +22,11 @@ ReStatementsAfterReturnConditionalRule class >> group [
 	^ 'Potential Bugs'
 ]
 
+{ #category : 'accessing' }
+ReStatementsAfterReturnConditionalRule class >> ruleName [
+	^ 'statements written after conditional return'
+]
+
 { #category : 'running' }
 ReStatementsAfterReturnConditionalRule >> basicCheck: aNode [
 
@@ -30,12 +35,6 @@ ReStatementsAfterReturnConditionalRule >> basicCheck: aNode [
 	aNode arguments do: [ :arg |
 		(arg isBlock and: [ arg statements last isReturn ]) ifFalse: [ ^ false ] ].
 	^ aNode ~= aNode methodNode statements last
-]
-
-{ #category : 'accessing' }
-ReStatementsAfterReturnConditionalRule >> name [
-
-	^ 'statements written after conditional return'
 ]
 
 { #category : 'utilities' }

--- a/src/General-Rules/ReStringConcatenationRule.class.st
+++ b/src/General-Rules/ReStringConcatenationRule.class.st
@@ -31,6 +31,11 @@ ReStringConcatenationRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReStringConcatenationRule class >> ruleName [
+	^ 'String concatenation instead of streams'
+]
+
+{ #category : 'accessing' }
 ReStringConcatenationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -65,11 +70,6 @@ ReStringConcatenationRule >> initialize [
 		'``@collection anySatisfy: ``@argument'
 		'``@collection allSatisfy: ``@argument'
 		'``@collection noneSatisfy: ``@argument' )
-]
-
-{ #category : 'accessing' }
-ReStringConcatenationRule >> name [
-	^ 'String concatenation instead of streams'
 ]
 
 { #category : 'hooks' }

--- a/src/General-Rules/ReStringConcatenationRule.class.st
+++ b/src/General-Rules/ReStringConcatenationRule.class.st
@@ -26,6 +26,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReStringConcatenationRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReStringConcatenationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -43,11 +48,6 @@ ReStringConcatenationRule >> afterCheck: aNode mappings: mappingDict [
 			^ self performsConcatenation: arg2 ]).
 
 	^ false
-]
-
-{ #category : 'accessing' }
-ReStringConcatenationRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSubclassResponsibilityNotDefinedRule.class.st
+++ b/src/General-Rules/ReSubclassResponsibilityNotDefinedRule.class.st
@@ -20,6 +20,11 @@ ReSubclassResponsibilityNotDefinedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSubclassResponsibilityNotDefinedRule class >> rationale [
+	^ 'Checks that all methods which send #subclassResponsibility, which indicates that they are abstract, are defined in all leaf classes.'
+]
+
+{ #category : 'accessing' }
 ReSubclassResponsibilityNotDefinedRule class >> ruleName [
 	^ '#subclassResponsibility not defined'
 ]
@@ -46,11 +51,6 @@ ReSubclassResponsibilityNotDefinedRule >> check: aClass forCritiquesDo: aCriticB
 						selector: method selector)
 						beShouldBeImplemented;
 						yourself ] ]) ]
-]
-
-{ #category : 'accessing' }
-ReSubclassResponsibilityNotDefinedRule >> rationale [
-	^ 'Checks that all methods which send #subclassResponsibility, which indicates that they are abstract, are defined in all leaf classes.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSubclassResponsibilityNotDefinedRule.class.st
+++ b/src/General-Rules/ReSubclassResponsibilityNotDefinedRule.class.st
@@ -30,6 +30,11 @@ ReSubclassResponsibilityNotDefinedRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReSubclassResponsibilityNotDefinedRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReSubclassResponsibilityNotDefinedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -51,9 +56,4 @@ ReSubclassResponsibilityNotDefinedRule >> check: aClass forCritiquesDo: aCriticB
 						selector: method selector)
 						beShouldBeImplemented;
 						yourself ] ]) ]
-]
-
-{ #category : 'accessing' }
-ReSubclassResponsibilityNotDefinedRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReSubclassResponsibilityNotDefinedRule.class.st
+++ b/src/General-Rules/ReSubclassResponsibilityNotDefinedRule.class.st
@@ -15,6 +15,11 @@ ReSubclassResponsibilityNotDefinedRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReSubclassResponsibilityNotDefinedRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSubclassResponsibilityNotDefinedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -36,11 +41,6 @@ ReSubclassResponsibilityNotDefinedRule >> check: aClass forCritiquesDo: aCriticB
 						selector: method selector)
 						beShouldBeImplemented;
 						yourself ] ]) ]
-]
-
-{ #category : 'accessing' }
-ReSubclassResponsibilityNotDefinedRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSubclassResponsibilityNotDefinedRule.class.st
+++ b/src/General-Rules/ReSubclassResponsibilityNotDefinedRule.class.st
@@ -20,6 +20,11 @@ ReSubclassResponsibilityNotDefinedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSubclassResponsibilityNotDefinedRule class >> ruleName [
+	^ '#subclassResponsibility not defined'
+]
+
+{ #category : 'accessing' }
 ReSubclassResponsibilityNotDefinedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -41,11 +46,6 @@ ReSubclassResponsibilityNotDefinedRule >> check: aClass forCritiquesDo: aCriticB
 						selector: method selector)
 						beShouldBeImplemented;
 						yourself ] ]) ]
-]
-
-{ #category : 'accessing' }
-ReSubclassResponsibilityNotDefinedRule >> name [
-	^ '#subclassResponsibility not defined'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSuperSendsNewRule.class.st
+++ b/src/General-Rules/ReSuperSendsNewRule.class.st
@@ -16,6 +16,11 @@ ReSuperSendsNewRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSuperSendsNewRule class >> ruleName [
+	^ 'Sends super new initialize or self new initialize'
+]
+
+{ #category : 'accessing' }
 ReSuperSendsNewRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -35,9 +40,4 @@ ReSuperSendsNewRule >> initialize [
 			'(super new: `@expr) initialize'
 			'self new initialize'
 			'(self new: `@expr) initialize' )
-]
-
-{ #category : 'accessing' }
-ReSuperSendsNewRule >> name [
-	^ 'Sends super new initialize or self new initialize'
 ]

--- a/src/General-Rules/ReSuperSendsNewRule.class.st
+++ b/src/General-Rules/ReSuperSendsNewRule.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSuperSendsNewRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReSuperSendsNewRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -20,11 +25,6 @@ ReSuperSendsNewRule class >> uniqueIdentifierName [
 { #category : 'hooks' }
 ReSuperSendsNewRule >> afterCheck: aNode mappings: mappingDict [
 	^ aNode methodNode methodClass isMeta
-]
-
-{ #category : 'accessing' }
-ReSuperSendsNewRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSuperSendsRule.class.st
+++ b/src/General-Rules/ReSuperSendsRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReSuperSendsRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReSuperSendsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'SuperSendsRule'
-]
-
-{ #category : 'accessing' }
-ReSuperSendsRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReSuperSendsRule.class.st
+++ b/src/General-Rules/ReSuperSendsRule.class.st
@@ -15,6 +15,11 @@ ReSuperSendsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReSuperSendsRule class >> ruleName [
+	^ 'Rewrite super messages to self messages'
+]
+
+{ #category : 'accessing' }
 ReSuperSendsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -27,11 +32,6 @@ ReSuperSendsRule >> initialize [
 	self
 		replace: 'super `@message: ``@args'
 		with: 'self `@message: ``@args'
-]
-
-{ #category : 'accessing' }
-ReSuperSendsRule >> name [
-	^ 'Rewrite super messages to self messages'
 ]
 
 { #category : 'testing' }

--- a/src/General-Rules/ReSuperWithoutSend.class.st
+++ b/src/General-Rules/ReSuperWithoutSend.class.st
@@ -14,6 +14,11 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReSuperWithoutSend class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'running' }
 ReSuperWithoutSend >> basicCheck: aNode [
 	aNode isVariable ifFalse: [ ^ false ].
@@ -23,11 +28,6 @@ ReSuperWithoutSend >> basicCheck: aNode [
 		^aNode parent receiver ~= aNode
 	].
 	^true
-]
-
-{ #category : 'accessing' }
-ReSuperWithoutSend >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReSuperWithoutSend.class.st
+++ b/src/General-Rules/ReSuperWithoutSend.class.st
@@ -19,6 +19,11 @@ ReSuperWithoutSend class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReSuperWithoutSend class >> ruleName [
+	^ 'super makes only sense as the receiver of a message'
+]
+
 { #category : 'running' }
 ReSuperWithoutSend >> basicCheck: aNode [
 	aNode isVariable ifFalse: [ ^ false ].
@@ -28,9 +33,4 @@ ReSuperWithoutSend >> basicCheck: aNode [
 		^aNode parent receiver ~= aNode
 	].
 	^true
-]
-
-{ #category : 'accessing' }
-ReSuperWithoutSend >> name [
-	^ 'super makes only sense as the receiver of a message'
 ]

--- a/src/General-Rules/ReTempVarOverridesInstVarRule.class.st
+++ b/src/General-Rules/ReTempVarOverridesInstVarRule.class.st
@@ -20,6 +20,11 @@ ReTempVarOverridesInstVarRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReTempVarOverridesInstVarRule class >> ruleName [
+	^ 'Outer variable shadowed by temporary variable or argument'
+]
+
+{ #category : 'accessing' }
 ReTempVarOverridesInstVarRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -47,9 +52,4 @@ ReTempVarOverridesInstVarRule >> critiqueFor: aMethod about: aVarNode [
 		by: self)
 		tinyHint: aVarNode name;
 		yourself
-]
-
-{ #category : 'accessing' }
-ReTempVarOverridesInstVarRule >> name [
-	^ 'Outer variable shadowed by temporary variable or argument'
 ]

--- a/src/General-Rules/ReTempVarOverridesInstVarRule.class.st
+++ b/src/General-Rules/ReTempVarOverridesInstVarRule.class.st
@@ -15,6 +15,11 @@ ReTempVarOverridesInstVarRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReTempVarOverridesInstVarRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReTempVarOverridesInstVarRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -42,11 +47,6 @@ ReTempVarOverridesInstVarRule >> critiqueFor: aMethod about: aVarNode [
 		by: self)
 		tinyHint: aVarNode name;
 		yourself
-]
-
-{ #category : 'accessing' }
-ReTempVarOverridesInstVarRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTemporaryNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReTemporaryNeitherReadNorWrittenRule.class.st
@@ -14,15 +14,15 @@ ReTemporaryNeitherReadNorWrittenRule class >> group [
 	^ 'Optimization'
 ]
 
+{ #category : 'accessing' }
+ReTemporaryNeitherReadNorWrittenRule class >> ruleName [
+	^ 'Temporary variables not read or not written'
+]
+
 { #category : 'running' }
 ReTemporaryNeitherReadNorWrittenRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isTempVariable ifFalse: [ ^ self ].
 	aNode isDefinition ifFalse: [ ^ self ].
 	aNode variable isReferenced ifFalse: [
 		aBlock cull: (self critiqueFor: aNode) ]
-]
-
-{ #category : 'accessing' }
-ReTemporaryNeitherReadNorWrittenRule >> name [
-	^ 'Temporary variables not read or not written'
 ]

--- a/src/General-Rules/ReTemporaryNeitherReadNorWrittenRule.class.st
+++ b/src/General-Rules/ReTemporaryNeitherReadNorWrittenRule.class.st
@@ -9,17 +9,17 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReTemporaryNeitherReadNorWrittenRule class >> group [
+	^ 'Optimization'
+]
+
 { #category : 'running' }
 ReTemporaryNeitherReadNorWrittenRule >> check: aNode forCritiquesDo: aBlock [
 	aNode isTempVariable ifFalse: [ ^ self ].
 	aNode isDefinition ifFalse: [ ^ self ].
 	aNode variable isReferenced ifFalse: [
 		aBlock cull: (self critiqueFor: aNode) ]
-]
-
-{ #category : 'accessing' }
-ReTemporaryNeitherReadNorWrittenRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTemporaryVariableCapitalizationRule.class.st
+++ b/src/General-Rules/ReTemporaryVariableCapitalizationRule.class.st
@@ -9,6 +9,11 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReTemporaryVariableCapitalizationRule class >> group [
+	^ 'Style'
+]
+
 { #category : 'running' }
 ReTemporaryVariableCapitalizationRule >> basicCheck: aNode [
 	aNode isLocalVariable ifFalse: [ ^false ].
@@ -34,11 +39,6 @@ ReTemporaryVariableCapitalizationRule >> critiqueFor: aNode [
 				selector: aNode methodNode selector).
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReTemporaryVariableCapitalizationRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTemporaryVariableCapitalizationRule.class.st
+++ b/src/General-Rules/ReTemporaryVariableCapitalizationRule.class.st
@@ -14,6 +14,11 @@ ReTemporaryVariableCapitalizationRule class >> group [
 	^ 'Style'
 ]
 
+{ #category : 'accessing' }
+ReTemporaryVariableCapitalizationRule class >> ruleName [
+	^ 'Temporary variable (or parameter) capitalized'
+]
+
 { #category : 'running' }
 ReTemporaryVariableCapitalizationRule >> basicCheck: aNode [
 	aNode isLocalVariable ifFalse: [ ^false ].
@@ -39,9 +44,4 @@ ReTemporaryVariableCapitalizationRule >> critiqueFor: aNode [
 				selector: aNode methodNode selector).
 
 	^ crit
-]
-
-{ #category : 'accessing' }
-ReTemporaryVariableCapitalizationRule >> name [
-	^ 'Temporary variable (or parameter) capitalized'
 ]

--- a/src/General-Rules/ReTempsReadBeforeWrittenRule.class.st
+++ b/src/General-Rules/ReTempsReadBeforeWrittenRule.class.st
@@ -32,6 +32,11 @@ ReTempsReadBeforeWrittenRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReTempsReadBeforeWrittenRule class >> ruleName [
+	^ 'Temporaries may be read before written'
+]
+
+{ #category : 'accessing' }
 ReTempsReadBeforeWrittenRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -56,10 +61,4 @@ ReTempsReadBeforeWrittenRule >> findReadsBeforeWrittenTemporariesIn: aMethod [
 
 	^ (RBReadBeforeWrittenTester variablesReadBeforeWrittenIn:
 		   aMethod ast) array select: #isNotNil
-]
-
-{ #category : 'accessing' }
-ReTempsReadBeforeWrittenRule >> name [
-
-	^ 'Temporaries may be read before written'
 ]

--- a/src/General-Rules/ReTempsReadBeforeWrittenRule.class.st
+++ b/src/General-Rules/ReTempsReadBeforeWrittenRule.class.st
@@ -27,6 +27,11 @@ ReTempsReadBeforeWrittenRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReTempsReadBeforeWrittenRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReTempsReadBeforeWrittenRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -51,11 +56,6 @@ ReTempsReadBeforeWrittenRule >> findReadsBeforeWrittenTemporariesIn: aMethod [
 
 	^ (RBReadBeforeWrittenTester variablesReadBeforeWrittenIn:
 		   aMethod ast) array select: #isNotNil
-]
-
-{ #category : 'accessing' }
-ReTempsReadBeforeWrittenRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTestCaseShouldNotUseInitializeRule.class.st
+++ b/src/General-Rules/ReTestCaseShouldNotUseInitializeRule.class.st
@@ -19,6 +19,11 @@ ReTestCaseShouldNotUseInitializeRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReTestCaseShouldNotUseInitializeRule class >> group [
+	^ 'Clean Code'
+]
+
+{ #category : 'accessing' }
 ReTestCaseShouldNotUseInitializeRule >> basicCheck: aClass [
 
 	| alteredVariables expectedVariables |
@@ -36,11 +41,6 @@ ReTestCaseShouldNotUseInitializeRule >> basicCheck: aClass [
 	expectedVariables := aClass new instanceVariablesToKeep.
 
 	^ alteredVariables anySatisfy: [ :e | (expectedVariables includes: e name) not ]
-]
-
-{ #category : 'accessing' }
-ReTestCaseShouldNotUseInitializeRule >> group [
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTestCaseShouldNotUseInitializeRule.class.st
+++ b/src/General-Rules/ReTestCaseShouldNotUseInitializeRule.class.st
@@ -24,6 +24,11 @@ ReTestCaseShouldNotUseInitializeRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReTestCaseShouldNotUseInitializeRule class >> ruleName [
+	^ 'Tests should not use initialize'
+]
+
+{ #category : 'accessing' }
 ReTestCaseShouldNotUseInitializeRule >> basicCheck: aClass [
 
 	| alteredVariables expectedVariables |
@@ -41,10 +46,4 @@ ReTestCaseShouldNotUseInitializeRule >> basicCheck: aClass [
 	expectedVariables := aClass new instanceVariablesToKeep.
 
 	^ alteredVariables anySatisfy: [ :e | (expectedVariables includes: e name) not ]
-]
-
-{ #category : 'accessing' }
-ReTestCaseShouldNotUseInitializeRule >> name [
-
-	^ 'Tests should not use initialize'
 ]

--- a/src/General-Rules/ReThemeAPIUpdateRule.class.st
+++ b/src/General-Rules/ReThemeAPIUpdateRule.class.st
@@ -11,15 +11,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReThemeAPIUpdateRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReThemeAPIUpdateRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ThemeAPIUpdateRule'
-]
-
-{ #category : 'accessing' }
-ReThemeAPIUpdateRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReThemeAPIUpdateRule.class.st
+++ b/src/General-Rules/ReThemeAPIUpdateRule.class.st
@@ -16,6 +16,11 @@ ReThemeAPIUpdateRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReThemeAPIUpdateRule class >> ruleName [
+	^ 'Use "Smalltalk ui theme" and "Smalltalk ui icons"'
+]
+
+{ #category : 'accessing' }
 ReThemeAPIUpdateRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,9 +35,4 @@ ReThemeAPIUpdateRule >> initialize [
 			with: 'Smalltalk ui theme';
 		replace: 'ThemeIcons current'
 			with: 'Smalltalk ui icons'
-]
-
-{ #category : 'accessing' }
-ReThemeAPIUpdateRule >> name [
-	^ 'Use "Smalltalk ui theme" and "Smalltalk ui icons"'
 ]

--- a/src/General-Rules/ReThreeElementPointRule.class.st
+++ b/src/General-Rules/ReThreeElementPointRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReThreeElementPointRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReThreeElementPointRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -47,11 +52,6 @@ ReThreeElementPointRule >> findSuspiciousParentFor: aNode ifNone: alternativeBlo
 	^ self
 		findSuspiciousParentFor: tentativeNode
 		ifNone: alternativeBlock
-]
-
-{ #category : 'accessing' }
-ReThreeElementPointRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReThreeElementPointRule.class.st
+++ b/src/General-Rules/ReThreeElementPointRule.class.st
@@ -15,6 +15,11 @@ ReThreeElementPointRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReThreeElementPointRule class >> ruleName [
+	^ 'Possible three element point (e.g., x @ y + q @ r)'
+]
+
+{ #category : 'accessing' }
 ReThreeElementPointRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -52,9 +57,4 @@ ReThreeElementPointRule >> findSuspiciousParentFor: aNode ifNone: alternativeBlo
 	^ self
 		findSuspiciousParentFor: tentativeNode
 		ifNone: alternativeBlock
-]
-
-{ #category : 'accessing' }
-ReThreeElementPointRule >> name [
-	^ 'Possible three element point (e.g., x @ y + q @ r)'
 ]

--- a/src/General-Rules/ReToDoCollectRule.class.st
+++ b/src/General-Rules/ReToDoCollectRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReToDoCollectRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReToDoCollectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ToDoCollectRule'
-]
-
-{ #category : 'accessing' }
-ReToDoCollectRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReToDoCollectRule.class.st
+++ b/src/General-Rules/ReToDoCollectRule.class.st
@@ -15,6 +15,11 @@ ReToDoCollectRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReToDoCollectRule class >> ruleName [
+	^ 'to:do: used instead of collect:'
+]
+
+{ #category : 'accessing' }
 ReToDoCollectRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -47,9 +52,4 @@ ReToDoCollectRule >> initialize [
 					`collection at: `i put: `@obj.
 					`@.BStmt2].
 			`@.Stmts3' )
-]
-
-{ #category : 'accessing' }
-ReToDoCollectRule >> name [
-	^ 'to:do: used instead of collect:'
 ]

--- a/src/General-Rules/ReToDoWithIncrementRule.class.st
+++ b/src/General-Rules/ReToDoWithIncrementRule.class.st
@@ -18,6 +18,11 @@ ReToDoWithIncrementRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReToDoWithIncrementRule class >> rationale [
+	^ 'Checks for users of to:do: that also increment or decrement a counter.'
+]
+
+{ #category : 'accessing' }
 ReToDoWithIncrementRule class >> ruleName [
 	^ 'to:do: loop also increments a counter'
 ]
@@ -37,9 +42,4 @@ ReToDoWithIncrementRule >> initialize [
 			'`@i to: `@j by: `@k do: [:`e | | `@temps | `@.Stmts. `x := `x + `@k. `@.Stmts2]'
 			'`@i to: `@j do: [:`e | | `@temps | `@.Stmts. `x := `x - 1. `@.Stmts2]'
 			'`@i to: `@j by: `@k do: [:`e | | `@temps | `@.Stmts. `x := `x - `@k. `@.Stmts2]')
-]
-
-{ #category : 'accessing' }
-ReToDoWithIncrementRule >> rationale [
-	^ 'Checks for users of to:do: that also increment or decrement a counter.'
 ]

--- a/src/General-Rules/ReToDoWithIncrementRule.class.st
+++ b/src/General-Rules/ReToDoWithIncrementRule.class.st
@@ -13,15 +13,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReToDoWithIncrementRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReToDoWithIncrementRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ToDoWithIncrementRule'
-]
-
-{ #category : 'accessing' }
-ReToDoWithIncrementRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReToDoWithIncrementRule.class.st
+++ b/src/General-Rules/ReToDoWithIncrementRule.class.st
@@ -18,6 +18,11 @@ ReToDoWithIncrementRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReToDoWithIncrementRule class >> ruleName [
+	^ 'to:do: loop also increments a counter'
+]
+
+{ #category : 'accessing' }
 ReToDoWithIncrementRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -32,11 +37,6 @@ ReToDoWithIncrementRule >> initialize [
 			'`@i to: `@j by: `@k do: [:`e | | `@temps | `@.Stmts. `x := `x + `@k. `@.Stmts2]'
 			'`@i to: `@j do: [:`e | | `@temps | `@.Stmts. `x := `x - 1. `@.Stmts2]'
 			'`@i to: `@j by: `@k do: [:`e | | `@temps | `@.Stmts. `x := `x - `@k. `@.Stmts2]')
-]
-
-{ #category : 'accessing' }
-ReToDoWithIncrementRule >> name [
-	^ 'to:do: loop also increments a counter'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTrueFalseDuplicationRule.class.st
+++ b/src/General-Rules/ReTrueFalseDuplicationRule.class.st
@@ -26,6 +26,11 @@ ReTrueFalseDuplicationRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReTrueFalseDuplicationRule class >> rationale [
+	^ 'Checks for ifTrue:ifFalse: blocks that have the same code at the beginning or end.'
+]
+
+{ #category : 'accessing' }
 ReTrueFalseDuplicationRule class >> ruleName [
 	^ 'Check for same statements at end of ifTrue:ifFalse: blocks'
 ]
@@ -112,11 +117,6 @@ ReTrueFalseDuplicationRule >> initialize [
 			ifFalse: [ | `@falseTemps | `@.FalseStatements. ]
 			ifTrue: [ | `@trueTemps | `@.TrueStatements. ].
 		`.@PostStatements.'
-]
-
-{ #category : 'accessing' }
-ReTrueFalseDuplicationRule >> rationale [
-	^ 'Checks for ifTrue:ifFalse: blocks that have the same code at the beginning or end.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTrueFalseDuplicationRule.class.st
+++ b/src/General-Rules/ReTrueFalseDuplicationRule.class.st
@@ -26,6 +26,11 @@ ReTrueFalseDuplicationRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReTrueFalseDuplicationRule class >> ruleName [
+	^ 'Check for same statements at end of ifTrue:ifFalse: blocks'
+]
+
+{ #category : 'accessing' }
 ReTrueFalseDuplicationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -107,11 +112,6 @@ ReTrueFalseDuplicationRule >> initialize [
 			ifFalse: [ | `@falseTemps | `@.FalseStatements. ]
 			ifTrue: [ | `@trueTemps | `@.TrueStatements. ].
 		`.@PostStatements.'
-]
-
-{ #category : 'accessing' }
-ReTrueFalseDuplicationRule >> name [
-	^ 'Check for same statements at end of ifTrue:ifFalse: blocks'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReTrueFalseDuplicationRule.class.st
+++ b/src/General-Rules/ReTrueFalseDuplicationRule.class.st
@@ -21,6 +21,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReTrueFalseDuplicationRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReTrueFalseDuplicationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -37,11 +42,6 @@ ReTrueFalseDuplicationRule >> afterCheck: aNode mappings: mappingDict [
 
 	"the first statement is duplicated"
 	^ true
-]
-
-{ #category : 'accessing' }
-ReTrueFalseDuplicationRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReTrueFalseDuplicationRule.class.st
+++ b/src/General-Rules/ReTrueFalseDuplicationRule.class.st
@@ -36,6 +36,11 @@ ReTrueFalseDuplicationRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReTrueFalseDuplicationRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReTrueFalseDuplicationRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -117,9 +122,4 @@ ReTrueFalseDuplicationRule >> initialize [
 			ifFalse: [ | `@falseTemps | `@.FalseStatements. ]
 			ifTrue: [ | `@trueTemps | `@.TrueStatements. ].
 		`.@PostStatements.'
-]
-
-{ #category : 'accessing' }
-ReTrueFalseDuplicationRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReUnaryAccessingMethodWithoutReturnRule.class.st
+++ b/src/General-Rules/ReUnaryAccessingMethodWithoutReturnRule.class.st
@@ -15,6 +15,11 @@ ReUnaryAccessingMethodWithoutReturnRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUnaryAccessingMethodWithoutReturnRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReUnaryAccessingMethodWithoutReturnRule class >> uniqueIdentifierName [
 
 	^ 'UnaryAccessingMethodWithoutReturnRule'
@@ -26,11 +31,6 @@ ReUnaryAccessingMethodWithoutReturnRule >> basicCheck: aMethod [
 	(aMethod numArgs > 0 or: [ aMethod isAbstract ]) ifTrue: [ ^ false ].
 	(aMethod protocolName beginsWith: 'accessing') ifFalse: [ ^ false ].
 	^ aMethod ast allChildren noneSatisfy: [ :each | each isReturn ]
-]
-
-{ #category : 'accessing' }
-ReUnaryAccessingMethodWithoutReturnRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnaryAccessingMethodWithoutReturnRule.class.st
+++ b/src/General-Rules/ReUnaryAccessingMethodWithoutReturnRule.class.st
@@ -20,6 +20,11 @@ ReUnaryAccessingMethodWithoutReturnRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUnaryAccessingMethodWithoutReturnRule class >> ruleName [
+	^ 'Unary "accessing" method without explicit return'
+]
+
+{ #category : 'accessing' }
 ReUnaryAccessingMethodWithoutReturnRule class >> uniqueIdentifierName [
 
 	^ 'UnaryAccessingMethodWithoutReturnRule'
@@ -31,9 +36,4 @@ ReUnaryAccessingMethodWithoutReturnRule >> basicCheck: aMethod [
 	(aMethod numArgs > 0 or: [ aMethod isAbstract ]) ifTrue: [ ^ false ].
 	(aMethod protocolName beginsWith: 'accessing') ifFalse: [ ^ false ].
 	^ aMethod ast allChildren noneSatisfy: [ :each | each isReturn ]
-]
-
-{ #category : 'accessing' }
-ReUnaryAccessingMethodWithoutReturnRule >> name [
-	^ 'Unary "accessing" method without explicit return'
 ]

--- a/src/General-Rules/ReUnclassifiedMethodsRule.class.st
+++ b/src/General-Rules/ReUnclassifiedMethodsRule.class.st
@@ -15,6 +15,11 @@ ReUnclassifiedMethodsRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUnclassifiedMethodsRule class >> group [
+	^ 'Style'
+]
+
+{ #category : 'accessing' }
 ReUnclassifiedMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ ReUnclassifiedMethodsRule class >> uniqueIdentifierName [
 ReUnclassifiedMethodsRule >> basicCheck: aMethod [
 
 	^ aMethod isClassified not
-]
-
-{ #category : 'accessing' }
-ReUnclassifiedMethodsRule >> group [
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnclassifiedMethodsRule.class.st
+++ b/src/General-Rules/ReUnclassifiedMethodsRule.class.st
@@ -20,6 +20,11 @@ ReUnclassifiedMethodsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUnclassifiedMethodsRule class >> ruleName [
+	^ 'Unclassified methods'
+]
+
+{ #category : 'accessing' }
 ReUnclassifiedMethodsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,9 +35,4 @@ ReUnclassifiedMethodsRule class >> uniqueIdentifierName [
 ReUnclassifiedMethodsRule >> basicCheck: aMethod [
 
 	^ aMethod isClassified not
-]
-
-{ #category : 'accessing' }
-ReUnclassifiedMethodsRule >> name [
-	^ 'Unclassified methods'
 ]

--- a/src/General-Rules/ReUncommonMessageSendRule.class.st
+++ b/src/General-Rules/ReUncommonMessageSendRule.class.st
@@ -17,6 +17,11 @@ ReUncommonMessageSendRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUncommonMessageSendRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReUncommonMessageSendRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -38,11 +43,6 @@ ReUncommonMessageSendRule >> check: aMethod forCritiquesDo: aCriticBlock [
 ReUncommonMessageSendRule >> commonLiterals [
 
 	^ #(#self #super #thisContext #true #false #nil)
-]
-
-{ #category : 'accessing' }
-ReUncommonMessageSendRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUncommonMessageSendRule.class.st
+++ b/src/General-Rules/ReUncommonMessageSendRule.class.st
@@ -22,6 +22,11 @@ ReUncommonMessageSendRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUncommonMessageSendRule class >> ruleName [
+	^ 'Uncommon message send'
+]
+
+{ #category : 'accessing' }
 ReUncommonMessageSendRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -43,9 +48,4 @@ ReUncommonMessageSendRule >> check: aMethod forCritiquesDo: aCriticBlock [
 ReUncommonMessageSendRule >> commonLiterals [
 
 	^ #(#self #super #thisContext #true #false #nil)
-]
-
-{ #category : 'accessing' }
-ReUncommonMessageSendRule >> name [
-	^ 'Uncommon message send'
 ]

--- a/src/General-Rules/ReUnconditionalRecursionRule.class.st
+++ b/src/General-Rules/ReUnconditionalRecursionRule.class.st
@@ -16,6 +16,11 @@ ReUnconditionalRecursionRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUnconditionalRecursionRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReUnconditionalRecursionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ ReUnconditionalRecursionRule class >> uniqueIdentifierName [
 { #category : 'hooks' }
 ReUnconditionalRecursionRule >> afterCheck: aNode mappings: mappingDict [
 	^ (mappingDict at: '`@.before') noneSatisfy: #containsReturn
-]
-
-{ #category : 'accessing' }
-ReUnconditionalRecursionRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUnconditionalRecursionRule.class.st
+++ b/src/General-Rules/ReUnconditionalRecursionRule.class.st
@@ -21,6 +21,11 @@ ReUnconditionalRecursionRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUnconditionalRecursionRule class >> ruleName [
+	^ 'Unconditional recursion'
+]
+
+{ #category : 'accessing' }
 ReUnconditionalRecursionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -41,11 +46,6 @@ ReUnconditionalRecursionRule >> initialize [
 			`@.before.
 			self `@message: `@args.
 			`@.after'
-]
-
-{ #category : 'accessing' }
-ReUnconditionalRecursionRule >> name [
-	^ 'Unconditional recursion'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnconditionalRecursionRule.class.st
+++ b/src/General-Rules/ReUnconditionalRecursionRule.class.st
@@ -26,6 +26,11 @@ ReUnconditionalRecursionRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReUnconditionalRecursionRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReUnconditionalRecursionRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -46,9 +51,4 @@ ReUnconditionalRecursionRule >> initialize [
 			`@.before.
 			self `@message: `@args.
 			`@.after'
-]
-
-{ #category : 'accessing' }
-ReUnconditionalRecursionRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReUndeclaredVariableRule.class.st
+++ b/src/General-Rules/ReUndeclaredVariableRule.class.st
@@ -14,6 +14,11 @@ ReUndeclaredVariableRule class >> group [
 	^ 'Bugs'
 ]
 
+{ #category : 'accessing' }
+ReUndeclaredVariableRule class >> ruleName [
+	^ 'References an undeclared variable'
+]
+
 { #category : 'running' }
 ReUndeclaredVariableRule >> basicCheck: aNode [
 	^ aNode isVariable and: [ aNode isUndeclaredVariable ]
@@ -24,11 +29,6 @@ ReUndeclaredVariableRule >> critiqueFor: aNode [
 	^ (super critiqueFor: aNode)
 		tinyHint: aNode name;
 		yourself
-]
-
-{ #category : 'accessing' }
-ReUndeclaredVariableRule >> name [
-	^ 'References an undeclared variable'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUndeclaredVariableRule.class.st
+++ b/src/General-Rules/ReUndeclaredVariableRule.class.st
@@ -19,6 +19,11 @@ ReUndeclaredVariableRule class >> ruleName [
 	^ 'References an undeclared variable'
 ]
 
+{ #category : 'accessing' }
+ReUndeclaredVariableRule class >> severity [
+	^ #error
+]
+
 { #category : 'running' }
 ReUndeclaredVariableRule >> basicCheck: aNode [
 	^ aNode isVariable and: [ aNode isUndeclaredVariable ]
@@ -29,9 +34,4 @@ ReUndeclaredVariableRule >> critiqueFor: aNode [
 	^ (super critiqueFor: aNode)
 		tinyHint: aNode name;
 		yourself
-]
-
-{ #category : 'accessing' }
-ReUndeclaredVariableRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReUndeclaredVariableRule.class.st
+++ b/src/General-Rules/ReUndeclaredVariableRule.class.st
@@ -9,6 +9,11 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReUndeclaredVariableRule class >> group [
+	^ 'Bugs'
+]
+
 { #category : 'running' }
 ReUndeclaredVariableRule >> basicCheck: aNode [
 	^ aNode isVariable and: [ aNode isUndeclaredVariable ]
@@ -19,11 +24,6 @@ ReUndeclaredVariableRule >> critiqueFor: aNode [
 	^ (super critiqueFor: aNode)
 		tinyHint: aNode name;
 		yourself
-]
-
-{ #category : 'accessing' }
-ReUndeclaredVariableRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnnecessaryAssignmentRule.class.st
+++ b/src/General-Rules/ReUnnecessaryAssignmentRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUnnecessaryAssignmentRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReUnnecessaryAssignmentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -21,11 +26,6 @@ ReUnnecessaryAssignmentRule >> basicCheck: aNode [
 	aNode isReturn ifFalse: [ ^ false ].
 	aNode isAssignment ifFalse: [ ^ false ].
 	^ (aNode whoDefines: aNode variable name) isNotNil
-]
-
-{ #category : 'accessing' }
-ReUnnecessaryAssignmentRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnnecessaryAssignmentRule.class.st
+++ b/src/General-Rules/ReUnnecessaryAssignmentRule.class.st
@@ -20,6 +20,11 @@ ReUnnecessaryAssignmentRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReUnnecessaryAssignmentRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReUnnecessaryAssignmentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -31,9 +36,4 @@ ReUnnecessaryAssignmentRule >> basicCheck: aNode [
 	aNode isReturn ifFalse: [ ^ false ].
 	aNode isAssignment ifFalse: [ ^ false ].
 	^ (aNode whoDefines: aNode variable name) isNotNil
-]
-
-{ #category : 'accessing' }
-ReUnnecessaryAssignmentRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReUnnecessaryAssignmentRule.class.st
+++ b/src/General-Rules/ReUnnecessaryAssignmentRule.class.st
@@ -15,6 +15,11 @@ ReUnnecessaryAssignmentRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUnnecessaryAssignmentRule class >> ruleName [
+	^ 'Unnecessary assignment to a temporary variable'
+]
+
+{ #category : 'accessing' }
 ReUnnecessaryAssignmentRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -26,11 +31,6 @@ ReUnnecessaryAssignmentRule >> basicCheck: aNode [
 	aNode isReturn ifFalse: [ ^ false ].
 	aNode isAssignment ifFalse: [ ^ false ].
 	^ (aNode whoDefines: aNode variable name) isNotNil
-]
-
-{ #category : 'accessing' }
-ReUnnecessaryAssignmentRule >> name [
-	^ 'Unnecessary assignment to a temporary variable'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnoptimizedAndOrRule.class.st
+++ b/src/General-Rules/ReUnoptimizedAndOrRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUnoptimizedAndOrRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReUnoptimizedAndOrRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnoptimizedAndOrRule'
-]
-
-{ #category : 'accessing' }
-ReUnoptimizedAndOrRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUnoptimizedAndOrRule.class.st
+++ b/src/General-Rules/ReUnoptimizedAndOrRule.class.st
@@ -15,6 +15,11 @@ ReUnoptimizedAndOrRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUnoptimizedAndOrRule class >> ruleName [
+	^ 'Uses "(a and: [b]) and: [c]" instead of "a and: [b and: [c]]"'
+]
+
+{ #category : 'accessing' }
 ReUnoptimizedAndOrRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -27,9 +32,4 @@ ReUnoptimizedAndOrRule >> initialize [
 	self matchesAny: #(
 			'(`@a and: `@b) and: `@c'
 			'(`@a or: `@b) or: `@c' )
-]
-
-{ #category : 'accessing' }
-ReUnoptimizedAndOrRule >> name [
-	^ 'Uses "(a and: [b]) and: [c]" instead of "a and: [b and: [c]]"'
 ]

--- a/src/General-Rules/ReUnoptimizedToDoRule.class.st
+++ b/src/General-Rules/ReUnoptimizedToDoRule.class.st
@@ -16,15 +16,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUnoptimizedToDoRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReUnoptimizedToDoRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnoptimizedToDoRule'
-]
-
-{ #category : 'accessing' }
-ReUnoptimizedToDoRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUnoptimizedToDoRule.class.st
+++ b/src/General-Rules/ReUnoptimizedToDoRule.class.st
@@ -21,6 +21,11 @@ ReUnoptimizedToDoRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUnoptimizedToDoRule class >> ruleName [
+	^ 'Uses (to:)do: instead of to:do:'
+]
+
+{ #category : 'accessing' }
 ReUnoptimizedToDoRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -31,9 +36,4 @@ ReUnoptimizedToDoRule class >> uniqueIdentifierName [
 ReUnoptimizedToDoRule >> initialize [
 	super initialize.
 	self matches: '(`@a to: `@b) do: `@c'
-]
-
-{ #category : 'accessing' }
-ReUnoptimizedToDoRule >> name [
-	^ 'Uses (to:)do: instead of to:do:'
 ]

--- a/src/General-Rules/ReUnpackagedCodeRule.class.st
+++ b/src/General-Rules/ReUnpackagedCodeRule.class.st
@@ -25,6 +25,11 @@ ReUnpackagedCodeRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUnpackagedCodeRule class >> ruleName [
+	^ 'Unpackaged code'
+]
+
+{ #category : 'accessing' }
 ReUnpackagedCodeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -35,9 +40,4 @@ ReUnpackagedCodeRule class >> uniqueIdentifierName [
 ReUnpackagedCodeRule >> basicCheck: anEntity [
 
 	^ anEntity package isNotNil and: [ anEntity package isUndefined ]
-]
-
-{ #category : 'accessing' }
-ReUnpackagedCodeRule >> name [
-	^ 'Unpackaged code'
 ]

--- a/src/General-Rules/ReUnpackagedCodeRule.class.st
+++ b/src/General-Rules/ReUnpackagedCodeRule.class.st
@@ -20,6 +20,11 @@ ReUnpackagedCodeRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUnpackagedCodeRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReUnpackagedCodeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReUnpackagedCodeRule class >> uniqueIdentifierName [
 ReUnpackagedCodeRule >> basicCheck: anEntity [
 
 	^ anEntity package isNotNil and: [ anEntity package isUndefined ]
-]
-
-{ #category : 'accessing' }
-ReUnpackagedCodeRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUnwindBlocksRule.class.st
+++ b/src/General-Rules/ReUnwindBlocksRule.class.st
@@ -28,6 +28,11 @@ ReUnwindBlocksRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUnwindBlocksRule class >> ruleName [
+	^ 'Move assignment out of unwind blocks'
+]
+
+{ #category : 'accessing' }
 ReUnwindBlocksRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -46,9 +51,4 @@ ReUnwindBlocksRule >> initialize [
 			with: '`var := [| `@temps | ``@.Statements. ``@object] ifCurtailed: ``@block';
 		replace:'[| `@temps | ``@.Statements. ^``@object] ifCurtailed: ``@block'
 			with: '^[| `@temps | ``@.Statements. ``@object] ifCurtailed: ``@block'
-]
-
-{ #category : 'accessing' }
-ReUnwindBlocksRule >> name [
-	^ 'Move assignment out of unwind blocks'
 ]

--- a/src/General-Rules/ReUnwindBlocksRule.class.st
+++ b/src/General-Rules/ReUnwindBlocksRule.class.st
@@ -23,15 +23,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUnwindBlocksRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReUnwindBlocksRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'UnwindBlocksRule'
-]
-
-{ #category : 'accessing' }
-ReUnwindBlocksRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUseIsEmptyNotSizeRule.class.st
+++ b/src/General-Rules/ReUseIsEmptyNotSizeRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUseIsEmptyNotSizeRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReUseIsEmptyNotSizeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'ConsistencyCheckRule'
-]
-
-{ #category : 'accessing' }
-ReUseIsEmptyNotSizeRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUseIsEmptyNotSizeRule.class.st
+++ b/src/General-Rules/ReUseIsEmptyNotSizeRule.class.st
@@ -15,6 +15,11 @@ ReUseIsEmptyNotSizeRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUseIsEmptyNotSizeRule class >> ruleName [
+	^ 'Checks for empty collection using #size instead of #isEmpty" or #isNotEmpty'
+]
+
+{ #category : 'accessing' }
 ReUseIsEmptyNotSizeRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -29,9 +34,4 @@ ReUseIsEmptyNotSizeRule >> initialize [
 		'`@object size = 0'
 		'`@object size > 0'
 		'`@object size >= 1')
-]
-
-{ #category : 'accessing' }
-ReUseIsEmptyNotSizeRule >> name [
-	^ 'Checks for empty collection using #size instead of #isEmpty" or #isNotEmpty'
 ]

--- a/src/General-Rules/ReUseSetUpRule.class.st
+++ b/src/General-Rules/ReUseSetUpRule.class.st
@@ -9,17 +9,17 @@ Class {
 	#tag : 'Migrated'
 }
 
+{ #category : 'accessing' }
+ReUseSetUpRule class >> group [
+
+	^ 'Design Flaws'
+]
+
 { #category : 'manifest' }
 ReUseSetUpRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^ 'UseSetUpRule'
-]
-
-{ #category : 'accessing' }
-ReUseSetUpRule >> group [
-
-	^ 'Design Flaws'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReUseSetUpRule.class.st
+++ b/src/General-Rules/ReUseSetUpRule.class.st
@@ -15,6 +15,11 @@ ReUseSetUpRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReUseSetUpRule class >> ruleName [
+	^ 'Uses setUp instead of initialize for Test class.'
+]
+
 { #category : 'manifest' }
 ReUseSetUpRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -31,12 +36,6 @@ ReUseSetUpRule >> initialize [
 		'initialize |`@temps| super initialize. `.@statements'
 		rewriteTo: 'setUp |`@temps| super setUp. `.@statements'.
 	self addMatchingMethod: 'initialize' rewriteTo: 'setUp'
-]
-
-{ #category : 'accessing' }
-ReUseSetUpRule >> name [
-
-	^ 'Uses setUp instead of initialize for Test class.'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUseSetUpRule.class.st
+++ b/src/General-Rules/ReUseSetUpRule.class.st
@@ -20,6 +20,12 @@ ReUseSetUpRule class >> ruleName [
 	^ 'Uses setUp instead of initialize for Test class.'
 ]
 
+{ #category : 'accessing' }
+ReUseSetUpRule class >> severity [
+
+	^ #error 
+]
+
 { #category : 'manifest' }
 ReUseSetUpRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -36,12 +42,6 @@ ReUseSetUpRule >> initialize [
 		'initialize |`@temps| super initialize. `.@statements'
 		rewriteTo: 'setUp |`@temps| super setUp. `.@statements'.
 	self addMatchingMethod: 'initialize' rewriteTo: 'setUp'
-]
-
-{ #category : 'accessing' }
-ReUseSetUpRule >> severity [
-
-	^ #error 
 ]
 
 { #category : 'testing' }

--- a/src/General-Rules/ReUsesAddRule.class.st
+++ b/src/General-Rules/ReUsesAddRule.class.st
@@ -15,6 +15,11 @@ ReUsesAddRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUsesAddRule class >> ruleName [
+	^ 'Uses the result of an add: message'
+]
+
+{ #category : 'accessing' }
 ReUsesAddRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -24,9 +29,4 @@ ReUsesAddRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReUsesAddRule >> basicCheck: node [
 	^ node isMessage and: [ (#(#add: #addAll:) includes: node selector) and: [ node isEssential ] ]
-]
-
-{ #category : 'accessing' }
-ReUsesAddRule >> name [
-	^ 'Uses the result of an add: message'
 ]

--- a/src/General-Rules/ReUsesAddRule.class.st
+++ b/src/General-Rules/ReUsesAddRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUsesAddRule class >> group [
+	^ 'Potential Bugs'
+]
+
+{ #category : 'accessing' }
 ReUsesAddRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -19,11 +24,6 @@ ReUsesAddRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReUsesAddRule >> basicCheck: node [
 	^ node isMessage and: [ (#(#add: #addAll:) includes: node selector) and: [ node isEssential ] ]
-]
-
-{ #category : 'accessing' }
-ReUsesAddRule >> group [
-	^ 'Potential Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUsesTrueRule.class.st
+++ b/src/General-Rules/ReUsesTrueRule.class.st
@@ -17,6 +17,11 @@ ReUsesTrueRule class >> checksMethod [
 ]
 
 { #category : 'accessing' }
+ReUsesTrueRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReUsesTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReUsesTrueRule >> check: aMethod forCritiquesDo: aCriticBlock [
 			                 aNode isGlobalVariable and: [ #( True False ) includes: aNode name ] ].
 	problemUsages do: [ :ref |
 		aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: ref hint: ref name asString)]
-]
-
-{ #category : 'accessing' }
-ReUsesTrueRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUsesTrueRule.class.st
+++ b/src/General-Rules/ReUsesTrueRule.class.st
@@ -22,6 +22,11 @@ ReUsesTrueRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUsesTrueRule class >> ruleName [
+	^ 'Uses True/False instead of true/false'
+]
+
+{ #category : 'accessing' }
 ReUsesTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -35,11 +40,6 @@ ReUsesTrueRule >> check: aMethod forCritiquesDo: aCriticBlock [
 			                 aNode isGlobalVariable and: [ #( True False ) includes: aNode name ] ].
 	problemUsages do: [ :ref |
 		aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: ref hint: ref name asString)]
-]
-
-{ #category : 'accessing' }
-ReUsesTrueRule >> name [
-	^ 'Uses True/False instead of true/false'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUsesTrueRule.class.st
+++ b/src/General-Rules/ReUsesTrueRule.class.st
@@ -27,6 +27,11 @@ ReUsesTrueRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReUsesTrueRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReUsesTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -40,9 +45,4 @@ ReUsesTrueRule >> check: aMethod forCritiquesDo: aCriticBlock [
 			                 aNode isGlobalVariable and: [ #( True False ) includes: aNode name ] ].
 	problemUsages do: [ :ref |
 		aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: ref hint: ref name asString)]
-]
-
-{ #category : 'accessing' }
-ReUsesTrueRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/ReUsesWorldGlobalRule.class.st
+++ b/src/General-Rules/ReUsesWorldGlobalRule.class.st
@@ -11,6 +11,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReUsesWorldGlobalRule class >> group [
+	^ 'Bugs'
+]
+
+{ #category : 'accessing' }
 ReUsesWorldGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -20,11 +25,6 @@ ReUsesWorldGlobalRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReUsesWorldGlobalRule >> basicCheck: aNode [
 	^ aNode isGlobalVariable and: [ #(#World #ActiveWorld) includes: aNode name ]
-]
-
-{ #category : 'accessing' }
-ReUsesWorldGlobalRule >> group [
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReUsesWorldGlobalRule.class.st
+++ b/src/General-Rules/ReUsesWorldGlobalRule.class.st
@@ -16,6 +16,11 @@ ReUsesWorldGlobalRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReUsesWorldGlobalRule class >> ruleName [
+	^ 'Uses World or ActiveWorld directly'
+]
+
+{ #category : 'accessing' }
 ReUsesWorldGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,9 +30,4 @@ ReUsesWorldGlobalRule class >> uniqueIdentifierName [
 { #category : 'running' }
 ReUsesWorldGlobalRule >> basicCheck: aNode [
 	^ aNode isGlobalVariable and: [ #(#World #ActiveWorld) includes: aNode name ]
-]
-
-{ #category : 'accessing' }
-ReUsesWorldGlobalRule >> name [
-	^ 'Uses World or ActiveWorld directly'
 ]

--- a/src/General-Rules/ReVariableAssignedLiteralRule.class.st
+++ b/src/General-Rules/ReVariableAssignedLiteralRule.class.st
@@ -15,6 +15,11 @@ ReVariableAssignedLiteralRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReVariableAssignedLiteralRule class >> group [
+	^ 'Design Flaws'
+]
+
 { #category : 'running' }
 ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -26,11 +31,6 @@ ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 		assignmentNodes size = 1 ifFalse: [ ^ self ].
 		assignmentNodes first value isLiteralNode ifTrue: [
 			aCriticBlock cull: (self critiqueFor: aClass about: variable name) ] ]
-]
-
-{ #category : 'accessing' }
-ReVariableAssignedLiteralRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReVariableAssignedLiteralRule.class.st
+++ b/src/General-Rules/ReVariableAssignedLiteralRule.class.st
@@ -20,6 +20,11 @@ ReVariableAssignedLiteralRule class >> group [
 	^ 'Design Flaws'
 ]
 
+{ #category : 'accessing' }
+ReVariableAssignedLiteralRule class >> ruleName [
+	^ 'Variable is only assigned a single literal value'
+]
+
 { #category : 'running' }
 ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 
@@ -31,9 +36,4 @@ ReVariableAssignedLiteralRule >> check: aClass forCritiquesDo: aCriticBlock [
 		assignmentNodes size = 1 ifFalse: [ ^ self ].
 		assignmentNodes first value isLiteralNode ifTrue: [
 			aCriticBlock cull: (self critiqueFor: aClass about: variable name) ] ]
-]
-
-{ #category : 'accessing' }
-ReVariableAssignedLiteralRule >> name [
-	^ 'Variable is only assigned a single literal value'
 ]

--- a/src/General-Rules/ReVariableReferencedOnceRule.class.st
+++ b/src/General-Rules/ReVariableReferencedOnceRule.class.st
@@ -15,6 +15,11 @@ ReVariableReferencedOnceRule class >> checksClass [
 ]
 
 { #category : 'accessing' }
+ReVariableReferencedOnceRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 ReVariableReferencedOnceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ ReVariableReferencedOnceRule >> check: aClass forCritiquesDo: aCriticBlock [
 		  (RBReadBeforeWrittenTester
 				  isVariable: slot name
 				  writtenBeforeReadIn: usingMethods first ast) ifTrue: [aCriticBlock cull: (self critiqueFor: aClass about: slot  name)   ]]
-]
-
-{ #category : 'accessing' }
-ReVariableReferencedOnceRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReVariableReferencedOnceRule.class.st
+++ b/src/General-Rules/ReVariableReferencedOnceRule.class.st
@@ -20,6 +20,11 @@ ReVariableReferencedOnceRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReVariableReferencedOnceRule class >> ruleName [
+	^ 'Variable referenced in only one method and always assigned first'
+]
+
+{ #category : 'accessing' }
 ReVariableReferencedOnceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -35,11 +40,6 @@ ReVariableReferencedOnceRule >> check: aClass forCritiquesDo: aCriticBlock [
 		  (RBReadBeforeWrittenTester
 				  isVariable: slot name
 				  writtenBeforeReadIn: usingMethods first ast) ifTrue: [aCriticBlock cull: (self critiqueFor: aClass about: slot  name)   ]]
-]
-
-{ #category : 'accessing' }
-ReVariableReferencedOnceRule >> name [
-	^ 'Variable referenced in only one method and always assigned first'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReVariableReferencedOnceRule.class.st
+++ b/src/General-Rules/ReVariableReferencedOnceRule.class.st
@@ -25,6 +25,11 @@ ReVariableReferencedOnceRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReVariableReferencedOnceRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReVariableReferencedOnceRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -40,9 +45,4 @@ ReVariableReferencedOnceRule >> check: aClass forCritiquesDo: aCriticBlock [
 		  (RBReadBeforeWrittenTester
 				  isVariable: slot name
 				  writtenBeforeReadIn: usingMethods first ast) ifTrue: [aCriticBlock cull: (self critiqueFor: aClass about: slot  name)   ]]
-]
-
-{ #category : 'accessing' }
-ReVariableReferencedOnceRule >> severity [
-	^ #information
 ]

--- a/src/General-Rules/ReWhileTrueRule.class.st
+++ b/src/General-Rules/ReWhileTrueRule.class.st
@@ -20,15 +20,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReWhileTrueRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReWhileTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'WhileTrueRule'
-]
-
-{ #category : 'accessing' }
-ReWhileTrueRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/General-Rules/ReWhileTrueRule.class.st
+++ b/src/General-Rules/ReWhileTrueRule.class.st
@@ -25,6 +25,11 @@ ReWhileTrueRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReWhileTrueRule class >> rationale [
+	^ 'Checks for users of whileTrue: when the shorter to:do: would work.'
+]
+
+{ #category : 'accessing' }
 ReWhileTrueRule class >> ruleName [
 	^ 'Uses whileTrue: instead of to:do:'
 ]
@@ -72,9 +77,4 @@ ReWhileTrueRule >> initialize [
 					`@.BlockStmts1.
 					`index := `index - 1].
 			`@.Statements2' )
-]
-
-{ #category : 'accessing' }
-ReWhileTrueRule >> rationale [
-	^ 'Checks for users of whileTrue: when the shorter to:do: would work.'
 ]

--- a/src/General-Rules/ReWhileTrueRule.class.st
+++ b/src/General-Rules/ReWhileTrueRule.class.st
@@ -25,6 +25,11 @@ ReWhileTrueRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReWhileTrueRule class >> ruleName [
+	^ 'Uses whileTrue: instead of to:do:'
+]
+
+{ #category : 'accessing' }
 ReWhileTrueRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -67,11 +72,6 @@ ReWhileTrueRule >> initialize [
 					`@.BlockStmts1.
 					`index := `index - 1].
 			`@.Statements2' )
-]
-
-{ #category : 'accessing' }
-ReWhileTrueRule >> name [
-	^ 'Uses whileTrue: instead of to:do:'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReYourselfNotUsedRule.class.st
+++ b/src/General-Rules/ReYourselfNotUsedRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReYourselfNotUsedRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReYourselfNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -21,11 +26,6 @@ ReYourselfNotUsedRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^ false ].
 	aNode selector = #yourself ifFalse: [ ^ false ].
 	^ aNode isUsedAsReturnValue not
-]
-
-{ #category : 'accessing' }
-ReYourselfNotUsedRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/ReYourselfNotUsedRule.class.st
+++ b/src/General-Rules/ReYourselfNotUsedRule.class.st
@@ -15,6 +15,11 @@ ReYourselfNotUsedRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReYourselfNotUsedRule class >> ruleName [
+	^ 'Doesn''t use the result of a yourself message'
+]
+
+{ #category : 'accessing' }
 ReYourselfNotUsedRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -26,9 +31,4 @@ ReYourselfNotUsedRule >> basicCheck: aNode [
 	aNode isMessage ifFalse: [ ^ false ].
 	aNode selector = #yourself ifFalse: [ ^ false ].
 	^ aNode isUsedAsReturnValue not
-]
-
-{ #category : 'accessing' }
-ReYourselfNotUsedRule >> name [
-	^ 'Doesn''t use the result of a yourself message'
 ]

--- a/src/General-Rules/SendsDeprecatedMethodToGlobalRule.class.st
+++ b/src/General-Rules/SendsDeprecatedMethodToGlobalRule.class.st
@@ -10,6 +10,11 @@ Class {
 }
 
 { #category : 'accessing' }
+SendsDeprecatedMethodToGlobalRule class >> group [
+	^ 'Design Flaws'
+]
+
+{ #category : 'accessing' }
 SendsDeprecatedMethodToGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -25,11 +30,6 @@ SendsDeprecatedMethodToGlobalRule >> basicCheck: aNode [
 	^value class classAndMethodFor: aNode selector
 		do: [ :class :method | method isDeprecated ]
 		ifAbsent: [ false ]
-]
-
-{ #category : 'accessing' }
-SendsDeprecatedMethodToGlobalRule >> group [
-	^ 'Design Flaws'
 ]
 
 { #category : 'accessing' }

--- a/src/General-Rules/SendsDeprecatedMethodToGlobalRule.class.st
+++ b/src/General-Rules/SendsDeprecatedMethodToGlobalRule.class.st
@@ -20,6 +20,11 @@ SendsDeprecatedMethodToGlobalRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+SendsDeprecatedMethodToGlobalRule class >> severity [
+	^ #error
+]
+
+{ #category : 'accessing' }
 SendsDeprecatedMethodToGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -35,9 +40,4 @@ SendsDeprecatedMethodToGlobalRule >> basicCheck: aNode [
 	^value class classAndMethodFor: aNode selector
 		do: [ :class :method | method isDeprecated ]
 		ifAbsent: [ false ]
-]
-
-{ #category : 'accessing' }
-SendsDeprecatedMethodToGlobalRule >> severity [
-	^ #error
 ]

--- a/src/General-Rules/SendsDeprecatedMethodToGlobalRule.class.st
+++ b/src/General-Rules/SendsDeprecatedMethodToGlobalRule.class.st
@@ -15,6 +15,11 @@ SendsDeprecatedMethodToGlobalRule class >> group [
 ]
 
 { #category : 'accessing' }
+SendsDeprecatedMethodToGlobalRule class >> ruleName [
+	^ 'Sends a deprecated message to a known global'
+]
+
+{ #category : 'accessing' }
 SendsDeprecatedMethodToGlobalRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -30,11 +35,6 @@ SendsDeprecatedMethodToGlobalRule >> basicCheck: aNode [
 	^value class classAndMethodFor: aNode selector
 		do: [ :class :method | method isDeprecated ]
 		ifAbsent: [ false ]
-]
-
-{ #category : 'accessing' }
-SendsDeprecatedMethodToGlobalRule >> name [
-	^ 'Sends a deprecated message to a known global'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReAbstractCritique.class.st
+++ b/src/Renraku/ReAbstractCritique.class.st
@@ -201,13 +201,14 @@ ReAbstractCritique >> tinyHint: anObject [
 
 { #category : 'accessing' }
 ReAbstractCritique >> title [
+
 	^ (self tinyHint isNil or: [ self tinyHint isEmpty ])
-		ifTrue: [ rule name ]
-		ifFalse: [
-			String streamContents: [ :s |
-				s
-					nextPut: $[;
-					nextPutAll: self tinyHint;
-					nextPutAll: '] ';
-					nextPutAll: rule name ] ]
+		  ifTrue: [ rule ruleName ]
+		  ifFalse: [
+			  String streamContents: [ :s |
+				  s
+					  nextPut: $[;
+					  nextPutAll: self tinyHint;
+					  nextPutAll: '] ';
+					  nextPutAll: rule ruleName ] ]
 ]

--- a/src/Renraku/ReAbstractRule.class.st
+++ b/src/Renraku/ReAbstractRule.class.st
@@ -142,6 +142,16 @@ ReAbstractRule class >> methodOfInteresetSelectors [
 	^ #(checksMethod checksClass checksPackage checksNode)
 ]
 
+{ #category : 'accessing' }
+ReAbstractRule class >> ruleName [
+
+	(self selectors includes: #name) ifTrue: [
+		self deprecated:
+			'The method #name of rules should be implemented on the class side in Pharo 13+ and not in instance sice. It was also renamed into #ruleName.'.
+		^ self new name ].
+	^ self subclassResponsibility
+]
+
 { #category : 'manifest' }
 ReAbstractRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -265,9 +275,9 @@ ReAbstractRule >> isRewriteRule [
 
 { #category : 'accessing' }
 ReAbstractRule >> name [
-	"Answer a human readable name of the rule."
 
-	^ self subclassResponsibility
+	self deprecated: 'Use #ruleName instead.' transformWith: '`@rcv name' -> '`@rcv ruleName'.
+	^ self ruleName
 ]
 
 { #category : 'accessing' }
@@ -279,6 +289,13 @@ ReAbstractRule >> rationale [
 
 { #category : 'compatibility' }
 ReAbstractRule >> resetResult [
+]
+
+{ #category : 'accessing' }
+ReAbstractRule >> ruleName [
+	"Answer a human readable name of the rule."
+
+	^ self class ruleName
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReAbstractRule.class.st
+++ b/src/Renraku/ReAbstractRule.class.st
@@ -295,8 +295,9 @@ ReAbstractRule >> isRewriteRule [
 
 { #category : 'accessing' }
 ReAbstractRule >> name [
-
-	self deprecated: 'Use #ruleName instead.' transformWith: '`@rcv name' -> '`@rcv ruleName'.
+	
+	"Should be deprecated when CBCritiquesRuleGroup will implement #ruleName also but this is in NewTools"
+	"self deprecated: 'Use #ruleName instead.' transformWith: '`@rcv name' -> '`@rcv ruleName'."
 	^ self ruleName
 ]
 

--- a/src/Renraku/ReAbstractRule.class.st
+++ b/src/Renraku/ReAbstractRule.class.st
@@ -84,6 +84,15 @@ ReAbstractRule class >> enabledSettingID [
 	^ (self name, '_enabled') asSymbol
 ]
 
+{ #category : 'accessing' }
+ReAbstractRule class >> group [
+
+	(self selectors includes: #group) ifTrue: [
+		self deprecated: 'The method #group of rules should be implemented on the class side in Pharo 13+ and not in instance sice.'.
+		^ self new group ].
+	^ 'Unclassified rules'
+]
+
 { #category : 'manifest' }
 ReAbstractRule class >> identifierMinorVersionNumber [
 	"This number identifies the version of the rule definition. Each time the rule is updated and its changes invalidates previous false positives identification (and as such should be reassessed by developers) the number should be increased."
@@ -239,8 +248,7 @@ ReAbstractRule >> critiqueFor: aClass about: aVarName [
 
 { #category : 'accessing' }
 ReAbstractRule >> group [
-
-	^ 'Unclassified rules'
+	^ self class group
 ]
 
 { #category : 'testing' }

--- a/src/Renraku/ReAbstractRule.class.st
+++ b/src/Renraku/ReAbstractRule.class.st
@@ -143,6 +143,16 @@ ReAbstractRule class >> methodOfInteresetSelectors [
 ]
 
 { #category : 'accessing' }
+ReAbstractRule class >> rationale [
+	"Answer an explanation of the rule, usually in one line. Long description can be obtained using longDescription."
+
+	(self selectors includes: #rationale) ifTrue: [
+		self deprecated: 'The method #rationale of rules should be implemented on the class side in Pharo 13+ and not in instance sice.'.
+		^ self new rationale ].
+	^ self comment
+]
+
+{ #category : 'accessing' }
 ReAbstractRule class >> ruleName [
 
 	(self selectors includes: #name) ifTrue: [
@@ -282,9 +292,7 @@ ReAbstractRule >> name [
 
 { #category : 'accessing' }
 ReAbstractRule >> rationale [
-	"Answer an explanation of the rule, usually in one line. Long description can be obtained using longDescription."
-
-	^ self class comment
+	^ self class rationale
 ]
 
 { #category : 'compatibility' }

--- a/src/Renraku/ReAbstractRule.class.st
+++ b/src/Renraku/ReAbstractRule.class.st
@@ -162,6 +162,16 @@ ReAbstractRule class >> ruleName [
 	^ self subclassResponsibility
 ]
 
+{ #category : 'accessing' }
+ReAbstractRule class >> severity [
+	"Answer the severity of issues reported by this rule. This method should return one of #error, #warning, or #information."
+
+	(self selectors includes: #severity) ifTrue: [
+		self deprecated: 'The method #severity of rules should be implemented on the class side in Pharo 13+ and not in instance sice.'.
+		^ self new severity ].
+	^ #warning
+]
+
 { #category : 'manifest' }
 ReAbstractRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
@@ -310,7 +320,7 @@ ReAbstractRule >> ruleName [
 ReAbstractRule >> severity [
 	"Answer the severity of issues reported by this rule. This method should return one of #error, #warning, or #information."
 
-	^ #warning
+	^ self class severity
 ]
 
 { #category : 'testing' }

--- a/src/Renraku/ReClassSideInitializeMethodProtocolRule.class.st
+++ b/src/Renraku/ReClassSideInitializeMethodProtocolRule.class.st
@@ -9,14 +9,14 @@ Class {
 	#tag : 'Rules'
 }
 
-{ #category : 'accessing - defaults' }
-ReClassSideInitializeMethodProtocolRule >> protocolName [
+{ #category : 'accessing' }
+ReClassSideInitializeMethodProtocolRule class >> protocolName [
 
 	^ 'class initialization'
 ]
 
-{ #category : 'accessing - defaults' }
-ReClassSideInitializeMethodProtocolRule >> selector [
+{ #category : 'accessing' }
+ReClassSideInitializeMethodProtocolRule class >> selector [
 
 	^ #initialize
 ]

--- a/src/Renraku/ReClassSideResetMethodProtocolRule.class.st
+++ b/src/Renraku/ReClassSideResetMethodProtocolRule.class.st
@@ -9,14 +9,14 @@ Class {
 	#tag : 'Rules'
 }
 
-{ #category : 'accessing - defaults' }
-ReClassSideResetMethodProtocolRule >> protocolName [
+{ #category : 'accessing' }
+ReClassSideResetMethodProtocolRule class >> protocolName [
 
 	^ 'class initialization'
 ]
 
-{ #category : 'accessing - defaults' }
-ReClassSideResetMethodProtocolRule >> selector [
+{ #category : 'accessing' }
+ReClassSideResetMethodProtocolRule class >> selector [
 
 	^ #reset
 ]

--- a/src/Renraku/ReCompactSourceCodeRule.class.st
+++ b/src/Renraku/ReCompactSourceCodeRule.class.st
@@ -58,6 +58,11 @@ ReCompactSourceCodeRule class >> initialize [
 	self enabled: false
 ]
 
+{ #category : 'accessing' }
+ReCompactSourceCodeRule class >> ruleName [
+	^ 'Unnecessary characters found in method body'
+]
+
 { #category : 'running' }
 ReCompactSourceCodeRule >> basicCheck: aMethod [
 
@@ -73,12 +78,6 @@ ReCompactSourceCodeRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				ReCompactSourceCodeCritic
 					for: aMethod
 					by: self)  ]
-]
-
-{ #category : 'accessing' }
-ReCompactSourceCodeRule >> name [
-
-	^ 'Unnecessary characters found in method body'
 ]
 
 { #category : 'testing' }

--- a/src/Renraku/ReCompactSourceCodeRule.class.st
+++ b/src/Renraku/ReCompactSourceCodeRule.class.st
@@ -45,6 +45,12 @@ ReCompactSourceCodeRule class >> criticizeFinalDotInMethodBody: aBoolean [
 	CriticizeFinalDotInMethodBody := aBoolean
 ]
 
+{ #category : 'accessing' }
+ReCompactSourceCodeRule class >> group [
+
+	^ 'Clean Code'
+]
+
 { #category : 'class initialization' }
 ReCompactSourceCodeRule class >> initialize [
 
@@ -67,12 +73,6 @@ ReCompactSourceCodeRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				ReCompactSourceCodeCritic
 					for: aMethod
 					by: self)  ]
-]
-
-{ #category : 'accessing' }
-ReCompactSourceCodeRule >> group [
-
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReCompactSourceCodeRule.class.st
+++ b/src/Renraku/ReCompactSourceCodeRule.class.st
@@ -63,6 +63,12 @@ ReCompactSourceCodeRule class >> ruleName [
 	^ 'Unnecessary characters found in method body'
 ]
 
+{ #category : 'accessing' }
+ReCompactSourceCodeRule class >> severity [
+
+	^ #information
+]
+
 { #category : 'running' }
 ReCompactSourceCodeRule >> basicCheck: aMethod [
 
@@ -84,10 +90,4 @@ ReCompactSourceCodeRule >> check: aMethod forCritiquesDo: aCriticBlock [
 ReCompactSourceCodeRule >> providesChange [
 
 	^ true
-]
-
-{ #category : 'accessing' }
-ReCompactSourceCodeRule >> severity [
-
-	^ #information
 ]

--- a/src/Renraku/ReEndTrueFalseRule.class.st
+++ b/src/Renraku/ReEndTrueFalseRule.class.st
@@ -36,6 +36,11 @@ ReEndTrueFalseRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReEndTrueFalseRule class >> severity [
+	^ #information
+]
+
+{ #category : 'accessing' }
 ReEndTrueFalseRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -67,9 +72,4 @@ ReEndTrueFalseRule >> initialize [
 				ifTrue: [| `@temps2 | `@.Statements2. `.Statement]' '`@object
 				ifFalse: [| `@temps1 | `.Statement. `@.Statements1]
 				ifTrue: [| `@temps2 | `.Statement. `@.Statement2]')
-]
-
-{ #category : 'accessing' }
-ReEndTrueFalseRule >> severity [
-	^ #information
 ]

--- a/src/Renraku/ReEndTrueFalseRule.class.st
+++ b/src/Renraku/ReEndTrueFalseRule.class.st
@@ -21,6 +21,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ReEndTrueFalseRule class >> group [
+	^ 'Optimization'
+]
+
+{ #category : 'accessing' }
 ReEndTrueFalseRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -36,11 +41,6 @@ ReEndTrueFalseRule >> afterCheck: aNode mappings: mappingDict [
 			statement := aNode arguments first body statements last.
 			( statement isVariable and: [ statement = aNode arguments last body statements last ] ) not]
 		ifNotNil: [ true ]
-]
-
-{ #category : 'accessing' }
-ReEndTrueFalseRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'initialization' }

--- a/src/Renraku/ReEndTrueFalseRule.class.st
+++ b/src/Renraku/ReEndTrueFalseRule.class.st
@@ -26,6 +26,11 @@ ReEndTrueFalseRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReEndTrueFalseRule class >> ruleName [
+	^ 'Check for same statements at end of ifTrue:ifFalse: blocks'
+]
+
+{ #category : 'accessing' }
 ReEndTrueFalseRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -57,11 +62,6 @@ ReEndTrueFalseRule >> initialize [
 				ifTrue: [| `@temps2 | `@.Statements2. `.Statement]' '`@object
 				ifFalse: [| `@temps1 | `.Statement. `@.Statements1]
 				ifTrue: [| `@temps2 | `.Statement. `@.Statement2]')
-]
-
-{ #category : 'accessing' }
-ReEndTrueFalseRule >> name [
-	^ 'Check for same statements at end of ifTrue:ifFalse: blocks'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReEndTrueFalseRule.class.st
+++ b/src/Renraku/ReEndTrueFalseRule.class.st
@@ -26,6 +26,11 @@ ReEndTrueFalseRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReEndTrueFalseRule class >> rationale [
+	^ 'Checks for ifTrue:ifFalse: blocks that have the same code at the beginning or end.'
+]
+
+{ #category : 'accessing' }
 ReEndTrueFalseRule class >> ruleName [
 	^ 'Check for same statements at end of ifTrue:ifFalse: blocks'
 ]
@@ -62,11 +67,6 @@ ReEndTrueFalseRule >> initialize [
 				ifTrue: [| `@temps2 | `@.Statements2. `.Statement]' '`@object
 				ifFalse: [| `@temps1 | `.Statement. `@.Statements1]
 				ifTrue: [| `@temps2 | `.Statement. `@.Statement2]')
-]
-
-{ #category : 'accessing' }
-ReEndTrueFalseRule >> rationale [
-	^ 'Checks for ifTrue:ifFalse: blocks that have the same code at the beginning or end.'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReGuardingClauseRule.class.st
+++ b/src/Renraku/ReGuardingClauseRule.class.st
@@ -10,15 +10,15 @@ Class {
 }
 
 { #category : 'accessing' }
+ReGuardingClauseRule class >> group [
+	^ 'Coding Idiom Violation'
+]
+
+{ #category : 'accessing' }
 ReGuardingClauseRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
 	^'GuardingClauseRule'
-]
-
-{ #category : 'accessing' }
-ReGuardingClauseRule >> group [
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'initialization' }

--- a/src/Renraku/ReGuardingClauseRule.class.st
+++ b/src/Renraku/ReGuardingClauseRule.class.st
@@ -15,6 +15,11 @@ ReGuardingClauseRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReGuardingClauseRule class >> ruleName [
+	^ 'Guarding clauses'
+]
+
+{ #category : 'accessing' }
 ReGuardingClauseRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -34,11 +39,6 @@ ReGuardingClauseRule >> initialize [
 				'`@MethodName
 				`@.Statements.
 				`@condition ifFalse: [| `@BlockTemps | `.Statement1. `.Statement2. `@.BStatements]'
-]
-
-{ #category : 'accessing' }
-ReGuardingClauseRule >> name [
-	^ 'Guarding clauses'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReGuardingClauseRule.class.st
+++ b/src/Renraku/ReGuardingClauseRule.class.st
@@ -15,6 +15,11 @@ ReGuardingClauseRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReGuardingClauseRule class >> rationale [
+	^ 'Checks for ifTrue: or ifFalse: conditions at end of methods that have two or more statements inside their blocks. Such code might better represent the true meaning of the code if they returned self instead.'
+]
+
+{ #category : 'accessing' }
 ReGuardingClauseRule class >> ruleName [
 	^ 'Guarding clauses'
 ]
@@ -39,9 +44,4 @@ ReGuardingClauseRule >> initialize [
 				'`@MethodName
 				`@.Statements.
 				`@condition ifFalse: [| `@BlockTemps | `.Statement1. `.Statement2. `@.BStatements]'
-]
-
-{ #category : 'accessing' }
-ReGuardingClauseRule >> rationale [
-	^ 'Checks for ifTrue: or ifFalse: conditions at end of methods that have two or more statements inside their blocks. Such code might better represent the true meaning of the code if they returned self instead.'
 ]

--- a/src/Renraku/ReInstanceSideBaselineMethodProtocolRule.class.st
+++ b/src/Renraku/ReInstanceSideBaselineMethodProtocolRule.class.st
@@ -9,14 +9,14 @@ Class {
 	#tag : 'Rules'
 }
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideBaselineMethodProtocolRule >> protocolName [
+{ #category : 'accessing' }
+ReInstanceSideBaselineMethodProtocolRule class >> protocolName [
 
 	^ 'baselines'
 ]
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideBaselineMethodProtocolRule >> selector [
+{ #category : 'accessing' }
+ReInstanceSideBaselineMethodProtocolRule class >> selector [
 
 	^ #baseline:
 ]

--- a/src/Renraku/ReInstanceSideEqualsMethodProtocolRule.class.st
+++ b/src/Renraku/ReInstanceSideEqualsMethodProtocolRule.class.st
@@ -9,14 +9,14 @@ Class {
 	#tag : 'Rules'
 }
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideEqualsMethodProtocolRule >> protocolName [
+{ #category : 'accessing' }
+ReInstanceSideEqualsMethodProtocolRule class >> protocolName [
 
 	^ 'comparing'
 ]
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideEqualsMethodProtocolRule >> selector [
+{ #category : 'accessing' }
+ReInstanceSideEqualsMethodProtocolRule class >> selector [
 
 	^ #=
 ]

--- a/src/Renraku/ReInstanceSideFinalizeMethodProtocolRule.class.st
+++ b/src/Renraku/ReInstanceSideFinalizeMethodProtocolRule.class.st
@@ -9,14 +9,14 @@ Class {
 	#tag : 'Rules'
 }
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideFinalizeMethodProtocolRule >> protocolName [
+{ #category : 'accessing' }
+ReInstanceSideFinalizeMethodProtocolRule class >> protocolName [
 
 	^ 'finalization'
 ]
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideFinalizeMethodProtocolRule >> selector [
+{ #category : 'accessing' }
+ReInstanceSideFinalizeMethodProtocolRule class >> selector [
 
 	^ #finalize
 ]

--- a/src/Renraku/ReInstanceSideHashMethodProtocolRule.class.st
+++ b/src/Renraku/ReInstanceSideHashMethodProtocolRule.class.st
@@ -9,14 +9,14 @@ Class {
 	#tag : 'Rules'
 }
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideHashMethodProtocolRule >> protocolName [
+{ #category : 'accessing' }
+ReInstanceSideHashMethodProtocolRule class >> protocolName [
 
 	^ 'comparing'
 ]
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideHashMethodProtocolRule >> selector [
+{ #category : 'accessing' }
+ReInstanceSideHashMethodProtocolRule class >> selector [
 
 	^ #hash
 ]

--- a/src/Renraku/ReInstanceSideInitializeMethodProtocolRule.class.st
+++ b/src/Renraku/ReInstanceSideInitializeMethodProtocolRule.class.st
@@ -9,14 +9,14 @@ Class {
 	#tag : 'Rules'
 }
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideInitializeMethodProtocolRule >> protocolName [
+{ #category : 'accessing' }
+ReInstanceSideInitializeMethodProtocolRule class >> protocolName [
 
 	^ 'initialization'
 ]
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideInitializeMethodProtocolRule >> selector [
+{ #category : 'accessing' }
+ReInstanceSideInitializeMethodProtocolRule class >> selector [
 
 	^ #initialize
 ]

--- a/src/Renraku/ReInstanceSidePrintOnMethodProtocolRule.class.st
+++ b/src/Renraku/ReInstanceSidePrintOnMethodProtocolRule.class.st
@@ -9,14 +9,14 @@ Class {
 	#tag : 'Rules'
 }
 
-{ #category : 'accessing - defaults' }
-ReInstanceSidePrintOnMethodProtocolRule >> protocolName [
+{ #category : 'accessing' }
+ReInstanceSidePrintOnMethodProtocolRule class >> protocolName [
 
 	^ 'printing'
 ]
 
-{ #category : 'accessing - defaults' }
-ReInstanceSidePrintOnMethodProtocolRule >> selector [
+{ #category : 'accessing' }
+ReInstanceSidePrintOnMethodProtocolRule class >> selector [
 
 	^ #printOn:
 ]

--- a/src/Renraku/ReInstanceSideSpeciesMethodProtocolRule.class.st
+++ b/src/Renraku/ReInstanceSideSpeciesMethodProtocolRule.class.st
@@ -9,14 +9,14 @@ Class {
 	#tag : 'Rules'
 }
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideSpeciesMethodProtocolRule >> protocolName [
+{ #category : 'accessing' }
+ReInstanceSideSpeciesMethodProtocolRule class >> protocolName [
 
 	^ 'private'
 ]
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideSpeciesMethodProtocolRule >> selector [
+{ #category : 'accessing' }
+ReInstanceSideSpeciesMethodProtocolRule class >> selector [
 
 	^ #species
 ]

--- a/src/Renraku/ReInstanceSideValueMethodProtocolRule.class.st
+++ b/src/Renraku/ReInstanceSideValueMethodProtocolRule.class.st
@@ -9,14 +9,14 @@ Class {
 	#tag : 'Rules'
 }
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideValueMethodProtocolRule >> protocolName [
+{ #category : 'accessing' }
+ReInstanceSideValueMethodProtocolRule class >> protocolName [
 
 	^ 'evaluating'
 ]
 
-{ #category : 'accessing - defaults' }
-ReInstanceSideValueMethodProtocolRule >> selector [
+{ #category : 'accessing' }
+ReInstanceSideValueMethodProtocolRule class >> selector [
 
 	^ #value
 ]

--- a/src/Renraku/ReInvocationSequenceRule.class.st
+++ b/src/Renraku/ReInvocationSequenceRule.class.st
@@ -50,6 +50,11 @@ ReInvocationSequenceRule class >> noteCompilationOf: aSelector meta: isMeta [
 		ReRuleManager reset ]
 ]
 
+{ #category : 'accessing' }
+ReInvocationSequenceRule class >> ruleName [
+	^ 'Invocation order incorect'
+]
+
 { #category : 'adding' }
 ReInvocationSequenceRule >> add: preSelectors requiresPostSend: postSelectors [
 
@@ -96,12 +101,6 @@ ReInvocationSequenceRule >> initialize [
 
 	preConditions := Set new.
 	postConditions := Set new
-]
-
-{ #category : 'accessing' }
-ReInvocationSequenceRule >> name [
-
-	^ 'Invocation order incorect'
 ]
 
 { #category : 'running' }

--- a/src/Renraku/ReNoNilAssignationInInitializeRule.class.st
+++ b/src/Renraku/ReNoNilAssignationInInitializeRule.class.st
@@ -25,6 +25,11 @@ ReNoNilAssignationInInitializeRule class >> ruleName [
 	^ 'Initialize method does not need nil assignation'
 ]
 
+{ #category : 'accessing' }
+ReNoNilAssignationInInitializeRule class >> severity [
+	^ #information
+]
+
 { #category : 'running' }
 ReNoNilAssignationInInitializeRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| problemAssigments|
@@ -35,9 +40,4 @@ ReNoNilAssignationInInitializeRule >> check: aMethod forCritiquesDo: aCriticBloc
 	problemAssigments do: [ :assignment |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: assignment hint: 'nil').
 		 ]
-]
-
-{ #category : 'accessing' }
-ReNoNilAssignationInInitializeRule >> severity [
-	^ #information
 ]

--- a/src/Renraku/ReNoNilAssignationInInitializeRule.class.st
+++ b/src/Renraku/ReNoNilAssignationInInitializeRule.class.st
@@ -20,6 +20,11 @@ ReNoNilAssignationInInitializeRule class >> group [
 	^ 'Style'
 ]
 
+{ #category : 'accessing' }
+ReNoNilAssignationInInitializeRule class >> ruleName [
+	^ 'Initialize method does not need nil assignation'
+]
+
 { #category : 'running' }
 ReNoNilAssignationInInitializeRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| problemAssigments|
@@ -30,12 +35,6 @@ ReNoNilAssignationInInitializeRule >> check: aMethod forCritiquesDo: aCriticBloc
 	problemAssigments do: [ :assignment |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: assignment hint: 'nil').
 		 ]
-]
-
-{ #category : 'accessing' }
-ReNoNilAssignationInInitializeRule >> name [
-
-	^ 'Initialize method does not need nil assignation'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReNoNilAssignationInInitializeRule.class.st
+++ b/src/Renraku/ReNoNilAssignationInInitializeRule.class.st
@@ -14,6 +14,12 @@ ReNoNilAssignationInInitializeRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReNoNilAssignationInInitializeRule class >> group [
+
+	^ 'Style'
+]
+
 { #category : 'running' }
 ReNoNilAssignationInInitializeRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| problemAssigments|
@@ -24,12 +30,6 @@ ReNoNilAssignationInInitializeRule >> check: aMethod forCritiquesDo: aCriticBloc
 	problemAssigments do: [ :assignment |
 			aCriticBlock cull: (self createTrivialCritiqueOn: aMethod intervalOf: assignment hint: 'nil').
 		 ]
-]
-
-{ #category : 'accessing' }
-ReNoNilAssignationInInitializeRule >> group [
-
-	^ 'Style'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReNoPrintStringInPrintOnRule.class.st
+++ b/src/Renraku/ReNoPrintStringInPrintOnRule.class.st
@@ -27,6 +27,11 @@ ReNoPrintStringInPrintOnRule class >> initialize [
 ]
 
 { #category : 'accessing' }
+ReNoPrintStringInPrintOnRule class >> rationale [
+	^ 'Use the stream argument to #printOn: e.g.( stream print: anObject ) instead of creating an extra stream by using printString. e.g.( stream nextPutAll: anObject printString ).'
+]
+
+{ #category : 'accessing' }
 ReNoPrintStringInPrintOnRule class >> ruleName [
 	^ 'No printString inside printOn'
 ]
@@ -43,9 +48,4 @@ ReNoPrintStringInPrintOnRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				createTrivialCritiqueOn: aMethod
 				intervalOf: msgSend
 				hint: msgSend selector asString )]
-]
-
-{ #category : 'accessing' }
-ReNoPrintStringInPrintOnRule >> rationale [
-	^ 'Use the stream argument to #printOn: e.g.( stream print: anObject ) instead of creating an extra stream by using printString. e.g.( stream nextPutAll: anObject printString ).'
 ]

--- a/src/Renraku/ReNoPrintStringInPrintOnRule.class.st
+++ b/src/Renraku/ReNoPrintStringInPrintOnRule.class.st
@@ -16,6 +16,11 @@ ReNoPrintStringInPrintOnRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReNoPrintStringInPrintOnRule class >> group [
+	^ 'Optimization'
+]
+
 { #category : 'class initialization' }
 ReNoPrintStringInPrintOnRule class >> initialize [
     ReRuleManager cleanUp
@@ -33,11 +38,6 @@ ReNoPrintStringInPrintOnRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				createTrivialCritiqueOn: aMethod
 				intervalOf: msgSend
 				hint: msgSend selector asString )]
-]
-
-{ #category : 'accessing' }
-ReNoPrintStringInPrintOnRule >> group [
-	^ 'Optimization'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReNoPrintStringInPrintOnRule.class.st
+++ b/src/Renraku/ReNoPrintStringInPrintOnRule.class.st
@@ -26,6 +26,11 @@ ReNoPrintStringInPrintOnRule class >> initialize [
     ReRuleManager cleanUp
 ]
 
+{ #category : 'accessing' }
+ReNoPrintStringInPrintOnRule class >> ruleName [
+	^ 'No printString inside printOn'
+]
+
 { #category : 'running' }
 ReNoPrintStringInPrintOnRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| problemPrintStrings |
@@ -38,11 +43,6 @@ ReNoPrintStringInPrintOnRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				createTrivialCritiqueOn: aMethod
 				intervalOf: msgSend
 				hint: msgSend selector asString )]
-]
-
-{ #category : 'accessing' }
-ReNoPrintStringInPrintOnRule >> name [
-	^ 'No printString inside printOn'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/RePackageManifestShouldBePackagedInManifestTagRule.class.st
+++ b/src/Renraku/RePackageManifestShouldBePackagedInManifestTagRule.class.st
@@ -18,15 +18,15 @@ RePackageManifestShouldBePackagedInManifestTagRule class >> group [
 	^ 'Coding Idiom Violation'
 ]
 
+{ #category : 'accessing' }
+RePackageManifestShouldBePackagedInManifestTagRule class >> ruleName [
+	^ 'A package manifest should be tagged using ''Manifest'' class tag'
+]
+
 { #category : 'running' }
 RePackageManifestShouldBePackagedInManifestTagRule >> basicCheck: aClass [
 
 	^ (aClass inheritsFrom: PackageManifest) and: [ ((aClass package classesTaggedWith: 'Manifest') includes: aClass) not ]
-]
-
-{ #category : 'accessing' }
-RePackageManifestShouldBePackagedInManifestTagRule >> name [
-	^ 'A package manifest should be tagged using ''Manifest'' class tag'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/RePackageManifestShouldBePackagedInManifestTagRule.class.st
+++ b/src/Renraku/RePackageManifestShouldBePackagedInManifestTagRule.class.st
@@ -12,16 +12,16 @@ RePackageManifestShouldBePackagedInManifestTagRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+RePackageManifestShouldBePackagedInManifestTagRule class >> group [
+
+	^ 'Coding Idiom Violation'
+]
+
 { #category : 'running' }
 RePackageManifestShouldBePackagedInManifestTagRule >> basicCheck: aClass [
 
 	^ (aClass inheritsFrom: PackageManifest) and: [ ((aClass package classesTaggedWith: 'Manifest') includes: aClass) not ]
-]
-
-{ #category : 'accessing' }
-RePackageManifestShouldBePackagedInManifestTagRule >> group [
-
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/RePackageManifestShouldBePackagedInManifestTagRule.class.st
+++ b/src/Renraku/RePackageManifestShouldBePackagedInManifestTagRule.class.st
@@ -19,6 +19,11 @@ RePackageManifestShouldBePackagedInManifestTagRule class >> group [
 ]
 
 { #category : 'accessing' }
+RePackageManifestShouldBePackagedInManifestTagRule class >> rationale [
+	^ 'Check if the package manifest is tagged in class category ''Manifest'' to align with other packages and fulfil common expectations.'
+]
+
+{ #category : 'accessing' }
 RePackageManifestShouldBePackagedInManifestTagRule class >> ruleName [
 	^ 'A package manifest should be tagged using ''Manifest'' class tag'
 ]
@@ -27,9 +32,4 @@ RePackageManifestShouldBePackagedInManifestTagRule class >> ruleName [
 RePackageManifestShouldBePackagedInManifestTagRule >> basicCheck: aClass [
 
 	^ (aClass inheritsFrom: PackageManifest) and: [ ((aClass package classesTaggedWith: 'Manifest') includes: aClass) not ]
-]
-
-{ #category : 'accessing' }
-RePackageManifestShouldBePackagedInManifestTagRule >> rationale [
-	^ 'Check if the package manifest is tagged in class category ''Manifest'' to align with other packages and fulfil common expectations.'
 ]

--- a/src/Renraku/ReProperMethodProtocolNameRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameRule.class.st
@@ -34,6 +34,12 @@ ReProperMethodProtocolNameRule class >> goodMethodProtocolName [
 	^self protocolIdiom key
 ]
 
+{ #category : 'accessing' }
+ReProperMethodProtocolNameRule class >> group [
+
+	^ 'Coding Idiom Violation'
+]
+
 { #category : 'testing' }
 ReProperMethodProtocolNameRule class >> isAbstract [
 
@@ -75,12 +81,6 @@ ReProperMethodProtocolNameRule >> critiqueFor: aMethod [
 			   protocol: { proposedProtocol }
 			   inMethod: aMethod selector
 			   inClass: aMethod methodClass name)
-]
-
-{ #category : 'accessing' }
-ReProperMethodProtocolNameRule >> group [
-
-	^ 'Coding Idiom Violation'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReProperMethodProtocolNameRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameRule.class.st
@@ -54,6 +54,12 @@ ReProperMethodProtocolNameRule class >> protocolIdiom [
 ]
 
 { #category : 'accessing' }
+ReProperMethodProtocolNameRule class >> rationale [
+
+	^ 'Check if the method protocol name is appropriate and fulfils common expectations.'
+]
+
+{ #category : 'accessing' }
 ReProperMethodProtocolNameRule class >> ruleName [
 	^ 'Method categorization: use '''
 		  	, self class goodMethodProtocolName
@@ -101,12 +107,6 @@ ReProperMethodProtocolNameRule >> methodProtocolName [
 ReProperMethodProtocolNameRule >> methodProtocolName: anObject [
 
 	methodProtocolName := anObject
-]
-
-{ #category : 'accessing' }
-ReProperMethodProtocolNameRule >> rationale [
-
-	^ 'Check if the method protocol name is appropriate and fulfils common expectations.'
 ]
 
 { #category : 'private - utilities' }

--- a/src/Renraku/ReProperMethodProtocolNameRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameRule.class.st
@@ -61,10 +61,8 @@ ReProperMethodProtocolNameRule class >> rationale [
 
 { #category : 'accessing' }
 ReProperMethodProtocolNameRule class >> ruleName [
-	^ 'Method categorization: use '''
-		  	, self class goodMethodProtocolName
-  	  		, ''' as protocol name instead of '''
-	  		, self methodProtocolName asString , ''''
+
+	^ 'Method categorization: use ''' , self goodMethodProtocolName , ''' as protocol name instead of ''' , self badMethodProtocolNames asString , ''''
 ]
 
 { #category : 'private - utilities' }
@@ -107,6 +105,12 @@ ReProperMethodProtocolNameRule >> methodProtocolName [
 ReProperMethodProtocolNameRule >> methodProtocolName: anObject [
 
 	methodProtocolName := anObject
+]
+
+{ #category : 'accessing' }
+ReProperMethodProtocolNameRule >> ruleName [
+
+	^ 'Method categorization: use ''' , self class goodMethodProtocolName , ''' as protocol name instead of ''' , self methodProtocolName asString , ''''
 ]
 
 { #category : 'private - utilities' }

--- a/src/Renraku/ReProperMethodProtocolNameRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolNameRule.class.st
@@ -53,6 +53,14 @@ ReProperMethodProtocolNameRule class >> protocolIdiom [
 	^ self subclassResponsibility
 ]
 
+{ #category : 'accessing' }
+ReProperMethodProtocolNameRule class >> ruleName [
+	^ 'Method categorization: use '''
+		  	, self class goodMethodProtocolName
+  	  		, ''' as protocol name instead of '''
+	  		, self methodProtocolName asString , ''''
+]
+
 { #category : 'private - utilities' }
 ReProperMethodProtocolNameRule class >> use: valid insteadOf: arrayOfInvalid [
 	"Instead of directly creating an array we use this utility method for better readability
@@ -93,15 +101,6 @@ ReProperMethodProtocolNameRule >> methodProtocolName [
 ReProperMethodProtocolNameRule >> methodProtocolName: anObject [
 
 	methodProtocolName := anObject
-]
-
-{ #category : 'accessing' }
-ReProperMethodProtocolNameRule >> name [
-
-	^ 'Method categorization: use '''
-		  	, self class goodMethodProtocolName
-  	  		, ''' as protocol name instead of '''
-	  		, self methodProtocolName asString , ''''
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReProperMethodProtocolRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolRule.class.st
@@ -39,15 +39,27 @@ ReProperMethodProtocolRule class >> isAbstract [
 	^ self == ReProperMethodProtocolRule
 ]
 
+{ #category : 'accessing - defaults' }
+ReProperMethodProtocolRule class >> protocolName [
+
+	^ self subclassResponsibility
+]
+
 { #category : 'accessing' }
 ReProperMethodProtocolRule class >> ruleName [
+
 	| side |
-	side := self class checksClassMethod
+	side := self checksClassMethod
 		        ifTrue: [ 'Class' ]
 		        ifFalse: [ 'Instance' ].
 
-	^ side , ' side methods called #' , self selector asString
-	  , ' should be in the ''' , self protocolName , ''' protocol'
+	^ side , ' side methods called #' , self selector asString , ' should be in the ''' , self protocolName , ''' protocol'
+]
+
+{ #category : 'accessing - defaults' }
+ReProperMethodProtocolRule class >> selector [
+
+	^ self subclassResponsibility
 ]
 
 { #category : 'running' }
@@ -81,12 +93,10 @@ ReProperMethodProtocolRule >> critiqueFor: aMethod [
 
 { #category : 'accessing - defaults' }
 ReProperMethodProtocolRule >> protocolName [
-
-	^ self subclassResponsibility
+	^ self class protocolName
 ]
 
 { #category : 'accessing - defaults' }
 ReProperMethodProtocolRule >> selector [
-
-	^ self subclassResponsibility
+	^ self class selector
 ]

--- a/src/Renraku/ReProperMethodProtocolRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolRule.class.st
@@ -27,6 +27,12 @@ ReProperMethodProtocolRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReProperMethodProtocolRule class >> group [
+
+	^ 'Clean Code'
+]
+
 { #category : 'testing' }
 ReProperMethodProtocolRule class >> isAbstract [
 
@@ -60,12 +66,6 @@ ReProperMethodProtocolRule >> critiqueFor: aMethod [
 			   protocol: self protocolName
 			   inMethod: methodSymbol
 			   inClass: classSymbol)
-]
-
-{ #category : 'accessing' }
-ReProperMethodProtocolRule >> group [
-
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReProperMethodProtocolRule.class.st
+++ b/src/Renraku/ReProperMethodProtocolRule.class.st
@@ -39,6 +39,17 @@ ReProperMethodProtocolRule class >> isAbstract [
 	^ self == ReProperMethodProtocolRule
 ]
 
+{ #category : 'accessing' }
+ReProperMethodProtocolRule class >> ruleName [
+	| side |
+	side := self class checksClassMethod
+		        ifTrue: [ 'Class' ]
+		        ifFalse: [ 'Instance' ].
+
+	^ side , ' side methods called #' , self selector asString
+	  , ' should be in the ''' , self protocolName , ''' protocol'
+]
+
 { #category : 'running' }
 ReProperMethodProtocolRule >> basicCheck: aMethod [
 
@@ -66,18 +77,6 @@ ReProperMethodProtocolRule >> critiqueFor: aMethod [
 			   protocol: self protocolName
 			   inMethod: methodSymbol
 			   inClass: classSymbol)
-]
-
-{ #category : 'accessing' }
-ReProperMethodProtocolRule >> name [
-
-	| side |
-	side := self class checksClassMethod
-		        ifTrue: [ 'Class' ]
-		        ifFalse: [ 'Instance' ].
-
-	^ side , ' side methods called #' , self selector asString
-	  , ' should be in the ''' , self protocolName , ''' protocol'
 ]
 
 { #category : 'accessing - defaults' }

--- a/src/Renraku/ReReturnMethodRule.class.st
+++ b/src/Renraku/ReReturnMethodRule.class.st
@@ -28,15 +28,15 @@ ReReturnMethodRule class >> ruleName [
 	^ 'Method should explicitly return a value'
 ]
 
+{ #category : 'accessing' }
+ReReturnMethodRule class >> severity [
+
+	^ #error
+]
+
 { #category : 'running' }
 ReReturnMethodRule >> basicCheck: aMethod [
 	(aMethod overriddenMethods anySatisfy: [ :method | method hasPragmaNamed: #shouldReturn ]) ifFalse: [ ^ false ].
 
 	^ aMethod ast lastIsReturn not
-]
-
-{ #category : 'accessing' }
-ReReturnMethodRule >> severity [
-
-	^ #error
 ]

--- a/src/Renraku/ReReturnMethodRule.class.st
+++ b/src/Renraku/ReReturnMethodRule.class.st
@@ -23,17 +23,16 @@ ReReturnMethodRule class >> group [
 	^ 'Bugs'
 ]
 
+{ #category : 'accessing' }
+ReReturnMethodRule class >> ruleName [
+	^ 'Method should explicitly return a value'
+]
+
 { #category : 'running' }
 ReReturnMethodRule >> basicCheck: aMethod [
 	(aMethod overriddenMethods anySatisfy: [ :method | method hasPragmaNamed: #shouldReturn ]) ifFalse: [ ^ false ].
 
 	^ aMethod ast lastIsReturn not
-]
-
-{ #category : 'accessing' }
-ReReturnMethodRule >> name [
-
-	^ 'Method should explicitly return a value'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReReturnMethodRule.class.st
+++ b/src/Renraku/ReReturnMethodRule.class.st
@@ -17,17 +17,17 @@ ReReturnMethodRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReReturnMethodRule class >> group [
+
+	^ 'Bugs'
+]
+
 { #category : 'running' }
 ReReturnMethodRule >> basicCheck: aMethod [
 	(aMethod overriddenMethods anySatisfy: [ :method | method hasPragmaNamed: #shouldReturn ]) ifFalse: [ ^ false ].
 
 	^ aMethod ast lastIsReturn not
-]
-
-{ #category : 'accessing' }
-ReReturnMethodRule >> group [
-
-	^ 'Bugs'
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReRuleManager.class.st
+++ b/src/Renraku/ReRuleManager.class.st
@@ -160,6 +160,7 @@ ReRuleManager class >> ruleToggleGroupID [
 
 { #category : 'settings' }
 ReRuleManager class >> ruleToggleSettingsOn: aBuilder [
+
 	<systemsettings>
 	(aBuilder group: self ruleToggleGroupID)
 		order: 1;
@@ -167,16 +168,13 @@ ReRuleManager class >> ruleToggleSettingsOn: aBuilder [
 		description: 'Select which rules do you want to see in the live feedback';
 		parent: #qualityAssistant;
 		with: [
-			(self visibleRuleClasses sorted: [ :a :b | a name < b name ])
-				do: [ :rule |
-					| inst |
-					inst := rule new.
+			(self visibleRuleClasses sorted: [ :a :b | a name < b name ]) do: [ :rule |
 					(aBuilder setting: rule enabledSettingID)
-					selector: #enabled;
-					target: rule;
-					default: rule enabled;
-					label: inst name;
-					description: inst rationale ] ]
+						selector: #enabled;
+						target: rule;
+						default: rule enabled;
+						label: rule name;
+						description: rule rationale ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReThemeAccessRule.class.st
+++ b/src/Renraku/ReThemeAccessRule.class.st
@@ -14,6 +14,11 @@ ReThemeAccessRule class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReThemeAccessRule class >> group [
+	^ 'API Hints'
+]
+
 { #category : 'class initialization' }
 ReThemeAccessRule class >> initialize [
    " ReRuleManager cleanUp "
@@ -34,11 +39,6 @@ ReThemeAccessRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				createTrivialCritiqueOn: aMethod
 				intervalOf: msgSend
 				hint: msgSend selector asString) ]
-]
-
-{ #category : 'running' }
-ReThemeAccessRule >> group [
-	^ 'API Hints'
 ]
 
 { #category : 'running' }

--- a/src/Renraku/ReThemeAccessRule.class.st
+++ b/src/Renraku/ReThemeAccessRule.class.st
@@ -24,6 +24,11 @@ ReThemeAccessRule class >> initialize [
    " ReRuleManager cleanUp "
 ]
 
+{ #category : 'accessing' }
+ReThemeAccessRule class >> ruleName [
+	^ 'Access to UI theme.'
+]
+
 { #category : 'running' }
 ReThemeAccessRule >> check: aMethod forCritiquesDo: aCriticBlock [
 	| problemThemes |
@@ -39,9 +44,4 @@ ReThemeAccessRule >> check: aMethod forCritiquesDo: aCriticBlock [
 				createTrivialCritiqueOn: aMethod
 				intervalOf: msgSend
 				hint: msgSend selector asString) ]
-]
-
-{ #category : 'running' }
-ReThemeAccessRule >> name [
-	^ 'Access to UI theme.'
 ]

--- a/src/SUnit-Rules/ReAssertEqualSignIntoAssertEqualsRule.class.st
+++ b/src/SUnit-Rules/ReAssertEqualSignIntoAssertEqualsRule.class.st
@@ -12,6 +12,12 @@ Class {
 }
 
 { #category : 'accessing' }
+ReAssertEqualSignIntoAssertEqualsRule class >> group [
+
+	^ 'SUnit'
+]
+
+{ #category : 'accessing' }
 ReAssertEqualSignIntoAssertEqualsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 

--- a/src/SUnit-Rules/ReAssertEqualSignIntoAssertEqualsRule.class.st
+++ b/src/SUnit-Rules/ReAssertEqualSignIntoAssertEqualsRule.class.st
@@ -18,6 +18,11 @@ ReAssertEqualSignIntoAssertEqualsRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReAssertEqualSignIntoAssertEqualsRule class >> ruleName [
+	^ 'Use assert:equals: instead of assert: and = (or deny:/identicalTo: and ==)'
+]
+
+{ #category : 'accessing' }
 ReAssertEqualSignIntoAssertEqualsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -41,10 +46,4 @@ ReAssertEqualSignIntoAssertEqualsRule >> initialize [
 	self replace: 'self deny: ``@object1 = ``@object2' with: 'self deny: ``@object1 equals: ``@object2'.
 	self replace: 'self assert: ``@object1 == ``@object2' with: 'self assert: ``@object1 identicalTo: ``@object2'.
 	self replace: 'self deny: ``@object1 == ``@object2' with: 'self deny: ``@object1 identicalTo: ``@object2'
-]
-
-{ #category : 'accessing' }
-ReAssertEqualSignIntoAssertEqualsRule >> name [
-
-	^ 'Use assert:equals: instead of assert: and = (or deny:/identicalTo: and ==)'
 ]

--- a/src/SUnit-Rules/ReShouldSendSuperInitializeAsFirstMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperInitializeAsFirstMessage.class.st
@@ -19,6 +19,12 @@ ReShouldSendSuperInitializeAsFirstMessage class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReShouldSendSuperInitializeAsFirstMessage class >> group [
+
+	^ 'Clean Code'
+]
+
 { #category : 'utilities' }
 ReShouldSendSuperInitializeAsFirstMessage class >> parseTreeSearcher [
 
@@ -45,12 +51,6 @@ ReShouldSendSuperInitializeAsFirstMessage class >> superInitializeNotCalledFirst
 ReShouldSendSuperInitializeAsFirstMessage >> basicCheck: aMethod [
 
 	^ (aMethod isClassSide not) and: [ aMethod selector = #initialize and: [ self class superInitializeNotCalledFirstIn: aMethod ] ]
-]
-
-{ #category : 'accessing' }
-ReShouldSendSuperInitializeAsFirstMessage >> group [
-
-	^ 'Clean Code'
 ]
 
 { #category : 'accessing' }

--- a/src/SUnit-Rules/ReShouldSendSuperInitializeAsFirstMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperInitializeAsFirstMessage.class.st
@@ -31,6 +31,11 @@ ReShouldSendSuperInitializeAsFirstMessage class >> parseTreeSearcher [
 	^ RBParseTreeSearcher new
 ]
 
+{ #category : 'accessing' }
+ReShouldSendSuperInitializeAsFirstMessage class >> ruleName [
+	^ 'Provide a call to super initialize as the first message in the instance side #initialize method'
+]
+
 { #category : 'utilities' }
 ReShouldSendSuperInitializeAsFirstMessage class >> superInitializeNotCalledFirstIn: aCompiledMethod [
 	"Return true if the method is an instance side initialize method and a call to super initialize is not the first message send."
@@ -51,10 +56,4 @@ ReShouldSendSuperInitializeAsFirstMessage class >> superInitializeNotCalledFirst
 ReShouldSendSuperInitializeAsFirstMessage >> basicCheck: aMethod [
 
 	^ (aMethod isClassSide not) and: [ aMethod selector = #initialize and: [ self class superInitializeNotCalledFirstIn: aMethod ] ]
-]
-
-{ #category : 'accessing' }
-ReShouldSendSuperInitializeAsFirstMessage >> name [
-
-	^ 'Provide a call to super initialize as the first message in the instance side #initialize method'
 ]

--- a/src/SUnit-Rules/ReShouldSendSuperSetUpAsFirstMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperSetUpAsFirstMessage.class.st
@@ -29,6 +29,11 @@ ReShouldSendSuperSetUpAsFirstMessage class >> parseTreeSearcher [
 	^ RBParseTreeSearcher new
 ]
 
+{ #category : 'accessing' }
+ReShouldSendSuperSetUpAsFirstMessage class >> ruleName [
+	^ 'Provide a call to super setUp as the first message in the setUp method'
+]
+
 { #category : 'utilities' }
 ReShouldSendSuperSetUpAsFirstMessage class >> superSetUpNotCalledFirstIn: aCompiledMethod [
 	"Return true if the method is a setUp method and a call to super setUp is not the first message send."
@@ -54,10 +59,4 @@ ReShouldSendSuperSetUpAsFirstMessage >> basicCheck: aMethod [
 ReShouldSendSuperSetUpAsFirstMessage >> isClassToCheck: aClass [
 
 	^ { TestCase. TestResource } anySatisfy: [:each | aClass inheritsFrom: each ]
-]
-
-{ #category : 'accessing' }
-ReShouldSendSuperSetUpAsFirstMessage >> name [
-
-	^ 'Provide a call to super setUp as the first message in the setUp method'
 ]

--- a/src/SUnit-Rules/ReShouldSendSuperSetUpAsFirstMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperSetUpAsFirstMessage.class.st
@@ -17,6 +17,12 @@ ReShouldSendSuperSetUpAsFirstMessage class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReShouldSendSuperSetUpAsFirstMessage class >> group [
+
+	^ 'SUnit'
+]
+
 { #category : 'utilities' }
 ReShouldSendSuperSetUpAsFirstMessage class >> parseTreeSearcher [
 

--- a/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
@@ -17,6 +17,12 @@ ReShouldSendSuperTearDownAsLastMessage class >> checksMethod [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReShouldSendSuperTearDownAsLastMessage class >> group [
+
+	^ 'SUnit'
+]
+
 { #category : 'utilities' }
 ReShouldSendSuperTearDownAsLastMessage class >> parseTreeSearcher [
 

--- a/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
@@ -29,6 +29,11 @@ ReShouldSendSuperTearDownAsLastMessage class >> parseTreeSearcher [
 	^ RBParseTreeSearcher new
 ]
 
+{ #category : 'accessing' }
+ReShouldSendSuperTearDownAsLastMessage class >> ruleName [
+	^ 'Provide a call to super tearDown as the last message in the tearDown method'
+]
+
 { #category : 'utilities' }
 ReShouldSendSuperTearDownAsLastMessage class >> superTearDownNotCalledLastIn: aCompiledMethod [
 	"Return true if the method is a tearDown method and a call to super tearDown is not the last message send."
@@ -54,10 +59,4 @@ ReShouldSendSuperTearDownAsLastMessage >> basicCheck: aMethod [
 ReShouldSendSuperTearDownAsLastMessage >> isClassToCheck: aClass [
 
 	^ { TestCase. TestResource } anySatisfy: [:each | aClass inheritsFrom: each ]
-]
-
-{ #category : 'accessing' }
-ReShouldSendSuperTearDownAsLastMessage >> name [
-
-	^ 'Provide a call to super tearDown as the last message in the tearDown method'
 ]

--- a/src/SUnit-Rules/ReShouldTransformedIntoAssertRule.class.st
+++ b/src/SUnit-Rules/ReShouldTransformedIntoAssertRule.class.st
@@ -18,6 +18,11 @@ ReShouldTransformedIntoAssertRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReShouldTransformedIntoAssertRule class >> ruleName [
+	^ 'Use assert: instead of should:'
+]
+
+{ #category : 'accessing' }
 ReShouldTransformedIntoAssertRule class >> uniqueIdentifierName [
 
 	^'ShouldTransformedIntoAssert'
@@ -30,10 +35,4 @@ ReShouldTransformedIntoAssertRule >> initialize [
 	self
 		replace: 'self should: [ ``@object1 ]'
 		with: 'self assert: ``@object1'
-]
-
-{ #category : 'accessing' }
-ReShouldTransformedIntoAssertRule >> name [
-
-	^ 'Use assert: instead of should:'
 ]

--- a/src/SUnit-Rules/ReShouldTransformedIntoAssertRule.class.st
+++ b/src/SUnit-Rules/ReShouldTransformedIntoAssertRule.class.st
@@ -12,6 +12,12 @@ Class {
 }
 
 { #category : 'accessing' }
+ReShouldTransformedIntoAssertRule class >> group [
+
+	^ 'SUnit'
+]
+
+{ #category : 'accessing' }
 ReShouldTransformedIntoAssertRule class >> uniqueIdentifierName [
 
 	^'ShouldTransformedIntoAssert'

--- a/src/SUnit-Rules/ReTestClassNameShouldEndWithTestRule.class.st
+++ b/src/SUnit-Rules/ReTestClassNameShouldEndWithTestRule.class.st
@@ -17,6 +17,12 @@ ReTestClassNameShouldEndWithTestRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReTestClassNameShouldEndWithTestRule class >> group [
+
+	^ 'SUnit'
+]
+
 { #category : 'running' }
 ReTestClassNameShouldEndWithTestRule >> basicCheck: aClass [
 	| suffixes |

--- a/src/SUnit-Rules/ReTestClassNameShouldEndWithTestRule.class.st
+++ b/src/SUnit-Rules/ReTestClassNameShouldEndWithTestRule.class.st
@@ -23,16 +23,16 @@ ReTestClassNameShouldEndWithTestRule class >> group [
 	^ 'SUnit'
 ]
 
+{ #category : 'accessing' }
+ReTestClassNameShouldEndWithTestRule class >> ruleName [
+	^ 'A Test class'' name should end with ''Test'' '
+]
+
 { #category : 'running' }
 ReTestClassNameShouldEndWithTestRule >> basicCheck: aClass [
 	| suffixes |
 	suffixes := #('Test' 'TestCase').
 	^ (aClass inheritsFrom: TestCase) and: [ suffixes noneSatisfy: [ :suffix | aClass name asString endsWith: suffix ] ]
-]
-
-{ #category : 'accessing' }
-ReTestClassNameShouldEndWithTestRule >> name [
-	^ 'A Test class'' name should end with ''Test'' '
 ]
 
 { #category : 'accessing' }

--- a/src/SUnit-Rules/ReTestClassNameShouldEndWithTestRule.class.st
+++ b/src/SUnit-Rules/ReTestClassNameShouldEndWithTestRule.class.st
@@ -24,6 +24,11 @@ ReTestClassNameShouldEndWithTestRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReTestClassNameShouldEndWithTestRule class >> rationale [
+	^ 'A test class (subclass of TestCase) should have it''s name ending with ''Test'' or ''TestCase'''
+]
+
+{ #category : 'accessing' }
 ReTestClassNameShouldEndWithTestRule class >> ruleName [
 	^ 'A Test class'' name should end with ''Test'' '
 ]
@@ -33,9 +38,4 @@ ReTestClassNameShouldEndWithTestRule >> basicCheck: aClass [
 	| suffixes |
 	suffixes := #('Test' 'TestCase').
 	^ (aClass inheritsFrom: TestCase) and: [ suffixes noneSatisfy: [ :suffix | aClass name asString endsWith: suffix ] ]
-]
-
-{ #category : 'accessing' }
-ReTestClassNameShouldEndWithTestRule >> rationale [
-	^ 'A test class (subclass of TestCase) should have it''s name ending with ''Test'' or ''TestCase'''
 ]

--- a/src/SUnit-Rules/ReTestClassNameShouldNotEndWithTests.class.st
+++ b/src/SUnit-Rules/ReTestClassNameShouldNotEndWithTests.class.st
@@ -24,6 +24,11 @@ ReTestClassNameShouldNotEndWithTests class >> group [
 ]
 
 { #category : 'accessing' }
+ReTestClassNameShouldNotEndWithTests class >> rationale [
+	^ 'A test class (subclass of TestCase) should have it''s name ending with ''Test'' instead of ''Tests'' '
+]
+
+{ #category : 'accessing' }
 ReTestClassNameShouldNotEndWithTests class >> ruleName [
 	^ 'A Test class'' name should not end with ''Tests'' '
 ]
@@ -32,9 +37,4 @@ ReTestClassNameShouldNotEndWithTests class >> ruleName [
 ReTestClassNameShouldNotEndWithTests >> basicCheck: aClass [
 
 	^ (aClass inheritsFrom: TestCase) and: [aClass name asString endsWith: 'Tests']
-]
-
-{ #category : 'accessing' }
-ReTestClassNameShouldNotEndWithTests >> rationale [
-	^ 'A test class (subclass of TestCase) should have it''s name ending with ''Test'' instead of ''Tests'' '
 ]

--- a/src/SUnit-Rules/ReTestClassNameShouldNotEndWithTests.class.st
+++ b/src/SUnit-Rules/ReTestClassNameShouldNotEndWithTests.class.st
@@ -17,6 +17,12 @@ ReTestClassNameShouldNotEndWithTests class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReTestClassNameShouldNotEndWithTests class >> group [
+
+	^ 'SUnit'
+]
+
 { #category : 'running' }
 ReTestClassNameShouldNotEndWithTests >> basicCheck: aClass [
 

--- a/src/SUnit-Rules/ReTestClassNameShouldNotEndWithTests.class.st
+++ b/src/SUnit-Rules/ReTestClassNameShouldNotEndWithTests.class.st
@@ -23,15 +23,15 @@ ReTestClassNameShouldNotEndWithTests class >> group [
 	^ 'SUnit'
 ]
 
+{ #category : 'accessing' }
+ReTestClassNameShouldNotEndWithTests class >> ruleName [
+	^ 'A Test class'' name should not end with ''Tests'' '
+]
+
 { #category : 'running' }
 ReTestClassNameShouldNotEndWithTests >> basicCheck: aClass [
 
 	^ (aClass inheritsFrom: TestCase) and: [aClass name asString endsWith: 'Tests']
-]
-
-{ #category : 'accessing' }
-ReTestClassNameShouldNotEndWithTests >> name [
-	^ 'A Test class'' name should not end with ''Tests'' '
 ]
 
 { #category : 'accessing' }

--- a/src/SUnit-Rules/ReTestClassNotInPackageWithTestEndingNameRule.class.st
+++ b/src/SUnit-Rules/ReTestClassNotInPackageWithTestEndingNameRule.class.st
@@ -24,6 +24,11 @@ ReTestClassNotInPackageWithTestEndingNameRule class >> group [
 ]
 
 { #category : 'accessing' }
+ReTestClassNotInPackageWithTestEndingNameRule class >> rationale [
+	^ 'A test class (subclass of TestCase) should be placed in a package with a ''-Tests'' suffix'
+]
+
+{ #category : 'accessing' }
 ReTestClassNotInPackageWithTestEndingNameRule class >> ruleName [
 	^ 'Test class not in a package with name ending with ''-Tests'' '
 ]
@@ -32,9 +37,4 @@ ReTestClassNotInPackageWithTestEndingNameRule class >> ruleName [
 ReTestClassNotInPackageWithTestEndingNameRule >> basicCheck: aClass [
 
 	^ (aClass inheritsFrom: TestCase) and: [(aClass package name asString endsWith: '-Tests') not]
-]
-
-{ #category : 'accessing' }
-ReTestClassNotInPackageWithTestEndingNameRule >> rationale [
-	^ 'A test class (subclass of TestCase) should be placed in a package with a ''-Tests'' suffix'
 ]

--- a/src/SUnit-Rules/ReTestClassNotInPackageWithTestEndingNameRule.class.st
+++ b/src/SUnit-Rules/ReTestClassNotInPackageWithTestEndingNameRule.class.st
@@ -17,6 +17,12 @@ ReTestClassNotInPackageWithTestEndingNameRule class >> checksClass [
 	^ true
 ]
 
+{ #category : 'accessing' }
+ReTestClassNotInPackageWithTestEndingNameRule class >> group [
+
+	^ 'SUnit'
+]
+
 { #category : 'running' }
 ReTestClassNotInPackageWithTestEndingNameRule >> basicCheck: aClass [
 

--- a/src/SUnit-Rules/ReTestClassNotInPackageWithTestEndingNameRule.class.st
+++ b/src/SUnit-Rules/ReTestClassNotInPackageWithTestEndingNameRule.class.st
@@ -23,15 +23,15 @@ ReTestClassNotInPackageWithTestEndingNameRule class >> group [
 	^ 'SUnit'
 ]
 
+{ #category : 'accessing' }
+ReTestClassNotInPackageWithTestEndingNameRule class >> ruleName [
+	^ 'Test class not in a package with name ending with ''-Tests'' '
+]
+
 { #category : 'running' }
 ReTestClassNotInPackageWithTestEndingNameRule >> basicCheck: aClass [
 
 	^ (aClass inheritsFrom: TestCase) and: [(aClass package name asString endsWith: '-Tests') not]
-]
-
-{ #category : 'accessing' }
-ReTestClassNotInPackageWithTestEndingNameRule >> name [
-	^ 'Test class not in a package with name ending with ''-Tests'' '
 ]
 
 { #category : 'accessing' }

--- a/src/Specific-Rules/PharoBootstrapRule.class.st
+++ b/src/Specific-Rules/PharoBootstrapRule.class.st
@@ -23,6 +23,11 @@ PharoBootstrapRule class >> group [
 	^ 'Architectural'
 ]
 
+{ #category : 'accessing' }
+PharoBootstrapRule class >> ruleName [
+	^ 'Illegal dependency of Bootstrap Layer'
+]
+
 { #category : 'running' }
 PharoBootstrapRule >> basicCheck: aPackage [
 
@@ -48,11 +53,6 @@ PharoBootstrapRule >> critiqueFor: aPackage [
 { #category : 'private' }
 PharoBootstrapRule >> dependencyChecker [
 	^ (DependencyChecker ifNil: [ DADependencyChecker ]) new
-]
-
-{ #category : 'accessing' }
-PharoBootstrapRule >> name [
-	^ 'Illegal dependency of Bootstrap Layer'
 ]
 
 { #category : 'instance creation' }

--- a/src/Specific-Rules/PharoBootstrapRule.class.st
+++ b/src/Specific-Rules/PharoBootstrapRule.class.st
@@ -17,6 +17,12 @@ PharoBootstrapRule class >> checksPackage [
 	^ true
 ]
 
+{ #category : 'accessing' }
+PharoBootstrapRule class >> group [
+
+	^ 'Architectural'
+]
+
 { #category : 'running' }
 PharoBootstrapRule >> basicCheck: aPackage [
 
@@ -42,12 +48,6 @@ PharoBootstrapRule >> critiqueFor: aPackage [
 { #category : 'private' }
 PharoBootstrapRule >> dependencyChecker [
 	^ (DependencyChecker ifNil: [ DADependencyChecker ]) new
-]
-
-{ #category : 'accessing' }
-PharoBootstrapRule >> group [
-
-	^ 'Architectural'
 ]
 
 { #category : 'accessing' }

--- a/src/Specific-Rules/RbScriptingSetBeforeModel.class.st
+++ b/src/Specific-Rules/RbScriptingSetBeforeModel.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : 'accessing' }
-RbScriptingSetBeforeModel >> group [
+RbScriptingSetBeforeModel class >> group [
 	^ 'Rubric'
 ]
 

--- a/src/Specific-Rules/ReIconHardcodedMessageRule.class.st
+++ b/src/Specific-Rules/ReIconHardcodedMessageRule.class.st
@@ -21,6 +21,11 @@ ReIconHardcodedMessageRule class >> group [
 	^ 'API Change'
 ]
 
+{ #category : 'accessing' }
+ReIconHardcodedMessageRule class >> ruleName [
+	^ 'Use self iconNamed: #symbol instead of asIcon or Smalltalk ui icons iconNamed: #symbol'
+]
+
 { #category : 'initialization' }
 ReIconHardcodedMessageRule >> initialize [
 	super initialize.
@@ -29,12 +34,6 @@ ReIconHardcodedMessageRule >> initialize [
 		byEvaluating: [ :node :matchMap |
 			RBParser
 				parseExpression: 'self iconNamed: #' , (matchMap at: #'`iconName') ]
-]
-
-{ #category : 'accessing' }
-ReIconHardcodedMessageRule >> name [
-
-	^ 'Use self iconNamed: #symbol instead of asIcon or Smalltalk ui icons iconNamed: #symbol'
 ]
 
 { #category : 'accessing' }

--- a/src/Specific-Rules/ReIconHardcodedMessageRule.class.st
+++ b/src/Specific-Rules/ReIconHardcodedMessageRule.class.st
@@ -16,7 +16,7 @@ Class {
 }
 
 { #category : 'accessing' }
-ReIconHardcodedMessageRule >> group [
+ReIconHardcodedMessageRule class >> group [
 
 	^ 'API Change'
 ]

--- a/src/Specific-Rules/ReIconHardcodedMessageRule.class.st
+++ b/src/Specific-Rules/ReIconHardcodedMessageRule.class.st
@@ -26,6 +26,12 @@ ReIconHardcodedMessageRule class >> ruleName [
 	^ 'Use self iconNamed: #symbol instead of asIcon or Smalltalk ui icons iconNamed: #symbol'
 ]
 
+{ #category : 'accessing' }
+ReIconHardcodedMessageRule class >> severity [
+
+	^ #error
+]
+
 { #category : 'initialization' }
 ReIconHardcodedMessageRule >> initialize [
 	super initialize.
@@ -34,10 +40,4 @@ ReIconHardcodedMessageRule >> initialize [
 		byEvaluating: [ :node :matchMap |
 			RBParser
 				parseExpression: 'self iconNamed: #' , (matchMap at: #'`iconName') ]
-]
-
-{ #category : 'accessing' }
-ReIconHardcodedMessageRule >> severity [
-
-	^ #error
 ]

--- a/src/Specific-Rules/SettingDontTranslateDescriptionRule.class.st
+++ b/src/Specific-Rules/SettingDontTranslateDescriptionRule.class.st
@@ -15,6 +15,11 @@ SettingDontTranslateDescriptionRule class >> group [
 	^ 'API Hints'
 ]
 
+{ #category : 'accessing' }
+SettingDontTranslateDescriptionRule class >> ruleName [
+	^ 'Do not use #translated for setting''s description'
+]
+
 { #category : 'running' }
 SettingDontTranslateDescriptionRule >> basicCheck: aNode [
 	^ aNode methodNode ifNil: [ false ] ifNotNil: [ :methNode | self checkPreconditionOn: methNode ]
@@ -34,10 +39,4 @@ SettingDontTranslateDescriptionRule >> initialize [
 	self
 		replace: '`@recv description: `#str translated'
 		with: '`@recv description: `#str'
-]
-
-{ #category : 'accessing' }
-SettingDontTranslateDescriptionRule >> name [
-
-	^ 'Do not use #translated for setting''s description'
 ]

--- a/src/Specific-Rules/SettingDontTranslateDescriptionRule.class.st
+++ b/src/Specific-Rules/SettingDontTranslateDescriptionRule.class.st
@@ -9,6 +9,12 @@ Class {
 	#tag : 'System-Settings'
 }
 
+{ #category : 'accessing' }
+SettingDontTranslateDescriptionRule class >> group [
+
+	^ 'API Hints'
+]
+
 { #category : 'running' }
 SettingDontTranslateDescriptionRule >> basicCheck: aNode [
 	^ aNode methodNode ifNil: [ false ] ifNotNil: [ :methNode | self checkPreconditionOn: methNode ]
@@ -19,12 +25,6 @@ SettingDontTranslateDescriptionRule >> checkPreconditionOn: aMethodNode [
 
 	^ aMethodNode pragmas anySatisfy: [ :p |
 		p selector = #systemsettings ]
-]
-
-{ #category : 'accessing' }
-SettingDontTranslateDescriptionRule >> group [
-
-	^ 'API Hints'
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
This change moves the methods #group, #name (renamed into #ruleName), #severity and #rational of rules from the instance side to the class side. This is a metadata that will not change for any instance of the rule so it makes sense to have it class side. It will be useful for Angel to implement some features. Currently, if we want the group of a rule we need to create a new instance and this takes some times because of the initializations of the rules. This change will make it much faster to know the group of a rule for which we do not have an instance.

There is a temporary hack to deprecate the instance side group method that could still be here for rule existing outside pharo to let them move the group on the class side without breaking the tools that will use the new class side method

I also updated the setting browser to not create new instance of the rules to collect the info and this speed it up quite a bit actually 