### PR TITLE
Rename notices to start by AST instead of RB

### DIFF
--- a/src/AST-Core/ASTErrorNotice.class.st
+++ b/src/AST-Core/ASTErrorNotice.class.st
@@ -2,15 +2,15 @@
 I am a notice for syntaxic or semantic errors
 "
 Class {
-	#name : 'RBErrorNotice',
-	#superclass : 'RBNotice',
+	#name : 'ASTErrorNotice',
+	#superclass : 'ASTNotice',
 	#category : 'AST-Core-Notice',
 	#package : 'AST-Core',
 	#tag : 'Notice'
 }
 
 { #category : 'testing' }
-RBErrorNotice >> isError [
+ASTErrorNotice >> isError [
 
 	^ true
 ]

--- a/src/AST-Core/ASTNotice.class.st
+++ b/src/AST-Core/ASTNotice.class.st
@@ -2,7 +2,7 @@
 I represent error and warning information on a AST node.
 "
 Class {
-	#name : 'RBNotice',
+	#name : 'ASTNotice',
 	#superclass : 'Object',
 	#instVars : [
 		'messageText',
@@ -14,7 +14,7 @@ Class {
 }
 
 { #category : 'comparing' }
-RBNotice >> <= other [
+ASTNotice >> <= other [
 
 	self errorLevel = other errorLevel ifFalse: [
 		^ self errorLevel > other errorLevel ]. "Errors before warnings"
@@ -22,7 +22,7 @@ RBNotice >> <= other [
 ]
 
 { #category : 'accessing' }
-RBNotice >> description [
+ASTNotice >> description [
 
 	^ String streamContents: [ :stream |
 		  stream
@@ -51,7 +51,7 @@ RBNotice >> description [
 ]
 
 { #category : 'error handling' }
-RBNotice >> errorLevel [
+ASTNotice >> errorLevel [
 
 	self isSyntaxError ifTrue: [ ^ 3 ].
 	self isError ifTrue: [ ^ 2 ].
@@ -60,68 +60,68 @@ RBNotice >> errorLevel [
 ]
 
 { #category : 'inspecting' }
-RBNotice >> inspectionSource [
+ASTNotice >> inspectionSource [
 
 	<inspectorPresentationOrder: 30 title: 'Source'>
 	^ node inspectionSource
 ]
 
 { #category : 'testing' }
-RBNotice >> isError [
+ASTNotice >> isError [
 
 	^ false
 ]
 
 { #category : 'testing' }
-RBNotice >> isSyntaxError [
+ASTNotice >> isSyntaxError [
 
 	^ false
 ]
 
 { #category : 'testing' }
-RBNotice >> isUndeclaredNotice [
+ASTNotice >> isUndeclaredNotice [
 
 	^ false
 ]
 
 { #category : 'testing' }
-RBNotice >> isWarning [
+ASTNotice >> isWarning [
 
 	^ false
 ]
 
 { #category : 'accessing' }
-RBNotice >> messageText [
+ASTNotice >> messageText [
 
 	^ messageText
 ]
 
 { #category : 'signaling' }
-RBNotice >> messageText: aString [
+ASTNotice >> messageText: aString [
 
 	messageText := aString
 ]
 
 { #category : 'accessing' }
-RBNotice >> node [
+ASTNotice >> node [
 
 	^ node
 ]
 
 { #category : 'accessing' }
-RBNotice >> node: anObject [
+ASTNotice >> node: anObject [
 
 	node := anObject
 ]
 
 { #category : 'error handling' }
-RBNotice >> position [
+ASTNotice >> position [
 
 	^ node start
 ]
 
 { #category : 'printing' }
-RBNotice >> printOn: aStream [
+ASTNotice >> printOn: aStream [
 
 	aStream
 		nextPutAll: self class name;
@@ -133,7 +133,7 @@ RBNotice >> printOn: aStream [
 ]
 
 { #category : 'signalling' }
-RBNotice >> signalError [
+ASTNotice >> signalError [
 	"If a debugger is opened here, it means that a code error (syntax error or semantic error)
 	was uncaught while compiling some code.
 	Inspect `self` to get a view of the problematic source code.

--- a/src/AST-Core/ASTParseErrorNode.class.st
+++ b/src/AST-Core/ASTParseErrorNode.class.st
@@ -92,7 +92,7 @@ ASTParseErrorNode >> initialize [
 
 	super initialize.
 	"Add its own notice"
-	self addNotice: (RBSyntaxErrorNotice new)
+	self addNotice: (ASTSyntaxErrorNotice new)
 ]
 
 { #category : 'errors' }

--- a/src/AST-Core/ASTProgramNode.class.st
+++ b/src/AST-Core/ASTProgramNode.class.st
@@ -76,16 +76,16 @@ ASTProgramNode >> addError: anErrorMessage [
 	Semantic passes that check the validity of AST are the targetted clients of this method."
 
 	| notice |
-	notice := RBErrorNotice new messageText: anErrorMessage.
+	notice := ASTErrorNotice new messageText: anErrorMessage.
 	self addNotice: notice.
 	^ notice
 ]
 
 { #category : 'notice' }
-ASTProgramNode >> addNotice: aRBNotice [
+ASTProgramNode >> addNotice: aNotice [
 
-	(self propertyAt: #notices ifAbsentPut: [ OrderedCollection new ]) add: aRBNotice.
-	aRBNotice node: self
+	(self propertyAt: #notices ifAbsentPut: [ OrderedCollection new ]) add: aNotice.
+	aNotice node: self
 ]
 
 { #category : 'replacing' }
@@ -100,7 +100,7 @@ ASTProgramNode >> addWarning: aMessage [
 	| notice |
 	"Add a warning information to the node.
 	Semantic passes that check the validity of AST are the targetted clients of this method."
-	notice := RBWarningNotice new messageText: aMessage.
+	notice := ASTWarningNotice new messageText: aMessage.
 	self addNotice: notice.
 	^ notice
 ]

--- a/src/AST-Core/ASTSyntaxErrorNotice.class.st
+++ b/src/AST-Core/ASTSyntaxErrorNotice.class.st
@@ -2,27 +2,27 @@
 I am the implicit notice of a ASTParseErrorNode
 "
 Class {
-	#name : 'RBSyntaxErrorNotice',
-	#superclass : 'RBErrorNotice',
+	#name : 'ASTSyntaxErrorNotice',
+	#superclass : 'ASTErrorNotice',
 	#category : 'AST-Core-Notice',
 	#package : 'AST-Core',
 	#tag : 'Notice'
 }
 
 { #category : 'testing' }
-RBSyntaxErrorNotice >> isSyntaxError [
+ASTSyntaxErrorNotice >> isSyntaxError [
 
 	^ true
 ]
 
 { #category : 'accessing' }
-RBSyntaxErrorNotice >> messageText [
+ASTSyntaxErrorNotice >> messageText [
 
 	^ node errorMessage
 ]
 
 { #category : 'error handling' }
-RBSyntaxErrorNotice >> position [
+ASTSyntaxErrorNotice >> position [
 
 	^ node errorPosition
 ]

--- a/src/AST-Core/ASTWarningNotice.class.st
+++ b/src/AST-Core/ASTWarningNotice.class.st
@@ -2,15 +2,15 @@
 I am a notice for syntaxic or semantic warnings
 "
 Class {
-	#name : 'RBWarningNotice',
-	#superclass : 'RBNotice',
+	#name : 'ASTWarningNotice',
+	#superclass : 'ASTNotice',
 	#category : 'AST-Core-Notice',
 	#package : 'AST-Core',
 	#tag : 'Notice'
 }
 
 { #category : 'testing' }
-RBWarningNotice >> isWarning [
+ASTWarningNotice >> isWarning [
 
 	^ true
 ]

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -140,6 +140,11 @@ BaselineOfBasicTools >> postload: loader package: packageSpec [
 	ASTInvalidCascadeErrorNode deprecatedAliases: { #RBInvalidCascadeErrorNode }.
 	ASTParseErrorNode deprecatedAliases: { #RBParseErrorNode }.
 	
+	ASTErrorNotice deprecatedAliases: { #RBErrorNotice }.
+	ASTWarningNotice deprecatedAliases: { #RBWarningNotice }.
+	ASTSyntaxErrorNotice deprecatedAliases: { #RBSyntaxErrorNotice }.
+	ASTNotice deprecatedAliases: { #RBNotice }.
+	
 	ASTCommentToken deprecatedAliases: { #RBCommentToken}.
 	ASTLiteralToken deprecatedAliases: { #RBLiteralToken}.
 	ASTSpecialCharacterToken deprecatedAliases: { #RBSpecialCharacterToken}.

--- a/src/OpalCompiler-Core/ASTNotice.extension.st
+++ b/src/OpalCompiler-Core/ASTNotice.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'ASTNotice' }
+
+{ #category : '*OpalCompiler-Core' }
+ASTNotice >> reparator [
+
+	^ nil
+]

--- a/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
+++ b/src/OpalCompiler-Core/OCUndeclaredVariableNotice.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'OCUndeclaredVariableNotice',
-	#superclass : 'RBErrorNotice',
+	#superclass : 'ASTErrorNotice',
 	#category : 'OpalCompiler-Core-FrontEnd',
 	#package : 'OpalCompiler-Core',
 	#tag : 'FrontEnd'

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -280,7 +280,7 @@ OpalCompiler >> checkNotice: aNotice [
 	"This method handles all the logic of error handling.
 	
 	Error handing in the compiler is only performed at one place, after the parsing/semantic analysis/other parse plugins.
-	Each RBNotice in the AST is then checked with this method.
+	Each ASTNotice in the AST is then checked with this method.
 
 	There is only three outcomes:
 	* If this method returns true (OK), then the work of the compiler can continue.

--- a/src/OpalCompiler-Core/RBNotice.extension.st
+++ b/src/OpalCompiler-Core/RBNotice.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'RBNotice' }
-
-{ #category : '*OpalCompiler-Core' }
-RBNotice >> reparator [
-
-	^ nil
-]


### PR DESCRIPTION
See title