### PR TITLE
Use a setting declaration's typeClass to get default values

### DIFF
--- a/src/Settings-Polymorph/PolymorphSystemSettings.class.st
+++ b/src/Settings-Polymorph/PolymorphSystemSettings.class.st
@@ -238,7 +238,6 @@ PolymorphSystemSettings class >> desktopSettingsOn: aBuilder [
 				with: [
 					(aBuilder setting: #desktopLogoFileName)
 						type: #FilePathEncoder;
-						default: '';
 						description: 'The path of an image file for your own logo, the default pharo logo is used if empty.' ;
 						label: 'Logo image file name'].
 			self desktopColorSettingsOn: aBuilder.

--- a/src/System-Settings-Core/FilePathEncoder.extension.st
+++ b/src/System-Settings-Core/FilePathEncoder.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : 'FilePathEncoder' }
 
 { #category : '*System-Settings-Core' }
+FilePathEncoder class >> settingDeclarationDefault [
+
+	^ 'unset' asFileReference
+]
+
+{ #category : '*System-Settings-Core' }
 FilePathEncoder class >> settingInputWidgetForNode: aSettingNode [
 	^ aSettingNode  inputWidgetForFileOrDirectoryWithAction: #chooseFilePath
 ]

--- a/src/System-Settings-Core/Object.extension.st
+++ b/src/System-Settings-Core/Object.extension.st
@@ -17,3 +17,9 @@ Object >> exportSettingAction [
 
 	^ self class exportSettingAction
 ]
+
+{ #category : '*System-Settings-Core' }
+Object class >> settingDeclarationDefault [
+
+	^ nil
+]

--- a/src/System-Settings-Core/SettingDeclaration.class.st
+++ b/src/System-Settings-Core/SettingDeclaration.class.st
@@ -171,7 +171,9 @@ SettingDeclaration >> findCurrentSettingValue [
 SettingDeclaration >> findDeclarationDefault [
 	"Answer a default object according to the receiver's type"
 	
-	^ self typeClass settingDeclarationDefault
+	^ self typeClass 
+		ifNotNil: [ : tClass | tClass settingDeclarationDefault ]
+		ifNil: [ String empty ]
 ]
 
 { #category : 'accessing' }

--- a/src/System-Settings-Core/SettingDeclaration.class.st
+++ b/src/System-Settings-Core/SettingDeclaration.class.st
@@ -116,8 +116,9 @@ SettingDeclaration >> addToList: anItem [
 
 { #category : 'accessing' }
 SettingDeclaration >> default [
+
 	^ default
-		ifNil: [ default := String empty ]
+		ifNil: [ default := self findDeclarationDefault ]
 ]
 
 { #category : 'accessing' }
@@ -164,6 +165,13 @@ SettingDeclaration >> findCurrentSettingValue [
 	^ self targetSelector
 		ifNil: [ (Smalltalk at: targetSymbolOrObject) perform: self getSelector ]
 		ifNotNil: [ : s | ((Smalltalk at: targetSymbolOrObject) perform: s) perform: self getSelector].
+]
+
+{ #category : 'accessing' }
+SettingDeclaration >> findDeclarationDefault [
+	"Answer a default object according to the receiver's type"
+	
+	^ self typeClass settingDeclarationDefault
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Use a setting declaration's typeClass to delegate obtaining the default value from a target object (the typeClass) instead of setting an empty string for all cases.

This change is needed by the New Setting Browser Spec's support to display a file selector presenter.