### PR TITLE
Fedup to have around this initialize-release? Let us get rid of it!

### DIFF
--- a/src/AST-Core/ASTParseTreeRule.class.st
+++ b/src/AST-Core/ASTParseTreeRule.class.st
@@ -59,7 +59,7 @@ ASTParseTreeRule >> methodSearchString: aString [
 	searchTree := self parserClass parseRewriteMethod: aString
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ASTParseTreeRule >> owner: aParseTreeSearcher [
 	owner := aParseTreeSearcher
 ]

--- a/src/Athens-Cairo/AthensCairoCanvas.class.st
+++ b/src/Athens-Cairo/AthensCairoCanvas.class.st
@@ -147,7 +147,7 @@ AthensCairoCanvas >> handle [
 	^ handle value
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 AthensCairoCanvas >> initializeWithSurface: anAthensSurface [
 	super initializeWithSurface: anAthensSurface.
 	self paintMode default

--- a/src/Calypso-Browser/ClyTextEditingMode.class.st
+++ b/src/Calypso-Browser/ClyTextEditingMode.class.st
@@ -41,7 +41,7 @@ ClyTextEditingMode >> browserTool: aTextEditorTool [
 	browserTool := aTextEditorTool
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ClyTextEditingMode >> editorClass [
 	^ClyTextEditor
 ]
@@ -63,7 +63,7 @@ ClyTextEditingMode >> isScripting: anObject [
 	isForScripting := anObject
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ClyTextEditingMode >> updateTextAreaWhenPlugged [
 	super updateTextAreaWhenPlugged.
 	isForScripting ifTrue: [ self textArea shoutStyler beForSmalltalkScripting]

--- a/src/Epicea/EpProtocolChange.class.st
+++ b/src/Epicea/EpProtocolChange.class.st
@@ -46,7 +46,7 @@ EpProtocolChange >> doesOverride: aCodeChange [
 		aCodeChange protocol = self protocol ] ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 EpProtocolChange >> initializeWithBehavior: aBehavior protocol: aProtocol [
 	self initialize.
 	behavior := aBehavior asEpiceaRingDefinition.

--- a/src/Fuel-Core-Tests/FLGZipStrategy.class.st
+++ b/src/Fuel-Core-Tests/FLGZipStrategy.class.st
@@ -20,7 +20,7 @@ FLGZipStrategy class >> newWithTarget: aStreamStrategy [
 		yourself
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLGZipStrategy >> initializeWith: aStreamStrategy [
 
 	self initialize.

--- a/src/Fuel-Core/FLBufferedWriteStream.class.st
+++ b/src/Fuel-Core/FLBufferedWriteStream.class.st
@@ -110,7 +110,7 @@ FLBufferedWriteStream >> flushBufferIfFull [
 		ifTrue: [ self flushBuffer ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLBufferedWriteStream >> initializeOn: writeStream bufferSize: aSize [
 
 	self initialize.
@@ -119,7 +119,7 @@ FLBufferedWriteStream >> initializeOn: writeStream bufferSize: aSize [
 	position := 0.
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLBufferedWriteStream >> initializeStream: aWriteStream [
 	stream := aWriteStream.
 	"This is ugly, but it is an optimization for #flushBuffer"

--- a/src/Fuel-Core/FLCluster.class.st
+++ b/src/Fuel-Core/FLCluster.class.st
@@ -61,13 +61,13 @@ FLCluster >> fuelAccept: aGeneralMapper [
 	^ aGeneralMapper visitSubstitution: self by: nil
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLCluster >> initializeAnalyzing [
 
 	self initialize.
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLCluster >> initializeMaterializing [
 
 	self initialize.

--- a/src/Fuel-Core/FLGlobalSendCluster.class.st
+++ b/src/Fuel-Core/FLGlobalSendCluster.class.st
@@ -40,7 +40,7 @@ FLGlobalSendCluster >> add: anObject name: globalName selector: selector traceWi
 		ifAbsentPut: [ Association key: globalName value: selector ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLGlobalSendCluster >> initializeAnalyzing [
 	super initializeAnalyzing.
 	globalSends := IdentityDictionary new.

--- a/src/Fuel-Core/FLHookPrimitiveCluster.class.st
+++ b/src/Fuel-Core/FLHookPrimitiveCluster.class.st
@@ -40,7 +40,7 @@ FLHookPrimitiveCluster >> clusterSerializeStepWith: anEncoder [
 	anEncoder encodeReferenceToClusterObjectClass: theClass
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLHookPrimitiveCluster >> initializeAnalyzing: aClass [
 
 	self initializeAnalyzing.

--- a/src/Fuel-Core/FLIndexStream.class.st
+++ b/src/Fuel-Core/FLIndexStream.class.st
@@ -22,7 +22,7 @@ FLIndexStream class >> on: aStream digits: aNumberOfDigits [
 		yourself.
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLIndexStream >> initializeOn: aStream digits: aNumberOfDigits [
 
 	self initialize.

--- a/src/Fuel-Core/FLIteratingCluster.class.st
+++ b/src/Fuel-Core/FLIteratingCluster.class.st
@@ -56,7 +56,7 @@ FLIteratingCluster >> clusterSerializeStepWith: anEncoder [
 	anEncoder encodeUint32: objects size
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLIteratingCluster >> initializeAnalyzing [
 
 	super initializeAnalyzing.

--- a/src/Fuel-Core/FLObjectCluster.class.st
+++ b/src/Fuel-Core/FLObjectCluster.class.st
@@ -46,7 +46,7 @@ FLObjectCluster >> clusterSerializeStepWith: anEncoder [
 	anEncoder encodeReferenceToClusterObjectClass: theClass
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLObjectCluster >> initializeAnalyzing: aClass [
 
 	self initializeAnalyzing.

--- a/src/Fuel-Core/FLPluggableSubstitutionMapper.class.st
+++ b/src/Fuel-Core/FLPluggableSubstitutionMapper.class.st
@@ -25,7 +25,7 @@ FLPluggableSubstitutionMapper class >> when: aCondition substituteBy: aFactory [
 		yourself
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLPluggableSubstitutionMapper >> initializeWith: aCondition substitutionFactory: aBlock [
 
 	self initialize.

--- a/src/Fuel-Core/FLPointerObjectCluster.class.st
+++ b/src/Fuel-Core/FLPointerObjectCluster.class.st
@@ -33,7 +33,7 @@ FLPointerObjectCluster >> clusterSerializeStepWith: anEncoder [
 	variablesMapping serializeOn: anEncoder
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLPointerObjectCluster >> initializeAnalyzing: aClass [
 
 	super initializeAnalyzing: aClass.

--- a/src/Fuel-Core/FLSimpleStack.class.st
+++ b/src/Fuel-Core/FLSimpleStack.class.st
@@ -49,7 +49,7 @@ FLSimpleStack >> grow [
 	array := newArray
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLSimpleStack >> initialize: hintSize [
 
 	array := Array new: hintSize.

--- a/src/Fuel-Core/FLSubstitutionCluster.class.st
+++ b/src/Fuel-Core/FLSubstitutionCluster.class.st
@@ -44,7 +44,7 @@ FLSubstitutionCluster >> add: anObject substitutedBy: anotherObject traceWith: a
 			aAnalysis trace: anotherObject ].
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLSubstitutionCluster >> initializeAnalyzing [
 
 	super initializeAnalyzing.

--- a/src/Fuel-Core/FLVariablesMapping.class.st
+++ b/src/Fuel-Core/FLVariablesMapping.class.st
@@ -65,13 +65,13 @@ FLVariablesMapping >> initializeMaterializingFrom: aDecoder [
 	possibleTraitVariables := Dictionary new
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLVariablesMapping >> initializeWithClass: aClass [
 	self initialize.
 	theClass := aClass
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 FLVariablesMapping >> initializeWithClass: aClass references: aCollection [
 	self initialize.
 	theClass := aClass.

--- a/src/Kernel/Semaphore.class.st
+++ b/src/Kernel/Semaphore.class.st
@@ -201,7 +201,7 @@ Semaphore >> signalAll [
 	whileFalse: [ self signal ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 Semaphore >> terminateProcess [
 	"Terminate the process waiting on this semaphore, if any."
 

--- a/src/Metacello-GitBasedRepository/MCGitBasedNetworkRepository.class.st
+++ b/src/Metacello-GitBasedRepository/MCGitBasedNetworkRepository.class.st
@@ -440,7 +440,7 @@ MCGitBasedNetworkRepository >> goferVersionFrom: aVersionReference [
 	^ self localRepository goferVersionFrom: aVersionReference
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 MCGitBasedNetworkRepository >> hasNoLoadConflicts: anMCGitBasedRepository [
   (anMCGitBasedRepository isKindOf: self class)
     ifFalse: [ ^ false ].

--- a/src/MonticelloFileTree-Core/MCFileTreeAbstractStWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeAbstractStWriter.class.st
@@ -121,7 +121,7 @@ MCFileTreeAbstractStWriter >> visitTraitDefinition: definition [
     self subclassResponsibility
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 MCFileTreeAbstractStWriter >> writeBasicDefinitions: aCollection [
     "the correct initialization order is unknown if some classes are missing in the image"
 

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressWriter.class.st
@@ -314,7 +314,7 @@ MCFileTreeStCypressWriter >> writeMethodDefinition: methodDefinition to: methodP
     visit: [ self writeMethodDefinition: methodDefinition ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 MCFileTreeStCypressWriter >> writeMethodProperties: classMethodDefinitions [
     "Issue 33: https://github.com/dalehenrich/filetree/issues/33"
 

--- a/src/Morphic-Core/MorphicRenderLoop.class.st
+++ b/src/Morphic-Core/MorphicRenderLoop.class.st
@@ -12,13 +12,13 @@ MorphicRenderLoop >> defer: aValuable [
 	self currentWorld defer: aValuable
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 MorphicRenderLoop >> doOneCycle [
 
 	WorldMorph doOneCycle
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 MorphicRenderLoop >> doOneCycleWhile: aBlock [
 
 	[ aBlock value ] whileTrue: [

--- a/src/NECompletion/CompletionContext.class.st
+++ b/src/NECompletion/CompletionContext.class.st
@@ -64,7 +64,7 @@ CompletionContext >> engine [
 	^ engine
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 CompletionContext >> engine: aCompletionEngine class: aClass source: aString position: anInteger [
 	class := aClass.
 	source := aString.

--- a/src/Network-Kernel/SocketAddressInformation.class.st
+++ b/src/Network-Kernel/SocketAddressInformation.class.st
@@ -175,7 +175,7 @@ SocketAddressInformation >> connect [
 	^sock
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 SocketAddressInformation >> initSocketAddress: aSocketAddress family: familyInteger type: typeInteger protocol: protocolInteger [
 
 	socketAddress := aSocketAddress.

--- a/src/Refactoring-Changes/RBAddMethodChange.class.st
+++ b/src/Refactoring-Changes/RBAddMethodChange.class.st
@@ -164,7 +164,7 @@ RBAddMethodChange >> protocols [
 	^ protocols
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RBAddMethodChange >> protocols: aCollectionOrProtocol [
 
 	protocols := (aCollectionOrProtocol isCollection and: [ aCollectionOrProtocol isString not])

--- a/src/Refactoring-DataForTesting/RBBasicDummyLintRuleTest.class.st
+++ b/src/Refactoring-DataForTesting/RBBasicDummyLintRuleTest.class.st
@@ -1232,7 +1232,7 @@ RBBasicDummyLintRuleTest >> anInstVar [
 	^ anInstVar
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RBBasicDummyLintRuleTest >> anInstVar: anObject [
 	anInstVar := anObject
 ]
@@ -1298,7 +1298,7 @@ RBBasicDummyLintRuleTest >> problemCount [
 	^result problemCount
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RBBasicDummyLintRuleTest >> resetResult [
 	result := result copyEmpty.
 	result label: name
@@ -1309,7 +1309,7 @@ RBBasicDummyLintRuleTest >> result [
 	^result
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RBBasicDummyLintRuleTest >> result: aResult [
 	result := aResult copyEmpty
 ]

--- a/src/Refactoring-DataForTesting/RBBasicLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBBasicLintRuleTestData.class.st
@@ -264,7 +264,7 @@ RBBasicLintRuleTestData >> anInstVar [
 	^ anInstVar
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RBBasicLintRuleTestData >> anInstVar: anObject [
 	anInstVar := anObject
 ]
@@ -336,7 +336,7 @@ RBBasicLintRuleTestData >> problemCount [
 	^result problemCount
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RBBasicLintRuleTestData >> resetResult [
 	result := result copyEmpty.
 	result label: name
@@ -347,7 +347,7 @@ RBBasicLintRuleTestData >> result [
 	^result
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RBBasicLintRuleTestData >> result: aResult [
 	result := aResult copyEmpty
 ]

--- a/src/Refactoring-Environment/RBSelectorEnvironment.class.st
+++ b/src/Refactoring-Environment/RBSelectorEnvironment.class.st
@@ -177,7 +177,7 @@ RBSelectorEnvironment >> classNames [
 		yourself
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RBSelectorEnvironment >> classSelectors: classSelectorDictionary metaClassSelectors: metaClassSelectorDictionary [
 	classSelectors := classSelectorDictionary.
 	metaClassSelectors := metaClassSelectorDictionary

--- a/src/Regex-Core/RxmSpecial.class.st
+++ b/src/Regex-Core/RxmSpecial.class.st
@@ -15,7 +15,7 @@ Class {
 	#tag : 'Links'
 }
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RxmSpecial >> beBeginningOfLine [
 
 	matchSelector := #atBeginningOfLine

--- a/src/Regex-Core/RxmSubstring.class.st
+++ b/src/Regex-Core/RxmSubstring.class.st
@@ -30,7 +30,7 @@ RxmSubstring >> beCaseSensitive [
 	compare := [:char1 :char2 | char1 = char2]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RxmSubstring >> character: aCharacter ignoreCase: aBoolean [
 	"Match exactly this character."
 

--- a/src/Regex-Core/RxsContextCondition.class.st
+++ b/src/Regex-Core/RxsContextCondition.class.st
@@ -17,7 +17,7 @@ Class {
 	#tag : 'Nodes'
 }
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RxsContextCondition >> beAny [
 	"Matches anything but a newline."
 

--- a/src/Regex-Core/RxsPiece.class.st
+++ b/src/Regex-Core/RxsPiece.class.st
@@ -68,7 +68,7 @@ RxsPiece >> initializeOptionalAtom: anAtom [
 	self initializeAtom: anAtom min: 0 max: 1
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RxsPiece >> initializePlusAtom: anAtom [
 	"This piece is one or more occurrences of the specified RxsAtom."
 

--- a/src/Regex-Core/RxsPredicate.class.st
+++ b/src/Regex-Core/RxsPredicate.class.st
@@ -82,14 +82,14 @@ RxsPredicate class >> initializeNamedClassSelectors [
 		at: 'xdigit' put: #beHexDigit
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RxsPredicate >> beAlphaNumeric [
 
 	predicate := [:char | char isAlphaNumeric].
 	negation := [:char | char isAlphaNumeric not]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RxsPredicate >> beAlphabetic [
 
 	predicate := [:char | char isLetter].
@@ -141,7 +141,7 @@ RxsPredicate >> beLowercase [
 	negation := [:char | char isLowercase not]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RxsPredicate >> beNotDigit [
 
 	self
@@ -182,7 +182,7 @@ RxsPredicate >> bePunctuation [
 	negation := [:char | (punctuationChars includes: char) not]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RxsPredicate >> beSpace [
 
 	predicate := [:char | char isSeparator].
@@ -196,7 +196,7 @@ RxsPredicate >> beUppercase [
 	negation := [:char | char isUppercase not]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 RxsPredicate >> beWordConstituent [
 
 	predicate := [:char | char isAlphaNumeric or: [char == $_]].

--- a/src/STON-Core/Interval.extension.st
+++ b/src/STON-Core/Interval.extension.st
@@ -1,19 +1,19 @@
 Extension { #name : 'Interval' }
 
 { #category : '*STON-Core' }
-Interval >> fromSton: stonReader [
-	"Overwritten to get back the standard object behavior"
-
-	stonReader parseNamedInstVarsFor: self
-]
-
-{ #category : '*STON-Core' }
 Interval class >> fromSton: stonReader [
 	"Overwritten to get back the standard object behavior"
 
 	^ self new
 		fromSton: stonReader;
 		yourself
+]
+
+{ #category : '*STON-Core' }
+Interval >> fromSton: stonReader [
+	"Overwritten to get back the standard object behavior"
+
+	stonReader parseNamedInstVarsFor: self
 ]
 
 { #category : '*STON-Core' }

--- a/src/STON-Core/Object.extension.st
+++ b/src/STON-Core/Object.extension.st
@@ -1,6 +1,16 @@
 Extension { #name : 'Object' }
 
 { #category : '*STON-Core' }
+Object class >> fromSton: stonReader [
+	"Create a new instance and delegate decoding to instance side.
+	Override only when new instance should be created directly (see implementors). "
+
+	^ self new
+		fromSton: stonReader;
+		yourself
+]
+
+{ #category : '*STON-Core' }
 Object >> fromSton: stonReader [
 	"Decode non-variable classes from a map of their instance variables and values.
 	Override to customize and add a matching #toSton: (see implementors)."
@@ -10,16 +20,6 @@ Object >> fromSton: stonReader [
 			stonReader error: 'custom #fromSton: implementation needed for variable/indexable class' ]
 		ifFalse: [
 			stonReader parseNamedInstVarsFor: self ]
-]
-
-{ #category : '*STON-Core' }
-Object class >> fromSton: stonReader [
-	"Create a new instance and delegate decoding to instance side.
-	Override only when new instance should be created directly (see implementors). "
-
-	^ self new
-		fromSton: stonReader;
-		yourself
 ]
 
 { #category : '*STON-Core' }

--- a/src/STON-Core/STONCStyleCommentsSkipStream.class.st
+++ b/src/STON-Core/STONCStyleCommentsSkipStream.class.st
@@ -46,7 +46,7 @@ STONCStyleCommentsSkipStream >> atEnd [
 	^ self peek isNil
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 STONCStyleCommentsSkipStream >> close [
 	stream close
 ]
@@ -199,7 +199,7 @@ STONCStyleCommentsSkipStream >> nextNonCommentChar [
 		ifFalse: [ char ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 STONCStyleCommentsSkipStream >> on: readStream [
 	stream := readStream
 ]

--- a/src/STON-Core/SortedCollection.extension.st
+++ b/src/STON-Core/SortedCollection.extension.st
@@ -1,19 +1,19 @@
 Extension { #name : 'SortedCollection' }
 
 { #category : '*STON-Core' }
-SortedCollection >> fromSton: stonReader [
-	"Overwritten to get back the standard object behavior"
-
-	stonReader parseNamedInstVarsFor: self
-]
-
-{ #category : '*STON-Core' }
 SortedCollection class >> fromSton: stonReader [
 	"Overwritten to get back the standard object behavior"
 
 	^ self new
 		fromSton: stonReader;
 		yourself
+]
+
+{ #category : '*STON-Core' }
+SortedCollection >> fromSton: stonReader [
+	"Overwritten to get back the standard object behavior"
+
+	stonReader parseNamedInstVarsFor: self
 ]
 
 { #category : '*STON-Core' }

--- a/src/System-Sources/SourceFileBufferedReadWriteStream.class.st
+++ b/src/System-Sources/SourceFileBufferedReadWriteStream.class.st
@@ -88,7 +88,7 @@ SourceFileBufferedReadWriteStream >> closed [
 	^ innerStream closed
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 SourceFileBufferedReadWriteStream >> collectionSpecies [
 	^ innerStream isBinary
 		ifTrue: [ ByteArray ]
@@ -314,7 +314,7 @@ SourceFileBufferedReadWriteStream >> size [
 	^ streamSize max: (bufferOffset + bufferLength)
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 SourceFileBufferedReadWriteStream >> sizeBuffer: size [
 
 	bufferLength > 0 ifTrue: [ self flush ].

--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
@@ -67,7 +67,7 @@ ZnBufferedReadStream >> back [
 				char ] ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnBufferedReadStream >> close [
 	stream close
 ]
@@ -242,7 +242,7 @@ ZnBufferedReadStream >> nextWord [
 	^ self nextIntegerOfSize: 2 signed: false bigEndian: true
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnBufferedReadStream >> on: readStream [
 	stream := readStream.
 	self sizeBuffer: self defaultBufferSize
@@ -359,7 +359,7 @@ ZnBufferedReadStream >> size [
 	^ stream size
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnBufferedReadStream >> sizeBuffer: size [
 	buffer := self collectionSpecies new: size
 ]

--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadWriteStream.class.st
@@ -184,7 +184,7 @@ ZnBufferedReadWriteStream >> size [
 	^ readStream size
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnBufferedReadWriteStream >> sizeBuffer: anInteger [
 
 	readStream sizeBuffer: anInteger.

--- a/src/Zinc-Character-Encoding-Core/ZnBufferedWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedWriteStream.class.st
@@ -59,7 +59,7 @@ ZnBufferedWriteStream >> bufferSize [
 	^ buffer ifNil: [ self defaultBufferSize ] ifNotNil: [ buffer size ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnBufferedWriteStream >> close [
 	self flushBuffer.
 	stream close
@@ -91,7 +91,7 @@ ZnBufferedWriteStream >> discardBuffer [
 	position := 0
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnBufferedWriteStream >> finish [
 	self flushBuffer
 ]
@@ -240,7 +240,7 @@ ZnBufferedWriteStream >> nextWordPut: integer [
 	^ self nextIntegerOfSize: 2 signed: false bigEndian: true put: integer
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnBufferedWriteStream >> on: writeStream [
 	stream := writeStream.
 	position := 0

--- a/src/Zinc-Character-Encoding-Core/ZnEncodedStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnEncodedStream.class.st
@@ -40,7 +40,7 @@ ZnEncodedStream class >> on: wrappedStream encoding: encoding [
 		yourself
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnEncodedStream >> close [
 	stream close
 ]
@@ -55,12 +55,12 @@ ZnEncodedStream >> encoder [
 	^ encoder ifNil: [ encoder := self class defaultEncoder ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnEncodedStream >> encoder: characterEncoder [
 	encoder := characterEncoder
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnEncodedStream >> encoding: encoding [
 	encoder := encoding asZnCharacterEncoder
 ]
@@ -80,7 +80,7 @@ ZnEncodedStream >> isStream [
   ^ true
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnEncodedStream >> on: wrappedStream [
 	stream := wrappedStream
 ]

--- a/src/Zinc-Character-Encoding-Core/ZnEndianessReadWriteStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnEndianessReadWriteStream.class.st
@@ -50,7 +50,7 @@ ZnEndianessReadWriteStream >> nextLittleEndianNumber: n put: value [
 	stream nextPutAll: bytes
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnEndianessReadWriteStream >> on: aStream [
 
 	stream := aStream

--- a/src/Zinc-Character-Encoding-Core/ZnPercentEncoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnPercentEncoder.class.st
@@ -41,7 +41,7 @@ ZnPercentEncoder >> characterEncoder [
 	^ characterEncoder ifNil: [ characterEncoder := ZnDefaultCharacterEncoder value ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnPercentEncoder >> characterEncoder: object [
 	"Set the character encoding to use to object."
 
@@ -86,7 +86,7 @@ ZnPercentEncoder >> decodePlusAsSpace [
 	^ decodePlusAsSpace ifNil: [ decodePlusAsSpace := true ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnPercentEncoder >> decodePlusAsSpace: boolean [
 	"When boolean is true, $+ on input will be decoded as Character space.
 	Else $+ is treated as a normal character, filtered by the safe set.
@@ -151,7 +151,7 @@ ZnPercentEncoder >> safeSet [
 	^ safeSet ifNil: [ safeSet := self class rfc3986UnreservedCharacters asByteArray ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnPercentEncoder >> safeSet: string [
 	"Set my safe set to be the characters in string, which I will convert to bytes"
 

--- a/src/Zinc-Character-Encoding-Core/ZnPositionableReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnPositionableReadStream.class.st
@@ -79,7 +79,7 @@ ZnPositionableReadStream >> bufferSize [
 	^ buffer size
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnPositionableReadStream >> close [
 	"Close me after which I can no longer be accessed. I delegate this to the stream that I wrap."
 
@@ -254,7 +254,7 @@ ZnPositionableReadStream >> savingPositionDo: block [
 	^ block ensure: [ self position: savedPosition ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnPositionableReadStream >> sizeBuffer: size [
 	"Change the buffer size. This should be done when I am still in my initial state."
 

--- a/src/Zinc-HTTP-Examples/ZnKeyValueStoreClient.class.st
+++ b/src/Zinc-HTTP-Examples/ZnKeyValueStoreClient.class.st
@@ -58,7 +58,7 @@ ZnKeyValueStoreClient >> at: key put: value [
 		contents: value asString
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnKeyValueStoreClient >> close [
 	httpClient ifNotNil: [
 		httpClient close.

--- a/src/Zinc-HTTP/ZnApplicationFormUrlEncodedEntity.class.st
+++ b/src/Zinc-HTTP/ZnApplicationFormUrlEncodedEntity.class.st
@@ -126,7 +126,7 @@ ZnApplicationFormUrlEncodedEntity >> printContentsOn: stream [
 	fields printElementsOn: stream
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnApplicationFormUrlEncodedEntity >> readFrom: stream [
 	"We parse from stream, limited to content length if available."
 

--- a/src/Zinc-HTTP/ZnBivalentWriteStream.class.st
+++ b/src/Zinc-HTTP/ZnBivalentWriteStream.class.st
@@ -30,7 +30,7 @@ ZnBivalentWriteStream class >> on: writeStream [
 		yourself
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnBivalentWriteStream >> close [
 	stream close
 ]
@@ -87,7 +87,7 @@ ZnBivalentWriteStream >> nextPutAll: collection [
 		ifFalse: [ stream nextPutAll: collection asString ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnBivalentWriteStream >> on: writeStream [
 	stream := writeStream
 ]

--- a/src/Zinc-HTTP/ZnByteArrayEntity.class.st
+++ b/src/Zinc-HTTP/ZnByteArrayEntity.class.st
@@ -79,7 +79,7 @@ ZnByteArrayEntity >> printContentsOn: stream [
 			print: self bytes ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnByteArrayEntity >> readFrom: stream [
 	self contentLength
 		ifNil: [

--- a/src/Zinc-HTTP/ZnChunkedReadStream.class.st
+++ b/src/Zinc-HTTP/ZnChunkedReadStream.class.st
@@ -49,7 +49,7 @@ ZnChunkedReadStream >> chunkCount [
 	^ chunkCount
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnChunkedReadStream >> close [
 	stream ifNotNil: [ stream close. stream := nil ]
 ]
@@ -207,7 +207,7 @@ ZnChunkedReadStream >> next: requestedCount into: collection startingAt: offset 
 		ifFalse: [ collection copyFrom: 1 to: offset + readCount - 1 ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnChunkedReadStream >> on: readStream [
 	stream := readStream
 ]

--- a/src/Zinc-HTTP/ZnChunkedWriteStream.class.st
+++ b/src/Zinc-HTTP/ZnChunkedWriteStream.class.st
@@ -29,7 +29,7 @@ ZnChunkedWriteStream class >> on: writeStream [
 		yourself
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnChunkedWriteStream >> binary [
 	stream binary
 ]
@@ -39,7 +39,7 @@ ZnChunkedWriteStream >> chunkCount [
 	^ chunkCount
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnChunkedWriteStream >> close [
 	self finish.
 	stream close
@@ -55,14 +55,14 @@ ZnChunkedWriteStream >> extraHeaders [
 	^ extraHeaders ifNil: [ extraHeaders := ZnHeaders new ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnChunkedWriteStream >> finish [
 	self writeChunkSize: 0.
 	self crlf.
 	extraHeaders ifNotNil: [ extraHeaders writeOn: stream ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnChunkedWriteStream >> flush [
 	stream flush
 ]
@@ -114,7 +114,7 @@ ZnChunkedWriteStream >> nextPutAll: collection [
 		startingAt: 1
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnChunkedWriteStream >> on: writeStream [
 	stream := writeStream
 ]

--- a/src/Zinc-HTTP/ZnCookie.class.st
+++ b/src/Zinc-HTTP/ZnCookie.class.st
@@ -49,7 +49,7 @@ ZnCookie >> = aCookie [
 	^ (aCookie name = self name) & (aCookie path = self path) & (aCookie domain = self domain)
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnCookie >> defaultDomain: aDomain [
 	self domain ifNil: [ self domain: aDomain ]
 ]
@@ -94,7 +94,7 @@ ZnCookie >> extraAttributes [
 	^ attributes associationsSelect: [ :ea | (ea key = 'name' or: [ ea key = 'value' ]) not ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnCookie >> fromString: aString [
 	| tokens val data i |
 	tokens := aString substrings: ';'.
@@ -205,7 +205,7 @@ ZnCookie >> printOn: stream [
 	self writeOn: stream
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnCookie >> readAttribute: aToken [
 	| i key data |
 	i := aToken indexOf: $=.

--- a/src/Zinc-HTTP/ZnEntity.class.st
+++ b/src/Zinc-HTTP/ZnEntity.class.st
@@ -165,7 +165,7 @@ ZnEntity >> asByteArray [
 	^ ByteArray streamContents: [ :stream | self writeOn: stream ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnEntity >> close [
 ]
 
@@ -245,12 +245,12 @@ ZnEntity >> printOn: stream [
 	stream nextPut: $)
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnEntity >> readBinaryFrom: stream [
 	self readFrom: stream
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnEntity >> readFrom: stream [
 	self subclassResponsibility
 ]

--- a/src/Zinc-HTTP/ZnHeaders.class.st
+++ b/src/Zinc-HTTP/ZnHeaders.class.st
@@ -303,7 +303,7 @@ ZnHeaders >> printOn: stream [
 	self isEmpty ifFalse: [ self headers printElementsOn: stream ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnHeaders >> readFrom: stream [
 	| line reader |
 	reader := ZnLineReader on: stream.
@@ -361,7 +361,7 @@ ZnHeaders >> singleAt: headerName ifAbsent: block [
 		ifFalse: [ value last ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnHeaders >> unlimited [
 	self headers unlimited
 ]

--- a/src/Zinc-HTTP/ZnHtmlOutputStream.class.st
+++ b/src/Zinc-HTTP/ZnHtmlOutputStream.class.st
@@ -68,7 +68,7 @@ ZnHtmlOutputStream >> << anObject [
  	anObject putOn: self
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnHtmlOutputStream >> close [
 	stream close
 ]
@@ -182,7 +182,7 @@ ZnHtmlOutputStream >> nextPutAll: collection [
 		startingAt: 1
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnHtmlOutputStream >> on: writeStream [
 	stream := writeStream
 ]

--- a/src/Zinc-HTTP/ZnLimitedReadStream.class.st
+++ b/src/Zinc-HTTP/ZnLimitedReadStream.class.st
@@ -33,7 +33,7 @@ ZnLimitedReadStream >> atEnd [
 	^ position >= limit or: [ stream atEnd ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnLimitedReadStream >> close [
 	stream ifNotNil: [ stream close. stream := nil ]
 ]
@@ -156,7 +156,7 @@ ZnLimitedReadStream >> nextInto: collection [
 		into: collection
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnLimitedReadStream >> on: readStream limit: integer [
 	stream := readStream.
 	limit := integer.

--- a/src/Zinc-HTTP/ZnLineReader.class.st
+++ b/src/Zinc-HTTP/ZnLineReader.class.st
@@ -50,7 +50,7 @@ ZnLineReader >> nextLine [
 	^ buffer copyFrom: 1 to: position
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnLineReader >> on: readStream [
 	stream := readStream.
 	buffer := String new: 64.

--- a/src/Zinc-HTTP/ZnLoggingReadStream.class.st
+++ b/src/Zinc-HTTP/ZnLoggingReadStream.class.st
@@ -56,7 +56,7 @@ ZnLoggingReadStream >> collectionSpecies [
 	^ ByteArray
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnLoggingReadStream >> identifier: string [
 	identifier := string
 ]
@@ -74,7 +74,7 @@ ZnLoggingReadStream >> isBinary [
 	^ true
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnLoggingReadStream >> logLevel: integer [
 	"logLevel 1 logs reads with next and friends
 	logLevl 2 logs peek and atEnd too"
@@ -82,7 +82,7 @@ ZnLoggingReadStream >> logLevel: integer [
 	logLevel := integer
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnLoggingReadStream >> logger: oneArgumentBlock [
 	logger := oneArgumentBlock
 ]
@@ -133,7 +133,7 @@ ZnLoggingReadStream >> next: requestedCount into: collection startingAt: offset 
 		ifFalse: [ collection copyFrom: 1 to: offset + readCount - 1 ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnLoggingReadStream >> on: binaryReadStream [
 	stream := binaryReadStream
 ]

--- a/src/Zinc-HTTP/ZnMessage.class.st
+++ b/src/Zinc-HTTP/ZnMessage.class.st
@@ -177,7 +177,7 @@ ZnMessage >> postCopy [
 	"Note that we don't copy the entity, see also #resetEntity: and ZnClient>>#resetEntity"
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessage >> readBinaryFrom: stream [
 	| entityReader |
 	self readHeaderFrom: stream.
@@ -186,23 +186,23 @@ ZnMessage >> readBinaryFrom: stream [
 	self entity: entityReader readEntity
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessage >> readEntityFrom: stream [
 	self entity: (self entityReaderOn: stream) readEntity
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessage >> readFrom: stream [
 	self readHeaderFrom: stream.
 	self readEntityFrom: stream
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessage >> readHeaderFrom: stream [
 	self headers: (ZnHeaders readFrom: stream)
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessage >> readStreamingFrom: stream [
 	| entityReader |
 	self readHeaderFrom: stream.

--- a/src/Zinc-HTTP/ZnMimePart.class.st
+++ b/src/Zinc-HTTP/ZnMimePart.class.st
@@ -237,7 +237,7 @@ ZnMimePart >> printOn: stream [
 	stream nextPut: $)
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMimePart >> readBinaryFrom: stream [
 	| entityReader |
 	self headers: (ZnHeaders readFrom: stream).
@@ -246,7 +246,7 @@ ZnMimePart >> readBinaryFrom: stream [
 	self entity: entityReader readEntity
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMimePart >> readFrom: stream [
 	self headers: (ZnHeaders readFrom: stream).
 	self entity: (self entityReaderOn: stream) readEntity

--- a/src/Zinc-HTTP/ZnMultiPartFormDataEntity.class.st
+++ b/src/Zinc-HTTP/ZnMultiPartFormDataEntity.class.st
@@ -164,7 +164,7 @@ ZnMultiPartFormDataEntity >> printContentsOn: stream [
 	self parts printElementsOn: stream
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMultiPartFormDataEntity >> readBinaryFrom: stream [
 	"Switch to streaming implementation later on"
 
@@ -180,7 +180,7 @@ ZnMultiPartFormDataEntity >> readBinaryFrom: stream [
 	self parse: bytes boundary: self getBoundary asByteArray binary: true
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMultiPartFormDataEntity >> readFrom: stream [
 	"Switch to streaming implementation later on"
 

--- a/src/Zinc-HTTP/ZnNetworkingUtils.class.st
+++ b/src/Zinc-HTTP/ZnNetworkingUtils.class.st
@@ -221,7 +221,7 @@ ZnNetworkingUtils >> secureSocketStreamClass [
 		secureSocketStreamClass := Smalltalk globals at: #ZdcSecureSocketStream ifAbsent: [ nil ] ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnNetworkingUtils >> secureSocketStreamClass: anObject [
 	secureSocketStreamClass := anObject
 ]
@@ -296,7 +296,7 @@ ZnNetworkingUtils >> socketStreamClass [
 	^ socketStreamClass ifNil: [ socketStreamClass := SocketStream ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnNetworkingUtils >> socketStreamClass: anObject [
 	socketStreamClass := anObject
 ]
@@ -343,7 +343,7 @@ ZnNetworkingUtils >> sslSessionClass [
 		sslSessionClass := Smalltalk globals at: #ZdcPluginSSLSession ifAbsent: [ nil ] ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnNetworkingUtils >> sslSessionClass: anObject [
 	sslSessionClass := anObject
 ]

--- a/src/Zinc-HTTP/ZnRequest.class.st
+++ b/src/Zinc-HTTP/ZnRequest.class.st
@@ -165,7 +165,7 @@ ZnRequest >> method [
 	^ self requestLine method
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnRequest >> method: method [
 	self requestLine method: method
 ]
@@ -184,7 +184,7 @@ ZnRequest >> printOn: stream [
 	stream nextPut: $)
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnRequest >> readHeaderFrom: stream [
 	self requestLine: (ZnRequestLine readFrom: stream).
 	super readHeaderFrom: stream
@@ -271,7 +271,7 @@ ZnRequest >> url [
 	^ self uri
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnRequest >> url: url [
 	self requestLine uri: url.
 	self headers request: self url

--- a/src/Zinc-HTTP/ZnRequestLine.class.st
+++ b/src/Zinc-HTTP/ZnRequestLine.class.st
@@ -101,7 +101,7 @@ ZnRequestLine >> printOn: stream [
 	stream nextPut: $)
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnRequestLine >> readFrom: stream [
 	| line lineStream |
 	line := (ZnLineReader on: stream) nextLine.

--- a/src/Zinc-HTTP/ZnResponse.class.st
+++ b/src/Zinc-HTTP/ZnResponse.class.st
@@ -292,13 +292,13 @@ ZnResponse >> printOn: stream [
 	stream nextPut: $)
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnResponse >> readEntityFrom: stream [
 	(self isInformational or: [ self isNoContent or: [ self isNotModified ] ])
 		ifFalse: [ super readEntityFrom: stream ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnResponse >> readHeaderFrom: stream [
 	self statusLine: (ZnStatusLine readFrom: stream).
 	super readHeaderFrom: stream

--- a/src/Zinc-HTTP/ZnServerSession.class.st
+++ b/src/Zinc-HTTP/ZnServerSession.class.st
@@ -60,7 +60,7 @@ ZnServerSession >> id [
 	^ id
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnServerSession >> id: anObject [
 	id := anObject
 ]

--- a/src/Zinc-HTTP/ZnStatusLine.class.st
+++ b/src/Zinc-HTTP/ZnStatusLine.class.st
@@ -162,7 +162,7 @@ ZnStatusLine >> printOn: stream [
 	stream nextPut: $)
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnStatusLine >> readFrom: stream [
 	| line lineStream httpCode |
 	line := (ZnLineReader on: stream) nextLine.

--- a/src/Zinc-HTTP/ZnStreamingEntity.class.st
+++ b/src/Zinc-HTTP/ZnStreamingEntity.class.st
@@ -53,7 +53,7 @@ ZnStreamingEntity class >> readFrom: stream usingType: mimeType andLength: lengt
 		yourself
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnStreamingEntity >> close [
 	stream ifNotNil: [
 		stream close.
@@ -85,7 +85,7 @@ ZnStreamingEntity >> isEmpty [
 	^ false
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnStreamingEntity >> readFrom: readStream [
 
 	self contentLength

--- a/src/Zinc-HTTP/ZnStringEntity.class.st
+++ b/src/Zinc-HTTP/ZnStringEntity.class.st
@@ -170,7 +170,7 @@ ZnStringEntity >> printContentsOn: stream [
 			nextPutAll: self string ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnStringEntity >> readFrom: stream [
 	| buffer totalRead read readStream stringStream total |
 	total := self contentLength.

--- a/src/Zinc-HTTP/ZnValueDelegate.class.st
+++ b/src/Zinc-HTTP/ZnValueDelegate.class.st
@@ -31,7 +31,7 @@ ZnValueDelegate >> handleRequest: request [
 	^ object value: request
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnValueDelegate >> object: anObject [
 	object := anObject
 ]

--- a/src/Zinc-Resource-Meta-Core/ZnMultiValueDictionary.class.st
+++ b/src/Zinc-Resource-Meta-Core/ZnMultiValueDictionary.class.st
@@ -81,7 +81,7 @@ ZnMultiValueDictionary >> checkLimitForKey: aKey [
 		ifTrue: [ (ZnTooManyDictionaryEntries limit: self limit) signal ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMultiValueDictionary >> initialize: n [
 	super initialize: n.
 	limit := self class defaultLimit
@@ -106,12 +106,12 @@ ZnMultiValueDictionary >> limit [
 	^ limit
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMultiValueDictionary >> limit: numberOfEntries [
 	limit := numberOfEntries
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMultiValueDictionary >> unlimited [
 	self limit: nil
 ]

--- a/src/Zinc-Tests/ZnMessageBenchmark.class.st
+++ b/src/Zinc-Tests/ZnMessageBenchmark.class.st
@@ -77,7 +77,7 @@ ZnMessageBenchmark class >> responses [
 		binaryResponse8k binaryResponse64k binaryResponse256k )
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> asciiResponse256k [
 	message := ZnResponse ok:
 		(ZnEntity
@@ -85,7 +85,7 @@ ZnMessageBenchmark >> asciiResponse256k [
 			type: 'text/plain;charset=ascii')
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> asciiResponse64k [
 	message := ZnResponse ok:
 		(ZnEntity
@@ -93,7 +93,7 @@ ZnMessageBenchmark >> asciiResponse64k [
 			type: 'text/plain;charset=ascii')
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> asciiResponse8k [
 	message := ZnResponse ok:
 		(ZnEntity
@@ -111,17 +111,17 @@ ZnMessageBenchmark >> benchWrite [
 	^ [ self write ] bench
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> binaryResponse256k [
 	message := ZnResponse ok: (ZnEntity with: (self randomBytes: 256 * 1024))
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> binaryResponse64k [
 	message := ZnResponse ok: (ZnEntity with: (self randomBytes: 64 * 1024))
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> binaryResponse8k [
 	message := ZnResponse ok: (ZnEntity with: (self randomBytes: 8 * 1024))
 ]
@@ -136,7 +136,7 @@ ZnMessageBenchmark >> message [
 	^ message
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> postRequest [
 	message := (ZnRequest post: 'http://zn.stfx.eu/echo/one/two/three?param1=123&param2=foobar')
 		setAcceptEncodingGzip;
@@ -195,12 +195,12 @@ ZnMessageBenchmark >> read: count [
 	count timesRepeat: [ self read ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> simpleRequest [
 	message := ZnRequest get: 'http://zn.stfx.eu/dw-bench'
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> simpleResponse [
 	message := ZnResponse ok: (ZnEntity html: ZnDefaultServerDelegate new generateDWBench)
 ]
@@ -210,7 +210,7 @@ ZnMessageBenchmark >> sizeBuffer: size [
 	buffer := ByteArray new: size
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> standardRequest [
 	message := (ZnRequest get: 'http://zn.stfx.eu/echo/one/two/three?param1=123&param2=foobar')
 		setAcceptEncodingGzip;
@@ -218,32 +218,32 @@ ZnMessageBenchmark >> standardRequest [
 		yourself
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> textResponse256k [
 	message := ZnResponse ok: (ZnEntity with: (self randomUnicodeString: 256 * 1024))
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> textResponse64k [
 	message := ZnResponse ok: (ZnEntity with: (self randomUnicodeString: 64 * 1024))
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> textResponse8k [
 	message := ZnResponse ok: (ZnEntity with: (self randomUnicodeString: 8 * 1024))
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> textResponseWide256k [
 	message := ZnResponse ok: (ZnEntity with: (self randomUnicodeWideString: 256 * 1024))
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> textResponseWide64k [
 	message := ZnResponse ok: (ZnEntity with: (self randomUnicodeWideString: 64 * 1024))
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> textResponseWide8k [
 	message := ZnResponse ok: (ZnEntity with: (self randomUnicodeWideString: 8 * 1024))
 ]
@@ -261,13 +261,13 @@ ZnMessageBenchmark >> write: count [
 	count timesRepeat: [ self write ]
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> writeRepresentation [
 	representation := self write contents.
 	self sizeBuffer: representation size + 1024
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZnMessageBenchmark >> writeUsingGzipEncodingAndChunkingRepresentation [
 	message
 		setContentEncodingGzip;

--- a/src/Zodiac-Core/ZdcAbstractSocketStream.class.st
+++ b/src/Zodiac-Core/ZdcAbstractSocketStream.class.st
@@ -58,7 +58,7 @@ ZdcAbstractSocketStream >> bufferSize: numberOfBytes [
 	"Not yet implemented. See #initializeBuffers."
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcAbstractSocketStream >> close [
 	"Close the stream, flush if necessary"
 
@@ -111,7 +111,7 @@ ZdcAbstractSocketStream >> initialize [
 	self initializeBuffers
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcAbstractSocketStream >> initializeBuffers [
 	readBuffer := ZdcIOBuffer onByteArrayOfSize: 4096.
 	writeBuffer := ZdcIOBuffer onByteArrayOfSize: 4096
@@ -243,7 +243,7 @@ ZdcAbstractSocketStream >> nextPutAll: collection [
 		startingAt: 1
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcAbstractSocketStream >> on: object [
 	socket := object
 ]

--- a/src/Zodiac-Core/ZdcIOBuffer.class.st
+++ b/src/Zodiac-Core/ZdcIOBuffer.class.st
@@ -108,7 +108,7 @@ ZdcIOBuffer >> capacity [
 	^ self gapAtFront + self availableForWriting
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcIOBuffer >> close [
 	buffer ifNotNil: [
 		ZdcByteArrayManager current recycle: buffer.
@@ -231,7 +231,7 @@ ZdcIOBuffer >> nextPut: anObject [
 	^ anObject
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcIOBuffer >> on: sequenceableCollection [
 	buffer := sequenceableCollection.
 	self reset

--- a/src/Zodiac-Core/ZdcSecureSocketStream.class.st
+++ b/src/Zodiac-Core/ZdcSecureSocketStream.class.st
@@ -56,7 +56,7 @@ ZdcSecureSocketStream >> atEnd [
 	^ self isConnected not
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcSecureSocketStream >> close [
 	"Close the stream, flush if necessary.
 	Destory the SSLSession object."
@@ -152,7 +152,7 @@ ZdcSecureSocketStream >> initialize [
 	connecting := false
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcSecureSocketStream >> initializeBuffers [
 	"The maximum payload message length of a TLS record is 16Kb,
 	add a margin for the header and trailer."

--- a/src/Zodiac-Core/ZdcSimpleSocketStream.class.st
+++ b/src/Zodiac-Core/ZdcSimpleSocketStream.class.st
@@ -62,7 +62,7 @@ ZdcSimpleSocketStream >> atEnd [
 	^ self isConnected not
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcSimpleSocketStream >> connectTo: hostAddress port: portNumber [
 	"Connect our socket to hostAddress:portNumber.
 	Wait up to timeout for a connection"

--- a/src/Zodiac-Extra/ZdcSecureSMTPClient.class.st
+++ b/src/Zodiac-Extra/ZdcSecureSMTPClient.class.st
@@ -177,7 +177,7 @@ ZdcSecureSMTPClient >> setupStreamForStartTLS [
 	self startTLS
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcSecureSMTPClient >> skipRequireStartSSL [
 	"Normally, the server advertises is capabilities before the upgrade from plain to TLS.
 	It should list STARTTLS as one of its capabilities. If not, we signal an error.
@@ -205,12 +205,12 @@ ZdcSecureSMTPClient >> stream: aStream [
 	lineReader := ZnLineReader on: self stream
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcSecureSMTPClient >> useSSL [
 	variant := #ssl
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'initialization' }
 ZdcSecureSMTPClient >> useStartTLS [
 	variant := #startTLS
 ]


### PR DESCRIPTION
```
| pkgPrefix newClassPrefix env model |
env := RBBrowserEnvironment new 
			forClasses: (Smalltalk allClasses 
									select: [ :each | each protocolNames includes: #'initialize-release' ]).
			
model := (RBNamespace onEnvironment: env) name: 'MyModel'; yourself.
RBProtocolRegexTransformation new
	model: model;
	replace: 'initialize-release' with: 'initialization';
  execute.
```