### PR TITLE
 Add custom comparator support to SequenceableCollection

### DIFF
--- a/src/Collections-Abstract-Tests/TIndexAccess.trait.st
+++ b/src/Collections-Abstract-Tests/TIndexAccess.trait.st
@@ -90,6 +90,33 @@ TIndexAccess >> testIndexOfIfAbsent [
 ]
 
 { #category : 'tests - index access' }
+TIndexAccess >> testIndexOfIfAbsentUsing [
+
+	| collection equalityComparisonBlock identityComparisonBlock |
+	collection := self collectionMoreThan1NoDuplicates.
+	equalityComparisonBlock := [ : a : b | a = b ].
+	identityComparisonBlock := [ : a : b | a == b ].
+
+	self assert: (collection
+			indexOf: collection first
+			ifAbsent: [ 33 ]
+			using: equalityComparisonBlock) equals: 1.
+	self assert: (collection
+			indexOf: self elementNotInForIndexAccessing
+			ifAbsent: [ 33 ]
+			using: equalityComparisonBlock) equals: 33.
+			
+	self assert: (collection
+			indexOf: collection first
+			ifAbsent: [ 33 ]
+			using: identityComparisonBlock) equals: 1.
+	self assert: (collection
+			indexOf: self elementNotInForIndexAccessing
+			ifAbsent: [ 33 ]
+			using: identityComparisonBlock) equals: 33
+]
+
+{ #category : 'tests - index access' }
 TIndexAccess >> testIndexOfStartingAt [
 
 	| element collection |
@@ -127,6 +154,47 @@ TIndexAccess >> testIndexOfStartingAtIfAbsent [
 			indexOf: self elementNotInForIndexAccessing
 			startingAt: 1
 			ifAbsent: [ 99 ]) equals: 99
+]
+
+{ #category : 'tests - index access' }
+TIndexAccess >> testIndexOfStartingAtIfAbsentUsing [
+
+	| element collection equalityComparisonBlock identityComparisonBlock |
+	collection := self collectionMoreThan1NoDuplicates.
+	element := collection first.
+	equalityComparisonBlock := [ : a : b | a = b ].
+	identityComparisonBlock := [ : a : b | a == b ].
+	self assert: (collection
+			indexOf: element
+			startingAt: 2
+			ifAbsent: [ 99 ]
+			using: equalityComparisonBlock) equals: 99.
+	self assert: (collection
+			indexOf: element
+			startingAt: 1
+			ifAbsent: [ 99 ]
+			using: equalityComparisonBlock) equals: 1.
+	self assert: (collection
+			indexOf: self elementNotInForIndexAccessing
+			startingAt: 1
+			ifAbsent: [ 99 ]
+			using: equalityComparisonBlock) equals: 99.
+			
+	self assert: (collection
+			indexOf: element
+			startingAt: 2
+			ifAbsent: [ 99 ]
+			using: identityComparisonBlock) equals: 99.
+	self assert: (collection
+			indexOf: element
+			startingAt: 1
+			ifAbsent: [ 99 ]
+			using: identityComparisonBlock) equals: 1.
+	self assert: (collection
+			indexOf: self elementNotInForIndexAccessing
+			startingAt: 1
+			ifAbsent: [ 99 ]
+			using: identityComparisonBlock) equals: 99
 ]
 
 { #category : 'tests - index access' }

--- a/src/Collections-Sequenceable/SequenceableCollection.class.st
+++ b/src/Collections-Sequenceable/SequenceableCollection.class.st
@@ -1272,6 +1272,16 @@ SequenceableCollection >> indexOf: anElement ifAbsent: exceptionBlock [
 ]
 
 { #category : 'accessing' }
+SequenceableCollection >> indexOf: anElement ifAbsent: exceptionBlock using: comparisonBlock [
+	"Answer the index of the first occurrence of anElement within the receiver. If the receiver does not contain anElement, answer the
+	result of evaluating the argument, exceptionBlock."	
+	"	(#(a b c d e) indexOf: #c ifAbsent: 7 using: [ : a : b | a = b ]) >>> 3. "
+	" 	(#(a b c d e) indexOf: #x ifAbsent: 7 using: [ : a : b | a = b ]) >>> 7 "
+
+	^ self indexOf: anElement startingAt: 1 ifAbsent: exceptionBlock using: comparisonBlock
+]
+
+{ #category : 'accessing' }
 SequenceableCollection >> indexOf: anElement startingAt: start [
        "Answer the index of the first occurrence of anElement after start within the receiver. If the receiver does not contain anElement, answer 0."
 	"(#(a b c d e) indexOf: #c startingAt: 2) >>> 3"
@@ -1291,6 +1301,21 @@ SequenceableCollection >> indexOf: anElement startingAt: start ifAbsent: excepti
 	start to: self size do:
 		[:index |
 		(self at: index) = anElement ifTrue: [^ index]].
+	^ exceptionBlock value
+]
+
+{ #category : 'accessing' }
+SequenceableCollection >> indexOf: anElement startingAt: start ifAbsent: exceptionBlock using: comparisonBlock [
+	"Answer the index of the first occurrence of anElement after start
+	within the receiver. If the receiver does not contain anElement,
+	answer the 	result of evaluating the argument, exceptionBlock."
+	"	(#(a b c d e) indexOf: #c startingAt: 2 ifAbsent: 7 using: [ : a : b | a = b ]) >>> 3. "
+	" 	(#(a b c d e) indexOf: #x startingAt: 2 ifAbsent: 7 using: [ : a : b | a = b ]) >>> 7 "
+
+
+	start to: self size do: [ : index | 
+		(comparisonBlock value: (self at: index) value: anElement) 
+			ifTrue: [ ^ index ] ].
 	^ exceptionBlock value
 ]
 


### PR DESCRIPTION
This PR introduces a new method to enhance the flexibility of item lookup in SequenceableCollection:

- `SequenceableCollection>>#indexOf:startingAt:ifAbsent:using:`
- `SequenceableCollection>>#indexOf:ifAbsent:using:`

and add relevant tests to cover the new functionality.

These methods allows specifying a custom comparison block, enabling more precise control over how items are matched within the collection.  

This enhancement is particularly useful for collections containing complex objects like FileReferences, where identity comparison is often insufficient. It provides a more robust and configurable way to search for items based on
specific criteria without modifying the collection's contents or the objects themselves. Notice that handling comparisons between objects, particularly those representing file paths or URLs, can be tricky due to the nature of object identity versus equality. An issue with `FileReference` objects highlights a common challenge: distinguishing between identical objects (the same instance in memory) versus equivalent objects (instances that represent the same value but are not necessarily the same instance).

Related to issues

- https://github.com/pharo-spec/NewTools/issues/803
- https://github.com/pharo-spec/Spec/pull/1568/files#diff-3c17de54703d070cd1141484acb53ac182273a63667fd5f739bb3c5977499567R84
- https://github.com/pharo-project/pharo/issues/16911
- https://github.com/pharo-project/pharo/issues/16855

