### PR TITLE
Fix deprecated usage of StInspector

### DIFF
--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -58,7 +58,7 @@ PharoCommonTools class >> settingsOn: aBuilder [
 						targetSelector: #tools;
 						getSelector: #inspectorTool;
 						setSelector: #inspectorTool:;
-						default: (self environment at: #StInspector);
+						default: (self environment at: #StInspectorPresenter);
 						label: 'Inspector';
 						domainValues: Smalltalk tools recentInspectorTools ];
 		with: [


### PR DESCRIPTION
Use the class that is not deprecated. This is also a pretty bad dependency :/ But I'll not fix it in this PR because I don't have the time.

This will allow to remove NewTools deprecated classed of P12