### PR TITLE
Include only bare addresses in MailMessage>>recipientList as needed byy SMTPClient (fixes #17240)

### DIFF
--- a/src/Network-Mail-Tests/MailMessageTest.class.st
+++ b/src/Network-Mail-Tests/MailMessageTest.class.st
@@ -154,12 +154,30 @@ MailMessageTest >> testMultiPartMixed [
 MailMessageTest >> testRecipientList [
 
 	| message |
-	message := MailMessage fromRfc822: 'To: pharo-project@lists.gforge.inria.fr, pharo-users@lists.gforge.inria.fr'.
-
+	message := MailMessage fromRfc822:
+		           'To: pharo-project@lists.pharo.org, "Pharo Users" <pharo-users@lists.pharo.org>'.
 	self
 		assert: message recipientList size equals: 2;
-		assert: message recipientList first equals: 'pharo-project@lists.gforge.inria.fr';
-		assert: message recipientList second equals: 'pharo-users@lists.gforge.inria.fr'
+		assert: message recipientList first
+		equals: 'pharo-project@lists.pharo.org';
+		assert: message recipientList second
+		equals: 'pharo-users@lists.pharo.org'.
+
+	message
+		setField: 'cc'
+		toString: '"Pharo Development" <pharo-dev@lists.pharo.org>'.
+	self assert: message recipientList size equals: 3.
+	self
+		assert: message recipientList third
+		equals: 'pharo-dev@lists.pharo.org'.
+
+	message
+		setField: 'bcc'
+		toString: '"Pharo IOT" <pharo-iot@lists.pharo.org>'.
+	self assert: message recipientList size equals: 4.
+	self
+		assert: message recipientList fourth
+		equals: 'pharo-iot@lists.pharo.org'
 ]
 
 { #category : 'tests' }

--- a/src/Network-Mail/MailMessage.class.st
+++ b/src/Network-Mail/MailMessage.class.st
@@ -273,6 +273,12 @@ MailMessage >> attachmentSeparator [
 ]
 
 { #category : 'accessing' }
+MailMessage >> bcc [
+
+	^self fieldsNamed: 'bcc' separatedBy: ', '
+]
+
+{ #category : 'accessing' }
 MailMessage >> body [
 	"return just the body of the message"
 	^body
@@ -726,7 +732,9 @@ MailMessage >> readStringLineFrom: aStream [
 { #category : 'accessing' }
 MailMessage >> recipientList [
 
-	^ (self to findTokens: $,) collect: [ :e | e trimLeft ]
+	^ (MailAddressParser addressesIn: self to)
+	  , (MailAddressParser addressesIn: self cc)
+	  , (MailAddressParser addressesIn: self bcc)
 ]
 
 { #category : 'printing/formatting' }


### PR DESCRIPTION
Use MailAddressParser to extract the address part from `"Name" <name@example.com>` format. Also include any addresses found in CC and BCC fields.