### PR TITLE
[P12] Fix MetacelloRepositoryGroup with duplicated repository

### DIFF
--- a/src/Metacello-Core/MetacelloRepositoryGroup.class.st
+++ b/src/Metacello-Core/MetacelloRepositoryGroup.class.st
@@ -17,6 +17,12 @@ MetacelloRepositoryGroup class >> onRepositories: aRepositoryCollection [
 		yourself
 ]
 
+{ #category : 'fetching' }
+MetacelloRepositoryGroup >> fetchPackageNamed: aString [
+
+	self uniqueRepository fetchPackageNamed: aString
+]
+
 { #category : 'accessing' }
 MetacelloRepositoryGroup >> loadPackageNamed: aName intoLoader: aLoader [
 	"Find the first repository that defines the package"
@@ -31,4 +37,26 @@ MetacelloRepositoryGroup >> loadPackageNamed: aName intoLoader: aLoader [
 { #category : 'accessing' }
 MetacelloRepositoryGroup >> repositories: aCollection [ 
 	repositories := aCollection
+]
+
+{ #category : 'accessing' }
+MetacelloRepositoryGroup >> repositoryDescription [
+
+	^ self uniqueRepository repositoryDescription
+]
+
+{ #category : 'accessing' }
+MetacelloRepositoryGroup >> repositoryVersionString [
+
+	^ self uniqueRepository repositoryVersionString
+]
+
+{ #category : 'accessing' }
+MetacelloRepositoryGroup >> uniqueRepository [
+
+	repositories asSet isEmpty ifTrue: [
+		self error: 'No repositories found!' ].
+	repositories asSet size = 1 ifTrue: [
+		self error: 'Conflicting repositories!' ].
+	^ repositories anyOne
 ]


### PR DESCRIPTION
Fix MetacelloRepositoryGroup when in presence of the same repository twice.

This fixes a DNU happenning when downloading the project:

```smalltalk
Metacello new
repository: 'github://vitormcruz/tome:v0.1.1';
baseline: 'Tome';
load.
```

This should be forward ported to P13