### PR TITLE
16704-Undeclared-variable-error-when-evaluating-an-st-file

### DIFF
--- a/src/CodeImport-Tests/ChunkImportTestCase.class.st
+++ b/src/CodeImport-Tests/ChunkImportTestCase.class.st
@@ -296,5 +296,5 @@ ChunkImportTestCase >> testImportString [
 
 { #category : 'tests' }
 ChunkImportTestCase >> testImportUndeclared [
-	self assert: 4 equals: (CodeImporter evaluateString: 'myCodeImortUndecl := 4')
+	self assert: 4 equals: (CodeImporter evaluateString: 'myCodeImportUndecl := 4')
 ]

--- a/src/CodeImport-Tests/ChunkImportTestCase.class.st
+++ b/src/CodeImport-Tests/ChunkImportTestCase.class.st
@@ -293,3 +293,8 @@ ChunkImportTestCase >> testImportFromReadStream [
 ChunkImportTestCase >> testImportString [
 	self assert: 4 equals: (CodeImporter evaluateString: '2+2!')
 ]
+
+{ #category : 'tests' }
+ChunkImportTestCase >> testImportUndeclared [
+	self assert: 4 equals: (CodeImporter evaluateString: 'myCodeImortUndecl := 4')
+]

--- a/src/CodeImport/DoItChunk.class.st
+++ b/src/CodeImport/DoItChunk.class.st
@@ -41,11 +41,13 @@ DoItChunk >> importFor: requestor logSource: logSource [
 	(self isPackageAddition: ast) ifTrue: [ ^ self packageOrganizer ensurePackageMatching: ast arguments first value ].
 	(OldClassDefinitionBuilder isOldClassCreation: ast) ifTrue: [ ^ OldClassDefinitionBuilder buildFromAST: ast ].
 
-	^ self class compiler class new
+	"For DoIts we allow undelared variables"
+	^ [self class compiler class new
 		  source: contents;
 		  requestor: requestor;
 		  logged: logSource;
-		  evaluate
+		  permitUndeclared: true;
+		  evaluate] on: UndeclaredVariableError do: [ :ex | ex resume ] 
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
test and fix to allow undeclared vars in the code importer DoIts. This is used e.g. when scripts are evaluated and undeclareds can be used there when copying a snippit from the playground (which would auto-declare the var)

