### PR TITLE
Revert "Backport change of default value for setting #autoSetCanvasScaleFactor to true"

### DIFF
--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -23,7 +23,7 @@ Class {
 { #category : 'accessing' }
 OSWorldRenderer class >> autoSetCanvasScaleFactor [
 
-	^ autoSetCanvasScaleFactor ifNil: [ autoSetCanvasScaleFactor := true ]
+	^ autoSetCanvasScaleFactor ifNil: [ autoSetCanvasScaleFactor := false ]
 ]
 
 { #category : 'accessing' }
@@ -79,7 +79,7 @@ OSWorldRenderer class >> settingsOn: aBuilder [
 			(aBuilder setting: #autoSetCanvasScaleFactor)
 				label: 'Set canvas scale factor automatically';
 				target: self;
-				default: true ]
+				default: false ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Reverts pharo-project/pharo#16783

I have a problem that seems to come from this PR but IDK why, the cleaning step of the bootstrap does not work anymore on my computer so I'd like to use the CI to produce a new image with this reverted to see if my problem gets fixed