### PR TITLE
Revert #readFrom: on ZipArchive to use a ZnBufferedReadStream

### DIFF
--- a/src/Compression/ZipArchive.class.st
+++ b/src/Compression/ZipArchive.class.st
@@ -271,12 +271,7 @@ ZipArchive >> readFrom: aStreamOrFile [
 	| stream name eocdPosition |
 	stream := aStreamOrFile isStream
 		ifTrue: [ name := aStreamOrFile printString. aStreamOrFile ]
-		ifFalse: [ 
-			name := aStreamOrFile asFileReference fullName.
-			
-			"Workaround: Force load the entire contents in memory.
-			The zip read stream breaks with Zn buffered streams otherwise"
-			aStreamOrFile asFileReference binaryReadStream contents readStream ].
+		ifFalse: [ name := aStreamOrFile asFileReference fullName. aStreamOrFile asFileReference binaryReadStream ].
 	eocdPosition := self class findEndOfCentralDirectoryFrom: stream.
 	eocdPosition <= 0 ifTrue: [ ZipArchiveError signal: 'can''t find EOCD position' ].
 	self readEndOfCentralDirectoryFrom: stream.


### PR DESCRIPTION
This pull request reverses pull request #16806 as the patch should no longer be necessary since the merge of pull request #17055.