### PR TITLE
Fix #17170: DrTest does not set the /pass/error/failure state on the test method (in systemBrowser)

### DIFF
--- a/src/DrTests-TestsRunner/DTTestsRunnerPlugin.class.st
+++ b/src/DrTests-TestsRunner/DTTestsRunnerPlugin.class.st
@@ -145,6 +145,7 @@ DTTestsRunnerPlugin >> runTestSuites: testSuites [
 				self runSuite: testSuite withResult: specificResult.
 				result mergeWith: specificResult ]
 			displayingProgress: 'Running Tests' ].
+	result updateResultsInHistory.
 	^ result
 ]
 


### PR DESCRIPTION
Give the ability to DrTest to change the color of the bullet next to the test methods in SystemBrowser


Co-authored-by: fouziray faouzirayan@gmail.com