### PR TITLE
Fix/Patch production build zip error

### DIFF
--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -271,7 +271,12 @@ ZipArchive >> readFrom: aStreamOrFile [
 	| stream name eocdPosition |
 	stream := aStreamOrFile isStream
 		ifTrue: [ name := aStreamOrFile printString. aStreamOrFile ]
-		ifFalse: [ name := aStreamOrFile asFileReference fullName. aStreamOrFile asFileReference binaryReadStream contents readStream ].
+		ifFalse: [ 
+			name := aStreamOrFile asFileReference fullName.
+			
+			"Workaround: Force load the entire contents in memory.
+			The zip read stream breaks with Zn buffered streams otherwise"
+			aStreamOrFile asFileReference binaryReadStream contents readStream ].
 	eocdPosition := self class findEndOfCentralDirectoryFrom: stream.
 	eocdPosition <= 0 ifTrue: [ ZipArchiveError signal: 'can''t find EOCD position' ].
 	self readEndOfCentralDirectoryFrom: stream.

--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -271,7 +271,7 @@ ZipArchive >> readFrom: aStreamOrFile [
 	| stream name eocdPosition |
 	stream := aStreamOrFile isStream
 		ifTrue: [ name := aStreamOrFile printString. aStreamOrFile ]
-		ifFalse: [ name := aStreamOrFile asFileReference fullName. aStreamOrFile asFileReference binaryReadStream ].
+		ifFalse: [ name := aStreamOrFile asFileReference fullName. aStreamOrFile asFileReference binaryReadStream contents readStream ].
 	eocdPosition := self class findEndOfCentralDirectoryFrom: stream.
 	eocdPosition <= 0 ifTrue: [ ZipArchiveError signal: 'can''t find EOCD position' ].
 	self readEndOfCentralDirectoryFrom: stream.


### PR DESCRIPTION
There is a bug in the collaboration between ZipArchive and Zinc buffered streams that prevents some Zips to be read. Loading the entire contents in memory and using a normal in-memory read stream solves the urgency.