### PR TITLE
Update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -6,6 +6,19 @@ labels: 'Type: Bug'
 assignees: ''
 
 ---
+Thanks for taking the time to fill out this bug report 🤗
+Please make sure there aren't any open/closed issues for this topic 😃
+
+**Is this the right place to report this issue?**
+
+Please note that projects have their own repositories and issue trackers:
+
+Pharo Launcher -> https://github.com/pharo-project/pharo-launcher
+Virtual Machine -> https://github.com/pharo-project/pharo-vm
+Spec -> https://github.com/pharo-spec/Spec
+GTK -> https://github.com/pharo-spec/Spec-Gtk and https://github.com/pharo-spec/gtk-bindings
+NewTools (Debugger, Playground, CodeCritiques, Spotter, New File Browser, New Finder, New Settings Browser) -> https://github.com/pharo-spec/NewTools
+Roassal -> https://github.com/ObjectProfile/Roassal3
 
 **Bug description**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/cleanup-report.md
+++ b/.github/ISSUE_TEMPLATE/cleanup-report.md
@@ -6,6 +6,19 @@ labels: 'Type: Cleanup'
 assignees: ''
 
 ---
+Thanks for taking the time to fill out this cleanup 🤗
+Please make sure there aren't any open/closed cleanup for this topic 😃
+
+**Is this the right place to report this cleanup?**
+
+Please note that projects have their own repositories and issue trackers:
+
+Pharo Launcher -> https://github.com/pharo-project/pharo-launcher
+Virtual Machine -> https://github.com/pharo-project/pharo-vm
+Spec -> https://github.com/pharo-spec/Spec
+GTK -> https://github.com/pharo-spec/Spec-Gtk and https://github.com/pharo-spec/gtk-bindings
+NewTools (Debugger, Playground, CodeCritiques, Spotter, New File Browser, New Finder, New Settings Browser) -> https://github.com/pharo-spec/NewTools
+Roassal -> https://github.com/ObjectProfile/Roassal3
 
 **Describe the problem**
 A clear and concise description of what the problem is.

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -6,9 +6,22 @@ labels: 'Type: Enhancement'
 assignees: ''
 
 ---
-
 _An enhancement is a slight modification of an existing behavior. If you want a new feature use the 
 feature request template._
+
+Thanks for taking the time to fill out this enhacement request 🤗
+Please make sure there aren't any open/closed enhacement request for this topic 😃
+
+**Is this the right place to report this enhacement request?**
+
+Please note that projects have their own repositories and issue trackers:
+
+Pharo Launcher -> https://github.com/pharo-project/pharo-launcher
+Virtual Machine -> https://github.com/pharo-project/pharo-vm
+Spec -> https://github.com/pharo-spec/Spec
+GTK -> https://github.com/pharo-spec/Spec-Gtk and https://github.com/pharo-spec/gtk-bindings
+NewTools (Debugger, Playground, CodeCritiques, Spotter, New File Browser, New Finder, New Settings Browser) -> https://github.com/pharo-spec/NewTools
+Roassal -> https://github.com/ObjectProfile/Roassal3
 
 **Describe the request**
 A clear and concise description of what is missing and how it could be enhanced.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,8 +6,21 @@ labels: 'Type: New Feature'
 assignees: ''
 
 ---
-
 _A new feature is some behavior that is not existing already. If what you describe is a slight variation of something already existing please use a enhancement request._
+
+Thanks for taking the time to fill out this feature request 🤗
+Please make sure there aren't any open/closed request for this topic 😃
+
+**Is this the right place to report this request?**
+
+Please note that projects have their own repositories and issue trackers:
+
+Pharo Launcher -> https://github.com/pharo-project/pharo-launcher
+Virtual Machine -> https://github.com/pharo-project/pharo-vm
+Spec -> https://github.com/pharo-spec/Spec
+GTK -> https://github.com/pharo-spec/Spec-Gtk and https://github.com/pharo-spec/gtk-bindings
+NewTools (Debugger, Playground, CodeCritiques, Spotter, New File Browser, New Finder, New Settings Browser) -> https://github.com/pharo-spec/NewTools
+Roassal -> https://github.com/ObjectProfile/Roassal3
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]


### PR DESCRIPTION
PR to update the GitHub templates with links to other Pharo-related repositories, as described in #16922 
