### PR TITLE
Open Shortcuts Editor from Settings Browser

### DIFF
--- a/src/Commander-Activators-Shortcut/CmdShortcutActivation.class.st
+++ b/src/Commander-Activators-Shortcut/CmdShortcutActivation.class.st
@@ -34,30 +34,29 @@ Class {
 }
 
 { #category : 'settings' }
-CmdShortcutActivation class >> buildSettingsFor: activations on: aBuilder [
-	| sorted |
-	sorted := activations sorted: [ :a :b | a commandClass name <= b commandClass name ].
-	sorted do: [ :each |	each buildSettingNodeOn: aBuilder]
-]
-
-{ #category : 'settings' }
 CmdShortcutActivation class >> buildSettingsOn: aBuilder [
 	<systemsettings>
-	(aBuilder group: #shortcuts)
-		label: 'Shortcuts';
+
+	(aBuilder button: #openShortcutsEditor)
+		order: 1;
+		parent: #tools;
+		buttonLabel: 'Open';
+		label: 'Shortcuts Editor';
 		description: 'All System Command Shortcuts';
-		with: [
-			self buildSettingsFor: self redefiningInstances on: aBuilder.
-			self
-				buildSettingsFor: (self registeredInstances copyWithoutAll: self redefiningInstances)
-				on: aBuilder.
-		]
+		target: self.
+
 ]
 
 { #category : 'instance creation' }
 CmdShortcutActivation class >> by: aKeyCombination for: anAnnotationUser [
 	^(self for: anAnnotationUser)
 		keyCombination: aKeyCombination
+]
+
+{ #category : 'settings' }
+CmdShortcutActivation class >> openShortcutsEditor [
+
+	KMDescriptionPresenter open
 ]
 
 { #category : 'well known shortcuts' }
@@ -74,28 +73,11 @@ CmdShortcutActivation class >> renamingFor: anAnnotationUser [
 	^self by: $r meta for: anAnnotationUser
 ]
 
-{ #category : 'settings' }
-CmdShortcutActivation class >> settingInputWidgetForNode: aShortcutSetting [
-	| catcherMorph theme |
-	theme := UITheme builder.
-	catcherMorph := KMCatcherMorph for: aShortcutSetting.
-	^ theme newRow: {catcherMorph}
-]
-
 { #category : 'accessing' }
 CmdShortcutActivation >> action [
 	"Answer a <CompiledMethod> defining the receiver's action"
 
 	^ self annotatedClass class lookupSelector: self declarationSelector
-]
-
-{ #category : 'settings' }
-CmdShortcutActivation >> buildSettingNodeOn: aBuilder [
-	| nodeBuilder |
-	nodeBuilder := aBuilder
-		nodeClass: CmdShortcutSetting name: self id.
-	nodeBuilder node item shortcutActivation: self.
-	^nodeBuilder
 ]
 
 { #category : 'printing' }

--- a/src/Keymapping-Tools-Spec/KMDescriptionPresenter.class.st
+++ b/src/Keymapping-Tools-Spec/KMDescriptionPresenter.class.st
@@ -182,9 +182,10 @@ KMDescriptionPresenter >> initializeShortcutList [
 
 { #category : 'initialization' }
 KMDescriptionPresenter >> initializeWindow: aWindowPresenter [
+
 	aWindowPresenter
 		title: 'Shortcuts Editor';
-		initialExtent: 600 @ 350
+		initialExtent: 900 @ 650
 ]
 
 { #category : 'initialization' }

--- a/src/System-Settings-Core/SettingDeclaration.class.st
+++ b/src/System-Settings-Core/SettingDeclaration.class.st
@@ -256,11 +256,12 @@ SettingDeclaration >> inputMorphFor: aContainer [
 SettingDeclaration >> inputWidget [
 	"return the default widget for the input a the setting"
 	| inputWidget xtraDialogWidget |
+
 	xtraDialogWidget := super inputWidget.
 	inputWidget :=  self localInputWidgetSelector ifNotNil: [:localSel | self perform: localSel].
+
 	(inputWidget isNil and: [self typeClass isNotNil])
-		ifTrue: [inputWidget := (self inputWidgetSelectorInClass: self typeClass)
-			ifNotNil: [:selector | self typeClass perform: selector with: self]].
+		ifTrue: [ inputWidget := self typeClass settingInputWidgetForNode: self ].
 	inputWidget
 		ifNotNil: [(inputWidget respondsTo: #model:)
 		  ifTrue: [inputWidget model ifNil: [inputWidget model: self]]].
@@ -405,13 +406,6 @@ SettingDeclaration >> inputWidgetForString [
 	widget hResizing: #rigid.
 	widget width: 450.
 	^ widget
-]
-
-{ #category : 'user interface' }
-SettingDeclaration >> inputWidgetSelectorInClass: aClass [
-	| selector |
-	^ (aClass respondsTo: (selector := #settingInputWidgetForNode:))
-		ifTrue: [selector]
 ]
 
 { #category : 'export' }


### PR DESCRIPTION
This PR is a compatibility update to the old Settings Browser. The most important change is that the entry of Shortcuts in the Settings Browser is replaced by an "Open" button in the Tools category, to open a Shortcuts Editor.

- Clean unnecessary method in SettindDeclaration (inputWidgetSelectorInClass: aClass)
- Update Shortcuts access in Settings Browser to open the new Shortcuts Editor instead of the broken KMCatcherMorph.

Fixes #17275

