### PR TITLE
Fix setting of the position of the TransferMorph in #startDrag: on FTTableMorph to take into account that the event’s position is in local coordinates

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -1208,7 +1208,8 @@ FTTableMorph >> startDrag: event [
 
 	passengers := self selectedIndexes collect: [ :each | self dataSource passengerAt: each ].
 	transferMorph := self dataSource transferFor: passengers from: self.
-	transferMorph align: transferMorph draggedMorph topLeft with: event position.
+	transferMorph align: transferMorph draggedMorph topLeft with: ((self transformedFrom: event hand owner)
+		localPointToGlobal: event position).
 	transferMorph dragTransferType: self dataSource dragTransferType.
 
 	event hand grabMorph: transferMorph


### PR DESCRIPTION
This pull request fixes the setting of the position of the TransferMorph in `#startDrag:` on FTTableMorph to take into account that the event’s position is in local coordinates.

The following two screenshots show an item being dragged using SpPaginatorExample with its `#updatePresenter` method modified to enable dragging on each SpListPresenter.

Screenshot taken before applying this fix:  
<p><img width="224" src="https://github.com/user-attachments/assets/7253be53-fa0b-4b10-98c1-53490628d738"></p>

Screenshot taken after applying this fix:  
<p><img width="224" src="https://github.com/user-attachments/assets/5e1babae-fc84-4982-8870-ca3b49d6bcef"></p>