### PR TITLE
Use #update:to: instead of #make: and #fillFor:

### DIFF
--- a/src/Fuel-Core-Tests/FLMigrationTest.class.st
+++ b/src/Fuel-Core-Tests/FLMigrationTest.class.st
@@ -17,10 +17,7 @@ FLMigrationTest class >> resources [
 { #category : 'running' }
 FLMigrationTest >> redefined: aClass with: instanceVariableNames [
 
-	^ self classFactory make: [ :aBuilder |
-		  aBuilder
-			  fillFor: aClass;
-			  slots: instanceVariableNames ]
+	^ self classFactory update: aClass to: [ :aBuilder | aBuilder slots: instanceVariableNames ]
 ]
 
 { #category : 'running' }

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -311,12 +311,11 @@ ClassFactoryForTestCase >> update: aClass to: aBlock [
 	Once the test is finished, I'll remove the created class or trait."
 
 	| newClass |
-	newClass := self class classInstaller make: [ :aBuilder | "Let's but some default values."
-		    			aBuilder fillFor: aClass.        
-						aBuilder
+	newClass := self class classInstaller update: aClass to: [ :aBuilder | "Let's but some default values."
+		            aBuilder
 			            installingEnvironment: self environment;
 			            package: self packageName.
-						
+
 		            "Now we let the users specify what they want."
 		            aBlock value: aBuilder ].
 

--- a/src/Traits-Tests/ShTraitInstallerTest.class.st
+++ b/src/Traits-Tests/ShTraitInstallerTest.class.st
@@ -28,32 +28,6 @@ ShTraitInstallerTest >> testCreatingFullTraitHasAllElements [
 ]
 
 { #category : 'tests' }
-ShTraitInstallerTest >> testRemovingTraitCompositionOfAClassAfterFillForShouldUpdateItsMetaclass [
-
-	| t1 |
-	t1 := ShiftClassInstaller make: [ :builder |
-		      builder
-			      name: #TShCITestClass;
-			      beTrait;
-			      package: self generatedClassesPackageName ].
-
-	newClass := ShiftClassInstaller make: [ :builder |
-		            builder
-			            name: #ShCITestClass;
-			            traits: t1;
-			            package: self generatedClassesPackageName ].
-
-	self assert: newClass class class equals: TraitedMetaclass.
-
-	newClass := ShiftClassInstaller make: [ :builder |
-		            builder
-			            fillFor: newClass;
-			            traits: {  } ].
-
-	self assert: newClass class class equals: Metaclass
-]
-
-{ #category : 'tests' }
 ShTraitInstallerTest >> testRemovingTraitCompositionOfAClassShouldUpdateItsMetaclass [
 
 	| t1 |
@@ -74,6 +48,29 @@ ShTraitInstallerTest >> testRemovingTraitCompositionOfAClassShouldUpdateItsMetac
 		            builder
 			            name: #ShCITestClass;
 			            package: self generatedClassesPackageName ].
+
+	self assert: newClass class class equals: Metaclass
+]
+
+{ #category : 'tests' }
+ShTraitInstallerTest >> testRemovingTraitCompositionOfAClassThroughAnUpdateShouldUpdateItsMetaclass [
+
+	| t1 |
+	t1 := ShiftClassInstaller make: [ :builder |
+		      builder
+			      name: #TShCITestClass;
+			      beTrait;
+			      package: self generatedClassesPackageName ].
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #ShCITestClass;
+			            traits: t1;
+			            package: self generatedClassesPackageName ].
+
+	self assert: newClass class class equals: TraitedMetaclass.
+
+	newClass := ShiftClassInstaller update: newClass to: [ :builder | builder traits: {  } ].
 
 	self assert: newClass class class equals: Metaclass
 ]

--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -80,13 +80,7 @@ TraitTest >> testAddingATraitToAClassWithSubclasses [
 	c2 := self newClass: #C2 superclass: c1 traits: {  }.
 	t1 := self newTrait: #T1.
 
-	self
-		shouldnt: [
-			self class classInstaller make: [ :aBuilder |
-				aBuilder
-					fillFor: c1;
-					traits: t1 ] ]
-		raise: Error.
+	self shouldnt: [ self class classInstaller update: c1 to: [ :aBuilder | aBuilder traits: t1 ] ] raise: Error.
 
 	self assert: (c1 includesTrait: t1).
 	self deny: (c2 includesTrait: t1)


### PR DESCRIPTION
The method #fillFor: of the shift class builder allows to update a class but a method #update:to: was introduced on ShiftClassInstaller to be higher level and not show implementation details to the users.

Here I'm updating some of the users of #fillFor: to use #update:to: instead to show the right way to do to the users that could browse Pharo code