### PR TITLE
fix #15070: Rename Regex-Core into Regex 

### DIFF
--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -40,7 +40,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'Morphic-Widgets-FastTable-Tests';
 			package: 'NECompletion-Tests';
 			package: 'ProfStef-Tests';
-			package: 'Regex-Core-Tests';
+			package: 'Regex-Tests';
 			package: 'Ring-Definitions-Monticello-Tests';
 			package: 'Rubric-Tests';
 			package: 'ScriptingExtensions-Tests';


### PR DESCRIPTION
we changed Regex-Core-Tests  to Regex-Tests following naming conventions