### PR TITLE
Small PR to add support to set class rules in the Smallint checker

### DIFF
--- a/src/General-Rules-Tests/ReSmalllintTest.class.st
+++ b/src/General-Rules-Tests/ReSmalllintTest.class.st
@@ -213,6 +213,19 @@ ReSmalllintTest >> runRuleFor: aTestSelector onEnvironment: anEnvironment [
 	^ runner criticsOf: rule
 ]
 
+{ #category : 'private' }
+ReSmalllintTest >> testAddClassRules [
+
+	| checker |
+	
+	checker := ReSmalllintChecker new 
+		classRules: (ReAbstractRule allSubclasses collect: #new);
+		yourself.
+
+	self denyEmpty: checker classRules
+
+]
+
 { #category : 'tests' }
 ReSmalllintTest >> testAddRemoveDependents [
 	self classRuleFor: self currentSelector

--- a/src/Renraku/ReSmalllintChecker.class.st
+++ b/src/Renraku/ReSmalllintChecker.class.st
@@ -68,6 +68,22 @@ ReSmalllintChecker >> checkPackage: aPackage [
 	(environment includesPackage: aPackage) ifTrue: [ self getCritiquesAbout: aPackage by: packageRules ]
 ]
 
+{ #category : 'accessing' }
+ReSmalllintChecker >> classRules [
+
+	^ classRules
+]
+
+{ #category : 'accessing' }
+ReSmalllintChecker >> classRules: aCollectionOfRules [
+	"Select and set class rules from aCollectionOfRules"
+
+	classRules := Set new.
+	aCollectionOfRules
+		select: [ :r | r class checksClass ]
+		thenDo: [ : r | classRules add: r ]
+]
+
 { #category : 'manifest' }
 ReSmalllintChecker >> cleanAllManifest [
 	| manifests |

--- a/src/SystemCommands-ClassCommands/SycCmDuplicateClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmDuplicateClassCommand.class.st
@@ -14,7 +14,7 @@ SycCmDuplicateClassCommand >> executeRefactoring [
 	driver := (ReDuplicateClassDriver className: self targetClass name) scopes: refactoringScopes.
 	driver runRefactoring ifNil: [ ^ self ].
 	(self confirm: 'Do you want to browse the new class?')
-		ifTrue: [ context browser openOnClass: (driver model classNamed: driver newClassName) ].
+		ifTrue: [ context browser class openOnClass: (driver model classNamed: driver newClassName) ].
 
 ]
 


### PR DESCRIPTION
Add support to set class rules for the Smallint checker and a test method.
Fix a minor issue by opening the browser using the duplicate class command.
