### PR TITLE
[Backport] Update FormSet to not recompute each scalling all the time

### DIFF
--- a/src/Graphics-Display Objects/CachedFormSet.class.st
+++ b/src/Graphics-Display Objects/CachedFormSet.class.st
@@ -4,10 +4,15 @@ I am a FormSet that will save the forms I'm scaling for performance reasons.
 For example, if you have a background in Pharo it takes time to scale the beackground at each refresh of the UI.
 
 Like this we can use FormSet when we want to save memory and CachedFormSet when we want to save time.
+
+The difference with my super class is that I'll save all requested scallings in a cache instead of recomputing all the time the scales.
 "
 Class {
 	#name : 'CachedFormSet',
 	#superclass : 'FormSet',
+	#instVars : [
+		'cache'
+	],
 	#category : 'Graphics-Display Objects-Forms',
 	#package : 'Graphics-Display Objects',
 	#tag : 'Forms'
@@ -16,12 +21,25 @@ Class {
 { #category : 'converting' }
 CachedFormSet >> asFormWithExtent: formExtent [
 
-	^ forms
+	^ cache
 		  detect: [ :form | form extent = formExtent ]
 		  ifFound: [ :form | form asFormOfDepth: depth ]
 		  ifNone: [
 			  | newForm |
-			  newForm := forms first scaledToExactSize: formExtent.
-			  forms := forms copyWith: newForm.
+			  newForm := super asFormWithExtent: formExtent.
+			  cache := cache copyWith: newForm.
 			  newForm asFormOfDepth: depth ]
+]
+
+{ #category : 'private' }
+CachedFormSet >> flushCache [
+
+	cache := #(  )
+]
+
+{ #category : 'initialization' }
+CachedFormSet >> initialize [
+
+	super initialize.
+	self flushCache
 ]

--- a/src/Graphics-Display Objects/CachedFormSet.class.st
+++ b/src/Graphics-Display Objects/CachedFormSet.class.st
@@ -1,0 +1,27 @@
+"
+I am a FormSet that will save the forms I'm scaling for performance reasons. 
+
+For example, if you have a background in Pharo it takes time to scale the beackground at each refresh of the UI.
+
+Like this we can use FormSet when we want to save memory and CachedFormSet when we want to save time.
+"
+Class {
+	#name : 'CachedFormSet',
+	#superclass : 'FormSet',
+	#category : 'Graphics-Display Objects-Forms',
+	#package : 'Graphics-Display Objects',
+	#tag : 'Forms'
+}
+
+{ #category : 'converting' }
+CachedFormSet >> asFormWithExtent: formExtent [
+
+	^ forms
+		  detect: [ :form | form extent = formExtent ]
+		  ifFound: [ :form | form asFormOfDepth: depth ]
+		  ifNone: [
+			  | newForm |
+			  newForm := forms first scaledToExactSize: formExtent.
+			  forms := forms copyWith: newForm.
+			  newForm asFormOfDepth: depth ]
+]

--- a/src/Graphics-Display Objects/FormSet.class.st
+++ b/src/Graphics-Display Objects/FormSet.class.st
@@ -49,14 +49,9 @@ FormSet >> asFormAtScale: scale [
 { #category : 'converting' }
 FormSet >> asFormWithExtent: formExtent [
 
-	^ forms
-		  detect: [ :form | form extent = formExtent ]
-		  ifFound: [ :form | form asFormOfDepth: depth ]
-		  ifNone: [
-			  | newForm |
-			  newForm := forms first scaledToExactSize: formExtent.
-			  forms := forms copyWith: newForm.
-			  newForm asFormOfDepth: depth ]
+	^ (forms detect: [ :form | form extent = formExtent ]
+		ifFound: [ :form | form asFormOfDepth: depth ]
+		ifNone: [ (forms first asFormOfDepth: depth) scaledToExactSize: formExtent ])
 ]
 
 { #category : 'accessing' }

--- a/src/Graphics-Display Objects/FormSet.class.st
+++ b/src/Graphics-Display Objects/FormSet.class.st
@@ -49,9 +49,14 @@ FormSet >> asFormAtScale: scale [
 { #category : 'converting' }
 FormSet >> asFormWithExtent: formExtent [
 
-	^ (forms detect: [ :form | form extent = formExtent ]
-		ifFound: [ :form | form asFormOfDepth: depth ]
-		ifNone: [ (forms first asFormOfDepth: depth) scaledToExactSize: formExtent ])
+	^ forms
+		  detect: [ :form | form extent = formExtent ]
+		  ifFound: [ :form | form asFormOfDepth: depth ]
+		  ifNone: [
+			  | newForm |
+			  newForm := forms first scaledToExactSize: formExtent.
+			  forms := forms copyWith: newForm.
+			  newForm asFormOfDepth: depth ]
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Base/AlphaImageMorph.class.st
+++ b/src/Morphic-Base/AlphaImageMorph.class.st
@@ -368,7 +368,7 @@ AlphaImageMorph >> scaledFormSetBy: imageScale [
 	| scaledExtent |
 
 	scaledExtent := (formSet extent * imageScale) truncated.
-	^ FormSet extent: scaledExtent depth: formSet depth
+	^ CachedFormSet extent: scaledExtent depth: formSet depth
 		forms: (formSet forms collect: [ :form | form magnifyBy: (scaledExtent / formSet extent) smoothing: 2 ])
 ]
 


### PR DESCRIPTION
Having a scaling that is different of 1 can slow down a lot the image. For example, if we set a background in the image then the perf will be horrible because we will scale the Form of the background all the time and it takes time.

I'm proposing to save the forms we are scaling in the FormSet. Like this we only have to scale once.

Backport of https://github.com/pharo-project/pharo/pull/16886