### PR TITLE
Introduce SystemBuildInfo

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -225,6 +225,7 @@ ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Smalltalk vm par
 
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "MCCacheRepository uniqueInstance enable. FFIMethodRegistry resetAll. PharoSourcesCondenser condenseNewSources. Smalltalk garbageCollect"
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" clean --release
+${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "SystemBuildInfo current initializeForRelease"
 
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save "Pharo"
 echo "${PHARO_SHORT_VERSION}" > pharo.version

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -234,7 +234,7 @@ BaselineOfIDE >> microdown: spec [
 	spec baseline: 'Microdown' with: [ 
 		spec 
 			repository: (self class environment at: #BaselineOfPharo) microdownRepository;
-			loads: #('RichText' 'Tests') ]
+			loads: #('RichText' 'Tests' 'ForPharo') ]
 ]
 
 { #category : 'baselines - dependencies' }

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -238,7 +238,7 @@ BaselineOfIDE >> microdown: spec [
 
 	spec baseline: 'Microdown' with: [ 
 		spec 
-			repository: (self class environment at: #BaselineOfPharo) microdownRepository;
+			repository: (self classNamed: #BaselineOfPharo) microdownRepository;
 			loads: #('RichText' 'Tests' 'ForPharo') ]
 ]
 

--- a/src/System-Support-Tests/SystemBuildInfoTest.class.st
+++ b/src/System-Support-Tests/SystemBuildInfoTest.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : 'SystemBuildInfoTest',
+	#superclass : 'TestCase',
+	#category : 'System-Support-Tests-Image',
+	#package : 'System-Support-Tests',
+	#tag : 'Image'
+}
+
+{ #category : 'tests' }
+SystemBuildInfoTest >> testIsBuildFinished [
+
+	| buildInfo |
+	buildInfo := SystemBuildInfo new.
+
+	self deny: buildInfo isBuildFinished.
+
+	buildInfo initializeForRelease.
+
+	self assert: buildInfo isBuildFinished
+]
+
+{ #category : 'tests' }
+SystemBuildInfoTest >> testSystemPackageNames [
+
+	| buildInfo newPackage |
+	buildInfo := SystemBuildInfo new.
+	buildInfo initializeForRelease.
+
+	self denyEmpty: buildInfo systemPackageNames.
+	buildInfo systemPackageNames do: [ :package | self assert: (self packageOrganizer packageNames includes: package) ].
+
+	[
+	newPackage := self packageOrganizer ensurePackage: 'NewPackageNotPartOfPharo'.
+
+	self deny: (buildInfo systemPackageNames includes: newPackage name) ] ensure: [ self packageOrganizer removePackage: 'NewPackageNotPartOfPharo' ]
+]
+
+{ #category : 'tests' }
+SystemBuildInfoTest >> testSystemPackages [
+
+	| buildInfo newPackage |
+	buildInfo := SystemBuildInfo new.
+	buildInfo initializeForRelease.
+
+	self denyEmpty: buildInfo systemPackages.
+	buildInfo systemPackages do: [ :package |
+		self assert: package isPackage.
+		self assert: (self packageOrganizer packages includes: package) ].
+
+	[
+	newPackage := self packageOrganizer ensurePackage: 'NewPackageNotPartOfPharo'.
+
+	self deny: (buildInfo systemPackages includes: newPackage) ] ensure: [ self packageOrganizer removePackage: 'NewPackageNotPartOfPharo' ]
+]

--- a/src/System-Support/SystemBuildInfo.class.st
+++ b/src/System-Support/SystemBuildInfo.class.st
@@ -1,0 +1,53 @@
+"
+I am a class providing informations on the Pharo build. 
+
+Currently I'm allowing one to know:
+- if we are currently in the middle of a Pharo bootstrap or if it is done
+- access the list of the system package
+
+More info can be added later depending on needs
+"
+Class {
+	#name : 'SystemBuildInfo',
+	#superclass : 'Object',
+	#instVars : [
+		'systemPackagesNames'
+	],
+	#classVars : [
+		'Current'
+	],
+	#category : 'System-Support-Image',
+	#package : 'System-Support',
+	#tag : 'Image'
+}
+
+{ #category : 'accessing' }
+SystemBuildInfo class >> current [
+
+	^ Current ifNil: [ Current := self new ]
+]
+
+{ #category : 'initialization' }
+SystemBuildInfo >> initializeForRelease [
+
+	systemPackagesNames := self packageOrganizer packageNames
+]
+
+{ #category : 'testing' }
+SystemBuildInfo >> isBuildFinished [
+	"We initialize the list of packages at the end so we can now if the build is finished when we have packages"
+
+	^ systemPackagesNames isNotNil
+]
+
+{ #category : 'accessing' }
+SystemBuildInfo >> systemPackageNames [
+
+	^ systemPackagesNames
+]
+
+{ #category : 'accessing' }
+SystemBuildInfo >> systemPackages [
+
+	^ self packageOrganizer packages select: [ :package | self systemPackageNames includes: package name ]
+]


### PR DESCRIPTION
This class can tell us info such as "is the Pharo bootstrap finished?" or the list of system packages.

This will help us to improve the loading of Microdown in Pharo.

I also fixed the groups of Microdown because one important is missing.