### PR TITLE
Fix drag detection in MouseClickState to take changes to the client morph’s transform into account

### DIFF
--- a/src/Morphic-Base/MouseClickState.class.st
+++ b/src/Morphic-Base/MouseClickState.class.st
@@ -23,6 +23,7 @@ Class {
 		'firstClickDown',
 		'firstClickUp',
 		'firstClickTime',
+		'firstClickGlobalPosition',
 		'clickSelector',
 		'dragSelector',
 		'dragThreshold',
@@ -116,6 +117,8 @@ MouseClickState >> client: aMorph click: aClickSelector dblClick: aDblClickSelec
 	dragThreshold := aNumber.
 	firstClickDown := firstClickEvent.
 	firstClickTime := firstClickEvent timeStamp.
+	firstClickGlobalPosition := (aMorph transformedFrom: firstClickEvent hand owner)
+		localPointToGlobal: firstClickEvent position.
 	clickState := #firstClickDown.
 	localStamp := Time millisecondClockValue
 ]
@@ -221,7 +224,9 @@ MouseClickState >> dragThreshold: anObject [
 MouseClickState >> event: aMouseEvent [
 	self
 		firstClickDown: aMouseEvent;
-		firstClickTime: aMouseEvent timeStamp
+		firstClickTime: aMouseEvent timeStamp;
+		firstClickGlobalPosition: ((clickClient transformedFrom: aMouseEvent hand owner)
+			localPointToGlobal: aMouseEvent position)
 ]
 
 { #category : 'accessing' }
@@ -234,6 +239,18 @@ MouseClickState >> firstClickDown [
 MouseClickState >> firstClickDown: anObject [
 
 	firstClickDown := anObject
+]
+
+{ #category : 'accessing' }
+MouseClickState >> firstClickGlobalPosition [
+
+	^ firstClickGlobalPosition
+]
+
+{ #category : 'accessing' }
+MouseClickState >> firstClickGlobalPosition: anObject [
+
+	firstClickGlobalPosition := anObject
 ]
 
 { #category : 'accessing' }
@@ -268,8 +285,8 @@ MouseClickState >> handleEvent: evt from: aHand [
 	| localEvt timedOut isDrag isDragSecond |
 	timedOut := (evt timeStamp - firstClickTime) > doubleClickTime.
 	localEvt := evt transformedBy: (clickClient transformedFrom: aHand owner).
-	isDrag := (localEvt position - firstClickDown position) r > dragThreshold.
-	isDragSecond := localEvt position ~= firstClickDown position.
+	isDrag := (evt position - firstClickGlobalPosition) r > dragThreshold.
+	isDragSecond := evt position ~= firstClickGlobalPosition.
 	clickState == #firstClickDown ifTrue: [
 		"Careful here - if we had a slow cycle we may have a timedOut mouseUp event"
 		(timedOut and:[localEvt isMouseUp not]) ifTrue:[


### PR DESCRIPTION
This pull request fixes the drag detection in MouseClickState to take into account that the client morph’s transform can change between events.

Without this fix, after modifying `#initializePresenters` on StRawInspectionPresenter to enable dragging on the `attributeTable`, when you inspect `1->(2->nil)` and click on the ‘value’ for the second association, the click is erroneously detected as the start of a drag:

<p align="center">
<img width="400" src="https://github.com/user-attachments/assets/0e07fc30-248b-4bb2-bdf7-60a6ac784c41">
</p>