### PR TITLE
Support methods for the new setting browser

### DIFF
--- a/src/Renraku/ReSettings.class.st
+++ b/src/Renraku/ReSettings.class.st
@@ -22,19 +22,13 @@ ReSettings class >> cleanUp [
 ReSettings class >> resetButtonSettingsOn: aBuilder [
 	<systemsettings>
 
-	(aBuilder group: #'resetRules')
+	(aBuilder button: #resetWithInform)
 		order: 10;
-		target: self;
+		target: ReRuleManager;
 		label: 'Rule cache';
 		parent: #qualityAssistant;
 		description: 'Renraku (the engine behind quality rules) caches the rule objects for performance boost. Here you can reset the cache, this may be useful if you''ve implemented a new rule and want to include it.';
-		dialog: [
-			SimpleButtonMorph new
-				target: ReRuleManager;
-				label: 'Reset rule cache';
-				actionSelector: #resetWithInform;
-				themeChanged;
-				yourself ]
+		buttonLabel: 'Reset'
 ]
 
 { #category : 'settings-accessing' }

--- a/src/Settings-System/SystemSystemSettings.class.st
+++ b/src/Settings-System/SystemSystemSettings.class.st
@@ -17,9 +17,9 @@ SystemSystemSettings class >> systemSettingOn: aBuilder [
 		description: 'Settings related to Tools'.
 
 	(aBuilder group: #SCM)
-		label: 'Software Configuration Management';
+		label: 'SCM';
 		parent: #tools;
-		description: 'Settings related to version management and code sharing'.
+		description: 'Settings related to Software Configuration Management (version management and code sharing)'.
 
 	(aBuilder group: #pharoSystem)
 		label: 'System';

--- a/src/System-Settings-Core/ActionSettingDeclaration.class.st
+++ b/src/System-Settings-Core/ActionSettingDeclaration.class.st
@@ -27,7 +27,7 @@ ActionSettingDeclaration >> inputWidget [
 
 	^ SimpleButtonMorph new
 		target: self target;
-		label: (self label ifNil: [ '(Error: no label defined)' ]);
+		label: (self actionLabel ifNil: [ '(Error: no label defined)' ]);
 		actionSelector: self name;
 		themeChanged; "This is to avoid green button?"
 		yourself

--- a/src/System-Settings-Core/PragmaSetting.class.st
+++ b/src/System-Settings-Core/PragmaSetting.class.st
@@ -237,7 +237,9 @@ PragmaSetting >> labelMorphFor: aContainer [
 
 { #category : 'accessing' }
 PragmaSetting >> name [
-	^ name ifNil: [super name] ifNotNil: [name]
+	^ name 
+		ifNil: [ 'Unnamed ' , self class name ] 
+		ifNotNil: [ name ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This PR includes small changes to support the new Setting Browser, and not lose compatibility with the Morphic one during migration:

- Use the actionLabel in the Morphic Setting Browser (part of NewTools Setting Browser migration).
- Use abbreviated SCM instead of 'Software Configuration Management' for a shorter New Setting Browser tab naming.
- PragmaSetting name should default to a secure String value instead of relying on #name superimplementor (that is missing now)