### PR TITLE
Rename SystemDictionary into SystemEnvironment

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -156,6 +156,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" initializePackages --proto
 echo $(date -u) "[Compiler] Installing compiler through Hermes"
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Debugging-Utils.hermes OpalCompiler-Core.hermes CodeImport.hermes CodeImportCommandLineHandlers.hermes --save --no-fail-on-undeclared
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "OpalCompiler register. CompilationContext initialize. OCASTTranslator initialize."
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "SystemEnvironment deprecatedAliases: { #SystemDictionary }." # This line should be removed in Pharo 14 since it is for backward compatibility.
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/01-init.st --no-source --save --quit
 
 echo $(date -u) "[Compiler] Initializing Unicode"

--- a/src/Collections-Unordered-Tests/DictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/DictionaryTest.class.st
@@ -266,7 +266,7 @@ DictionaryTest >> otherCollection [
 DictionaryTest >> otherDictionaryClasses [
 	"(DictionaryTest withAllSubclasses collect: [:each | each new classToBeTested]) asArray"
 	^ {SmallDictionary. IdentityDictionary. PluggableDictionary.
-		WeakValueDictionary. SystemDictionary. WeakKeyDictionary. SmallIdentityDictionary.
+		WeakValueDictionary. SystemEnvironment. WeakKeyDictionary. SmallIdentityDictionary.
 		WeakIdentityKeyDictionary. Dictionary}
 			reject: [:each | each new species == self classToBeTested new species]
 ]

--- a/src/Fuel-Core-Tests/FLBasicSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLBasicSerializationTest.class.st
@@ -765,8 +765,8 @@ FLBasicSerializationTest >> testSymbol [
 ]
 
 { #category : 'tests-globals' }
-FLBasicSerializationTest >> testSystemDictionary [
-	"We want to treat the <Smalltalk globals> instance of SystemDictionary
+FLBasicSerializationTest >> testSystemEnvironment [
+	"We want to treat the <Smalltalk globals> instance of SystemEnvironment
 	specially but want to serialize all others"
 
 	self assertSerializationEqualityOf: SystemEnvironment new

--- a/src/Fuel-Core-Tests/FLBasicSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLBasicSerializationTest.class.st
@@ -769,7 +769,7 @@ FLBasicSerializationTest >> testSystemDictionary [
 	"We want to treat the <Smalltalk globals> instance of SystemDictionary
 	specially but want to serialize all others"
 
-	self assertSerializationEqualityOf: SystemDictionary new
+	self assertSerializationEqualityOf: SystemEnvironment new
 ]
 
 { #category : 'tests' }

--- a/src/Fuel-Core-Tests/FLSystemGlobalsTestResource.class.st
+++ b/src/Fuel-Core-Tests/FLSystemGlobalsTestResource.class.st
@@ -23,7 +23,7 @@ FLSystemGlobalsTestResource >> globals [
 FLSystemGlobalsTestResource >> setUp [
 	super setUp.
 
-	globals := SystemDictionary new: Smalltalk globals size.
+	globals := SystemEnvironment new: Smalltalk globals size.
 	"Can't use #newFrom: because associations must be unique"
 	Smalltalk globals keysAndValuesDo: [ :key :value |
 		globals

--- a/src/Fuel-Core/SystemEnvironment.extension.st
+++ b/src/Fuel-Core/SystemEnvironment.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : 'SystemDictionary' }
+Extension { #name : 'SystemEnvironment' }
 
 { #category : '*Fuel-Core' }
-SystemDictionary >> fuelAccept: aGeneralMapper [
+SystemEnvironment >> fuelAccept: aGeneralMapper [
 	"serialize all instances except for <Smalltalk globals>"
 	^ self == Smalltalk globals 
 		ifFalse: [ super fuelAccept: aGeneralMapper ]
@@ -9,13 +9,13 @@ SystemDictionary >> fuelAccept: aGeneralMapper [
 ]
 
 { #category : '*Fuel-Core' }
-SystemDictionary class >> materializeFrom: aDecoder [
+SystemEnvironment class >> materializeFrom: aDecoder [
 	"Answer my well-known instance"
 
 	^ Smalltalk globals
 ]
 
 { #category : '*Fuel-Core' }
-SystemDictionary >> serializeOn: anEncoder [
+SystemEnvironment >> serializeOn: anEncoder [
 	"Do nothing"
 ]

--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -1,7 +1,7 @@
 "
 I add a number of facilities to those in ClassDescription:
 	A set of all my subclasses (defined in ClassDescription, but only used here and below)
-	A name by which I can be found in a SystemDictionary
+	A name by which I can be found in a SystemEnvironment
 	A classPool for class variables shared between this class and its metaclass
 	A list of sharedPools which probably should be supplanted by some better mechanism.
 

--- a/src/Kernel-CodeModel/PackageOrganizer.class.st
+++ b/src/Kernel-CodeModel/PackageOrganizer.class.st
@@ -1,7 +1,7 @@
 "
 I am responsible for providing all the package currently defined in an environment.
 
-The system currently hold a global environment with a default package organizer but it is possible to create new enviornemnt with `SystemDictionary new` and they will come with a new package organizer.
+The system currently hold a global environment with a default package organizer but it is possible to create new enviornemnt with `SystemEnvironment new` and they will come with a new package organizer.
 
 I am used as en entry point to access packages and tags and update the model.
 "
@@ -103,8 +103,8 @@ PackageOrganizer >> environment [
 ]
 
 { #category : 'accessing' }
-PackageOrganizer >> environment: aSystemDictionary [
-	 environment := aSystemDictionary
+PackageOrganizer >> environment: aSystemEnvironment [
+	 environment := aSystemEnvironment
 ]
 
 { #category : 'testing' }

--- a/src/NautilusRefactoring/RBRefactoring.extension.st
+++ b/src/NautilusRefactoring/RBRefactoring.extension.st
@@ -3,5 +3,5 @@ Extension { #name : 'RBRefactoring' }
 { #category : '*NautilusRefactoring' }
 RBRefactoring >> whatToDisplayIn: aBrowser [
 
-	^ (self changes changes collect: [:change | change onSystemDictionary: self model environment systemDictionary]) flatCollect: [:e | e whatToDisplayIn: aBrowser ]
+	^ (self changes changes collect: [:change | change onSystemEnvironment: self model environment systemDictionary]) flatCollect: [:e | e whatToDisplayIn: aBrowser ]
 ]

--- a/src/OpalCompiler-Core/CompilationContext.class.st
+++ b/src/OpalCompiler-Core/CompilationContext.class.st
@@ -9,7 +9,7 @@ semanticScope <SemapticScope> defines the meaning of the code which is compiled 
 logged <Boolean> true if the sources will be logged in external logging system (change file, epicea, ...)
 interactive <Boolean> Interactive mode is typically used in the IDE (showing errors when compiling code inlined,  pop-ups for some errors/warnings, ...), non-interactive mode is used for headless & code loading to compile code by logging into stdout or Transcript but no interaction required by the user.
 options <Set of Symbols> See optionsDescription method comment class side
-environment <SystemDictionary> place to look for literal variables (Globals for instance)
+environment <SystemEnvironment> place to look for literal variables (Globals for instance)
 
 "
 Class {

--- a/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
+++ b/src/OpalCompiler-Tests/OCASTTranslatorTest.class.st
@@ -151,7 +151,7 @@ OCASTTranslatorTest >> setUp [
 
 	super setUp.
 	instance := OCOpalExamples new.
-	globals := SystemDictionary new
+	globals := SystemEnvironment new
 ]
 
 { #category : 'running' }

--- a/src/OpalCompiler-Tests/OCEnvironmentScopeTest.class.st
+++ b/src/OpalCompiler-Tests/OCEnvironmentScopeTest.class.st
@@ -15,7 +15,7 @@ OCEnvironmentScopeTest >> testCompileWithEnvironment [
 
 
 	| environment method return |
-	environment := SystemDictionary new.
+	environment := SystemEnvironment new.
 	environment at: #MyClass put: Point copy.
 	(environment at: #MyClass) environment: environment.
 	method := OpalCompiler new

--- a/src/PharoBootstrap/PBAbstractImageBuilder.class.st
+++ b/src/PharoBootstrap/PBAbstractImageBuilder.class.st
@@ -324,7 +324,7 @@ PBAbstractImageBuilder >> createInitialObjects [
 
 			self bootstrapInterpreter evaluateCode: 'Undeclared := UndeclaredRegistry new.'.
 			self bootstrapInterpreter evaluateCode: 'Smalltalk := SmalltalkImage basicNew.'.
-			self bootstrapInterpreter evaluateCode: 'Smalltalk instVarAt: 1 put: SystemDictionary new.'.
+			self bootstrapInterpreter evaluateCode: 'Smalltalk instVarAt: 1 put: SystemEnvironment new.'.
 			self bootstrapInterpreter evaluateCode: 'Smalltalk globals at: #Smalltalk put: Smalltalk.'.
 			self bootstrapInterpreter evaluateCode: 'Smalltalk globals at: #Undeclared put: Undeclared.'.
 

--- a/src/Refactoring-Changes/RBAddClassChange.class.st
+++ b/src/Refactoring-Changes/RBAddClassChange.class.st
@@ -34,7 +34,7 @@ RBAddClassChange class >> make: aBlock [
 RBAddClassChange >> asUndoOperation [
 
 	| class |
-	class := onSystemDictionary classNamed: self changeClassName.
+	class := onSystemEnvironment classNamed: self changeClassName.
 
 	^ class isBehavior
 		  ifTrue: [ changeFactory addClassDefinition: [ :aBuilder | aBuilder fillFor: class ] ]
@@ -82,7 +82,7 @@ RBAddClassChange >> definedClass [
 { #category : 'private' }
 RBAddClassChange >> definitionClass [
 
-	^ onSystemDictionary classNamed:
+	^ onSystemEnvironment classNamed:
 		  (self superclassName ifNil: [ #ProtoObject ])
 ]
 

--- a/src/Refactoring-Changes/RBAddMethodChange.class.st
+++ b/src/Refactoring-Changes/RBAddMethodChange.class.st
@@ -117,7 +117,7 @@ RBAddMethodChange >> hash [
 RBAddMethodChange >> oldVersionTextToDisplay [
 	| class |
 
-	class := (onSystemDictionary
+	class := (onSystemEnvironment
 					classNamed: className)
 					ifNil: [ ^ super oldVersionTextToDisplay ].
 

--- a/src/Refactoring-Changes/RBRefactoryChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChange.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'name',
 		'changeFactory',
-		'onSystemDictionary'
+		'onSystemEnvironment'
 	],
 	#category : 'Refactoring-Changes-Base',
 	#package : 'Refactoring-Changes',
@@ -73,7 +73,7 @@ RBRefactoryChange >> executeNotifying: aBlock [
 { #category : 'initialization' }
 RBRefactoryChange >> initialize [
 	super initialize.
-	onSystemDictionary := Smalltalk globals.
+	onSystemEnvironment := Smalltalk globals.
 	changeFactory := RBRefactoryChangeManager changeFactory
 ]
 
@@ -102,15 +102,15 @@ RBRefactoryChange >> oldVersionTextToDisplay [
 ]
 
 { #category : 'accessing' }
-RBRefactoryChange >> onSystemDictionary [
+RBRefactoryChange >> onSystemEnvironment [
 
-	^ onSystemDictionary
+	^ onSystemEnvironment
 ]
 
 { #category : 'accessing' }
-RBRefactoryChange >> onSystemDictionary: anObject [
+RBRefactoryChange >> onSystemEnvironment: anObject [
 
-	onSystemDictionary := anObject
+	onSystemEnvironment := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChangeManager.class.st
@@ -217,8 +217,8 @@ RBRefactoryChangeManager >> performChanges: aRefactoringChangesList [
 	| compositeChange |
 	aRefactoringChangesList ifEmpty: [ ^ self ].
 	compositeChange := RBCompositeRefactoryChange new.
-	compositeChange onSystemDictionary:
-		aRefactoringChangesList first onSystemDictionary.
+	compositeChange onSystemEnvironment:
+		aRefactoringChangesList first onSystemEnvironment.
 	compositeChange changes: aRefactoringChangesList.
 	self performCompositeChange: compositeChange
 ]

--- a/src/Refactoring-Changes/RBRefactoryClassChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryClassChange.class.st
@@ -40,7 +40,7 @@ RBRefactoryClassChange >> asUndoOperation [
 RBRefactoryClassChange >> changeClass [
 
 	| class |
-	class := onSystemDictionary
+	class := onSystemEnvironment
 		         at: self changeClassName
 		         ifAbsent: [ ^ nil ].
 	^ isMeta

--- a/src/Refactoring-Changes/RBRemoveClassChange.class.st
+++ b/src/Refactoring-Changes/RBRemoveClassChange.class.st
@@ -19,7 +19,7 @@ RBRemoveClassChange class >> remove: aClass [
 RBRemoveClassChange class >> removeClassName: aSymbol [
 
 	^ self basicNew
-		  onSystemDictionary: self environment;
+		  onSystemEnvironment: self environment;
 		  changeClassName: aSymbol;
 		  initialize
 ]

--- a/src/Refactoring-Changes/RBRenameClassChange.class.st
+++ b/src/Refactoring-Changes/RBRenameClassChange.class.st
@@ -30,8 +30,8 @@ RBRenameClassChange >> = aRenameClassChange [
 { #category : 'accessing' }
 RBRenameClassChange >> changeClass [
 
-	^ (onSystemDictionary classNamed: oldName) ifNil: [
-		  onSystemDictionary classNamed: newName ]
+	^ (onSystemEnvironment classNamed: oldName) ifNil: [
+		  onSystemEnvironment classNamed: newName ]
 ]
 
 { #category : 'private' }

--- a/src/Refactoring-Changes/RBRenameVariableChange.class.st
+++ b/src/Refactoring-Changes/RBRenameVariableChange.class.st
@@ -47,7 +47,7 @@ RBRenameVariableChange >> addNewVariable [
 RBRenameVariableChange >> changeClass [
 
 	| class |
-	class := onSystemDictionary classNamed: self changeClassName.
+	class := onSystemEnvironment classNamed: self changeClassName.
 	^ isMeta
 		  ifTrue: [ class class ]
 		  ifFalse: [ class ]

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -431,7 +431,7 @@ RBNamespace >> includesPackageNamed: aSymbol [
 { #category : 'initialization' }
 RBNamespace >> initialize [
 	super initialize.
-	changes := changeFactory compositeRefactoryChange onSystemDictionary: self environment.
+	changes := changeFactory compositeRefactoryChange onSystemEnvironment: self environment.
 	newClasses := IdentityDictionary new.
 	newPackages := IdentityDictionary new.
 	changedClasses := IdentityDictionary new.

--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -92,7 +92,7 @@ RBBrowserEnvironment >> allClasses [
 
 { #category : 'accessing - classes' }
 RBBrowserEnvironment >> allClassesAndTraits [
-	" compatibility method with SystemDictionary "
+	" compatibility method with SystemEnvironment"
 
 	| allClassesAndTraits |
 	allClassesAndTraits := OrderedCollection new: 4096.

--- a/src/Refactoring-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveDirectAccessToVariableTransformationTest.class.st
@@ -103,7 +103,7 @@ RBRemoveDirectAccessToVariableTransformationTest >> testRefactoring [
 		assert: (class parseTreeForSelector: #initialize)
 		equals: (self parseMethod: 'initialize
 	super initialize.
-	changes := changeFactory compositeRefactoryChange onSystemDictionary: self environment.
+	changes := changeFactory compositeRefactoryChange onSystemEnvironment: self environment.
 	newClasses := IdentityDictionary new.
 	newPackages := IdentityDictionary new.
 	changedClasses := IdentityDictionary new.

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -42,10 +42,10 @@ Class {
 }
 
 { #category : 'instance creation' }
-ClassFactoryForTestCase class >> environment: aSystemDictionary [
+ClassFactoryForTestCase class >> environment: aSystemEnvironment [
 
 	^ self new
-		  environment: aSystemDictionary;
+		  environment: aSystemEnvironment;
 		  yourself
 ]
 

--- a/src/SUnit-Tests/ClassFactoryWithNonDefaultEnvironmentTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryWithNonDefaultEnvironmentTest.class.st
@@ -24,7 +24,7 @@ ClassFactoryWithNonDefaultEnvironmentTest >> environment [
 ClassFactoryWithNonDefaultEnvironmentTest >> setUp [
 
 	super setUp.
-	factory := ClassFactoryForTestCase environment: SystemDictionary new
+	factory := ClassFactoryForTestCase environment: SystemEnvironment new
 ]
 
 { #category : 'testing' }

--- a/src/Slot-Tests/SlotEnvironmentTest.class.st
+++ b/src/Slot-Tests/SlotEnvironmentTest.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : 'tests' }
 SlotEnvironmentTest >> testBasicEnvironment [
 	| environment |
-	environment := SystemDictionary new.
+	environment := SystemEnvironment new.
 
 	aClass := self make: [ :builder | builder environment: environment ].
 

--- a/src/System-Announcements/ClassRenamed.class.st
+++ b/src/System-Announcements/ClassRenamed.class.st
@@ -2,7 +2,7 @@
 the announcement will be emitted when renaming a class or a trait using:  
 	=> RenameClassRefactoring >> rename:to:
 	=> class>>rename:
-The corresponding event is raised in: SystemDictionary>>renameClass:from:to:
+The corresponding event is raised in: SystemEnvironment>>renameClass:from:to:
 "
 Class {
 	#name : 'ClassRenamed',

--- a/src/System-Support-Tests/SystemEnvironmentTest.class.st
+++ b/src/System-Support-Tests/SystemEnvironmentTest.class.st
@@ -2,7 +2,7 @@
 SUnit tests for SystemDictionary
 "
 Class {
-	#name : 'SystemDictionaryTest',
+	#name : 'SystemEnvironmentTest',
 	#superclass : 'DictionaryTest',
 	#category : 'System-Support-Tests-Utilities',
 	#package : 'System-Support-Tests',
@@ -10,40 +10,40 @@ Class {
 }
 
 { #category : 'building suites' }
-SystemDictionaryTest class >> shouldInheritSelectors [
+SystemEnvironmentTest class >> shouldInheritSelectors [
 
 	^ true
 ]
 
 { #category : 'requirements' }
-SystemDictionaryTest >> associationWithKeyAlreadyInToAdd [
+SystemEnvironmentTest >> associationWithKeyAlreadyInToAdd [
 	" return an association that will be used to add to nonEmptyDict (the key of this association is already included in nonEmptyDict)"
 
 	^ GlobalVariable key: self nonEmptyDict keys anyOne value: valueNotIn
 ]
 
 { #category : 'requirements' }
-SystemDictionaryTest >> canBeUnhealthy [
+SystemEnvironmentTest >> canBeUnhealthy [
 	"uses GlobalVariables instead of associations"
 
 	^ false
 ]
 
 { #category : 'coverage' }
-SystemDictionaryTest >> classToBeTested [
+SystemEnvironmentTest >> classToBeTested [
 
-	^ SystemDictionary
+	^ SystemEnvironment
 ]
 
 { #category : 'requirements' }
-SystemDictionaryTest >> elementToAdd [
+SystemEnvironmentTest >> elementToAdd [
 	" return an element of type 'nonEmpy' elements'type'"
 
 	^ GlobalVariable key: #u value: 5
 ]
 
 { #category : 'running' }
-SystemDictionaryTest >> setUp [
+SystemEnvironmentTest >> setUp [
 
 	super setUp.
 
@@ -51,41 +51,41 @@ SystemDictionaryTest >> setUp [
 ]
 
 { #category : 'requirements' }
-SystemDictionaryTest >> supportsNilKey [
+SystemEnvironmentTest >> supportsNilKey [
 
 	^ false
 ]
 
 { #category : 'tests - DictionaryIndexAccessing' }
-SystemDictionaryTest >> testAtPutNil [
+SystemEnvironmentTest >> testAtPutNil [
 
 	self should: [ self collection at: nil put: nil ] raise: Error
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testClassOrTraitNamedReturnsClassForClasses [
+SystemEnvironmentTest >> testClassOrTraitNamedReturnsClassForClasses [
 
 	self assert: Object identicalTo: (testingEnvironment classOrTraitNamed: 'Object').
 	self assert: Object identicalTo: (testingEnvironment classOrTraitNamed: #Object)
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testClassOrTraitNamedReturnsNilForGlobals [
+SystemEnvironmentTest >> testClassOrTraitNamedReturnsNilForGlobals [
 
 	self assert: nil equals: (testingEnvironment classOrTraitNamed: 'Undeclared').
 	self assert: nil equals: (testingEnvironment classOrTraitNamed: #Undeclared)
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testEnvironmentOfOrganization [
+SystemEnvironmentTest >> testEnvironmentOfOrganization [
 
 	| aDictionary |
-	aDictionary := SystemDictionary new.
+	aDictionary := SystemEnvironment new.
 	self assert: aDictionary organization environment equals: aDictionary
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testHasBindingThatBeginsWith [
+SystemEnvironmentTest >> testHasBindingThatBeginsWith [
 
 	super testHasBindingThatBeginsWith.
 	self assert: (Smalltalk globals hasBindingThatBeginsWith: 'Obje').
@@ -93,7 +93,7 @@ SystemDictionaryTest >> testHasBindingThatBeginsWith [
 ]
 
 { #category : 'tests - testing' }
-SystemDictionaryTest >> testIncludesAssociationNoValue [
+SystemEnvironmentTest >> testIncludesAssociationNoValue [
 
 	| association dictionary |
 
@@ -109,7 +109,7 @@ SystemDictionaryTest >> testIncludesAssociationNoValue [
 ]
 
 { #category : 'tests - testing' }
-SystemDictionaryTest >> testIncludesAssociationWithValue [
+SystemEnvironmentTest >> testIncludesAssociationWithValue [
 
 	| association dictionary |
 	association := GlobalVariable key: #key value: 1.
@@ -120,31 +120,31 @@ SystemDictionaryTest >> testIncludesAssociationWithValue [
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testOrganizationPerInstance [
+SystemEnvironmentTest >> testOrganizationPerInstance [
 
-	self deny: SystemDictionary new organization equals: SystemDictionary new organization
+	self deny: SystemEnvironment new organization equals: SystemEnvironment new organization
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testOtherInstancesOfSystemDictionaryAsString [
+SystemEnvironmentTest >> testOtherInstancesOfSystemDictionaryAsString [
 
-	self deny: SystemDictionary new asString equals: 'Smalltalk'
+	self deny: SystemEnvironment new asString equals: 'Smalltalk'
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testOtherInstancesOfSystemDictionaryPrintString [
+SystemEnvironmentTest >> testOtherInstancesOfSystemDictionaryPrintString [
 
-	self deny: SystemDictionary new printString equals: 'Smalltalk'
+	self deny: SystemEnvironment new printString equals: 'Smalltalk'
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testOtherInstancesOfSystemDictionarySelfEvaluating [
+SystemEnvironmentTest >> testOtherInstancesOfSystemDictionarySelfEvaluating [
 
-	self deny: SystemDictionary new isSelfEvaluating
+	self deny: SystemEnvironment new isSelfEvaluating
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testPrintOn [
+SystemEnvironmentTest >> testPrintOn [
 
 	| printed splittedString |
 	printed := String streamContents: [ :stream |
@@ -161,10 +161,10 @@ SystemDictionaryTest >> testPrintOn [
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testSetOrganizationSetBackPointer [
+SystemEnvironmentTest >> testSetOrganizationSetBackPointer [
 
 	| systemDictionary packageOrganizer |
-	systemDictionary := SystemDictionary new.
+	systemDictionary := SystemEnvironment new.
 	packageOrganizer := PackageOrganizer new.
 	systemDictionary organization: packageOrganizer.
 	self assert: packageOrganizer environment identicalTo: systemDictionary.
@@ -172,25 +172,25 @@ SystemDictionaryTest >> testSetOrganizationSetBackPointer [
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testSmalltalkAsString [
+SystemEnvironmentTest >> testSmalltalkAsString [
 
 	self assert: Smalltalk asString equals: 'Smalltalk'
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testSmalltalkPrintString [
+SystemEnvironmentTest >> testSmalltalkPrintString [
 
 	self assert: Smalltalk printString equals: 'Smalltalk'
 ]
 
 { #category : 'tests' }
-SystemDictionaryTest >> testSmalltalkSelfEvaluating [
+SystemEnvironmentTest >> testSmalltalkSelfEvaluating [
 
 	self assert: Smalltalk isSelfEvaluating
 ]
 
 { #category : 'tests - printing' }
-SystemDictionaryTest >> testStoreOnWithNegativeInteger [
+SystemEnvironmentTest >> testStoreOnWithNegativeInteger [
 
 	| dictionary |
 	dictionary := { (GlobalVariable key: 'x' value: -1) } as: self classToBeTested.

--- a/src/System-Support-Tests/SystemEnvironmentTest.class.st
+++ b/src/System-Support-Tests/SystemEnvironmentTest.class.st
@@ -1,5 +1,5 @@
 "
-SUnit tests for SystemDictionary
+SUnit tests for SystemEnvironment
 "
 Class {
 	#name : 'SystemEnvironmentTest',
@@ -126,19 +126,19 @@ SystemEnvironmentTest >> testOrganizationPerInstance [
 ]
 
 { #category : 'tests' }
-SystemEnvironmentTest >> testOtherInstancesOfSystemDictionaryAsString [
+SystemEnvironmentTest >> testOtherInstancesOfSystemEnvironmentAsString [
 
 	self deny: SystemEnvironment new asString equals: 'Smalltalk'
 ]
 
 { #category : 'tests' }
-SystemEnvironmentTest >> testOtherInstancesOfSystemDictionaryPrintString [
+SystemEnvironmentTest >> testOtherInstancesOfSystemEnvironmentPrintString [
 
 	self deny: SystemEnvironment new printString equals: 'Smalltalk'
 ]
 
 { #category : 'tests' }
-SystemEnvironmentTest >> testOtherInstancesOfSystemDictionarySelfEvaluating [
+SystemEnvironmentTest >> testOtherInstancesOfSystemEnvironmentSelfEvaluating [
 
 	self deny: SystemEnvironment new isSelfEvaluating
 ]

--- a/src/System-Support/ExternalSemaphoreTable.class.st
+++ b/src/System-Support/ExternalSemaphoreTable.class.st
@@ -1,6 +1,6 @@
 "
 By John M McIntosh johnmci@smalltalkconsulting.com
-This class was written to mange the external semaphore table. When I was writing a Socket test server I discovered various race conditions on the access to the externalSemaphore table. This new class uses class side methods to restrict access using two mutex semaphores, one for removal and one for additions to the table. It seemed cleaner to delegate the responsibility here versus adding more code and another class variable to SystemDictionary 
+This class was written to mange the external semaphore table. When I was writing a Socket test server I discovered various race conditions on the access to the externalSemaphore table. This new class uses class side methods to restrict access using two mutex semaphores, one for removal and one for additions to the table. It seemed cleaner to delegate the responsibility here versus adding more code and another class variable to SystemEnvironment 
 
 Note that in Smalltalk recreateSpecialObjectsArray we still directly play with the table.
 

--- a/src/System-Support/ManifestSystemSupport.class.st
+++ b/src/System-Support/ManifestSystemSupport.class.st
@@ -21,7 +21,7 @@ ManifestSystemSupport class >> manuallyResolvedDependencies [
 
 { #category : 'code-critics' }
 ManifestSystemSupport class >> ruleBadMessageRule2V1FalsePositive [
-	^ #(#(#(#RGMethodDefinition #(#SystemDictionary #poolUsers #false)) #'2021-11-02T17:56:27.52638+01:00') #(#(#RGMethodDefinition #(#SystemDictionary #fillCaches #false)) #'2021-11-02T17:58:27.713429+01:00') )
+	^ #(#(#(#RGMethodDefinition #(#SystemEnvironment #poolUsers #false)) #'2021-11-02T17:56:27.52638+01:00') #(#(#RGMethodDefinition #(#SystemEnvironment #fillCaches #false)) #'2021-11-02T17:58:27.713429+01:00') )
 ]
 
 { #category : 'code-critics' }
@@ -31,10 +31,10 @@ ManifestSystemSupport class >> ruleClassNameInSelectorRuleV1FalsePositive [
 
 { #category : 'code-critics' }
 ManifestSystemSupport class >> ruleInconsistentMethodClassificationRuleV1FalsePositive [
-	^ #(#(#(#RGMethodDefinition #(#SystemDictionary #at:put: #false)) #'2021-11-02T18:04:16.398839+01:00') #(#(#RGMethodDefinition #(#SystemDictionary #removeKey:ifAbsent: #false)) #'2021-11-02T18:06:16.506535+01:00') )
+	^ #(#(#(#RGMethodDefinition #(#SystemEnvironment #at:put: #false)) #'2021-11-02T18:04:16.398839+01:00') #(#(#RGMethodDefinition #(#SystemEnvironment #removeKey:ifAbsent: #false)) #'2021-11-02T18:06:16.506535+01:00') )
 ]
 
 { #category : 'code-critics' }
 ManifestSystemSupport class >> ruleUtilityMethodsRuleV1FalsePositive [
-	^ #(#(#(#RGMethodDefinition #(#SystemDictionary #veryDeepCopyWith: #false)) #'2021-11-02T18:14:26.131262+01:00') )
+	^ #(#(#(#RGMethodDefinition #(#SystemEnvironment #veryDeepCopyWith: #false)) #'2021-11-02T18:14:26.131262+01:00') )
 ]

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -472,7 +472,7 @@ SmalltalkImage >> defaultLogFileName [
 
 { #category : 'accessing' }
 SmalltalkImage >> environment [
-	"For conversion from Smalltalk to SystemDictionary"
+	"For conversion from Smalltalk to SystemEnvironment"
 
 	^globals
 ]
@@ -711,16 +711,16 @@ SmalltalkImage >> getFileNameFromUser [
 
 { #category : 'accessing' }
 SmalltalkImage >> globals [
-	"Answer the global SystemDictionary"
+	"Answer the global SystemEnvironment"
 	^globals
 ]
 
 { #category : 'private' }
-SmalltalkImage >> globals: aSystemDictionary [
+SmalltalkImage >> globals: aSystemEnvironment [
 	"Sets the system-wide globals"
 
 	globals ifNotNil: [self error: 'Cannot overwrite existing globals'].
-	globals := aSystemDictionary
+	globals := aSystemEnvironment
 ]
 
 { #category : 'memory space' }
@@ -886,7 +886,7 @@ SmalltalkImage >> lastQuitLogPosition [
 
 { #category : 'sources, change log' }
 SmalltalkImage >> lastQuitLogPosition: aNumber [
-	"should be only use to ensure the transition from SystemDictionary to SmalltalkImage, then  	be removed"
+	"should be only use to ensure the transition from SystemEnvironment to SmalltalkImage, then be removed"
 
 	LastQuitLogPosition := aNumber
 ]

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -1,5 +1,8 @@
 "
-I represent a special dictionary used as global namespace for class names :
+I represent an environment in Pharo.
+An environment has its package manager, its classes, its system announcers and so on.
+
+I am a dictionary to save the bindings of my classes and globals. You can get the class names of the global environment like this:
 
 	Smalltalk globals classNames.
 
@@ -20,7 +23,7 @@ As the above example let you guess, the global namespace of Smalltalk system is 
 	Smalltalk globals.
 "
 Class {
-	#name : 'SystemDictionary',
+	#name : 'SystemEnvironment',
 	#superclass : 'IdentityDictionary',
 	#instVars : [
 		'cachedClassNames',
@@ -34,13 +37,13 @@ Class {
 }
 
 { #category : 'cleanup' }
-SystemDictionary class >> cleanUp [
+SystemEnvironment class >> cleanUp [
 
 	Smalltalk globals flushClassNameCache
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> allBehaviors [
+SystemEnvironment >> allBehaviors [
 	"Return all the classes and traits defined in the Smalltalk SystemDictionary"
 
 	^ cachedBehaviors ifNil: [
@@ -48,62 +51,62 @@ SystemDictionary >> allBehaviors [
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> allBehaviorsDo: aBlock [
+SystemEnvironment >> allBehaviorsDo: aBlock [
 	"Execute a block on each class, metaclass, trait and trait class"
 
 	self allBehaviors do: aBlock
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> allClasses [
+SystemEnvironment >> allClasses [
 	"Return all the class defines in the Smalltalk SystemDictionary"
 
 	^ self classNames collect: [:name | self at: name ]
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> allClassesAndTraits [
+SystemEnvironment >> allClassesAndTraits [
 	"Return all the classes and traits defined in the Smalltalk SystemDictionary"
 
 	^ self classAndTraitNames collect: [:each | self at: each ]
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> allClassesAndTraitsDo: aBlock [
+SystemEnvironment >> allClassesAndTraitsDo: aBlock [
 	"Evaluate the argument, aBlock, for each class and trait in the system."
 
 	^self classAndTraitNames do: [:each | aBlock value: (self at: each) ]
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> allClassesDo: aBlock [
+SystemEnvironment >> allClassesDo: aBlock [
 	"Evaluate the argument, aBlock, for each class in the system."
 
 	^self classNames do: [:name | aBlock value: (self at: name) ]
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> allMethods [
+SystemEnvironment >> allMethods [
 	"all methods, including copies from Traits"
 	^ self allBehaviors flatCollect: [ :behavior | behavior methods ]
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> allTraits [
+SystemEnvironment >> allTraits [
 	"Return all traits defined in the Smalltalk SystemDictionary"
 
 	^ self traitNames collect: [:each | self at: each ]
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> allTraitsDo: aBlock [
+SystemEnvironment >> allTraitsDo: aBlock [
 	"Evaluate the argument, aBlock, for each trait in the system."
 
 	^ self traitNames do: [ :name | aBlock value: (self at: name) ]
 ]
 
 { #category : 'accessing - dictionary access' }
-SystemDictionary >> at: aKey put: anObject [
+SystemEnvironment >> at: aKey put: anObject [
 	"Override from Dictionary to check Undeclared and fix up
 	references to undeclared variables."
 	| index assoc registeredMethods |
@@ -133,21 +136,21 @@ SystemDictionary >> at: aKey put: anObject [
 ]
 
 { #category : 'adding' }
-SystemDictionary >> atNewIndex: index put: aGlobalVariable [
+SystemEnvironment >> atNewIndex: index put: aGlobalVariable [
 
 	aGlobalVariable isAssociation ifTrue: [ self error: 'Only global variables should be added to the SystemDictionary and not associations.' ].
 	^ super atNewIndex: index put: aGlobalVariable
 ]
 
 { #category : 'accessing - variable lookup' }
-SystemDictionary >> bindingOf: varName [
+SystemEnvironment >> bindingOf: varName [
 	"SystemDictionaries includes symbols only"
 
 	^ super bindingOf: varName asSymbol
 ]
 
 { #category : 'accessing - class and trait names' }
-SystemDictionary >> classAndTraitNames [
+SystemEnvironment >> classAndTraitNames [
 	"Answer a sorted collection of all class and trait (not including class-traits) names.
 	Now traits are normal classes. So they are in same class list.
 	Do not bother to sort"
@@ -156,20 +159,20 @@ SystemDictionary >> classAndTraitNames [
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> classNamed: className [
+SystemEnvironment >> classNamed: className [
 
 	^ self classOrTraitNamed: className
 ]
 
 { #category : 'accessing - class and trait names' }
-SystemDictionary >> classNames [
+SystemEnvironment >> classNames [
 	"Answer a sorted collection of all class names. Use the return value of #fillCaches to avoid concurrency issues."
 
 	^cachedClassNames ifNil: [ self fillCaches at: 1 ]
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> classOrTraitNamed: aString [
+SystemEnvironment >> classOrTraitNamed: aString [
 	"aString is either a class or trait name or a class or trait name followed by ' class' or 'classTrait'
 	respectively. Answer the class or metaclass it names."
 
@@ -194,7 +197,7 @@ SystemDictionary >> classOrTraitNamed: aString [
 ]
 
 { #category : 'accessing' }
-SystemDictionary >> codeChangeAnnouncer [
+SystemEnvironment >> codeChangeAnnouncer [
 	"A code change announcer is an announcer to register to Class, Method, Package and Protocol announcement."
 
 	"This should not be hardcoded in the futurebut I should have my own instance."
@@ -203,7 +206,7 @@ SystemDictionary >> codeChangeAnnouncer [
 ]
 
 { #category : 'accessing' }
-SystemDictionary >> codeSupportAnnouncer [
+SystemEnvironment >> codeSupportAnnouncer [
 	"A code support announcer is an announcer used for tooling support such as the breakpoints or AST cache."
 
 	"This should not be hardcoded in the futurebut I should have my own instance."
@@ -212,14 +215,14 @@ SystemDictionary >> codeSupportAnnouncer [
 ]
 
 { #category : 'accessing' }
-SystemDictionary >> environment [
+SystemEnvironment >> environment [
 	"For conversion from SmalltalkImage to SystemDictionary"
 
 	^ self
 ]
 
 { #category : 'accessing - class and trait names' }
-SystemDictionary >> fillCaches [
+SystemEnvironment >> fillCaches [
 	"Fill cachedClassNames and cachedNonClassNames. Return an array with the calculated values."
 
 	| classNames nonClassNames |
@@ -247,7 +250,7 @@ SystemDictionary >> fillCaches [
 ]
 
 { #category : 'accessing - class and trait names' }
-SystemDictionary >> flushClassNameCache [
+SystemEnvironment >> flushClassNameCache [
 	"Force recomputation of the cached list of class names and non-class names."
 
 	<script: 'Smalltalk flushClassNameCache'>
@@ -255,7 +258,7 @@ SystemDictionary >> flushClassNameCache [
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> forgetClass: aClass [
+SystemEnvironment >> forgetClass: aClass [
 	"Delete the class, aClass, from the system.
 	Note that this doesn't do everything required to dispose of a class - to do that use Class>>removeFromSystem."
 
@@ -264,7 +267,7 @@ SystemDictionary >> forgetClass: aClass [
 ]
 
 { #category : 'testing' }
-SystemDictionary >> hasBindingThatBeginsWith: aString [
+SystemEnvironment >> hasBindingThatBeginsWith: aString [
 	"Use the cached class and non-class names for better performance."
 
 	| name searchBlock |
@@ -284,7 +287,7 @@ SystemDictionary >> hasBindingThatBeginsWith: aString [
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> hasClassNamed: aString [
+SystemEnvironment >> hasClassNamed: aString [
 	"Answer whether there is a class of the given name, but don't intern aString if it's not already interned."
 
 	Symbol
@@ -294,7 +297,7 @@ SystemDictionary >> hasClassNamed: aString [
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> hasClassOrTraitNamed: aString [
+SystemEnvironment >> hasClassOrTraitNamed: aString [
 	"Answer whether there is a class of the given name, but don't intern aString if it's not already interned."
 
 	Symbol
@@ -305,13 +308,13 @@ SystemDictionary >> hasClassOrTraitNamed: aString [
 ]
 
 { #category : 'accessing - variable lookup' }
-SystemDictionary >> lookupVar: name [
+SystemEnvironment >> lookupVar: name [
 	"Return a var with this name.  Return nil if none found"
 	^self pseudoVariables at: name ifAbsent: [self bindingOf: name]
 ]
 
 { #category : 'accessing - system attributes' }
-SystemDictionary >> maxIdentityHash [
+SystemEnvironment >> maxIdentityHash [
 	"Answer the maximum identityHash value supported by the VM."
 	<primitive: 176>
 
@@ -319,20 +322,20 @@ SystemDictionary >> maxIdentityHash [
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> methods [
+SystemEnvironment >> methods [
 	"all methods, but without those installed by Traits"
 	^ self allBehaviors flatCollect: [ :behavior | behavior localMethods ]
 ]
 
 { #category : 'accessing - class and trait names' }
-SystemDictionary >> nonClassNames [
+SystemEnvironment >> nonClassNames [
 	"Answer a sorted collection of all non-class names. Use the return value of #fillCaches to avoid concurrency issues."
 
 	^ cachedNonClassNames ifNil: [ self fillCaches at: 2 ]
 ]
 
 { #category : 'accessing' }
-SystemDictionary >> organization [
+SystemEnvironment >> organization [
 	"Return the organizer for the receiver"
 
 	^ self at: #SystemOrganization ifAbsent: [
@@ -341,7 +344,7 @@ SystemDictionary >> organization [
 ]
 
 { #category : 'accessing' }
-SystemDictionary >> organization: anOrganization [
+SystemEnvironment >> organization: anOrganization [
 	"Return the organizer for the receiver"
 
 	anOrganization environment: self.
@@ -349,13 +352,13 @@ SystemDictionary >> organization: anOrganization [
 ]
 
 { #category : 'accessing - variable lookup' }
-SystemDictionary >> outerScope [
+SystemEnvironment >> outerScope [
 
 	^ nil
 ]
 
 { #category : 'accessing' }
-SystemDictionary >> poolUsers [
+SystemEnvironment >> poolUsers [
 	"Answer a dictionary of pool name -> classes that refer to it.
 	Also includes any globally know dictionaries (such as
 	Smalltalk, Undeclared etc) which although not strictly
@@ -379,13 +382,13 @@ SystemDictionary >> poolUsers [
 ]
 
 { #category : 'printing' }
-SystemDictionary >> printElementsOn: aStream [
+SystemEnvironment >> printElementsOn: aStream [
 
 	aStream nextPutAll: '(lots of globals)'
 ]
 
 { #category : 'accessing - variable lookup' }
-SystemDictionary >> pseudoVariables [
+SystemEnvironment >> pseudoVariables [
 	"We cache the variables for speed"
 
 	^ pseudoVariables ifNil: [
@@ -393,7 +396,7 @@ SystemDictionary >> pseudoVariables [
 ]
 
 { #category : 'accessing - classes and traits' }
-SystemDictionary >> removeClassNamed: aName [
+SystemEnvironment >> removeClassNamed: aName [
 	"Invoked from fileouts: if there is currently a class in the system named aName, then remove it"
 
 	self
@@ -402,7 +405,7 @@ SystemDictionary >> removeClassNamed: aName [
 ]
 
 { #category : 'removing' }
-SystemDictionary >> removeFromCaches: aKey [
+SystemEnvironment >> removeFromCaches: aKey [
 	"In case we remove a key from the system dictionary, we do not need to flush all the caches. We can just remove it from the class name and non class name caches."
 
 	cachedClassNames ifNotNil: [ :cache | cache remove: aKey ifAbsent: [  ] ].
@@ -411,14 +414,14 @@ SystemDictionary >> removeFromCaches: aKey [
 ]
 
 { #category : 'accessing - dictionary access' }
-SystemDictionary >> removeKey: key ifAbsent: aBlock [
+SystemEnvironment >> removeKey: key ifAbsent: aBlock [
 
 	self removeFromCaches: key.
 	^ super removeKey: key ifAbsent: aBlock
 ]
 
 { #category : 'renaming' }
-SystemDictionary >> renameClass: aClass from: oldName [
+SystemEnvironment >> renameClass: aClass from: oldName [
 
 	| oldref |
 	oldref := self associationAt: oldName.
@@ -431,7 +434,7 @@ SystemDictionary >> renameClass: aClass from: oldName [
 ]
 
 { #category : 'renaming' }
-SystemDictionary >> renameClassNamed: oldName as: newName [
+SystemEnvironment >> renameClassNamed: oldName as: newName [
 	"Invoked from fileouts: if there is currently a class in the system named oldName, then rename it to newName. If anything untoward happens, report it in the Transcript."
 
 	| oldClass |
@@ -444,14 +447,14 @@ SystemDictionary >> renameClassNamed: oldName as: newName [
 ]
 
 { #category : 'accessing - variable lookup' }
-SystemDictionary >> resetPseudoVariables [
+SystemEnvironment >> resetPseudoVariables [
 	"Lazy init in the accessor, resetting it will take new subclasses on PseudoVariable into account"
 
 	^ pseudoVariables := nil
 ]
 
 { #category : 'accessing - class and trait names' }
-SystemDictionary >> traitNames [
+SystemEnvironment >> traitNames [
 	"Answer a SortedCollection of all traits (not including class-traits) names."
 
 	^ self classNames select: [ :name |
@@ -463,13 +466,13 @@ SystemDictionary >> traitNames [
 ]
 
 { #category : 'accessing' }
-SystemDictionary >> undeclaredRegistry [
+SystemEnvironment >> undeclaredRegistry [
 	"For now we are referencing a global variable of the default environment of Pharo. But in the future each environments should have their undeclared registry, else we have memory leaks of the environments."
 
 	^ Undeclared
 ]
 
 { #category : 'copying' }
-SystemDictionary >> veryDeepCopyWith: deepCopier [
+SystemEnvironment >> veryDeepCopyWith: deepCopier [
 	"Return self. I can't be copied. Do not record me."
 ]

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -144,7 +144,7 @@ SystemEnvironment >> atNewIndex: index put: aGlobalVariable [
 
 { #category : 'accessing - variable lookup' }
 SystemEnvironment >> bindingOf: varName [
-	"SystemDictionaries includes symbols only"
+	"SystemEnvironment includes symbols only"
 
 	^ super bindingOf: varName asSymbol
 ]

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -44,7 +44,7 @@ SystemEnvironment class >> cleanUp [
 
 { #category : 'accessing - classes and traits' }
 SystemEnvironment >> allBehaviors [
-	"Return all the classes and traits defined in the Smalltalk SystemDictionary"
+	"Return all the classes and traits defined in the Smalltalk SystemEnvironment"
 
 	^ cachedBehaviors ifNil: [
 		  cachedBehaviors := self allClassesAndTraits flatCollect: [ :each | { each. each classSide } ] ]
@@ -59,14 +59,14 @@ SystemEnvironment >> allBehaviorsDo: aBlock [
 
 { #category : 'accessing - classes and traits' }
 SystemEnvironment >> allClasses [
-	"Return all the class defines in the Smalltalk SystemDictionary"
+	"Return all the class defines in the Smalltalk SystemEnvironment"
 
 	^ self classNames collect: [:name | self at: name ]
 ]
 
 { #category : 'accessing - classes and traits' }
 SystemEnvironment >> allClassesAndTraits [
-	"Return all the classes and traits defined in the Smalltalk SystemDictionary"
+	"Return all the classes and traits defined in the Smalltalk SystemEnvironment"
 
 	^ self classAndTraitNames collect: [:each | self at: each ]
 ]
@@ -93,7 +93,7 @@ SystemEnvironment >> allMethods [
 
 { #category : 'accessing - classes and traits' }
 SystemEnvironment >> allTraits [
-	"Return all traits defined in the Smalltalk SystemDictionary"
+	"Return all traits defined in the Smalltalk SystemEnvironment"
 
 	^ self traitNames collect: [:each | self at: each ]
 ]
@@ -110,7 +110,7 @@ SystemEnvironment >> at: aKey put: anObject [
 	"Override from Dictionary to check Undeclared and fix up
 	references to undeclared variables."
 	| index assoc registeredMethods |
-	aKey isSymbol ifFalse: [ self error: 'Only symbols are accepted as keys in SystemDictionary' ].
+	aKey isSymbol ifFalse: [ self error: 'Only symbols are accepted as keys in SystemEnvironment' ].
 
 	registeredMethods := #().
 
@@ -138,7 +138,7 @@ SystemEnvironment >> at: aKey put: anObject [
 { #category : 'adding' }
 SystemEnvironment >> atNewIndex: index put: aGlobalVariable [
 
-	aGlobalVariable isAssociation ifTrue: [ self error: 'Only global variables should be added to the SystemDictionary and not associations.' ].
+	aGlobalVariable isAssociation ifTrue: [ self error: 'Only global variables should be added to the SystemEnvironment and not associations.' ].
 	^ super atNewIndex: index put: aGlobalVariable
 ]
 
@@ -216,7 +216,7 @@ SystemEnvironment >> codeSupportAnnouncer [
 
 { #category : 'accessing' }
 SystemEnvironment >> environment [
-	"For conversion from SmalltalkImage to SystemDictionary"
+	"For conversion from SmalltalkImage to SystemEnvironment"
 
 	^ self
 ]

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -1,7 +1,7 @@
 "
 I support the navigation of the system. 
 I act as a facade but as I could require some state or different way of navigating the system all my behavior are on the instance side.
-I should (it is not complety done yet) be parametrized by an environment (aSystemDictionary) that scopes my queries.
+I should (it is not complety done yet) be parametrized by an environment (aSystemEnvironment) that scopes my queries.
 "
 Class {
 	#name : 'SystemNavigation',
@@ -279,9 +279,9 @@ SystemNavigation >> environment [
 ]
 
 { #category : 'accessing' }
-SystemNavigation >> environment: aSystemDictionary [
+SystemNavigation >> environment: aSystemEnvironment [
 
-	environment := aSystemDictionary
+	environment := aSystemEnvironment
 ]
 
 { #category : 'private' }

--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
@@ -286,7 +286,7 @@ SycRefactoringPreviewPresenter >> updateTablePresenter [
 	"We get the environment to apply the changes from any element in the changes instance variable"
 	anEnvironment := self activeRBEnvironment.
 	aCompositeChange := RBCompositeRefactoryChange new
-		onSystemDictionary: anEnvironment.
+		onSystemEnvironment: anEnvironment.
 	changes do: [ :each | aCompositeChange addChange: each ].
 
 	table items: (self changesFrom: aCompositeChange forEnvironment: anEnvironment).

--- a/src/Tool-Profilers/SpaceTally.class.st
+++ b/src/Tool-Profilers/SpaceTally.class.st
@@ -9,7 +9,7 @@ try something like:
 SpaceTally new systemWideSpaceTally
 
 
-This class has been created from a part of SystemDictionary. It still deserves a nice
+This class has been created from a part of SystemEnvironment. It still deserves a nice
 clean, such as using object instead of array having 4 slots.
 
 sd-20 June 2003


### PR DESCRIPTION
SystemDictionary is a name based on the implementation of this class but it does not represent what really is this class.

This class contains the classes of an environment, a package manager, announcers, undefined registry and so on. It represents an environment in Pharo. 

I'd like to rename the class to show what it really is and I'm proposing SystemEnvironment.