### PR TITLE
Remove store:path:node: (broken and unused)

### DIFF
--- a/src/FileSystem-Core/DiskDirectoryEntry.class.st
+++ b/src/FileSystem-Core/DiskDirectoryEntry.class.st
@@ -56,14 +56,6 @@ DiskDirectoryEntry class >> reference: aFileReference statAttributes: anArray [
 	^self new initializeWithReference: aFileReference statAttributes: anArray
 ]
 
-{ #category : 'instance creation' }
-DiskDirectoryEntry class >> store: aDiskStore path: aPath node: aNode [
-
-	^(super store: aDiskStore path: aPath)
-		statAttributes: (aNode at: 2);
-		yourself
-]
-
 { #category : 'private - accessing' }
 DiskDirectoryEntry >> accessAttributeMask [
 	"Answer the mask used to retrieve access attributes"

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -546,7 +546,7 @@ ReleaseTest >> testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented 
 	                    'ComplexBorderStyle>>#drawPolyPatchFrom:to:on:usingEnds:' 'ComplexBorderStyle>>#drawLineFrom:to:on:'
 	                    'Context>>#simulatePrimitive:in:receiver:arguments:' 'Context>>#doPrimitive:method:receiver:args:'
 	                    'Context>>#failPrimitiveWith:' 'DAPackageAnalyzerDiffTreePresenter>>#buildRoots' 'DTReRunConfiguration>>#items'
-	                    'DebugSession>>#shouldDisplayContext:basedOnFilters:' 'DiskDirectoryEntry class>>#store:path:node:'
+	                    'DebugSession>>#shouldDisplayContext:basedOnFilters:'
 	                    'EDEmergencyDebugger>>#resetDisplay' 'EDTest>>#prepareMethodVersionTest' 'ExternalDropHandler class>>#defaultHandler'
 	                    'FFICallbackArgumentReader>>#stackPointer' 'FFIFloat32>>#callbackReturnOn:for:' 'FFIFloatType>>#callbackReturnOn:for:'
 	                    'FFIIndirectFunctionResolution>>#resolveFunction:' 'FileDialogWindow>>#saveForcedSelectedFile' 'FileList class>>#morphicViewOnFile:contents:fileList:'


### PR DESCRIPTION
This is an unused method with broken code inside. There is no senders.