### PR TITLE
Fix Pull Up precondition bug

### DIFF
--- a/src/Refactoring-Core-Tests/RBAbstractConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/RBAbstractConditionTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'RBAbstractConditionTest',
 	#superclass : 'TestCase',
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'testing' }

--- a/src/Refactoring-Core-Tests/RBConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/RBConditionTest.class.st
@@ -7,8 +7,9 @@ Class {
 		'messageNodeClass',
 		'newClass'
 	],
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'running' }

--- a/src/Refactoring-Core-Tests/RBMaxOneAssignmentWithReferencesConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/RBMaxOneAssignmentWithReferencesConditionTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'RBMaxOneAssignmentWithReferencesConditionTest',
 	#superclass : 'RBAbstractConditionTest',
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'tests' }

--- a/src/Refactoring-Core-Tests/RBMethodNameTest.class.st
+++ b/src/Refactoring-Core-Tests/RBMethodNameTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'RBMethodNameTest',
 	#superclass : 'TestCase',
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'tests' }

--- a/src/Refactoring-Core-Tests/RBNotInCascadedMessageConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/RBNotInCascadedMessageConditionTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'RBNotInCascadedMessageConditionTest',
 	#superclass : 'RBAbstractConditionTest',
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'tests' }

--- a/src/Refactoring-Core-Tests/RBSubtreeDoesNotContainReturnConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/RBSubtreeDoesNotContainReturnConditionTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'RBSubtreeDoesNotContainReturnConditionTest',
 	#superclass : 'RBAbstractConditionTest',
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'tests' }

--- a/src/Refactoring-Core-Tests/RBVariablesNotReadBeforeWrittenConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/RBVariablesNotReadBeforeWrittenConditionTest.class.st
@@ -4,8 +4,9 @@ A RBTemporariesNotReadBeforeWrittenConditionTest is a test class for testing the
 Class {
 	#name : 'RBVariablesNotReadBeforeWrittenConditionTest',
 	#superclass : 'RBAbstractConditionTest',
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'tests' }

--- a/src/Refactoring-Core-Tests/ReClassHasSubclassesTest.class.st
+++ b/src/Refactoring-Core-Tests/ReClassHasSubclassesTest.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'model'
 	],
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'tests' }

--- a/src/Refactoring-Core-Tests/ReHierarchyDefinesMethodTest.class.st
+++ b/src/Refactoring-Core-Tests/ReHierarchyDefinesMethodTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'ReHierarchyDefinesMethodTest',
 	#superclass : 'TestCase',
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'tests' }

--- a/src/Refactoring-Core-Tests/ReMethodsDontReferToInstVarsTest.class.st
+++ b/src/Refactoring-Core-Tests/ReMethodsDontReferToInstVarsTest.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'model'
 	],
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'accessing' }

--- a/src/Refactoring-Core-Tests/ReMethodsDontReferToSharedVarsTest.class.st
+++ b/src/Refactoring-Core-Tests/ReMethodsDontReferToSharedVarsTest.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'model'
 	],
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'tests' }

