### PR TITLE
Remove duplicated ZipArchive class>>#extractAllIn:

### DIFF
--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -42,16 +42,6 @@ ZipArchive class >> compressionStored [
 ]
 
 { #category : 'file in/out' }
-ZipArchive class >> extractAllIn: aFileReferenceOrFileName [
-	"Service method to extract all contents of a zip."
-	| directory |
-	directory := (UIManager default chooseDirectoryFrom: aFileReferenceOrFileName asFileReference) ifNil: [^ self].
-	^ (self new)
-		readFrom: aFileReferenceOrFileName;
-		extractAllTo: directory
-]
-
-{ #category : 'file in/out' }
 ZipArchive class >> extractFrom: aZipFile to: aDirectory [
 
 	^ self new


### PR DESCRIPTION
This method got moved to NewTools to be able to show better UIs but the original method never got removed from Pharo.  This gets Pharo dirty (when you recalculate dirty packages)

Fixes #16238