### PR TITLE
Remove references to SystemAnnouncer from Breakpoint tests

### DIFF
--- a/src/Reflectivity-Tools-Tests/BreakpointObserverTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointObserverTest.class.st
@@ -27,8 +27,8 @@ BreakpointObserverTest >> setUp [
 
 	super setUp.
 	previousBreakpoints := Breakpoint all copy.
-	oldSystemAnnouncer := SystemAnnouncer uniqueInstance.
-	SystemAnnouncer announcer: nil.
+	oldSystemAnnouncer := self class codeSupportAnnouncer.
+	self class environment codeSupportAnnouncer: nil.
 	cls := self newDummyClass.
 	breakpoint := Breakpoint new.
 	cls compile: 'dummy ^42'.
@@ -45,13 +45,13 @@ BreakpointObserverTest >> tearDown [
 	self packageOrganizer removePackage: 'DummyPackage'.
 	Breakpoint removeAll.
 	Breakpoint all addAll: previousBreakpoints.
-	SystemAnnouncer announcer: oldSystemAnnouncer.
+	self class environment codeSupportAnnouncer: oldSystemAnnouncer.
 	super tearDown
 ]
 
 { #category : 'tests' }
 BreakpointObserverTest >> testNotifyBreakpointAdded [
-	SystemAnnouncer uniqueInstance when: BreakpointAdded send: #update: to: observer.
+	self class codeSupportAnnouncer when: BreakpointAdded send: #update: to: observer.
 	breakpoint install.
 	self assert: observer tag class equals: BreakpointAdded.
 	self assert: observer tag breakpoint identicalTo: breakpoint.
@@ -60,7 +60,7 @@ BreakpointObserverTest >> testNotifyBreakpointAdded [
 
 { #category : 'tests' }
 BreakpointObserverTest >> testNotifyBreakpointHit [
-	SystemAnnouncer uniqueInstance when: BreakpointHit send: #update: to: observer.
+	self class codeSupportAnnouncer when: BreakpointHit send: #update: to: observer.
 	breakpoint install.
 	self should: [cls new dummy] raise: Break.
 	self assert: observer tag class equals: BreakpointHit.
@@ -71,7 +71,7 @@ BreakpointObserverTest >> testNotifyBreakpointHit [
 { #category : 'tests' }
 BreakpointObserverTest >> testNotifyBreakpointRemoved [
 	breakpoint install.
-	SystemAnnouncer uniqueInstance when: BreakpointRemoved send: #update: to: observer.
+	self class codeSupportAnnouncer when: BreakpointRemoved send: #update: to: observer.
 	breakpoint remove.
 	self assert: observer tag class equals: BreakpointRemoved.
 	self assert: observer tag breakpoint identicalTo: breakpoint.

--- a/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
+++ b/src/Reflectivity-Tools-Tests/BreakpointTest.class.st
@@ -32,8 +32,8 @@ BreakpointTest >> setUp [
 	super setUp.
 	cls := self newDummyClass.
 	previousBreakpoints := Breakpoint all copy.
-	oldSystemAnnouncer := SystemAnnouncer uniqueInstance.
-	SystemAnnouncer announcer: nil.
+	oldSystemAnnouncer := self class codeSupportAnnouncer.
+	self class environment codeSupportAnnouncer: nil.
 	Breakpoint registerInterestToSystemAnnouncement.
 	Breakpoint all removeAll
 ]
@@ -43,7 +43,7 @@ BreakpointTest >> tearDown [
 
 	Breakpoint removeAll.
 	Breakpoint all addAll: previousBreakpoints.
-	SystemAnnouncer announcer: oldSystemAnnouncer.
+	self class environment codeSupportAnnouncer: oldSystemAnnouncer.
 	cls ifNotNil: [ cls isObsolete ifFalse: [ cls removeFromSystem ] ].
 	self packageOrganizer removePackage: 'DummyPackage'.
 	super tearDown

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -29,7 +29,9 @@ Class {
 		'cachedClassNames',
 		'cachedNonClassNames',
 		'cachedBehaviors',
-		'pseudoVariables'
+		'pseudoVariables',
+		'codeChangeAnnouncer',
+		'codeSupportAnnouncer'
 	],
 	#category : 'System-Support-Utilities',
 	#package : 'System-Support',
@@ -202,7 +204,13 @@ SystemEnvironment >> codeChangeAnnouncer [
 
 	"This should not be hardcoded in the futurebut I should have my own instance."
 
-	^ SystemAnnouncer uniqueInstance
+	^ codeChangeAnnouncer ifNil: [ codeChangeAnnouncer := SystemAnnouncer uniqueInstance ]
+]
+
+{ #category : 'accessing' }
+SystemEnvironment >> codeChangeAnnouncer: anAnnouncer [
+
+	^ codeChangeAnnouncer := anAnnouncer
 ]
 
 { #category : 'accessing' }
@@ -211,7 +219,13 @@ SystemEnvironment >> codeSupportAnnouncer [
 
 	"This should not be hardcoded in the futurebut I should have my own instance."
 
-	^ SystemAnnouncer uniqueInstance
+	^ codeSupportAnnouncer ifNil: [ codeSupportAnnouncer := SystemAnnouncer uniqueInstance ]
+]
+
+{ #category : 'accessing' }
+SystemEnvironment >> codeSupportAnnouncer: anAnnouncer [
+
+	^ codeSupportAnnouncer := anAnnouncer
 ]
 
 { #category : 'accessing' }

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -202,7 +202,7 @@ SystemEnvironment >> codeChangeAnnouncer [
 
 	"This should not be hardcoded in the futurebut I should have my own instance."
 
-	^ "codeChangeAnnouncer ifNil: [ codeChangeAnnouncer := "SystemAnnouncer uniqueInstance" ]"
+	^ SystemAnnouncer uniqueInstance
 ]
 
 { #category : 'accessing' }
@@ -220,7 +220,7 @@ SystemEnvironment >> codeSupportAnnouncer [
 
 	"This should not be hardcoded in the futurebut I should have my own instance."
 
-	^ "codeSupportAnnouncer ifNil: [ codeSupportAnnouncer := "SystemAnnouncer uniqueInstance "]"
+	^ SystemAnnouncer uniqueInstance
 ]
 
 { #category : 'accessing' }

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -29,9 +29,7 @@ Class {
 		'cachedClassNames',
 		'cachedNonClassNames',
 		'cachedBehaviors',
-		'pseudoVariables',
-		'codeChangeAnnouncer',
-		'codeSupportAnnouncer'
+		'pseudoVariables'
 	],
 	#category : 'System-Support-Utilities',
 	#package : 'System-Support',
@@ -204,13 +202,16 @@ SystemEnvironment >> codeChangeAnnouncer [
 
 	"This should not be hardcoded in the futurebut I should have my own instance."
 
-	^ codeChangeAnnouncer ifNil: [ codeChangeAnnouncer := SystemAnnouncer uniqueInstance ]
+	^ "codeChangeAnnouncer ifNil: [ codeChangeAnnouncer := "SystemAnnouncer uniqueInstance" ]"
 ]
 
 { #category : 'accessing' }
 SystemEnvironment >> codeChangeAnnouncer: anAnnouncer [
+	"For now the announcer is still saved in SystemAnnouncer so we access it there. In the future we should save it in the environment.
+	
+	codeChangeAnnouncer := anAnnouncer"
 
-	^ codeChangeAnnouncer := anAnnouncer
+	SystemAnnouncer announcer: anAnnouncer
 ]
 
 { #category : 'accessing' }
@@ -219,13 +220,16 @@ SystemEnvironment >> codeSupportAnnouncer [
 
 	"This should not be hardcoded in the futurebut I should have my own instance."
 
-	^ codeSupportAnnouncer ifNil: [ codeSupportAnnouncer := SystemAnnouncer uniqueInstance ]
+	^ "codeSupportAnnouncer ifNil: [ codeSupportAnnouncer := "SystemAnnouncer uniqueInstance "]"
 ]
 
 { #category : 'accessing' }
 SystemEnvironment >> codeSupportAnnouncer: anAnnouncer [
+	"For now the announcer is still saved in SystemAnnouncer so we access it there. In the future we should save it in the environment.
+	
+	codeSupportAnnouncer := anAnnouncer"
 
-	^ codeSupportAnnouncer := anAnnouncer
+	SystemAnnouncer announcer: anAnnouncer
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This PR removes SystemAnnouncer references from breakpoint tests. In order to do that I had to make announcers in SystemEnvironment configurable. For now they point to SystemAnnouncer unique instance so it should change nothing in the behavior.

The goal is still to kill the SystemAnnouncer singleton

Requires https://github.com/pharo-project/pharo/pull/16999 (I did not wanted to risk a conflict :) )
