### PR TITLE
Moved pragma declaration to top of methods

### DIFF
--- a/src/Compression/DeflateStream.class.st
+++ b/src/Compression/DeflateStream.class.st
@@ -343,8 +343,8 @@ DeflateStream >> updateHashAt: here [
 
 { #category : 'private' }
 DeflateStream >> updateHashTable: table delta: delta [
-	| pos |
 	<primitive: 'primitiveDeflateUpdateHashTable' module: 'ZipPlugin'>
+	| pos |
 	1 to: table size do:[:i|
 		"Discard entries that are out of range"
 		(pos := table at: i) >= delta

--- a/src/Compression/FastInflateStream.class.st
+++ b/src/Compression/FastInflateStream.class.st
@@ -57,8 +57,8 @@ FastInflateStream >> decompressBlock: llTable with: dTable [
 	"Process the compressed data in the block.
 	llTable is the huffman table for literal/length codes
 	and dTable is the huffman table for distance codes."
-	| value extra length distance oldPos oldBits oldBitPos |
 	<primitive: 'primitiveInflateDecompressBlock' module: 'ZipPlugin'>
+	| value extra length distance oldPos oldBits oldBitPos |
 	[readLimit < collection size and:[sourcePos <= sourceLimit]] whileTrue:[
 		"Back up stuff if we're running out of space"
 		oldBits := bitBuf.

--- a/src/Compression/ZipEncoder.class.st
+++ b/src/Compression/ZipEncoder.class.st
@@ -103,8 +103,8 @@ ZipEncoder >> pastEndPut: anObject [
 { #category : 'private' }
 ZipEncoder >> privateSendBlock: literalStream with: distanceStream with: litTree with: distTree [
 	"Send the current block using the encodings from the given literal/length and distance tree"
-	| lit dist code extra sum |
 	<primitive: 'primitiveZipSendBlock' module: 'ZipPlugin'>
+	| lit dist code extra sum |
 	sum := 0.
 	[ lit := literalStream next.
 	  dist := distanceStream next.


### PR DESCRIPTION
Pharo's syntax is relaxed in the sense that allows the pragma declaration on top or bottom of the temp declaration. This can cause inconsistent behavior in the AST. We discussed and one solution to this is to do not allow the pragma declaration below the temp variables. This is a first step for that.

For example,

If one has a method that looks like this:

```st
methodWithPragma
  <primitive: 'prim' module: 'AModule' error: error>
  | var1 var2 |
  var1 := 4.
  self doSomething: error
```

And if one asks to the compiled method instance `compiledMethod methodNode body sourceCode` it will return this:

```st
| var1 var2 |
var1 := 4.
self doSomething: error
```

Which doesn't have the pragma(s).

BUT
If the method code has the temp vars declaration before the pragma

```st
methodWithPragma
  | var1 var2 |
  <primitive: 'prim' module: 'AModule' error: error>      
  var1 := 4.
  self doSomething: error
```

Then, the same expression `compiledMethod methodNode body sourceCode` it will return this:

```st
| var1 var2 |
<primitive: 'prim' module: 'InstrumentationProfilers' error: error>
var1 := 4.
self doSomething: error
```

That does include the pragma.