### PR TITLE
Add owning class info to Protocol

### DIFF
--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -67,7 +67,7 @@ ClassDescription >> addProtocol: aProtocol [
 
 	(self hasProtocol: aProtocol) ifTrue: [ ^ self protocolNamed: protocolName ].
 
-	protocol := Protocol named: protocolName.
+	protocol := Protocol named: protocolName class: self.
 
 	oldProtocols := self protocolNames copy.
 

--- a/src/Kernel-CodeModel/Protocol.class.st
+++ b/src/Kernel-CodeModel/Protocol.class.st
@@ -1,8 +1,8 @@
 "
 A Protocol is a categorization of methods in Pharo. 
-A class has methods, and the methods are classified into protocols.
-A class holds my instances (for now through ClassOrganization but we want to remove this class in the future) and I hold the selectors of the methods that are inside me.
-I have a name that is used in browsers to display the different protocols.
+A class has methods, and the methods are classified into protocols. We currently have 1 protocol by method.
+A class holds my instances and I hold the selectors of the methods that are inside me.
+I have a name that is used in browsers to display the different protocols and I know which class owns me.
 "
 Class {
 	#name : 'Protocol',
@@ -123,6 +123,7 @@ Protocol >> name: anObject [
 
 { #category : 'accessing' }
 Protocol >> owningClass [
+	"The owning class is the class in which I am defined."
 
 	^ owningClass
 ]

--- a/src/Kernel-CodeModel/Protocol.class.st
+++ b/src/Kernel-CodeModel/Protocol.class.st
@@ -9,7 +9,8 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'name',
-		'methodSelectors'
+		'methodSelectors',
+		'owningClass'
 	],
 	#category : 'Kernel-CodeModel-Classes',
 	#package : 'Kernel-CodeModel',
@@ -29,6 +30,14 @@ Protocol class >> named: aStrings [
 
 	^ self new
 		  name: aStrings;
+		  yourself
+]
+
+{ #category : 'instance creation' }
+Protocol class >> named: aString class: aClass [
+
+	^ (self named: aString)
+		  owningClass: aClass;
 		  yourself
 ]
 
@@ -110,6 +119,18 @@ Protocol >> name [
 { #category : 'accessing' }
 Protocol >> name: anObject [
 	name := anObject asSymbol
+]
+
+{ #category : 'accessing' }
+Protocol >> owningClass [
+
+	^ owningClass
+]
+
+{ #category : 'accessing' }
+Protocol >> owningClass: aClass [
+
+	owningClass := aClass
 ]
 
 { #category : 'printing' }

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -40,7 +40,8 @@ ClassDescriptionProtocolsTest >> testAddProtocolWithProtocolFromOtherClass [
 
 	"The class should have created a new protocol of the same name."
 	self assert: (class hasProtocol: #titan).
-	self deny: (class protocolNamed: #titan) identicalTo: titan
+	self deny: (class protocolNamed: #titan) identicalTo: titan.
+	self assert: (class protocolNamed: #titan) owningClass equals: class
 ]
 
 { #category : 'tests' }
@@ -180,7 +181,8 @@ ClassDescriptionProtocolsTest >> testClassifyUnderWithProtocolFromOtherClass [
 	self assertCollection: (class selectorsInProtocol: #which) hasSameElements: #( #luz ).
 
 	"Since the protocol was not from the class, it should not be the same instance."
-	self deny: (class protocolNamed: #which) identicalTo: which
+	self deny: (class protocolNamed: #which) identicalTo: which.
+	self assert: (class protocolNamed: #which) owningClass equals: class
 ]
 
 { #category : 'tests' }
@@ -193,6 +195,7 @@ ClassDescriptionProtocolsTest >> testEnsureProtocol [
 
 	self assertCollection: class protocolNames hasSameElements: { #titan }.
 	self assert: (class ensureProtocol: #titan) equals: protocol.
+	self assert: (class ensureProtocol: #titan) owningClass equals: class.
 	self assert: (class ensureProtocol: protocol) equals: protocol.
 	self assert: (class ensureProtocol: outsideProtocol) equals: protocol.
 	self deny: (class ensureProtocol: outsideProtocol) identicalTo: outsideProtocol.

--- a/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ProtocolAnnouncementsTest.class.st
@@ -25,6 +25,7 @@ ProtocolAnnouncementsTest >> testAddProtocolAnnouncement2 [
 
 	self when: ProtocolAdded do: [ :ann |
 		self assert: ann protocol name equals: #king.
+		self assert: ann protocol owningClass equals: class.
 		self assert: ann classReorganized name equals: self classNameForTests ].
 
 	class addProtocol: (Protocol named: #king).

--- a/src/SystemCommands-RefactoringSupport/CmdCommand.extension.st
+++ b/src/SystemCommands-RefactoringSupport/CmdCommand.extension.st
@@ -4,9 +4,7 @@ Extension { #name : 'CmdCommand' }
 CmdCommand >> confirmRefactoringInContext: aToolContext by: aCommandActivator [
 
 	| submitDialog |
-	submitDialog := SycRefactoringPreviewPresenter
-		                for: self
-		                scopes: aToolContext refactoringScopes.
+	submitDialog := SycRefactoringPreviewPresenter for: self scopes: aToolContext refactoringScopes.
 	submitDialog existChanges
 		ifTrue: [
 			submitDialog openDialog
@@ -14,9 +12,7 @@ CmdCommand >> confirmRefactoringInContext: aToolContext by: aCommandActivator [
 					submitDialog accept.
 					aCommandActivator applyCommandResult ];
 				cancelAction: [ :p | p beCancel ] ]
-		ifFalse: [
-			submitDialog alert:
-				'There is no change produced by this refactoring' ].
+		ifFalse: [ submitDialog alert: 'There is no change produced by this refactoring' ].
 	CmdCommandAborted signal
 ]
 


### PR DESCRIPTION
Currently a protocol does not know which class owns it. This change adds this info via the #owningClass API