### PR TITLE
Move NumberParsingTests to NumberParser-Tests package

### DIFF
--- a/src/NumberParser-Tests/NumberParsingTest.class.st
+++ b/src/NumberParser-Tests/NumberParsingTest.class.st
@@ -6,9 +6,8 @@ Note: ScaledDecimalTest contains related tests for parsing ScaledDecimal.
 Class {
 	#name : 'NumberParsingTest',
 	#superclass : 'TestCase',
-	#category : 'AST-Core-Tests-Parser',
-	#package : 'AST-Core-Tests',
-	#tag : 'Parser'
+	#category : 'NumberParser-Tests',
+	#package : 'NumberParser-Tests'
 }
 
 { #category : 'tests - Float' }


### PR DESCRIPTION
Because AST-Core-Tests is not its place

Fixes #17149