### PR TITLE
Fix Issue #16945: Refactorings -> add argument: fails on unary messages

### DIFF
--- a/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
+++ b/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
@@ -195,11 +195,16 @@ RBChangeMethodNameRefactoring >> renameMethod: aSelector in: aClass to: newSel p
 
 { #category : 'transforming' }
 RBChangeMethodNameRefactoring >> replaceMessageSends [
-
+	| className |
+	
+	className :=  class name, (class isMeta 
+		ifTrue: [ ' class' ]
+		ifFalse: [ '' ]).
+	
 	self generateChangesFor: (RBReplaceMessageSendTransformation
 			 model: self model
 			 replaceMethod: oldSelector
-			 in: class
+			 in: (self model classNamed: className)
 			 to: newSelector
 			 permutation: permutation
 			 inAllClasses: true

--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
@@ -163,6 +163,7 @@ SycRefactoringPreviewPresenter >> generateChanges [
 	rbEnvironment := self activeRBEnvironment.
 	changes do: [ :each |
 		each model environment: rbEnvironment.
+		"test"
 		each generateChanges ]
 ]
 

--- a/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycRefactoringPreviewPresenter.class.st
@@ -161,9 +161,11 @@ SycRefactoringPreviewPresenter >> generateChanges [
 	| rbEnvironment |
 	changes := command asRefactorings.
 	rbEnvironment := self activeRBEnvironment.
-	changes do: [ :each |
-		each model environment: rbEnvironment.
-		"test"
+	changes do: [ :each | | model |
+		model := (RBNamespace onEnvironment: rbEnvironment )
+				name: 'Changes for ', each class name asString;
+				yourself.
+		each model: model.
 		each generateChanges ]
 ]
 


### PR DESCRIPTION
Fix [Issue#16945](https://github.com/pharo-project/pharo/issues/16945)
Replaces [PR#16951](https://github.com/pharo-project/pharo/pull/16951)

When the method generateChanges is sent, it checks for preconditions and then it performs the corresponding changes on the object rb-class (which represents the real class)
Since the UI used to execute "Add argument" allows sending the `messagegenerateChanges` more than once, the second time the message is sent, preconditions fail because the rb-class instance was modified before.

The issue was solved by generating a new model according to the selected scope each time the scope is changed by the user.