### PR TITLE
Custom scopes can be browsed in Calypso

### DIFF
--- a/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
+++ b/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
@@ -132,6 +132,7 @@ Class {
 
 { #category : 'default' }
 ClyNavigationEnvironment class >> defaultOver: aSystem [
+	" Using an IdentityDictionary as the defaultGlobalEnvironments doen't smell good "
 	defaultGlobalEnvironments ifNil: [ defaultGlobalEnvironments := IdentityDictionary new ].
 
 	^defaultGlobalEnvironments at: aSystem ifAbsentPut: 

--- a/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
+++ b/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
@@ -132,13 +132,14 @@ Class {
 
 { #category : 'default' }
 ClyNavigationEnvironment class >> defaultOver: aSystem [
-	" Using an IdentityDictionary as the defaultGlobalEnvironments doen't smell good "
-	defaultGlobalEnvironments ifNil: [ defaultGlobalEnvironments := IdentityDictionary new ].
-
-	^defaultGlobalEnvironments at: aSystem ifAbsentPut: 
-		((ClyNavigationEnvironment over: aSystem)
-			setUpAvailablePlugins;
-			attachToSystem)
+	
+	defaultGlobalEnvironments ifNil: [
+		defaultGlobalEnvironments := Dictionary new ].
+	
+	^ defaultGlobalEnvironments at: aSystem ifAbsentPut: [
+		  (self class over: aSystem)
+			  setUpAvailablePlugins;
+			  attachToSystem ]
 ]
 
 { #category : 'default' }

--- a/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
+++ b/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
@@ -134,10 +134,10 @@ Class {
 ClyNavigationEnvironment class >> defaultOver: aSystem [
 	defaultGlobalEnvironments ifNil: [ defaultGlobalEnvironments := IdentityDictionary new ].
 
-	^defaultGlobalEnvironments at: aSystem ifAbsentPut: [
-		(ClyNavigationEnvironment over: aSystem)
+	^defaultGlobalEnvironments at: aSystem ifAbsentPut: 
+		((ClyNavigationEnvironment over: aSystem)
 			setUpAvailablePlugins;
-			attachToSystem ]
+			attachToSystem)
 ]
 
 { #category : 'default' }

--- a/src/Calypso-SystemQueries/ClyPackageScope.class.st
+++ b/src/Calypso-SystemQueries/ClyPackageScope.class.st
@@ -34,8 +34,9 @@ ClyPackageScope >> classGroupProvidersDo: aBlock [
 
 { #category : 'queries' }
 ClyPackageScope >> classesDo: aBlock [
+
 	self packagesDo: [ :package |
-		package definedClasses do: aBlock]
+		(environment system definedClassesInPackage: package) do: aBlock ]
 ]
 
 { #category : 'system changes' }

--- a/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
@@ -12,9 +12,9 @@ Class {
 	#tag : 'Domain'
 }
 
-{ #category : 'accessing' }
+{ #category : 'comparing' }
 ClyScopedSystemEnvironment >> == anObject [
-	^ anObject scope == self scope
+	^ anObject scope label == self scope label
 ]
 
 { #category : 'accessing' }
@@ -85,7 +85,7 @@ ClyScopedSystemEnvironment >> createPackageNamed: packageName [
 { #category : 'class management' }
 ClyScopedSystemEnvironment >> definedClassesInPackage: aPackage [
 
-	^ self classes select: [ :class | class package = aPackage ]
+	^ scope definedClasses select: [ :class | class package = aPackage ]
 ]
 
 { #category : 'accessing' }
@@ -101,7 +101,12 @@ ClyScopedSystemEnvironment >> extractPackageNameFrom: aDefinitionString [
 	^ (CDFluidClassDefinitionParser parse: aDefinitionString) packageName
 ]
 
-{ #category : 'accessing' }
+{ #category : 'comparing' }
+ClyScopedSystemEnvironment >> identityHash [
+	^ self scope label identityHash
+]
+
+{ #category : 'class management' }
 ClyScopedSystemEnvironment >> includesClassNamed: aSymbol [
 	|class|
 	
@@ -119,6 +124,19 @@ ClyScopedSystemEnvironment >> packageNamed: aString [
 ClyScopedSystemEnvironment >> packages [
 	
 	^ scope packages
+]
+
+{ #category : 'printing' }
+ClyScopedSystemEnvironment >> printOn: aStream [
+	| title |
+	title := self class name.
+	aStream
+		nextPutAll: (title first isVowel ifTrue: ['an '] ifFalse: ['a ']);
+		nextPutAll: title.
+
+	aStream nextPut: $(.
+	aStream nextPutAll: scope label.
+	aStream nextPut: $)
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
@@ -13,6 +13,11 @@ Class {
 }
 
 { #category : 'accessing' }
+ClyScopedSystemEnvironment >> == anObject [
+	^ anObject scope == self scope
+]
+
+{ #category : 'accessing' }
 ClyScopedSystemEnvironment >> asGlobalScopeIn: aNavigationEnvironment [
 	^ super asGlobalScopeIn: aNavigationEnvironment
  
@@ -77,6 +82,12 @@ ClyScopedSystemEnvironment >> createPackageNamed: packageName [
 	^ packageOrganizer addPackage: packageName
 ]
 
+{ #category : 'class management' }
+ClyScopedSystemEnvironment >> definedClassesInPackage: aPackage [
+
+	^ self classes select: [ :class | class package = aPackage ]
+]
+
 { #category : 'accessing' }
 ClyScopedSystemEnvironment >> ensurePackage: packageName [
 	"Should we allow creating new packages while calypso is displaying a scope?".
@@ -108,6 +119,11 @@ ClyScopedSystemEnvironment >> packageNamed: aString [
 ClyScopedSystemEnvironment >> packages [
 	
 	^ scope packages
+]
+
+{ #category : 'accessing' }
+ClyScopedSystemEnvironment >> scope [
+	^ scope
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
@@ -13,8 +13,9 @@ Class {
 }
 
 { #category : 'comparing' }
-ClyScopedSystemEnvironment >> == anObject [
-	^ anObject scope label == self scope label
+ClyScopedSystemEnvironment >> = anObject [
+
+	^ anObject class = self class and: [ anObject scope = self scope ]
 ]
 
 { #category : 'accessing' }
@@ -102,8 +103,8 @@ ClyScopedSystemEnvironment >> extractPackageNameFrom: aDefinitionString [
 ]
 
 { #category : 'comparing' }
-ClyScopedSystemEnvironment >> identityHash [
-	^ self scope label identityHash
+ClyScopedSystemEnvironment >> hash [
+	^ self scope hash
 ]
 
 { #category : 'class management' }

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -179,6 +179,12 @@ ClySystemEnvironment >> defaultClassCompiler [
 	^ self class compiler
 ]
 
+{ #category : 'class management' }
+ClySystemEnvironment >> definedClassesInPackage: aPackage [
+	 
+	^ aPackage definedClasses
+]
+
 { #category : 'package management' }
 ClySystemEnvironment >> ensurePackage: packageName [
 


### PR DESCRIPTION
Currently, custom scopes, these are scopes created by users through the scopes editor, cannot be correctly browsed on Calypso.
This PR correctly enables the previous feature.

However, creating/editing/removing classes, methods, etc in the scope has not been tested, and remains as work to be done.

This work depends on [NewTools PR#783](https://github.com/pharo-spec/NewTools/pull/783)