### PR TITLE
Make #postload:package: on BaselineOfIDE set PharoLightTheme as current again

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -296,7 +296,7 @@ BaselineOfIDE >> postload: loader package: packageSpec [
 
 	RubAbstractTextArea highlightMessageSend: true.
 
-	DarkBlueTheme beCurrent.
+	PharoLightTheme beCurrent.
 
 	SDL_Event initialize.
 


### PR DESCRIPTION
This pull request makes `#postload:package:` on BaselineOfIDE set PharoLightTheme as current again to be consistent with it being the default (see issue #16797).