### PR TITLE
Update roassal to v1.06f

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -119,7 +119,7 @@ BaselineOfPharo class >> roassal [
 		  newName: 'Roassal'
 		  owner: 'pharo-graphics'
 		  project: 'Roassal'
-		  version: 'v1.06e'
+		  version: 'v1.06f'
 ]
 
 { #category : 'repository urls' }


### PR DESCRIPTION
## What's Changed
* Migrate to Tonel V3 by @jecisc in https://github.com/pharo-graphics/Roassal/pull/69
* Fix deprecated usages by @jecisc in https://github.com/pharo-graphics/Roassal/pull/70

**Full Changelog**: https://github.com/pharo-graphics/Roassal/compare/v1.06e...v1.06f