### PR TITLE
Avoid rewriting methods that are not installed

### DIFF
--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -244,7 +244,12 @@ Deprecation >> transform [
 
 	self rewriterClass ifNil:[ ^ self ].
 	aMethod := self contextOfSender homeMethod.
-	aMethod isDoIt ifTrue:[ ^ self ]. "no need to transform doits"
+	
+	"no need to transform doits or non installed methods.
+	Non installed methods can arise if we are rewriting a closure whose home method was rewritten"
+	aMethod isDoIt ifTrue:[ ^ self ].
+	aMethod isInstalled ifFalse: [ ^ self ].
+	
 	node := self contextOfSender sourceNodeExecuted.
 	RecursionStopper during: [
 		rewriteRule := self rewriterClass new


### PR DESCRIPTION
When a rewriting deprecation happens inside a closure, it could happen that the home method is not installed anymore: it has been rewritten. In that case, the rewriting is useless or even harmful, it can overwrite the rewritten method.

This PR inserts a rule to avoid rewriting deprecations of non installed methods.

This should be forward ported to P13