### PR TITLE
Add some useful methods on Color

### DIFF
--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -79,6 +79,26 @@ Class {
 	#tag : 'Base'
 }
 
+{ #category : 'instance creation' }
+Color class >> R: r G: g B: b [
+	"Return a color with the given R, G, and B components in the range [0..255]."
+
+	"(Color R: 255 G: 255 B: 255) >>> Color white"
+
+	^ self r: r g: g b: b range: 255
+]
+
+{ #category : 'instance creation' }
+Color class >> R: r G: g B: b A: alpha [
+	"Return a color with the given R, G, and B components in the range [0..255] and an alpha in the range [0.0..1.0]."
+	"(Color R: 255 G: 255 B: 255 A: 1) >>> Color white"
+	"(Color R: 255 G: 255 B: 255 A: 0.5) >>> (Color white alpha: 0.5)"
+
+	| c |
+	c := self r: r g: g b: b range: 255.
+	^ c alpha: alpha
+]
+
 { #category : 'private - colormaps' }
 Color class >> aaFontsColormapDepth [
 	"Adjust balance between colored AA text quality (especially if subpixel AA is used) and space / performance.
@@ -1292,6 +1312,23 @@ Color >> colorForInsets [
 	^ self
 ]
 
+{ #category : 'accessing' }
+Color >> contrast: aColor [
+	"Get a constrast ratio between to colors. 
+	Constrast is computed from luminance value of these colors.
+	Formula L1/L2 is based on ISO-9241-3 and ANSI-HFES-100-1988.
+	https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests"
+
+	| l1 l2 a |
+	l1 := self relativeLuminance.
+	l2 := aColor relativeLuminance.
+	a := 0.05.
+
+	^ l1 > l2
+		  ifTrue: [ l1 + a / (l2 + a) ]
+		  ifFalse: [ l2 + a / (l1 + a) ]
+]
+
 { #category : 'converting' }
 Color >> contrastingBlackAndWhiteColor [
 	"Answer black or white depending on the luminance."
@@ -1662,6 +1699,29 @@ Color >> isColor [
 ]
 
 { #category : 'testing' }
+Color >> isContrastCompliantForISO92413: aColor [
+	"Return true if the ISO92413 stardard consider myself and the given color with enough contrast to be used in an UI."
+
+	^ (self contrast: aColor) > 3
+]
+
+{ #category : 'testing' }
+Color >> isContrastCompliantForWCAG2AA: aColor [
+	"Return true if the WCAG2AA stardard consider myself and the given color with enough contrast to be used in an UI.
+	With this standard respecrted, your UI is considered good for the majority of population"
+
+	^ (self contrast: aColor) > 4.5
+]
+
+{ #category : 'testing' }
+Color >> isContrastCompliantForWCAG2AAA: aColor [
+	"Return true if the WCAG2AA stardard consider myself and the given color with enough contrast to be used in an UI.
+	With this standard respecrted, your UI is considered good for people of 80yo"
+
+	^ (self contrast: aColor) > 7
+]
+
+{ #category : 'testing' }
 Color >> isGradientFill [
 
 	^ false
@@ -1950,6 +2010,30 @@ Color >> red [
 	"Return the red component of this color, a float in the range [0.0..1.0]."
 
 	^ self privateRed asFloat / ComponentMax
+]
+
+{ #category : 'accessing' }
+Color >> relativeLuminance [
+	"Return the relative luminance Y of this color, a derivation of luminance signal from ITU-R BT.709-6 to considere human eye colors different sensitivity.
+	https://www.w3.org/WAI/GL/wiki/Relative_luminance"
+
+	| r g b a |
+	r := (self red * 255 roundTo: 1) / 255.
+	g := (self green * 255 roundTo: 1) / 255.
+	b := (self blue * 255 roundTo: 1) / 255.
+	a := 0.055.
+
+	r := r <= 0.04045
+		     ifTrue: [ r / 12.92 ]
+		     ifFalse: [ r + a / (1 + a) raisedTo: 2.4 ].
+	g := g <= 0.04045
+		     ifTrue: [ g / 12.92 ]
+		     ifFalse: [ g + a / (1 + a) raisedTo: 2.4 ].
+	b := b <= 0.04045
+		     ifTrue: [ b / 12.92 ]
+		     ifFalse: [ b + a / (1 + a) raisedTo: 2.4 ].
+
+	^ 0.2126 * r + (0.7152 * g) + (0.0722 * b)
 ]
 
 { #category : 'other' }


### PR DESCRIPTION
- R:G:B:(A:) constructor taking red, blue and green value in a range from 0 to 255 because this is the standard everywhere in the world but in Pharo #r:g:b: takes a range between 0 and 1
- #relativeLuminance Return the relative luminance Y of this color, a derivation of luminance signal from ITU-R BT.709-6 to considere human eye colors different sensitivity.
- #contrast: Rate the contrast between two colors

And some methods to know if some colors are contrasted enough for some standards