### PR TITLE
Use allNonMetaClasses in Duplicate Class driver

### DIFF
--- a/src/Refactoring-UI/ReDuplicateClassDriver.class.st
+++ b/src/Refactoring-UI/ReDuplicateClassDriver.class.st
@@ -137,7 +137,7 @@ ReDuplicateClassDriver >> scopes: refactoringScopes [
 	
 	scopes := refactoringScopes.
 	model := self refactoringScopeOn: scopes last.
-	selectedClass := model environment classes anyOne.	
+	selectedClass := model environment allNonMetaClasses anyOne.	
 
 	rbClass := model classFor: selectedClass.
 	rbMetaclass := model classFor: selectedClass class.


### PR DESCRIPTION
Use allNonMetaClasses to prevent getting metaclasses where are not needed, as reported in #17262 
