### PR TITLE
Move #isRoot to fast table

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTBasicItem.class.st
+++ b/src/Morphic-Widgets-FastTable/FTBasicItem.class.st
@@ -231,12 +231,12 @@ FTBasicItem >> initialize [
 	recentlyChanged := false
 ]
 
-{ #category : 'accessing' }
+{ #category : 'testing' }
 FTBasicItem >> isExpanded [
 	^ isExpanded
 ]
 
-{ #category : 'accessing' }
+{ #category : 'testing' }
 FTBasicItem >> isRootItem [
 	^ self depth = 0
 ]

--- a/src/Morphic-Widgets-FastTable/FTRootItem.class.st
+++ b/src/Morphic-Widgets-FastTable/FTRootItem.class.st
@@ -57,8 +57,13 @@ FTRootItem >> expandAllTo: aDepth [
 	children do: [ :each | each expandAllTo: aDepth ]
 ]
 
-{ #category : 'accessing' }
+{ #category : 'testing' }
 FTRootItem >> isExpanded [
+	^ true
+]
+
+{ #category : 'testing' }
+FTRootItem >> isRoot [
 	^ true
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTTreeItem.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTreeItem.class.st
@@ -102,9 +102,14 @@ FTTreeItem >> hasChildren [
 	^ self children size ~= 0
 ]
 
-{ #category : 'updating' }
+{ #category : 'testing' }
 FTTreeItem >> isExpanded [
 	^ self subclassResponsibility
+]
+
+{ #category : 'testing' }
+FTTreeItem >> isRoot [
+	^ false
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Iceberg is adding #isRoot methods to FastTable and currently the users of this methods are in the Spec morphic adapter. 

IMO their place are not in Iceberg. I first was thinking about putting this code in Spec but it seems generic enough to put it directly into FastTable.

I also cleaned some protocols