### PR TITLE
16927-todo-optimization-evaluates-argument-before-receiver 

### DIFF
--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -371,6 +371,12 @@ OCASTTranslator >> emitToDo: aMessageNode step: step [
 	block := aMessageNode arguments last.
 	iterator := block arguments first variable.
 
+	
+	"evaluate the receiver first"
+	self visitNode: aMessageNode receiver.
+	iterator emitStore: methodBuilder.
+
+	"now the limit argument"
 	limitEmit := [self visitNode: limit].
 	"if the limit is not just a literal or a non-writable variable, make a temp store it there"
 	(limit isLiteralNode or: [limit isVariable and: [limit variable isWritable not]]) ifFalse: [
@@ -381,8 +387,7 @@ OCASTTranslator >> emitToDo: aMessageNode step: step [
 		limitEmit := [methodBuilder pushTemp: ('0limit_', iterator name)]].
 
 	"push start. allocate and initialize iterator"
-	self visitNode: aMessageNode receiver.
-	iterator emitStore: methodBuilder.
+
 	methodBuilder jumpBackTarget: #start.
 	iterator emitValue: methodBuilder.
 	limitEmit value.

--- a/src/OpalCompiler-Tests/OCCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OCCompilerTest.class.st
@@ -198,6 +198,15 @@ OCCompilerTest >> testNoShadowing [
 		^nil ]
 ]
 
+{ #category : 'tests' }
+OCCompilerTest >> testOptimizedToDo [
+	| stream results |
+	results := OrderedCollection new.
+	stream := #( 1 5 ) readStream.
+	stream next to: stream next do: [ :i | results add: i ].
+	self assertCollection: results  hasSameElements: #(1 2 3 4 5)
+]
+
 { #category : 'tests - shadowing' }
 OCCompilerTest >> testPseudoVariableShadowing [
 


### PR DESCRIPTION
add test and make sure that we evaluate the receiver fist in OCASTTranslator>>#emitToDo:step:

fixes #16927