### PR TITLE
Remove debugger code overriding itself

### DIFF
--- a/src/Debugging-Core/Process.extension.st
+++ b/src/Debugging-Core/Process.extension.st
@@ -17,24 +17,6 @@ Process >> complete: aContext [
 ]
 
 { #category : '*Debugging-Core' }
-Process >> debug [
-	^ self debugWithTitle: 'Debug'
-]
-
-{ #category : '*Debugging-Core' }
-Process >> debugWithTitle: title [
-
-	| context |
-	context := self isActiveProcess
-		           ifTrue: [ thisContext ]
-		           ifFalse: [ self suspendedContext ].
-	UIManager default
-		requestDebuggerOpeningForProcess: self
-		named: title
-		inContext: context
-]
-
-{ #category : '*Debugging-Core' }
 Process >> step: aContext [
 	"Resume self until aContext is on top, or if already on top, do next step"
 


### PR DESCRIPTION
Two methods of the debugger are present in two packages. This got introduced while trying to reduce the references to UIManager.  I'm removing the version with UI manager. 

I discussed of this with Steven already