### PR TITLE
Fixing issue#14145: ycAbstractAllInstVarAccessorsCommand >> variable never set

### DIFF
--- a/src/SystemCommands-ClassCommands/SycAbstractAllInstVarAccessorsCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycAbstractAllInstVarAccessorsCommand.class.st
@@ -10,15 +10,17 @@ Class {
 
 { #category : 'accessing' }
 SycAbstractAllInstVarAccessorsCommand >> asRefactorings [
+
 	| refactorings env |
-	refactorings := classes flatCollect: [:each |
-		each value collect: [:var |
-			| refactoring |
-			env
-				ifNil: [ refactoring := var createRefactoring: RBAbstractInstanceVariableRefactoring for: each key.
-							env := refactoring model ]
-				ifNotNil: [refactoring := var createRefactoring: RBAbstractInstanceVariableRefactoring for: each key in: env ].
-			refactoring ]].
+	refactorings := classes flatCollect: [ :each |
+		                each value collect: [ :var |
+			                | refactoring |
+			                refactoring := var
+				                               createRefactoring:
+				                               RBAbstractInstanceVariableRefactoring
+				                               for: each key.
+			                env := refactoring model.
+			                refactoring ] ].
 	^ refactorings
 ]
 


### PR DESCRIPTION
fixing issue https://github.com/pharo-project/pharo/issues/14145 by removing an unused conditional branch in SycAbstractAllnsVarAccessorsCommands >> asRefactorings