### PR TITLE
Move Tool-Diff to Morphic

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -95,7 +95,6 @@ BaselineOfBasicTools >> baseline: spec [
 		self specRefactoring: spec.
 
 		spec package: 'Tools-CodeNavigation'.
-		spec package: 'Tool-Diff'.
 		spec package: 'Tool-FileList'.
 		spec package: 'Tool-Finder'.
 		spec package: 'Tool-Finder-UI'.

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -118,6 +118,7 @@ BaselineOfMorphic >> baseline: spec [
 		spec package: 'System-Sound'.
 
 		spec package: 'Text-Diff'.
+		spec package: 'Tool-Diff'.
 		spec package: 'Text-Edition'.
 		spec package: 'Text-Scanning'.
 


### PR DESCRIPTION
Tool-Diff is mostly morphs so I'm moving this package to the UI baseline in Morphic.

This is needed because Spec depends on Diffs and diffs are currently loaded after Spec.