### PR TITLE
Adding "OnStack replacement" feature to Reflectivity

### DIFF
--- a/src/BaselineOfReflectivity/BaselineOfReflectivity.class.st
+++ b/src/BaselineOfReflectivity/BaselineOfReflectivity.class.st
@@ -5,6 +5,23 @@ Class {
 	#package : 'BaselineOfReflectivity'
 }
 
+{ #category : 'system annoucements' }
+BaselineOfReflectivity class >> handleMethodModified: aMethodModified [
+
+	aMethodModified oldMethod saveBcToASTCacheWithAST:
+		aMethodModified oldMethod ast
+]
+
+{ #category : 'system annoucements' }
+BaselineOfReflectivity class >> subscribeToMethodModified [
+
+	<script>
+	self codeChangeAnnouncer weak
+		when: MethodModified
+		send: #handleMethodModified:
+		to: self
+]
+
 { #category : 'baselines' }
 BaselineOfReflectivity >> baseline: spec [
 
@@ -37,5 +54,7 @@ BaselineOfReflectivity >> baseline: spec [
 
 { #category : 'baselines' }
 BaselineOfReflectivity >> postload: loader package: packageSpec [
+
 	ASTCache cacheMissStrategy: RFReflectivityASTCacheStrategy new.
+	self class subscribeToMethodModified
 ]

--- a/src/BaselineOfReflectivity/BaselineOfReflectivity.class.st
+++ b/src/BaselineOfReflectivity/BaselineOfReflectivity.class.st
@@ -5,23 +5,6 @@ Class {
 	#package : 'BaselineOfReflectivity'
 }
 
-{ #category : 'system annoucements' }
-BaselineOfReflectivity class >> handleMethodModified: aMethodModified [
-
-	aMethodModified oldMethod saveBcToASTCacheWithAST:
-		aMethodModified oldMethod ast
-]
-
-{ #category : 'system annoucements' }
-BaselineOfReflectivity class >> subscribeToMethodModified [
-
-	<script>
-	self codeChangeAnnouncer weak
-		when: MethodModified
-		send: #handleMethodModified:
-		to: self
-]
-
 { #category : 'baselines' }
 BaselineOfReflectivity >> baseline: spec [
 
@@ -55,6 +38,5 @@ BaselineOfReflectivity >> baseline: spec [
 { #category : 'baselines' }
 BaselineOfReflectivity >> postload: loader package: packageSpec [
 
-	ASTCache cacheMissStrategy: RFReflectivityASTCacheStrategy new.
-	self class subscribeToMethodModified
+	ASTCache cacheMissStrategy: RFReflectivityASTCacheStrategy new
 ]

--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -6,6 +6,21 @@ CompiledBlock >> ast [
 ]
 
 { #category : '*OpalCompiler-Core' }
+CompiledBlock >> bcToASTCacheKey [
+
+	| key outerCode |
+	key := self pcInOuter asString.
+	outerCode := self outerCode.
+
+	outerCode isCompiledBlock ifTrue: [
+		key := '{1}>{2}' format: {
+				       outerCode pcInOuter.
+				       key }.
+		outerCode := outerCode outerCode ].
+	^ key
+]
+
+{ #category : '*OpalCompiler-Core' }
 CompiledBlock >> sourceNode [
 	^ self sourceNodeInOuter
 ]
@@ -18,7 +33,7 @@ CompiledBlock >> sourceNodeForPC: aPC [
 	"Bug in the cache? The mapping is returning Return node instead of Block"
 	blockNode isReturn ifTrue: [ blockNode := blockNode value ].
 	self method
-		propertyAt: self printString asSymbol
+		propertyAt: self bcToASTCacheKey asSymbol
 		ifPresent: [ :bcToASTCache |
 			blockNode sourceNodeForPC: aPC usingBcToASTCache: bcToASTCache ].
 	^ blockNode sourceNodeForPC: aPC

--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -7,6 +7,9 @@ CompiledBlock >> ast [
 
 { #category : '*OpalCompiler-Core' }
 CompiledBlock >> bcToASTCacheKey [
+	"The bcToASTCache of a compiled block is saved in its home method's properties, with its pc in outer code as key.
+	So this block is created at pc `48` in its outer code, which is its home method, then its key would be `#48`.
+	If this block is created at pc `57` in its outer code, which is itself a block created at pc `48` in its outer code that is its home method, then the key of this block would be `#48>57`"
 
 	| key outerCode |
 	key := self pcInOuter asString.

--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -17,6 +17,10 @@ CompiledBlock >> sourceNodeForPC: aPC [
 	blockNode := self outerCode sourceNodeForPC: self pcInOuter.
 	"Bug in the cache? The mapping is returning Return node instead of Block"
 	blockNode isReturn ifTrue: [ blockNode := blockNode value ].
+	self method
+		propertyAt: self printString asSymbol
+		ifPresent: [ :bcToASTCache |
+			blockNode sourceNodeForPC: aPC usingBcToASTCache: bcToASTCache ].
 	^ blockNode sourceNodeForPC: aPC
 ]
 

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -49,7 +49,7 @@ CompiledMethod >> saveBcToASTCacheWithAST: aMethodAST [
 				compiledBlockAST start ~= 0 ] ]
 		thenDo: [ :compiledBlock |
 			self
-				propertyAt: compiledBlock printString
+				propertyAt: compiledBlock bcToASTCacheKey
 				put: compiledBlockAST bcToASTCache ]
 ]
 

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -45,7 +45,8 @@ CompiledMethod >> saveBcToASTCacheWithAST: aMethodAST [
 
 	self allBlocks
 		select: [ :compiledBlock | "Installing metalinks in certain situations (e.g: installing a metalink after on a sequence node of a block node) may create other compiled blocks, which are not attached to a block node (e.g: a sequence node). We just ignore these blocks."
-			(compiledBlockAST := compiledBlock ast) isBlock ]
+			(compiledBlockAST := compiledBlock ast) isBlock and: [ "In other cases, installing metalinks create compiled blocks that are associated to invisible block nodes that are children of an `RFMessageNode`. In this case, its start index and stop index are equal to 0 in the source code. Its source code interval goes from 0 to 0 but is not considered empty because the method `Interval>>#isEmpty` does not consider these extreme bounds. We ignore these blocks too"
+				compiledBlockAST start ~= 0 ] ]
 		thenDo: [ :compiledBlock |
 			self
 				propertyAt: compiledBlock printString

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -53,7 +53,13 @@ CompiledMethod >> sourceNode [
 
 { #category : '*OpalCompiler-Core' }
 CompiledMethod >> sourceNodeForPC: aPC [
-	^self sourceNode sourceNodeForPC: aPC
+
+	| sourceNode |
+	sourceNode := self sourceNode.
+
+	self propertyAt: #bcToASTCache ifPresent: [ :bcToASTCache |
+		^ sourceNode sourceNodeForPC: aPC usingBcToASTCache: bcToASTCache ].
+	^ sourceNode sourceNodeForPC: aPC
 ]
 
 { #category : '*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -39,11 +39,17 @@ CompiledMethod >> reformat [
 { #category : '*OpalCompiler-Core' }
 CompiledMethod >> saveBcToASTCacheWithAST: aMethodAST [
 
+	| compiledBlockAST |
+	self propertyAt: #bcToASTCache ifPresent: [ :bcToASTCache | ^ self ].
 	self propertyAt: #bcToASTCache put: aMethodAST bcToASTCache.
-	self allBlocksDo: [ :compiledBlock |
-		self
-			propertyAt: compiledBlock printString
-			put: compiledBlock ast bcToASTCache ]
+
+	self allBlocks
+		select: [ :compiledBlock | "Installing metalinks in certain situations (e.g: installing a metalink after on a sequence node of a block node) may create other compiled blocks, which are not attached to a block node (e.g: a sequence node). We just ignore these blocks."
+			(compiledBlockAST := compiledBlock ast) isBlock ]
+		thenDo: [ :compiledBlock |
+			self
+				propertyAt: compiledBlock printString
+				put: compiledBlockAST bcToASTCache ]
 ]
 
 { #category : '*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/CompiledMethod.extension.st
+++ b/src/OpalCompiler-Core/CompiledMethod.extension.st
@@ -37,6 +37,16 @@ CompiledMethod >> reformat [
 ]
 
 { #category : '*OpalCompiler-Core' }
+CompiledMethod >> saveBcToASTCacheWithAST: aMethodAST [
+
+	self propertyAt: #bcToASTCache put: aMethodAST bcToASTCache.
+	self allBlocksDo: [ :compiledBlock |
+		self
+			propertyAt: compiledBlock printString
+			put: compiledBlock ast bcToASTCache ]
+]
+
+{ #category : '*OpalCompiler-Core' }
 CompiledMethod >> sourceNode [
 	^self ast
 ]

--- a/src/OpalCompiler-Core/RBBlockNode.extension.st
+++ b/src/OpalCompiler-Core/RBBlockNode.extension.st
@@ -93,3 +93,9 @@ RBBlockNode >> resetBcToASTCache [
 RBBlockNode >> sourceNodeForPC: anInteger [
 	^ self bcToASTCache nodeForPC: anInteger
 ]
+
+{ #category : '*OpalCompiler-Core' }
+RBBlockNode >> sourceNodeForPC: anInteger usingBcToASTCache: aBcToASTCache [
+
+	^ aBcToASTCache nodeForPC: anInteger
+]

--- a/src/OpalCompiler-Core/RBMethodNode.extension.st
+++ b/src/OpalCompiler-Core/RBMethodNode.extension.st
@@ -183,3 +183,9 @@ RBMethodNode >> primitiveFromPragma [
 RBMethodNode >> sourceNodeForPC: anInteger [
 	^ self bcToASTCache nodeForPC: anInteger
 ]
+
+{ #category : '*OpalCompiler-Core' }
+RBMethodNode >> sourceNodeForPC: anInteger usingBcToASTCache: aBcToASTCache [
+
+	^ aBcToASTCache nodeForPC: anInteger
+]

--- a/src/Reflectivity-Tests/ReflectivityExampleOnStack.class.st
+++ b/src/Reflectivity-Tests/ReflectivityExampleOnStack.class.st
@@ -1,0 +1,175 @@
+"
+Examples that wait on a semaphore
+
+Two cases:
+
+- we add the metalink before the pc that the waiting method is executing
+- ae add it *after*.
+
+The after case is simpler to implement as we do not need to change the PC of the method on the stack
+
+PLAN:
+
+solve second case first.
+"
+Class {
+	#name : 'ReflectivityExampleOnStack',
+	#superclass : 'Object',
+	#instVars : [
+		'tag',
+		'semaphore'
+	],
+	#category : 'Reflectivity-Tests-Data',
+	#package : 'Reflectivity-Tests',
+	#tag : 'Data'
+}
+
+{ #category : 'waiting' }
+ReflectivityExampleOnStack >> continue [
+
+	semaphore signal
+]
+
+{ #category : 'examples' }
+ReflectivityExampleOnStack >> exampleMethodWaitingOnSemaphore [
+
+	2 + 3.
+	self wait.
+	7 + 5.
+]
+
+{ #category : 'examples' }
+ReflectivityExampleOnStack >> exampleMethodWaitingOnSemaphoreDirectly [
+
+	2 + 3.
+	semaphore wait.
+	7 + 5
+]
+
+{ #category : 'examples' }
+ReflectivityExampleOnStack >> exampleMethodWaitingOnSemaphoreInBlock [
+
+	| a block |
+	a := 2.
+	block := [
+	         a := 2 + 3.
+	         semaphore wait.
+	         a := 7 + 5 ].
+	^ a + block value
+]
+
+{ #category : 'examples' }
+ReflectivityExampleOnStack >> exampleMethodWaitingOnSemaphoreInEmbeddedBlock [ 
+
+	| a block | 
+	a := 2.
+	block := [
+	         | b block2 |
+	         a := 2 + 3.
+	         block2 := [
+	                   b := 2 + 3.
+	                   semaphore wait.
+	                   b := 7 + 5 ].
+	         a := 4 + 2.
+	         block2 value ].
+	^ a + block value
+]
+
+{ #category : 'examples' }
+ReflectivityExampleOnStack >> exampleMethodWaitingOnSemaphoreInInlineBlock [
+
+	2 + 3.
+	true ifTrue: [
+		1 + 1.
+		semaphore wait. 
+		3 + 3 ].
+	7 + 5
+]
+
+{ #category : 'examples' }
+ReflectivityExampleOnStack >> exampleMethodWaitingOnSemaphoreInMethodWithOuterBlockStoreInVariableBefore [
+
+	| a block |
+	a := 2.
+	block := [
+	         | b block2 |
+	         a := 2 + 3.
+	         block2 := [
+	                   b := 2 + 3.
+	                   b := 4 + 2.
+	                   b := 7 + 5 ].
+	         a := 4 + 2.
+	         block2 value ].
+	semaphore wait.
+	^ a + block value
+]
+
+{ #category : 'examples' }
+ReflectivityExampleOnStack >> exampleMethodWaitingOnSemaphoreInOuterBlockWithEmbeddedBlockStoreInVariableBefore [
+
+	| a block |
+	a := 2.
+	block := [
+	         | b block2 |
+	         a := 2 + 3.
+	         block2 := [
+	                   b := 2 + 3.
+	                   b := 4 + 2.
+	                   b := 7 + 5 ].
+	         semaphore wait.
+	         a := 4 + 2.
+	         block2 value ].
+	^ a + block value
+]
+
+{ #category : 'examples' }
+ReflectivityExampleOnStack >> exampleMethodWaitingOnSemaphoreWithBlockAfter [
+
+	| a |
+	a := 2.
+	semaphore wait.
+
+	^ a + [
+	  a := 2 + 3.
+	  a := 4 + 2.
+	  a := 7 + 5 ] value
+]
+
+{ #category : 'examples' }
+ReflectivityExampleOnStack >> exampleMethodWaitingOnSemaphoreWithBlockStoreInVariableBefore [
+
+	| a block |
+	a := 2.
+	block := [
+	         a := 2 + 3.
+	         a := 4 + 2.
+	         a := 7 + 5 ].
+	semaphore wait.
+	^ a + block value
+]
+
+{ #category : 'initialization' }
+ReflectivityExampleOnStack >> initialize [
+	semaphore := Semaphore new.
+]
+
+{ #category : 'accessing' }
+ReflectivityExampleOnStack >> tag [
+	^tag
+]
+
+{ #category : 'accessing' }
+ReflectivityExampleOnStack >> tagExec: anObject [
+	tag := anObject
+]
+
+{ #category : 'waiting' }
+ReflectivityExampleOnStack >> wait [
+	semaphore wait.
+]
+
+{ #category : 'examples' }
+ReflectivityExampleOnStack >> wait2 [
+
+	self wait
+]

--- a/src/Reflectivity-Tests/ReflectivityOnStackTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityOnStackTest.class.st
@@ -1,0 +1,1384 @@
+Class {
+	#name : 'ReflectivityOnStackTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'tag',
+		'link',
+		'link2',
+		'tag2'
+	],
+	#category : 'Reflectivity-Tests-Base',
+	#package : 'Reflectivity-Tests',
+	#tag : 'Base'
+}
+
+{ #category : 'accessing' }
+ReflectivityOnStackTest >> tag [
+
+	^ tag
+]
+
+{ #category : 'accessing' }
+ReflectivityOnStackTest >> tag2 [
+
+	^ tag2
+]
+
+{ #category : 'accessing' }
+ReflectivityOnStackTest >> tag2: anObject [
+
+	tag2 := anObject
+]
+
+{ #category : 'tagging' }
+ReflectivityOnStackTest >> tag2Exec [
+
+	tag2 := #yes
+]
+
+{ #category : 'accessing' }
+ReflectivityOnStackTest >> tag: anObject [
+
+	tag := anObject
+]
+
+{ #category : 'tagging' }
+ReflectivityOnStackTest >> tagExec [
+	tag := #yes
+]
+
+{ #category : 'running' }
+ReflectivityOnStackTest >> tearDown [
+
+	link ifNotNil: [ link uninstall ].
+	link2 ifNotNil: [ link2 uninstall ].
+	super tearDown
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaiting [
+	| instance process |
+	instance := ReflectivityExampleOnStack new.
+	
+	process := [ instance exampleMethodWaitingOnSemaphore ] fork.
+
+	"here check that the method is on the stack"	
+	0.1 seconds wait.
+	self assert: process suspendedContext sender method equals: ReflectivityExampleOnStack>>#exampleMethodWaitingOnSemaphore.
+	
+	"process should be running"
+	self deny: process isTerminated.
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithAfterLinkInstalledAfterExecutionAtInstructionChangeInterruptedMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphoreDirectly ] fork.
+	0.1 seconds wait.
+
+	"If we install the link before the instruction the program stopped to, it should not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphoreDirectly) ast
+		               sendNodes second.
+	link := MetaLink new
+		        metaObject: self;
+		        control: #after;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreDirectly) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreDirectly) class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphoreDirectly)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method:
+		ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphoreDirectly.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals: #exampleMethodWaitingOnSemaphoreDirectly.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It got executed!!"
+	self assert: tag notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithAfterLinkInstalledAfterExecutionAtInstructionChangeMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphore ] fork.
+	0.1 seconds wait.
+
+	"If we install the link before the instruction the program stopped to, it should not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphore) ast sendNodes
+		               second.
+	link := MetaLink new
+		        metaObject: self;
+		        control: #after;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+			class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+			class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext sender method:
+		ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext sender method selector
+		equals: #exampleMethodWaitingOnSemaphore.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It got executed!!"
+	self assert: tag notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithBeforeLinkInstalledAfterExecutionAtInstructionChangeInterruptedMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphoreDirectly ] fork.
+	0.1 seconds wait.
+
+	"If we install the link before the instruction the program stopped to, it should not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphoreDirectly) ast
+		               sendNodes second.
+	link := MetaLink new
+		        metaObject: self;
+		        control: #before;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreDirectly) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreDirectly) class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >> #exampleMethodWaitingOnSemaphoreDirectly)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method:
+		ReflectivityExampleOnStack
+		>> #exampleMethodWaitingOnSemaphoreDirectly.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals: #exampleMethodWaitingOnSemaphoreDirectly.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It has not been executed!!"
+	self assert: tag isNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithBeforeLinkInstalledAfterExecutionAtInstructionChangeMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphore ] fork.
+	0.1 seconds wait.
+
+	"If we install the link before the instruction the program stopped to, it should not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphore) ast sendNodes
+		               second.
+	link := MetaLink new
+		        metaObject: self;
+		        control: #before;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+			class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+			class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext sender method:
+		ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext sender method selector
+		equals: #exampleMethodWaitingOnSemaphore.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It has not been executed!!"
+	self assert: tag isNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledAfterExecution [
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+	
+	
+	
+	process := [ instance exampleMethodWaitingOnSemaphore  ] fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore) ast sendNodes third.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self assert: (ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore) class equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+	"here check that the method is on the stack"	
+	
+	self assert: process suspendedContext sender method selector equals: #exampleMethodWaitingOnSemaphore.
+	"process should be running"
+	self deny: process isTerminated.
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+	
+	
+	"here the tag should not be nil, the metalink should have been executed."
+	self deny: tag notNil.
+	
+	"but if we execute again, it workd"
+
+	process := [ instance exampleMethodWaitingOnSemaphore ] fork.
+	instance continue.
+	0.1 seconds wait.
+	self assert: tag notNil.
+
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledAfterExecutionBeforeInstructionChangeInterruptedMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphoreDirectly ] fork.
+	0.1 seconds wait.
+	"If we install a link before the instruction the program stopped to, the link should not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphoreDirectly) ast
+		               sendNodes first.
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreDirectly) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+
+	"Here we could do the on stack replacement manually"
+
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreDirectly) class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >> #exampleMethodWaitingOnSemaphoreDirectly)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method:
+		ReflectivityExampleOnStack
+		>> #exampleMethodWaitingOnSemaphoreDirectly.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals: #exampleMethodWaitingOnSemaphoreDirectly.
+	"process should be running"
+	self deny: process isTerminated.
+	
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It was not executed!!"
+	self assert: tag isNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledAfterExecutionBeforeInstructionChangeMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphore ] fork.
+	0.1 seconds wait.
+
+	"If we install the link before the instruction the program stopped to, it should not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphore) ast sendNodes
+		               first.
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+			class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+			class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext sender method:
+		ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext sender method selector
+		equals: #exampleMethodWaitingOnSemaphore.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It has not been executed!!"
+	self assert: tag isNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledAfterExecutionChangeInterruptedMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphoreDirectly ] fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphoreDirectly) ast
+		               sendNodes third.
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreDirectly) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+
+	"Here we could do the on stack replacement manually"
+
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreDirectly) class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >> #exampleMethodWaitingOnSemaphoreDirectly)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method:
+		ReflectivityExampleOnStack
+		>> #exampleMethodWaitingOnSemaphoreDirectly.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals: #exampleMethodWaitingOnSemaphoreDirectly.
+	"process should be running"
+	self deny: process isTerminated.
+	
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It got executed!!"
+	self assert: tag notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledAfterExecutionChangeMethodManually [
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+	
+	
+	
+	process := [ instance exampleMethodWaitingOnSemaphore  ] fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore) ast sendNodes third.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self assert: (ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore) class equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+
+	"Here we could do the on stack replacement manually"
+	
+	self assert:	 (ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore) class equals: ReflectiveMethod.
+	
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore) compileAndInstallCompiledMethod.
+	
+	process suspendedContext sender method: (ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore).
+	
+	"here check that the method is on the stack"	
+	
+	self assert: process suspendedContext sender method selector equals: #exampleMethodWaitingOnSemaphore.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+	
+	
+	"It got executed!!"
+	self assert: tag notNil.
+
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledAfterExecutionOfMethodAfterExecutionOfBlockAfterCreationOfBlockChangeMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+
+
+	process := [ instance exampleMethodWaitingOnSemaphoreInBlock ] fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphoreInBlock) ast
+		               blockNodes first assignmentNodes second.
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert:
+			(ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreInBlock) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+
+	"Here we could do the on stack replacement manually"
+
+	self
+		assert:
+			(ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreInBlock) class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >> #exampleMethodWaitingOnSemaphoreInBlock)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method:
+		ReflectivityExampleOnStack
+		>> #exampleMethodWaitingOnSemaphoreInBlock.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals: #exampleMethodWaitingOnSemaphoreInBlock.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It got executed!!"
+	self assert: tag notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledAfterExecutionOfMethodBeforeExecutionOfBlockAfterCreationOfBlockChangeMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+
+
+	process := [
+	           instance
+		           exampleMethodWaitingOnSemaphoreWithBlockStoreInVariableBefore ]
+		           fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >>
+	                #exampleMethodWaitingOnSemaphoreWithBlockStoreInVariableBefore)
+		               ast blockNodes first assignmentNodes second.
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreWithBlockStoreInVariableBefore)
+				class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+
+	"Here we could do the on stack replacement manually"
+
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreWithBlockStoreInVariableBefore)
+				class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >> #exampleMethodWaitingOnSemaphoreWithBlockStoreInVariableBefore)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method: ReflectivityExampleOnStack
+		>> #exampleMethodWaitingOnSemaphoreWithBlockStoreInVariableBefore.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals:
+		#exampleMethodWaitingOnSemaphoreWithBlockStoreInVariableBefore.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It got executed!!"
+	self assert: tag notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledAfterExecutionOfMethodBeforeExecutionOfBlockBeforeCreationOfBlockChangeMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+
+
+	process := [ instance exampleMethodWaitingOnSemaphoreWithBlockAfter ]
+		           fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphoreWithBlockAfter)
+		               ast blockNodes first assignmentNodes second.
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreWithBlockAfter) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+
+	"Here we could do the on stack replacement manually"
+
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreWithBlockAfter) class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >> #exampleMethodWaitingOnSemaphoreWithBlockAfter)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method: ReflectivityExampleOnStack
+		>> #exampleMethodWaitingOnSemaphoreWithBlockAfter.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals: #exampleMethodWaitingOnSemaphoreWithBlockAfter.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It got executed!!"
+	self assert: tag notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledAfterExecutionOfMethodBeforeExecutionOfEmbeddedBlockAfterCreationChangeMethodManually [
+
+	| instance messageNode process messageNode2 |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [
+	           instance
+		           exampleMethodWaitingOnSemaphoreInOuterBlockWithEmbeddedBlockStoreInVariableBefore ]
+		           fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >>
+	                #exampleMethodWaitingOnSemaphoreInOuterBlockWithEmbeddedBlockStoreInVariableBefore)
+		               ast blockNodes first assignmentNodes third.
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+	messageNode link: link.
+
+	messageNode2 := (ReflectivityExampleOnStack
+	                 >>
+	                 #exampleMethodWaitingOnSemaphoreInOuterBlockWithEmbeddedBlockStoreInVariableBefore)
+		                ast blockNodes second assignmentNodes second.
+	link2 := MetaLink new
+		         metaObject: self;
+		         selector: #tag2Exec.
+	messageNode2 link: link2.
+
+	self assert: messageNode hasMetalink.
+	self assert: messageNode2 hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >>
+			 #exampleMethodWaitingOnSemaphoreInOuterBlockWithEmbeddedBlockStoreInVariableBefore)
+				class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	self assert: tag2 isNil.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >>
+	 #exampleMethodWaitingOnSemaphoreInOuterBlockWithEmbeddedBlockStoreInVariableBefore)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method: ReflectivityExampleOnStack
+		>>
+		#exampleMethodWaitingOnSemaphoreInOuterBlockWithEmbeddedBlockStoreInVariableBefore.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals:
+		#exampleMethodWaitingOnSemaphoreInOuterBlockWithEmbeddedBlockStoreInVariableBefore.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+	"It got executed!!"
+	self assert: tag notNil.
+	self assert: tag2 notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledAfterExecutionOfMethodInInlinedBlockChangeMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+
+
+	process := [ instance exampleMethodWaitingOnSemaphoreInInlineBlock ]
+		           fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphoreInInlineBlock)
+		               ast blockNodes first sendNodes third.
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreInInlineBlock) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+
+	"Here we could do the on stack replacement manually"
+
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreInInlineBlock) class
+		equals: ReflectiveMethod.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >> #exampleMethodWaitingOnSemaphoreInInlineBlock)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method: ReflectivityExampleOnStack
+		>> #exampleMethodWaitingOnSemaphoreInInlineBlock.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals: #exampleMethodWaitingOnSemaphoreInInlineBlock.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"It got executed!!"
+	self assert: tag notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledBeforeExecution [
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+	
+	"If we install a link before we execute, we just see its effects. This test is just to make sure we have the stuff working
+	like we expect"
+	messageNode := (ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore) ast sendNodes first.
+	link := MetaLink new
+		metaObject: self;
+		selector: #tagExec.
+	messageNode link: link.
+	self assert: messageNode hasMetalink.
+	self assert: (ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore) class equals: ReflectiveMethod.
+	self assert: tag isNil.
+	
+	process := [ instance exampleMethodWaitingOnSemaphore ] fork.
+
+	"here check that the method is on the stack"	
+	0.1 seconds wait.
+	self assert: process suspendedContext sender method equals: ReflectivityExampleOnStack>>#exampleMethodWaitingOnSemaphore.
+	"process should be running"
+	self deny: process isTerminated.
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+	
+	
+	"here the tag should not be nil, the metalink should have been executed."
+	self assert: tag notNil
+
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledInEmbeddedBlockAfterExecutionOfMethodAfterExecutionOfEmbeddedBlockChangeMethodManually [
+
+	| instance process messageNode2 |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphoreInEmbeddedBlock ]
+		           fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode2 := (ReflectivityExampleOnStack
+	                 >> #exampleMethodWaitingOnSemaphoreInEmbeddedBlock)
+		                ast blockNodes second assignmentNodes second.
+	link2 := MetaLink new
+		         metaObject: self;
+		         selector: #tag2Exec.
+	messageNode2 link: link2.
+
+	self assert: messageNode2 hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreInEmbeddedBlock) class
+		equals: ReflectiveMethod.
+	self assert: tag2 isNil.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >> #exampleMethodWaitingOnSemaphoreInEmbeddedBlock)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method: ReflectivityExampleOnStack
+		>> #exampleMethodWaitingOnSemaphoreInEmbeddedBlock.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals: #exampleMethodWaitingOnSemaphoreInEmbeddedBlock.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+	"It got executed!!"
+	self assert: tag2 notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinkInstalledInOuterMethodAfterExecutionOfMethodAfterExecutionOfEmbeddedBlockChangeMethodManually [
+
+	| instance messageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphoreInEmbeddedBlock ]
+		           fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphoreInEmbeddedBlock)
+		               ast sendNodes last parent.
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+	messageNode link: link.
+
+	self assert: messageNode hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreInEmbeddedBlock) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >> #exampleMethodWaitingOnSemaphoreInEmbeddedBlock)
+		compileAndInstallCompiledMethod.
+
+	(process findContextsForMethod: process suspendedContext homeMethod)
+		do: [ :ctx |
+			ctx method: ReflectivityExampleOnStack
+				>> #exampleMethodWaitingOnSemaphoreInEmbeddedBlock ].
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext sender sender method selector
+		equals: #exampleMethodWaitingOnSemaphoreInEmbeddedBlock.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+	"It got executed!!"
+	self assert: tag notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithLinksInstalledAfterExecutionOfMethodBeforeExecutionOfOuterAndEmbeddedBlockAfterCreationChangeMethodManually [
+
+	| instance messageNode process messageNode2 |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [
+	           instance
+		           exampleMethodWaitingOnSemaphoreInMethodWithOuterBlockStoreInVariableBefore ]
+		           fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >>
+	                #exampleMethodWaitingOnSemaphoreInMethodWithOuterBlockStoreInVariableBefore)
+		               ast blockNodes first assignmentNodes second.
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+	messageNode link: link.
+
+	messageNode2 := (ReflectivityExampleOnStack
+	                 >>
+	                 #exampleMethodWaitingOnSemaphoreInMethodWithOuterBlockStoreInVariableBefore)
+		                ast blockNodes second assignmentNodes second.
+	link2 := MetaLink new
+		         metaObject: self;
+		         selector: #tag2Exec.
+	messageNode2 link: link2.
+
+	self assert: messageNode hasMetalink.
+	self assert: messageNode2 hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >>
+			 #exampleMethodWaitingOnSemaphoreInMethodWithOuterBlockStoreInVariableBefore)
+				class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	self assert: tag2 isNil.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >>
+	 #exampleMethodWaitingOnSemaphoreInMethodWithOuterBlockStoreInVariableBefore)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method: ReflectivityExampleOnStack
+		>>
+		#exampleMethodWaitingOnSemaphoreInMethodWithOuterBlockStoreInVariableBefore.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals:
+		#exampleMethodWaitingOnSemaphoreInMethodWithOuterBlockStoreInVariableBefore.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+	"It got executed!!"
+	self assert: tag notNil.
+	self assert: tag2 notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithTwoLinksInstalledAfterExecutionBeforeAndAfterInstructionChangeInterruptedMethodManually [
+
+	| instance thirdMessageNode secondMessageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphoreDirectly ] fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	thirdMessageNode := (ReflectivityExampleOnStack
+	                     >> #exampleMethodWaitingOnSemaphoreDirectly) ast
+		                    sendNodes third.
+
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+
+	thirdMessageNode link: link.
+
+	self assert: thirdMessageNode hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreDirectly) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	self assert: tag2 isNil.
+
+	"we install second link"
+	secondMessageNode := (ReflectivityExampleOnStack
+	                      >> #exampleMethodWaitingOnSemaphoreDirectly)
+		                     ast sendNodes second.
+	link2 := MetaLink new
+		         metaObject: self;
+		         selector: #tag2Exec.
+	secondMessageNode link: link2.
+
+	self assert: thirdMessageNode hasMetalink.
+	self assert: secondMessageNode hasMetalink.
+	self
+		assert: (ReflectivityExampleOnStack
+			 >> #exampleMethodWaitingOnSemaphoreDirectly) class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	self assert: tag2 isNil.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack
+	 >> #exampleMethodWaitingOnSemaphoreDirectly)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method:
+		ReflectivityExampleOnStack
+		>> #exampleMethodWaitingOnSemaphoreDirectly.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals: #exampleMethodWaitingOnSemaphoreDirectly.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"only the metalink on the third message node got executed, because the second message node had already been executed"
+	self assert: tag notNil.
+	self assert: tag2 isNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithTwoLinksInstalledAfterExecutionBeforeAndAfterInstructionChangeMethodManually [
+
+	| instance thirdMessageNode secondMessageNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphore ] fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	thirdMessageNode := (ReflectivityExampleOnStack
+	                     >> #exampleMethodWaitingOnSemaphore) ast
+		                    sendNodes third.
+
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+
+	thirdMessageNode link: link.
+
+	self assert: thirdMessageNode hasMetalink.
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+			class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	self assert: tag2 isNil.
+
+	"we install second link"
+	secondMessageNode := (ReflectivityExampleOnStack
+	                      >> #exampleMethodWaitingOnSemaphore) ast
+		                     sendNodes second.
+	link2 := MetaLink new
+		         metaObject: self;
+		         selector: #tag2Exec.
+	secondMessageNode link: link2.
+
+	self assert: thirdMessageNode hasMetalink.
+	self assert: secondMessageNode hasMetalink.
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+			class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	self assert: tag2 isNil.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext sender method:
+		ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext sender method selector
+		equals: #exampleMethodWaitingOnSemaphore.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"only the metalink on the third message node got executed, because the second message node had already been executed"
+	self assert: tag notNil.
+	self assert: tag2 isNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithTwoLinksInstalledAfterExecutionChangeInterruptedMethodManually [
+
+	| instance messageNode variableNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphoreDirectly ] fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphoreDirectly) ast sendNodes
+		               third.
+
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+
+	messageNode link: link.
+
+	self assert: messageNode hasMetalink.
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphoreDirectly)
+			class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	self assert: tag2 isNil.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphoreDirectly)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method:
+		ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphoreDirectly.
+		
+	"we install second link"
+	variableNode := messageNode receiver.
+	link2 := MetaLink new
+		         metaObject: self;
+		         selector: #tag2Exec.
+	variableNode link: link2.
+
+	self assert: messageNode hasMetalink.
+	self assert: variableNode hasMetalink.
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphoreDirectly)
+			class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	self assert: tag2 isNil.
+	
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphoreDirectly)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext method:
+		ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphoreDirectly.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext method selector
+		equals: #exampleMethodWaitingOnSemaphoreDirectly.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"Both metalinks got executed!!"
+	self assert: tag notNil.
+	self assert: tag2 notNil
+]
+
+{ #category : 'tests' }
+ReflectivityOnStackTest >> testExecuteWithWaitingWithTwoLinksInstalledAfterExecutionChangeMethodManually [
+
+	| instance messageNode variableNode process |
+	instance := ReflectivityExampleOnStack new.
+
+	process := [ instance exampleMethodWaitingOnSemaphore ] fork.
+	0.1 seconds wait.
+	"If we install a link after we execute, we expect it to not matter for this test, as the new code will not be executed"
+	messageNode := (ReflectivityExampleOnStack
+	                >> #exampleMethodWaitingOnSemaphore) ast sendNodes
+		               third.
+
+	link := MetaLink new
+		        metaObject: self;
+		        selector: #tagExec.
+
+	messageNode link: link.
+
+	self assert: messageNode hasMetalink.
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+			class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	self assert: tag2 isNil.
+
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext sender method:
+		ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore.
+		
+	"we install second link"
+	variableNode := messageNode receiver.
+	link2 := MetaLink new
+		         metaObject: self;
+		         selector: #tag2Exec.
+	variableNode link: link2.
+
+	self assert: messageNode hasMetalink.
+	self assert: variableNode hasMetalink.
+	self
+		assert:
+		(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+			class
+		equals: ReflectiveMethod.
+	self assert: tag isNil.
+	self assert: tag2 isNil.
+	
+	"make sure to create the compiledMethod"
+	(ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore)
+		compileAndInstallCompiledMethod.
+
+	process suspendedContext sender method:
+		ReflectivityExampleOnStack >> #exampleMethodWaitingOnSemaphore.
+
+	"here check that the method is on the stack"
+
+	self
+		assert: process suspendedContext sender method selector
+		equals: #exampleMethodWaitingOnSemaphore.
+	"process should be running"
+	self deny: process isTerminated.
+
+	instance continue.
+	0.1 seconds wait.
+	self assert: process isTerminated.
+
+
+	"Both metalinks got executed!!"
+	self assert: tag notNil.
+	self assert: tag2 notNil
+]
+
+{ #category : 'tests - finding' }
+ReflectivityOnStackTest >> testFindContextForMethod [
+	  "look for the context that calls this method when running the test"
+
+	  | contexts |
+	  [
+	  contexts := Processor findContextsForMethod:
+		              DelayBasicScheduler >> #runBackendLoopAtTimingPriority.
+
+	  "The assertion depends on what we want to do: if we want to replace the context by another one, then we should use the first assertion as we need to return the callee to modify its sender. If we want to simply change the method of the context, then we should use the second assert because there is no need to return the callee if we do not change its sender"
+
+	  "	self
+		assert: contexts first sender method selector
+		equals: #runBackendLoopAtTimingPriority "
+	  self
+		  assert: contexts first method selector
+		  equals: #runBackendLoopAtTimingPriority ] valueUnpreemptively
+]

--- a/src/Reflectivity-Tests/ReflectivityOnStackTest.class.st
+++ b/src/Reflectivity-Tests/ReflectivityOnStackTest.class.st
@@ -1363,22 +1363,3 @@ ReflectivityOnStackTest >> testExecuteWithWaitingWithTwoLinksInstalledAfterExecu
 	self assert: tag notNil.
 	self assert: tag2 notNil
 ]
-
-{ #category : 'tests - finding' }
-ReflectivityOnStackTest >> testFindContextForMethod [
-	  "look for the context that calls this method when running the test"
-
-	  | contexts |
-	  [
-	  contexts := Processor findContextsForMethod:
-		              DelayBasicScheduler >> #runBackendLoopAtTimingPriority.
-
-	  "The assertion depends on what we want to do: if we want to replace the context by another one, then we should use the first assertion as we need to return the callee to modify its sender. If we want to simply change the method of the context, then we should use the second assert because there is no need to return the callee if we do not change its sender"
-
-	  "	self
-		assert: contexts first sender method selector
-		equals: #runBackendLoopAtTimingPriority "
-	  self
-		  assert: contexts first method selector
-		  equals: #runBackendLoopAtTimingPriority ] valueUnpreemptively
-]

--- a/src/Reflectivity/Context.extension.st
+++ b/src/Reflectivity/Context.extension.st
@@ -1,0 +1,97 @@
+Extension { #name : 'Context' }
+
+{ #category : '*Reflectivity' }
+Context >> computePCForNewMethod: aCompiledMethod [
+
+	| offset currentSymbolicBytecodes newSymbolicBytecodes currentSymbolicBytecodeIndex newSymbolicBytecodeIndex currentBytecode newBytecode |
+	"This method makes the assumption that the new method only adds bytecodes to the old one, and does not remove any bytecode of the old method"
+	offset := self pc - self startpc.
+	newSymbolicBytecodes := aCompiledMethod symbolicBytecodes.
+	currentSymbolicBytecodes := self compiledCode symbolicBytecodes
+		                            select: [ :bytecode |
+		                            bytecode offset <= self pc ].
+	currentSymbolicBytecodeIndex := 1.
+	currentBytecode := currentSymbolicBytecodes at:
+		                   currentSymbolicBytecodeIndex.
+	newSymbolicBytecodeIndex := 1.
+	newBytecode := newSymbolicBytecodes at: newSymbolicBytecodeIndex.
+	[ "While all bytecodes from current method have not been found in new method:"
+	currentSymbolicBytecodeIndex < currentSymbolicBytecodes size "=" ]
+		whileTrue: [ "If the two bytecodes are the same, then no offset need to be added, else it means a bytecode has been added in the new method and the offset should be increased by the size of this bytecode:"
+			currentBytecode := currentSymbolicBytecodes at:
+				                   currentSymbolicBytecodeIndex.
+			newBytecode := newSymbolicBytecodes at: newSymbolicBytecodeIndex.
+			(self
+				 currentBytecode: currentBytecode
+				 equalsToNewBytecode: newBytecode
+				 withCurrents: self compiledCode symbolicBytecodes
+				 withNews: aCompiledMethod symbolicBytecodes)
+				ifTrue: [
+				currentSymbolicBytecodeIndex := currentSymbolicBytecodeIndex + 1 ]
+				ifFalse: [ offset := offset + newBytecode bytes size ].
+			newSymbolicBytecodeIndex := newSymbolicBytecodeIndex + 1 ].
+	^ aCompiledMethod initialPC + offset
+]
+
+{ #category : '*Reflectivity' }
+Context >> currentBytecode: currentBytecode equalsToNewBytecode: newBytecode withCurrents: currentSymbolicBytecodes withNews: newSymbolicBytecodes [
+
+	| result |
+	result := currentBytecode description = newBytecode description.
+	^ result
+		  ifTrue: [ true ]
+		  ifFalse: [
+			  ((currentBytecode description beginsWith: 'jump') and: [
+				   newBytecode description beginsWith: 'jump' ])
+				  ifFalse: [ false ]
+				  ifTrue: [
+					  | currentSplitDescription newSplitDescription |
+					  currentSplitDescription := $: split:
+						                             currentBytecode description.
+					  newSplitDescription := $: split: newBytecode description.
+					  (currentSplitDescription size = 2 and: [
+						   newSplitDescription size = 2 and: [
+							   currentSplitDescription first = newSplitDescription first ] ])
+						  ifFalse: [ false ]
+						  ifTrue: [
+							  | currentJumpPc newJumpPc currentJumpBytecode newJumpBytecode |
+							  currentJumpPc := (currentSplitDescription at: 2) asInteger.
+							  newJumpPc := (newSplitDescription at: 2) asInteger.
+							  currentJumpBytecode := currentSymbolicBytecodes
+								                         detect: [ :csb |
+								                         csb offset = currentJumpPc ]
+								                         ifNone: [ ^ false ].
+							  newJumpBytecode := newSymbolicBytecodes
+								                     detect: [ :nsb | nsb offset = newJumpPc ]
+								                     ifNone: [ ^ false ].
+							  self
+								  currentBytecode: currentJumpBytecode
+								  equalsToNewBytecode: newJumpBytecode
+								  withCurrents: currentSymbolicBytecodes
+								  withNews: newSymbolicBytecodes ] ] ]
+]
+
+{ #category : '*Reflectivity' }
+Context >> method: aCompiledMethod [
+
+	| compiledCode |
+	compiledCode := method ast == aCompiledMethod ast
+		                ifTrue: [ aCompiledMethod ]
+		                ifFalse: [
+			                aCompiledMethod allBlocks detect: [ :compiledBlock |
+				                compiledBlock ast = method ast ] ].
+
+	1 to: self stackPtr do: [ :index |
+		| obj |
+		obj := self at: index.
+		obj isClosure ifTrue: [
+			obj compiledBlock:
+				(aCompiledMethod allBlocks detect: [ :compiledBlock |
+					 compiledBlock ast = obj compiledBlock ast ]) ] ].
+
+	pc := self computePCForNewMethod: compiledCode.
+	method := compiledCode.
+	closureOrNil ifNotNil: [
+		self assert: compiledCode isCompiledBlock.
+		closureOrNil compiledBlock: compiledCode ]
+]

--- a/src/Reflectivity/Context.extension.st
+++ b/src/Reflectivity/Context.extension.st
@@ -92,6 +92,5 @@ Context >> method: aCompiledMethod [
 	pc := self computePCForNewMethod: compiledCode.
 	method := compiledCode.
 	closureOrNil ifNotNil: [
-		self assert: compiledCode isCompiledBlock.
 		closureOrNil compiledBlock: compiledCode ]
 ]

--- a/src/Reflectivity/Process.extension.st
+++ b/src/Reflectivity/Process.extension.st
@@ -1,0 +1,20 @@
+Extension { #name : 'Process' }
+
+{ #category : '*Reflectivity' }
+Process >> findContextsForMethod: aMethod [
+
+	| context priorContext found methodClass methodSelector homeMethod |
+	found := OrderedCollection new.
+	methodClass := aMethod methodClass.
+	methodSelector := aMethod selector.
+
+	context := suspendedContext.
+	priorContext := nil.
+	[ context isNil ] whileFalse: [
+		homeMethod := context homeMethod.
+		(homeMethod methodClass == methodClass and: [
+			 homeMethod selector == methodSelector ]) ifTrue: [ found add: context ].
+		priorContext := context.
+		context := context sender ].
+	^ found
+]

--- a/src/Reflectivity/ProcessorScheduler.extension.st
+++ b/src/Reflectivity/ProcessorScheduler.extension.st
@@ -5,11 +5,3 @@ ProcessorScheduler >> allProcesses [
 
 	^ Process allSubInstances
 ]
-
-{ #category : '*Reflectivity' }
-ProcessorScheduler >> findContextsForMethod: aMethod [
-	"Take care: users should call within #valueUnpreemptively"
-
-	^ self allProcesses flatCollect: [ :process |
-		  process findContextsForMethod: aMethod ]
-]

--- a/src/Reflectivity/ProcessorScheduler.extension.st
+++ b/src/Reflectivity/ProcessorScheduler.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : 'ProcessorScheduler' }
+
+{ #category : '*Reflectivity' }
+ProcessorScheduler >> allProcesses [
+
+	^ Process allSubInstances
+]
+
+{ #category : '*Reflectivity' }
+ProcessorScheduler >> findContextsForMethod: aMethod [
+	"Take care: users should call within #valueUnpreemptively"
+
+	^ self allProcesses flatCollect: [ :process |
+		  process findContextsForMethod: aMethod ]
+]

--- a/src/Reflectivity/RFReflectivityASTCacheStrategy.class.st
+++ b/src/Reflectivity/RFReflectivityASTCacheStrategy.class.st
@@ -16,6 +16,29 @@ Class {
 	#tag : 'Compiler'
 }
 
+{ #category : 'system annoucements' }
+RFReflectivityASTCacheStrategy class >> handleMethodModified: aMethodModified [
+
+	aMethodModified oldMethod saveBcToASTCacheWithAST:
+		aMethodModified oldMethod ast
+]
+
+{ #category : 'class initialization' }
+RFReflectivityASTCacheStrategy class >> initialize [
+
+	self subscribeToMethodModified
+]
+
+{ #category : 'system annoucements' }
+RFReflectivityASTCacheStrategy class >> subscribeToMethodModified [
+
+	<script>
+	self codeChangeAnnouncer weak
+		when: MethodModified
+		send: #handleMethodModified:
+		to: self
+]
+
 { #category : 'accessing' }
 RFReflectivityASTCacheStrategy >> getASTFor: aCompiledMethod [
 	^ aCompiledMethod reflectiveMethod

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -33,7 +33,9 @@ ReflectiveMethod >> ast [
 
 { #category : 'evaluation' }
 ReflectiveMethod >> compileAST [
+
 	| method |
+	compiledMethod saveBcToASTCacheWithAST: ast.
 	OCASTSemanticCleaner clean: ast.
 	ast compilationContext
 		semanticAnalyzerClass: RFSemanticAnalyzer;
@@ -43,7 +45,7 @@ ReflectiveMethod >> compileAST [
 	"#generateMethod sets the generated method as a property, put back the old"
 	ast compiledMethod: compiledMethod.
 	method sourcePointer: compiledMethod sourcePointer.
-	^method.
+	^ method
 ]
 
 { #category : 'evaluation' }


### PR DESCRIPTION
Adds "on stack replacement" feature to Reflectivity: a context can now change the method it is executing without restarting it, **if and only if we replace the method by a reflective version of this method that adds `#before` and/or `#after` metalinks.

This will be used to install breakpoints (debug points) directly in the debugger without restarting the program: A second PR is coming in NewTools for that.

To replace the method by a reflective version of it that adds code to it, I search for all contexts in the corresponding process that execute the method that should be replaced and for each of them I:
- detect if it is a block or a method context, to recover the bytecodes of the old method and the bytecodes of the new method that should be compared
- I compare the bytecodes one by one between  the two versions of the block/method, using the description of the symbolic bytecodes.
- I change the pc of the context to **the pc of the first bytecode in the new method that is after the last executed bytecode in the old method**
- I search for block closures the value stack of this context, and I replace the compiled block of each closure by the compiled block in the reflective method that has the same AST than the old one

@StevenCostiou 