### PR TITLE
Adapt #ensureWindowOpen on EDDisplayInterface to use of ScalingCanvas in OSWindowFormRenderer

### DIFF
--- a/src/EmergencyDebugger/EDDisplayInterface.class.st
+++ b/src/EmergencyDebugger/EDDisplayInterface.class.st
@@ -90,7 +90,7 @@ EDDisplayInterface >> ensureWindowOpen [
 	window := OSWindow
 		createWithAttributes: attrs
 		eventHandler: (EDDisplayEventHandler on: self).
-	renderer := window newFormRenderer: (Form extent: self extent depth: 32)
+	renderer := window newFormRenderer: (Form extent: self extent * OSWorldRenderer canvasScaleFactor depth: 32)
 ]
 
 { #category : 'private - display' }


### PR DESCRIPTION
This pull request adapts `#ensureWindowOpen` on EDDisplayInterface to changes done in pull request #15647: the extent of the form passed to the renderer needs to be scaled by the factor used by the canvas in `#getCanvas` on OSWindowFormRenderer.