### PR TITLE
Moving cursor and stop on upper cases

### DIFF
--- a/src/Morphic-Core/UserInputEvent.class.st
+++ b/src/Morphic-Core/UserInputEvent.class.st
@@ -126,6 +126,14 @@ UserInputEvent >> handler: anObject [
 	handler := anObject
 ]
 
+{ #category : 'modifier state' }
+UserInputEvent >> metaKeyPressed [
+
+	^ Smalltalk platform isMacOS
+		  ifTrue: [ self commandKeyPressed ]
+		  ifFalse: [ self controlKeyPressed ]
+]
+
 { #category : 'printing' }
 UserInputEvent >> modifierString [
 	"Return a string identifying the currently pressed modifiers"

--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -86,6 +86,51 @@ RubTextEditorTest >> testNextWord [
 ]
 
 { #category : 'tests' }
+RubTextEditorTest >> testNextWordStopOnUpperCase [
+
+	| textSize |
+	string := 'loRem ipSum '.
+	editor addString: string.
+	textSize := string size.
+	self assert: (editor nextWord: -999 stopOnUpperCase: true) equals: 3. "Out of range means start of text"
+	self assert: (editor nextWord: 0 stopOnUpperCase: true) equals: 3. "Out of range means start of text"
+
+	1 to: 3 do: [ :i |
+		"From:   |loRem ipSum 
+		 To:     lo|Rem ipSum 
+		 Should be: lo|Rem ipSum "
+		self assert: (editor nextWord: i stopOnUpperCase: true) equals: 3 ].
+
+	4 to: 5 do: [ :i |
+		"From:   loR|em ipSum 
+		 To:     loRe|m ipSum 
+		 Should be: loRem| ipSum "
+		self assert: (editor nextWord: i stopOnUpperCase: true) equals: 6 ].
+
+
+	"Lorem| ipsum >> Lorem |ipsum"
+	self assert: (editor nextWord: 6 stopOnUpperCase: true) equals: 7.
+
+	7 to: 8 do: [ :i |
+		"From:   loRem |ipSum 
+		 To:     loRem i|pSum 
+		 Should be: loRem ip|Sum "
+		self assert: (editor nextWord: i stopOnUpperCase: true) equals: 9 ].
+
+	10 to: 11 do: [ :i |
+		"From:   loRem ip|Sum 
+		 To:     loRem ipSum| 
+		 Should be: loRem ipSum| "
+		self assert: (editor nextWord: i stopOnUpperCase: true) equals: 12 ].
+
+	"There is a space after ipsum:"
+	"Lorem ipsum| >> Lorem ipsum |"
+	self assert: (editor nextWord: 12 stopOnUpperCase: true) equals: 13.
+
+	self assert: (editor nextWord: 999 stopOnUpperCase: true) equals: textSize + 1. "Out of range"
+]
+
+{ #category : 'tests' }
 RubTextEditorTest >> testPreviousWord [
 
 	| textSize |
@@ -95,17 +140,54 @@ RubTextEditorTest >> testPreviousWord [
 
 	1 to: 7 do: [ :i |
 		"From:   |Lorem ipsum
-		 To:     Lore|m ipsum
-		 Should be: Lorem| ipsum"
+		 To:     Lorem |ipsum
+		 Should be: |Lorem ipsum"
 		self assert: (editor previousWord: i) equals: 1 ].
 
 	8 to: 13 do: [ :i |
 		"From:   Lorem |ipsum
-		 To:     Lorem ipsu|m
-		 Should be: Lorem ipsum|"
+		 To:     Lorem ipsum|
+		 Should be: Lorem |ipsum"
 		self assert: (editor previousWord: i) equals: 7 ].
 
 	self assert: (editor previousWord: 999) equals: 7. "Out of range"
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordStopOnUpperCase [
+
+	| textSize |
+	string := 'LoRem ipSum '.
+	editor addString: string.
+	textSize := string size.
+	self assert: (editor previousWord: -999 stopOnUpperCase: true) equals: 1. "Out of range"
+	self assert: (editor previousWord: 0 stopOnUpperCase: true) equals: 1. "Out of range"
+
+	1 to: 3 do: [ :i |
+		"From:   |LoRem ipSum 
+		 To:     Lo|Rem ipSum 
+		 Should be: |LoRem ipSum "
+		self assert: (editor previousWord: i stopOnUpperCase: true) equals: 1 ].
+
+	4 to: 7 do: [ :i |
+		"From:   LoR|em ipSum 
+		 To:     LoRem |ipSum 
+		 Should be: Lo|Rem ipSum "
+		self assert: (editor previousWord: i stopOnUpperCase: true) equals: 3 ].
+
+	8 to: 9 do: [ :i |
+		"From:   LoRem i|pSum 
+		 To:     LoRem ip|Sum 
+		 Should be: Lorem |ipsum"
+		self assert: (editor previousWord: i stopOnUpperCase: true) equals: 7 ].
+
+	10 to: 13 do: [ :i |
+		"From:   LoRem ipS|um 
+		 To:     LoRem ipSum|
+		 Should be: LoRem ip|Sum"
+		self assert: (editor previousWord: i stopOnUpperCase: true) equals: 9 ].
+
+	self assert: (editor previousWord: 999 stopOnUpperCase: true) equals: 9. "Out of range"
 ]
 
 { #category : 'tests' }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -804,19 +804,20 @@ RubSmalltalkEditor >> isSmalltalkEditor [
 ]
 
 { #category : 'private' }
-RubSmalltalkEditor >> isWordCharacterAt: index in: aString [
+RubSmalltalkEditor >> isWordCharacterAt: index in: aString except: aBlock [
 	"By default, group alphanumeric and non-alphanumeric separately"
+
 	| character |
 	character := aString at: index.
+	(aBlock value: character) ifTrue: [ ^ false ].
 	"In smalltalk code, colons make part of selectors too and are part of a word"
-	^ character isAlphaNumeric or: [
-		"Check that it is a keyword selector.
+	^ character isAlphaNumeric or: [ 
+		"Check that it is a keyword selector:
 		 - followed by a colon
 		 - but not by an assignment "
-		(character = $_) or: [
-			(character = $:) and: [
-				aString size = index
-					or: [  (aString at: index + 1) ~= $= ] ] ] ]
+		  character = $_ or: [
+			  character = $: and: [
+				  aString size = index or: [ (aString at: index + 1) ~= $= ] ] ] ]
 ]
 
 { #category : 'menu messages' }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -669,9 +669,12 @@ RubTextEditor >> cursorLeft: aKeyboardEvent [
 	textArea editing ifTrue: [ ^ false ].
 	self closeTypeIn.
 	self
-		moveCursor:[:position | position - 1 max: 1]
+		moveCursor: [ :position | position - 1 max: 1 ]
 		forward: false
-		specialBlock:[:position | self previousWord: position]
+		specialBlock: [ :position |
+			self
+				previousWord: position
+				stopOnUpperCase: aKeyboardEvent optionKeyPressed ]
 		event: aKeyboardEvent.
 	^ true
 ]
@@ -718,9 +721,12 @@ RubTextEditor >> cursorRight: aKeyboardEvent [
 	textArea editing ifTrue: [ ^ false ].
 	self closeTypeIn.
 	self
-		moveCursor: [:position | position + 1]
+		moveCursor: [ :position | position + 1 ]
 		forward: true
-		specialBlock:[:position | self nextWord: position]
+		specialBlock: [ :position |
+			self
+				nextWord: position
+				stopOnUpperCase: aKeyboardEvent optionKeyPressed ]
 		event: aKeyboardEvent.
 	^ true
 ]
@@ -1431,8 +1437,18 @@ RubTextEditor >> isTextEditor [
 
 { #category : 'private' }
 RubTextEditor >> isWordCharacterAt: index in: aString [
+
+	^ self isWordCharacterAt: index in: aString except: [ :char | false ]
+]
+
+{ #category : 'private' }
+RubTextEditor >> isWordCharacterAt: index in: aString except: aBlock [
 	"By default, group alphanumeric and non-alphanumeric separately"
-	^ (aString at: index) isAlphaNumeric
+
+	| character |
+	character := aString at: index.
+	(aBlock value: character) ifTrue: [ ^ false ].
+	^ character isAlphaNumeric
 ]
 
 { #category : 'typing support' }
@@ -1606,20 +1622,24 @@ RubTextEditor >> moveCursor: directionBlock forward: forward specialBlock: speci
 	directionBlock is a one argument Block that computes the new Position from a given one.
 	specialBlock is a one argumentBlock that computes the new position from a given one under the alternate semantics.
 	Note that directionBlock always is evaluated first."
+
 	| shift indices newPosition |
 	shift := aKeyboardEvent shiftPressed.
 	indices := self setIndices: shift forward: forward.
 	newPosition := directionBlock value: (indices at: #moving).
-	(aKeyboardEvent commandKeyPressed or: [ aKeyboardEvent controlKeyPressed ])
-		ifTrue: [newPosition := specialBlock value: newPosition].
+
+	aKeyboardEvent metaKeyPressed ifTrue: [
+		newPosition := specialBlock value: newPosition ].
+
 	shift
-		ifTrue: [self selectMark: (indices at: #fixed) point: newPosition - 1]
-		ifFalse: [self selectAt: newPosition].
+		ifTrue: [ self selectMark: (indices at: #fixed) point: newPosition - 1 ]
+		ifFalse: [ self selectAt: newPosition ].
+
 	self setEmphasisHereFromTextForward: forward.
 
-	textArea
-		requestTextEditingAt: (textArea cursor positionInWorld
-			corner: textArea cursor positionInWorld)
+	textArea requestTextEditingAt:
+		(textArea cursor positionInWorld corner:
+			 textArea cursor positionInWorld)
 ]
 
 { #category : 'nesting' }
@@ -1652,9 +1672,15 @@ RubTextEditor >> nextCharacterIfAbsent: aBlock [
 { #category : 'private' }
 RubTextEditor >> nextWord: position [
 
-	| string index initialIsAlphaNumeric size |
+	^ self nextWord: position stopOnUpperCase: false
+]
+
+{ #category : 'private' }
+RubTextEditor >> nextWord: position stopOnUpperCase: stopOnUpperCase [
 	"Positions go from 1 to size + 1
 	Position N + 1 is after the Nth character"
+
+	| string index initialIsAlphaNumeric size |
 	index := 1 max: position.
 
 	string := self string.
@@ -1665,8 +1691,11 @@ RubTextEditor >> nextWord: position [
 
 	[
 	index < size and: [
-		(self isWordCharacterAt: index in: string) = initialIsAlphaNumeric ] ]
-		whileTrue: [ index := index + 1 ].
+		(self
+			 isWordCharacterAt: index
+			 in: string
+			 except: [ :char | stopOnUpperCase and: [ char isUppercase ] ])
+		= initialIsAlphaNumeric ] ] whileTrue: [ index := index + 1 ].
 
 	^ index
 ]
@@ -1814,6 +1843,12 @@ RubTextEditor >> previousCharacterIfAbsent: aBlock [
 { #category : 'private' }
 RubTextEditor >> previousWord: position [
 
+	^ self previousWord: position stopOnUpperCase: false
+]
+
+{ #category : 'private' }
+RubTextEditor >> previousWord: position stopOnUpperCase: stopOnUpperCase [ 
+
 	| string index size beforeCaretIsAlpha afterCaretIsAlpha |
 	"The main strategy behind this is to move the caret backwards until there is a alpha/nonalpha or nonalpha/alpha pair.
 	To avoid staying in the same place, we need always move the character at least once before checking the condition"
@@ -1839,7 +1874,7 @@ RubTextEditor >> previousWord: position [
 	"Finally, iterate backwards until the alphanumericness before and after the caret changes"
 	[
 	afterCaretIsAlpha := beforeCaretIsAlpha := index = 1 or: [
-		                      self isWordCharacterAt: index in: string ].
+		                      self isWordCharacterAt: index in: string except: [ :char | stopOnUpperCase and: [ char isUppercase ] ] ].
 	beforeCaretIsAlpha := index = 1 or: [
 		                      self isWordCharacterAt: index - 1 in: string ].
 	beforeCaretIsAlpha = afterCaretIsAlpha and: [ index > 1 ] ]


### PR DESCRIPTION
This PR makes the navigation of the cursor stop on each upper case.

Now the behaviour is:
- Simple left/right (arrow keys alone) moves 1 step
- Using "meta key" (Command or Control) moves between words
- Using "meta + option" moves between words in `camel|Case` (stop on upper case)


_Made on Sprint!_ 🌞