### PR TITLE
Calypso cmd-v method versions shortcut

### DIFF
--- a/src/Calypso-SystemTools-Core/SycShowMethodVersionCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycShowMethodVersionCommand.extension.st
@@ -13,3 +13,10 @@ SycShowMethodVersionCommand class >> methodMenuActivation [
 
 	^CmdContextMenuActivation byItemOf: ClyQueryMenuGroup for: ClyMethod asCalypsoItemContext
 ]
+
+{ #category : '*Calypso-SystemTools-Core' }
+SycShowMethodVersionCommand class >> methodShortcutActivation [
+    <classAnnotation>
+    ^ CmdShortcutActivation by: $v meta for: ClyMethod asCalypsoItemContext
+
+]


### PR DESCRIPTION
Add shortcut cmd-v to open a Versions browser while the cursor focus is in the method list in Calypso. 
Fix by Stephane Ducasse in #16694 
