### PR TITLE
Rename 'copy all package' to 'duplicate package'

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/SycDuplicatePackageCommand.extension.st
+++ b/src/Calypso-SystemTools-FullBrowser/SycDuplicatePackageCommand.extension.st
@@ -1,14 +1,14 @@
-Extension { #name : 'SycCopyPackageCommand' }
+Extension { #name : 'SycDuplicatePackageCommand' }
 
 { #category : '*Calypso-SystemTools-FullBrowser' }
-SycCopyPackageCommand class >> fullBrowserMenuActivation [
+SycDuplicatePackageCommand class >> fullBrowserMenuActivation [
 	<classAnnotation>
 
 	^CmdContextMenuActivation byRootGroupItemOrder: 1.1 for: ClyFullBrowserPackageContext
 ]
 
 { #category : '*Calypso-SystemTools-FullBrowser' }
-SycCopyPackageCommand class >> fullBrowserShortcutActivation [
+SycDuplicatePackageCommand class >> fullBrowserShortcutActivation [
 	<classAnnotation>
 
 	^CmdShortcutActivation by: $c meta for: ClyFullBrowserPackageContext

--- a/src/SystemCommands-PackageCommands/SycDuplicatePackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycDuplicatePackageCommand.class.st
@@ -8,7 +8,7 @@ Internal Representation and Key Implementation Points.
 	package:		<Package>
 "
 Class {
-	#name : 'SycCopyPackageCommand',
+	#name : 'SycDuplicatePackageCommand',
 	#superclass : 'CmdCommand',
 	#category : 'SystemCommands-PackageCommands-Scope',
 	#package : 'SystemCommands-PackageCommands',
@@ -16,23 +16,23 @@ Class {
 }
 
 { #category : 'testing' }
-SycCopyPackageCommand class >> canBeExecutedInContext: aToolContext [
+SycDuplicatePackageCommand class >> canBeExecutedInContext: aToolContext [
 
 	^ aToolContext isPackageSelected
 ]
 
 { #category : 'accessing' }
-SycCopyPackageCommand >> defaultMenuIconName [
+SycDuplicatePackageCommand >> defaultMenuIconName [
 	^#smallCopy
 ]
 
 { #category : 'accessing' }
-SycCopyPackageCommand >> defaultMenuItemName [
-	^'Copy all package'
+SycDuplicatePackageCommand >> defaultMenuItemName [
+	^'Duplicate package'
 ]
 
 { #category : 'execution' }
-SycCopyPackageCommand >> prepareFullExecutionInContext: aToolContext [
+SycDuplicatePackageCommand >> prepareFullExecutionInContext: aToolContext [
 
 	| dialog package newName |
 


### PR DESCRIPTION
"Copy class" has been renamed into "Duplicate class". So I think it is fitting to rename it "Duplicate package". 

Fixes #16978