### PR TITLE
Fix: deprecate method refactoring to applicability preconditions as list

### DIFF
--- a/src/Refactoring-UI/RBDeprecateMethodDriver.class.st
+++ b/src/Refactoring-UI/RBDeprecateMethodDriver.class.st
@@ -52,7 +52,7 @@ RBDeprecateMethodDriver >> runRefactoring [
 							"the user pressed cancel"
 							useInsteadSelector ifNil: [ ^ self ].
 							refactoring newSelector: useInsteadSelector.
-							isValid := refactoring applicabilityPreconditions check.
+							isValid := refactoring failedApplicabilityPreconditions isEmpty.
 							isValid ifFalse: [ self selectorToReplaceDeprecatedSelector ].
 							isValid ] whileFalse.
 							


### PR DESCRIPTION
This wasn't migrated when all refactoring preconditions were migrated to a list of preconditions.