--- a/src/Refactoring-Core-Tests/ReMethodsHaveNoSuperCallInSiblingsConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/ReMethodsHaveNoSuperCallInSiblingsConditionTest.class.st
@@ -10,16 +10,48 @@ Class {
 }
 
 { #category : 'tests' }
-ReMethodsHaveNoSuperCallInSiblingsConditionTest >> testTargetClassIsTwoLevelsAboveAndSuperSendInSubclass [
+ReMethodsHaveNoSuperCallInSiblingsConditionTest >> testFailureWhenSiblingSendsSuperToTargetClass [
 
-	| model myClassAlpha myClassBetaSub cond |
-	model := self modelOnClasses: { MyClassAlpha . MyClassBeta. MyClassBetaSub . MyClassBetaSubSub }.
-	myClassAlpha := model classNamed: #MyClassAlpha. 
-	myClassBetaSub := model classNamed: #MyClassBetaSub.
+	| model target source cond |
+	model := self modelOnClasses: { MyClassAlpha . MyClassBeta. MyClassBetaSub . MyClassBetaSubSub . MyClassBetaSibling }.
+	target := model classNamed: #MyClassAlpha. 
+	source := model classNamed: #MyClassBeta.
 	
 	cond := ReMethodsHaveNoSuperCallInSiblingsCondition new
-			class: myClassBetaSub
-		   targetSuperclass: myClassAlpha
+			class: source
+		   targetSuperclass: target
+		   selectors: { #methodForSupersend }.
+
+	self deny: cond check
+]
+
+{ #category : 'tests' }
+ReMethodsHaveNoSuperCallInSiblingsConditionTest >> testTargetClassIsSuperclassAndSuperSendInSubclass [
+
+	| model target source cond |
+	model := self modelOnClasses: { MyClassAlpha . MyClassBeta. MyClassBetaSub . MyClassBetaSubSub . MyClassBetaSibling }.
+	target := model classNamed: #MyClassBeta. 
+	source := model classNamed: #MyClassBetaSub.
+	
+	cond := ReMethodsHaveNoSuperCallInSiblingsCondition new
+			class: source
+		   targetSuperclass: target
+		   selectors: { #overridenInSubclassAndNoWhereElse }.
+
+	self assert: cond check
+]
+
+{ #category : 'tests' }
+ReMethodsHaveNoSuperCallInSiblingsConditionTest >> testTargetClassIsTwoLevelsAboveAndSuperSendInSubclass [
+
+	| model target source cond |
+	model := self modelOnClasses: { MyClassAlpha . MyClassBeta. MyClassBetaSub . MyClassBetaSubSub . MyClassBetaSibling }.
+	target := model classNamed: #MyClassAlpha. 
+	source := model classNamed: #MyClassBetaSub.
+	
+	cond := ReMethodsHaveNoSuperCallInSiblingsCondition new
+			class: source
+		   targetSuperclass: target
 		   selectors: { #overridenInSubclassAndNoWhereElse }.
 
 	self assert: cond check

--- a/src/Refactoring-Core-Tests/ReMethodsHaveNoSuperCallInSiblingsConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/ReMethodsHaveNoSuperCallInSiblingsConditionTest.class.st
@@ -1,0 +1,26 @@
+"
+A ReMethodsHaveNoSuperCallInSiblingsConditionTest is a test class for testing the behavior of ReMethodsHaveNoSuperCallInSiblingsCondition
+"
+Class {
+	#name : 'ReMethodsHaveNoSuperCallInSiblingsConditionTest',
+	#superclass : 'RBAbstractConditionTest',
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
+}
+
+{ #category : 'tests' }
+ReMethodsHaveNoSuperCallInSiblingsConditionTest >> testTargetClassIsTwoLevelsAboveAndSuperSendInSubclass [
+
+	| model myClassAlpha myClassBetaSub cond |
+	model := self modelOnClasses: { MyClassAlpha . MyClassBeta. MyClassBetaSub . MyClassBetaSubSub }.
+	myClassAlpha := model classNamed: #MyClassAlpha. 
+	myClassBetaSub := model classNamed: #MyClassBetaSub.
+	
+	cond := ReMethodsHaveNoSuperCallInSiblingsCondition new
+			class: myClassBetaSub
+		   targetSuperclass: myClassAlpha
+		   selectors: { #overridenInSubclassAndNoWhereElse }.
+
+	self assert: cond check
+]

--- a/src/Refactoring-Core-Tests/ReMethodsReceiveNoSupersendsTest.class.st
+++ b/src/Refactoring-Core-Tests/ReMethodsReceiveNoSupersendsTest.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'model'
 	],
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'accessing' }

--- a/src/Refactoring-Core-Tests/ReMethodsSendNoSupersendsTest.class.st
+++ b/src/Refactoring-Core-Tests/ReMethodsSendNoSupersendsTest.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'model'
 	],
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'accessing' }

--- a/src/Refactoring-Core-Tests/ReSingleAssignmentConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/ReSingleAssignmentConditionTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'ReSingleAssignmentConditionTest',
 	#superclass : 'RBAbstractConditionTest',
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'tests - fixture' }

--- a/src/Refactoring-Core-Tests/ReUpToRootDefinesMethodTest.class.st
+++ b/src/Refactoring-Core-Tests/ReUpToRootDefinesMethodTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'ReUpToRootDefinesMethodTest',
 	#superclass : 'TestCase',
-	#category : 'Refactoring-Core-Tests',
-	#package : 'Refactoring-Core-Tests'
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
 }
 
 { #category : 'tests' }

--- a/src/Refactoring-Core/ReMethodsHaveNoSuperCallInSiblingsCondition.class.st
+++ b/src/Refactoring-Core/ReMethodsHaveNoSuperCallInSiblingsCondition.class.st
@@ -44,8 +44,11 @@ ReMethodsHaveNoSuperCallInSiblingsCondition >> checkSiblingSuperSendsFrom: aRBCl
 					definer := aRBClass superclass whichClassIncludesSelector:  aSelector.
 
 					(definer isNotNil and: [ class includesClass: definer ]) ifTrue: [
-						violators add: { aSelector. aRBClass. each }  ] ] ] ] ].
-	aRBClass allSubclasses do: [ :each |
+						violators add: { aSelector. aRBClass . each }  ] ] ] ] ].
+	"if we are pulling up to a target subclass that is two or more classes above `class`
+	it is not enough to reject class in `checkSuperSendsFromSiblings`, but we need to check
+	it for each subclass as well, otherwise we can have false negatives"
+	aRBClass subclasses reject: [ :each | each = class ] thenDo: [ :each |
 		self checkSiblingSuperSendsFrom: each ]
 ]
 
