### PR TITLE
Cleanup: ZnCharacterEncoder, ZnEncodedStream, ZnEncodedReadStream and ZnEncodedWriteStream should be abstract classes

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnCharacterEncoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCharacterEncoder.class.st
@@ -85,6 +85,12 @@ ZnCharacterEncoder class >> handlesEncoding: string [
 	self subclassResponsibility
 ]
 
+{ #category : 'testing' }
+ZnCharacterEncoder class >> isAbstract [
+
+	^ self == ZnCharacterEncoder
+]
+
 { #category : 'convenience' }
 ZnCharacterEncoder class >> iso88591 [
 	^ self newForEncoding: 'iso-8859-1'

--- a/src/Zinc-Character-Encoding-Core/ZnEncodedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnEncodedReadStream.class.st
@@ -14,6 +14,12 @@ Class {
 }
 
 { #category : 'testing' }
+ZnEncodedReadStream class >> isAbstract [
+
+	^ self == ZnEncodedReadStream
+]
+
+{ #category : 'testing' }
 ZnEncodedReadStream >> atEnd [
 	^ peeked isNil and: [ stream atEnd ]
 ]

--- a/src/Zinc-Character-Encoding-Core/ZnEncodedStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnEncodedStream.class.st
@@ -19,6 +19,12 @@ ZnEncodedStream class >> defaultEncoder [
 	^ ZnCharacterEncoder utf8
 ]
 
+{ #category : 'testing' }
+ZnEncodedStream class >> isAbstract [
+
+	^ self == ZnEncodedStream
+]
+
 { #category : 'instance creation' }
 ZnEncodedStream class >> on: wrappedStream [
 	^ self new

--- a/src/Zinc-Character-Encoding-Core/ZnEncodedWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnEncodedWriteStream.class.st
@@ -10,6 +10,12 @@ Class {
 	#package : 'Zinc-Character-Encoding-Core'
 }
 
+{ #category : 'testing' }
+ZnEncodedWriteStream class >> isAbstract [
+
+	^ self == ZnEncodedWriteStream
+]
+
 { #category : 'accessing' }
 ZnEncodedWriteStream >> << anObject [
 	"Write anObject to the receiver, dispatching using #putOn:


### PR DESCRIPTION
Fix #16708

@svenvc 