### PR TITLE
16897-Deprecation--messageText-results-in-MNU

### DIFF
--- a/src/Kernel-Tests/DeprecationTest.class.st
+++ b/src/Kernel-Tests/DeprecationTest.class.st
@@ -7,7 +7,7 @@ Class {
 }
 
 { #category : 'tests' }
-DeprecationTest >> testMessageTextUnkownMethod [
+DeprecationTest >> testMessageTextFromBlock [
 	| notification |
 	"messageText should not be nil even the call is from a block"
 	notification := [ self deprecated: 'test']

--- a/src/Kernel-Tests/DeprecationTest.class.st
+++ b/src/Kernel-Tests/DeprecationTest.class.st
@@ -7,6 +7,16 @@ Class {
 }
 
 { #category : 'tests' }
+DeprecationTest >> testMessageTextUnkownMethod [
+	| notification |
+	"messageText should not be nil even the call is from a block"
+	notification := [ self deprecated: 'test']
+			on: (self class environment at: #Deprecation)
+			do: [ :d | d ].
+	self assert: notification messageText notNil
+]
+
+{ #category : 'tests' }
 DeprecationTest >> testTransformingDeprecation [
 	<ignoreNotImplementedSelectors: #(sendsDeprecatedMessageWithTransform)>
 	| classFactory oldRaiseWarning oldActivateTransformations |

--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -131,7 +131,7 @@ Deprecation >> contextOfDeprecatedMethod [
 
 { #category : 'accessing' }
 Deprecation >> contextOfSender [
-	^context sender
+	^context home sender
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
fixes #16897 by going to the home context, in case deprecated: is send from a block