### PR TITLE
Fix Duplicate Class Refactoring Driver issues

### DIFF
--- a/src/Refactoring-Core/ReCopyClassRefactoring.class.st
+++ b/src/Refactoring-Core/ReCopyClassRefactoring.class.st
@@ -18,6 +18,7 @@ Class {
 	#instVars : [
 		'aClass',
 		'packageName',
+		'tagName',
 		'instanceMethods',
 		'classMethods'
 	],
@@ -79,9 +80,11 @@ ReCopyClassRefactoring >> classMethods: anObject [
 { #category : 'transforming' }
 ReCopyClassRefactoring >> copyClass [
 
-	self generateChangesFor: ((RBInsertNewClassRefactoring model: self model className: className)
+	self generateChangesFor:
+		((RBInsertNewClassRefactoring model: self model className: className)
 			 superclass: aClass superclass;
 			 packageName: self packageName;
+			 tagName: self tagName;
 			 comment: aClass comment;
 			 yourself)
 ]
@@ -187,4 +190,16 @@ ReCopyClassRefactoring >> privateTransform [
 ReCopyClassRefactoring >> sourceClass: classToCopy [
 
 	aClass := self classObjectFor: classToCopy
+]
+
+{ #category : 'accessing' }
+ReCopyClassRefactoring >> tagName [
+
+	^ tagName
+]
+
+{ #category : 'accessing' }
+ReCopyClassRefactoring >> tagName: anObject [
+
+	tagName := anObject
 ]

--- a/src/Refactoring-UI-Tests/ReDuplicateClassDriverTest.class.st
+++ b/src/Refactoring-UI-Tests/ReDuplicateClassDriverTest.class.st
@@ -21,9 +21,17 @@ ReDuplicateClassDriverTest >> setUpMocksOn: driver [
 
 	| dialog |
 	dialog := MockObject new.
+	
 	dialog
-		on: #window respond: SpDialogWindowPresenter new beOk;
+		on: #presenter respond: dialog;
+		on: #packageName respond: self classToBeDuplicated packageName;
+		on: #tagName respond: #ForDuplication;
 		on:	 #newClassName respond: #ReClassCopiedToBeDeleted;
+		on: #packageName respond: self classToBeDuplicated packageName;
+		on: #tagName respond: #ForDuplication;
+		on:	 #newClassName respond: #ReClassCopiedToBeDeleted;
+		on: #selectedInstanceMethods respond: #();
+		on: #selectedClassMethods respond: #();
 		on: #isCancelled respond: true;
 		on: #openModal respond: dialog.
 	driver requestDialog: dialog.
@@ -34,17 +42,16 @@ ReDuplicateClassDriverTest >> setUpMocksOn: driver [
 { #category : 'tests' }
 ReDuplicateClassDriverTest >> testDuplicateClass [
 
-	| driver rbClass driverChanges |
-
+	| driver driverChanges |
+	
 	testingEnvironment := RBClassEnvironment class: self classToBeDuplicated.
 	driver := ReDuplicateClassDriver basicNew.
-
-	self setUpMocksOn: driver.
-
-	driver scopes: { testingEnvironment }.
-	rbClass := testingEnvironment class.
 	
-	driver refactoring	className: rbClass.
+	driver className: self classToBeDuplicated name.
+	driver scopes: { testingEnvironment }.
+	
+	self setUpMocksOn: driver.
+	
 	driver runRefactoring.
 	driverChanges := driver refactoring changes.
 	self 

--- a/src/Refactoring-UI/ReDuplicateClassDriver.class.st
+++ b/src/Refactoring-UI/ReDuplicateClassDriver.class.st
@@ -47,8 +47,28 @@ ReDuplicateClassDriver >> className: aClassName [
 
 { #category : 'accessing' }
 ReDuplicateClassDriver >> configureRefactoring [
+	" This verification is necessary to make tests work "
+	refactoring ifNil: [ refactoring := ReCopyClassRefactoring new ]
+]
 
-	refactoring := ReCopyClassRefactoring new.
+{ #category : 'private' }
+ReDuplicateClassDriver >> fillFromDialog: aDialog [
+
+	| presenter |
+	presenter := aDialog presenter.
+
+	self
+		packageName: presenter packageName;
+		tagName: presenter tagName;
+		newClassName: presenter newClassName.
+
+	refactoring
+		packageName: presenter packageName;
+		tagName: presenter tagName;
+		className: presenter newClassName;
+		sourceClass: className;
+		instanceMethods: presenter selectedInstanceMethods;
+		classMethods: presenter selectedClassMethods
 ]
 
 { #category : 'accessing' }
@@ -72,21 +92,15 @@ ReDuplicateClassDriver >> requestNewClass [
 			withClassMethods: rbMetaclass allMethods;
 			onCancel: [ : dialog | dialog close ];
 			onAccept: [ :dialog |
-				self
-					packageName: dialog presenter packageName;
-					tagName: dialog presenter tagName;
-					newClassName: dialog presenter newClassName.
-				refactoring
-					packageName: dialog presenter packageName;
-					className: dialog presenter newClassName;
-					sourceClass: className;
-					instanceMethods: dialog presenter selectedInstanceMethods;
-					classMethods: dialog presenter selectedClassMethods.
+				self fillFromDialog: dialog.
 
 				dialog close ];
 			selectAll;
 			openModal;
 			yourself ]
+		
+		ifNotNil: [ 
+			self fillFromDialog: requestDialog ]
 ]
 
 { #category : 'execution' }
@@ -102,14 +116,12 @@ ReDuplicateClassDriver >> runRefactoring [
 { #category : 'accessing' }
 ReDuplicateClassDriver >> scopes: refactoringScopes [
 
-	| selectedClass |
-	
 	scopes := refactoringScopes.
-	model := self refactoringScopeOn: scopes last.
-	selectedClass := model environment classes anyOne.	
-
-	rbClass := model classFor: selectedClass.
-	rbMetaclass := model classFor: selectedClass class.
+	model := self refactoringScopeOn: scopes first.
+	
+	rbClass := model classNamed: self className.
+	rbMetaclass := model classNamed: self className, ' class'.
+	packageName := rbClass packageName
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/StRequestClassPresenter.class.st
+++ b/src/Refactoring-UI/StRequestClassPresenter.class.st
@@ -28,7 +28,7 @@ StRequestClassPresenter >> initializePackagesPresenter [
 	packagePresenter := self newDropList
 		startWithSelection;
 		items: driver packageNames;
-		displayIcon: [ : aPackage | self iconNamed: aPackage systemIconName ];
+		displayIcon: [ : aPackageName | self iconNamed: #package ];
 		sortingBlock: [ : a : b | a model < b model ];
 		whenSelectedItemChangedDo: [ : item | 
 			self updateTagItems: item.

--- a/src/Refactoring-UI/StRequestClassPresenter.class.st
+++ b/src/Refactoring-UI/StRequestClassPresenter.class.st
@@ -28,7 +28,7 @@ StRequestClassPresenter >> initializePackagesPresenter [
 	packagePresenter := self newDropList
 		startWithSelection;
 		items: driver packageNames;
-		displayIcon: [ : aPackageName | self iconNamed: #package ];
+		displayIcon: [ : aPackage | self iconNamed: aPackage systemIconName ];
 		sortingBlock: [ : a : b | a model < b model ];
 		whenSelectedItemChangedDo: [ : item | 
 			self updateTagItems: item.


### PR DESCRIPTION
**This is a work in progress, please do not review yet**
While checking for failing tests in Refactoring packages, I found some issues in `ReDuplicateClassDriver`.

The following issues are solved to this point: 
- The list of methods to be copied now belongs to the target class
- The target class package is selected by default
- Partially fix test by completing the mock object's understood messages

The following issues are not yet fixed:
- Unselected methods are copied anyway
- Test assertion is failing