### PR TITLE
17058-ASTLiteralValueNodesourceText-leads-to-infinite-recursion-when-value-is-a-BreakDebugPoint 

### DIFF
--- a/src/AST-Core/ASTLiteralValueNode.class.st
+++ b/src/AST-Core/ASTLiteralValueNode.class.st
@@ -87,7 +87,7 @@ ASTLiteralValueNode >> sourceText [
 			  	ifFalse: [ "For other literals, we assume that storeOn returns a valid literal syntactic representation."
 				 	 value storeOn: aStream ] ] ] .
 		"if we abuse the node to store a normal object (e.g. used for metalinks), do not use #storeOn:"
-	^ '<an unprintable nonliteral value>'
+	^ '''<an unprintable nonliteral value>'''
 ]
 
 { #category : 'accessing' }

--- a/src/AST-Core/ASTLiteralValueNode.class.st
+++ b/src/AST-Core/ASTLiteralValueNode.class.st
@@ -79,12 +79,15 @@ ASTLiteralValueNode >> isString [
 ASTLiteralValueNode >> sourceText [
 
 	sourceText ifNotNil: [ ^ sourceText ].
-	^ String streamContents: [ :aStream |
-		  value class == Character
-			  ifTrue: [ "Character>>storeOn might return `Character space` (or something else) that is not a literal. So, force the `$x` syntax."
+	value isLiteral ifTrue: [  
+		^ String streamContents: [ :aStream |
+		 	 value class == Character
+			  	ifTrue: [ "Character>>storeOn might return `Character space` (or something else) that is not a literal. So, force the `$x` syntax."
 				  aStream nextPut: $$; nextPut: value ]
-			  ifFalse: [ "For other literals, we assume that storeOn returns a valid literal syntactic representation."
-				  value storeOn: aStream ] ]
+			  	ifFalse: [ "For other literals, we assume that storeOn returns a valid literal syntactic representation."
+				 	 value storeOn: aStream ] ] ] .
+		"if we abuse the node to store a normal object (e.g. used for metalinks), do not use #storeOn:"
+	^ '<an unprintable nonliteral value>'
 ]
 
 { #category : 'accessing' }

--- a/src/AST-Core/RBSimpleFormatter.class.st
+++ b/src/AST-Core/RBSimpleFormatter.class.st
@@ -458,11 +458,7 @@ RBSimpleFormatter >> visitLiteralArrayNode: aRBArrayLiteralNode [
 
 { #category : 'visiting' }
 RBSimpleFormatter >> visitLiteralNode: aLiteralNode [
-	self
-		writeString:
-			(aLiteralNode value isLiteral
-				ifFalse: [ '''<an unprintable nonliteral value>''' ]
-				ifTrue: [ aLiteralNode sourceText ])
+	self writeString: aLiteralNode sourceText
 ]
 
 { #category : 'visiting' }

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -2184,9 +2184,7 @@ EFFormatter >> visitLiteralArrayNode: aRBArrayLiteralNode [
 
 { #category : 'visiting' }
 EFFormatter >> visitLiteralNode: aLiteralNode [
-	aLiteralNode value isLiteral
-		ifFalse: [ self writeString: '''<an unprintable nonliteral value>''' ]
-		ifTrue: [ self writeString: aLiteralNode sourceText ]
+		self writeString: aLiteralNode sourceText
 ]
 
 { #category : 'visiting' }


### PR DESCRIPTION
move the #isLiteral check to ASTLiteralValueNodesourceText>>#sourceText

fixes #17058