### PR TITLE
Deprecate BlockClosure>>#valueWithoutNotifications

### DIFF
--- a/src/Deprecated13/BlockClosure.extension.st
+++ b/src/Deprecated13/BlockClosure.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : 'BlockClosure' }
+
+{ #category : '*Deprecated13' }
+BlockClosure >> valueWithoutNotifications [
+
+	self deprecated: 'System announcement will be splitted between two announcers. This code should be replaced by either of those:
+	
+	self class codeChangeAnnouncer suspendAllWhile: [ ... ] 
+	
+	or
+	
+	self class codeSupportAnnouncer suspendAllWhile: [ ... ] 
+	
+	This will depend if you want to suspend announcements about the code changes in Pharo such as MethodAdded or ClassRemoved or announcements about Pharo tools such as BreakpointAdded
+	'.
+	^ SystemAnnouncer uniqueInstance suspendAllWhile: self
+]

--- a/src/System-Announcements/BlockClosure.extension.st
+++ b/src/System-Announcements/BlockClosure.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : 'BlockClosure' }
-
-{ #category : '*System-Announcements' }
-BlockClosure >> valueWithoutNotifications [
-	^SystemAnnouncer uniqueInstance suspendAllWhile: self
-]


### PR DESCRIPTION
This method does not bring much value and will be hard to handle once we remove the global system announcer. So I propose to deprecated it for the time been