### PR TITLE
Fix some wrong rewritting of the ReCollectionProtocolRule

### DIFF
--- a/src/General-Rules-Tests/ReCollectionProtocolRuleTest.class.st
+++ b/src/General-Rules-Tests/ReCollectionProtocolRuleTest.class.st
@@ -1,0 +1,40 @@
+"
+A ReCollectionProtocolRuleTest is a test class for testing the behavior of ReCollectionProtocolRule
+"
+Class {
+	#name : 'ReCollectionProtocolRuleTest',
+	#superclass : 'ReAbstractRuleTestCase',
+	#category : 'General-Rules-Tests-Coding Idiom Violation',
+	#package : 'General-Rules-Tests',
+	#tag : 'Coding Idiom Violation'
+}
+
+{ #category : 'tests' }
+ReCollectionProtocolRuleTest >> testRule [
+
+	| critiques |
+	self class compile: 'method | set col | set := #(1 2 3). col := OrderedCollection new. set do: [ :number | col add: number ] ' classified: 'test-helper'.
+	[
+	critiques := self myCritiquesOnMethod: self class >> #method.
+	self assert: critiques size equals: 1 ] ensure: [ (self class >> #method) removeFromSystem ]
+]
+
+{ #category : 'tests' }
+ReCollectionProtocolRuleTest >> testRuleNotViolatedWithCollect [
+
+	| critiques |
+	self class compile: 'method | set col | set := #(1 2 3). col := set collect: [ :number | number ] ' classified: 'test-helper'.
+	[
+	critiques := self myCritiquesOnMethod: self class >> #method.
+	self assertEmpty: critiques ] ensure: [ (self class >> #method) removeFromSystem ]
+]
+
+{ #category : 'tests' }
+ReCollectionProtocolRuleTest >> testRuleNotViolatedWithSelect [
+
+	| critiques |
+	self class compile: 'method | set col | set := #(1 2 3). col := set select: [ :number | number%2 ~= 0] ' classified: 'test-helper'.
+	[
+	critiques := self myCritiquesOnMethod: self class >> #method.
+	self assertEmpty: critiques ] ensure: [ (self class >> #method) removeFromSystem ]
+]

--- a/src/General-Rules/ReCollectionProtocolRule.class.st
+++ b/src/General-Rules/ReCollectionProtocolRule.class.st
@@ -30,25 +30,40 @@ ReCollectionProtocolRule class >> uniqueIdentifierName [
 ReCollectionProtocolRule >> initialize [
 
 	super initialize.
-	self 		replace:
-			'`@collection do: [:`each | | `@temps | `@.Statements. `@object add: `@arg ]'
-		with:
-			'`@object addAll: (`@collection collect: [:`each | | `@temps | `@.Statements. `@arg ])';
-			
-		replace: '`@collection do: [:`each | | `@temps |
-			`@.Statements.
-			`@condition ifTrue: [| `@blockTemps |
-					`@.BlockStatements.
-					`@object add: `@arg ] ]'
-		with:
-			'`@object addAll: (`@collection select: [ :`each | | `@temps | `@.Statements. `@condition ifTrue: [| `@blockTemps |
-					`@.BlockStatements] ] )';
-			
-		replace: '`@collection do: [:`each | | `@temps |
-			`@.Statements.
-			`@condition ifFalse: [| `@blockTemps |
-					`@.BlockStatements.
-					`@object add: `@arg ] ]'
-		with: '`@object addAll: (`@collection select: [ :`each | | `@temps | `@.Statements. `@condition ifFalse: [| `@blockTemps |
-					`@.BlockStatements] ] )'
+	self
+		replace: '`@collection
+					do: [:`each |
+						| `@temps |
+						`@.Statements.
+						`@object add: `@arg ]'
+		with: '`@object
+					addAll: (`@collection
+									collect: [:`each |
+										| `@temps |
+										`@.Statements.
+										`@arg ])';
+
+		replace: '`@collection
+						do: [ :`each |
+							| `@temps |
+							`@.Statements.
+							`@condition ifTrue: [ `@object add: `@arg ] ]'
+		with: '`@object
+					addAll: (`@collection
+								select: [ :`each |
+									| `@temps |
+									`@.Statements.
+									`@condition ] )';
+
+		replace: '`@collection
+						do: [ :`each |
+							| `@temps |
+							`@.Statements.
+							`@condition ifFalse: [ `@object add: `@arg ] ]'
+		with: '`@object
+					addAll: (`@collection
+								reject: [ :`each |
+									| `@temps |
+									`@.Statements.
+									`@condition ] )'
 ]


### PR DESCRIPTION
Some rewritting proposed were producing wrong code and this change fixes it. Also, the rule produces now less critics (it does not raise a critic when we have more statements in the #ifTrue: or ifFalse: blocks before the add because the code to update is not more readable than the original code)