### PR TITLE
Unhook Settings Browser `dialog:` method from Morphic

### DIFF
--- a/src/Morphic-Base/ShortcutReminder.class.st
+++ b/src/Morphic-Base/ShortcutReminder.class.st
@@ -100,17 +100,6 @@ ShortcutReminder >> createLabelMorph: aString [
 		yourself
 ]
 
-{ #category : 'settings' }
-ShortcutReminder >> createResetCountButtonMorph [
-
-	^SimpleButtonMorph new
-		target: self;
-		label: 'Reset notification counts';
-		actionSelector: #resetCount;
-		themeChanged;
-		yourself
-]
-
 { #category : 'shortcut creation' }
 ShortcutReminder >> createShortcutMorphFor: aMenuItem [
 
@@ -158,11 +147,12 @@ ShortcutReminder >> customSettingsOn: aBuilder [
 		default: self defaultLimit;
 		range: (-1 to: 100).
 
-	(aBuilder group: #'Reset count')
+	(aBuilder button: #resetCount)
 		order: 7;
 		target: self;
 		label: 'Reset the reminder count';
-		dialog: [ self createResetCountButtonMorph ]
+		buttonLabel: 'Apply';
+		dialog: [ self resetCount ]
 ]
 
 { #category : 'defaults' }
@@ -311,7 +301,8 @@ ShortcutReminder >> remind: aMenuItem [
 { #category : 'settings' }
 ShortcutReminder >> resetCount [
 
-	countDict := Dictionary new
+	countDict := Dictionary new.
+	self inform: 'Shortcut reminder count reset'
 ]
 
 { #category : 'shortcut creation' }

--- a/src/System-Settings-Browser/SettingNodeBuilder.class.st
+++ b/src/System-Settings-Browser/SettingNodeBuilder.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'node',
-		'builder'
+		'builder',
+		'callback'
 	],
 	#category : 'System-Settings-Browser',
 	#package : 'System-Settings-Browser'
@@ -20,6 +21,19 @@ SettingNodeBuilder >> asParentWhile: aBlock [
 { #category : 'accessing' }
 SettingNodeBuilder >> builder: aTreeBuilder [
 	builder := aTreeBuilder
+]
+
+{ #category : 'initialization' }
+SettingNodeBuilder >> buttonLabel: aString [ 
+	"Set the current's node declaration button label to aString"
+
+	node item actionLabel: aString
+]
+
+{ #category : 'accessing' }
+SettingNodeBuilder >> callback: aFullBlockClosure [ 
+
+	callback := aFullBlockClosure 
 ]
 
 { #category : 'declaration accessing' }

--- a/src/System-Settings-Browser/SettingTreeBuilder.class.st
+++ b/src/System-Settings-Browser/SettingTreeBuilder.class.st
@@ -25,6 +25,12 @@ SettingTreeBuilder >> buildPragma: aPragma [
 	^ nodeList
 ]
 
+{ #category : 'accessing - structure variables' }
+SettingTreeBuilder >> button: aSymbol [
+
+	^ self nodeClass: ActionSettingDeclaration name: aSymbol
+]
+
 { #category : 'tree building' }
 SettingTreeBuilder >> group: aSymbol [
 	^ self nodeClass: PragmaSetting name: aSymbol

--- a/src/System-Settings-Core/ActionSettingDeclaration.class.st
+++ b/src/System-Settings-Core/ActionSettingDeclaration.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : 'ActionSettingDeclaration',
+	#superclass : 'SettingDeclaration',
+	#instVars : [
+		'actionLabel'
+	],
+	#category : 'System-Settings-Core-Base',
+	#package : 'System-Settings-Core',
+	#tag : 'Base'
+}
+
+{ #category : 'accessing' }
+ActionSettingDeclaration >> actionLabel [
+
+	^ actionLabel
+]
+
+{ #category : 'accessing' }
+ActionSettingDeclaration >> actionLabel: anObject [
+
+	actionLabel := anObject
+]
+
+{ #category : 'user interface' }
+ActionSettingDeclaration >> inputWidget [
+	"Private - Morphic requirement. To be deleted when morphic gets removed"
+
+	^ SimpleButtonMorph new
+		target: self target;
+		label: 'Apply';
+		actionSelector: #resetCount;
+		themeChanged;
+		yourself
+]
+
+{ #category : 'accessing' }
+ActionSettingDeclaration >> realValue [
+	"Private - Morphic requirement. To be deleted when morphic gets removed"
+
+	^ false
+]


### PR DESCRIPTION
## TL;DR

This PR introduces a mechanism to unhook the `dialog:` method from Morphic, used in Morphic Settings Browser.

## Details

- The `dialog` callback in `PragmaSetting` no longer requires answering a Morph.
- Introduce `ActionSettingDeclaration` for declarations applied through buttons.
- Introduce the `button:` method in `SettingTreeBuilder,` so we explicitly configure a button for a setting. It is paired with the new `ActionSettingDeclaration`. This means that settings using `#group:` now can use `#button:` to detach the Settings Browser from Morphic, as detailed in #16801.
- The `inputWidget` method used `dialog` bound to Morphic. 
- To keep the Morphic Settings Browser setting functional, `ActionSettingDeclaration` includes `inputWidget,` which should be removed when Morphic is removed. The same applies to the method `realValue`.

