### PR TITLE
17250 debug session cannot update their exception and then provides the debugger incorrect information about the execution state

### DIFF
--- a/src/Debugger-Model-Tests/DebugSessionExceptionTest.class.st
+++ b/src/Debugger-Model-Tests/DebugSessionExceptionTest.class.st
@@ -7,6 +7,22 @@ Class {
 }
 
 { #category : 'helpers' }
+DebugSessionExceptionTest >> debuggedProcessException [
+
+	^ thisProcess
+		  evaluate: [ LocalProcessException value ]
+		  onBehalfOf: process
+]
+
+{ #category : 'helpers' }
+DebugSessionExceptionTest >> debuggedProcessException: anObject [
+
+	^ thisProcess
+		  evaluate: [ LocalProcessException value: anObject ]
+		  onBehalfOf: process
+]
+
+{ #category : 'helpers' }
 DebugSessionExceptionTest >> methodWithHalt [
 	<haltOrBreakpointForTesting>
 	self halt.
@@ -19,7 +35,7 @@ DebugSessionExceptionTest >> testDefaultDebuggerException [
 	self settingUpSessionAndProcessAndContextForBlock: [
 		self methodWithHalt ].
 	
-	self assert: LocalProcessException value equals: nil.
+	self assert: self debuggedProcessException equals: nil.
 	self assert: session exception equals: nil
 ]
 
@@ -28,12 +44,12 @@ DebugSessionExceptionTest >> testProcessExceptionPrevailsOverSessionException [
 
 	self settingUpSessionAndProcessAndContextForBlock: [
 		self methodWithHalt ].
-	
+
 	session exception: 1.
 	self assert: session exception equals: 1.
 	
-	LocalProcessException value: 2.
-	self assert: session exception equals: LocalProcessException value.
+	self debuggedProcessException: 2.
+	self assert: session exception equals: self debuggedProcessException.
 	self assert: session exception equals: 2
 ]
 

--- a/src/Debugger-Model-Tests/DebugSessionExceptionTest.class.st
+++ b/src/Debugger-Model-Tests/DebugSessionExceptionTest.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : 'DebugSessionExceptionTest',
+	#superclass : 'DebuggerTest',
+	#category : 'Debugger-Model-Tests-Core',
+	#package : 'Debugger-Model-Tests',
+	#tag : 'Core'
+}
+
+{ #category : 'helpers' }
+DebugSessionExceptionTest >> methodWithHalt [
+	<haltOrBreakpointForTesting>
+	self halt.
+	^1+1
+]
+
+{ #category : 'tests' }
+DebugSessionExceptionTest >> testDefaultDebuggerException [
+
+	self settingUpSessionAndProcessAndContextForBlock: [
+		self methodWithHalt ].
+	
+	self assert: LocalProcessException value equals: nil.
+	self assert: session exception equals: nil
+]
+
+{ #category : 'tests' }
+DebugSessionExceptionTest >> testProcessExceptionPrevailsOverSessionException [
+
+	self settingUpSessionAndProcessAndContextForBlock: [
+		self methodWithHalt ].
+	
+	session exception: 1.
+	self assert: session exception equals: 1.
+	
+	LocalProcessException value: 2.
+	self assert: session exception equals: LocalProcessException value.
+	self assert: session exception equals: 2
+]
+
+{ #category : 'tests' }
+DebugSessionExceptionTest >> testProcessExceptionUpdatesWhenRaisedDuringStepping [
+
+	self settingUpSessionAndProcessAndContextForBlock: [
+		self methodWithHalt ].
+	
+	session exception: OupsNullException new.
+	session stepOver.
+	self assert: session exception class equals: Halt
+	
+]

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -108,7 +108,9 @@ DebugSession >> createModelForContext: aContext [
 { #category : 'accessing' }
 DebugSession >> exception [
 
-	^ LocalProcessException value ifNil: [ exception ]
+	^ (thisProcess
+		   evaluate: [ LocalProcessException value ]
+		   onBehalfOf: interruptedProcess) ifNil: [ exception ]
 ]
 
 { #category : 'accessing' }

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -107,7 +107,8 @@ DebugSession >> createModelForContext: aContext [
 
 { #category : 'accessing' }
 DebugSession >> exception [
-	^ exception
+
+	^ LocalProcessException value ifNil: [ exception ]
 ]
 
 { #category : 'accessing' }

--- a/src/Debugger-Model/LocalProcessException.class.st
+++ b/src/Debugger-Model/LocalProcessException.class.st
@@ -1,0 +1,10 @@
+"
+I store the execeptions silently raised when stepping a process execution to keep trace that this particular exception was raised.
+"
+Class {
+	#name : 'LocalProcessException',
+	#superclass : 'ProcessLocalVariable',
+	#category : 'Debugger-Model-Processes',
+	#package : 'Debugger-Model',
+	#tag : 'Processes'
+}

--- a/src/Debugging-Core/Process.extension.st
+++ b/src/Debugging-Core/Process.extension.st
@@ -13,7 +13,9 @@ Process >> complete: aContext [
 	suspendedContext := pair first.
 	^ pair second
 		ifNil: [ suspendedContext ]
-		ifNotNil: [ :error | error completeProcess: self with: aContext ]
+		ifNotNil: [ :error | 
+			LocalProcessException value: error.
+			error completeProcess: self with: aContext ]
 ]
 
 { #category : '*Debugging-Core' }

--- a/src/Debugging-Core/Process.extension.st
+++ b/src/Debugging-Core/Process.extension.st
@@ -6,16 +6,16 @@ Process >> complete: aContext [
 
 	| ctxt pair |
 	ctxt := suspendedContext.
-	suspendedContext := nil.	"disable this process while running its stack in active process below"
+	suspendedContext := nil. "disable this process while running its stack in active process below"
 	pair := Processor activeProcess
-				evaluate: [ ctxt runUntilErrorOrReturnFrom: aContext ]
-				onBehalfOf: self.
+		        evaluate: [ ctxt runUntilErrorOrReturnFrom: aContext ]
+		        onBehalfOf: self.
 	suspendedContext := pair first.
-	^ pair second
-		ifNil: [ suspendedContext ]
-		ifNotNil: [ :error | 
-			LocalProcessException value: error.
-			error completeProcess: self with: aContext ]
+	^ pair second ifNil: [ suspendedContext ] ifNotNil: [ :error |
+		  thisProcess
+			  evaluate: [ LocalProcessException value: error ]
+			  onBehalfOf: self.
+		  error completeProcess: self with: aContext ]
 ]
 
 { #category : '*Debugging-Core' }

--- a/src/Kernel/LocalProcessException.class.st
+++ b/src/Kernel/LocalProcessException.class.st
@@ -4,7 +4,7 @@ I store the execeptions silently raised when stepping a process execution to kee
 Class {
 	#name : 'LocalProcessException',
 	#superclass : 'ProcessLocalVariable',
-	#category : 'Debugger-Model-Processes',
-	#package : 'Debugger-Model',
+	#category : 'Kernel-Processes',
+	#package : 'Kernel',
 	#tag : 'Processes'
 }


### PR DESCRIPTION
Debugged processes now store a local exception when they encounter in during stepping.
The debug session has a base exception (set when opening the debugger) that is preempted by the one in the process if any.

This is designed to help the debugger have correct information about the debugged process exception, which was discarded before this PR.

Fixes part of https://github.com/pharo-project/pharo/issues/17250 (requires a NewTools adaptation to fully fix it).