### PR TITLE
Catch CmCommandAborted in Calypso

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -74,7 +74,7 @@ ClyMethodEditorToolMorph >> chooseClassForNewMethodIfNone: aBlock [
 			requestSingleObject: 'Where to install new method?'
 			from: (ClyAllClassesQuery as: ClyMethodVisibilityProviderAnnotation defaultHierarchy asQueryResult)
 			inScope: (ClyClassScope ofAll: targetClasses)]
-		on: CmdCommandAborted do: [:err | aBlock value ]
+		on: CmdCommandAborted, CmCommandAborted do: [:err | aBlock value ]
 ]
 
 { #category : 'events handling' }

--- a/src/Calypso-SystemTools-Core/ClyMethodExtensionSwitchMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodExtensionSwitchMorph.class.st
@@ -65,6 +65,6 @@ ClyMethodExtensionSwitchMorph >> label [
 { #category : 'operations' }
 ClyMethodExtensionSwitchMorph >> toggle [
 
-	[ownerTool toggleExtendingPackage] on: CmdCommandAborted do: [ :err | ].
+	[ownerTool toggleExtendingPackage] on: CmdCommandAborted, CmCommandAborted do: [ :err | ].
 	checkbox updateLabel
 ]

--- a/src/Calypso-SystemTools-Core/ClyProtocolEditorMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyProtocolEditorMorph.class.st
@@ -139,7 +139,7 @@ ClyProtocolEditorMorph >> printProtocolOrPackage [
 { #category : 'operations' }
 ClyProtocolEditorMorph >> requestChangeBy: aBlock [
 
-	aBlock on: CmdCommandAborted do: [ :err ].
+	aBlock on: CmdCommandAborted, CmCommandAborted do: [ :err ].
 
 	self update
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClyBrowserMorph.extension.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyBrowserMorph.extension.st
@@ -25,7 +25,7 @@ ClyBrowserMorph >> chooseClassToBrowseFrom: aClassNamePattern [
 
 	^[self searchDialog
 		requestSingleObject: 'Choose a class to browse...'
-		from: query] on: CmdCommandAborted do: [ nil ]
+		from: query] on: CmdCommandAborted, CmCommandAborted do: [ nil ]
 ]
 
 { #category : '*Calypso-SystemTools-FullBrowser' }


### PR DESCRIPTION
Calypso was written with Commander 1. But we started to introduce Commander2 commands also in SystemCommands. 

Here is a PR so that error handling of Calypso manages both Commander1 and 2 errors. This will allow me to migrate some code from Commander 1 to Commander 2. This should be the first step to fix a dependency problem with 'Commander-Core' (this requires a second step after this one)