### PR TITLE
Refactoring of rename temp and extract method while mutation testing

### DIFF
--- a/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
@@ -111,10 +111,12 @@ RBRenameArgumentOrTemporaryRefactoring >> prepareForExecution [
 	| variableNode |
 	oldName := self getExistingNameFromInterval.
 	parseTree := class parseTreeForSelector: selector.
-	variableNode := self
+	variableNode := [ self
 		                whichVariableNode: parseTree
 		                inInterval: interval
-		                name: oldName.
+		                name: oldName. ]
+		on: CodeError 
+		do: [ self refactoringError: 'Selected code does not contain any variables or contains multiple of them.' ].
 	(variableNode isNil or: [ variableNode isVariable not ]) ifTrue: [
 		self refactoringError: oldName asString , ' isn''t a valid variable' ].
 	variableNode name = oldName ifFalse: [

--- a/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
@@ -14,7 +14,8 @@ Class {
 		'interval',
 		'oldName',
 		'newName',
-		'parseTree'
+		'parseTree',
+		'definingNode'
 	],
 	#category : 'Refactoring-Core-Refactorings',
 	#package : 'Refactoring-Core',
@@ -57,16 +58,7 @@ RBRenameArgumentOrTemporaryRefactoring >> applicabilityPreconditions [
 RBRenameArgumentOrTemporaryRefactoring >> applicabilityPreconditionsIndependentOfTheNewName [
 	"Those are the preconditions that should be checked before even asking to the user a new name for the temporary."
 
-	^ {
-		  (RBCondition withBlock: [
-			   | methodSource |
-			   interval first > interval last ifTrue: [ self refactoringError: 'You must select a variable name' ].
-			   methodSource := class sourceCodeFor: selector.
-			   methodSource size >= interval last ifFalse: [ self refactoringError: 'Invalid range for variable' ].
-			   oldName := methodSource copyFrom: interval first to: interval last.
-			   true ]).
-
-		  (RBCondition definesSelector: selector in: class) }
+	^ { (RBCondition definesSelector: selector in: class) }
 ]
 
 { #category : 'preconditions' }
@@ -76,7 +68,7 @@ RBRenameArgumentOrTemporaryRefactoring >> applicabilityPreconditionsOfTheNewName
 	^ {
 		  (RBCondition isValidInstanceVariableName: newName for: class).
 
-		  (ReCheckVariableNameCondition class: class variableName: newName parseTree: (class parseTreeForSelector: selector)) }
+		  (ReCheckVariableNameCondition class: class variableName: newName parseTree: parseTree) }
 ]
 
 { #category : 'initialization' }
@@ -96,32 +88,53 @@ RBRenameArgumentOrTemporaryRefactoring >> class: aClass selector: aSelector inte
 ]
 
 { #category : 'accessing' }
+RBRenameArgumentOrTemporaryRefactoring >> getExistingNameFromInterval [
+
+	| methodSource |
+	interval first > interval last ifTrue: [
+		self refactoringError: 'You must select a variable name' ].
+	methodSource := class sourceCodeFor: selector.
+	methodSource size >= interval last ifFalse: [
+		self refactoringError: 'Invalid range for variable' ].
+	^ methodSource copyFrom: interval first to: interval last.
+]
+
+{ #category : 'accessing' }
 RBRenameArgumentOrTemporaryRefactoring >> newName: aString [
 
 	newName := aString
 ]
 
-{ #category : 'tranforming' }
-RBRenameArgumentOrTemporaryRefactoring >> privateTransform [
-	| definingNode variableNode |
+{ #category : 'transforming' }
+RBRenameArgumentOrTemporaryRefactoring >> prepareForExecution [
+
+	| variableNode |
+	oldName := self getExistingNameFromInterval.
 	parseTree := class parseTreeForSelector: selector.
-	variableNode := self whichVariableNode: parseTree inInterval: interval name: oldName.
-	(variableNode isNil or: [ variableNode isVariable not ])
-		ifTrue: [ self refactoringError: oldName asString , ' isn''t a valid variable' ].
-	variableNode name = oldName
-		ifFalse: [ self refactoringError: 'Invalid selection' ].
+	variableNode := self
+		                whichVariableNode: parseTree
+		                inInterval: interval
+		                name: oldName.
+	(variableNode isNil or: [ variableNode isVariable not ]) ifTrue: [
+		self refactoringError: oldName asString , ' isn''t a valid variable' ].
+	variableNode name = oldName ifFalse: [
+		self refactoringError: 'Invalid selection' ].
 	definingNode := variableNode whoDefines: oldName.
-	definingNode ifNil: [ self refactoringError: oldName asString , ' isn''t defined by the method' ].
+	definingNode ifNil: [
+		self refactoringError:
+			oldName asString , ' isn''t defined by the method' ]
+]
+
+{ #category : 'transforming' }
+RBRenameArgumentOrTemporaryRefactoring >> privateTransform [
+
 	self renameNode: definingNode.
 	class compileTree: parseTree
 ]
 
-{ #category : 'tranforming' }
+{ #category : 'transforming' }
 RBRenameArgumentOrTemporaryRefactoring >> renameNode: aParseTree [
-	(aParseTree whoDefines: newName)
-		ifNotNil: [ self refactoringError: newName asString , ' is already defined' ].
-	(aParseTree allDefinedVariables includes: newName)
-		ifTrue: [ self refactoringError: newName asString , ' is already defined' ].
+
 	(self parseTreeRewriterClass rename: oldName to: newName) executeTree: aParseTree
 ]
 

--- a/src/Refactoring-Core/ReCheckVariableNameCondition.class.st
+++ b/src/Refactoring-Core/ReCheckVariableNameCondition.class.st
@@ -34,6 +34,9 @@ ReCheckVariableNameCondition >> check [
    		violators add: ('<1p> defines a class variable named <2s>'
       		expandMacrosWith: class
          with: variableName)].
+	(parseTree whoDefines: variableName)
+		ifNotNil: [ 
+			violators add: ('<1s> is already defined' expandMacrosWith: variableName) ].
 	(parseTree allDefinedVariables includes: variableName ) ifTrue: [
 		violators add: ('<1s> is already a temporary variable name'
       		expandMacrosWith: variableName )].

--- a/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
@@ -29,7 +29,8 @@ Class {
 		'arguments',
 		'temporaries',
 		'assignments',
-		'needsReturn'
+		'needsReturn',
+		'interval'
 	],
 	#category : 'Refactoring-Transformations-Model-Unused',
 	#package : 'Refactoring-Transformations',
@@ -265,12 +266,12 @@ ReCompositeExtractMethodRefactoring >> extractInterval: anInterval from: aSelect
 	
 	class := self model classNamed: aClassName.
 	selector := aSelector.
-	sourceCode := self getSourceFromInterval: anInterval
+	interval := anInterval.
 ]
 
 { #category : 'api' }
 ReCompositeExtractMethodRefactoring >> extractInterval: anInterval from: aSelector to: aNewSelector in: aClassName [
-	
+
 	self extractInterval: anInterval from: aSelector in: aClassName.
 	newSelector := aNewSelector.
 	
@@ -308,13 +309,13 @@ ReCompositeExtractMethodRefactoring >> generateNewMethodWith: aMethodName [
 ]
 
 { #category : 'instance creation' }
-ReCompositeExtractMethodRefactoring >> getSourceFromInterval: anInterval [
+ReCompositeExtractMethodRefactoring >> getSourceFromInterval [
 	| source |
 	source := class sourceCodeFor: selector.
-	((anInterval first between: 1 and: source size)
-		and: [anInterval last between: 1 and: source size])
+	((interval first between: 1 and: source size)
+		and: [interval last between: 1 and: source size])
 			ifFalse: [self refactoringError: 'Invalid interval'].
-	^source copyFrom: anInterval first to: anInterval last
+	^source copyFrom: interval first to: interval last
 ]
 
 { #category : 'utilities' }
@@ -457,6 +458,7 @@ ReCompositeExtractMethodRefactoring >> preconditionTemporariesAreNotReadBeforeWr
 { #category : 'transforming' }
 ReCompositeExtractMethodRefactoring >> prepareForExecution [
 
+	sourceCode ifNil: [ sourceCode := self getSourceFromInterval ].
 	subtree := self calculateSubtree.
 	subtree ifNotNil: [  
 		temporaries := self calculateTemporaries.


### PR DESCRIPTION
Small refactorings done during mutation testing of refactorings:

- move preconditions code to correct place for rename argument or temp
- store interval for composite extract method