### PR TITLE
Add back old playground shortcut with deprecation

### DIFF
--- a/src/Deprecated13/ToolShortcutsCategory.extension.st
+++ b/src/Deprecated13/ToolShortcutsCategory.extension.st
@@ -5,6 +5,6 @@ ToolShortcutsCategory >> openPlaygroundOldShortcut [
 
 	<shortcut>
 	^ KMKeymap shortcut: $o meta , $w meta action: [
-		  self inform: 'CMD/CTRL + O + W shortcut to open the playground has been deprecated in favor of CMD/CTRL + O + P'.
+		  self inform: 'CMD/CTRL + O + W shortcut used to open the playground has been deprecated in favor of CMD/CTRL + O + P'.
 		  self tools workspace open ]
 ]

--- a/src/Deprecated13/ToolShortcutsCategory.extension.st
+++ b/src/Deprecated13/ToolShortcutsCategory.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'ToolShortcutsCategory' }
+
+{ #category : '*Deprecated13' }
+ToolShortcutsCategory >> openPlaygroundOldShortcut [
+
+	<shortcut>
+	^ KMKeymap shortcut: $o meta , $w meta action: [
+		  self inform: 'CMD/CTRL + O + W shortcut to open the playground has been deprecated in favor of CMD/CTRL + O + P'.
+		  self tools workspace open ]
+]


### PR DESCRIPTION
Add CMD + O + W shortcut with a warning to the user that this shortcut got deprecated.