### PR TITLE
Migrate Rename Temporary to use the Driver architecture

### DIFF
--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -46,13 +46,14 @@ RBCondition class >> checkClassVarName: aName in: aClass [
 
 { #category : 'utilities' }
 RBCondition class >> checkInstanceVariableName: aName in: aClass [
+
 	| string |
-	aName isString ifFalse: [^false].
-	string := aName asString.
-	string isEmpty ifTrue: [^false].
-	(self reservedNames includes: string) ifTrue: [^false].
-	string first isUppercase ifTrue: [^false].
-	^RBScanner isVariable: string
+	aName isString ifFalse: [ ^ false ].
+	string := aName.
+	string ifEmpty: [ ^ false ].
+	(self reservedNames includes: string) ifTrue: [ ^ false ].
+	string first isUppercase ifTrue: [ ^ false ].
+	^ RBScanner isVariable: string
 ]
 
 { #category : 'utilities' }

--- a/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
@@ -33,6 +33,12 @@ RBRenameArgumentOrTemporaryRefactoring class >> model: aRBSmalltalk renameTempor
 ]
 
 { #category : 'instance creation' }
+RBRenameArgumentOrTemporaryRefactoring class >> renameTemporaryFrom: anInterval in: aClass selector: aSelector [
+
+	^ self new class: aClass selector: aSelector interval: anInterval
+]
+
+{ #category : 'instance creation' }
 RBRenameArgumentOrTemporaryRefactoring class >> renameTemporaryFrom: anInterval to: newName in: aClass selector: aSelector [
 	^ self new
 		class: aClass
@@ -44,22 +50,41 @@ RBRenameArgumentOrTemporaryRefactoring class >> renameTemporaryFrom: anInterval 
 { #category : 'preconditions' }
 RBRenameArgumentOrTemporaryRefactoring >> applicabilityPreconditions [
 
+	^ self applicabilityPreconditionsIndependentOfTheNewName , self applicabilityPreconditionsOfTheNewName
+]
+
+{ #category : 'preconditions' }
+RBRenameArgumentOrTemporaryRefactoring >> applicabilityPreconditionsIndependentOfTheNewName [
+	"Those are the preconditions that should be checked before even asking to the user a new name for the temporary."
+
 	^ {
 		  (RBCondition withBlock: [
 			   | methodSource |
-			   interval first > interval last ifTrue: [
-				   self refactoringError: 'You must select a variable name' ].
+			   interval first > interval last ifTrue: [ self refactoringError: 'You must select a variable name' ].
 			   methodSource := class sourceCodeFor: selector.
-			   methodSource size >= interval last ifFalse: [
-				   self refactoringError: 'Invalid range for variable' ].
-			   oldName := methodSource
-				              copyFrom: interval first
-				              to: interval last.
+			   methodSource size >= interval last ifFalse: [ self refactoringError: 'Invalid range for variable' ].
+			   oldName := methodSource copyFrom: interval first to: interval last.
 			   true ]).
+
+		  (RBCondition definesSelector: selector in: class) }
+]
+
+{ #category : 'preconditions' }
+RBRenameArgumentOrTemporaryRefactoring >> applicabilityPreconditionsOfTheNewName [
+	"Those are the preconditions that should be checked after asking to the user a new name for the temporary."
+
+	^ {
 		  (RBCondition isValidInstanceVariableName: newName for: class).
-		  (RBCondition definesSelector: selector in: class).
-		  (RBCondition definesInstanceVariable: newName in: class) not.
-		  (RBCondition definesClassVariable: newName in: class) not }
+
+		  (ReCheckVariableNameCondition class: class variableName: newName parseTree: (class parseTreeForSelector: selector)) }
+]
+
+{ #category : 'initialization' }
+RBRenameArgumentOrTemporaryRefactoring >> class: aClass selector: aSelector interval: anInterval [
+
+	class := self classObjectFor: aClass.
+	selector := aSelector.
+	interval := anInterval
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-UI/RBInteractionDriver.class.st
+++ b/src/Refactoring-UI/RBInteractionDriver.class.st
@@ -197,6 +197,18 @@ RBInteractionDriver >> runRefactoring [
 	self subclassResponsibility
 ]
 
+{ #category : 'accessing' }
+RBInteractionDriver >> scopes [
+
+	^ scopes
+]
+
+{ #category : 'accessing' }
+RBInteractionDriver >> scopes: anObject [
+
+	scopes := anObject
+]
+
 { #category : 'configuration' }
 RBInteractionDriver >> selectDialog [
 	

--- a/src/Refactoring-UI/ReExtractMethodDriver.class.st
+++ b/src/Refactoring-UI/ReExtractMethodDriver.class.st
@@ -141,8 +141,3 @@ ReExtractMethodDriver >> runRefactoring [
 	"self configureMessage."
 	self applyChanges 
 ]
-
-{ #category : 'accessing' }
-ReExtractMethodDriver >> scopes: aCollection [ 
-	scopes := aCollection
-]

--- a/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
+++ b/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
@@ -1,0 +1,95 @@
+"
+I am a driver to manage the interractions during a rename argument or temporary refactoring. 
+
+I'll check that the interval selected by the user is right. I'll ask a new name and check that it is valid. If it is not, I'll ask again to the user except if they cancel.
+"
+Class {
+	#name : 'ReRenameArgumentOrTemporaryDriver',
+	#superclass : 'RBInteractionDriver',
+	#instVars : [
+		'sourceNode',
+		'newName',
+		'method'
+	],
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
+}
+
+{ #category : 'execution' }
+ReRenameArgumentOrTemporaryDriver >> changes [
+
+	^ refactoring
+		  privateTransform;
+		  changes
+]
+
+{ #category : 'resources' }
+ReRenameArgumentOrTemporaryDriver >> configureRefactoring [
+
+	refactoring := RBRenameArgumentOrTemporaryRefactoring renameTemporaryFrom: sourceNode sourceInterval in: method origin selector: method selector
+]
+
+{ #category : 'accessing' }
+ReRenameArgumentOrTemporaryDriver >> method [
+
+	^ method
+]
+
+{ #category : 'accessing' }
+ReRenameArgumentOrTemporaryDriver >> method: anObject [
+
+	method := anObject
+]
+
+{ #category : 'accessing' }
+ReRenameArgumentOrTemporaryDriver >> newName [
+
+	^ newName
+]
+
+{ #category : 'accessing' }
+ReRenameArgumentOrTemporaryDriver >> newName: anObject [
+
+	newName := anObject
+]
+
+{ #category : 'execution' }
+ReRenameArgumentOrTemporaryDriver >> runRefactoring [
+
+	| cancelled |
+	self configureRefactoring.
+	(refactoring applicabilityPreconditionsIndependentOfTheNewName reject: [ :condition | condition check ]) ifNotEmpty: [
+		^ self inform: 'The interval selected is not right to rename a temporary variable.' ].
+
+	cancelled := false.
+
+	[
+	refactoring newName: (self defaultRequestDialog
+			 title: 'Rename a temp variable';
+			 label: 'New name of the variable';
+			 text: sourceNode name;
+			 onCancel: [ "We cannot return in this block so we save the result as a boolean to check it later." cancelled := true ];
+			 openModal).
+
+	cancelled ifTrue: [ ^ self inform: 'Refactoring cancelled' ].
+
+	refactoring applicabilityPreconditionsOfTheNewName allSatisfy: [ :condition | condition check ] ] whileFalse: [
+		refactoring applicabilityPreconditionsOfTheNewName
+			detect: [ :condition | condition check ]
+			ifFound: [ :condition | self inform: condition errorString ] ].
+
+	self applyChanges
+]
+
+{ #category : 'accessing' }
+ReRenameArgumentOrTemporaryDriver >> sourceNode [
+
+	^ sourceNode
+]
+
+{ #category : 'accessing' }
+ReRenameArgumentOrTemporaryDriver >> sourceNode: anObject [
+
+	sourceNode := anObject
+]

--- a/src/Refactoring-UI/ReRenameClassDriver.class.st
+++ b/src/Refactoring-UI/ReRenameClassDriver.class.st
@@ -101,12 +101,6 @@ ReRenameClassDriver >> runRefactoring [
 	
 ]
 
-{ #category : 'accessing' }
-ReRenameClassDriver >> scopes: aScope [
-
-	scopes := aScope
-]
-
 { #category : 'validation' }
 ReRenameClassDriver >> validateName: aName onPresenter: presenter [ 
 	

--- a/src/SystemCommands-SourceCodeCommands/SycRenameArgOrTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycRenameArgOrTempCommand.class.st
@@ -10,7 +10,8 @@ Class {
 	#name : 'SycRenameArgOrTempCommand',
 	#superclass : 'SycSourceCodeRefactoringCommand',
 	#instVars : [
-		'newName'
+		'newName',
+		'toolContext'
 	],
 	#category : 'SystemCommands-SourceCodeCommands',
 	#package : 'SystemCommands-SourceCodeCommands'
@@ -30,15 +31,6 @@ SycRenameArgOrTempCommand >> applyResultInContext: aSourceCodeContext [
 	aSourceCodeContext showVariableNamed: newName
 ]
 
-{ #category : 'execution' }
-SycRenameArgOrTempCommand >> asRefactorings [
-	^ {RBRenameArgumentOrTemporaryRefactoring
-		renameTemporaryFrom: sourceNode sourceInterval
-		to: newName
-		in: method origin
-		selector: method selector}
-]
-
 { #category : 'accessing' }
 SycRenameArgOrTempCommand >> defaultMenuIconName [
 	^ #edit
@@ -50,12 +42,25 @@ SycRenameArgOrTempCommand >> defaultMenuItemName [
 ]
 
 { #category : 'execution' }
-SycRenameArgOrTempCommand >> prepareFullExecutionInContext: aSourceCodeContext [
-	super prepareFullExecutionInContext: aSourceCodeContext.
+SycRenameArgOrTempCommand >> execute [
 
-	newName := self morphicUIManager
-		request: 'New name of the variable'
-		initialAnswer: sourceNode name
-		title: 'Rename a temp variable'.
-	newName isEmptyOrNil | (newName = sourceNode name) ifTrue: [ CmdCommandAborted signal ]
+	^ (ReRenameArgumentOrTemporaryDriver new
+		   sourceNode: sourceNode;
+		   method: method;
+		   scopes: toolContext refactoringScopes;
+		   yourself) runRefactoring
+]
+
+{ #category : 'testing' }
+SycRenameArgOrTempCommand >> isComplexRefactoring [
+
+	^ false
+]
+
+{ #category : 'execution' }
+SycRenameArgOrTempCommand >> prepareFullExecutionInContext: aToolContext [
+
+	super prepareFullExecutionInContext: aToolContext.
+
+	toolContext := aToolContext
 ]


### PR DESCRIPTION
This change fixes the rename temporary refactoring that is currently broken. In order to do that I am migrating this refactoring to use the Driver infrastructure instead of the Commander 1 commands in Calypso

Fixes #17075