### PR TITLE
Add Icons Pack Manager UI

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -136,6 +136,7 @@ BaselineOfIDE >> baseline: spec [
 		self roassal: spec.
 		
 		spec package: 'DarkBlueTheme'.
+		spec package: 'IconPacks'.
 
 		spec baseline: 'ThreadedFFI' with: [ spec repository: repository ].
 

--- a/src/IconPacks/IconPacksFetchPresenter.class.st
+++ b/src/IconPacks/IconPacksFetchPresenter.class.st
@@ -2,14 +2,68 @@ Class {
 	#name : 'IconPacksFetchPresenter',
 	#superclass : 'SpPresenter',
 	#instVars : [
-		'choosePresenter',
 		'fetchButton',
-		'buttonBar',
-		'cancelButton'
+		'cancelButton',
+		'searchIconTextPresenter',
+		'searchButtonPresenter',
+		'availableIconPacksPresenter',
+		'fetchedIconPacks',
+		'updateListButton',
+		'iconsTablePresenter',
+		'mainButtonBar',
+		'iconPacksButtonBar',
+		'applyButton',
+		'closeButton',
+		'repositoryListIconPacksPresenter',
+		'logPresenter'
+	],
+	#classVars : [
+		'JSONList'
 	],
 	#category : 'IconPacks',
 	#package : 'IconPacks'
 }
