### PR TITLE
Move UndefinedClassVariable out of the Kernel

### DIFF
--- a/src/ClassParser/UndefinedClassVariable.class.st
+++ b/src/ClassParser/UndefinedClassVariable.class.st
@@ -10,9 +10,9 @@ Class {
 		'ast',
 		'classIsRebuild'
 	],
-	#category : 'Kernel-Variables',
-	#package : 'Kernel',
-	#tag : 'Variables'
+	#category : 'ClassParser-Utils',
+	#package : 'ClassParser',
+	#tag : 'Utils'
 }
 
 { #category : 'instance creation' }


### PR DESCRIPTION
UndefinedClassVariable is used only in the ClassParser and nowhere else. It is currently packaged in Kernel and I propose to move it to the ClassParser since it's the only user and it will reduce the size of the Kernel.