### PR TITLE
Backport change of default value for setting #autoSetCanvasScaleFactor to true

### DIFF
--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -23,7 +23,7 @@ Class {
 { #category : 'accessing' }
 OSWorldRenderer class >> autoSetCanvasScaleFactor [
 
-	^ autoSetCanvasScaleFactor ifNil: [ autoSetCanvasScaleFactor := false ]
+	^ autoSetCanvasScaleFactor ifNil: [ autoSetCanvasScaleFactor := true ]
 ]
 
 { #category : 'accessing' }
@@ -79,7 +79,7 @@ OSWorldRenderer class >> settingsOn: aBuilder [
 			(aBuilder setting: #autoSetCanvasScaleFactor)
 				label: 'Set canvas scale factor automatically';
 				target: self;
-				default: false ]
+				default: true ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This pull request changes the default value for the setting `#autoSetCanvasScaleFactor` to true for Pharo 12 as well. It was changed for Pharo 13 in pull request #16529 as a test, and at least as far as I’m aware, there have been no reports of that having created a problem for someone so far.