### PR TITLE
Fix bug causing classes to lose their traits.

### DIFF
--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -603,22 +603,27 @@ TraitTest >> testRemovingTraitsRemoveTraitedClassMethods [
 
 { #category : 'tests' }
 TraitTest >> testRemovingTraitsRemoveTraitedClassMethodsWithSubclasses [
-	| t1 t2 c2 c1 |
+	| t1 t2 c2 c1 c3 |
 
 	t1 := self createT1.
 	t2 := self createT2.
 	c1 := self newClass: #C1 with: #(g h) traits: t1.
 	c2 := self newClass: #C2 superclass: c1 traits: t2.
+	c3 := self newClass: #C3 superclass: c1 traits: {}.
 
 	self assert: (c1 class includesSelector: #traits).
 	self deny: (c1 class includesLocalSelector: #traits).
 	self assert: (c2 class lookupSelector: #traits) isNotNil.
 	self deny: (c2 class includesLocalSelector: #traits).
+	self assert: (c3 class lookupSelector: #traits) isNotNil.
+	self deny: (c3 class includesLocalSelector: #traits).
 
 	c1 := self newClass: #C1 with: #(g h) traits: {}.
 
 	"Now c1 has no more traits, c2 remains unchanged"
 	self deny: (c1 class includesSelector: #traits).
+	self assert: (c2 class includesSelector: #traits).
+	self deny: (c2 class includesLocalSelector: #traits).
 	self assert: (c2 class includesSelector: #traits).
 	self deny: (c2 class includesLocalSelector: #traits).
 ]
@@ -689,6 +694,43 @@ TraitTest >> testSettingAClassInAClassTraitCompositionShouldRaiseAnError [
 
 	self should: [ t1 traitComposition: c1 ] raise: Error.
 	self should: [ t1 classTrait traitComposition: c1 ] raise: Error.
+]
+
+{ #category : 'tests' }
+TraitTest >> testSettingEmptyTraitCompositionDoesNotModifiyTraitedSubclasses [
+
+	| t1 t2 c2 c1 |
+	t1 := self createT1.
+	t2 := self createT2.
+	c1 := self newClass: #C1 with: #( g h ) traits: t1.
+	c2 := self newClass: #C2 superclass: c1 traits: t2.
+
+	c1 setTraitComposition: {  }.
+
+	self assert: c2 hasTraitComposition.
+	self assert: (c2 traits includes: t2).
+	self assert: (t2 users includes: c2)
+]
+
+{ #category : 'tests' }
+TraitTest >> testSettingEmptyTraitCompositionUpdatesMetaclass [
+
+	| t1 t2 c2 c1 c3 |
+	t1 := self createT1.
+	t2 := self createT2.
+	c1 := self newClass: #C1 with: #( g h ) traits: t1.
+	c2 := self newClass: #C2 superclass: c1 traits: t2.
+	c3 := self newClass: #C3 superclass: c1 traits: {  }.
+
+	self assert: (c1 class includesSelector: #traits).
+	self deny: (c2 class includesSelector: #traits).
+	self deny: (c3 class includesSelector: #traits).
+
+	c1 setTraitComposition: {  }.
+
+	self deny: (c1 class includesSelector: #traits).
+	self assert: (c2 class includesSelector: #traits).
+	self deny: (c3 class includesSelector: #traits)
 ]
 
 { #category : 'tests' }

--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -563,6 +563,30 @@ TraitTest >> testRemoveFromSystem [
 ]
 
 { #category : 'tests' }
+TraitTest >> testRemovingTraitsDoesNotModifiyTraitedSubclasses [
+
+	| t1 t2 c2 c1 |
+	t1 := self newTrait: #T1.
+	t2 := self newTrait: #T2.
+	c1 := self newClass: #C1 traits: t1.
+	c2 := self newClass: #C2 superclass: c1 traits: t2.
+
+	self assert: c1 hasTraitComposition.
+	self assert: (c1 traits includes: t1).
+	self assert: c2 hasTraitComposition.
+	self assert: (c2 traits includes: t2).
+	self assert: (t2 users includes: c2).
+
+	c1 := self newClass: #C1 traits: {  }.
+
+	self deny: c1 hasTraitComposition.
+	self deny: (c1 traits includes: t1).
+	self assert: c2 hasTraitComposition.
+	self assert: (c2 traits includes: t2).
+	self assert: (t2 users includes: c2)
+]
+
+{ #category : 'tests' }
 TraitTest >> testRemovingTraitsRemoveTraitedClassMethods [
 	| t1 t2 c1 |
 

--- a/src/Traits/TraitBuilderEnhancer.class.st
+++ b/src/Traits/TraitBuilderEnhancer.class.st
@@ -11,7 +11,8 @@ Class {
 	#name : 'TraitBuilderEnhancer',
 	#superclass : 'ShDefaultBuilderEnhancer',
 	#instVars : [
-		'builder'
+		'builder',
+		'shouldUpdateSubclassesMethodDictionaries'
 	],
 	#category : 'Traits-Class-Builder',
 	#package : 'Traits',
@@ -49,8 +50,15 @@ TraitBuilderEnhancer >> afterMethodsCompiled: aBuilder [
 { #category : 'migrating' }
 TraitBuilderEnhancer >> afterMigratingClass: aBuilder installer: anInstaller [
 
-	(self isTraitedMetaclass: aBuilder)
-		ifFalse: [ ^ self ].
+	"In case the class to build had traits and we remove them, we need to rebuild the method dictionary of subclasses in case they have traits and need the TraitedClass methods in their method dictionary."
+	shouldUpdateSubclassesMethodDictionaries ifTrue: [
+		aBuilder newClass allSubclassesDo: [ :subclass |
+			subclass class
+				initializeBasicMethods;
+				rebuildMethodDictionary.
+			subclass rebuildMethodDictionary ] ].
+
+	(self isTraitedMetaclass: aBuilder) ifFalse: [ ^ self ].
 
 	aBuilder newClass traitComposition addUser: aBuilder newClass.
 	aBuilder newMetaclass traitComposition addUser: aBuilder newMetaclass.
@@ -60,8 +68,8 @@ TraitBuilderEnhancer >> afterMigratingClass: aBuilder installer: anInstaller [
 	"If this is a trait I have to update the users"
 	aBuilder newClass isTrait ifFalse: [ ^ self ].
 
-	builder newMetaclass traitUsers do: [:e | e rebuildMethodDictionary].
-	aBuilder newClass traitUsers do: [:e | e rebuildMethodDictionary]
+	builder newMetaclass traitUsers do: [ :e | e rebuildMethodDictionary ].
+	aBuilder newClass traitUsers do: [ :e | e rebuildMethodDictionary ]
 ]
 
 { #category : 'accessing' }
@@ -92,7 +100,12 @@ TraitBuilderEnhancer >> allSlotsToInstallForBuilder: aBuilder [
 
 { #category : 'migrating' }
 TraitBuilderEnhancer >> beforeMigratingClass: aBuilder installer: anInstaller [
+
 	aBuilder oldClass ifNil: [ ^ self ].
+
+	"In case a class that had traits does not have them anymore, we need to check if the subclasses also have traits to rebuild their method dictionary.
+	Here, we check this info and in the post migration we will use this info to do the rebuild."
+	shouldUpdateSubclassesMethodDictionaries := aBuilder oldClass class class = TraitedMetaclass and: [ (self isTraitedMetaclass: aBuilder) not ].
 
 	aBuilder oldClass traitComposition removeUser: aBuilder oldClass.
 	aBuilder oldMetaclass traitComposition removeUser: aBuilder oldMetaclass.
@@ -102,7 +115,7 @@ TraitBuilderEnhancer >> beforeMigratingClass: aBuilder installer: anInstaller [
 	"If it is a Trait we should migrate the users "
 	aBuilder newClass isTrait ifFalse: [ ^ self ].
 	aBuilder newClass users: aBuilder oldClass users.
-	aBuilder newMetaclass users: aBuilder oldMetaclass users.
+	aBuilder newMetaclass users: aBuilder oldMetaclass users
 ]
 
 { #category : 'events' }
@@ -176,6 +189,12 @@ TraitBuilderEnhancer >> fillBuilder: aBuilder from: aClass [
 
 	aBuilder traitComposition: aClass traitComposition.
 	aBuilder classTraitComposition: aClass class basicTraitComposition
+]
+
+{ #category : 'initialization' }
+TraitBuilderEnhancer >> initialize [
+	super initialize.
+	shouldUpdateSubclassesMethodDictionaries := false
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
Imagine you have two traits T1 and T2. You also have a class C1 using T1 and a class C2 subclassing C1 and using T2. Now if you remove T1 from C1 a bug causes C2 to also lose its trait T2.

The bug comes from the fact that in the trait implementation we copy methods from TraitedMetaclass and TraitedClass in the class using traits. But only in the top most class. Thus, if we update the superclass and it does not have the traits methods anymore, then all subclasses also loses this API.

My proposed fix is to keep a flag to know if a class update makes it go from a TraitedMetaclass to another metaclass class and if this flag is true, we update the method dictionaries of the subclasses to get the methods from TraitedMetaclass and TraitedClass.

I added a test to check this