### PR TITLE
Cleanup: unify printing CleanBlockClosure 

### DIFF
--- a/src/Kernel-CodeModel/CleanBlockClosure.class.st
+++ b/src/Kernel-CodeModel/CleanBlockClosure.class.st
@@ -37,12 +37,6 @@ CleanBlockClosure class >> compiledBlock: aCompiledBlock [
 		compiledBlock: aCompiledBlock
 ]
 
-{ #category : 'printing' }
-CleanBlockClosure >> doPrintOn: aStream [
-
-	aStream nextPutAll: self sourceNode value sourceCode
-]
-
 { #category : 'testing' }
 CleanBlockClosure >> hasLiteral: aLiteral [
 	^self compiledBlock hasLiteral: aLiteral


### PR DESCRIPTION
small cleanup: the superclass method does the same (just with support of no compiler)