### PR TITLE
Categorize each uncategorized method inidividually

### DIFF
--- a/src/SystemCommands-ClassCommands-Tests/ManifestSystemCommandsClassCommandsTests.class.st
+++ b/src/SystemCommands-ClassCommands-Tests/ManifestSystemCommandsClassCommandsTests.class.st
@@ -1,0 +1,31 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestSystemCommandsClassCommandsTests',
+	#superclass : 'PackageManifest',
+	#category : 'SystemCommands-ClassCommands-Tests-Manifest',
+	#package : 'SystemCommands-ClassCommands-Tests',
+	#tag : 'Manifest'
+}
+
+{ #category : 'code-critics' }
+ManifestSystemCommandsClassCommandsTests class >> ruleJustSendsSuperRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGClassDefinition #(#SycCategorizeAllUnclassifiedTestClass)) #'2024-09-26T08:59:32.876+02:00') )
+]
+
+{ #category : 'code-critics' }
+ManifestSystemCommandsClassCommandsTests class >> ruleReInstanceSideInitializeMethodProtocolRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGClassDefinition #(#SycCategorizeAllUnclassifiedTestClass)) #'2024-09-26T08:59:29.025+02:00') )
+]
+
+{ #category : 'code-critics' }
+ManifestSystemCommandsClassCommandsTests class >> ruleUnclassifiedMethodsRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGClassDefinition #(#SycCategorizeAllUnclassifiedTestClass)) #'2024-09-26T08:58:03.844+02:00') )
+]

--- a/src/SystemCommands-ClassCommands-Tests/SycCategorizeAllUnclassifiedMethodsCommandTest.class.st
+++ b/src/SystemCommands-ClassCommands-Tests/SycCategorizeAllUnclassifiedMethodsCommandTest.class.st
@@ -1,0 +1,53 @@
+"
+A SycCategorizeAllUnclassifiedMethodsCommandTest is a test class for testing the behavior of SycCategorizeAllUnclassifiedMethodsCommand
+"
+Class {
+	#name : 'SycCategorizeAllUnclassifiedMethodsCommandTest',
+	#superclass : 'TestCase',
+	#category : 'SystemCommands-ClassCommands-Tests-Tests',
+	#package : 'SystemCommands-ClassCommands-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'running' }
+SycCategorizeAllUnclassifiedMethodsCommandTest >> setUp [
+
+	super setUp.
+
+	SycCategorizeAllUnclassifiedTestClass methods do: [ :each |
+		each unclassify ]
+]
+
+{ #category : 'running' }
+SycCategorizeAllUnclassifiedMethodsCommandTest >> tearDown [
+
+	SycCategorizeAllUnclassifiedTestClass methods do: [ :each |
+		each unclassify ].
+
+	super tearDown
+]
+
+{ #category : 'tests' }
+SycCategorizeAllUnclassifiedMethodsCommandTest >> testHandlesEachMethodIndividually [
+
+	| command |
+	self
+		assert:
+		(SycCategorizeAllUnclassifiedTestClass >> #initialize) protocolName
+		equals: Protocol unclassified.
+	self
+		assert:
+		(SycCategorizeAllUnclassifiedTestClass >> #name) protocolName
+		equals: Protocol unclassified.
+
+	command := SycCategorizeAllUnclassifiedMethodsCommand for:
+		           { SycCategorizeAllUnclassifiedTestClass }.
+
+	command execute.
+
+	self
+		deny:
+		(SycCategorizeAllUnclassifiedTestClass >> #initialize) protocolName
+		equals:
+		(SycCategorizeAllUnclassifiedTestClass >> #name) protocolName
+]

--- a/src/SystemCommands-ClassCommands-Tests/SycCategorizeAllUnclassifiedTestClass.class.st
+++ b/src/SystemCommands-ClassCommands-Tests/SycCategorizeAllUnclassifiedTestClass.class.st
@@ -1,0 +1,27 @@
+"
+Class used for testing SycCategorizeAllUnclassifierMethodsCommand in SycCategorizeAllUnclassifierMethodsCommandTest
+
+
+"
+Class {
+	#name : 'SycCategorizeAllUnclassifiedTestClass',
+	#superclass : 'Object',
+	#instVars : [
+		'name'
+	],
+	#category : 'SystemCommands-ClassCommands-Tests-TestData',
+	#package : 'SystemCommands-ClassCommands-Tests',
+	#tag : 'TestData'
+}
+
+{ #category : 'as yet unclassified' }
+SycCategorizeAllUnclassifiedTestClass >> initialize [
+
+	super initialize
+]
+
+{ #category : 'as yet unclassified' }
+SycCategorizeAllUnclassifiedTestClass >> name [
+
+	^ name
+]

--- a/src/SystemCommands-ClassCommands-Tests/package.st
+++ b/src/SystemCommands-ClassCommands-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'SystemCommands-ClassCommands-Tests' }

--- a/src/SystemCommands-ClassCommands/SycCategorizeAllUnclassifiedMethodsCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCategorizeAllUnclassifiedMethodsCommand.class.st
@@ -20,13 +20,11 @@ SycCategorizeAllUnclassifiedMethodsCommand >> defaultMenuItemName [
 
 { #category : 'execution' }
 SycCategorizeAllUnclassifiedMethodsCommand >> execute [
-	| classifier |
 	"MethodClassifier should not be hardcoded and should be based on Smalltalk tools"
-	classifier := MethodClassifier new.
 
 	classes do: [ :each |
-		each uncategorizedSelectors do: [ :selector|
-			classifier classify: each >> selector ]]
+		each uncategorizedSelectors do: [ :selector |
+			MethodClassifier classify: each >> selector ] ]
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
Fixes #17161
"Categorize all uncategorized" command (`SycCategorizeAllUnclassifiedMethodsCommand`) always categorized all the methods into a single protocol (of the first method), now it treats each method individually



