### PR TITLE
Change last assertion in #test2 on LibTTYTest to use an empty environment to avoid translation of the error message

### DIFF
--- a/src/UnifiedFFI-Tests/LibTTYTest.class.st
+++ b/src/UnifiedFFI-Tests/LibTTYTest.class.st
@@ -197,7 +197,7 @@ LibTTYTest >> test2 [
 
 	self assertProcessSpawnedWithPseudoTerminalPath: '/bin/doesnotexist'
 		arguments: #('/bin/doesnotexist')
-		environment: Dictionary new
+		environment: (OrderedDictionary with: 'LC_ALL' -> 'C')
 		input: ''
 		writes: 'Error in tty_spawn at execve(path, argv, envp): No such file or directory' , String crlf
 		hasStatus: 127.

--- a/src/UnifiedFFI-Tests/LibTTYTest.class.st
+++ b/src/UnifiedFFI-Tests/LibTTYTest.class.st
@@ -197,7 +197,7 @@ LibTTYTest >> test2 [
 
 	self assertProcessSpawnedWithPseudoTerminalPath: '/bin/doesnotexist'
 		arguments: #('/bin/doesnotexist')
-		environment: Smalltalk os environment
+		environment: Dictionary new
 		input: ''
 		writes: 'Error in tty_spawn at execve(path, argv, envp): No such file or directory' , String crlf
 		hasStatus: 127.


### PR DESCRIPTION
This pull request changes last assertion in `#test2` on LibTTYTest to use an empty environment to avoid translation of the error message (issue #17127).