### PR TITLE
Renraku should not use old icon names

### DIFF
--- a/src/Renraku/ReAbstractCritique.class.st
+++ b/src/Renraku/ReAbstractCritique.class.st
@@ -141,7 +141,7 @@ ReAbstractCritique >> guidedBan [
 { #category : 'accessing' }
 ReAbstractCritique >> icon [
 
-	^ self iconNamed: ('small', rule severity capitalized, 'Icon') asSymbol
+	^ self iconNamed: ('small' , rule severity capitalized) asSymbol
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
The way to get icons from names changed years ago but renraku was still using the old way. Here I'm fixing it.