### PR TITLE
reintroduce waitTimeoutMSecs:

### DIFF
--- a/src/System-Time/Semaphore.extension.st
+++ b/src/System-Time/Semaphore.extension.st
@@ -21,3 +21,13 @@ Semaphore >> wait: aDuration onCompletion: completionBlock onTimeout: timeoutBlo
 		  onCompletion: completionBlock
 		  onTimeout: timeoutBlock
 ]
+
+{ #category : '*System-Time' }
+Semaphore >> waitTimeoutMSecs: anInteger [
+
+	self
+		deprecated: 'Use #waitTimeoutMilliseconds: instead'
+		transformWith:
+		'`@x waitTimeoutMSecs: `@y' -> '`@x waitTimeoutMilliseconds: `@y'.
+	^ self waitTimeoutMilliseconds: anInteger
+]


### PR DESCRIPTION
waitTimeoutMSecs: anInteger

	self
		deprecated: 'Use #waitTimeoutMilliseconds: instead'
		transformWith:
		'`@x waitTimeoutMSecs: `@y' -> '`@x waitTimeoutMilliseconds: `@y'.
	^ self waitTimeoutMilliseconds: anInteger