### PR TITLE
Improvements in undo/redo

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -338,7 +338,7 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 
 	The completion context uses this API to insert text into the text editor"
 
-	| newString wordEnd old doubleSpace wordStart |
+	| newString wordEnd doubleSpace wordStart oldSelectionInterval |
 
 	newString := aString.
 	wordStart := self completionTokenStart.
@@ -355,12 +355,12 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 	"If the returned index is the size of the text that means that the caret is at the end of the text and there is no more word after, so add 1 to the index to be out of range to select the entierely word because of the selectInvisiblyFrom:to: remove 1 just after to be at the end of then final word"
 	wordEnd > self editor text size ifTrue:[ wordEnd := wordEnd + 1 ].
 
+	oldSelectionInterval := self editor selectionInterval.
 	self editor
 		selectInvisiblyFrom: wordStart
 		to: wordEnd - 1.
-	old := self editor selection.
 
-	self editor replaceSelectionWith: newString.
+	self editor replaceSelectionWith: newString fromSelection: oldSelectionInterval.
 
 	doubleSpace := newString indexOfSubCollection: '  ' startingAt: 1 ifAbsent: [ newString size ].
 	self editor selectAt: wordStart + doubleSpace.

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -31,6 +31,12 @@ CompletionEngineTest >> editorTextWithCaret [
 	^ (source copyFrom: 1 to: editor caret-1), '|', (source copyFrom: editor caret to: source size)
 ]
 
