### PR TITLE
Fix Duplicate class command UX issues

### DIFF
--- a/src/Refactoring-UI/ReDuplicateClassDriver.class.st
+++ b/src/Refactoring-UI/ReDuplicateClassDriver.class.st
@@ -70,6 +70,8 @@ ReDuplicateClassDriver >> requestNewClass [
 		requestDialog := (StClassAndMethodsSelectionPresenter on: self)
 			withInstanceMethods: rbClass methods
 			withClassMethods: rbMetaclass allMethods;
+			baseClassName: self className;
+			basePackageName: (self model environment at: self className) packageName;
 			onCancel: [ : dialog | dialog close ];
 			onAccept: [ :dialog |
 				self

--- a/src/Refactoring-UI/StClassAndMethodsSelectionPresenter.class.st
+++ b/src/Refactoring-UI/StClassAndMethodsSelectionPresenter.class.st
@@ -52,7 +52,7 @@ StClassAndMethodsSelectionPresenter >> baseClassName: aString [
 	textInput text: aString
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 StClassAndMethodsSelectionPresenter >> basePackageName: aString [
 
  	packagePresenter selectItem: aString.

--- a/src/Refactoring-UI/StClassAndMethodsSelectionPresenter.class.st
+++ b/src/Refactoring-UI/StClassAndMethodsSelectionPresenter.class.st
@@ -45,6 +45,19 @@ StClassAndMethodsSelectionPresenter class >> defaultExtent [
 	^ 500 @ 700
 ]
 
+{ #category : 'initialization' }
+StClassAndMethodsSelectionPresenter >> baseClassName: aString [
+	"By default set a name close to the original one."
+
+	textInput text: aString
+]
+
+{ #category : 'as yet unclassified' }
+StClassAndMethodsSelectionPresenter >> basePackageName: aString [
+
+ 	packagePresenter selectItem: aString.
+]
+
 { #category : 'accessing' }
 StClassAndMethodsSelectionPresenter >> classMethods [
 


### PR DESCRIPTION
This PR adds two methods to set defaults in the duplicate class presenter dialog, as requested by @jecisc in #16921.

It also updates the requestNewClass method to set reasonable UX defaults.

