### PR TITLE
Cleaning monolithic extract method

### DIFF
--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -70,7 +70,6 @@ RBExtractMethodRefactoring >> applicabilityPreconditions [
 			   self checkSpecialExtractions.
 			   self checkReturn.
 			   needsReturn ifTrue: [ extractedParseTree addReturn ].
-			   self checkTemporaries.
 			   true ]) }
 ]
 
@@ -423,6 +422,7 @@ RBExtractMethodRefactoring >> placeholderNode [
 RBExtractMethodRefactoring >> prepareForExecution [ 
 
 	self extractMethod.
+	self checkTemporaries.
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -404,6 +404,12 @@ RBExtractMethodRefactoring >> parameterMap: aDictionary [
 ]
 
 { #category : 'transforming' }
+RBExtractMethodRefactoring >> parameters [
+
+	^ parameters
+]
+
+{ #category : 'transforming' }
 RBExtractMethodRefactoring >> parameters: anOrderedCollection [
 	parameters := anOrderedCollection
 ]

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -169,6 +169,49 @@ RBExtractMethodRefactoring >> compileExtractedMethod [
 		  withAttributesFrom: (class methodFor: selector)
 ]
 
+{ #category : 'preparation' }
+RBExtractMethodRefactoring >> createModifiedParseTreeForNonSequenceSelection [
+
+	| parseTree subtree newCode |
+	parseTree := class parseTreeForSelector: selector.
+	parseTree ifNil: [ self refactoringError: 'Could not parse ' , selector printString ].
+	subtree := self parseTreeSearcherClass treeMatching: extractedParseTree sourceCode in: parseTree.
+	subtree ifNil: [ self refactoringError: 'Could not extract code from method' ].
+	newCode := self methodDelimiter.
+	modifiedParseTree := self parseTreeRewriterClass
+		replace: subtree formattedCode
+		with: newCode
+		in: parseTree
+		onInterval: extractionInterval
+]
+
+{ #category : 'preparation' }
+RBExtractMethodRefactoring >> createModifiedParseTreeForSequenceSelection [
+
+	| parseTree subtree stmts newCode |
+	parseTree := class parseTreeForSelector: selector.
+	parseTree
+		ifNil: [ self refactoringError: 'Could not parse ' , selector printString ].
+	subtree := self parseTreeSearcherClass
+		treeMatchingStatements: extractedParseTree body formattedCode
+		in: parseTree.
+	subtree ifNil: [ self refactoringError: 'Could not extract code from method' ].
+	newCode := self methodDelimiter.
+	stmts := extractedParseTree body statements.
+	stmts
+		ifNotEmpty: [ stmts last isAssignment
+			ifTrue: [ | name |
+					name := stmts last variable name.
+					(self shouldExtractAssignmentTo: name)
+						ifFalse: [ newCode := '<1s> := <2s>' expandMacrosWith: name with: newCode.
+							stmts at: stmts size put: stmts last value ] ] ].
+	modifiedParseTree := self parseTreeRewriterClass
+		replaceStatements: subtree formattedCode
+		with: newCode
+		in: parseTree
+		onInterval: extractionInterval
+]
+
 { #category : 'transforming' }
 RBExtractMethodRefactoring >> existingSelector [
 	"Try to find an existing method instead of creating a new one"
@@ -188,7 +231,7 @@ RBExtractMethodRefactoring >> extract: anInterval from: aSelector in: aClass [
 
 { #category : 'transforming' }
 RBExtractMethodRefactoring >> extractMethod [
-	| parseTree isSequence extractCode newCode |
+	| isSequence extractCode |
 	extractCode := self getExtractedSource.
 	extractedParseTree := self parserClass new
 		source: extractCode;
@@ -215,40 +258,10 @@ RBExtractMethodRefactoring >> extractMethod [
 	extractedParseTree body temporaries
 		ifNotEmpty: [ extractedParseTree body temporaries: #() ].
 	extractedParseTree source: extractCode.
-	parseTree := class parseTreeForSelector: selector.
-	parseTree
-		ifNil: [ self refactoringError: 'Could not parse ' , selector printString ].
+
 	isSequence
-		ifTrue: [ 
-			| subtree stmts |
-			subtree := self parseTreeSearcherClass
-				treeMatchingStatements: extractedParseTree body formattedCode
-				in: parseTree.
-			subtree ifNil: [ self refactoringError: 'Could not extract code from method' ].
-			newCode := self methodDelimiter.
-			stmts := extractedParseTree body statements.
-			stmts
-				ifNotEmpty: [ stmts last isAssignment
-						ifTrue: [ | name |
-							name := stmts last variable name.
-							(self shouldExtractAssignmentTo: name)
-								ifFalse: [ newCode := '<1s> := <2s>' expandMacrosWith: name with: newCode.
-									stmts at: stmts size put: stmts last value ] ] ].
-			modifiedParseTree := self parseTreeRewriterClass
-				replaceStatements: subtree formattedCode
-				with: newCode
-				in: parseTree
-				onInterval: extractionInterval ]
-		ifFalse: [ 
-			| subtree |
-			subtree := self parseTreeSearcherClass treeMatching: extractCode in: parseTree.
-			subtree ifNil: [ self refactoringError: 'Could not extract code from method' ].
-			newCode := self methodDelimiter.
-			modifiedParseTree := self parseTreeRewriterClass
-				replace: subtree formattedCode
-				with: newCode
-				in: parseTree
-				onInterval: extractionInterval ].
+		ifTrue: [ self createModifiedParseTreeForSequenceSelection ]
+		ifFalse: [ self createModifiedParseTreeForNonSequenceSelection ].
 ]
 
 { #category : 'instance creation' }

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -188,7 +188,7 @@ RBExtractMethodRefactoring >> extract: anInterval from: aSelector in: aClass [
 
 { #category : 'transforming' }
 RBExtractMethodRefactoring >> extractMethod [
-	| parseTree isSequence extractCode subtree newCode |
+	| parseTree isSequence extractCode newCode |
 	extractCode := self getExtractedSource.
 	extractedParseTree := self parserClass new
 		source: extractCode;
@@ -218,17 +218,14 @@ RBExtractMethodRefactoring >> extractMethod [
 	parseTree := class parseTreeForSelector: selector.
 	parseTree
 		ifNil: [ self refactoringError: 'Could not parse ' , selector printString ].
-	subtree := isSequence
-		ifTrue: [ self parseTreeSearcherClass
-				treeMatchingStatements: extractedParseTree body formattedCode
-				in: parseTree ]
-		ifFalse:
-			[ self parseTreeSearcherClass treeMatching: extractCode in: parseTree ].
-	subtree
-		ifNil: [ self refactoringError: 'Could not extract code from method' ].
-	newCode := self methodDelimiter.
 	isSequence
-		ifTrue: [ | stmts |
+		ifTrue: [ 
+			| subtree stmts |
+			subtree := self parseTreeSearcherClass
+				treeMatchingStatements: extractedParseTree body formattedCode
+				in: parseTree.
+			subtree ifNil: [ self refactoringError: 'Could not extract code from method' ].
+			newCode := self methodDelimiter.
 			stmts := extractedParseTree body statements.
 			stmts
 				ifNotEmpty: [ stmts last isAssignment
@@ -236,18 +233,22 @@ RBExtractMethodRefactoring >> extractMethod [
 							name := stmts last variable name.
 							(self shouldExtractAssignmentTo: name)
 								ifFalse: [ newCode := '<1s> := <2s>' expandMacrosWith: name with: newCode.
-									stmts at: stmts size put: stmts last value ] ] ] ].
-	modifiedParseTree := isSequence
-		ifTrue: [ self parseTreeRewriterClass
+									stmts at: stmts size put: stmts last value ] ] ].
+			modifiedParseTree := self parseTreeRewriterClass
 				replaceStatements: subtree formattedCode
 				with: newCode
 				in: parseTree
 				onInterval: extractionInterval ]
-		ifFalse: [ self parseTreeRewriterClass
+		ifFalse: [ 
+			| subtree |
+			subtree := self parseTreeSearcherClass treeMatching: extractCode in: parseTree.
+			subtree ifNil: [ self refactoringError: 'Could not extract code from method' ].
+			newCode := self methodDelimiter.
+			modifiedParseTree := self parseTreeRewriterClass
 				replace: subtree formattedCode
 				with: newCode
 				in: parseTree
-				onInterval: extractionInterval ]
+				onInterval: extractionInterval ].
 ]
 
 { #category : 'instance creation' }

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -233,6 +233,23 @@ RBExtractMethodRefactoring >> extract: anInterval from: aSelector in: aClass [
 RBExtractMethodRefactoring >> extractMethod [
 	| isSequence extractCode |
 	extractCode := self getExtractedSource.
+	self extractParseTreeForSelection: extractCode.
+	(extractedParseTree isSequence
+		and: [ extractedParseTree statements isEmpty ])
+		ifTrue: [ self refactoringError: 'Select some code to extract' ].
+	isSequence := extractedParseTree isSequence
+		or: [ extractedParseTree isReturn ].
+		
+	self wrapExtractedParseTreeInMethodNode: extractCode.
+
+	isSequence
+		ifTrue: [ self createModifiedParseTreeForSequenceSelection ]
+		ifFalse: [ self createModifiedParseTreeForNonSequenceSelection ].
+]
+
+{ #category : 'preparation' }
+RBExtractMethodRefactoring >> extractParseTreeForSelection: extractCode [
+
 	extractedParseTree := self parserClass new
 		source: extractCode;
 		parseExpression.
@@ -240,28 +257,7 @@ RBExtractMethodRefactoring >> extractMethod [
 		ifNil: [ self refactoringError: 'Invalid source to extract' ].
 	extractedParseTree isFaulty
 		ifTrue: [ self
-				refactoringError: 'Invalid source to extract - ' , extractedParseTree allErrorNotices first messageText ].
-	(extractedParseTree isSequence
-		and: [ extractedParseTree statements isEmpty ])
-		ifTrue: [ self refactoringError: 'Select some code to extract' ].
-	isSequence := extractedParseTree isSequence
-		or: [ extractedParseTree isReturn ].
-	extractedParseTree := ASTMethodNode
-		selector: #value
-		arguments: #()
-		body:
-			(extractedParseTree isSequence
-				ifTrue: [ extractedParseTree ]
-				ifFalse: [ ASTSequenceNode
-						temporaries: #()
-						statements: (OrderedCollection with: extractedParseTree) ]).
-	extractedParseTree body temporaries
-		ifNotEmpty: [ extractedParseTree body temporaries: #() ].
-	extractedParseTree source: extractCode.
-
-	isSequence
-		ifTrue: [ self createModifiedParseTreeForSequenceSelection ]
-		ifFalse: [ self createModifiedParseTreeForNonSequenceSelection ].
+			refactoringError: 'Invalid source to extract - ' , extractedParseTree allErrorNotices first messageText ].
 ]
 
 { #category : 'instance creation' }
@@ -546,4 +542,21 @@ RBExtractMethodRefactoring >> validateRenameNode: aParseTree withOldName: oldNam
 { #category : 'renaming' }
 RBExtractMethodRefactoring >> validateRenameOf: oldName to: newName [
 	self validateRenameNode: extractedParseTree withOldName: oldName toWithName: newName
+]
+
+{ #category : 'preparation' }
+RBExtractMethodRefactoring >> wrapExtractedParseTreeInMethodNode: extractCode [
+
+	extractedParseTree := ASTMethodNode
+		selector: #value
+		arguments: #()
+		body:
+			(extractedParseTree isSequence
+				ifTrue: [ extractedParseTree ]
+				ifFalse: [ ASTSequenceNode
+						temporaries: #()
+						statements: (OrderedCollection with: extractedParseTree) ]).
+	extractedParseTree body temporaries
+		ifNotEmpty: [ extractedParseTree body temporaries: #() ].
+	extractedParseTree source: extractCode.
 ]

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -67,7 +67,6 @@ RBExtractMethodRefactoring >> applicabilityPreconditions [
 	^ {
 		  (RBCondition definesSelector: selector in: class).
 		  (RBCondition withBlock: [
-			   self extractMethod.
 			   self checkSpecialExtractions.
 			   self checkReturn.
 			   needsReturn ifTrue: [ extractedParseTree addReturn ].
@@ -418,6 +417,12 @@ RBExtractMethodRefactoring >> placeholderNode [
 		in: modifiedParseTree.
 	node ifNil: [ self refactoringError: 'Cannot extract code' ].
 	^ node
+]
+
+{ #category : 'transforming' }
+RBExtractMethodRefactoring >> prepareForExecution [ 
+
+	self extractMethod.
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -69,7 +69,6 @@ RBExtractMethodRefactoring >> applicabilityPreconditions [
 		  (RBCondition withBlock: [
 			   self checkSpecialExtractions.
 			   self checkReturn.
-			   needsReturn ifTrue: [ extractedParseTree addReturn ].
 			   true ]) }
 ]
 
@@ -95,6 +94,7 @@ RBExtractMethodRefactoring >> checkAssignments: variableNames [
 
 { #category : 'transforming' }
 RBExtractMethodRefactoring >> checkReturn [
+
 	needsReturn := self placeholderNode isUsedAsReturnValue.
 	extractedParseTree containsReturn ifFalse: [^self].
 	extractedParseTree lastIsReturn ifTrue: [^self].
@@ -429,6 +429,7 @@ RBExtractMethodRefactoring >> prepareForExecution [
 RBExtractMethodRefactoring >> privateTransform [
 
 	| existingSelector |
+	needsReturn ifTrue: [ extractedParseTree addReturn ].
 	existingSelector := self existingSelector.
 	self nameNewMethod: (existingSelector
 			 ifNil: [ newExtractedSelector ifNil: [ self getNewMethodName ] ]

--- a/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractSetUpMethodRefactoring.class.st
@@ -63,12 +63,9 @@ RBExtractSetUpMethodRefactoring >> applicabilityPreconditions [
 		ifNotNil: [ self trueCondition ]).
 	  (RBCondition withBlock: [ class allSuperclasses anySatisfy: [ :e | e name = #TestCase ] ]).
 	  (RBCondition withBlock:
-		[self extractMethod.
-		self checkSpecialExtractions.
-		self checkReturn.
-		needsReturn ifTrue: [extractedParseTree addReturn].
-		self checkTemporaries.
-		true]) }
+		[ self checkSpecialExtractions.
+		  self checkReturn.
+		  true]) }
 ]
 
 { #category : 'transforming' }
@@ -116,9 +113,10 @@ RBExtractSetUpMethodRefactoring >> nameNewMethod: aSymbol [
 RBExtractSetUpMethodRefactoring >> privateTransform [
 
 	| existingSelector |
+	needsReturn ifTrue: [extractedParseTree addReturn].
 	existingSelector := self existingSelector.
 	self nameNewMethod: #setUp.
-	existingSelector ifNil: [
+	(existingSelector isNil or: [ existingSelector ~= #setUp ]) ifTrue: [
 		self renameAllParameters.
 		extractedParseTree body addNodeFirst: (RBParser parseExpression: 'super setUp').
 		self generateChangesFor:
@@ -126,7 +124,7 @@ RBExtractSetUpMethodRefactoring >> privateTransform [
 				sourceCode: extractedParseTree newSource
 				in: class
 				withProtocol: #running)].
-	modifiedParseTree body removeNode: (modifiedParseTree body statements at: 1).
+	modifiedParseTree body removeNode: (modifiedParseTree body statements first).
 	class compileTree: modifiedParseTree
 ]
 

--- a/src/Refactoring-Transformations-Tests/RBExtractSetUpMethodAndOccurrencesParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractSetUpMethodAndOccurrencesParametrizedTest.class.st
@@ -19,6 +19,40 @@ RBExtractSetUpMethodAndOccurrencesParametrizedTest >> constructor [
 ]
 
 { #category : 'tests' }
+RBExtractSetUpMethodAndOccurrencesParametrizedTest >> testExtractSetUpWorksWellInOtherMethod [
+
+	| class refactoring |
+	refactoring := self createRefactoringWithArguments: { (47 to: 109) . #testExtractSetupExample6 . RBTestAsDataForExtractSetupTransformationTest }.
+	self setupSearchInAllHierarchyFor: refactoring toReturn: true.
+	self executeRefactoring: refactoring.
+	class := refactoring model classNamed: #RBTestAsDataForExtractSetupTransformationTest.
+	self assert: (class instanceVariableNames includes: #aString2).
+	self assert: (class instanceVariableNames includes: #aNumber).
+	
+	"Pay attention that method body is created this way to support potential selector rename"
+	self 
+		assert: (class parseTreeForSelector: #testExtractSetupExample6) 
+		equals: (self parseMethod: #testExtractSetupExample6 asString, Character cr asString,
+	'self assert: aString2 isNotEmpty.
+	self deny: (aString2 , aNumber asString) isEmpty.
+	self assert: true').
+	
+	"This method was the same as setUp so now it is empty."
+	self 
+		assert: (class parseTreeForSelector: #testExtractSetupExample8) 
+		equals: (self parseMethod: #testExtractSetupExample8 asString, Character cr asString,
+'	"this is an example to see if the extracted as setup expressions are also extracted from this one too."
+').
+			
+	self assert: (class parseTreeForSelector: #setUp) equals: (self parseMethod: 'setUp
+	super setUp.
+	aString2 := ''Some string''.
+	self someMethod.
+	aNumber := 4').
+
+]
+
+{ #category : 'tests' }
 RBExtractSetUpMethodAndOccurrencesParametrizedTest >> testExtractSimpleMethodAndOcurrences [
 	|class refactoring|
 	refactoring := self createRefactoringWithArguments: { (15+12 to: 59+12) . #testExtractSetupExample1 . RBTestAsDataForExtractSetupTransformationTest }.

--- a/src/Refactoring-Transformations-Tests/RBExtractSetUpMethodParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractSetUpMethodParametrizedTest.class.st
@@ -117,58 +117,6 @@ RBExtractSetUpMethodParametrizedTest >> testExtractSetUpAndConvertTwoTempsToInst
 	aNumber := 4')
 ]
 
-{ #category : 'tests' }
-RBExtractSetUpMethodParametrizedTest >> testExtractSetUpWorksWellInOtherMethod [
-	| class refactoring |
-	self skip.
-	 
-	"if we extract as Setup 
-		 aString2 := 'Some string'.
-		self someMethod.
-	from method testExtractSetupExample6
-	
-	we get effectively and correctly the expression removed from the other methods such as 
-	
-		testExtractSetupExample8
-
-		| aNumber |
-		""this is an example to see if the extracted as setup expressions are also extracted from this one too.""
-		aNumber := 4
-	
-	Now I do not succeed to convert this in a test.
-	So I skip it for now.
-	
-	"
-	refactoring := self createRefactoringWithArguments: { (47 to: 109) . #testExtractSetupExample6 . RBTestAsDataForExtractSetupTransformationTest }.
-	self executeRefactoring: refactoring.
-	class := refactoring model classNamed: #RBTestAsDataForExtractSetupTransformationTest.
-	self assert: (class instanceVariableNames includes: #aString2).
-	self assert: (class instanceVariableNames includes: #aNumber).
-	
-	"Pay attention that method body is created this way to support potential selector rename"
-	
-	self 
-		assert: (class parseTreeForSelector: #testExtractSetupExample6) 
-		equals: (self parseMethod: #testExtractSetupExample6 asString, Character cr asString,
-'self assert: aString2 isNotEmpty.
-	self deny: (aString2 , aNumber asString) isEmpty.
-	self assert: true').
-	
-	"no idea what the extraction is not executed in testExtractSetupExample8 because when trying it works.
-	This may be due to the fact that nautilus refactoring defines different options! "
-	self 
-		assert: (class parseTreeForSelector: #testExtractSetupExample8) 
-		equals: (self parseMethod: #testExtractSetupExample8 asString, Character cr asString,
-'	| aNumber |
-	"this is an example to see if the extracted as setup expressions are also extracted from this one too."
-	aNumber := 4').
-	
-	self assert: (class parseTreeForSelector: #setUp) equals: (self parseMethod: 'setUp
-	super setUp.
-	aString2 := ''Some string''.
-	self someMethod.')
-]
-
 { #category : 'failure tests' }
 RBExtractSetUpMethodParametrizedTest >> testFailureBadClass [
 	model := self modelOnClasses: { RBLintRuleTestData }.

--- a/src/Refactoring-Transformations-Tests/RBExtractSetUpMethodParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractSetUpMethodParametrizedTest.class.st
@@ -80,7 +80,6 @@ RBExtractSetUpMethodParametrizedTest >> testExtractSetUpAndConvertTempsToInstVar
 { #category : 'tests' }
 RBExtractSetUpMethodParametrizedTest >> testExtractSetUpAndConvertTwoTempsToInstVars [
 	| class refactoring |
-	self skip.
 	refactoring := self createRefactoringWithArguments: { (47 to: 109) . #testExtractSetupExample6 . RBTestAsDataForExtractSetupTransformationTest }.
 	self executeRefactoring: refactoring.
 	class := refactoring model classNamed: #RBTestAsDataForExtractSetupTransformationTest.
@@ -102,11 +101,6 @@ RBExtractSetUpMethodParametrizedTest >> testExtractSetUpAndConvertTwoTempsToInst
 	self someMethod.
 	aNumber := 4.
 	self assert: aString2 isNotEmpty.').
-	
-	"I do not get why the following is not working since the expression has been correctly removed from testExtractSetupExample6
-	and in addition the tests with a single iv works and we have the two instance variables. 
-	After trying during too long, I saw that the options of the refactorings can be changing (nautilus refactoring defines others and these are the ones
-	used interactively. In addition randomly I got some do you want to search in the complete hierarchy."
 	
 	self 
 		assert: (class parseTreeForSelector: #setUp) 


### PR DESCRIPTION
A lot of cleaning of monolithic implementation of extract method:
- introduce prepare for execution
- clean the notorious `extractMethod` function (that wasn't extracting the method but performing a bunch of set up and preparations and some validation)
- move code out of applicability to either `prepareForExecution` or `privateTransform` depending on its meaning
- migrate same refactoring to extract set up
- fix skipping tests for extract set up

Check this [commit](https://github.com/pharo-project/pharo/commit/9f9df92e44ba56e7dbcc481d29bff022ec69f8b8) for a discussion on fix for extract setUp and the  consequences it brought.

Finally, this is not ideal state, and I would like to perform more cleaning, mainly in the prepare for execution and preconditions steps since those two are very twisted and very tightly coupled. This is just a first step! 🚀 