### PR TITLE
add ReAssignmentFormattingRule and his tests

### DIFF
--- a/src/General-Rules-Tests/ReAssignmentFormattingRuleTest.class.st
+++ b/src/General-Rules-Tests/ReAssignmentFormattingRuleTest.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : 'ReAssignmentFormattingRuleTest',
+	#superclass : 'ReAbstractRuleTestCase',
+	#category : 'General-Rules-Tests-Formatting',
+	#package : 'General-Rules-Tests',
+	#tag : 'Formatting'
+}
+
+{ #category : 'running' }
+ReAssignmentFormattingRuleTest >> testRuleCase1 [ 
+
+	| critiques | 
+	
+	self class compile: 'method | arg | arg:=1' classified: 'test-helper'.
+	[ critiques := self myCritiquesOnMethod: self class >> #method.
+	  self assert: critiques size equals: 1 ] ensure: [ (self class >> #method) removeFromSystem ]
+]
+
+{ #category : 'running' }
+ReAssignmentFormattingRuleTest >> testRuleCase2 [
+
+	| critiques | 
+	
+	self class compile: 'method | arg | arg:= 1' classified: 'test-helper'.
+	[ critiques := self myCritiquesOnMethod: self class >> #method.
+	  self assert: critiques size equals: 1 ] ensure: [ (self class >> #method) removeFromSystem ]
+]
+
+{ #category : 'tests' }
+ReAssignmentFormattingRuleTest >> testRuleCase3 [
+
+	| critiques | 
+	
+	self class compile: 'method | arg | arg :=1' classified: 'test-helper'.
+	[ critiques := self myCritiquesOnMethod: self class >> #method.
+	  self assert: critiques size equals: 1 ] ensure: [ (self class >> #method) removeFromSystem ]
+]
+
+{ #category : 'tests' }
+ReAssignmentFormattingRuleTest >> testRuleNotViolated [ 
+
+	| critiques | 
+	
+	self class compile: 'method | arg | arg := 1' classified: 'test-helper'.
+	[ critiques := self myCritiquesOnMethod: self class >> #method.
+	  self assertEmpty: critiques ] ensure: [ (self class >> #method) removeFromSystem ]
+]

--- a/src/General-Rules/ReAssignmentFormattingRule.class.st
+++ b/src/General-Rules/ReAssignmentFormattingRule.class.st
@@ -1,0 +1,44 @@
+"
+This rule verify if there is spaces when you make an assignement
+
+Prefer
+arg := 1
+over
+arg:=1
+"
+Class {
+	#name : 'ReAssignmentFormattingRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'General-Rules-Formatting',
+	#package : 'General-Rules',
+	#tag : 'Formatting'
+}
+
+{ #category : 'accessing' }
+ReAssignmentFormattingRule class >> group [ 
+
+	^ 'Formatting'
+]
+
+{ #category : 'accessing' }
+ReAssignmentFormattingRule class >> rationale [ 
+
+	^ 'there should be an space between the temporary, ":=" and the assignment variable'
+]
+
+{ #category : 'accessing' }
+ReAssignmentFormattingRule class >> ruleName [
+
+	^ 'Assignment formatting'
+]
+
+{ #category : 'running' }
+ReAssignmentFormattingRule >> basicCheck: aNode [ 
+
+	| arg variable |
+
+	aNode isAssignment ifFalse: [ ^ false ].
+	arg := aNode children first.
+	variable := aNode children second.
+	^ variable stop + 5 > arg start 
+]


### PR DESCRIPTION
This PR propose a rule for the indentation on assignments 

Example: 
good indentation 
```
arg := 1
```
bad indentation 
```
arg:=1
```
```
arg:= 1
```
```
arg :=1
```