### PR TITLE
Custom scopes can be browsed in Calypso (retry)

### DIFF
--- a/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
+++ b/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
@@ -132,10 +132,10 @@ Class {
 
 { #category : 'default' }
 ClyNavigationEnvironment class >> defaultOver: aSystem [
-	defaultGlobalEnvironments ifNil: [ defaultGlobalEnvironments := IdentityDictionary new ].
+	defaultGlobalEnvironments ifNil: [ defaultGlobalEnvironments := Dictionary new ].
 
 	^defaultGlobalEnvironments at: aSystem ifAbsentPut: [
-		(ClyNavigationEnvironment over: aSystem)
+		(self class over: aSystem)
 			setUpAvailablePlugins;
 			attachToSystem ]
 ]

--- a/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
+++ b/src/Calypso-NavigationModel/ClyNavigationEnvironment.class.st
@@ -135,7 +135,7 @@ ClyNavigationEnvironment class >> defaultOver: aSystem [
 	defaultGlobalEnvironments ifNil: [ defaultGlobalEnvironments := Dictionary new ].
 
 	^defaultGlobalEnvironments at: aSystem ifAbsentPut: [
-		(self class over: aSystem)
+		(self over: aSystem)
 			setUpAvailablePlugins;
 			attachToSystem ]
 ]

--- a/src/Calypso-SystemQueries/ClyPackageScope.class.st
+++ b/src/Calypso-SystemQueries/ClyPackageScope.class.st
@@ -34,8 +34,15 @@ ClyPackageScope >> classGroupProvidersDo: aBlock [
 
 { #category : 'queries' }
 ClyPackageScope >> classesDo: aBlock [
+
 	self packagesDo: [ :package |
-		(environment system definedClassesInPackage: package) do: aBlock]
+		| classes |
+		classes := (environment isNotNil and: [ environment system isNotNil ])
+			           ifTrue: [
+			           environment system definedClassesInPackage: package ]
+			           ifFalse: [ package definedClasses ].
+
+		classes do: aBlock ]
 ]
 
 { #category : 'system changes' }

--- a/src/Calypso-SystemQueries/ClyPackageScope.class.st
+++ b/src/Calypso-SystemQueries/ClyPackageScope.class.st
@@ -35,7 +35,7 @@ ClyPackageScope >> classGroupProvidersDo: aBlock [
 { #category : 'queries' }
 ClyPackageScope >> classesDo: aBlock [
 	self packagesDo: [ :package |
-		package definedClasses do: aBlock]
+		(environment system definedClassesInPackage: package) do: aBlock]
 ]
 
 { #category : 'system changes' }

--- a/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
@@ -12,6 +12,12 @@ Class {
 	#tag : 'Domain'
 }
 
+{ #category : 'comparing' }
+ClyScopedSystemEnvironment >> = anObject [
+
+	^ anObject class = self class and: [ anObject scope = self scope ]
+]
+
 { #category : 'accessing' }
 ClyScopedSystemEnvironment >> asGlobalScopeIn: aNavigationEnvironment [
 	^ super asGlobalScopeIn: aNavigationEnvironment
@@ -78,6 +84,12 @@ ClyScopedSystemEnvironment >> createPackageNamed: packageName [
 ]
 
 { #category : 'accessing' }
+ClyScopedSystemEnvironment >> definedClassesInPackage: aPackage [
+
+	^ scope definedClasses select: [ :class | class package = aPackage ]
+]
+
+{ #category : 'accessing' }
 ClyScopedSystemEnvironment >> ensurePackage: packageName [
 	"Should we allow creating new packages while calypso is displaying a scope?".
 	
@@ -88,6 +100,12 @@ ClyScopedSystemEnvironment >> ensurePackage: packageName [
 ClyScopedSystemEnvironment >> extractPackageNameFrom: aDefinitionString [
 
 	^ (CDFluidClassDefinitionParser parse: aDefinitionString) packageName
+]
+
+{ #category : 'comparing' }
+ClyScopedSystemEnvironment >> hash [
+
+	^ self scope hash
 ]
 
 { #category : 'accessing' }
@@ -108,6 +126,27 @@ ClyScopedSystemEnvironment >> packageNamed: aString [
 ClyScopedSystemEnvironment >> packages [
 	
 	^ scope packages
+]
+
+{ #category : 'printing' }
+ClyScopedSystemEnvironment >> printOn: aStream [
+
+	| title |
+	title := self class name.
+	aStream
+		nextPutAll: (title first isVowel
+				 ifTrue: [ 'an ' ]
+				 ifFalse: [ 'a ' ]);
+		nextPutAll: title.
+
+	aStream nextPut: $(.
+	aStream nextPutAll: scope label.
+	aStream nextPut: $)
+]
+
+{ #category : 'accessing' }
+ClyScopedSystemEnvironment >> scope [
+	^ scope
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -179,6 +179,12 @@ ClySystemEnvironment >> defaultClassCompiler [
 	^ self class compiler
 ]
 
+{ #category : 'accessing' }
+ClySystemEnvironment >> definedClassesInPackage: aPackage [
+
+	^ aPackage definedClasses
+]
+
 { #category : 'package management' }
 ClySystemEnvironment >> ensurePackage: packageName [
 


### PR DESCRIPTION
This is a redo or [PR#16771](https://github.com/pharo-project/pharo/pull/16771) 
The previous PR broke Calypso  with a DNU when browsing senders and implementors of methods in a custom scope. 

Senders and implementors work fine on this PR's generated image, as shown in the video

https://github.com/pharo-project/pharo/assets/4822303/c6fa2db2-5692-4792-b167-7910e94a107d



