### PR TITLE
Speed up more refactoring tests by constricting the refactoring model

### DIFF
--- a/src/Refactoring-Core-Tests/RBClassTest.class.st
+++ b/src/Refactoring-Core-Tests/RBClassTest.class.st
@@ -16,7 +16,7 @@ Class {
 RBClassTest >> setUp [
 
 	super setUp.
-	rbNamespace := RBNamespace new.
+	rbNamespace := RBNamespace onEnvironment: (RBClassEnvironment classes:  {Behavior. Class. ClassDescription. MOPTestClassD. Model. MyClassB. Object. Object. Object class. ProtoObject class. RBAbstractTransformation. RBAbstractTransformation. RBClassRefactoring. RBRefactoring. Trait2}).
 	abstractTransformationClass := rbNamespace classNamed: #RBAbstractTransformation.
 	objectClass := rbNamespace classNamed: #Object.
 	refactoringClass := rbNamespace classNamed: #RBClassRefactoring.

--- a/src/Refactoring-Core-Tests/RBConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/RBConditionTest.class.st
@@ -13,9 +13,12 @@ Class {
 
 { #category : 'running' }
 RBConditionTest >> setUp [
-
+	| classenv classes |
 	super setUp.
-	rbNamespace := RBNamespace new.
+	classes := { Object . RBMessageNode . TextConstants } asOrderedCollection addAll: self class withAllSuperclasses; yourself.
+	classenv := RBClassEnvironment classes: classes.
+	rbNamespace := RBNamespace onEnvironment: classenv.
+	
 	objectClass := rbNamespace classNamed: #Object.
 	messageNodeClass := rbNamespace classNamed: #RBMessageNode.
 	rbNamespace defineClass: [ :aBuilder |

--- a/src/Refactoring-Core-Tests/RBNamespaceTest.class.st
+++ b/src/Refactoring-Core-Tests/RBNamespaceTest.class.st
@@ -151,7 +151,10 @@ RBNamespaceTest >> testClassesReferencingClass [
 
 { #category : 'tests - classes' }
 RBNamespaceTest >> testCommentChange [
-	| cl |
+	| cl classenv |
+	classenv := RBClassEnvironment class: self class.
+	namespace := RBNamespace onEnvironment: classenv.
+	
 	cl := namespace classNamed: self class name.
 	self assert: cl comment isString.
 	cl comment: 'a comment'.
@@ -166,7 +169,10 @@ RBNamespaceTest >> testCommentChange [
 
 { #category : 'tests - classes' }
 RBNamespaceTest >> testDefineClassAfterDeletedChange [
-
+	| packageenv |
+	packageenv := RBPackageEnvironment packageNames: { self class packageName }.
+	namespace := RBNamespace onEnvironment: packageenv.
+	
 	namespace removeClassNamed: self class name.
 	self deny: (namespace includesClassNamed: self class name).
 	namespace defineClass: [ :aBuilder | aBuilder fillFor: self class ].
@@ -176,7 +182,10 @@ RBNamespaceTest >> testDefineClassAfterDeletedChange [
 
 { #category : 'tests - classes' }
 RBNamespaceTest >> testDefineClassChange [
-
+	| classenv |
+	classenv := RBClassEnvironment classes: {}.
+	namespace := RBNamespace onEnvironment: classenv.
+	
 	namespace defineClass: [ :aBuilder |
 		aBuilder
 			superclassName: #RefactoringBrowserTest;
@@ -282,9 +291,13 @@ RBNamespaceTest >> testReferencesPrintOn [
 { #category : 'tests - classes' }
 RBNamespaceTest >> testReferencesPrintOnAfterAddition [
 
-	| hasFoundObject hasFoundSelf |
+	| classenv hasFoundObject hasFoundSelf |
+	classenv := RBClassEnvironment classes: { Object . self class }.
+	namespace := RBNamespace onEnvironment: classenv.
+	
 	hasFoundObject := false.
 	hasFoundSelf := false.
+	
 	(namespace classNamed: #Object)
 		compile: 'someTestReference self printOn: nil'
 		classified: 'testing'.
@@ -305,7 +318,10 @@ RBNamespaceTest >> testReferencesPrintOnAfterAddition [
 { #category : 'tests - classes' }
 RBNamespaceTest >> testReferencesPrintOnAfterRemove [
 
-	| hasFoundObject hasFoundSelf |
+	| classenv hasFoundObject hasFoundSelf |
+	classenv := RBClassEnvironment classes: { Object . self class }.
+	namespace := RBNamespace onEnvironment: classenv.
+	
 	hasFoundObject := false.
 	hasFoundSelf := false.
 
@@ -326,7 +342,10 @@ RBNamespaceTest >> testReferencesPrintOnAfterRemove [
 
 { #category : 'tests - classes' }
 RBNamespaceTest >> testRemoveClassChange [
-
+	| classenv |
+	classenv := RBClassEnvironment classes: { self class }.
+	namespace := RBNamespace onEnvironment: classenv.
+	
 	namespace removeClassNamed: self class name.
 	self deny: (namespace includesClassNamed: self class name).
 	self assert: (namespace classNamed: self class name) isNil
@@ -335,7 +354,11 @@ RBNamespaceTest >> testRemoveClassChange [
 { #category : 'tests - classes' }
 RBNamespaceTest >> testReparentSuperclassChange [
 
-	| superclass subclasses |
+	| classes classenv superclass subclasses |
+	classes := TestCase subclasses asOrderedCollection addAll: { TestCase . TestCase superclass }; yourself.
+	classenv := RBClassEnvironment classes: classes.
+	namespace := RBNamespace onEnvironment: classenv.
+	
 	superclass := namespace classFor: TestCase superclass.
 	subclasses := TestCase subclasses collect: [:each | namespace classFor: each].
 	namespace reparentClasses: subclasses to: superclass.

--- a/src/Refactoring-Transformations-Tests/RBAddParameterParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBAddParameterParametrizedTest.class.st
@@ -20,6 +20,20 @@ RBAddParameterParametrizedTest >> constructor [
 	^ #addParameterToMethod:in:newSelector:permutation:newArgs:
 ]
 
+{ #category : 'mocking' }
+RBAddParameterParametrizedTest >> rbModelForVariableTest [
+
+	| newModel classEnvironment |
+	
+	classEnvironment := RBClassEnvironment classes: { RBClassDataForRefactoringTest . OrderedCollection . RBLintRuleTestData . RBRefactoring . Object}.
+	newModel := self defaultNamespaceClass onEnvironment: classEnvironment.
+	newModel name: 'Test'.
+	
+	self defineFooBarIn: newModel.
+
+	^ newModel
+]
+
 { #category : 'running' }
 RBAddParameterParametrizedTest >> setUp [
 	super setUp.
@@ -34,7 +48,7 @@ RBAddParameterParametrizedTest >> testAddParameterAndRenameParameters [
 	and rewriting the code in a bad way so for now do not change them."
 	newSelector := #called:bar:on:.
 	newArg := RBArgumentName name: 'anObject' value: '#(1.0)'.
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{ oldSelector . RBClassDataForRefactoringTest . newSelector . #(1 -1 2) . { newArg }}.
 	refactoring renameMap: (Array with: ((RBArgumentName name: 'aBlock') newName: 'aBlock1')).
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
@@ -61,7 +75,7 @@ RBAddParameterParametrizedTest >> testAddParameterForTwoArgumentMessage [
 	and rewriting the code in a bad way so for now do not change them."
 	newSelector := #called:bar:on:.
 	newArg := RBArgumentName name: 'anObject' value: '#(1.0)'.
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{oldSelector . RBClassDataForRefactoringTest . newSelector . #(1 -1 2) . { newArg }}.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBClassDataForRefactoringTest.
@@ -85,7 +99,7 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesABlockWithInstan
 	oldSelector := ('test' , 'Foo:') asSymbol.
 	newSelector := #testFoo:bar:.
 	newArg := RBArgumentName name: 'aFoo' value: '[ :each | each + instanceVariable ]'.
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{oldSelector . RBClassDataForRefactoringTest . newSelector . #(1 -1) . {newArg}}.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBClassDataForRefactoringTest.
@@ -108,7 +122,7 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesGlobalAndLiteral
 	oldSelector := ('test' , 'Foo:') asSymbol.
 	newSelector := #testFoo:bar:.
 	newArg := RBArgumentName name: 'anObject' value: 'OrderedCollection new: 5'.
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{ oldSelector . RBClassDataForRefactoringTest . newSelector . #(1 -1) . {newArg} }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBClassDataForRefactoringTest.
@@ -130,7 +144,7 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesInstanceVariable
 	oldSelector := ('test' , 'Foo:') asSymbol.
 	newSelector := #testFoo:bar:.
 	newArg := RBArgumentName name: 'aFoo' value: 'instanceVariable'.
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{oldSelector . RBClassDataForRefactoringTest . newSelector . #(1 -1) . {newArg}}.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBClassDataForRefactoringTest.
@@ -175,7 +189,7 @@ RBAddParameterParametrizedTest >> testAddParameterThatReferencesSelf [
 	oldSelector := ('test' , 'Foo:') asSymbol.
 	newSelector := #testFoo:bar:.
 	newArg := RBArgumentName name: 'aFoo' value: 'self printString'.
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{oldSelector . RBClassDataForRefactoringTest . newSelector . #(1 -1) . {newArg}}.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBClassDataForRefactoringTest.
@@ -199,7 +213,7 @@ RBAddParameterParametrizedTest >> testAddTwoParameters [
 	newSelector := #testColl:foo:string:.
 	newArgs := Array with: (RBArgumentName name: 'aColl' value: 'OrderedCollection new: 5')
 		with: (RBArgumentName name: 'aString' value: '''string''').
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{ oldSelector . RBClassDataForRefactoringTest . newSelector . #(-1 1 -2) . newArgs }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBClassDataForRefactoringTest.
@@ -219,7 +233,7 @@ RBAddParameterParametrizedTest >> testFailureBadDefaultValueForNewArgument [
 
 	| newArg |
 	newArg := RBArgumentName name: 'anObject' value: 'brokenExpression:'.
-	self shouldFail: (self createRefactoringWithArguments: {
+	self shouldFail: (self createRefactoringWithModel: model andArguments: {
 				 #name.
 				 RBLintRuleTestData.
 				 #name:.
@@ -240,7 +254,7 @@ RBAddParameterParametrizedTest >> testFailureInvalidNumArgsOfNewSelector [
 
 	| newArg |
 	newArg := RBArgumentName name: 'anObject' value: 'nil'.
-	self shouldFail: (self createRefactoringWithArguments: {
+	self shouldFail: (self createRefactoringWithModel: model andArguments: {
 				 #checkSendersAccessTo:.
 				 RBLintRuleTestData.
 				 #checkSendersAccessTo:.

--- a/src/Refactoring-Transformations-Tests/RBRenameMethodParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRenameMethodParametrizedTest.class.st
@@ -19,16 +19,34 @@ RBRenameMethodParametrizedTest >> constructor [
 	^ #renameMethod:in:to:permutation:
 ]
 
+{ #category : 'mocking' }
+RBRenameMethodParametrizedTest >> rbModelForVariableTest [
+
+	| newModel classEnvironment |
+	
+	classEnvironment := RBClassEnvironment classes: { RBBasicLintRuleTestData . RBClassToRename . RBTDummy . RBClassUsingSharedPoolForTestData . RBClassDataForRefactoringTest . Object }.
+	newModel := self defaultNamespaceClass onEnvironment: classEnvironment.
+	newModel name: 'Test'.
+	
+	^ newModel
+]
+
+{ #category : 'running' }
+RBRenameMethodParametrizedTest >> setUp [
+	super setUp.
+	model := self rbModelForVariableTest
+]
+
 { #category : 'failure tests' }
 RBRenameMethodParametrizedTest >> testFailureWithNonCorrectNumberOfArgs [
-	self shouldFail: (self createRefactoringWithArguments:
+	self shouldFail: (self createRefactoringWithModel: model andArguments:
 		{ #checkClass: . RBBasicLintRuleTestData . #checkClass . (1 to: 1) })
 ]
 
 { #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenameMethodFromTrait [
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{ ('just', 'ForTest') asSymbol . RBClassToRename classSide . #justForTest1 . (1 to: 0)}.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	
@@ -95,7 +113,7 @@ RBRenameMethodParametrizedTest >> testRenameMethodPermuteArgs [
 		^ self demoRenameMethod: 2 PermuteArgs: 1
 	
 	"
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{ ('demoRenameMethod:' , 'PermuteArgs:') asSymbol . RBClassDataForRefactoringTest .
 		('demoRenameMethod:' , 'PermuteArgs:') asSymbol . #(2 1) }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
@@ -120,7 +138,7 @@ RBRenameMethodParametrizedTest >> testRenameMethodPermuteArgs [
 { #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenamePermuteArgs [
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{ ('rename:' , 'two:') asSymbol . RBClassDataForRefactoringTest .
 		('rename:' , 'two:') asSymbol . #(2 1 ) }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
@@ -156,7 +174,7 @@ RBRenameMethodParametrizedTest >> testRenamePrimitive [
 { #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenameTestMethod [
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{ ('rename' , 'ThisMethod:') asSymbol . RBClassDataForRefactoringTest . #renameThisMethod2: . (1 to: 1) }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBClassDataForRefactoringTest.
@@ -180,7 +198,7 @@ RBRenameMethodParametrizedTest >> testRenameTestMethod [
 { #category : 'tests' }
 RBRenameMethodParametrizedTest >> testRenameTestMethod1 [
 	| refactoring class |
-	refactoring := self createRefactoringWithArguments:
+	refactoring := self createRefactoringWithModel: model andArguments:
 		{ 'testMethod1' asSymbol . RBClassDataForRefactoringTest . #testMethod2 . (1 to: 0) }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	class := refactoring model classNamed: #RBClassDataForRefactoringTest.

--- a/src/Refactoring-Transformations-Tests/RBReplaceMessageSendParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBReplaceMessageSendParametrizedTest.class.st
@@ -13,6 +13,14 @@ RBReplaceMessageSendParametrizedTest class >> testParameters [
 		yourself
 ]
 
+{ #category : 'running' }
+RBReplaceMessageSendParametrizedTest >> setUp [
+	| classEnv |
+	super setUp.
+	classEnv := RBClassEnvironment classes: { RBReplaceMessageSendTransformation . RBClassDataForRefactoringTest . RBBasicLintRuleTestData }.
+	model := self defaultNamespaceClass onEnvironment: classEnv
+]
+
 { #category : 'failure tests' }
 RBReplaceMessageSendParametrizedTest >> testFailureIncompleteInitializers [
 	"please note that this strange way to create symbol is because some tests are counting symbol

--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -48,7 +48,8 @@ SystemDependenciesTest >> knownBasicToolsDependencies [
 	^ #( 'AST-Core-Tests' 'Athens-Cairo' 'Athens-Core' #'Athens-Morphic'
 	     #'Refactoring-Critics' #'Commander-Core' #Reflectivity
 	     #'Reflectivity-Tools' #Shout 'HeuristicCompletion-Model'
-	     #VariablesLibrary #'Spec2-CommonWidgets' #'NewTools-Scopes' )
+	     #VariablesLibrary #'Spec2-CommonWidgets' #'NewTools-Scopes'
+		  #Traits-Tests )
 ]
 
 { #category : 'known dependencies' }

--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -49,7 +49,7 @@ SystemDependenciesTest >> knownBasicToolsDependencies [
 	     #'Refactoring-Critics' #'Commander-Core' #Reflectivity
 	     #'Reflectivity-Tools' #Shout 'HeuristicCompletion-Model'
 	     #VariablesLibrary #'Spec2-CommonWidgets' #'NewTools-Scopes'
-		  #Traits-Tests )
+		  #'Traits-Tests' )
 ]
 
 { #category : 'known dependencies' }


### PR DESCRIPTION
(Work in progress, do not review yet)

Refactoring tests take too long to run, this PR constrains the model of many refactoring tests (specifically parametriezed tests) to make them run faster.
This PR is a continuation of [PR#16807](https://github.com/pharo-project/pharo/pull/16807).

This PR does not speed up all refactoring tests. This work will continue in future PRs