### PR TITLE
Fix repeat events

### DIFF
--- a/src/Keymapping-Core/KMDispatchChain.class.st
+++ b/src/Keymapping-Core/KMDispatchChain.class.st
@@ -26,8 +26,16 @@ KMDispatchChain class >> from: anInitialTarget andDispatcher: aDispatcher [
 { #category : 'dispatching' }
 KMDispatchChain >> dispatch: aKeyboardEvent [
 	self do: [ :targetToDispatch |
-		targetToDispatch dispatch: KMBuffer uniqueInstance buffer copy.
+		| sequence |
+		sequence := KMBuffer uniqueInstance buffer copy.
+		targetToDispatch dispatch: sequence.
 		aKeyboardEvent wasHandled ifTrue: [ ^self ].
+		"Let's try to match this sequence of events again.
+		This time ignoring any repeated events."
+		sequence removeAllSuchThat: [ :ev | ev isRepeat ].
+		sequence isNotEmpty ifTrue: [
+			targetToDispatch dispatch: sequence.
+			aKeyboardEvent wasHandled ifTrue: [ ^self ] ]
 	].
 	"This should be a noMatch event"
 	aKeyboardEvent wasHandled ifFalse: [ KMBuffer uniqueInstance clearBuffer ]

--- a/src/Keymapping-Tests/KMDispatcherTest.class.st
+++ b/src/Keymapping-Tests/KMDispatcherTest.class.st
@@ -126,3 +126,43 @@ KMDispatcherTest >> testNoStaggeredTrigger [
 	self deny: flag1.
 	self assert: flag2
 ]
+
+{ #category : 'tests' }
+KMDispatcherTest >> testRepeatEvents [
+	| morph flag category pressA repeatPressA pressB repeatPressB pressC |
+	category := KMCategory named: #TestBlah.
+	KMRepository default addCategory: category.
+
+	morph := BorderedMorph new.
+	morph kmDispatcher reset.
+	flag := false.
+
+	category addKeymapEntry: (KMKeymap named: #Foo shortcut: $a asKeyCombination, $b asKeyCombination, $c asKeyCombination action: [flag := true]).
+	morph attachKeymapCategory: #TestBlah.
+
+	pressA := self eventKey: $a.
+	morph kmDispatcher dispatchKeystroke: pressA.
+	self assert: morph kmDispatcher buffer asArray equals: {pressA}.
+	
+	repeatPressA := (self eventKey: $a) isRepeat: true; yourself.
+	morph kmDispatcher dispatchKeystroke: repeatPressA.
+	self assert: morph kmDispatcher buffer asArray equals: {pressA. repeatPressA}.
+	self assert: (morph kmDispatcher buffer asArray collect: [ :v | v isRepeat ]) equals: {false. true}.
+
+	pressB := self eventKey: $b.
+	morph kmDispatcher dispatchKeystroke: pressB.
+	self assert: morph kmDispatcher buffer asArray equals: {pressA. repeatPressA. pressB}.
+	self assert: (morph kmDispatcher buffer asArray collect: [ :v | v isRepeat ]) equals: {false. true. false}.
+
+	repeatPressB := (self eventKey: $b) isRepeat: true; yourself.
+	morph kmDispatcher dispatchKeystroke: repeatPressB.
+	self assert: morph kmDispatcher buffer asArray equals: {pressA. repeatPressA. pressB. repeatPressB}.
+	self assert: (morph kmDispatcher buffer asArray collect: [ :v | v isRepeat ]) equals: {false. true. false. true}.
+
+	pressC := self eventKey: $c.
+	morph kmDispatcher
+		dispatchKeystroke: pressC.
+	self assert: morph kmDispatcher buffer isEmpty.
+
+	self assert: flag
+]

--- a/src/Morphic-Core/KeyboardEvent.class.st
+++ b/src/Morphic-Core/KeyboardEvent.class.st
@@ -54,7 +54,8 @@ KeyboardEvent >> hash [
 KeyboardEvent >> initialize [
 
 	super initialize.
-	supressNextKeyPress := false
+	supressNextKeyPress := false.
+	isRepeat := false
 ]
 
 { #category : 'testing' }

--- a/src/Morphic-Core/KeyboardEvent.class.st
+++ b/src/Morphic-Core/KeyboardEvent.class.st
@@ -89,9 +89,9 @@ KeyboardEvent >> isRepeat [
 ]
 
 { #category : 'accessing' }
-KeyboardEvent >> isRepeat: anObject [
+KeyboardEvent >> isRepeat: aBoolean [
 
-	isRepeat := anObject
+	isRepeat := aBoolean
 ]
 
 { #category : 'keyboard' }

--- a/src/Morphic-Core/KeyboardEvent.class.st
+++ b/src/Morphic-Core/KeyboardEvent.class.st
@@ -9,7 +9,8 @@ Class {
 		'charCode',
 		'scanCode',
 		'key',
-		'supressNextKeyPress'
+		'supressNextKeyPress',
+		'isRepeat'
 	],
 	#category : 'Morphic-Core-Events',
 	#package : 'Morphic-Core',
@@ -79,6 +80,18 @@ KeyboardEvent >> isKeystroke [
 { #category : 'testing' }
 KeyboardEvent >> isMouseMove [
 	^false
+]
+
+{ #category : 'accessing' }
+KeyboardEvent >> isRepeat [
+
+	^ isRepeat
+]
+
+{ #category : 'accessing' }
+KeyboardEvent >> isRepeat: anObject [
+
+	isRepeat := anObject
 ]
 
 { #category : 'keyboard' }

--- a/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
+++ b/src/OSWindow-Core/OSWindowMorphicEventHandler.class.st
@@ -220,7 +220,8 @@ OSWindowMorphicEventHandler >> visitKeyDownEvent: anEvent [
 		stamp: Time millisecondClockValue.
 	keyEvent
 		scanCode: anEvent scanCode;
-		key: (OSKeySymbols mapKeySymbolValueToKeyboardKey: anEvent symbol).
+		key: (OSKeySymbols mapKeySymbolValueToKeyboardKey: anEvent symbol);
+		isRepeat: anEvent repeat = 1.
 	self dispatchMorphicEvent: keyEvent
 ]
 
@@ -237,7 +238,8 @@ OSWindowMorphicEventHandler >> visitKeyUpEvent: anEvent [
 		stamp: Time millisecondClockValue.
 	keyEvent
 		scanCode: anEvent scanCode;
-		key: (OSKeySymbols mapKeySymbolValueToKeyboardKey: anEvent symbol).
+		key: (OSKeySymbols mapKeySymbolValueToKeyboardKey: anEvent symbol);
+		isRepeat: anEvent repeat = 1.
 	^ keyEvent
 ]
 

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -683,7 +683,6 @@ OSSDL2BackendWindow >> visitKeyDownEvent: event [
 	self convertButtonState: SDL2 mouseState modState: keysym mod modifiers: osEvent modifiers.
 	self convertNumpadKeysOf: osEvent.
 
-	osEvent repeat = 1 ifTrue: [ ^ self ].
 	^ osEvent deliver
 ]
 
@@ -700,7 +699,6 @@ OSSDL2BackendWindow >> visitKeyUpEvent: event [
 	self convertButtonState: SDL2 mouseState modState: keysym mod modifiers: osEvent modifiers.
 	self convertNumpadKeysOf: osEvent.
 
-	osEvent repeat = 1 ifTrue: [ ^ self ].
 	^ osEvent deliver
 ]
 

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -683,6 +683,7 @@ OSSDL2BackendWindow >> visitKeyDownEvent: event [
 	self convertButtonState: SDL2 mouseState modState: keysym mod modifiers: osEvent modifiers.
 	self convertNumpadKeysOf: osEvent.
 
+	osEvent repeat = 1 ifTrue: [ ^ self ].
 	^ osEvent deliver
 ]
 
@@ -699,6 +700,7 @@ OSSDL2BackendWindow >> visitKeyUpEvent: event [
 	self convertButtonState: SDL2 mouseState modState: keysym mod modifiers: osEvent modifiers.
 	self convertNumpadKeysOf: osEvent.
 
+	osEvent repeat = 1 ifTrue: [ ^ self ].
 	^ osEvent deliver
 ]
 


### PR DESCRIPTION
https://github.com/libsdl-org/SDL/commit/61cd57d378e6bf5a62a8bf49e02164df63924c56 made SDL2 trigger new _repeat_ keydown events in order to notify the library user that modifiers may have changed.

This change messed up the way we did keybind matching. Doing sequences like `Cmd+Shift+W, E` never matched because those new keydown events broke everything.

After pursuing multiple solutions this one that I found worked best. Still, it feels like a hack and I'm open for alternatives.

## Solutions tried
- **Ignoring all repeat events:** This is undesirable because we depend on those for repeat keyup/keydown/delete presses. We DO have a system somewhere that does repeat keypresses on text editors. I tried and failed to locate that part of the system so I don't know if doing repeat events inside pharo is doable or not.
- **Modifying the keybinding match code:** With a bit more work this may be doable. My naive attempts ended up with a sequence of keypresses that some keybindings recognized as a viable prefix but never ended up deciding for or against them.
- **Try to match only non-repeated keybindings:** Same as before, we end up with weird behavior where it is reasonable to invoke some single-key keybindings on fake repeat presses.

## Solution proposed
When trying to match a keybinding we now try to match it against the buffered sequence of events. If that fails we remove the repeated events and try again.

## Why did you do this?

This change restores most of the window tiling keybindings (for some reason `Cmd+Shift+W, Q` does not work).

Thanks @PalumboN and @guillep for their help on diagnosing this :)