### PR TITLE
[Backport] Remove usage of cached repository from file base repositories

### DIFF
--- a/src/Monticello/MCFileBasedRepository.class.st
+++ b/src/Monticello/MCFileBasedRepository.class.st
@@ -32,27 +32,20 @@ MCFileBasedRepository class >> flushAllCaches [
 ]
 
 { #category : 'settings' }
-MCFileBasedRepository class >> monticelloSettingsOn: aBuilder [  
-	<systemsettings>  
+MCFileBasedRepository class >> monticelloSettingsOn: aBuilder [
+
+	<systemsettings>
 	(aBuilder group: #monticello)
 		label: 'Monticello';
 		parent: #SCM;
 		description: 'All Monticello settings';
-		with: [ 
+		with: [
 			(aBuilder setting: #defaultDirectoryName)
 				type: #Directory;
 				target: MCDirectoryRepository;
-				description: 'The path of a directory where you want to start out when choosing local repository locations' ;
+				description: 'The path of a directory where you want to start out when choosing local repository locations';
 				default: FileSystem workingDirectory fullName;
-				label: 'Default local repository directory'.
-			(aBuilder setting: #cacheDirectory)
-				type: #Directory;
-				target: MCCacheRepository;
-				default: (FileLocator localDirectory / 'package-cache') asFileReference;
-				description: 'The path of the local repository cache';
-				label: 'Local cache directory'.	
-				
-				].
+				label: 'Default local repository directory' ]
 ]
 
 { #category : 'accessing' }
@@ -148,10 +141,9 @@ MCFileBasedRepository >> closestAncestorVersionFor: anAncestry ifNone: errorBloc
 
 { #category : 'fetching' }
 MCFileBasedRepository >> fetchPackageNamed: aName [
+	"Do nothing when we are not remote."
 
-	| references |
-	references := self packageNamed: aName.
-	MCCacheRepository default storeVersion: references
+	
 ]
 
 { #category : 'accessing' }
@@ -198,10 +190,7 @@ MCFileBasedRepository >> loadPackageNamed: aString intoLoader: aMCVersionLoader 
 { #category : 'private' }
 MCFileBasedRepository >> loadVersionFromFileNamed: aString [
 
-	(MCCacheRepository uniqueInstance includesFileNamed: aString)
-		ifTrue: [ ^ MCCacheRepository uniqueInstance loadVersionFromFileNamed: aString].
-	
-	^ self versionReaderForFileNamed: aString do: [:r | r version]
+	^ self versionReaderForFileNamed: aString do: [ :r | r version ]
 ]
 
 { #category : 'loading' }
@@ -353,15 +342,13 @@ MCFileBasedRepository >> versionReaderForFileNamed: aString do: aBlock [
 
 { #category : 'interface' }
 MCFileBasedRepository >> versionWithInfo: aVersionInfo ifAbsent: errorBlock [
-	"get a version for the given versionInfo. always query first the packageCache and only then try to load the version from the remote location"
-	^ MCCacheRepository uniqueInstance
-		versionWithInfo: aVersionInfo 
-		ifAbsent: [
-			(self allFileNamesForVersionNamed: aVersionInfo name) do:
-				[:fileName | | version |
-				version := self versionFromRepositoryFromFileNamed: fileName.
-				version info = aVersionInfo ifTrue: [^ version]].
-			^ errorBlock value].
+	"get a version for the given versionInfo"
+
+	(self allFileNamesForVersionNamed: aVersionInfo name) do: [ :fileName |
+		| version |
+		version := self versionFromRepositoryFromFileNamed: fileName.
+		version info = aVersionInfo ifTrue: [ ^ version ] ].
+	^ errorBlock value
 ]
 
 { #category : 'accessing' }

--- a/src/Monticello/MCRepository.class.st
+++ b/src/Monticello/MCRepository.class.st
@@ -164,16 +164,6 @@ MCRepository >> printOn: aStream [
 ]
 
 { #category : 'storing' }
-MCRepository >> storeDependencies: aVersion [
-	MCCacheRepository uniqueInstance cacheAllFileNamesDuring: 
-		[self cacheAllFileNamesDuring: 
-			[aVersion allAvailableDependenciesDo:
-				[:dep |
-					(self includesVersionNamed: dep info name)
-						ifFalse: [self storeVersion: dep]]]]
-]
-
-{ #category : 'storing' }
 MCRepository >> storeVersion: aVersion [
 
 	self basicStoreVersion: aVersion

--- a/src/MonticelloRemoteRepositories/MCFtpRepository.class.st
+++ b/src/MonticelloRemoteRepositories/MCFtpRepository.class.st
@@ -3,7 +3,7 @@ I am an monticello repository implementation for the FTP protocol.
 "
 Class {
 	#name : 'MCFtpRepository',
-	#superclass : 'MCFileBasedRepository',
+	#superclass : 'MCRemoteFileBasedRepository',
 	#instVars : [
 		'host',
 		'directory',

--- a/src/MonticelloRemoteRepositories/MCHttpRepository.class.st
+++ b/src/MonticelloRemoteRepositories/MCHttpRepository.class.st
@@ -4,7 +4,7 @@ I support the general protocol for listing files in a remote repository.
 "
 Class {
 	#name : 'MCHttpRepository',
-	#superclass : 'MCFileBasedRepository',
+	#superclass : 'MCRemoteFileBasedRepository',
 	#instVars : [
 		'location',
 		'user',

--- a/src/MonticelloRemoteRepositories/MCRemoteFileBasedRepository.class.st
+++ b/src/MonticelloRemoteRepositories/MCRemoteFileBasedRepository.class.st
@@ -1,0 +1,48 @@
+"
+I am a repository representing a remove file bsed repository. I'll mostly add some caching of the code I'm loading so that if we load it mulitple times, we do not need to get the code from the remote location all the time.
+"
+Class {
+	#name : 'MCRemoteFileBasedRepository',
+	#superclass : 'MCFileBasedRepository',
+	#category : 'MonticelloRemoteRepositories',
+	#package : 'MonticelloRemoteRepositories'
+}
+
+{ #category : 'testing' }
+MCRemoteFileBasedRepository class >> isAbstract [
+	^ self = MCRemoteFileBasedRepository 
+]
+
+{ #category : 'testing' }
+MCRemoteFileBasedRepository class >> monticelloSettingsOn: aBuilder [
+
+	<systemsettings>
+	(aBuilder setting: #cacheDirectory)
+		type: #Directory;
+		parent: #monticello;
+		target: MCCacheRepository;
+		default: (FileLocator localDirectory / 'package-cache') asFileReference;
+		description: 'The path of the local repository cache';
+		label: 'Local cache directory'
+]
+
+{ #category : 'fetching' }
+MCRemoteFileBasedRepository >> fetchPackageNamed: aName [
+
+	MCCacheRepository default storeVersion: (self packageNamed: aName)
+]
+
+{ #category : 'private' }
+MCRemoteFileBasedRepository >> loadVersionFromFileNamed: aString [
+
+	(MCCacheRepository uniqueInstance includesFileNamed: aString) ifTrue: [ ^ MCCacheRepository uniqueInstance loadVersionFromFileNamed: aString ].
+
+	super loadVersionFromFileNamed: aString
+]
+
+{ #category : 'interface' }
+MCRemoteFileBasedRepository >> versionWithInfo: aVersionInfo ifAbsent: errorBlock [
+	"get a version for the given versionInfo. always query first the packageCache and only then try to load the version from the remote location"
+
+	^ MCCacheRepository uniqueInstance versionWithInfo: aVersionInfo ifAbsent: [ super versionWithInfo: aVersionInfo ifAbsent: errorBlock ]
+]


### PR DESCRIPTION
All FileBasedRepositories in Monticello are using a MCCachedRepository to save all fetched packages in a package cache. 

This can be useful when we have a remote file based repository to avoid using the network too much, but this seems overkill for local repositories. I propose to push that down in the hierarchy to use this mecanism only on remote file based repositories.

This might also fix some issues with TonelRepositories that sometimes fails to save code with complex slots.

I'm proposing a backport because this fixes a bug in Famix CI