### PR TITLE
17090-Wrong-compilation-to-ConstantBlockClosure

### DIFF
--- a/src/AST-Core-Tests/ASTBlockNodeTest.class.st
+++ b/src/AST-Core-Tests/ASTBlockNodeTest.class.st
@@ -64,7 +64,9 @@ ASTBlockNodeTest >> testIsConstant [
 	self assert: [  ] sourceNode isConstant.
 	self assert: [ 1 ] sourceNode isConstant.
 	self deny: [ ^1 ] sourceNode isConstant.
-	self deny: [ 1 sin. 1 ] sourceNode isConstant
+	"only one statement is allowed, even if the first is constant"
+	self deny: [ 1 sin. 1 ] sourceNode isConstant.
+	self deny: [ 1 . 1 ] sourceNode isConstant
 ]
 
 { #category : 'tests' }

--- a/src/AST-Core-Tests/RBCodeSnippet.class.st
+++ b/src/AST-Core-Tests/RBCodeSnippet.class.st
@@ -193,7 +193,7 @@ RBCodeSnippet class >> badComments [
 			         nodeAt: 'DDD 00EEE0548884449994A0CCC00 FFF';
 			         styled: '""" 0 """ n """ . """ n """ 0 """';
 			         formattedCode: '[ "a""b""f" 1. "c" "d" 2 "e" ]';
-			         value: 1).
+			         value: 2).
 		        (self new
 			         source: '"a" [ "b" : "c" x "d" : "e" y "f" | "g" ] "h"';
 			         nodeAt: '888 00999000AAA030BBB000FFF0C0GGG000III00 JJJ';

--- a/src/AST-Core/ASTBlockNode.class.st
+++ b/src/AST-Core/ASTBlockNode.class.st
@@ -285,7 +285,7 @@ ASTBlockNode >> isConstant [
 	"is the block just returning a literal?"
 	^ body statements
 		ifEmpty: [ true "empty block returns nil" ]
-		ifNotEmpty: [:statements | statements first isLiteralNode ]
+		ifNotEmpty: [:statements | statements size = 1 and: [statements first isLiteralNode] ]
 ]
 
 { #category : 'errors' }


### PR DESCRIPTION
add test and fix to make sure that constant blocks have just one statement.

fixes #17090