### PR TITLE
fix #17037: DAPackageAnalyzerDiffTreePresenter uses old Spec method

### DIFF
--- a/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerDiffTreePresenter.class.st
+++ b/src/Tool-DependencyAnalyser-UI/DAPackageAnalyzerDiffTreePresenter.class.st
@@ -29,7 +29,7 @@ DAPackageAnalyzerDiffTreePresenter class >> title [
 { #category : 'initialization' }
 DAPackageAnalyzerDiffTreePresenter >> buildRoots [
 	self treeDiff roots: packageRelationGraphDiff packagesDiffToDisplay.
-	self treeDiff whenBuiltDo: [ treeDiff rootNodeHolder: [ :item | DAPackageItemDiffNode new content: item ] ]
+	self treeDiff whenBuiltDo: [ treeDiff children: [ :item | DAPackageItemDiffNode new content: item ] ]
 ]
 
 { #category : 'specs' }


### PR DESCRIPTION
using `children:` while building roots `buildRoots` instead of the old `rootNodeHolder:` method.