### PR TITLE
Clean tools registration

### DIFF
--- a/src/BaselineOfDrTests/BaselineOfDrTests.class.st
+++ b/src/BaselineOfDrTests/BaselineOfDrTests.class.st
@@ -29,9 +29,8 @@ BaselineOfDrTests >> baseline: spec [
 
 { #category : 'actions' }
 BaselineOfDrTests >> postload: loader package: packageSpec [
-	
-	Smalltalk tools register: DrTests as: #testRunner.
 
+	self tools register: DrTests as: #testRunner
 ]
 
 { #category : 'baselines' }

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -264,17 +264,18 @@ BaselineOfIDE >> postload: loader package: packageSpec [
 	Initialized = true ifTrue: [ ^ self ].
 
 	"collect and process the standard tools registrations"
-	Smalltalk tools initDefaultToolSet.
+	self tools initDefaultToolSet.
 
 	EpMonitor current enable.
 
-	Smalltalk tools register: ExternalChangesBrowser as: #changeList.
-	Smalltalk tools register: FileList as: #fileList.
-	Smalltalk tools register: Finder as: #finder.
-	Smalltalk tools register: ProcessBrowser as: #processBrowser.
+	self tools
+		register: ExternalChangesBrowser as: #changeList;
+		register: StFileSystemPresenter as: #fileList;
+		register: Finder as: #finder;
+		register: ProcessBrowser as: #processBrowser.
 
 	(MorphicCoreUIManager readClassVariableNamed: #UIProcess) ifNotNil: [ :proc | proc terminate ].
-	MorphicCoreUIManager writeClassVariableNamed: #UIProcess   value: nil.
+	MorphicCoreUIManager writeClassVariableNamed: #UIProcess value: nil.
 
 	PolymorphSystemSettings desktopColor: Color veryVeryLightGray lighter.
 	SourceCodeFonts setSourceCodeFonts: 10.

--- a/src/Metacello-Base/BaselineOf.class.st
+++ b/src/Metacello-Base/BaselineOf.class.st
@@ -209,7 +209,7 @@ BaselineOf >> projectClass [
 { #category : 'queries' }
 BaselineOf >> tools [
 
-	^ self class environment tools
+	^ Smalltalk tools
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
- The tools are not in the environment but in the image
- Reduces references to `Smalltalk tools`
- Register new file browser as default