### PR TITLE
fix #16799: Better api for beReadOnlyObject

### DIFF
--- a/src/Kernel-Extended-Tests/WriteBarrierTest.class.st
+++ b/src/Kernel-Extended-Tests/WriteBarrierTest.class.st
@@ -429,8 +429,20 @@ WriteBarrierTest >> testProxyObject: object initialState: initialState tuples: t
 
 { #category : 'tests - object' }
 WriteBarrierTest >> testReadOnlyImmediate [
+	"immediate objects like SmallIntegers are read only"
+	self assert: 1 isReadOnlyObject.
 	"we can call beReadOnlyObject on an immediate object"
-  
+	self assert: 1 beReadOnlyObject isReadOnlyObject 
+]
+
+{ #category : 'tests - object' }
+WriteBarrierTest >> testReadOnlyObject [
+
+	| anObject |
+	anObject := Object new.
+	"objects are not read only"
+	self deny: anObject isReadOnlyObject.
+	"we can call beReadOnlyObject on the object then it should be read only"
 	self assert: 1 beReadOnlyObject isReadOnlyObject
 ]
 

--- a/src/Kernel-Extended-Tests/WriteBarrierTest.class.st
+++ b/src/Kernel-Extended-Tests/WriteBarrierTest.class.st
@@ -429,10 +429,9 @@ WriteBarrierTest >> testProxyObject: object initialState: initialState tuples: t
 
 { #category : 'tests - object' }
 WriteBarrierTest >> testReadOnlyImmediate [
-	"immediate objects like SmallIntegers are read only"
-	self assert: 1 isReadOnlyObject.
 	"we can call beReadOnlyObject on an immediate object"
-	self assert: 1 beReadOnlyObject
+  
+	self assert: 1 beReadOnlyObject isReadOnlyObject
 ]
 
 { #category : 'tests - object' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -453,7 +453,7 @@ Object >> beReadOnlyObject [
 	 cause the VM to send attemptToAssign:withIndex: to the read-only object.
 	 An attempt to modify a read-only object in a primitive will cause the
 	 primitive to fail with a #'no modification' error code.
-	 Set the read-only flag of the receiver to true and answer the previous vaue of the flag."
+	 Set the read-only flag of the receiver to true and answer the object itself."
 
 	self setIsReadOnlyObject: true.
 	^ self

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -454,7 +454,9 @@ Object >> beReadOnlyObject [
 	 An attempt to modify a read-only object in a primitive will cause the
 	 primitive to fail with a #'no modification' error code.
 	 Set the read-only flag of the receiver to true and answer the previous vaue of the flag."
-	^self setIsReadOnlyObject: true
+
+	self setIsReadOnlyObject: true.
+	^ self
 ]
 
 { #category : 'write barrier' }


### PR DESCRIPTION
fixes #16799

The method now returns the object, and all senders are updated.