### PR TITLE
Fix multiple bugs in metaclass management of ShiftClassBuilder

### DIFF
--- a/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
@@ -233,27 +233,6 @@ ShClassInstallerTest >> testCreatedClassWithAllElements [
 ]
 
 { #category : 'tests' }
-ShClassInstallerTest >> testCreatingFullTraitHasAllElements [
-
-	newClass := ShiftClassInstaller make: [ :builder |
-		            builder
-			            beTrait;
-			            name: #TSHClass;
-			            slots: { #a. #b };
-			            traits: { TViewModelMock };
-			            tag: 'boring';
-			            package: self generatedClassesPackageName ].
-
-	self assert: newClass name equals: #TSHClass.
-	self assert: newClass slots size equals: 2.
-	self assert: newClass slotNames equals: #( a b ).
-	self assert: newClass traitComposition equals: { TViewModelMock } asTraitComposition.
-	self assert: newClass class traitComposition equals: { TViewModelMock classSide } asTraitComposition.
-	self assert: newClass package name equals: self generatedClassesPackageName.
-	self assert: newClass packageTag name equals: 'boring'
-]
-
-{ #category : 'tests' }
 ShClassInstallerTest >> testDuplicateClassError [
 
  	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable => BooleanSlot}.

--- a/src/Shift-ClassBuilder/ShDefaultBuilderEnhancer.class.st
+++ b/src/Shift-ClassBuilder/ShDefaultBuilderEnhancer.class.st
@@ -82,8 +82,10 @@ ShDefaultBuilderEnhancer >> initializeBuilder: aBuilder [
 	aBuilder addChangeComparer: ShMetaclassChangeDetector
 ]
 
-{ #category : 'events' }
-ShDefaultBuilderEnhancer >> metaclassCreated: builder [
+{ #category : 'accessing' }
+ShDefaultBuilderEnhancer >> metaclassClassFor: aBuilder [
+
+	^ Metaclass
 ]
 
 { #category : 'events' }
@@ -96,11 +98,6 @@ ShDefaultBuilderEnhancer >> migrateInstancesTo: aClass installer: aShiftClassIns
 ShDefaultBuilderEnhancer >> migrateToClass: aClass installer: aShiftClassInstaller [
 
 	aShiftClassInstaller migrateClassTo: aClass
-]
-
-{ #category : 'class modifications' }
-ShDefaultBuilderEnhancer >> newMetaclass: builder [
-	^ builder metaclassClass new
 ]
 
 { #category : 'class modifications' }

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -49,7 +49,6 @@ Class {
 		'oldClass',
 		'oldMetaclass',
 		'builderEnhancer',
-		'metaclassClass',
 		'extensibleProperties',
 		'changeComparers',
 		'changes',

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -250,15 +250,13 @@ ShiftClassBuilder >> createClass [
 { #category : 'building' }
 ShiftClassBuilder >> createMetaclass [
 
-	newMetaclass := self builderEnhancer newMetaclass: self.
+	newMetaclass := self metaclassClass new.
 
 	self builderEnhancer
 		configureMetaclass: newMetaclass
 		superclass: self metaSuperclass
 		withLayoutType: FixedLayout
-		slots: (self withAdditionalSlots: self classSlots).
-
-	self builderEnhancer metaclassCreated: self
+		slots: (self withAdditionalSlots: self classSlots)
 ]
 
 { #category : 'building' }
@@ -317,9 +315,7 @@ ShiftClassBuilder >> fillClassSideFromEnvironment: anEnvironment [
 	| old |
 	old := anEnvironment at: name ifAbsent: [ ^ self ].
 
-	self metaclassClass: old class class.
-	self classSlots: old class slots.
-	self classTraits: old class traitComposition
+	self classSlots: old class slots
 ]
 
 { #category : 'initialization' }
@@ -482,12 +478,9 @@ ShiftClassBuilder >> metaSuperclass: aClass [
 
 { #category : 'accessing' }
 ShiftClassBuilder >> metaclassClass [
-	^ metaclassClass ifNil: [ Metaclass ]
-]
+	"The metaclass class is determined by the builder enhancer. In case you want to play with your own metaclass class, you can implement a subclass of the buildre enhancer and use this one overriding the method #metaclassClassFor:."
 
-{ #category : 'accessing' }
-ShiftClassBuilder >> metaclassClass: anObject [
-	metaclassClass := anObject
+	^ self builderEnhancer metaclassClassFor: self
 ]
 
 { #category : 'accessing' }

--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -253,6 +253,7 @@ SystemDependenciesTest >> testExternalIDEDependencies [
 	BaselineOfMorphicCore.
 	BaselineOfSlot.
 	BaselineOfSUnit.
+	BaselineOfShift.
 	BaselineOfTraits.
 	BaselineOfUI.
 	BaselineOfUnifiedFFI.

--- a/src/Traits-Tests/ShTraitBuilderTest.class.st
+++ b/src/Traits-Tests/ShTraitBuilderTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : 'ShTraitBuilderTest',
+	#superclass : 'ShiftClassBuilderTest',
+	#category : 'Traits-Tests-ShiftClassInstaller',
+	#package : 'Traits-Tests',
+	#tag : 'ShiftClassInstaller'
+}
+
+{ #category : 'tests' }
+ShTraitBuilderTest >> testRemovingTraitCompositionOfAClassShouldUpdateItsMetaclass [
+
+	| t1 newClass |
+	t1 := (Trait << #TShCITestClass package: self packageNameForTest) install.
+
+	newClass := ((Object << #ShCITestClass)
+		             traits: t1;
+		             package: self packageNameForTest) install.
+
+	self assert: newClass class class equals: TraitedMetaclass.
+
+	newClass := (Object << #ShCITestClass package: self packageNameForTest) install.
+
+	self assert: newClass class class equals: Metaclass
+]

--- a/src/Traits-Tests/ShTraitInstallerTest.class.st
+++ b/src/Traits-Tests/ShTraitInstallerTest.class.st
@@ -1,0 +1,79 @@
+Class {
+	#name : 'ShTraitInstallerTest',
+	#superclass : 'ShClassInstallerTest',
+	#category : 'Traits-Tests-ShiftClassInstaller',
+	#package : 'Traits-Tests',
+	#tag : 'ShiftClassInstaller'
+}
+
+{ #category : 'tests' }
+ShTraitInstallerTest >> testCreatingFullTraitHasAllElements [
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            beTrait;
+			            name: #TSHClass;
+			            slots: { #a. #b };
+			            traits: { TViewModelMock };
+			            tag: 'boring';
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass name equals: #TSHClass.
+	self assert: newClass slots size equals: 2.
+	self assert: newClass slotNames equals: #( a b ).
+	self assert: newClass traitComposition equals: { TViewModelMock } asTraitComposition.
+	self assert: newClass class traitComposition equals: { TViewModelMock classSide } asTraitComposition.
+	self assert: newClass package name equals: self generatedClassesPackageName.
+	self assert: newClass packageTag name equals: 'boring'
+]
+
+{ #category : 'tests' }
+ShTraitInstallerTest >> testRemovingTraitCompositionOfAClassAfterFillForShouldUpdateItsMetaclass [
+
+	| t1 |
+	t1 := ShiftClassInstaller make: [ :builder |
+		      builder
+			      name: #TShCITestClass;
+			      beTrait;
+			      package: self generatedClassesPackageName ].
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestClass;
+			            traits: t1;
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass class class equals: TraitedMetaclass.
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            fillFor: newClass;
+			            traits: {  } ].
+
+	self assert: newClass class class equals: Metaclass
+]
+
+{ #category : 'tests' }
+ShTraitInstallerTest >> testRemovingTraitCompositionOfAClassShouldUpdateItsMetaclass [
+
+	| t1 |
+	t1 := ShiftClassInstaller make: [ :builder |
+		      builder
+			      name: #TShCITestClass;
+			      beTrait;
+			      package: self generatedClassesPackageName ].
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestClass;
+			            traits: t1;
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass class class equals: TraitedMetaclass.
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestClass;
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass class class equals: Metaclass
+]

--- a/src/Traits/ShiftClassBuilder.extension.st
+++ b/src/Traits/ShiftClassBuilder.extension.st
@@ -53,6 +53,9 @@ ShiftClassBuilder >> traitComposition [
 ShiftClassBuilder >> traitComposition: aValue [
 
 	self classTraitComposition: aValue asTraitComposition classComposition.
+	"Cyril: The next line is for the case where we update a class that had a trait and we remove the used traits. The metaclass should be updated also.
+	But, IMO we could do better. Instead of having a state for the metaclassClass we should resolve it via the enhancer during the building. And someone could set its own using its own enhancer."
+	(aValue isEmpty and: [ metaclassClass = TraitedMetaclass ]) ifTrue: [ metaclassClass := Metaclass ].
 	^ self privateTraitComposition: aValue
 ]
 

--- a/src/Traits/ShiftClassBuilder.extension.st
+++ b/src/Traits/ShiftClassBuilder.extension.st
@@ -5,8 +5,7 @@ ShiftClassBuilder >> beTrait [
 
 	self
 		superclass: nil;
-		metaSuperclass: Trait;
-		metaclassClass: MetaclassForTraits
+		metaSuperclass: Trait
 ]
 
 { #category : '*Traits' }
@@ -53,9 +52,7 @@ ShiftClassBuilder >> traitComposition [
 ShiftClassBuilder >> traitComposition: aValue [
 
 	self classTraitComposition: aValue asTraitComposition classComposition.
-	"Cyril: The next line is for the case where we update a class that had a trait and we remove the used traits. The metaclass should be updated also.
-	But, IMO we could do better. Instead of having a state for the metaclassClass we should resolve it via the enhancer during the building. And someone could set its own using its own enhancer."
-	(aValue isEmpty and: [ metaclassClass = TraitedMetaclass ]) ifTrue: [ metaclassClass := Metaclass ].
+
 	^ self privateTraitComposition: aValue
 ]
 

--- a/src/Traits/TraitBuilderEnhancer.class.st
+++ b/src/Traits/TraitBuilderEnhancer.class.st
@@ -193,7 +193,7 @@ TraitBuilderEnhancer >> isTraitedMetaclass: aBuilder [
 	^ aBuilder metaclassClass includesBehavior: TraitedMetaclass
 ]
 
-{ #category : 'class modifications' }
+{ #category : 'accessing' }
 TraitBuilderEnhancer >> metaclassClassFor: aBuilder [
 
 	aBuilder metaSuperclass = Trait ifTrue: [ ^ MetaclassForTraits ].

--- a/src/Traits/TraitBuilderEnhancer.class.st
+++ b/src/Traits/TraitBuilderEnhancer.class.st
@@ -172,13 +172,10 @@ TraitBuilderEnhancer >> eliminateDuplicates: aSlotCollection withSuperclassSlots
 { #category : 'initialization' }
 TraitBuilderEnhancer >> fillBuilder: aBuilder from: aClass [
 
-	(aBuilder superclass isNil and: [ aClass superclass isNil ]) ifTrue: [
-		aBuilder metaSuperclass: aClass class superclass ].
+	(aBuilder superclass isNil and: [ aClass superclass isNil ]) ifTrue: [ aBuilder metaSuperclass: aClass class superclass ].
 
 	aBuilder traitComposition: aClass traitComposition.
-	aBuilder classTraitComposition: aClass class basicTraitComposition.
-
-	aBuilder metaclassClass: aClass class class
+	aBuilder classTraitComposition: aClass class basicTraitComposition
 ]
 
 { #category : 'initialization' }
@@ -196,6 +193,17 @@ TraitBuilderEnhancer >> isTraitedMetaclass: aBuilder [
 	^ aBuilder metaclassClass includesBehavior: TraitedMetaclass
 ]
 
+{ #category : 'class modifications' }
+TraitBuilderEnhancer >> metaclassClassFor: aBuilder [
+
+	aBuilder metaSuperclass = Trait ifTrue: [ ^ MetaclassForTraits ].
+
+	(aBuilder traitComposition asTraitComposition isNotEmpty or: [
+		 aBuilder classTraitComposition asTraitComposition isNotEmpty or: [ aBuilder superclass class class = TraitedMetaclass ] ]) ifTrue: [ ^ TraitedMetaclass ].
+
+	^ super metaclassClassFor: aBuilder
+]
+
 { #category : 'events' }
 TraitBuilderEnhancer >> migrateInstancesTo: aClass installer: aShiftClassInstaller [
 
@@ -204,18 +212,6 @@ TraitBuilderEnhancer >> migrateInstancesTo: aClass installer: aShiftClassInstall
 		ifTrue: [ ^ self ].
 
 	super migrateInstancesTo: aClass installer: aShiftClassInstaller
-]
-
-{ #category : 'class modifications' }
-TraitBuilderEnhancer >> newMetaclass: aBuilder [
-
-	(aBuilder traitComposition asTraitComposition isNotEmpty or: [ aBuilder classTraitComposition asTraitComposition isNotEmpty or: [ aBuilder superclass class class = TraitedMetaclass]])
-		ifTrue: [ aBuilder metaclassClass: TraitedMetaclass ].
-
-	aBuilder metaSuperclass = Trait
-		ifTrue: [ aBuilder metaclassClass: MetaclassForTraits ].
-
-	^ super newMetaclass: aBuilder
 ]
 
 { #category : 'class modifications' }


### PR DESCRIPTION
This PR fixes multiples bugs I detected in the management of metaclasses of the ShiftClassBuilder.

1) The first bug was appearing when we had a class using a trait and we updated it using #fillFor: in the class builder block, then we removed the trait composition. This produced a class without trait but with a TraitedMetaclass class. 

2) When using the #<< method to have the Fluid syntax, if the class had a trait in the past, it would always be produced with a TraitedMetaclass as a class even if the traits are removed.

3) I don't know why but using #<< was always preserving the old class trait composition which could lead to some problems in case you removed a trait. 

My way to fix the problem is to update the management of the metaclass class in the ShiftClassBuilder. Before it was a variable that we had to set when we were managing our traits. Now this is an information that is resolved during the class building. It is delegated to the BuilderEnhancer. Thus, it is still possible to set our own metaclass class by adding a new buider enhancer!

Fixes #16472 