### PR TITLE
Move the Class Critique Browser to the new Extras group.

### DIFF
--- a/src/SystemCommands-ClassCommands/SycClassExtraCmCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycClassExtraCmCommand.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : 'SycClassExtraCmCommand',
+	#superclass : 'SycCmCommand',
+	#category : 'SystemCommands-ClassCommands',
+	#package : 'SystemCommands-ClassCommands'
+}
+
+{ #category : 'execution' }
+SycClassExtraCmCommand class >> activationStrategy [
+
+	^ SycExtraMenuActivation
+]

--- a/src/SystemCommands-ClassCommands/SycOpenExtraInClassMenuCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycOpenExtraInClassMenuCommand.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : 'SycOpenExtraInClassMenuCommand',
+	#superclass : 'SycOpenContextMenuCommand',
+	#category : 'SystemCommands-ClassCommands',
+	#package : 'SystemCommands-ClassCommands'
+}
+
+{ #category : 'activation' }
+SycOpenExtraInClassMenuCommand class >> browserContextMenuActivation [
+	<classAnnotation>
+
+	^ CmdContextMenuActivation byRootGroupItemOrder: 1.56 for: ClyClass asCalypsoItemContext
+]
+
+{ #category : 'execution' }
+SycOpenExtraInClassMenuCommand >> activationStrategy [
+	^ SycExtraMenuActivation
+]
+
+{ #category : 'context menu' }
+SycOpenExtraInClassMenuCommand >> cmCommandClass [
+	^ SycClassExtraCmCommand
+]
+
+{ #category : 'accessing' }
+SycOpenExtraInClassMenuCommand >> defaultMenuIconName [
+	^ #smallRedo
+]
+
+{ #category : 'accessing' }
+SycOpenExtraInClassMenuCommand >> defaultMenuItemName [
+
+	^ 'Extras'
+]

--- a/src/SystemCommands-RefactoringSupport/SycExtraMenuActivation.class.st
+++ b/src/SystemCommands-RefactoringSupport/SycExtraMenuActivation.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'SycExtraMenuActivation',
+	#superclass : 'CmdMenuCommandActivationStrategy',
+	#category : 'SystemCommands-RefactoringSupport-Extra',
+	#package : 'SystemCommands-RefactoringSupport',
+	#tag : 'Extra'
+}


### PR DESCRIPTION
This PR creates a new group called "Extras" for the class menu in Calypso, as requested in #17079 by @Ducasse 

The new Extras group is compatible with Commander 2, and the class menu items in the "Extra" group should be migrated to Commander 2 to participate in this group.

To not mix PRs, migration will be done in another branch.


