### PR TITLE
16923-ReferenceFinder-should-not-look-at-ephemeron-references 

### DIFF
--- a/src/ReferenceFinder-Core/ReferenceFinder.class.st
+++ b/src/ReferenceFinder-Core/ReferenceFinder.class.st
@@ -244,9 +244,16 @@ ReferenceFinder >> searchIndicesIn: anObject [
 { #category : 'private' }
 ReferenceFinder >> searchVariablesIn: anObject [
 
-	| class |
+		| class |
 	class := self _objectClass: anObject.
-	1 to: class instSize do: [ :i | (self processLinkTo: (self _object: anObject instVarAt: i) from: anObject) ifNotNil: [ :path | ^ path ] ].
+	(class isEphemeronClass ifTrue: [ 2 ] ifFalse: [ 1 ])
+		to: class instSize
+		do: [ :i | 
+			| path |
+			path := self
+					processLinkTo: (self _object: anObject instVarAt: i)
+					from: anObject.
+			path ifNotNil: [ ^ path ] ].
 	^ nil
 ]
 

--- a/src/ReferenceFinder-Core/ReferenceFinderTest.class.st
+++ b/src/ReferenceFinder-Core/ReferenceFinderTest.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : 'ReferenceFinderTest',
+	#superclass : 'TestCase',
+	#category : 'ReferenceFinder-Core-Base',
+	#package : 'ReferenceFinder-Core',
+	#tag : 'Base'
+}
+
+{ #category : 'tests' }
+ReferenceFinderTest >> testEphemeronsAreIgnored [
+	| obj dict |
+	obj := Object new.
+	dict := WeakKeyDictionary new.
+	dict at: obj put: 1.
+	self assert: (ReferenceFinder findPathTo: obj from: dict) isNil
+]


### PR DESCRIPTION
add test and fix  from issue tracker

Fixes #16923.

(this adds the test for now in the package, should be moved to a test package later)