### PR TITLE
Apply addition of discardBuffer to ZnBufferedReadStream>>#readInto:startingAt:count in the case that the buffer is bypassed

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
@@ -273,15 +273,14 @@ ZnBufferedReadStream >> peekFor: object [
 
 { #category : 'accessing' }
 ZnBufferedReadStream >> position [
-
 	"If the buffer advanced, we need to check the original stream position, minus what we have read.
 	The -1 is because the buffer is base 1"
+
 	^ stream position - limit + position - 1
 ]
 
 { #category : 'accessing' }
 ZnBufferedReadStream >> position: anInteger [
-
 	| bufferEnd bufferStart |
 	bufferEnd := stream position.
 	bufferStart := bufferEnd - limit.
@@ -289,8 +288,7 @@ ZnBufferedReadStream >> position: anInteger [
 		ifTrue: [ position := anInteger - bufferStart + 1 ]
 		ifFalse: [
 			"We reset the buffer and update the position in the underlying stream"
-			limit := 0.
-			position := 1.
+			self discardBuffer.
 			stream position: anInteger ]
 ]
 
@@ -327,12 +325,13 @@ ZnBufferedReadStream >> readInto: collection startingAt: offset count: requested
 			| newOffset |
 			newOffset := offset + countRead.
 			(self shouldBufferReadOfCount: countYetToRead)
-				ifTrue: [ self nextBuffer.
+				ifTrue: [
+					self nextBuffer.
 					limit > 0
-						ifTrue:
-							[ countRead := countRead + (self readInto: collection startingAt: newOffset count: countYetToRead) ] ]
-				ifFalse:
-					[ countRead := countRead + (stream readInto: collection startingAt: newOffset count: countYetToRead) ] ].
+						ifTrue: [ countRead := countRead + (self readInto: collection startingAt: newOffset count: countYetToRead) ] ]
+				ifFalse: [
+					self discardBuffer.
+					countRead := countRead + (stream readInto: collection startingAt: newOffset count: countYetToRead) ] ].
 	^ countRead
 ]
 

--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
@@ -57,6 +57,29 @@ ZnBufferedReadStreamTest >> testPeek [
 ]
 
 { #category : 'tests' }
+ZnBufferedReadStreamTest >> testPositioning [
+	| byteArray stream |
+
+	byteArray := (1 to: 255) as: ByteArray.
+
+	stream := ZnBufferedReadStream on: byteArray readStream.
+	stream sizeBuffer: 32.
+
+	self assert: stream position equals: 0.
+	self assert: stream next equals: 1.
+	self assert: stream position equals: 1.
+
+	self assert: (stream next: 100) equals: ((2 to: 101) as: ByteArray).
+	self assert: stream position equals: 101.
+
+	stream position: 99.
+	self assert: stream position equals: 99.
+	
+	self assert: stream next equals: 100.
+	self assert: stream position equals: 100
+]
+
+{ #category : 'tests' }
 ZnBufferedReadStreamTest >> testReadInto [
 	| stream buffer count |
 	stream := ZnBufferedReadStream on: '0123456789' readStream.


### PR DESCRIPTION
This pull request applies the changes from [Zinc commit ca180a2](https://github.com/svenvc/zinc/commit/ca180a2fe12baab91bdbca397f0824e2b9596efc). This is related to issue #14235.