### PR TITLE
Add `CompiledBlock>>#browse` and `BlockClosure>>#browse`

### DIFF
--- a/src/Tools/BlockClosure.extension.st
+++ b/src/Tools/BlockClosure.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'BlockClosure' }
+
+{ #category : '*Tools' }
+BlockClosure >> browse [
+
+	^ compiledBlock browse
+]

--- a/src/Tools/CompiledBlock.extension.st
+++ b/src/Tools/CompiledBlock.extension.st
@@ -1,0 +1,20 @@
+Extension { #name : 'CompiledBlock' }
+
+{ #category : '*Tools' }
+CompiledBlock >> browse [
+	| method |
+
+	method := self method.
+	
+	method isInstalled
+		ifTrue: [
+			^ Smalltalk tools browser
+				openOnClass: self methodClass
+				selector: self selector
+				highlight: self sourceNode sourceCode ]
+		ifFalse: [
+			^ Smalltalk tools browser
+				openOnClass: self methodClass
+				selector: self selector ]
+
+]


### PR DESCRIPTION
This change allows the _browse_ action to be a bit more intuitive. The implementation highlights the text if the method is installed. If the method is not instaled then it may happen that there's not an equivalent block in the installed version, so it just tries to show a method with that name (like `CompiledMethod>>#browse`).