### PR TITLE
Fix failing tests making CI to fail

### DIFF
--- a/src/Debugger-Oups-Tests/OupsDummyDebuggerSystem.class.st
+++ b/src/Debugger-Oups-Tests/OupsDummyDebuggerSystem.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : 'OupsDummyDebuggerSystem',
 	#superclass : 'OupsDebuggerSystem',
 	#instVars : [
-		'newUIProcessSpawned',
 		'customUIManager',
 		'debugRequestSentToHandleDebugRequest',
 		'callsToHandleDebugRequest'

--- a/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilderTest.class.st
+++ b/src/Reflectivity-Tests/MetaLinkAnonymousClassBuilderTest.class.st
@@ -141,7 +141,8 @@ MetaLinkAnonymousClassBuilderTest >> testMigrateObjectToAnonymousClass [
 	self assert: realClass identicalTo: subclass.
 	self assert: (builder soleInstanceOf: realClass) identicalTo: object.
 
-	originalClass := object originalClass.
+	"originalClass is defined in #classAccessorsForAnonymousClasses"
+	originalClass := object perform: #originalClass.
 	currentClass := object class.
 	self assert: currentClass identicalTo: class.
 	self assert: currentClass identicalTo: originalClass
@@ -156,7 +157,7 @@ MetaLinkAnonymousClassBuilderTest >> testMigrateObjectToOriginalClass [
 	builder migrateObjectToOriginalClass: object.
 
 	self should: [ object realClass ] raise: MessageNotUnderstood.
-	self should: [ object originalClass ] raise: MessageNotUnderstood.
+	self should: [ object perform: #originalClass ] raise: MessageNotUnderstood.
 	self assert: object class identicalTo: class
 ]
 


### PR DESCRIPTION
This is a small PR to fix the issues:

- #16825 : The problem is that the unknown method that makes testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented fail is created in an anonymous class by Reflectivity.
- #16824
