### PR TITLE
Improve the Duplicate class refactoring

### DIFF
--- a/src/Refactoring-Core/ReCopyClassRefactoring.class.st
+++ b/src/Refactoring-Core/ReCopyClassRefactoring.class.st
@@ -27,7 +27,8 @@ Class {
 		'packageName',
 		'classMethods',
 		'instanceMethods',
-		'superclassName'
+		'superclassName',
+		'packageTagName'
 	],
 	#category : 'Refactoring-Core-Refactorings',
 	#package : 'Refactoring-Core',
@@ -92,6 +93,7 @@ ReCopyClassRefactoring >> copyClass [
 			 superclass: aClass superclass;
 			 packageName: self packageName;
 			 comment: aClass comment;
+			 tagName: self packageTagName;
 			 yourself)
 ]
 
@@ -183,6 +185,18 @@ ReCopyClassRefactoring >> packageName [
 ReCopyClassRefactoring >> packageName: anObject [
 
 	packageName := anObject
+]
+
+{ #category : 'accessing' }
+ReCopyClassRefactoring >> packageTagName [
+
+	^ packageTagName
+]
+
+{ #category : 'accessing' }
+ReCopyClassRefactoring >> packageTagName: aString [
+
+	packageTagName := aString
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-UI/ReClassInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReClassInteractionDriver.class.st
@@ -57,7 +57,8 @@ ReClassInteractionDriver >> scopes: refactoringScopes [
 
 { #category : 'accessing' }
 ReClassInteractionDriver >> tagName [
-	^ self subclassResponsibility
+
+	^ tagName
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReDuplicateClassDriver.class.st
+++ b/src/Refactoring-UI/ReDuplicateClassDriver.class.st
@@ -81,6 +81,7 @@ ReDuplicateClassDriver >> requestNewClass [
 			withClassMethods: rbMetaclass allMethods;
 			baseClassName: self className;
 			basePackageName: (self model environment at: self className) packageName;
+			basePackageTagName: (self model environment at: self className) packageTag name;
 			onCancel: [ : dialog | dialog close ];
 			onAccept: [ :dialog |
 				self
@@ -94,7 +95,8 @@ ReDuplicateClassDriver >> requestNewClass [
 					superclassName: dialog presenter selectedSuperclassName;					
 					sourceClass: className;
 					instanceMethods: dialog presenter selectedInstanceMethods;
-					classMethods: dialog presenter selectedClassMethods.
+					classMethods: dialog presenter selectedClassMethods;
+					packageTagName: dialog presenter tagName.
 
 				dialog close ];
 			selectAll;
@@ -151,10 +153,4 @@ ReDuplicateClassDriver >> superclassName [
 ReDuplicateClassDriver >> superclassName: anObject [
 
 	superclassName := anObject
-]
-
-{ #category : 'accessing' }
-ReDuplicateClassDriver >> tagName [
-
-	^ tagName
 ]

--- a/src/Refactoring-UI/StClassAndMethodsSelectionPresenter.class.st
+++ b/src/Refactoring-UI/StClassAndMethodsSelectionPresenter.class.st
@@ -60,6 +60,12 @@ StClassAndMethodsSelectionPresenter >> basePackageName: aString [
 ]
 
 { #category : 'accessing' }
+StClassAndMethodsSelectionPresenter >> basePackageTagName: aString [
+
+	tagPresenter selectItem: aString
+]
+
+{ #category : 'accessing' }
 StClassAndMethodsSelectionPresenter >> classMethods [
 
 	^ classMethods


### PR DESCRIPTION
- Automatically select the package tag corresponding to the package tag of the entity to duplicate
- Respect the package tag selected by the user when applying the refactoring

Fixes #17166