### PR TITLE
Move "Extras" menu item to last position in the Calypso Class menu

### DIFF
--- a/src/SystemCommands-ClassCommands/SycOpenExtraInClassMenuCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycOpenExtraInClassMenuCommand.class.st
@@ -9,7 +9,9 @@ Class {
 SycOpenExtraInClassMenuCommand class >> browserContextMenuActivation [
 	<classAnnotation>
 
-	^ CmdContextMenuActivation byRootGroupItemOrder: 1.56 for: ClyClass asCalypsoItemContext
+	^ CmdContextMenuActivation 
+		byRootGroupItemOrder: 10200 
+		for: ClyClass asCalypsoItemContext
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
One-liner PR to restore the previous layout of the menu items in Calypso class contextual menu

<img width="860" alt="Screenshot 2024-09-21 at 22 06 24" src="https://github.com/user-attachments/assets/3d1304b3-0108-4578-ab03-b7aab50bee32">