+{ #category : 'helpers' }
+CompletionEngineTest >> expectText: aString [ 
+
+	self assert: editor text asString equals: aString
+]
+
 { #category : 'accessing' }
 CompletionEngineTest >> interactionModel [
 
@@ -994,4 +1000,48 @@ CompletionEngineTest >> testSmartQuoteSurroundsSelection [
 
 	controller smartCharacterWithEvent: (self keyboardPressFor: $').
 	self assert: editor text equals: ' ''text'' '
+]
+
+{ #category : 'tests - undo' }
+CompletionEngineTest >> testUndoAutocompleteLeavesCursorInOriginalPosition [
+
+	"If the caret is at the end of a word, replace the entire word"
+	editor addString: 'self'.
+	editor closeTypeIn.
+	editor unselect.
+	
+	"Put the cursor after the `sel` token, and then we will simulate code completion"
+	self selectAt: 'self' size - 1.
+
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'selection'.
+	
+	editor undo.
+	self expectText: 'self'.
+	self assert: editor selectionInterval equals: (3 to: 2)
+]
+
+{ #category : 'tests - undo' }
+CompletionEngineTest >> testUndoCompletionEntryKeepsFollowingLine [
+
+	"If the caret is at the end of a word, replace the entire word"
+
+	| text |
+	text := 'self mEthOdThatDoes
+nextLine'.
+
+	self
+		setEditorText: text;
+		selectAt: text lines first size.
+
+	editor textArea openInWorld.
+	controller openMenu.
+
+	controller context replaceTokenInEditorWith: 'mEthOdThatDoesNotExist'.
+
+	editor undo.
+	
+	self assert: editor text asString equals: text
 ]

--- a/src/Rubric-Tests/RubAbstractTest.class.st
+++ b/src/Rubric-Tests/RubAbstractTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : 'RubAbstractTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'string',
+		'editor'
+	],
+	#category : 'Rubric-Tests-Editing-Core',
+	#package : 'Rubric-Tests',
+	#tag : 'Editing-Core'
+}
+
+{ #category : 'running' }
+RubAbstractTest >> setUp [
+
+	super setUp.
+	editor := RubTextEditor forTextArea: RubEditingArea new.
+	"Add text with a paragraph"
+	string := 'Lorem ipsum '
+]

--- a/src/Rubric-Tests/RubTextEditorLocalHistoryTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorLocalHistoryTest.class.st
@@ -1,0 +1,87 @@
+Class {
+	#name : 'RubTextEditorLocalHistoryTest',
+	#superclass : 'RubAbstractTest',
+	#category : 'Rubric-Tests-Editing-Core',
+	#package : 'Rubric-Tests',
+	#tag : 'Editing-Core'
+}
+
+{ #category : 'tests - undo' }
+RubTextEditorLocalHistoryTest >> expectText: aString [ 
+
+	self assert: editor text asString equals: aString
+]
+
+{ #category : 'tests - undo' }
+RubTextEditorLocalHistoryTest >> selectAt: anIndex [
+	editor selectFrom: anIndex to: anIndex - 1
+]
+
+{ #category : 'tests - undo' }
+RubTextEditorLocalHistoryTest >> testRedoCompletionEntryKeepsFollowingLine [
+
+	"If the caret is at the end of a word, replace the entire word"
+	editor addString: 'self'.
+	editor closeTypeIn.
+	editor unselect.
+	"Simulate an enter"
+	editor crWithIndent: KeyboardEvent new.
+	editor addString: '	b'.
+	editor closeTypeIn.
+	editor unselect.
+	
+	"Put the cursor after the `self` token, and then we will simulate code completion"
+	self selectAt: 'self' size + 1.
+	editor addString: ' te'.
+	editor closeTypeIn.
+
+	self expectText: 'self te
+	b'.
+	
+	editor undo.
+	self expectText: 'self
+	b'.
+
+	editor redo.
+	self expectText: 'self te
+	b'.
+]
+
+{ #category : 'tests - undo' }
+RubTextEditorLocalHistoryTest >> testRedoLeavesCursorInOriginalPosition [
+
+	"If the caret is at the end of a word, replace the entire word"
+	editor addString: 'self'.
+	editor unselect.
+	editor undo.
+	editor redo.
+	
+	self expectText: 'self'.
+	self assert: editor selectionInterval equals: (5 to: 4)
+]
+
+{ #category : 'tests - undo' }
+RubTextEditorLocalHistoryTest >> testUndoAfterTypeThenTabUndoesOnlyTheTab [
+
+	editor addString: 'self'.
+	editor unselect.
+	editor tab: KeyboardEvent new.
+
+	editor undo.
+
+	self expectText: 'self'
+]
+
+{ #category : 'tests - undo' }
+RubTextEditorLocalHistoryTest >> testUndoWordUndoesOneWordAtATime [
+
+	editor addString: 'self'.
+	editor unselect.
+	editor space: KeyboardEvent new.
+	
+	editor addString: 'toto'.
+
+	editor undo.
+
+	self expectText: 'self'
+]

--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -3,11 +3,7 @@ A RubTextEditorTest is a test class for testing the behavior of RubTextEditor
 "
 Class {
 	#name : 'RubTextEditorTest',
-	#superclass : 'TestCase',
-	#instVars : [
-		'editor',
-		'string'
-	],
+	#superclass : 'RubAbstractTest',
 	#category : 'Rubric-Tests-Editing-Core',
 	#package : 'Rubric-Tests',
 	#tag : 'Editing-Core'

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -1744,7 +1744,13 @@ RubAbstractTextArea >> recomputeSelection [
 
 { #category : 'multi level undo' }
 RubAbstractTextArea >> redoTypeIn: aText interval: anInterval [
-	self handleEdit: [self editor redoTypeIn: aText interval: anInterval]
+	
+	^ self redoTypeIn: aText interval: anInterval selection: anInterval
+]
+
+{ #category : 'multi level undo' }
+RubAbstractTextArea >> redoTypeIn: aText interval: anInterval selection: selection [
+	self handleEdit: [self editor redoTypeIn: aText interval: anInterval selection: selection]
 ]
 
 { #category : 'caching' }
@@ -2105,7 +2111,13 @@ RubAbstractTextArea >> undoRedoExchange: aninterval with: anotherInterval [
 
 { #category : 'multi level undo' }
 RubAbstractTextArea >> undoTypeIn: aText interval: anInterval [
-	self handleEdit: [self editor undoTypeIn: aText interval: anInterval]
+
+	^ self undoTypeIn: aText interval: anInterval selection: anInterval
+]
+
+{ #category : 'multi level undo' }
+RubAbstractTextArea >> undoTypeIn: aText interval: anInterval selection: aSelection [
+	self handleEdit: [self editor undoTypeIn: aText interval: anInterval selection: aSelection]
 ]
 
 { #category : 'private' }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -152,18 +152,29 @@ RubTextEditor >> addString: aString [
 
 { #category : 'undo - redo private' }
 RubTextEditor >> addTypeInUndoRecord [
-	| begin stop undoText redoText |
-	begin := self startOfTyping min: self stopIndex.
-	stop := self stopIndex max: self startOfTyping.
+	| begin stop undoText redoText selectionBeforeChange |
+	begin := self startOfTyping.
+	stop := self stopIndex.
+
+	selectionBeforeChange := self selectionInterval.
 	self editingState previousInterval: (begin to: stop - 1).
 	undoText := self nullText.
 	redoText := stop > begin
 			ifTrue: [self text copyFrom: begin to: stop - 1]
 			ifFalse: [self nullText].
-	((undoText isEmpty and: [redoText isEmpty]) and: [self editingState previousInterval size < 1])
-			ifFalse: [self
-				redoArray: { textArea. #redoTypeIn:interval:.  {redoText. begin to: begin + self selection size - 1} }
-				undoArray: {textArea. #undoTypeIn:interval:.  {undoText. begin to: stop - 1} }]
+
+	((undoText isEmpty and: [redoText isEmpty])
+		and: [self editingState previousInterval size < 1]) ifTrue: [ ^ self ] .
+
+	self
+		redoArray: { textArea. #redoTypeIn:interval:selection:. { 
+			redoText. 
+			begin to: begin - 1.
+			selectionBeforeChange } }
+		undoArray: { textArea. #undoTypeIn:interval:selection:. { 
+			undoText.
+			begin to: stop - 1.
+			(begin to: begin -1) } }
 ]
 
 { #category : 'new selection' }
@@ -781,6 +792,7 @@ RubTextEditor >> defaultCommandKeymapping [
 	(KeyboardKey enter -> #crWithIndent:).
 	(KeyboardKey escape -> #escape:).
 	(KeyboardKey left -> #cursorLeft:).
+	(KeyboardKey space -> #space:).
 	(KeyboardKey right -> #cursorRight:).
 	(KeyboardKey up -> #cursorUp:).
 	(KeyboardKey down -> #cursorDown:).
@@ -849,21 +861,6 @@ RubTextEditor >> doubleClick: evt [
 		ifTrue: [ self selectWord ].
 	self setEmphasisHereFromText.
 	self storeSelectionInText
-]
-
-{ #category : 'editing keys' }
-RubTextEditor >> duplicate: aKeyboardEvent [
-	"Paste the current selection over the prior selection, if it is non-overlapping and
-	 legal.  Undoer & Redoer: undoAndReselect."
-
-	self closeTypeIn.
-	(self hasSelection and: [self isDisjointFrom: self editingState previousInterval])
-		ifTrue: "Something to duplicate"
-			[self replace: self editingState previousInterval with: self selection and:
-				[self selectAt: self pointIndex]]
-		ifFalse:
-			[textArea flash].
-	^true
 ]
 
 { #category : 'accessing - selection' }
@@ -1903,10 +1900,13 @@ RubTextEditor >> redoArray: doArray undoArray: undoArray [
 ]
 
 { #category : 'undoers - redoers' }
-RubTextEditor >> redoTypeIn: aText interval: anInterval [
+RubTextEditor >> redoTypeIn: aText interval: anInterval selection: selection [
+
 	self selectInterval: anInterval.
-	self replace: self selectionInterval with: aText and:
-		[self selectInterval: (anInterval first to: anInterval first + aText size - 1)]
+	self
+		replace: self selectionInterval
+		with: aText
+		and: [ self selectInterval: selection ]
 ]
 
 { #category : 'accessing' }
@@ -1914,17 +1914,45 @@ RubTextEditor >> replace: xoldInterval with: newText and: selectingBlock [
 	"Replace the text in oldInterval with newText and
 	execute selectingBlock to establish the new selection.
 	Create an UndoRecord to allow perfect undoing."
-	| prevSel currInterval |
+
+	self replace: xoldInterval with: newText and: selectingBlock selection: self selectionInterval
+]
+
+{ #category : 'accessing' }
+RubTextEditor >> replace: xoldInterval with: newText and: selectingBlock selection: fromSelection [
+	"Replace the text in oldInterval with newText and
+	execute selectingBlock to establish the new selection.
+	Create an UndoRecord to allow perfect undoing."
+
+	| prevSel currInterval cursorAfterInsertion |
 	self selectInterval: xoldInterval.
 	prevSel := self selection.
 	currInterval := self selectionInterval.
 	self editingState previousInterval: currInterval.
+
 	self zapSelectionWith: newText.
+	cursorAfterInsertion := currInterval first + newText size - 1.
+
 	selectingBlock value.
-	((prevSel isEmpty and: [newText isEmpty]) and: [currInterval size < 1])
-		ifFalse: [self
-			redoArray: {textArea. #redoTypeIn:interval:. {newText. currInterval}}
-			undoArray: {textArea. #undoTypeIn:interval:. {prevSel. currInterval first to: currInterval first + newText size - 1}}]
+
+	((prevSel isEmpty and: [ newText isEmpty ]) and: [
+		 currInterval size < 1 ]) ifTrue: [ ^ self ].
+
+	self
+		redoArray: {
+				textArea.
+				#redoTypeIn:interval:selection:.
+				{
+					newText.
+					currInterval.
+					(cursorAfterInsertion + 1 to: cursorAfterInsertion) } }
+		undoArray: {
+				textArea.
+				#undoTypeIn:interval:selection:.
+				{
+					prevSel.
+					(currInterval first to: currInterval first + newText size - 1).
+					fromSelection } }
 ]
 
 { #category : 'find-select' }
@@ -1957,7 +1985,15 @@ RubTextEditor >> replaceAll: aRegex with: aText startingAt: startIdx [
 
 { #category : 'accessing' }
 RubTextEditor >> replaceSelectionWith: aText [
-	self replace: self selectionInterval with: aText and: []
+
+	self
+		replaceSelectionWith: aText
+		fromSelection: self selectionInterval
+]
+
+{ #category : 'accessing' }
+RubTextEditor >> replaceSelectionWith: aText fromSelection: fromSelection [
+	self replace: self selectionInterval with: aText and: [] selection: fromSelection
 ]
 
 { #category : 'accessing' }
@@ -2393,6 +2429,20 @@ RubTextEditor >> shouldEscapeCharacter: aCharacter [
 	^ #($" $') includes: aCharacter
 ]
 
+{ #category : 'typing/selecting keys' }
+RubTextEditor >> space: aKeyboardEvent [
+	"Append a space to the stream of characters and commit the undo/redo transaction.
+	This allows to manage undo/redo at a per-word granularity"
+
+	"We are consuming the space keydown event, do not send a keypress for it"
+	aKeyboardEvent supressNextKeyPress:  true.
+
+	self closeTypeIn.
+	self addString: String space.
+	self unselect.
+	^false
+]
+
 { #category : 'keymapping' }
 RubTextEditor >> specialShiftCmdKeys [
 
@@ -2503,6 +2553,7 @@ RubTextEditor >> swapChars: aKeyboardEvent [
 RubTextEditor >> tab: aKeyboardEvent [
 	"Append a line feed character to the stream of characters."
 
+	self closeTypeIn.
 	self addString: String tab.
 	self unselect.
 	^false
@@ -2617,10 +2668,13 @@ RubTextEditor >> undoRedoTransaction: aBlock [
 ]
 
 { #category : 'undoers - redoers' }
-RubTextEditor >> undoTypeIn: aText interval: anInterval [
+RubTextEditor >> undoTypeIn: aText interval: anInterval selection: aSelection [
+
 	self selectInterval: anInterval.
-	self replace: anInterval with: aText and:
-		[self selectInterval: (anInterval first to: anInterval first - 1)]
+	self
+		replace: anInterval
+		with: aText
+		and: [ self selectInterval: aSelection ]
 ]
 
 { #category : 'private' }

--- a/src/System-History/UndoRedoRecord.class.st
+++ b/src/System-History/UndoRedoRecord.class.st
@@ -78,6 +78,15 @@ UndoRedoRecord >> doMessage: aMessageSend [
 	^ self redoMessage: aMessageSend
 ]
 
+{ #category : 'printing' }
+UndoRedoRecord >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream nextPutAll: '('.
+	aStream print: redoMessage arguments.
+	aStream nextPutAll: ')'
+]
+
 { #category : 'redo-undo' }
 UndoRedoRecord >> redo [
 	^self redoMessage value


### PR DESCRIPTION
 - fix undo/redo cases that broke text, specially when in collaboration with the syntax highlighter
 - make undo/redo work on a word-by-word basis
 - make undo/redo restore selection and cursur when doing a replacement by paste/completion

Strong candidate to backport to P12