### PR TITLE
Fix for SettingsBrowser shows rule class and not rule text

### DIFF
--- a/src/Renraku/ReRuleManager.class.st
+++ b/src/Renraku/ReRuleManager.class.st
@@ -238,7 +238,7 @@ ReRuleManager class >> subSettingsOn: aBuilder with: rules [
 			  selector: #enabled;
 			  target: rule;
 			  default: rule enabled;
-			  label: rule name;
+			  label: rule ruleName;
 			  description: rule rationale ]
 ]
 


### PR DESCRIPTION
This PR updates a method to use ruleName instead of the deprecated name to get Renraku rule names for Setting Browser, as reported by @astares in #16912 