### PR TITLE
Fix keyboard focus of rename method refactoring window

### DIFF
--- a/src/Refactoring-UI/StMethodNameEditorPresenter.class.st
+++ b/src/Refactoring-UI/StMethodNameEditorPresenter.class.st
@@ -353,7 +353,8 @@ StMethodNameEditorPresenter >> initializeDialogWindow: aModalPresenter [
 					ifNil: [ '' ]
 					ifNotNil: [ :selector | ' : "', selector, '"' ]);		
 		addButton: 'Cancel' do: [ :presenter | presenter beCancel; close ];
-		addDefaultButton: 'Rename' do: [ :presenter | self renameMethodAndClose: presenter ]
+		addDefaultButton: 'Rename' do: [ :presenter | self renameMethodAndClose: presenter ];
+		whenOpenedDo: [ selectorInput takeKeyboardFocus; selectAll ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
Fix #16699  by setting the keyboard focus after the window is opened.

There is something weird on SpTextInputFieldPresenter. 

In `SpTextInputFieldPresenter>>takeKeyboardFocusWithoutSelecting` the comments state 
```"Unlike `takeKeyboardFocus` this method will not select the text inside."```

However `SpTextInputFieldPresenter>>takeKeyboardFocus` does not select by default, hence the additional selectAll in the implementation.