### PR TITLE
Fix completion benchmark examples and recover inspector extension

### DIFF
--- a/src/HeuristicCompletion-Model/CoBenchmarkContext.class.st
+++ b/src/HeuristicCompletion-Model/CoBenchmarkContext.class.st
@@ -32,6 +32,12 @@ CoBenchmarkContext >> completionClass [
 ]
 
 { #category : 'accessing' }
+CoBenchmarkContext >> completionToken [
+	
+	^ callsite selector
+]
+
+{ #category : 'accessing' }
 CoBenchmarkContext >> doItContext [
 
 	^ nil

--- a/src/HeuristicCompletion-Model/CoStaticBenchmarks.class.st
+++ b/src/HeuristicCompletion-Model/CoStaticBenchmarks.class.st
@@ -8,6 +8,7 @@ I have an inspector extension to show the results in a table.
 
 Examples:
 
+```
 global := CoStaticBenchmarks new
 	scope: (CoBenchmarkPackage on: SpAbstractAdapter package);
 	builder: (CoGlobalSorterResultSetBuilder new
@@ -15,10 +16,19 @@ global := CoStaticBenchmarks new
 		yourself);
 	run.
 
+""Get the total accuracy of finding the right result among the first three when typing 2 characters.""
+(global accuracyForCompletionIndex: (1 to: 3) withPrefixSize: 2) asFloat. 
+```
+
+```
 staticHeuristics := CoStaticBenchmarks new
 	scope: (CoBenchmarkPackage on: SpAbstractAdapter package);
 	builder: CoASTHeuristicsResultSetBuilder new;
 	run.
+
+""Get the total accuracy of finding the right result among the first three when typing 2 characters.""
+(staticHeuristics accuracyForCompletionIndex: (1 to: 3) withPrefixSize: 2) asFloat. 
+```
 "
 Class {
 	#name : 'CoStaticBenchmarks',
@@ -117,7 +127,43 @@ CoStaticBenchmarks >> gradeForPrefixSize: prefixSize [
 CoStaticBenchmarks >> initialize [
 
 	super initialize.
-	completionBenchs := Dictionary new
+	completionBenchs := Dictionary new.
+	builder := CoASTHeuristicsResultSetBuilder new
+]
+
+{ #category : 'as yet unclassified' }
+CoStaticBenchmarks >> inspectionResults [
+
+	<inspectorPresentationOrder: 0 title: 'Results'>
+	| table |
+	table := SpTablePresenter new
+		         items: self completionIndexes;
+		         addColumn: (SpCompositeTableColumn new
+				          title: 'Prefix';
+				          addColumn:
+					          (SpStringTableColumn evaluated: [ :completionIndexRange |
+							           | label |
+							           label := '% '.
+							           label := label , (completionIndexRange size = 1
+									                     ifTrue: [
+										                     { 'fail'. '1st'. '2nd'. '3rd' } at:
+												                     completionIndexRange first + 1 ]
+									                     ifFalse: [
+										                     completionIndexRange first asString
+										                     , '-'
+										                     , completionIndexRange last asString ]).
+							           label ]);
+				          yourself).
+	self prefixSizes do: [ :prefixSize |
+		table addColumn: (SpStringTableColumn
+				 title: prefixSize asString
+				 evaluated: [ :completionIndexRange |
+					 | float |
+					 float := self
+						          accuracyForCompletionIndex: completionIndexRange
+						          withPrefixSize: prefixSize.
+					 float * 100 printShowingDecimalPlaces: 2 ]) ].
+	^ table
 ]
 
 { #category : 'inspector' }


### PR DESCRIPTION
The completion benchmark extensions were lost in Pharo 10.
Recover them and do a pass on the comments.