### PR TITLE
Enable Calypso to use a custom navigation history

### DIFF
--- a/src/Calypso-Browser/ClyBrowserMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserMorph.class.st
@@ -386,7 +386,7 @@ ClyBrowserMorph >> initialExtent [
 ClyBrowserMorph >> initialize [
 	super initialize.
 	navigationStarted := false.
-	navigationHistory := ClyNavigationHistory new.
+	navigationHistory := self class navigationHistoryClass new.
 	plugins := SortedCollection sortBlock: [ :a :b | a priority <= b priority ].
 	self extent: self initialExtent.
 	self changeProportionalLayout.

--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -194,13 +194,13 @@ ClyTextEditorToolMorph >> editingMode [
 ]
 
 { #category : 'accessing' }
-ClyTextEditorToolMorph >> editionTimestamp [
-  ^ Date today yyyymmdd, ' ', (Time now print24 first: 5)
+ClyTextEditorToolMorph >> editingText [
+	self subclassResponsibility
 ]
 
 { #category : 'accessing' }
-ClyTextEditorToolMorph >> editingText [
-	self subclassResponsibility
+ClyTextEditorToolMorph >> editionTimestamp [
+  ^ Date today yyyymmdd, ' ', (Time now print24 first: 5)
 ]
 
 { #category : 'selecting text' }


### PR DESCRIPTION
The Calypso navigation history configuration does not use the new setting added in #16982. This PR updates a single line in the browser `initialize` to effectively use the new setting value.