+
+{ #category : 'accessing' }
+IconPacksFetchPresenter class >> descriptionText [
+
+	^ ''
+]
+
+{ #category : 'accessing' }
+IconPacksFetchPresenter class >> fetchJsonList [
+
+	^ ZnClient new
+			get: 'https://api.github.com/repos/pharo-project/pharo-icon-packs/branches';
+			contents
+]
+
+{ #category : 'accessing' }
+IconPacksFetchPresenter class >> jsonList [
+	"Answer a <String> representing a JSON with the icon-packs meta-information obtained from remote repository"
+
+	^ JSONList
+		ifNil: [ JSONList := self fetchJsonList ]
+]
+
+{ #category : 'accessing' }
+IconPacksFetchPresenter class >> jsonList: aJSONString [
+	"Set a <String> representing a JSON with the icon-packs meta-information obtained from remote repository"
+
+	JSONList := aJSONString
+]
+
+{ #category : 'world menu' }
+IconPacksFetchPresenter class >> menuCommandOn: aBuilder [
+	<worldMenu>
+
+	(aBuilder item: 'Icon Studio')
+		action: [ self open ];
+		order: 37;
+		parent: #Tools;
+		icon: (self iconNamed: #configuration);
+		help: self descriptionText
+]
 
 { #category : 'instance creation' }
 IconPacksFetchPresenter class >> open [
@@ -18,61 +72,141 @@ IconPacksFetchPresenter class >> open [
 	^ self new open
 ]
 
+{ #category : 'class initialization' }
+IconPacksFetchPresenter class >> reset [
+	<script>
+
+	JSONList := nil.
+]
+
 { #category : 'layout' }
 IconPacksFetchPresenter >> defaultLayout [
 
-	^ SpBoxLayout newTopToBottom
-		add: choosePresenter;
-		add:  buttonBar expand: false;
+	^ SpBoxLayout newTopToBottom 
+		spacing: 5;
+		add: (SpBoxLayout newLeftToRight 
+			spacing: 5;
+			add: (SpBoxLayout newTopToBottom 
+				spacing: 5;			
+				add: repositoryListIconPacksPresenter;
+				add: (SpBoxLayout newLeftToRight 
+					add: updateListButton;
+					add: fetchButton;
+					yourself) expand: false;
+				add: availableIconPacksPresenter;
+				yourself) expand: false;
+			add: (SpBoxLayout newTopToBottom 
+				spacing: 5;
+				add: (SpBoxLayout newLeftToRight
+					spacing: 5;
+					add: searchIconTextPresenter;
+					add: searchButtonPresenter expand: false;
+					yourself) expand: false;			
+				add: iconsTablePresenter;
+				add: 'Log' expand: false;
+				add: logPresenter height: 100;
+				yourself);
+			yourself);
+		add: mainButtonBar expand: false;
 		yourself
+]
+
+{ #category : 'callbacks' }
+IconPacksFetchPresenter >> downloadedIconPacksNames [
+	"Answer a <Collection> of <ThemeIcons> each one representing a downloaded Icon Pack"
+
+	^ ThemeIcons availablePacks
 ]
 
 { #category : 'accessing' }
 IconPacksFetchPresenter >> fetchPacks [
-	"Retrieve all packs available from repository"
+	"Retrieve all packs available from repository. This fetch the **names** of the icon packs, not the icon resources. Answer a <Collection> of <ThemeIcon>"
 
-	| jsonList |
 	[
-	jsonList := ZnClient new
-		            get:
-			            'https://api.github.com/repos/pharo-project/pharo-icon-packs/branches';
-		            contents ]
-		on: Error
-		do: [ :e | "in case of error (no inet connection, for example) I retrieve just current icon set"
-			e crTrace.
-			^ { Smalltalk ui icons } ].
-	^ (STON fromString: jsonList)
+		self jsonList: self class fetchJsonList
+	]
+	on: Error
+	do: [ :e | "in case of error (no inet connection, for example) I retrieve just current icon set"
+		e crTrace.
+		^ { Smalltalk ui icons } ].
+
+	^ (STON fromString: self jsonList)
 		  collect: [ :each |
 			  | packName |
 			  "Ensure we have just one instance of current pack"
-			  packName := each at: 'name'.
-			  packName = (self iconNamed: #name)
+			  (packName := each at: 'name') = Smalltalk ui icons name
 				  ifTrue: [ Smalltalk ui icons ]
 				  ifFalse: [ ThemeIcons named: packName ] ]
 		  as: Array
 ]
 
-{ #category : 'initialization' }
+{ #category : 'callbacks' }
+IconPacksFetchPresenter >> fetchSelectedIconPack: aThemeIcons [
+
+	self updateLogPresenter: (self newLogEntryFromZipFile: aThemeIcons downloadFromUrl).
+]
+
+{ #category : 'callbacks' }
 IconPacksFetchPresenter >> fetchSelectedIconPacks [
 	"Callback to make a remote request to download available icon packs"
 
 	self selectedIconPacks 
-		do: [ : iconPack | iconPack downloadFromUrl ]
-		displayingProgress: 'Downloading selected icon packs'
+		ifNotEmpty: [ : selectedIconsPck |
+			selectedIconsPck 
+				do: [ : iconPack | self fetchSelectedIconPack: iconPack ]
+				displayingProgress: 'Downloading selected icon packs'.
+			self updateDownloadedIconPacks ]
+		ifEmpty: [ self inform: 'No selected icon(s) pack(s) to fetch' ]
+	
+]
+
+{ #category : 'accessing' }
+IconPacksFetchPresenter >> fetchedIconPacks [
+	"Answer a <Collection> of <ThemeIcons>"
+	
+	^ fetchedIconPacks
+		ifNil: [ fetchedIconPacks := self fetchPacks ]
+]
+
+{ #category : 'private' }
+IconPacksFetchPresenter >> iconDimensions: aForm [
+
+	^ String streamContents: [ : stream |
+		stream 
+			<< aForm width asString;
+			<< $x;
+			<< aForm height asString;
+			<< $x;
+			<< aForm depth asString ]
 
 ]
 
 { #category : 'initialization' }
-IconPacksFetchPresenter >> initializePresenters [ 
+IconPacksFetchPresenter >> initializeButtonsPresenters [
 
-	choosePresenter := SpChooserPresenter new
-		sourceItems: self fetchPacks;
-		displayBlock: [ : themeIcons | themeIcons name ];
+	applyButton := self newButton
+		label: 'Set Current';
+		action: [ self setCurrentIconPack ];
+		disable;
+		yourself.
+		
+	closeButton := self newButton
+		label: 'Close';
+		action: [ self delete ];
 		yourself.
 
+	mainButtonBar := self newButtonBar 
+		add: applyButton;
+		add: closeButton;
+		yourself
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> initializeIconPacksButtonsPresenters [
+
 	fetchButton := self newButton
-		help: 'Fetch Icon Packs from remote repository';
 		label: 'Fetch';
+		help: 'Fetch Icon Packs from remote repository';
 		icon: (self iconNamed: #down);
 		action: [ self fetchSelectedIconPacks ];
 		yourself.
@@ -81,12 +215,95 @@ IconPacksFetchPresenter >> initializePresenters [
 		icon: (self iconNamed: #smallCancel);
 		action: [ self delete ];
 		yourself.
+	updateListButton := self newButton
+		label: 'Update';
+		help: 'Update the icon packs list';
+		icon: (self iconNamed: #smallUpdate);
+		action: [ self fetchedIconPacks ];
+		yourself.
 
-	buttonBar := self newButtonBar 
+	iconPacksButtonBar := self newButtonBar 
 		add: cancelButton;
-		add:  fetchButton;
+		add: updateListButton;
+		add: fetchButton;
+		yourself
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> initializeIconPacksPresenters [
+
+	repositoryListIconPacksPresenter := (self instantiate: SpFilteringSelectableListPresenter)
+		headerTitle: 'Available Icon Packs';
+		items: self fetchedIconPacks;
+		display: [ : themeIcons | themeIcons name ];
+		contextMenu: [  ];
+		yourself.
+	availableIconPacksPresenter := self newList
+		headerTitle: 'Downloaded Icon Packs';
+		items: self downloadedIconPacksNames;
+		display: [ : iconsPack | iconsPack name ];
+		whenSelectedItemChangedDo: [ : iconPack | 
+			applyButton enable.
+			self updateIconsTable: iconPack ];
+		"contextMenu: [ self availableIconsPackcontextMenuCommands ];"
+		yourself.
+
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> initializeIconTablePresenter [
+
+	iconsTablePresenter := self newTable
+		addColumn: (SpImageTableColumn new 
+			width: 30;
+			title: 'Icon';
+			evaluated: [ : iconAssoc | iconAssoc value  ];
+			beNotExpandable;
+			yourself);
+		addColumn: (SpStringTableColumn new  
+			title: 'Name'; 
+			evaluated: [ : iconAssoc | iconAssoc key asString ];
+			beSortable;
+			yourself);
+		addColumn: (SpStringTableColumn new
+			title: 'Dimensions (W x H x D)';
+			evaluated: [ : iconAssoc | self iconDimensions: iconAssoc value ];
+			beSortable;
+			yourself);
 		yourself
 
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> initializeLogPresenter [
+
+	logPresenter := self newList
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> initializePresenters [ 
+
+	self 
+		initializeSearchPresenters;
+		initializeIconPacksPresenters;
+		initializeIconPacksButtonsPresenters;
+		initializeButtonsPresenters;
+		initializeIconTablePresenter;
+		initializeLogPresenter
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> initializeSearchPresenters [
+
+	searchIconTextPresenter := self newSearchInput 
+		placeholder: 'Search icon by name';
+		whenTextChangedDo: [ :aString | self updateSearch: aString ];				
+		yourself.
+	searchButtonPresenter := self newButton
+		iconName: #smallFind;	
+		disable;			
+		action: [ self updateSearch: searchIconTextPresenter text ];
+		yourself.
 ]
 
 { #category : 'initialization' }
@@ -94,14 +311,110 @@ IconPacksFetchPresenter >> initializeWindow: aWindowPresenter [
 	super initializeWindow: aWindowPresenter.
 	
 	aWindowPresenter 
-		title: 'Icon Packs Downloader';
+		title: 'Icon Packs Manager';
 		initialExtent: (950 @ 650) scaledByDisplayScaleFactor;
 		centered
 ]
 
-{ #category : 'initialization' }
-IconPacksFetchPresenter >> selectedIconPacks [ 
-	"Answer a <Collection> of "
+{ #category : 'accessing' }
+IconPacksFetchPresenter >> installedFetchPacks [
+	"Answer a <Collection> with the receiver's icon packs which are installed in the system"
+
+	^ self fetchedIconPacks select: [ : iconPack | iconPack hasIcons ]
+]
+
+{ #category : 'accessing' }
+IconPacksFetchPresenter >> jsonList [
+	"Answer a <String> representing a JSON with the icon-packs meta-information obtained from remote repository"
 	
-	^ choosePresenter chosenItems
+	^ self class jsonList
+]
+
+{ #category : 'accessing' }
+IconPacksFetchPresenter >> jsonList: aJSONString [
+
+	self class jsonList: aJSONString
+]
+
+{ #category : 'accessing' }
+IconPacksFetchPresenter >> logPresenter [
+	^ logPresenter
+]
+
+{ #category : 'private' }
+IconPacksFetchPresenter >> newLogEntryFromThemeIcons: aThemeIcons [
+
+	^ String streamContents: [ : stream |
+		stream 
+			<< 'Loaded ';
+			<< aThemeIcons name;
+			<< ': ';
+			<< aThemeIcons icons size asString;
+			<< ' icons.';
+			<< ' Scale: ';
+			<< aThemeIcons scale asString;
+			<< '. URL: ';
+			<< aThemeIcons url asString ]
+]
+
+{ #category : 'private' }
+IconPacksFetchPresenter >> newLogEntryFromZipFile: aFileLocator [ 
+	"Answer a <String> with aFileLocator information for a log reporter"
+
+	^ aFileLocator isZipFile 
+		ifFalse: [ 'Not a ZIP file: ' , (aFileLocator asString first: 10) ]
+		ifTrue: [ String streamContents: [ : stream |
+				stream 
+					<< aFileLocator basename;
+					<< ' (';
+					<< aFileLocator humanReadableSize;
+					<< ')' ] ]
+]
+
+{ #category : 'accessing' }
+IconPacksFetchPresenter >> selectedIconPacks [ 
+	"Answer a <Collection> of <ThemeIcons> found in the repository"
+	
+	^ repositoryListIconPacksPresenter selectedItems
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> setCurrentIconPack [
+
+	(self confirm: 'Are you sure to replace the current icon pack?')
+		ifTrue: [ self halt. availableIconPacksPresenter selectedItem beCurrent ]
+
+]
+
+{ #category : 'callbacks' }
+IconPacksFetchPresenter >> updateDownloadedIconPacks [
+
+	availableIconPacksPresenter 
+		items: self downloadedIconPacksNames
+]
+
+{ #category : 'callbacks' }
+IconPacksFetchPresenter >> updateIconsTable: aThemeIcons [
+
+	aThemeIcons hasIcons
+		ifFalse: [ aThemeIcons loadIconsFromUrl ].
+	iconsTablePresenter 
+		items: aThemeIcons icons associations asSortedCollection.
+	self updateLogPresenter: (self newLogEntryFromThemeIcons: aThemeIcons)
+
+]
+
+{ #category : 'callbacks' }
+IconPacksFetchPresenter >> updateLogPresenter: aString [
+
+	| logItems newLogItems |
+	logItems := self logPresenter items asOrderedCollection.
+	newLogItems := logItems add: aString; yourself. 
+	self logPresenter items: newLogItems
+]
+
+{ #category : 'callbacks' }
+IconPacksFetchPresenter >> updateSearch: aString [
+
+	self shouldBeImplemented
 ]

--- a/src/IconPacks/IconPacksFetchPresenter.class.st
+++ b/src/IconPacks/IconPacksFetchPresenter.class.st
@@ -1,0 +1,107 @@
+Class {
+	#name : 'IconPacksFetchPresenter',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'choosePresenter',
+		'fetchButton',
+		'buttonBar',
+		'cancelButton'
+	],
+	#category : 'IconPacks',
+	#package : 'IconPacks'
+}
+
+{ #category : 'instance creation' }
+IconPacksFetchPresenter class >> open [
+	<script>
+
+	^ self new open
+]
+
+{ #category : 'layout' }
+IconPacksFetchPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		add: choosePresenter;
+		add:  buttonBar expand: false;
+		yourself
+]
+
+{ #category : 'accessing' }
+IconPacksFetchPresenter >> fetchPacks [
+	"Retrieve all packs available from repository"
+
+	| jsonList |
+	[
+	jsonList := ZnClient new
+		            get:
+			            'https://api.github.com/repos/pharo-project/pharo-icon-packs/branches';
+		            contents ]
+		on: Error
+		do: [ :e | "in case of error (no inet connection, for example) I retrieve just current icon set"
+			e crTrace.
+			^ { Smalltalk ui icons } ].
+	^ (STON fromString: jsonList)
+		  collect: [ :each |
+			  | packName |
+			  "Ensure we have just one instance of current pack"
+			  packName := each at: 'name'.
+			  packName = (self iconNamed: #name)
+				  ifTrue: [ Smalltalk ui icons ]
+				  ifFalse: [ ThemeIcons named: packName ] ]
+		  as: Array
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> fetchSelectedIconPacks [
+	"Callback to make a remote request to download available icon packs"
+
+	self selectedIconPacks 
+		do: [ : iconPack | iconPack downloadFromUrl ]
+		displayingProgress: 'Downloading selected icon packs'
+
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> initializePresenters [ 
+
+	choosePresenter := SpChooserPresenter new
+		sourceItems: self fetchPacks;
+		displayBlock: [ : themeIcons | themeIcons name ];
+		yourself.
+
+	fetchButton := self newButton
+		help: 'Fetch Icon Packs from remote repository';
+		label: 'Fetch';
+		icon: (self iconNamed: #down);
+		action: [ self fetchSelectedIconPacks ];
+		yourself.
+	cancelButton := self newButton
+		label: 'Close';
+		icon: (self iconNamed: #smallCancel);
+		action: [ self delete ];
+		yourself.
+
+	buttonBar := self newButtonBar 
+		add: cancelButton;
+		add:  fetchButton;
+		yourself
+
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> initializeWindow: aWindowPresenter [
+	super initializeWindow: aWindowPresenter.
+	
+	aWindowPresenter 
+		title: 'Icon Packs Downloader';
+		initialExtent: (950 @ 650) scaledByDisplayScaleFactor;
+		centered
+]
+
+{ #category : 'initialization' }
+IconPacksFetchPresenter >> selectedIconPacks [ 
+	"Answer a <Collection> of "
+	
+	^ choosePresenter chosenItems
+]

--- a/src/IconPacks/IconPacksFetchPresenter.class.st
+++ b/src/IconPacks/IconPacksFetchPresenter.class.st
@@ -77,9 +77,22 @@ IconPacksFetchPresenter class >> reset [
 	JSONList := nil.
 ]
 
+{ #category : 'settings' }
+IconPacksFetchPresenter class >> settingsOn: aBuilder [
+	<systemsettings>
+
+	(aBuilder button: #openIconsPackManager)
+		parent: #appearance;
+		order: 2;
+		target: self;
+		label: 'Icons Pack';
+		buttonLabel: 'Open'
+]
+
 { #category : 'private' }
 IconPacksFetchPresenter >> checkAPILimitExceeded: jsonResponse [
-
+	"Private - GitHub answer a JSON dictionary if there is any API error. Check jsonResponse and raise an <Error> if there was a API rate limit problem"
+	
 	(jsonResponse includesKey: 'message')
 		ifFalse: [ ^ self ].
 	((jsonResponse at: 'message') asLowercase beginsWith: 'api rate limit') 
@@ -223,7 +236,8 @@ IconPacksFetchPresenter >> initializeIconPacksButtonsPresenters [
 		icon: (self iconNamed: #smallUpdate);
 		action: [ 
 			self inform: 'Note that in case of error (no internet connection, for example) the remote Icons Pack list will display only the current icon set'.
-			fetchedIconPacks := self fetchPacks ];
+			fetchedIconPacks := self fetchPacks.
+			self updateLogPresenter: 'Fetched ' , fetchedIconPacks size asString , ' icon packs' ];
 		yourself.
 
 	fetchButton := self newButton
@@ -442,6 +456,7 @@ IconPacksFetchPresenter >> updateIconsTable: aThemeIcons [
 
 { #category : 'callbacks' }
 IconPacksFetchPresenter >> updateLogPresenter: aString [
+	"Private - Write aString to the receiver's log presenter pane"
 
 	| logItems newLogItems |
 	logItems := self logPresenter items asOrderedCollection.
@@ -452,10 +467,9 @@ IconPacksFetchPresenter >> updateLogPresenter: aString [
 { #category : 'callbacks' }
 IconPacksFetchPresenter >> updateSearch: aString [
 
+	iconsTablePresenter items: (self sortedIconsList: availableIconPacksPresenter selectedItem icons).
 	aString 
 		ifNotEmpty: [ searchButtonPresenter enable ]
-		ifEmpty: [ 
-			searchButtonPresenter disable.
-			iconsTablePresenter items: (self sortedIconsList: availableIconPacksPresenter selectedItem icons) ].
+		ifEmpty: [ searchButtonPresenter disable ].
 	self searchIcon: aString
 ]

--- a/src/IconPacks/IconPacksFetchPresenter.class.st
+++ b/src/IconPacks/IconPacksFetchPresenter.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : 'SpPresenter',
 	#instVars : [
 		'fetchButton',
-		'cancelButton',
 		'searchIconTextPresenter',
 		'searchButtonPresenter',
 		'availableIconPacksPresenter',
@@ -11,7 +10,6 @@ Class {
 		'updateListButton',
 		'iconsTablePresenter',
 		'mainButtonBar',
-		'iconPacksButtonBar',
 		'applyButton',
 		'closeButton',
 		'repositoryListIconPacksPresenter',
@@ -27,7 +25,7 @@ Class {
 { #category : 'accessing' }
 IconPacksFetchPresenter class >> descriptionText [
 
-	^ ''
+	^ 'UI tool to query, download and set Icon Packs in the system'
 ]
 
 { #category : 'accessing' }
@@ -57,7 +55,7 @@ IconPacksFetchPresenter class >> jsonList: aJSONString [
 IconPacksFetchPresenter class >> menuCommandOn: aBuilder [
 	<worldMenu>
 
-	(aBuilder item: 'Icon Studio')
+	(aBuilder item: 'Icons Pack Manager')
 		action: [ self open ];
 		order: 37;
 		parent: #Tools;
@@ -122,11 +120,12 @@ IconPacksFetchPresenter >> downloadedIconPacksNames [
 IconPacksFetchPresenter >> fetchPacks [
 	"Retrieve all packs available from repository. This fetch the **names** of the icon packs, not the icon resources. Answer a <Collection> of <ThemeIcon>"
 
-	[
-		self jsonList: self class fetchJsonList
+	[ 
+		self inform: 'Note that in case of error (no internet connection, for example) the remote Icons Pack list will display only the current icon set'.
+		self jsonList: self class fetchJsonList 
 	]
 	on: Error
-	do: [ :e | "in case of error (no inet connection, for example) I retrieve just current icon set"
+	do: [ :e | 
 		e crTrace.
 		^ { Smalltalk ui icons } ].
 
@@ -204,36 +203,28 @@ IconPacksFetchPresenter >> initializeButtonsPresenters [
 { #category : 'initialization' }
 IconPacksFetchPresenter >> initializeIconPacksButtonsPresenters [
 
-	fetchButton := self newButton
-		label: 'Fetch';
-		help: 'Fetch Icon Packs from remote repository';
-		icon: (self iconNamed: #down);
-		action: [ self fetchSelectedIconPacks ];
-		yourself.
-	cancelButton := self newButton
-		label: 'Close';
-		icon: (self iconNamed: #smallCancel);
-		action: [ self delete ];
-		yourself.
 	updateListButton := self newButton
 		label: 'Update';
-		help: 'Update the icon packs list';
+		help: 'Query available packs from remote repository';
 		icon: (self iconNamed: #smallUpdate);
 		action: [ self fetchedIconPacks ];
 		yourself.
 
-	iconPacksButtonBar := self newButtonBar 
-		add: cancelButton;
-		add: updateListButton;
-		add: fetchButton;
-		yourself
+	fetchButton := self newButton
+		label: 'Fetch';
+		help: 'Download selected Icon Packs from remote repository';
+		icon: (self iconNamed: #down);
+		action: [ self fetchSelectedIconPacks ];
+		yourself.
+
+
 ]
 
 { #category : 'initialization' }
 IconPacksFetchPresenter >> initializeIconPacksPresenters [
 
 	repositoryListIconPacksPresenter := (self instantiate: SpFilteringSelectableListPresenter)
-		headerTitle: 'Available Icon Packs';
+		"headerTitle: 'Remote Icon Packs';"
 		items: self fetchedIconPacks;
 		display: [ : themeIcons | themeIcons name ];
 		contextMenu: [  ];
@@ -371,6 +362,24 @@ IconPacksFetchPresenter >> newLogEntryFromZipFile: aFileLocator [
 					<< ')' ] ]
 ]
 
+{ #category : 'callbacks' }
+IconPacksFetchPresenter >> searchIcon: aString [ 
+	"Update the receiver's icon entries with items matching aString"
+
+	iconsTablePresenter items: (self searchedIconMatches: aString) reversed.
+
+]
+
+{ #category : 'callbacks' }
+IconPacksFetchPresenter >> searchedIconMatches: aString [ 
+	"If there are filters applied, then search aString in the subset of the filtered entries, otherwise search in the cached log entries"
+	
+	^ iconsTablePresenter items
+		select: [: iconAssoc | iconAssoc key asLowercase beginsWith: aString asLowercase ]
+
+
+]
+
 { #category : 'accessing' }
 IconPacksFetchPresenter >> selectedIconPacks [ 
 	"Answer a <Collection> of <ThemeIcons> found in the repository"
@@ -380,10 +389,15 @@ IconPacksFetchPresenter >> selectedIconPacks [
 
 { #category : 'initialization' }
 IconPacksFetchPresenter >> setCurrentIconPack [
+	
+	| selectedIconsPack |
 
 	(self confirm: 'Are you sure to replace the current icon pack?')
-		ifTrue: [ self halt. availableIconPacksPresenter selectedItem beCurrent ]
-
+		ifFalse: [ ^ self ].
+	selectedIconsPack := availableIconPacksPresenter selectedItem.
+	selectedIconsPack beCurrent.
+	self inform:
+		'Current Icons Pack updated to: ' , selectedIconsPack name
 ]
 
 { #category : 'callbacks' }
@@ -416,5 +430,8 @@ IconPacksFetchPresenter >> updateLogPresenter: aString [
 { #category : 'callbacks' }
 IconPacksFetchPresenter >> updateSearch: aString [
 
-	self shouldBeImplemented
+	aString 
+		ifNotEmpty: [ searchButtonPresenter enable ]
+		ifEmpty: [ searchButtonPresenter disable ].
+	self searchIcon: aString
 ]

--- a/src/IconPacks/IconPacksFetchPresenter.class.st
+++ b/src/IconPacks/IconPacksFetchPresenter.class.st
@@ -417,6 +417,12 @@ IconPacksFetchPresenter >> setCurrentIconPack [
 ]
 
 { #category : 'callbacks' }
+IconPacksFetchPresenter >> sortedIconsList: iconsCollection [
+
+	^ iconsCollection associations asSortedCollection
+]
+
+{ #category : 'callbacks' }
 IconPacksFetchPresenter >> updateDownloadedIconPacks [
 
 	availableIconPacksPresenter 
@@ -429,7 +435,7 @@ IconPacksFetchPresenter >> updateIconsTable: aThemeIcons [
 	aThemeIcons hasIcons
 		ifFalse: [ aThemeIcons loadIconsFromUrl ].
 	iconsTablePresenter 
-		items: aThemeIcons icons associations asSortedCollection.
+		items: (self sortedIconsList: aThemeIcons icons).
 	self updateLogPresenter: (self newLogEntryFromThemeIcons: aThemeIcons)
 
 ]
@@ -448,6 +454,8 @@ IconPacksFetchPresenter >> updateSearch: aString [
 
 	aString 
 		ifNotEmpty: [ searchButtonPresenter enable ]
-		ifEmpty: [ searchButtonPresenter disable ].
+		ifEmpty: [ 
+			searchButtonPresenter disable.
+			iconsTablePresenter items: (self sortedIconsList: availableIconPacksPresenter selectedItem icons) ].
 	self searchIcon: aString
 ]

--- a/src/IconPacks/IconPacksFetchPresenter.class.st
+++ b/src/IconPacks/IconPacksFetchPresenter.class.st
@@ -77,6 +77,17 @@ IconPacksFetchPresenter class >> reset [
 	JSONList := nil.
 ]
 
+{ #category : 'private' }
+IconPacksFetchPresenter >> checkAPILimitExceeded: jsonResponse [
+
+	(jsonResponse includesKey: 'message')
+		ifFalse: [ ^ self ].
+	((jsonResponse at: 'message') asLowercase beginsWith: 'api rate limit') 
+		ifFalse: [ ^ self ].
+	self inform: (jsonResponse at: 'message').
+	self error
+]
+
 { #category : 'layout' }
 IconPacksFetchPresenter >> defaultLayout [
 
@@ -120,16 +131,19 @@ IconPacksFetchPresenter >> downloadedIconPacksNames [
 IconPacksFetchPresenter >> fetchPacks [
 	"Retrieve all packs available from repository. This fetch the **names** of the icon packs, not the icon resources. Answer a <Collection> of <ThemeIcon>"
 
+	| jsonResponse fetchedJSONList |
 	[ 
-		self inform: 'Note that in case of error (no internet connection, for example) the remote Icons Pack list will display only the current icon set'.
-		self jsonList: self class fetchJsonList 
+		fetchedJSONList := self class fetchJsonList.
+		((jsonResponse := STON fromString: fetchedJSONList) isDictionary)
+			ifTrue: [ self checkAPILimitExceeded: jsonResponse ]
+			ifFalse: [ self jsonList: fetchedJSONList ]
 	]
 	on: Error
 	do: [ :e | 
 		e crTrace.
 		^ { Smalltalk ui icons } ].
 
-	^ (STON fromString: self jsonList)
+	^ jsonResponse
 		  collect: [ :each |
 			  | packName |
 			  "Ensure we have just one instance of current pack"
@@ -207,7 +221,9 @@ IconPacksFetchPresenter >> initializeIconPacksButtonsPresenters [
 		label: 'Update';
 		help: 'Query available packs from remote repository';
 		icon: (self iconNamed: #smallUpdate);
-		action: [ self fetchedIconPacks ];
+		action: [ 
+			self inform: 'Note that in case of error (no internet connection, for example) the remote Icons Pack list will display only the current icon set'.
+			fetchedIconPacks := self fetchPacks ];
 		yourself.
 
 	fetchButton := self newButton

--- a/src/IconPacks/package.st
+++ b/src/IconPacks/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'IconPacks' }

--- a/src/Morphic-Base/ShortcutReminder.class.st
+++ b/src/Morphic-Base/ShortcutReminder.class.st
@@ -151,8 +151,7 @@ ShortcutReminder >> customSettingsOn: aBuilder [
 		order: 7;
 		target: self;
 		label: 'Reset the reminder count';
-		buttonLabel: 'Apply';
-		dialog: [ self resetCount ]
+		buttonLabel: 'Apply'
 ]
 
 { #category : 'defaults' }

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -105,10 +105,11 @@ ThemeIcons class >> settingsOn: aBuilder [
 	<systemsettings>
 
 	(aBuilder button: #openIconsPackManager)
+		parent: #appearance;
 		order: 2;
 		target: self;
 		label: 'Icons Pack';
-		parent: #appearance
+		buttonLabel: 'Open'
 ]
 
 { #category : 'comparing' }

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -28,7 +28,8 @@ Class {
 		'iconsPerScale',
 		'scale',
 		'formSetsCache',
-		'reportNotFound'
+		'reportNotFound',
+		'zipArchive'
 	],
 	#classVars : [
 		'Current'
@@ -274,7 +275,7 @@ ThemeIcons >> doesNotUnderstand: aMessage [
 
 { #category : 'loading' }
 ThemeIcons >> downloadFromUrl [
-	| zipArchive |
+
 	self class destinationPath ensureCreateDirectory.
 	zipArchive := self class destinationPath / (self name, '.zip').
 	zipArchive exists
@@ -282,8 +283,6 @@ ThemeIcons >> downloadFromUrl [
 			ZnClient new
 				url: self url;
 				downloadTo: zipArchive ].
-
-	^ zipArchive
 ]
 
 { #category : 'utilities' }
@@ -376,11 +375,16 @@ ThemeIcons >> loadIconsFromUrl [
 
 { #category : 'loading' }
 ThemeIcons >> loadIconsFromUrlUsingScale: newScale [
-	| newIconsPerScale zipArchive zipContent |
+
+	self downloadFromUrl.
+	^ self loadIconsFromZipArchiveUsingScale: newScale
+]
+
+{ #category : 'loading' }
+ThemeIcons >> loadIconsFromZipArchiveUsingScale: newScale [
+	| newIconsPerScale zipContent |
 
 	newIconsPerScale := Dictionary new.
-	zipArchive := self downloadFromUrl.
-
 	zipContent := (FileSystem zip: zipArchive) open workingDirectory.
 
 	"If it has the old icon pack structure we handle as they don't have multiple sizes"

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -55,51 +55,6 @@ ThemeIcons class >> baseUrl [
 	^ 'https://github.com/pharo-project/pharo-icon-packs/archive' asUrl
 ]
 
-{ #category : 'settings' }
-ThemeIcons class >> createFetchButtonUpdating: listMorph [
-	^ (Smalltalk ui theme
-		newButtonIn: self
-		for: self
-		getState: nil
-		action: nil
-		arguments: nil
-		getEnabled: nil
-		getLabel: nil
-		help: 'Fetch icon pack from remote repository' translated)
-		label: 'Fetch from remote';
-		actionBlock: [
-			self uiFetchPacks.
-			listMorph update: #availablePacks ];
-		yourself
-]
-
-{ #category : 'settings' }
-ThemeIcons class >> createIconPackList [
-	^ (Smalltalk ui theme
-		newDropListIn: Morph new
-		for: self
-		list: #availablePacks
-		getSelected: #current
-		setSelected: #current:
-		getEnabled: nil
-		useIndex: false
-		help: nil)
-		wrapSelector: #name;
-		hResizing: #rigid;
-		width: 120;
-		yourself
-]
-
-{ #category : 'settings' }
-ThemeIcons class >> createSettingRow [
-	| list |
-	^ Smalltalk ui theme
-		newRowIn: self
-		for: {
-			list := self createIconPackList.
-			self createFetchButtonUpdating: list }
-]
-
 { #category : 'instance creation' }
 ThemeIcons class >> current [
 	"WARNING: Direct access to this method is ill-adviced, use Smalltalk ui icons instead."
@@ -119,28 +74,6 @@ ThemeIcons class >> destinationPath [
 	^ FileLocator localDirectory / 'icon-packs'
 ]
 
-{ #category : 'accessing' }
-ThemeIcons class >> fetchPacks [
-	"Retrieve all packs available from repository"
-	| jsonList |
-
-	[ jsonList := ZnClient new
-		get: 'https://api.github.com/repos/pharo-project/pharo-icon-packs/branches';
-		contents ]
-	on: Error do: [ :e |
-		"in case of error (no inet connection, for example) I retrieve just current icon set"
-		e crTrace.
-		^ { self current } ].
-	^ (STON fromString: jsonList)
-		collect: [ :each | | packName |
-			"Ensure we have just one instance of current pack"
-			packName := each at: 'name'.
-			packName = self current name
-				ifTrue: [ self current ]
-				ifFalse: [ self named: packName ] ]
-		as: Array
-]
-
 { #category : 'private' }
 ThemeIcons class >> loadDefault [
 	^ self new
@@ -154,6 +87,12 @@ ThemeIcons class >> named: aString [
 	^ self new name: aString
 ]
 
+{ #category : 'accessing' }
+ThemeIcons class >> openIconsPackManager [
+
+	IconPacksFetchPresenter open
+]
+
 { #category : 'class initialization' }
 ThemeIcons class >> reset [
 	<script>
@@ -165,40 +104,11 @@ ThemeIcons class >> reset [
 ThemeIcons class >> settingsOn: aBuilder [
 	<systemsettings>
 
-	(aBuilder setting: #current)
-		parent: #appearance;
+	(aBuilder button: #openIconsPackManager)
 		order: 2;
-		label: 'Icon Set';
-		default: (ThemeIcons named: 'svgPack');
 		target: self;
-		dialog: [ self createSettingRow ]
-]
-
-{ #category : 'settings' }
-ThemeIcons class >> uiFetchPacks [
-	| choosenPacks remotePacks |
-
-	self halt.
-	MorphicUIManager new
-		informUser: 'Retrieving available packs from remote repository'
-		during: [ remotePacks := self fetchPacks ].
-
-	choosenPacks := (TickDialogWindow
-		itemsList: remotePacks
-		itemsHeaderName: nil
-		wrapBlockOrSelector: #name
-		title: 'Remote available icon packs')
-		chooseFromOwner: self currentWorld.
-	choosenPacks ifNil: [ ^ self ].
-	MorphicUIManager new informUserDuring: [ :bar |
-		choosenPacks do: [ :each |
-			bar label: 'Retrieving "', each name, '" icon set from remote repository'.
-			each downloadFromUrl ]]
-]
-
-{ #category : 'settings' }
-ThemeIcons class >> wrapIconPack: aPack [
-	^ aPack name
+		label: 'Icons Pack';
+		parent: #appearance
 ]
 
 { #category : 'comparing' }

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -177,6 +177,7 @@ ThemeIcons class >> settingsOn: aBuilder [
 ThemeIcons class >> uiFetchPacks [
 	| choosenPacks remotePacks |
 
+	self halt.
 	MorphicUIManager new
 		informUser: 'Retrieving available packs from remote repository'
 		during: [ remotePacks := self fetchPacks ].

--- a/src/Polymorph-Widgets/ThemeIcons.class.st
+++ b/src/Polymorph-Widgets/ThemeIcons.class.st
@@ -70,16 +70,23 @@ ThemeIcons class >> current: aPack [
 ]
 
 { #category : 'accessing' }
+ThemeIcons class >> defaultIconsPack [
+
+	^ 'svgPack'
+]
+
+{ #category : 'accessing' }
 ThemeIcons class >> destinationPath [
 	^ FileLocator localDirectory / 'icon-packs'
 ]
 
 { #category : 'private' }
 ThemeIcons class >> loadDefault [
+
 	^ self new
-	name: 'svgPack';
-	loadIconsFromUrl;
-	yourself
+		  name: self defaultIconsPack;
+		  loadIconsFromUrl;
+		  yourself
 ]
 
 { #category : 'instance creation' }
@@ -87,29 +94,11 @@ ThemeIcons class >> named: aString [
 	^ self new name: aString
 ]
 
-{ #category : 'accessing' }
-ThemeIcons class >> openIconsPackManager [
-
-	IconPacksFetchPresenter open
-]
-
 { #category : 'class initialization' }
 ThemeIcons class >> reset [
 	<script>
 
 	Current := nil
-]
-
-{ #category : 'settings' }
-ThemeIcons class >> settingsOn: aBuilder [
-	<systemsettings>
-
-	(aBuilder button: #openIconsPackManager)
-		parent: #appearance;
-		order: 2;
-		target: self;
-		label: 'Icons Pack';
-		buttonLabel: 'Open'
 ]
 
 { #category : 'comparing' }

--- a/src/System-Settings-Core/ActionSettingDeclaration.class.st
+++ b/src/System-Settings-Core/ActionSettingDeclaration.class.st
@@ -27,9 +27,9 @@ ActionSettingDeclaration >> inputWidget [
 
 	^ SimpleButtonMorph new
 		target: self target;
-		label: self label;
+		label: (self label ifNil: [ '(Error: no label defined)' ]);
 		actionSelector: self name;
-		themeChanged;
+		themeChanged; "This is to avoid green button?"
 		yourself
 ]
 

--- a/src/System-Settings-Core/ActionSettingDeclaration.class.st
+++ b/src/System-Settings-Core/ActionSettingDeclaration.class.st
@@ -27,8 +27,8 @@ ActionSettingDeclaration >> inputWidget [
 
 	^ SimpleButtonMorph new
 		target: self target;
-		label: 'Apply';
-		actionSelector: #resetCount;
+		label: self label;
+		actionSelector: self name;
 		themeChanged;
 		yourself
 ]


### PR DESCRIPTION
This PR includes a new Spec presenter to manage Icons Packs in Pharo (video preview below)

- Replaces usage of Morphic in ThemeIcons settings, as described in #16801 
- Clean ThemeIcons class side morphic methods, as described in #6389
- Handles API rate exceeded limits
- Display information on each selected icon pack
- Provides information about each of the icons' dimensions
- Prevents constantly querying GitHub to get the list of the remote icon packs available.
- The new UI can be opened from the Library menu or the old Settings Browser.

https://github.com/user-attachments/assets/c4cf8c8d-3a7e-4646-9cde-d6b309e08e57

