### PR TITLE
Moved refactoring stuff from SycSourceCodeCommand to SycSourceCodeRefactoringCommand

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodAndOccurrencesCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodAndOccurrencesCommand.class.st
@@ -4,8 +4,6 @@ I am a command to extract selected ast node into separate method
 Class {
 	#name : 'SycExtractMethodAndOccurrencesCommand',
 	#superclass : 'SycSourceCodeRefactoringCommand',
-	#traits : 'TRefactoringCommandSupport',
-	#classTraits : 'TRefactoringCommandSupport classTrait',
 	#instVars : [
 		'selectedTextInterval'
 	],

--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -4,8 +4,6 @@ I am a command to extract selected ast node into separate method
 Class {
 	#name : 'SycExtractMethodCommand',
 	#superclass : 'SycSourceCodeRefactoringCommand',
-	#traits : 'TRefactoringCommandSupport',
-	#classTraits : 'TRefactoringCommandSupport classTrait',
 	#instVars : [
 		'selectedTextInterval',
 		'refactoringScopes'

--- a/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycSourceCodeCommand.class.st
@@ -10,8 +10,6 @@ Internal Representation and Key Implementation Points.
 Class {
 	#name : 'SycSourceCodeCommand',
 	#superclass : 'CmdCommand',
-	#traits : 'TRefactoringCommandSupport',
-	#classTraits : 'TRefactoringCommandSupport classTrait',
 	#instVars : [
 		'method',
 		'sourceNode'
@@ -30,26 +28,6 @@ SycSourceCodeCommand class >> method: aMethod node: aProgramNode [
 	^self new
 		method: aMethod;
 		sourceNode: aProgramNode
-]
-
-{ #category : 'converting' }
-SycSourceCodeCommand >> asRefactorings [
-	self subclassResponsibility
-]
-
-{ #category : 'execution' }
-SycSourceCodeCommand >> execute [
-
-	self executeRefactoring: self asRefactorings
-]
-
-{ #category : 'private' }
-SycSourceCodeCommand >> executeRefactoring: refactoring [
-
-	self initializeDefaultOptionsOf: refactoring.
-	[ refactoring execute ]
-		on: RBRefactoringError
-		do: [ :e | self morphicUIManager alert: e messageText ]
 ]
 
 { #category : 'accessing' }

--- a/src/SystemCommands-SourceCodeCommands/SycSourceCodeRefactoringCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycSourceCodeRefactoringCommand.class.st
@@ -1,6 +1,8 @@
 Class {
 	#name : 'SycSourceCodeRefactoringCommand',
 	#superclass : 'SycSourceCodeCommand',
+	#traits : 'TRefactoringCommandSupport',
+	#classTraits : 'TRefactoringCommandSupport classTrait',
 	#category : 'SystemCommands-SourceCodeCommands',
 	#package : 'SystemCommands-SourceCodeCommands'
 }
@@ -9,6 +11,26 @@ Class {
 SycSourceCodeRefactoringCommand class >> isAbstract [
 
 	^ self == SycSourceCodeRefactoringCommand
+]
+
+{ #category : 'converting' }
+SycSourceCodeRefactoringCommand >> asRefactorings [
+	self subclassResponsibility
+]
+
+{ #category : 'execution' }
+SycSourceCodeRefactoringCommand >> execute [
+
+	self executeRefactoring: self asRefactorings
+]
+
+{ #category : 'private' }
+SycSourceCodeRefactoringCommand >> executeRefactoring: refactoring [
+
+	self initializeDefaultOptionsOf: refactoring.
+	[ refactoring execute ]
+		on: RBRefactoringError
+		do: [ :e | self morphicUIManager alert: e messageText ]
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
`SycSourceCodeCommand` contained many refactoring-related stuff it did not use and even required all its subclasses to implement `asRefactorings`, although many of the subclasses are NOT refactorings and therefore did not implement it.
It seems the proper place for all these refactoring methods is `SycSourceCodeCommand`'s subclass `SycSourceCodeRefactoringCommand`, so I moved it all there. This includes usage of trait `TRefactoringCommandSupport`.
The same trait was redundantly implemented by few of their subclasses (specific commands), so I removed the trait usages from these.
Does cleanup https://github.com/pharo-project/pharo/issues/17053