### PR TITLE
Add isPackage

### DIFF
--- a/src/Kernel-CodeModel-Tests/PackageTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageTest.class.st
@@ -356,6 +356,12 @@ PackageTest >> testIncludesMethodOfClassInPresenceOfOtherPackageExtensions [
 	self deny: (yPackage includesSelector: #methodDefinedInP1 ofClass: a2)
 ]
 
+{ #category : 'tests - extensions' }
+PackageTest >> testIsPackage [
+
+	self assert: self class package name asPackage isPackage
+]
+
 { #category : 'tests' }
 PackageTest >> testIsTestPackage [
 

--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -397,6 +397,12 @@ Package >> isEmpty [
 ]
 
 { #category : 'testing' }
+Package >> isPackage [
+
+	^ true
+]
+
+{ #category : 'testing' }
 Package >> isTestPackage [
 	"1. Test package ends with suffix -Tests. Suffix is case sensitive.
 	 2. Or test package contains '-Tests-' in middle.

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1151,6 +1151,12 @@ Object >> isNumber [
 	^ false
 ]
 
+{ #category : 'testing' }
+Object >> isPackage [
+
+	^ false
+]
+
 { #category : 'pinning' }
 Object >> isPinned [
 	"self


### PR DESCRIPTION
This PR adds a utility method to check if an object is a `Package`, and its corresponding stupid test.

Use case: This method is useful to distinguish between multiple objects in a browser history.