### PR TITLE
Fix for globals references request error in Calypso

### DIFF
--- a/src/Kernel-CodeModel/Behavior.class.st
+++ b/src/Kernel-CodeModel/Behavior.class.st
@@ -1129,11 +1129,6 @@ Behavior >> isPointers [
 ]
 
 { #category : 'testing' }
-Behavior >> isPool [
-	^false
-]
-
-{ #category : 'testing' }
 Behavior >> isReferenced [
 	"Returns true if the class is referenced from a method."
 	^ self binding isReferenced

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1183,6 +1183,11 @@ Object >> isPoint [
 	^ false
 ]
 
+{ #category : 'testing' }
+Object >> isPool [
+	^ false
+]
+
 { #category : 'write barrier' }
 Object >> isReadOnlyObject [
 	"Answer if the receiver is read-only.

--- a/src/Ring-Definitions-Core/RGClassDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGClassDefinition.class.st
@@ -208,7 +208,7 @@ RGClassDefinition >> instanceSide [
 	^ self
 ]
 
-{ #category : 'managing pool users' }
+{ #category : 'testing' }
 RGClassDefinition >> isPool [
 	"The receiver is a shared pool if it inherits from SharedPool"
 

--- a/src/Ring-Definitions-Core/RGDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGDefinition.class.st
@@ -196,12 +196,6 @@ RGDefinition >> isPackage [
 ]
 
 { #category : 'testing - types' }
-RGDefinition >> isPool [
-
-	^false
-]
-
-{ #category : 'testing - types' }
 RGDefinition >> isReference [
 
 	^false


### PR DESCRIPTION
This PR fixes the error described in #17033: Requesting to browse references to globals in Calypso through CMD/CTRL + N raises a Debugger
Remove equivalent #isPool implementors.
