### PR TITLE
Fix bug in protocol management of Traits

### DIFF
--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -111,10 +111,6 @@ ShiftClassBuilder >> build [
 	self createMetaclass.
 	self createClass.
 
-	self oldClass ifNotNil: [
-		self copyProtocols.
-		self newClass commentSourcePointer: self oldClass commentSourcePointer ].
-
 	self createSharedVariables.
 
 	self installSlotsAndVariables.
@@ -236,6 +232,11 @@ ShiftClassBuilder >> createClass [
 		slots: (self withAdditionalSlots: self slots).
 
 	newClass environment: self installingEnvironment.
+	
+	"Since Traits might add some methods in #classCreated:, we need to copy the protocols before we add them."
+	self oldClass ifNotNil: [
+		self copyProtocols.
+		self newClass commentSourcePointer: self oldClass commentSourcePointer ].
 
 	self builderEnhancer classCreated: self
 ]

--- a/src/Traits-Tests/ShTraitInstallerTest.class.st
+++ b/src/Traits-Tests/ShTraitInstallerTest.class.st
@@ -7,6 +7,26 @@ Class {
 }
 
 { #category : 'tests' }
+ShTraitInstallerTest >> testAddingATraitToAClassHasRightProtocolsOnMetaclass [
+	"Regression test. Some methods were copied on the method dic of a metaclass but the protocols were lost"
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #SHClass;
+			            package: self generatedClassesPackageName ].
+
+	newClass := ShiftClassInstaller make: [ :builder |
+		            builder
+			            name: #SHClass;
+			            traits: { TViewModelMock };
+			            package: self generatedClassesPackageName ].
+
+	self assert: (newClass methods allSatisfy: [ :method | method protocol isNotNil ]).
+	self assert: (newClass class methods allSatisfy: [ :method | method protocol isNotNil ]).
+	self assert: (newClass class class methods allSatisfy: [ :method | method protocol isNotNil ])
+]
+
+{ #category : 'tests' }
 ShTraitInstallerTest >> testCreatingFullTraitHasAllElements [
 
 	newClass := ShiftClassInstaller make: [ :builder |


### PR DESCRIPTION
It happens currently that some methods copied from traits are not well categorized with their protocols.

This happens because we add the Traits methods in the class we are compiling before we copy the old protocols of the class.

I'm fixing the problem be copying the old protocols sooner and I'm adding a regression test that was failing before and is now passing.

This should fix the CI failures of https://github.com/pharo-spec/Spec/pull/1565 and https://github.com/pharo-spec/Spec/pull/1573