### PR TITLE
Remove (wrong) primitive usage

### DIFF
--- a/src/Random-Core/Random.class.st
+++ b/src/Random-Core/Random.class.st
@@ -104,7 +104,6 @@ more; go get coffee.
 Random class >> primitiveRandomNumber: stateArray [
 	"Answer a random Float in the interval [0 to 1)."
 
-	<primitive: 231>
 	| count returnValue |
 	returnValue := stateArray at: 1.
 


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/16775
Fix https://github.com/hpi-swa/smalltalkCI/pull/646#issuecomment-2169162697

Primitive 231 was never implemented on the VM, or at least not since a Loooong time.
[See https://github.com/pharo-project/pharo-vm/compare/v10.0.5...v10.2.1](https://github.com/pharo-project/pharo-vm/compare/v10.0.5...v10.2.1#diff-715172f5f9bc44477ac2dc857665367d6e38210cc77747ad5ea4da441814ca4aL1259)

```smalltalk
(231 239 primitiveFail)
```

And recently it got defined to provide an object's format:

```smalltalk
(231 primitiveFormat)
```

However, it is used in the Random class, probably a leftover of some prototype.

```smalltalk
"On Pharo"
Random class >> primitiveRandomNumber: stateArray
	"Answer a random Float in the interval [0 to 1)."

	<primitive: 231>
...
```

I'll propose a PR, just removing the primitive tag in primitiveRandomNumber: should be enough to get back the old behavior. We should also back port it to P12.