### PR TITLE
Improve contrasts of DarkBlueTheme

### DIFF
--- a/src/DarkBlueTheme/DarkBlueThemeConfigurator.class.st
+++ b/src/DarkBlueTheme/DarkBlueThemeConfigurator.class.st
@@ -21,7 +21,8 @@ DarkBlueThemeConfigurator >> balloonBackgroundColor [
 
 { #category : 'colors' }
 DarkBlueThemeConfigurator >> baseColor [
-	^ Color r: 16r26 g: 16r2f b: 16r49 range: 16rFF
+
+	^ Color r: 0.2 g: 0.24 b: 0.37
 ]
 
 { #category : 'colors' }
@@ -41,7 +42,8 @@ DarkBlueThemeConfigurator >> borderColor [
 
 { #category : 'colors' }
 DarkBlueThemeConfigurator >> darkBaseColor [
-	^ self baseColor
+
+	^ self baseColor lighter lighter
 ]
 
 { #category : 'colors' }

--- a/src/DarkBlueTheme/DarkBlueThemeConfigurator.class.st
+++ b/src/DarkBlueTheme/DarkBlueThemeConfigurator.class.st
@@ -40,11 +40,6 @@ DarkBlueThemeConfigurator >> borderColor [
 ]
 
 { #category : 'colors' }
-DarkBlueThemeConfigurator >> buttonColor [
-	^ self backgroundColor
-]
-
-{ #category : 'colors' }
 DarkBlueThemeConfigurator >> darkBaseColor [
 	^ self baseColor
 ]


### PR DESCRIPTION
This PR improves the contrast of different elements in the DarkBlueTheme

<img width="1800" alt="image" src="https://github.com/pharo-project/pharo/assets/9519971/b391ff5b-a4eb-421e-91bd-51c98d443a4c">

Fixes #16813
Works on #16791 

@astares 