### PR TITLE
[P12][P13] Preventing debug point removal when target method has been modified from reinstalling the method as it was before installation + adding tests

### DIFF
--- a/src/DebugPoints-Tests/DebugPointTest.class.st
+++ b/src/DebugPoints-Tests/DebugPointTest.class.st
@@ -519,9 +519,17 @@ DebugPointTest >> testModifyMethodWithBreakpoint [
 		      on: (DummyTestClass >> #dummy) ast.
 	self assertCollection: DebugPoint all includesAll: { dp }.
 	self should: [ DummyTestClass new dummy ] raise: Break.
+	self
+		assert: (DummyTestClass >> #dummy) sourceCode
+		equals: 'dummy ^42'.
+
 	DummyTestClass compile: 'dummy ^43'.
+
 	self denyCollection: DebugPoint all includesAll: { dp }.
-	self shouldnt: [ DummyTestClass new dummy ] raise: Break
+	self shouldnt: [ DummyTestClass new dummy ] raise: Break.
+	self
+		assert: (DummyTestClass >> #dummy) sourceCode
+		equals: 'dummy ^43'
 ]
 
 { #category : 'tests' }
@@ -825,6 +833,22 @@ DebugPointTest >> testRemoveClassWithBreakpoint [
 	self assertCollection: DebugPoint all includesAll: { dp }.
 	cls removeFromSystem.
 	self assertEmpty: Breakpoint all
+]
+
+{ #category : 'tests' }
+DebugPointTest >> testRemoveMethodWithBreakpoint [
+
+	cls compile: 'dummy ^42'.
+	dp := DebugPointManager
+		      installNew: BreakDebugPoint
+		      on: (cls >> #dummy) ast.
+	self assertCollection: DebugPoint all includesAll: { dp }.
+	self should: [ cls new dummy ] raise: Break.
+
+	(cls >> #dummy) removeFromSystem.
+
+	self denyCollection: DebugPoint all includesAll: { dp }.
+	self should: [ cls new dummy ] raise: MessageNotUnderstood
 ]
 
 { #category : 'tests' }

--- a/src/DebugPoints/DebugPoint.class.st
+++ b/src/DebugPoints/DebugPoint.class.st
@@ -283,13 +283,8 @@ DebugPoint >> properties [
 { #category : 'removing' }
 DebugPoint >> remove [
 
-	| nodes |
-	nodes := self link nodes copy.
-	self behaviors do: [ :bh | bh remove ].
-	self class remove: self.
-	self link ifNotNil: [ self link uninstall ].
-
-	DebugPointManager notifyDebugPointRemoved: self fromNodes: nodes
+	self removeWithoutUninstall.
+	self link ifNotNil: [ self link uninstall ]
 ]
 
 { #category : 'API' }
@@ -344,6 +339,16 @@ DebugPoint >> removeNode: aRBNode [
 DebugPoint >> removeSideEffectBehavior: aSideEffectBehavior [
 
 	sideEffectBehaviors remove: aSideEffectBehavior
+]
+
+{ #category : 'removing' }
+DebugPoint >> removeWithoutUninstall [
+
+	| nodes |
+	nodes := self link nodes copy.
+	self behaviors do: [ :bh | bh remove ].
+	self class remove: self.
+	DebugPointManager notifyDebugPointRemoved: self fromNodes: nodes
 ]
 
 { #category : 'scope' }

--- a/src/DebugPoints/DebugPointNodeTarget.class.st
+++ b/src/DebugPoints/DebugPointNodeTarget.class.st
@@ -55,7 +55,7 @@ DebugPointNodeTarget >> node: aNode [
 { #category : 'removing' }
 DebugPointNodeTarget >> removeFromMethod: aMethod for: aDebugPoint [
 
-	aDebugPoint remove
+	aDebugPoint removeWithoutUninstall
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Fixes #16743 

**Description:**
When modifying in the debugger a method with a debug point in it, it would reinstall the method correctly in the debugger (which is correct) while reinstalling the version of the method before installation of the debug point (which is not correct, the installed method should be the modified one).

**Explanation:**
When recompiling a method in the debugger, it install the method by the OpalCompiler.
As the method already exists is recompiled, it creates  a `MethodModified` announcement.
This announcement is received by the `DebugPointManager`, class-side.

```Smalltalk
DebugPointManager class >>  #registerInterestToSystemAnnouncement

	<systemEventRegistration>
	...
	self codeChangeAnnouncer weak when: MethodModified send: #handleMethodModified: to: self
       ...
```

```Smalltalk
DebugPointManager class >> #handleMethodModified: anAnnouncement
	self removeFromMethod: anAnnouncement oldMethod
```

At this stage, the modified method is installed in the system.
When the announcement is received, it finally calls the method `#removeFromMethod:` on each debug point targeting the modified method, which calls the method `#removeFromMethod:for:` on their target.
In the case of a node, the method simply removes the debug point:

```Smalltalk
DebugPointNodeTarget>>#removeFromMethod: aMethod for: aDebugPoint

	aDebugPoint remove
```

However, the method `remove` from debug points does several things including uninstalling its metalink:

```Smalltalk
DebugPoint>>#remove

	| nodes |
	nodes := self link nodes copy.
	self behaviors do: [ :bh | bh remove ].
	self class remove: self.
	self link ifNotNil: [ self link uninstall ].

	DebugPointManager notifyDebugPointRemoved: self fromNodes: nodes
```

Uninstalling the metalink uninstalls the associated reflective method. However, this metalink has the `compiledOnLinkInstallation` option.
In this case, uninstalling the reflective method actually reinstalls the compiled method as it was before the metalink was installed:

```Smalltalk
ReflectiveMethod> #removeLink: aMetaLink

	(aMetaLink optionCompileOnLinkInstallation or: [
		  compiledMethod isRealPrimitive ])
		ifTrue: [ self compileAndInstallCompiledMethod ]
		ifFalse: [ compiledMethod invalidate ].
	... 
```

```Smalltalk
CompiledMethod>>#invalidate
	| reflectiveMethod |
	self reflectivityDisabled ifTrue: [ ^self ].

	reflectiveMethod := self reflectiveMethod.
	reflectiveMethod ifNil: [^self "do nothing"].
	(self isRealPrimitive or: (reflectiveMethod ast metaLinkOptionsFromClassAndMethod includes: #optionCompileOnLinkInstallation))
					ifTrue: [reflectiveMethod compileAndInstallCompiledMethod ]
					ifFalse: [reflectiveMethod installReflectiveMethod]
```

So that's why the modified method in the debugger is overriden by the previous version of the method.
The problem didn't appear in the previous breakpoint system, because breakpoints didn't uninstall their metalink when their method was modified or remove.
So I fixed the problem by doing the same thing: for debug points: debug points do not uninstll their metalink if they are removed because their target method has been modified or removed.
To me, this solution is not very clean, but it is okay as the metalink should be garbage collected anyway and their target method is not installed anymore, so it should not have any effect.

Anyway, the bug must be in Pharo12 too so the fix should be backported later