### PR TITLE
Fix metaclass of a class after removing its traits

### DIFF
--- a/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
@@ -233,27 +233,6 @@ ShClassInstallerTest >> testCreatedClassWithAllElements [
 ]
 
 { #category : 'tests' }
-ShClassInstallerTest >> testCreatingFullTraitHasAllElements [
-
-	newClass := ShiftClassInstaller make: [ :builder |
-		            builder
-			            beTrait;
-			            name: #TSHClass;
-			            slots: { #a. #b };
-			            traits: { TViewModelMock };
-			            tag: 'boring';
-			            package: self generatedClassesPackageName ].
-
-	self assert: newClass name equals: #TSHClass.
-	self assert: newClass slots size equals: 2.
-	self assert: newClass slotNames equals: #( a b ).
-	self assert: newClass traitComposition equals: { TViewModelMock } asTraitComposition.
-	self assert: newClass class traitComposition equals: { TViewModelMock classSide } asTraitComposition.
-	self assert: newClass package name equals: self generatedClassesPackageName.
-	self assert: newClass packageTag name equals: 'boring'
-]
-
-{ #category : 'tests' }
 ShClassInstallerTest >> testDuplicateClassError [
 
  	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable => BooleanSlot}.

--- a/src/Traits-Tests/ShTraitInstallerTest.class.st
+++ b/src/Traits-Tests/ShTraitInstallerTest.class.st
@@ -1,0 +1,79 @@
+Class {
+	#name : 'ShTraitInstallerTest',
+	#superclass : 'ShClassInstallerTest',
+	#category : 'Traits-Tests-ShiftClassInstaller',
+	#package : 'Traits-Tests',
+	#tag : 'ShiftClassInstaller'
+}
+
+{ #category : 'tests' }
+ShTraitInstallerTest >> testCreatingFullTraitHasAllElements [
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            beTrait;
+			            name: #TSHClass;
+			            slots: { #a. #b };
+			            traits: { TViewModelMock };
+			            tag: 'boring';
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass name equals: #TSHClass.
+	self assert: newClass slots size equals: 2.
+	self assert: newClass slotNames equals: #( a b ).
+	self assert: newClass traitComposition equals: { TViewModelMock } asTraitComposition.
+	self assert: newClass class traitComposition equals: { TViewModelMock classSide } asTraitComposition.
+	self assert: newClass package name equals: self generatedClassesPackageName.
+	self assert: newClass packageTag name equals: 'boring'
+]
+
+{ #category : 'tests' }
+ShTraitInstallerTest >> testRemovingTraitCompositionOfAClassAfterFillForShouldUpdateItsMetaclass [
+
+	| t1 |
+	t1 := ShiftClassInstaller make: [ :builder |
+		      builder
+			      name: #TShCITestClass;
+			      beTrait;
+			      package: self generatedClassesPackageName ].
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestClass;
+			            traits: t1;
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass class class equals: TraitedMetaclass.
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            fillFor: newClass;
+			            traits: {  } ].
+
+	self assert: newClass class class equals: Metaclass
+]
+
+{ #category : 'tests' }
+ShTraitInstallerTest >> testRemovingTraitCompositionOfAClassShouldUpdateItsMetaclass [
+
+	| t1 |
+	t1 := ShiftClassInstaller make: [ :builder |
+		      builder
+			      name: #TShCITestClass;
+			      beTrait;
+			      package: self generatedClassesPackageName ].
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestClass;
+			            traits: t1;
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass class class equals: TraitedMetaclass.
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestClass;
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass class class equals: Metaclass
+]

--- a/src/Traits/ShiftClassBuilder.extension.st
+++ b/src/Traits/ShiftClassBuilder.extension.st
@@ -53,6 +53,9 @@ ShiftClassBuilder >> traitComposition [
 ShiftClassBuilder >> traitComposition: aValue [
 
 	self classTraitComposition: aValue asTraitComposition classComposition.
+	"Cyril: The next line is for the case where we update a class that had a trait and we remove the used traits. The metaclass should be updated also.
+	But, IMO we could do better. Instead of having a state for the metaclassClass we should resolve it via the enhancer during the building. And someone could set its own using its own enhancer."
+	(aValue isEmpty and: [ metaclassClass = TraitedMetaclass ]) ifTrue: [ metaclassClass := Metaclass ].
 	^ self privateTraitComposition: aValue
 ]
 


### PR DESCRIPTION
If you have a class using traits, its metaclass will be TraitedMetaclass. Now, if you remove its traits, its class should be Metaclass. The problem is that if you use #fillFor: it will not be the case.

The origin of the problem comes from the fact that #fillFor: will set the metaclass class to TraitedMetaclass and this will not be updated if you set the trait composition to be empty.

I provided a fix that is not so good in my opinion, but I'll try to change the way the class builder deals with metaclass class later to simplify this system and remove the need of this fix.

Finally I moved a test from shift class builder tests to traits tests since it uses a trait