### PR TITLE
Add SocketAddressInformation for IPv6 support

### DIFF
--- a/src/Network-Kernel/NetNameResolver.class.st
+++ b/src/Network-Kernel/NetNameResolver.class.st
@@ -305,6 +305,23 @@ NetNameResolver class >> nameForAddress: hostAddress timeout: secs [
 	^result
 ]
 
+{ #category : 'private' }
+NetNameResolver class >> nextSocketAddressInformation [
+
+	| addrSize addr info |
+	addrSize := self primGetAddressInfoSize.
+	addrSize < 0 ifTrue: [^nil].
+	addr := SocketAddress new: addrSize.
+	self primGetAddressInfoResult: addr.
+	info := SocketAddressInformation
+		withSocketAddress: addr
+		family: self primGetAddressInfoFamily
+		type: self primGetAddressInfoType
+		protocol: self primGetAddressInfoProtocol.
+	self primGetAddressInfoNext.
+	^info
+]
+
 { #category : 'primitives' }
 NetNameResolver class >> primAbortLookup [
 	"Abort the current lookup operation, freeing the name resolver for the next query."

--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -396,6 +396,19 @@ Socket >> address [
 	^self localAddress
 ]
 
+{ #category : 'ipv6' }
+Socket >> bindTo: aSocketAddress [
+
+	| status |
+	self initializeNetwork.
+	status := self primSocketConnectionStatus: socketHandle.
+	(status == Unconnected)
+		ifFalse: [InvalidSocketStatusException signal: 'Socket status must Unconnected when binding it to an address'].
+
+	self primSocket: socketHandle bindTo: aSocketAddress.
+
+]
+
 { #category : 'initialize - destroy' }
 Socket >> bindTo: anAddress port: aPort [
 	"Bind to the local port <aPort>, on the interface specified by <anAddress>
@@ -452,6 +465,19 @@ Socket >> closeAndDestroy: timeoutSeconds [
 			self destroy]
 ]
 
+{ #category : 'ipv6' }
+Socket >> connectNonBlockingTo: aSocketAddress [
+
+	| status |
+	self initializeNetwork.
+	status := self primSocketConnectionStatus: socketHandle.
+	(status == Unconnected)
+		ifFalse: [InvalidSocketStatusException signal: 'Socket status must Unconnected before opening a new connection'].
+
+	self primSocket: socketHandle connectTo: aSocketAddress.
+
+]
+
 { #category : 'connection open/close' }
 Socket >> connectNonBlockingTo: hostAddress port: port [
 	"Initiate a connection to the given port at the given host address. This operation will return immediately; follow it with waitForConnectionUntil: to wait until the connection is established."
@@ -463,6 +489,12 @@ Socket >> connectNonBlockingTo: hostAddress port: port [
 		ifFalse: [InvalidSocketStatusException signal: 'Socket status must Unconnected before opening a new connection'].
 
 	self primSocket: socketHandle connectTo: hostAddress port: port
+]
+
+{ #category : 'ipv6' }
+Socket >> connectTo: aSocketAddress [
+
+	self connectTo: aSocketAddress waitForConnectionFor: Socket standardTimeout
 ]
 
 { #category : 'connection open/close' }
@@ -489,6 +521,16 @@ Socket >> connectTo: hostAddress port: port waitForConnectionFor: timeout [
 			ConnectionTimedOut signal: 'Cannot connect to '
 				, (NetNameResolver stringFromAddress: hostAddress) , ':'
 				, port asString ]
+]
+
+{ #category : 'ipv6' }
+Socket >> connectTo: aSocketAddress waitForConnectionFor: timeout [ 
+
+	self connectNonBlockingTo: aSocketAddress.
+	self
+		waitForConnectionFor: timeout
+		ifTimedOut: [ConnectionTimedOut signal: ('Cannot connect to {1}' translated format: {aSocketAddress printString})]
+		ifRefused: [ConnectionRefused signal: ('Cannot connect to {1}' translated format: {aSocketAddress printString})]
 ]
 
 { #category : 'connection open/close' }
@@ -1656,6 +1698,24 @@ Socket >> waitForConnectionFor: timeout ifClosed: closedBlock ifTimedOut: timeou
 
 	status == WaitingForConnection ifTrue: [ ^ timeoutBlock value ].
 	status == Connected ifFalse: [ ^ closedBlock value ]
+]
+
+{ #category : 'waiting' }
+Socket >> waitForConnectionFor: timeout ifTimedOut: timeoutBlock ifRefused: refusedBlock [
+	"Wait up until the given deadline for a connection to be established. Return true if it is established by the deadline, false if not."
+
+	| deadline timeLeft status |
+	deadline := Time millisecondClockValue + (timeout * 1000) truncated.
+	(status := self primSocketConnectionStatus: socketHandle) == Connected ifTrue: [^true].
+	[ (status == WaitingForConnection) and: [ (timeLeft := deadline - Time millisecondClockValue) > 0 ] ]
+		whileTrue: [
+			semaphore waitTimeoutMilliseconds: timeLeft.
+			status := self primSocketConnectionStatus: socketHandle ].
+	status == Connected ifTrue: [ ^true ].
+	status == WaitingForConnection 
+		ifTrue: [ timeoutBlock value ]
+		ifFalse: [ refusedBlock value ].
+	^false
 ]
 
 { #category : 'waiting' }

--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -178,19 +178,31 @@ Socket class >> newAcceptCheck [
 
 { #category : 'instance creation' }
 Socket class >> newTCP [
+
+	^ self newTCP: SocketAddressInformation addressFamilyUnspecified
+]
+
+{ #category : 'instance creation' }
+Socket class >> newTCP: family [
 	"Create a socket and initialize it for TCP"
 
 	self initializeNetwork.
-	^ [ super new initialize: TCPSocketType ] repeatWithGCIf: [ :socket |
+	^ [ super new initialize: TCPSocketType family: family ] repeatWithGCIf: [ :socket |
 		  socket isValid not ]
 ]
 
 { #category : 'instance creation' }
 Socket class >> newUDP [
+
+	^ self newUDP: SocketAddressInformation addressFamilyUnspecified
+]
+
+{ #category : 'instance creation' }
+Socket class >> newUDP: family [
 	"Create a socket and initialize it for UDP"
 
 	self initializeNetwork.
-	^ [ super new initialize: UDPSocketType ] repeatWithGCIf: [ :socket |
+	^ [ super new initialize: UDPSocketType family: family ] repeatWithGCIf: [ :socket |
 		  socket isValid not ]
 ]
 
@@ -602,7 +614,7 @@ foo waitForConnectionUntil: (Socket standardDeadline).
 ]
 
 { #category : 'initialization' }
-Socket >> initialize: socketType [
+Socket >> initialize: socketType family: addressFamily [
 	"Initialize a new socket handle. If socket creation fails, socketHandle will be set to nil."
 
 	| semaIndex readSemaIndex writeSemaIndex |
@@ -614,7 +626,7 @@ Socket >> initialize: socketType [
 	readSemaIndex := Smalltalk registerExternalObject: readSemaphore.
 	writeSemaIndex := Smalltalk registerExternalObject: writeSemaphore.
 	socketHandle := self
-		primSocketCreateNetwork: 0
+		primSocketCreateNetwork: addressFamily
 		type: socketType
 		receiveBufferSize: 8000
 		sendBufSize: 8000

--- a/src/Network-Kernel/SocketAddressInformation.class.st
+++ b/src/Network-Kernel/SocketAddressInformation.class.st
@@ -162,6 +162,19 @@ SocketAddressInformation >> addressFamilyName [
 	^#(unspecified local inet4 inet6) at: addressFamily + 1
 ]
 
+{ #category : 'circuit setup' }
+SocketAddressInformation >> connect [
+
+	| sock |
+	socketType == SocketTypeStream ifFalse: [^nil].
+	sock := Socket newTCP: addressFamily.
+	sock connectTo: socketAddress.
+	sock waitForConnectionFor: Socket standardTimeout
+		ifTimedOut: [ConnectionTimedOut signal: ('Cannot connect to {1}' translated format: {self})]
+		ifRefused: [ConnectionRefused signal: ('Cannot connect to {1}' translated format: {self})].
+	^sock
+]
+
 { #category : 'initialize-release' }
 SocketAddressInformation >> initSocketAddress: aSocketAddress family: familyInteger type: typeInteger protocol: protocolInteger [
 
@@ -169,6 +182,17 @@ SocketAddressInformation >> initSocketAddress: aSocketAddress family: familyInte
 	addressFamily := familyInteger.
 	socketType := typeInteger.
 	protocol := protocolInteger.
+]
+
+{ #category : 'circuit setup' }
+SocketAddressInformation >> listenWithBacklog: backlog [
+
+	| sock |
+	(socketType == SocketTypeStream and: [protocol == ProtocolTCP]) ifFalse: [self error: 'cannot listen'].
+	sock := Socket newTCP: addressFamily.
+	sock bindTo: socketAddress.
+	sock listenWithBacklog: 5.
+	^sock
 ]
 
 { #category : 'printing' }

--- a/src/Network-Kernel/SocketAddressInformation.class.st
+++ b/src/Network-Kernel/SocketAddressInformation.class.st
@@ -1,0 +1,200 @@
+"
+I represent a local or remote network service.
+
+Instance Variables
+	addressFamily:	<SmallInteger> the address family (unix, inet4, inet6, ...) in which the service address is available.
+	protocol:		<SmallInteger> the protocol (tcp, udp, ...) that the service uses.
+	socketAddress:	<SocketAddress> the socket address at which the service can be contacted or created.
+	socketType:		<SmallInteger> the type (stream, dgram) of the socket that should be created for communication with the service.
+
+"
+Class {
+	#name : 'SocketAddressInformation',
+	#superclass : 'Object',
+	#instVars : [
+		'socketAddress',
+		'addressFamily',
+		'socketType',
+		'protocol'
+	],
+	#classVars : [
+		'AddressFamilyINET4',
+		'AddressFamilyINET6',
+		'AddressFamilyLocal',
+		'AddressFamilyUnspecified',
+		'NumericFlag',
+		'PassiveFlag',
+		'PrimitiveAccessProtect',
+		'ProtocolTCP',
+		'ProtocolUDP',
+		'ProtocolUnspecified',
+		'SocketTypeDGram',
+		'SocketTypeStream',
+		'SocketTypeUnspecified'
+	],
+	#category : 'Network-Kernel',
+	#package : 'Network-Kernel'
+}
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> addressFamilyINET4 [
+
+	^AddressFamilyINET4
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> addressFamilyINET6 [
+
+	^AddressFamilyINET6
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> addressFamilyLocal [
+
+	^AddressFamilyLocal
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> addressFamilyUnspecified [
+
+	^AddressFamilyUnspecified
+]
+
+{ #category : 'instance creation' }
+SocketAddressInformation class >> forHost: hostName service: servName flags: flags addressFamily: family socketType: type protocol: protocol [
+
+	| result addr |
+	PrimitiveAccessProtect critical: [
+		NetNameResolver initializeNetwork.
+			NetNameResolver
+				primGetAddressInfoHost: hostName
+				service: servName
+				flags: flags
+				family: family
+				type: type
+				protocol: protocol.
+			result := OrderedCollection new.
+			[(addr := NetNameResolver nextSocketAddressInformation) notNil]
+				whileTrue: [result add: addr]].
+	^ result
+]
+
+{ #category : 'class initialization' }
+SocketAddressInformation class >> initialize [
+	"SocketAddressInformation initialize"
+
+	NumericFlag := 1.
+	PassiveFlag := 2.
+	AddressFamilyUnspecified := 0.
+	AddressFamilyLocal := 1.
+	AddressFamilyINET4 := 2.
+	AddressFamilyINET6 := 3.
+	SocketTypeUnspecified := 0.
+	SocketTypeStream := 1.
+	SocketTypeDGram := 2.
+	ProtocolUnspecified := 0.
+	ProtocolTCP := 1.
+	ProtocolUDP := 2.
+
+	"SocketPlugin maintains internal state across primitive calls, so methods that rely
+	on the result of sequential primitive calls require concurrency control."
+	PrimitiveAccessProtect := Semaphore forMutualExclusion.
+
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> numericFlag [
+
+	^NumericFlag
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> passiveFlag [
+
+	^PassiveFlag
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> protocolTCP [
+
+	^ProtocolTCP
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> protocolUDP [
+
+	^ProtocolUDP
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> protocolUnspecified [
+
+	^ProtocolUnspecified
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> socketTypeDGram [
+
+	^SocketTypeDGram
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> socketTypeStream [
+
+	^SocketTypeStream
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation class >> socketTypeUnspecified [
+
+	^SocketTypeUnspecified
+]
+
+{ #category : 'instance creation' }
+SocketAddressInformation class >> withSocketAddress: socketAddress family: family type: type protocol: protocol [
+
+	^self new initSocketAddress: socketAddress family: family type: type protocol: protocol
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation >> addressFamilyName [
+
+	^#(unspecified local inet4 inet6) at: addressFamily + 1
+]
+
+{ #category : 'initialize-release' }
+SocketAddressInformation >> initSocketAddress: aSocketAddress family: familyInteger type: typeInteger protocol: protocolInteger [
+
+	socketAddress := aSocketAddress.
+	addressFamily := familyInteger.
+	socketType := typeInteger.
+	protocol := protocolInteger.
+]
+
+{ #category : 'printing' }
+SocketAddressInformation >> printOn: aStream [
+
+	aStream
+		print: socketAddress;
+		nextPut: $-; nextPutAll: self addressFamilyName;
+		nextPut: $-; nextPutAll: self socketTypeName;
+		nextPut: $-; nextPutAll: self protocolName
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation >> protocolName [
+
+	^#(unspecified tcp udp) at: socketType + 1
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation >> socketAddress [
+
+	^socketAddress
+]
+
+{ #category : 'accessing' }
+SocketAddressInformation >> socketTypeName [
+
+	^#(unspecified stream dgram) at: socketType + 1
+]


### PR DESCRIPTION
This pull request adds SocketAddressInformation and some auxiliary methods on Socket, copied from [Squeak 6.1 alpha 22998](https://squeak.js.org/run/#highdpi&zip=https://files.squeak.org/6.1alpha/Squeak6.1alpha-22998-32bit/Squeak6.1alpha-22998-32bit.zip), to allow making use of SocketPlugin’s IPv6 support. The methods `#primSocket:bindTo:` and `#primSocket:connectTo:` in Socket’s protocol ‘primitives - ipv6’ previously had no senders.

With SocketAddressInformation, a listening socket using IPv6 can be set up as follows:

```smalltalk
addressInformations := SocketAddressInformation forHost: ''
	service: 2000 asString
	flags: SocketAddressInformation passiveFlag
	addressFamily: SocketAddressInformation addressFamilyINET6
	socketType: SocketAddressInformation socketTypeStream
	protocol: SocketAddressInformation protocolTCP.
listeningSocket := addressInformations first listenWithBacklog: 5.
[
	acceptedSocket := listeningSocket waitForAcceptFor: 300.
	Transcript show: 'Received data: ' , acceptedSocket receiveData; cr.
	acceptedSocket close.
	listeningSocket close.
] fork.
```

It can then be connected to as follows:

```smalltalk
addressInformations := SocketAddressInformation forHost: ''
	service: 2000 asString
	flags: 0
	addressFamily: SocketAddressInformation addressFamilyINET6
	socketType: SocketAddressInformation socketTypeStream
	protocol: SocketAddressInformation protocolTCP.
connectedSocket := addressInformations first connect.
connectedSocket sendData: DateAndTime now asString; close.
```

A motivation for this pull request is the problem I encountered with Safari in [Pharo VM pull request #816](https://github.com/pharo-project/pharo-vm/pull/816) when using IPv4.