### PR TITLE
Remove useless method: CompiledMethod >> argumentNames

### DIFF
--- a/src/Kernel-CodeModel/CompiledMethod.class.st
+++ b/src/Kernel-CodeModel/CompiledMethod.class.st
@@ -134,11 +134,6 @@ CompiledMethod >> allIgnoredNotImplementedSelectors [
 		  ifNil: [ #(  ) ]
 ]
 
-{ #category : 'source code management' }
-CompiledMethod >> argumentNames [
-	^ self propertyAt: #argumentNames ifAbsent: [ super argumentNames ]
-]
-
 { #category : 'accessing - pragmas & properties' }
 CompiledMethod >> cachePragmas [
 


### PR DESCRIPTION
Removes a method doing the same thing in the superclass. We were looking the cache two times