@@ -72,9 +75,9 @@ ReMethodsHaveNoSuperCallInSiblingsCondition >> violationMessageOn: aStream [
 	| messageSent senderClass senderMessage |
 	
 	self violators do: [ :violator |
-		messageSent := violator at: 1.
-		senderClass := violator at: 2.
-		senderMessage := violator at: 3.
+		messageSent := violator first.
+		senderClass := violator second .
+		senderMessage := violator third.
 		
 		aStream
 			nextPutAll: senderClass name;
@@ -89,7 +92,7 @@ ReMethodsHaveNoSuperCallInSiblingsCondition >> violationMessageOn: aStream [
 { #category : 'accessing' }
 ReMethodsHaveNoSuperCallInSiblingsCondition >> violators [
 	violators ifNotNil: [ ^ violators ].
-	violators := #() asOrderedCollection.
+	violators := OrderedCollection new.
 	self checkSuperSendsFromSiblings.
 	^ violators
 ]

--- a/src/Refactoring-DataForTesting/MyClassBetaSub.class.st
+++ b/src/Refactoring-DataForTesting/MyClassBetaSub.class.st
@@ -42,7 +42,7 @@ MyClassBetaSub >> methodReferencingInstanceVariableDefinedInSuperclass [
 	^ instVarB
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'dummy methods' }
 MyClassBetaSub >> overridenInSubclassAndNoWhereElse [
 	"This is used to test pull up method when the target class is two levels above and I have override in subclass."
 	^ 42

--- a/src/Refactoring-DataForTesting/MyClassBetaSub.class.st
+++ b/src/Refactoring-DataForTesting/MyClassBetaSub.class.st
@@ -41,3 +41,9 @@ MyClassBetaSub >> methodReferencingInstVarDefinedInItsDefiningClassAndOneInItsSu
 MyClassBetaSub >> methodReferencingInstanceVariableDefinedInSuperclass [
 	^ instVarB
 ]
+
+{ #category : 'as yet unclassified' }
+MyClassBetaSub >> overridenInSubclassAndNoWhereElse [
+	"This is used to test pull up method when the target class is two levels above and I have override in subclass."
+	^ 42
+]

--- a/src/Refactoring-DataForTesting/MyClassBetaSubSub.class.st
+++ b/src/Refactoring-DataForTesting/MyClassBetaSubSub.class.st
@@ -6,7 +6,7 @@ Class {
 	#tag : 'StaticModel'
 }
 
-{ #category : 'as yet unclassified' }
+{ #category : 'dummy methods' }
 MyClassBetaSubSub >> overridenInSubclassAndNoWhereElse [
 
 	^ super overridenInSubclassAndNoWhereElse + 1

--- a/src/Refactoring-DataForTesting/MyClassBetaSubSub.class.st
+++ b/src/Refactoring-DataForTesting/MyClassBetaSubSub.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'MyClassBetaSubSub',
+	#superclass : 'MyClassBetaSub',
+	#category : 'Refactoring-DataForTesting-StaticModel',
+	#package : 'Refactoring-DataForTesting',
+	#tag : 'StaticModel'
+}
+
+{ #category : 'as yet unclassified' }
+MyClassBetaSubSub >> overridenInSubclassAndNoWhereElse [
+
+	^ super overridenInSubclassAndNoWhereElse + 1
+]


### PR DESCRIPTION
When target superclass is two levels above source class condition was failing. See related [commit](https://github.com/pharo-project/pharo/commit/de33fe94348b5fe5686ff407b7e551bcf0287354) for explanation as well as tests and inline comments.