### PR TITLE
Prevent raising an Error in updateSettingNode: during image start

### DIFF
--- a/src/System-Settings-Core/ActionSettingDeclaration.class.st
+++ b/src/System-Settings-Core/ActionSettingDeclaration.class.st
@@ -39,3 +39,8 @@ ActionSettingDeclaration >> realValue [
 
 	^ false
 ]
+
+{ #category : 'accessing' }
+ActionSettingDeclaration >> realValue: anObject [
+	"Private - Do nothing, to prevent raising an Error in updateSettingNode:"
+]


### PR DESCRIPTION
There is no need to set values on Action Setting Declarations so this PR overrides the realValue: logic used to get a setter on a stored setting during image start.

Fixes #17315
