### PR TITLE
Missing default setting in Cly navigation history configuraiton

### DIFF
--- a/src/Calypso-Browser/ClyBrowserMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserMorph.class.st
@@ -178,7 +178,7 @@ ClyBrowserMorph class >> settingsNavigationHistoryOn: aBuilder [
 		parent: #Calypso;
 		label: 'Navigation History';
 		domainValues: ClyNavigationHistory withAllSubclasses;
-		default: ClyNavigationHistory;
+		default: self navigationHistoryClass;
 		description: 'Enable to set a custom navigation history to handle how collection of visited items is managed';
 		target: self
 ]


### PR DESCRIPTION
One-line commit since I forgot the get the default from a setting class variable. Related to #16982 
