### PR TITLE
Update DarkBlueTheme background color

### DIFF
--- a/src/DarkBlueTheme/DarkBlueThemeConfigurator.class.st
+++ b/src/DarkBlueTheme/DarkBlueThemeConfigurator.class.st
@@ -48,7 +48,7 @@ DarkBlueThemeConfigurator >> darkBaseColor [
 
 { #category : 'colors' }
 DarkBlueThemeConfigurator >> desktopColor [
-	^ self backgroundColor muchDarker
+	^ Color fromHexString: '263238'
 ]
 
 { #category : 'colors' }


### PR DESCRIPTION
The background color of the DarkBlueTheme is pitch dark which is hard on the eye. I propose to update it to a dark blueish grey color instead to be less aggressive while staying dark

Before:

<img width="1799" alt="image" src="https://github.com/user-attachments/assets/404dea7a-1bed-4881-9fc1-92e225fe2e96">

After:

<img width="1799" alt="image" src="https://github.com/user-attachments/assets/1493a61f-9bed-4e70-a60c-e6bfecb24298">
