### PR TITLE
Backport use of FormSet for #withCloseBox and #withPinBox on MenuTitleMorph

### DIFF
--- a/src/Morphic-Base/MenuTitleMorph.class.st
+++ b/src/Morphic-Base/MenuTitleMorph.class.st
@@ -148,11 +148,12 @@ MenuTitleMorph >> pinColor [
 { #category : 'pinning' }
 MenuTitleMorph >> pinForm [
 
-	^CircleMorph new
+	^(CircleMorph new
 		extent: 8@8;
 		borderWidth: 2;
 		color: self pinColor;
-		imageForm
+		imageForm)
+			scaledByDisplayScaleFactor
 ]
 
 { #category : 'rounding' }
@@ -215,7 +216,7 @@ MenuTitleMorph >> withPinBox [
 
 	pinBox := self
 		iconButtonCalling: #pinBoxClicked
-		withForm: self pinForm scaledByDisplayScaleFactor
+		withForm: self pinForm
 		helpText: 'Keep this menu up'.
 
 	self addMorph: pinBox asElementNumber: 4

--- a/src/Morphic-Base/MenuTitleMorph.class.st
+++ b/src/Morphic-Base/MenuTitleMorph.class.st
@@ -146,14 +146,15 @@ MenuTitleMorph >> pinColor [
 ]
 
 { #category : 'pinning' }
-MenuTitleMorph >> pinForm [
+MenuTitleMorph >> pinFormSet [
 
-	^(CircleMorph new
-		extent: 8@8;
-		borderWidth: 2;
-		color: self pinColor;
-		imageForm)
-			scaledByDisplayScaleFactor
+	^ FormSet form:
+		(CircleMorph new
+			extent: 8@8;
+			borderWidth: 2;
+			color: self pinColor;
+			imageForm)
+				scaledByDisplayScaleFactor
 ]
 
 { #category : 'rounding' }
@@ -188,7 +189,7 @@ MenuTitleMorph >> title: aString [
 { #category : 'pinning' }
 MenuTitleMorph >> updatePinForm [
 
-	pinBox ifNotNil: [ pinBox labelGraphic: self pinForm; extent: self boxExtent ]
+	pinBox ifNotNil: [ pinBox labelFormSet: self pinFormSet; extent: self boxExtent ]
 ]
 
 { #category : 'rounding' }
@@ -216,7 +217,7 @@ MenuTitleMorph >> withPinBox [
 
 	pinBox := self
 		iconButtonCalling: #pinBoxClicked
-		withForm: self pinForm
+		withFormSet: self pinFormSet
 		helpText: 'Keep this menu up'.
 
 	self addMorph: pinBox asElementNumber: 4

--- a/src/Morphic-Base/MenuTitleMorph.class.st
+++ b/src/Morphic-Base/MenuTitleMorph.class.st
@@ -202,7 +202,7 @@ MenuTitleMorph >> withCloseBox [
 
 	closeBox := self
 		iconButtonCalling: #closeBoxClicked
-		withForm: self theme menuCloseForm
+		withFormSet: self theme menuCloseFormSet
 		helpText: 'Close this menu'.
 
 	self addMorph: closeBox asElementNumber: 1

--- a/src/Morphic-Base/MenuTitleMorph.class.st
+++ b/src/Morphic-Base/MenuTitleMorph.class.st
@@ -142,12 +142,12 @@ MenuTitleMorph >> pinColor [
 { #category : 'pinning' }
 MenuTitleMorph >> pinFormSet [
 
-	^ FormSet form:
+	^ FormSet forms: ((1 to: 2) collect: [ :scale |
 		(CircleMorph new
-			extent: (8@8) scaledByDisplayScaleFactor truncated;
-			borderWidth: 2 scaledByDisplayScaleFactor truncated;
+			extent: (8@8) scaledByDisplayScaleFactor truncated * scale;
+			borderWidth: 2 scaledByDisplayScaleFactor truncated * scale;
 			color: self pinColor;
-			imageForm)
+			imageForm) ])
 ]
 
 { #category : 'rounding' }

--- a/src/Morphic-Base/MenuTitleMorph.class.st
+++ b/src/Morphic-Base/MenuTitleMorph.class.st
@@ -92,9 +92,15 @@ MenuTitleMorph >> icon: aForm [
 { #category : 'private - creation' }
 MenuTitleMorph >> iconButtonCalling: aSelector withForm: aForm helpText: aText [
 
+	^ self iconButtonCalling: aSelector withFormSet: (FormSet form: aForm) helpText: aText
+]
+
+{ #category : 'private - creation' }
+MenuTitleMorph >> iconButtonCalling: aSelector withFormSet: aFormSet helpText: aText [
+
 	^IconicButtonMorph new target: self;
 		actionSelector: aSelector;
-		labelGraphic: aForm;
+		labelFormSet: aFormSet;
 		color: Color transparent;
 		extent: self boxExtent;
 		borderWidth: 0;

--- a/src/Morphic-Base/MenuTitleMorph.class.st
+++ b/src/Morphic-Base/MenuTitleMorph.class.st
@@ -90,12 +90,6 @@ MenuTitleMorph >> icon: aForm [
 ]
 
 { #category : 'private - creation' }
-MenuTitleMorph >> iconButtonCalling: aSelector withForm: aForm helpText: aText [
-
-	^ self iconButtonCalling: aSelector withFormSet: (FormSet form: aForm) helpText: aText
-]
-
-{ #category : 'private - creation' }
 MenuTitleMorph >> iconButtonCalling: aSelector withFormSet: aFormSet helpText: aText [
 
 	^IconicButtonMorph new target: self;

--- a/src/Morphic-Base/MenuTitleMorph.class.st
+++ b/src/Morphic-Base/MenuTitleMorph.class.st
@@ -144,11 +144,10 @@ MenuTitleMorph >> pinFormSet [
 
 	^ FormSet form:
 		(CircleMorph new
-			extent: 8@8;
-			borderWidth: 2;
+			extent: (8@8) scaledByDisplayScaleFactor truncated;
+			borderWidth: 2 scaledByDisplayScaleFactor truncated;
 			color: self pinColor;
 			imageForm)
-				scaledByDisplayScaleFactor
 ]
 
 { #category : 'rounding' }

--- a/src/Polymorph-Widgets/Object.extension.st
+++ b/src/Polymorph-Widgets/Object.extension.st
@@ -42,17 +42,17 @@ Object >> systemIconName [
 ]
 
 { #category : '*Polymorph-Widgets' }
-Object >> taskbarLabel [
-	"Answer the label string for the receiver in a task bar
-	or nil for the default."
-
-	^self class taskbarLabel
-]
-
-{ #category : '*Polymorph-Widgets' }
 Object class >> taskbarLabel [
 	"Answer the label string for the receiver in a task bar
 	or nil for the default."
 
 	^nil
+]
+
+{ #category : '*Polymorph-Widgets' }
+Object >> taskbarLabel [
+	"Answer the label string for the receiver in a task bar
+	or nil for the default."
+
+	^self class taskbarLabel
 ]

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -2143,9 +2143,15 @@ UITheme >> menuBorderWidth [
 
 { #category : 'label-styles' }
 UITheme >> menuCloseForm [
-	"Answer the form to use for the close button of a menu."
 
-	^self windowCloseForm
+	^self menuCloseFormSet asForm
+]
+
+{ #category : 'label-styles' }
+UITheme >> menuCloseFormSet [
+	"Answer the form set to use for the close button of a menu."
+
+	^self windowCloseFormSet
 ]
 
 { #category : 'accessing - colors' }


### PR DESCRIPTION
This pull request backports the changes of pull request #16696 to Pharo 12 (the branch is the same, I started it from the last common ancestor of the ‘Pharo13’ and ‘Pharo12’ branches to allow for that).