### PR TITLE
Restore the Calypso tab copy button to copy method name(s) to Clipboard

### DIFF
--- a/src/Calypso-SystemTools-Core/SycCopyMethodNameToClypboardCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycCopyMethodNameToClypboardCommand.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'SycCopyMethodNameToClypboardCommand' }
+
+{ #category : '*Calypso-SystemTools-Core' }
+SycCopyMethodNameToClypboardCommand class >> methodTabIconActivation [
+	<classAnnotation>
+
+	^ ClyBrowserTabCommandActivation for: ClyMethod asCalypsoItemContext
+]

--- a/src/SystemCommands-MethodCommands/SycCopyMethodNameToClypboardCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycCopyMethodNameToClypboardCommand.class.st
@@ -1,0 +1,32 @@
+"
+Copy selected methods selector into Clipboard as testOriginalSelector
+"
+Class {
+	#name : 'SycCopyMethodNameToClypboardCommand',
+	#superclass : 'SycMethodCommand',
+	#category : 'SystemCommands-MethodCommands',
+	#package : 'SystemCommands-MethodCommands'
+}
+
+{ #category : 'accessing' }
+SycCopyMethodNameToClypboardCommand >> defaultMenuIconName [
+	^#smallCopy
+]
+
+{ #category : 'accessing' }
+SycCopyMethodNameToClypboardCommand >> defaultMenuItemName [
+	^'Copy method name(s) to Clipboard'
+]
+
+{ #category : 'accessing' }
+SycCopyMethodNameToClypboardCommand >> description [
+	^'Copy selected methods into Clipboard as class>>selector'
+]
+
+{ #category : 'execution' }
+SycCopyMethodNameToClypboardCommand >> execute [
+	| text |
+	text := (methods collect: [ :each | each displayString ]) joinUsing: String cr.
+	Clipboard clipboardText: text.
+	self inform: 'Copied methods:', String cr, text
+]


### PR DESCRIPTION
 This PR restores the Calypso lost "copy method name" button, as reported in #17251 