### PR TITLE
Speed up some Package code

### DIFF
--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -182,7 +182,7 @@ Package >> definesOrExtendsClass: aClass [
 	"Returns true whether the class, aClass, is one of the locally defined classes of the receiver or
 	if the receiver extends such class (that is defined in another package)"
 
-	^ (self includesClass: aClass instanceSide) or: [ self extendedClasses includes: aClass instanceSide ]
+	^ (self includesClass: aClass instanceSide) or: [ self extendsClass: aClass ]
 ]
 
 { #category : 'converting' }

--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -253,9 +253,12 @@ Package >> extendedClasses [
 Package >> extendsClass: aClass [
 	"Returns true if the receiver extends aClass (that is defined in another package)"
 
-	| canonizedName |
-	canonizedName := aClass instanceSide name.
-	^ self extendedClassNames includes: canonizedName
+	| class |
+	class := aClass instanceSide.
+
+	extensionSelectors keysDo: [ :extendedClass | extendedClass instanceSide = class ifTrue: [ ^ true ] ].
+
+	^ false
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-Environment/RBPackageEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPackageEnvironment.class.st
@@ -110,8 +110,7 @@ RBPackageEnvironment >> definesClass: aClass [
 { #category : 'testing' }
 RBPackageEnvironment >> includesClass: aClass [
 
-	^ (super includesClass: aClass) and: [
-		  self packages anySatisfy: [ :package | (package includesClass: aClass) or: [ (package extensionProtocolsForClass: aClass) isNotEmpty ] ] ]
+	^ (super includesClass: aClass) and: [ self packages anySatisfy: [ :package | (package includesClass: aClass) or: [ package extendsClass: aClass ] ] ]
 ]
 
 { #category : 'testing' }

--- a/src/Refactoring-Environment/RBPackageEnvironment.class.st
+++ b/src/Refactoring-Environment/RBPackageEnvironment.class.st
@@ -88,18 +88,16 @@ RBPackageEnvironment >> classesAndSelectorsDo: aBlock [
 
 { #category : 'accessing' }
 RBPackageEnvironment >> classesDo: aBlock [
-	| enumerated enumerator |
+
+	| enumerated |
 	enumerated := IdentitySet new.
-	enumerator := [ :each |
-		(enumerated includes: each) ifFalse: [
-			(environment includesClass: each)
-				ifTrue: [ aBlock value: each ].
-			(environment includesClass: each classSide)
-				ifTrue: [ aBlock value: each classSide].
-			enumerated add: each ] ].
+
 	packages do: [ :package |
-		package classes do: enumerator.
-		package extendedClasses do: enumerator ]
+		package classes , package extendedClasses do: [ :class |
+			(enumerated includes: class) ifFalse: [
+				(environment includesClass: class) ifTrue: [ aBlock value: class ].
+				(environment includesClass: class classSide) ifTrue: [ aBlock value: class classSide ].
+				enumerated add: class ] ] ]
 ]
 
 { #category : 'testing' }
@@ -110,7 +108,7 @@ RBPackageEnvironment >> definesClass: aClass [
 { #category : 'testing' }
 RBPackageEnvironment >> includesClass: aClass [
 
-	^ (super includesClass: aClass) and: [ self packages anySatisfy: [ :package | (package includesClass: aClass) or: [ package extendsClass: aClass ] ] ]
+	^ (super includesClass: aClass) and: [ self packages anySatisfy: [ :package | package definesOrExtendsClass: aClass ] ]
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
This change is speeding up some methods in the Package class to know if a class is extended by a package.

The goal was to work on #17072 but in the end I think there is better to do than speeding up the package code. But I already produced those improvements so I'm proposing them to integration because it can be useful in other parts of the system 