### PR TITLE
Cleaning initialize protocol

### DIFF
--- a/src/Athens-Cairo/AthensCairoTransform.class.st
+++ b/src/Athens-Cairo/AthensCairoTransform.class.st
@@ -19,7 +19,7 @@ AthensCairoTransform class >> for: cairoCanvas [
 	^ self new canvas: cairoCanvas
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 AthensCairoTransform >> canvas: aCairoCanvas [
 	canvas := aCairoCanvas
 ]

--- a/src/Clap-Core/ClapPluggableStdio.class.st
+++ b/src/Clap-Core/ClapPluggableStdio.class.st
@@ -32,7 +32,7 @@ ClapPluggableStdio class >> onByteArraysWithInputBytes: aByteArray [
 		error: #[] writeStream
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 ClapPluggableStdio >> initializeInput: inputStream output: outputStream error: errorStream [
 	in := inputStream.
 	out := outputStream.

--- a/src/Collections-Streams/DecoratorStream.class.st
+++ b/src/Collections-Streams/DecoratorStream.class.st
@@ -49,7 +49,7 @@ DecoratorStream >> nextPut: anObject [
 	^anObject
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 DecoratorStream >> on: aStream [
 
 	self initialize.

--- a/src/Epicea/EpCompositeRefactoring.class.st
+++ b/src/Epicea/EpCompositeRefactoring.class.st
@@ -31,7 +31,7 @@ EpCompositeRefactoring >> childrenRefactorings [
 	^ childrenRefactorings
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 EpCompositeRefactoring >> initializeWith: someRefactorings [
 	self initialize.
 	childrenRefactorings := someRefactorings collect: [:each | each asEpiceaEvent]

--- a/src/Epicea/EpLogBrowserOperation.class.st
+++ b/src/Epicea/EpLogBrowserOperation.class.st
@@ -37,7 +37,7 @@ EpLogBrowserOperation >> entryReferences [
 	^ entryReferences
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 EpLogBrowserOperation >> initializeWith: aCollectionOfEntryReferences [
 	self initialize.
 	entryReferences := aCollectionOfEntryReferences

--- a/src/Epicea/EpMonticelloVersionsLoad.class.st
+++ b/src/Epicea/EpMonticelloVersionsLoad.class.st
@@ -52,7 +52,7 @@ EpMonticelloVersionsLoad >> hash [
 		bitXor: self versionNames hash
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 EpMonticelloVersionsLoad >> initializeWith: aCollectionOfVersionNames [
 	self initialize.
 	versionNames := aCollectionOfVersionNames

--- a/src/Fuel-Core/FLDecoder.class.st
+++ b/src/Fuel-Core/FLDecoder.class.st
@@ -81,7 +81,7 @@ FLDecoder >> initialize [
 	self initializeMigrations
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 FLDecoder >> initializeMigrations [
 	migrationsBySource := IdentityDictionary new.
 	migrationsByTarget := IdentityDictionary new.

--- a/src/Fuel-Core/FLMigration.class.st
+++ b/src/Fuel-Core/FLMigration.class.st
@@ -35,7 +35,7 @@ FLMigration >> applyTo: aVariablesMapping [
 			to: link value ]
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 FLMigration >> initializeClassNamed: aSymbol toClass: aClass variables: anArray [ 
 	
 	self initialize.

--- a/src/Monticello-Model/MCScriptDefinition.class.st
+++ b/src/Monticello-Model/MCScriptDefinition.class.st
@@ -59,7 +59,7 @@ MCScriptDefinition >> evaluate [
 	self class compiler evaluate: script
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 MCScriptDefinition >> initializeWithScript: aString packageName: packageString [
 	script := aString.
 	packageName := packageString

--- a/src/Monticello/MCAddition.class.st
+++ b/src/Monticello/MCAddition.class.st
@@ -37,7 +37,7 @@ MCAddition >> fromSource [
 	^ ''
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 MCAddition >> intializeWithDefinition: aDefinition [
 	definition := aDefinition
 ]

--- a/src/Monticello/MCModification.class.st
+++ b/src/Monticello/MCModification.class.st
@@ -38,7 +38,7 @@ MCModification >> fromSource [
 	^ obsoletion source
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 MCModification >> initializeWithBase: base target: target [
 	obsoletion := base.
 	modification := target.

--- a/src/Monticello/MCRemoval.class.st
+++ b/src/Monticello/MCRemoval.class.st
@@ -37,7 +37,7 @@ MCRemoval >> fromSource [
 	^ definition diffSource
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 MCRemoval >> intializeWithDefinition: aDefinition [
 	definition := aDefinition
 ]

--- a/src/Monticello/MCSnapshot.class.st
+++ b/src/Monticello/MCSnapshot.class.st
@@ -50,7 +50,7 @@ MCSnapshot >> hash [
 	^ definitions asArray hash
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 MCSnapshot >> initializeWithDefinitions: aCollection [
 	
 	definitions := aCollection.

--- a/src/Morphic-Widgets-Tree/LazyMorphTreeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/LazyMorphTreeMorph.class.st
@@ -13,7 +13,7 @@ Class {
 	#package : 'Morphic-Widgets-Tree'
 }
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 LazyMorphTreeMorph >> adjustSubmorphPositionsFrom: start to: stop [
 	"Fixed to not require setting item widths to 9999."
 
@@ -27,12 +27,12 @@ LazyMorphTreeMorph >> adjustSubmorphPositionsFrom: start to: stop [
 		p := p + (0@h)]
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 LazyMorphTreeMorph >> buildRowMorphsFrom: aNodeMorph [
 	self buildRowMorphsFrom: aNodeMorph increment: self lazyIncrement
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 LazyMorphTreeMorph >> buildRowMorphsFrom: aNodeMorph increment: anIncrement [
 
 	Cursor wait
@@ -43,7 +43,7 @@ LazyMorphTreeMorph >> buildRowMorphsFrom: aNodeMorph increment: anIncrement [
 			self buildRowMorphsFromIndex: idx to: max]
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 LazyMorphTreeMorph >> buildRowMorphsFromIndex: startIndex to: stopIndex [
 	| rowMorphsWidths subs |
 	subs := self allNodeMorphs.
@@ -62,12 +62,12 @@ LazyMorphTreeMorph >> indentingItemClass [
 	^ LazyMorphTreeNodeMorph
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 LazyMorphTreeMorph >> lazyIncrement [
 	^ lazyIncrement ifNil: [ lazyIncrement := 20 ]
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 LazyMorphTreeMorph >> lazyIncrement: anInteger [
 	lazyIncrement := anInteger
 ]

--- a/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeMorph.class.st
@@ -1445,7 +1445,7 @@ MorphTreeMorph >> registerRequestHandlers [
 	self model announcer when: MorphTreeChangeRequest send: #changeRequest: to: self
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 MorphTreeMorph >> release [
 
 	lineColorBlock := nil.

--- a/src/Morphic-Widgets-Tree/TreeChunkPagerMorph.class.st
+++ b/src/Morphic-Widgets-Tree/TreeChunkPagerMorph.class.st
@@ -26,7 +26,7 @@ TreeChunkPagerMorph >> atBottom: aBoolean [
 		ifTrue: [atBottom := aBoolean]
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 TreeChunkPagerMorph >> buildPanel [
 	| widgets nextButton lastPageButton searchEditor |
 	self removeAllMorphs.
@@ -180,7 +180,7 @@ TreeChunkPagerMorph >> onLastPage [
 	^ self lastIndex = self nodeList size
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 TreeChunkPagerMorph >> updateContents [
 	treeMorph vIsScrollable
 		ifFalse: [self atBottom: true].

--- a/src/Network-Kernel/Socket.class.st
+++ b/src/Network-Kernel/Socket.class.st
@@ -361,7 +361,7 @@ Socket >> accept [
 	^Socket acceptFrom: self
 ]
 
-{ #category : 'initialize - destroy' }
+{ #category : 'initialization' }
 Socket >> acceptFrom: aSocket [
 	"Initialize a new socket handle from an accept call"
 
@@ -409,7 +409,7 @@ Socket >> bindTo: aSocketAddress [
 
 ]
 
-{ #category : 'initialize - destroy' }
+{ #category : 'initialization' }
 Socket >> bindTo: anAddress port: aPort [
 	"Bind to the local port <aPort>, on the interface specified by <anAddress>
 	(`SocketAddress zero` specifies all interfaces).
@@ -418,7 +418,7 @@ Socket >> bindTo: anAddress port: aPort [
 	self primSocket: socketHandle bindTo: anAddress port: aPort
 ]
 
-{ #category : 'initialize - destroy' }
+{ #category : 'initialization' }
 Socket >> bindToPort: aPort [
 	"Bind to the local port <aPort>, often in order to listen for incoming connections."
 
@@ -548,7 +548,7 @@ Socket >> dataAvailable [
 	^ self primSocketReceiveDataAvailable: socketHandle
 ]
 
-{ #category : 'initialize - destroy' }
+{ #category : 'initialization' }
 Socket >> destroy [
 	"Destroy this socket. Its connection, if any, is aborted and its resources are freed.
 	Any processes waiting on the socket are freed immediately, but it is up to them to
@@ -685,7 +685,7 @@ Socket >> initialize: socketType family: addressFamily [
 		ifNotNil: [ self register ]
 ]
 
-{ #category : 'initialize - destroy' }
+{ #category : 'initialization' }
 Socket >> initializeNetwork [
 	self class initializeNetwork
 ]

--- a/src/OpalCompiler-Core/OCAbstractScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractScope.class.st
@@ -65,7 +65,7 @@ OCAbstractScope >> outerScope [
 	^ outerScope
 ]
 
-{ #category : 'initializing' }
+{ #category : 'initialization' }
 OCAbstractScope >> outerScope: aSemScope [
 
 	outerScope := aSemScope

--- a/src/Refactoring-Core/ReVariablesNotReadBeforeWrittenCondition.class.st
+++ b/src/Refactoring-Core/ReVariablesNotReadBeforeWrittenCondition.class.st
@@ -19,7 +19,7 @@ ReVariablesNotReadBeforeWrittenCondition >> check [
 		   in: subtree) isEmpty
 ]
 
-{ #category : 'initiali' }
+{ #category : 'initialization' }
 ReVariablesNotReadBeforeWrittenCondition >> variables: aCollection [ 
 	
 	variables := aCollection 

--- a/src/Regex-Core/RxsLookaround.class.st
+++ b/src/Regex-Core/RxsLookaround.class.st
@@ -21,12 +21,12 @@ RxsLookaround class >> with: anRsxPiece [
 		initializePiece: anRsxPiece
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 RxsLookaround >> beNegative [
 	positive := false
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 RxsLookaround >> bePositive [
 	positive := true
 ]
@@ -38,7 +38,7 @@ RxsLookaround >> dispatchTo: aBuilder [
 	^aBuilder syntaxLookaround: self
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 RxsLookaround >> initializePiece: anRsxPiece [
 	super initialize.
 	piece := anRsxPiece

--- a/src/Slot-Examples/BaseSlot.class.st
+++ b/src/Slot-Examples/BaseSlot.class.st
@@ -19,12 +19,12 @@ BaseSlot >> = other [
 	^ super = other and: [default = other default]
 ]
 
-{ #category : 'initalize' }
+{ #category : 'initialization' }
 BaseSlot >> default [
 	^ default
 ]
 
-{ #category : 'initalize' }
+{ #category : 'initialization' }
 BaseSlot >> default: anObject [
 	default := anObject
 ]
@@ -34,7 +34,7 @@ BaseSlot >> hash [
 	^super hash bitXor: default hash
 ]
 
-{ #category : 'initalize' }
+{ #category : 'initialization' }
 BaseSlot >> initialize: anObject [
 	self write: default copy to: anObject
 ]

--- a/src/Slot-Examples/RelationSet.class.st
+++ b/src/Slot-Examples/RelationSet.class.st
@@ -45,7 +45,7 @@ RelationSet >> do: aBlock [
 	set do: aBlock
 ]
 
-{ #category : 'initialize - release' }
+{ #category : 'initialization' }
 RelationSet >> initializeOwner: anObject slot: aToManyAssociation [
 
 	owner := anObject.


### PR DESCRIPTION
```
| pkgPrefix newClassPrefix env model prot|
prot := #'initialize - release'.
env := RBBrowserEnvironment new 
			forClasses: (Smalltalk allClasses 
									select: [ :each | each protocolNames includes: prot ]).
			
model := (RBNamespace onEnvironment: env) name: 'MyModel'; yourself.
RBProtocolRegexTransformation new
	model: model;
	replace: prot with: 'initialization';
  execute.
```

```
((Smalltalk allClasses reject: [:each | each isMeta ]) flatCollect: [ :each | each protocolNames ]) asSet select: [ :each | 'init*' match: each ]
```