### PR TITLE
Update some dialog icons to remove deprecated ways to declare them

### DIFF
--- a/src/Polymorph-Widgets/AlertDialogWindow.class.st
+++ b/src/Polymorph-Widgets/AlertDialogWindow.class.st
@@ -20,5 +20,5 @@ AlertDialogWindow class >> taskbarIconName [
 AlertDialogWindow >> icon [
 	"Answer an icon for the receiver."
 
-	^ self iconNamed: #warningIcon
+	^ self iconNamed: #warning
 ]

--- a/src/Polymorph-Widgets/DenyDialogWindow.class.st
+++ b/src/Polymorph-Widgets/DenyDialogWindow.class.st
@@ -20,5 +20,5 @@ DenyDialogWindow class >> taskbarIconName [
 DenyDialogWindow >> icon [
 	"Answer an icon for the receiver."
 
-	^ self iconNamed: #lockIcon
+	^ self iconNamed: #lock
 ]

--- a/src/Polymorph-Widgets/ErrorDialogWindow.class.st
+++ b/src/Polymorph-Widgets/ErrorDialogWindow.class.st
@@ -20,5 +20,5 @@ ErrorDialogWindow class >> taskbarIconName [
 ErrorDialogWindow >> icon [
 	"Answer an icon for the receiver."
 
-	^ self iconNamed: #errorIcon
+	^ self iconNamed: #error
 ]

--- a/src/Polymorph-Widgets/MessageDialogWindow.class.st
+++ b/src/Polymorph-Widgets/MessageDialogWindow.class.st
@@ -30,7 +30,7 @@ MessageDialogWindow >> defaultTextFont [
 MessageDialogWindow >> icon [
 	"Answer an icon for the receiver."
 
-	^ self iconNamed: #infoIcon
+	^ self iconNamed: #info
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Still removing the old way to get icons