### PR TITLE
Rename `{Cons,New}Array` into `NewArray{Stack,Nil}Init`

### DIFF
--- a/src/Debugging-Core/SymbolicBytecodeBuilder.class.st
+++ b/src/Debugging-Core/SymbolicBytecodeBuilder.class.st
@@ -197,12 +197,6 @@ SymbolicBytecodeBuilder >> pushClosureTemps: numTemps [
 ]
 
 { #category : 'instruction decoding' }
-SymbolicBytecodeBuilder >> pushConsArrayWithElements: numElements [
-
-	self addBytecode: 'pop ', numElements printString, ' into (Array new: ', numElements printString, ')'
-]
-
-{ #category : 'instruction decoding' }
 SymbolicBytecodeBuilder >> pushConstant: obj [
 	"Print the Push Constant, obj, on Top Of Stack bytecode."
 
@@ -235,6 +229,12 @@ SymbolicBytecodeBuilder >> pushLiteralVariable: anAssociation [
 SymbolicBytecodeBuilder >> pushNewArrayOfSize: numElements [
  
 	self addBytecode: 'push: (Array new: ', numElements printString, ')'
+]
+
+{ #category : 'instruction decoding' }
+SymbolicBytecodeBuilder >> pushNewArrayStackInitWithElements: numElements [
+
+	self addBytecode: 'pop ', numElements printString, ' into (Array new: ', numElements printString, ')'
 ]
 
 { #category : 'instruction decoding' }

--- a/src/Flashback-Decompiler-Tests/FBIRBytecodeDecompilerTest.class.st
+++ b/src/Flashback-Decompiler-Tests/FBIRBytecodeDecompilerTest.class.st
@@ -259,9 +259,9 @@ FBIRBytecodeDecompilerTest >> testPopTop [
 ]
 
 { #category : 'tests' }
-FBIRBytecodeDecompilerTest >> testPushConsArray [
+FBIRBytecodeDecompilerTest >> testPushNewArrayStackInit [
 	| ir1 ir2 method |
-	ir1 := IRBuilderTest new testPushConsArray.
+	ir1 := IRBuilderTest new testPushNewArrayStackInit.
 	method := ir1 compiledMethod.
 	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.
@@ -270,9 +270,9 @@ FBIRBytecodeDecompilerTest >> testPushConsArray [
 ]
 
 { #category : 'tests' }
-FBIRBytecodeDecompilerTest >> testPushConsArray2 [
+FBIRBytecodeDecompilerTest >> testPushNewArrayStackInit2 [
 	| ir1 ir2 method |
-	ir1 := IRBuilderTest new testPushConsArray2.
+	ir1 := IRBuilderTest new testPushNewArrayStackInit2.
 	method := ir1 compiledMethod.
 	ir2 := FBIRBytecodeDecompiler new decompile: method.
 	self deny: ir2 compiledMethod identicalTo: method.

--- a/src/Flashback-Decompiler/FBDDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBDDecompiler.class.st
@@ -498,14 +498,6 @@ FBDDecompiler >> pushCleanClosure: aCompiledBlock [
 ]
 
 { #category : 'data flow instructions' }
-FBDDecompiler >> pushConsArrayWithElements: numElements [
-	| array |
-	array := Array new: numElements.
-	numElements to: 1 by: -1 do: [ :i | array at: i put: simulatedStack removeLast ].
-	simulatedStack addLast: (builder codeArray: array)
-]
-
-{ #category : 'data flow instructions' }
 FBDDecompiler >> pushConstant: value [
 	value isEmbeddedBlock ifTrue: [ ^self pushCleanClosure: value compiledBlock  ].
 	simulatedStack addLast: (builder codeLiteral: value)
@@ -541,6 +533,14 @@ FBDDecompiler >> pushNewArrayOfSize: numElements [
 	tempVect := self createNTemps: numElements.
 	currentSequence addTemporariesNamed: (tempVect collect: [ :e | e name ]).
 	simulatedStack addLast: tempVect
+]
+
+{ #category : 'data flow instructions' }
+FBDDecompiler >> pushNewArrayStackInitWithElements: numElements [
+	| array |
+	array := Array new: numElements.
+	numElements to: 1 by: -1 do: [ :i | array at: i put: simulatedStack removeLast ].
+	simulatedStack addLast: (builder codeArray: array)
 ]
 
 { #category : 'data flow instructions' }

--- a/src/Flashback-Decompiler/FBIRBytecodeDecompiler.class.st
+++ b/src/Flashback-Decompiler/FBIRBytecodeDecompiler.class.st
@@ -204,11 +204,6 @@ FBIRBytecodeDecompiler >> pushActiveContext [
 ]
 
 { #category : 'instruction decoding' }
-FBIRBytecodeDecompiler >> pushConsArrayWithElements: numElements [
-	irBuilder pushConsArray: numElements
-]
-
-{ #category : 'instruction decoding' }
 FBIRBytecodeDecompiler >> pushConstant: value [
 	irBuilder pushLiteral: value
 ]
@@ -232,6 +227,11 @@ FBIRBytecodeDecompiler >> pushLiteralVariable: assoc [
 { #category : 'instruction decoding' }
 FBIRBytecodeDecompiler >> pushNewArrayOfSize: size [
 	newTempVector := IRRemoteArray new size: size
+]
+
+{ #category : 'instruction decoding' }
+FBIRBytecodeDecompiler >> pushNewArrayStackInitWithElements: numElements [
+	irBuilder pushNewArrayStackInit: numElements
 ]
 
 { #category : 'instruction decoding' }

--- a/src/Kernel-BytecodeEncoders/BytecodeEncoder.class.st
+++ b/src/Kernel-BytecodeEncoders/BytecodeEncoder.class.st
@@ -151,11 +151,6 @@ BytecodeEncoder >> sizePop [
 ]
 
 { #category : 'opcode sizing' }
-BytecodeEncoder >> sizePushConsArray: numElements [
-	^self sizeOpcodeSelector: #genPushConsArray: withArguments: {numElements}
-]
-
-{ #category : 'opcode sizing' }
 BytecodeEncoder >> sizePushInstVar: instVarIndex [
 	^self sizeOpcodeSelector: #genPushInstVar: withArguments: {instVarIndex}
 ]
@@ -176,8 +171,13 @@ BytecodeEncoder >> sizePushLiteralVar: literalIndex [
 ]
 
 { #category : 'opcode sizing' }
-BytecodeEncoder >> sizePushNewArray: size [
-	^self sizeOpcodeSelector: #genPushNewArray: withArguments: {size}
+BytecodeEncoder >> sizePushNewArrayNilInit: size [
+	^self sizeOpcodeSelector: #genPushNewArrayNilInit: withArguments: {size}
+]
+
+{ #category : 'opcode sizing' }
+BytecodeEncoder >> sizePushNewArrayStackInit: numElements [
+	^self sizeOpcodeSelector: #genPushNewArrayStackInit: withArguments: {numElements}
 ]
 
 { #category : 'opcode sizing' }

--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -1034,17 +1034,6 @@ EncoderForSistaV1 >> genPushCharacter: aCharacterOrCode [
 		nextPut: (code bitAnd: 255)
 ]
 
-{ #category : 'bytecode generation' }
-EncoderForSistaV1 >> genPushConsArray: size [
-	(size < 0 or: [size > 127]) ifTrue:
-		[^self outOfRangeError: 'size' index: size range: 0 to: 127].
-	"231		11100111	jkkkkkkk	Push (Array new: kkkkkkk) (j = 0)
-									&	Pop kkkkkkk elements into: (Array new: kkkkkkk) (j = 1)"
-	stream
-		nextPut: 231;
-		nextPut: size + 128
-]
-
 { #category : 'extended bytecode generation' }
 EncoderForSistaV1 >> genPushFullClosure: compiledBlockLiteralIndex numCopied: numCopied receiverOnStack: receiverOnStack outerContextNeeded: outerContextNeeded [
 	"*	249		11111001 	xxxxxxxx	siyyyyyy	push Closure Compiled block literal index xxxxxxxx (+ Extend A * 256) numCopied yyyyyy receiverOnStack: s = 1 ignoreOuterContext: i = 1"
@@ -1155,7 +1144,7 @@ EncoderForSistaV1 >> genPushLiteralVar: literalIndex [
 ]
 
 { #category : 'bytecode generation' }
-EncoderForSistaV1 >> genPushNewArray: size [
+EncoderForSistaV1 >> genPushNewArrayNilInit: size [
 	(size < 0 or: [size > 127]) ifTrue:
 		[^self outOfRangeError: 'size' index: size range: 0 to: 127].
 	"231		11100111	jkkkkkkk	Push (Array new: kkkkkkk) (j = 0)
@@ -1163,6 +1152,17 @@ EncoderForSistaV1 >> genPushNewArray: size [
 	stream
 		nextPut: 231;
 		nextPut: size
+]
+
+{ #category : 'bytecode generation' }
+EncoderForSistaV1 >> genPushNewArrayStackInit: size [
+	(size < 0 or: [size > 127]) ifTrue:
+		[^self outOfRangeError: 'size' index: size range: 0 to: 127].
+	"231		11100111	jkkkkkkk	Push (Array new: kkkkkkk) (j = 0)
+									&	Pop kkkkkkk elements into: (Array new: kkkkkkk) (j = 1)"
+	stream
+		nextPut: 231;
+		nextPut: size + 128
 ]
 
 { #category : 'bytecode generation' }

--- a/src/Kernel-CodeModel/Context.class.st
+++ b/src/Kernel-CodeModel/Context.class.st
@@ -1516,15 +1516,6 @@ Context >> pushClosureTemps: numTemps [
 ]
 
 { #category : 'instruction decoding' }
-Context >> pushConsArrayWithElements: numElements [
-	| array |
-	array := Array new: numElements.
-	numElements to: 1 by: -1 do: [ :i |
-		array at: i put: self pop ].
-	self push: array
-]
-
-{ #category : 'instruction decoding' }
 Context >> pushConstant: value [
 	"Simulate the action of bytecode that pushes the constant, value, on the
 	top of the stack."
@@ -1557,6 +1548,15 @@ Context >> pushLiteralVariable: value [
 { #category : 'instruction decoding' }
 Context >> pushNewArrayOfSize: arraySize [
 	self push: (Array new: arraySize)
+]
+
+{ #category : 'instruction decoding' }
+Context >> pushNewArrayStackInitWithElements: numElements [
+	| array |
+	array := Array new: numElements.
+	numElements to: 1 by: -1 do: [ :i |
+		array at: i put: self pop ].
+	self push: array
 ]
 
 { #category : 'instruction decoding' }

--- a/src/Kernel-CodeModel/InstructionStream.class.st
+++ b/src/Kernel-CodeModel/InstructionStream.class.st
@@ -77,7 +77,7 @@ InstructionStream >> interpretNext2ByteSistaV1Instruction: bytecode for: client 
 		bytecode = 231 ifTrue:
 			[^byte < 128
 				ifTrue: [client pushNewArrayOfSize: byte]
-				ifFalse: [client pushConsArrayWithElements: byte - 128]].
+				ifFalse: [client pushNewArrayStackInitWithElements: byte - 128]].
 		bytecode = 232 ifTrue:
 			[^client pushConstant: (extB bitShift: 8) + byte].
 		^client pushConstant: (Character value: (extB bitShift: 8) + byte)].

--- a/src/Kernel/InstructionClient.class.st
+++ b/src/Kernel/InstructionClient.class.st
@@ -149,11 +149,6 @@ InstructionClient >> pushClosureTemps: numTemps [
 ]
 
 { #category : 'instruction decoding' }
-InstructionClient >> pushConsArrayWithElements: numElements [
-	"Push Cons Array of size numElements popping numElements items from the stack into the array bytecode."
-]
-
-{ #category : 'instruction decoding' }
 InstructionClient >> pushConstant: value [
 	"Push Constant, value, on Top Of Stack bytecode."
 ]
@@ -171,6 +166,11 @@ InstructionClient >> pushLiteralVariable: anAssociation [
 { #category : 'instruction decoding' }
 InstructionClient >> pushNewArrayOfSize: numElements [
 	"Push New Array of size numElements bytecode."
+]
+
+{ #category : 'instruction decoding' }
+InstructionClient >> pushNewArrayStackInitWithElements: numElements [
+	"Push new Array of size numElements and fill it by popping numElements items from the stack into the array bytecode."
 ]
 
 { #category : 'instruction decoding' }

--- a/src/OpalCompiler-Core/IRBuilder.class.st
+++ b/src/OpalCompiler-Core/IRBuilder.class.st
@@ -306,12 +306,6 @@ IRBuilder >> properties: aDict [
 ]
 
 { #category : 'instructions' }
-IRBuilder >> pushConsArray: size [
-
-	self add: (IRInstruction pushConsArray: size)
-]
-
-{ #category : 'instructions' }
 IRBuilder >> pushDup [
 
 	self add: IRInstruction pushDup
@@ -348,9 +342,15 @@ IRBuilder >> pushLiteralVariable: object [
 ]
 
 { #category : 'instructions' }
-IRBuilder >> pushNewArray: size [
+IRBuilder >> pushNewArrayNilInit: size [
 
-	self add: (IRInstruction pushNewArray: size)
+	self add: (IRInstruction pushNewArrayNilInit: size)
+]
+
+{ #category : 'instructions' }
+IRBuilder >> pushNewArrayStackInit: size [
+
+	self add: (IRInstruction pushNewArrayStackInit: size)
 ]
 
 { #category : 'instructions' }

--- a/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/IRBytecodeGenerator.class.st
@@ -491,13 +491,6 @@ IRBytecodeGenerator >> properties: propDict [
 ]
 
 { #category : 'instructions' }
-IRBytecodeGenerator >> pushConsArray: size [
-	stack push.
-	stack pop: size.
-	encoder genPushConsArray: size
-]
-
-{ #category : 'instructions' }
 IRBytecodeGenerator >> pushDup [
 	stack push.
 	encoder genDup
@@ -540,9 +533,16 @@ IRBytecodeGenerator >> pushLiteralVariable: object [
 ]
 
 { #category : 'instructions' }
-IRBytecodeGenerator >> pushNewArray: size [
+IRBytecodeGenerator >> pushNewArrayNilInit: size [
 	stack push.
-	encoder genPushNewArray: size
+	encoder genPushNewArrayNilInit: size
+]
+
+{ #category : 'instructions' }
+IRBytecodeGenerator >> pushNewArrayStackInit: size [
+	stack push.
+	stack pop: size.
+	encoder genPushNewArrayStackInit: size
 ]
 
 { #category : 'instructions' }

--- a/src/OpalCompiler-Core/IRInstruction.class.st
+++ b/src/OpalCompiler-Core/IRInstruction.class.st
@@ -50,14 +50,6 @@ IRInstruction class >> popTop [
 ]
 
 { #category : 'instance creation' }
-IRInstruction class >> pushConsArray: aSize [
-	^IRPushArray new
-		size: aSize;
-		cons: true;
-		yourself
-]
-
-{ #category : 'instance creation' }
 IRInstruction class >> pushDup [
 
 	^ IRPushDup new
@@ -104,11 +96,19 @@ IRInstruction class >> pushLiteralVariable: object [
 ]
 
 { #category : 'instance creation' }
-IRInstruction class >> pushNewArray: aSize [
+IRInstruction class >> pushNewArrayNilInit: aSize [
 
 	^IRPushArray new
 		size: aSize;
-		cons: false;
+		initsFromStack: false;
+		yourself
+]
+
+{ #category : 'instance creation' }
+IRInstruction class >> pushNewArrayStackInit: aSize [
+	^IRPushArray new
+		size: aSize;
+		initsFromStack: true;
 		yourself
 ]
 

--- a/src/OpalCompiler-Core/IRPrinter.class.st
+++ b/src/OpalCompiler-Core/IRPrinter.class.st
@@ -100,11 +100,11 @@ IRPrinter >> visitPopIntoTemp: tmp [
 { #category : 'visiting' }
 IRPrinter >> visitPushArray: array [
 
-	array cons
+	array initsFromStack
 		ifTrue: [
-			stream nextPutAll: 'pushConsArray: ' ]
+			stream nextPutAll: 'pushNewArrayStackInit: ' ]
 		ifFalse: [
-			stream nextPutAll: 'pushNewArray: ' ].
+			stream nextPutAll: 'pushNewArrayNilInit: ' ].
 	array size printOn: stream
 ]
 

--- a/src/OpalCompiler-Core/IRPushArray.class.st
+++ b/src/OpalCompiler-Core/IRPushArray.class.st
@@ -8,7 +8,7 @@ Class {
 	#superclass : 'IRInstruction',
 	#instVars : [
 		'size',
-		'cons'
+		'initsFromStack'
 	],
 	#category : 'OpalCompiler-Core-IR-Nodes',
 	#package : 'OpalCompiler-Core',
@@ -20,20 +20,20 @@ IRPushArray >> accept: aVisitor [
 	^ aVisitor visitPushArray: self
 ]
 
-{ #category : 'accessing' }
-IRPushArray >> cons [
-	^ cons
-]
-
-{ #category : 'accessing' }
-IRPushArray >> cons: aBool [
-	cons := aBool
-]
-
 { #category : 'initialization' }
 IRPushArray >> initialize [
 	size := 0.
-	cons := false
+	initsFromStack := false
+]
+
+{ #category : 'accessing' }
+IRPushArray >> initsFromStack [
+	^ initsFromStack
+]
+
+{ #category : 'accessing' }
+IRPushArray >> initsFromStack: aBool [
+	initsFromStack := aBool
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Core/IRTranslator.class.st
+++ b/src/OpalCompiler-Core/IRTranslator.class.st
@@ -179,11 +179,11 @@ IRTranslator >> visitPopIntoTemp: tmp [
 { #category : 'visiting' }
 IRTranslator >> visitPushArray: array [
 
-	array cons
+	array initsFromStack
 		ifTrue: [
-			gen pushConsArray: array size ]
+			gen pushNewArrayStackInit: array size ]
 		ifFalse: [
-			gen pushNewArray: array size ]
+			gen pushNewArrayNilInit: array size ]
 ]
 
 { #category : 'visiting' }
@@ -328,6 +328,6 @@ IRTranslator >> visitStoreTemp: tmp [
 IRTranslator >> visitTempVector: tempVector [
 
 	tempVectorStack push: tempVector.
-	gen pushNewArray: tempVector vars size.
+	gen pushNewArrayNilInit: tempVector vars size.
 	gen storePopTemp: (self currentScope indexForVarNamed: tempVector name)
 ]

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -512,7 +512,7 @@ OCASTTranslator >> visitArrayNode: anArrayNode [
 
 	elementNodes := anArrayNode children.
 	elementNodes do: [:node | self visitNode: node].
-	methodBuilder pushConsArray: elementNodes size
+	methodBuilder pushNewArrayStackInit: elementNodes size
 ]
 
 { #category : 'visitor - double dispatching' }

--- a/src/OpalCompiler-Tests/IRBuilderTest.class.st
+++ b/src/OpalCompiler-Tests/IRBuilderTest.class.st
@@ -315,11 +315,30 @@ IRBuilderTest >> testPopTop [
 ]
 
 { #category : 'tests' }
-IRBuilderTest >> testPushConsArray [
+IRBuilderTest >> testPushNewArrayNilInit [
+
+	| iRMethod aCompiledMethod receiver |
+	iRMethod := IRBuilder new
+
+		pushNewArrayNilInit: 1;
+		returnTop;
+		ir.
+
+	aCompiledMethod := iRMethod compiledMethod.
+
+	receiver :=  (5@8).
+
+	self assert: (aCompiledMethod isKindOf: CompiledMethod).
+	self assert: ((aCompiledMethod valueWithReceiver: receiver) first isNil).
+	^iRMethod
+]
+
+{ #category : 'tests' }
+IRBuilderTest >> testPushNewArrayStackInit [
 	| iRMethod aCompiledMethod receiver |
 	iRMethod := IRBuilder new
 		pushReceiver;
-		pushConsArray: 1;
+		pushNewArrayStackInit: 1;
 		returnTop;
 		ir.
 
@@ -333,11 +352,11 @@ IRBuilderTest >> testPushConsArray [
 ]
 
 { #category : 'tests' }
-IRBuilderTest >> testPushConsArray2 [
+IRBuilderTest >> testPushNewArrayStackInit2 [
 	| iRMethod aCompiledMethod receiver |
 	iRMethod := IRBuilder new
 		pushLiteral: 'hi!';
-		pushConsArray: 1;
+		pushNewArrayStackInit: 1;
 		returnTop;
 		ir.
 
@@ -348,25 +367,6 @@ IRBuilderTest >> testPushConsArray2 [
 	self assert: (aCompiledMethod isKindOf: CompiledMethod).
 	self assert: (aCompiledMethod valueWithReceiver: receiver) equals: #('hi!').
 	^ iRMethod
-]
-
-{ #category : 'tests' }
-IRBuilderTest >> testPushNewArray [
-
-	| iRMethod aCompiledMethod receiver |
-	iRMethod := IRBuilder new
-
-		pushNewArray: 1;
-		returnTop;
-		ir.
-
-	aCompiledMethod := iRMethod compiledMethod.
-
-	receiver :=  (5@8).
-
-	self assert: (aCompiledMethod isKindOf: CompiledMethod).
-	self assert: ((aCompiledMethod valueWithReceiver: receiver) first isNil).
-	^iRMethod
 ]
 
 { #category : 'tests' }

--- a/src/OpalCompiler-Tests/IRPrinterTest.class.st
+++ b/src/OpalCompiler-Tests/IRPrinterTest.class.st
@@ -144,30 +144,30 @@ returnReceiver
 ]
 
 { #category : 'tests' }
-IRPrinterTest >> testPushConsArray [
+IRPrinterTest >> testPushNewArrayNilInit [
 	| ir |
-	ir := IRBuilderTest new testPushConsArray.
+	ir := IRBuilderTest new testPushNewArrayNilInit.
+	self
+		assert: ir longPrintString
+		equals:
+			'
+label: 1
+pushNewArrayNilInit: 1
+returnTop
+'
+]
+
+{ #category : 'tests' }
+IRPrinterTest >> testPushNewArrayStackInit [
+	| ir |
+	ir := IRBuilderTest new testPushNewArrayStackInit.
 	self
 		assert: ir longPrintString
 		equals:
 			'
 label: 1
 pushReceiver
-pushConsArray: 1
-returnTop
-'
-]
-
-{ #category : 'tests' }
-IRPrinterTest >> testPushNewArray [
-	| ir |
-	ir := IRBuilderTest new testPushNewArray.
-	self
-		assert: ir longPrintString
-		equals:
-			'
-label: 1
-pushNewArray: 1
+pushNewArrayStackInit: 1
 returnTop
 '
 ]

--- a/src/OpalCompiler-Tests/IRVisitorTest.class.st
+++ b/src/OpalCompiler-Tests/IRVisitorTest.class.st
@@ -68,16 +68,16 @@ IRVisitorTest >> testPopTop [
 ]
 
 { #category : 'tests' }
-IRVisitorTest >> testPushConsArray [
+IRVisitorTest >> testPushNewArrayNilInit [
 	| ir |
-	ir := IRBuilderTest new testPushConsArray.
+	ir := IRBuilderTest new testPushNewArrayNilInit.
 	self interpret: ir
 ]
 
 { #category : 'tests' }
-IRVisitorTest >> testPushNewArray [
+IRVisitorTest >> testPushNewArrayStackInit [
 	| ir |
-	ir := IRBuilderTest new testPushNewArray.
+	ir := IRBuilderTest new testPushNewArrayStackInit.
 	self interpret: ir
 ]
 

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -81,7 +81,7 @@ RFASTTranslator >> visitArrayNode: anArrayNode [
 	self emitMetaLinkBefore: anArrayNode.
 	anArrayNode hasMetalinkInstead
 		ifTrue: [ self emitMetaLinkInstead: anArrayNode ]
-		ifFalse: [ methodBuilder pushConsArray: elementNodes size ].
+		ifFalse: [ methodBuilder pushNewArrayStackInit: elementNodes size ].
 	self emitMetaLinkAfterNoEnsure: anArrayNode
 ]
 

--- a/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
+++ b/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
@@ -117,7 +117,7 @@ TFCalloutMethodBuilder >> generateFFICallout: builder spec: functionSpec ffiLibr
 			each resolvedType tfExternalTypeWithArity emitMarshallToPrimitive: builder ].
 
 	"create the array"
-	builder pushConsArray: functionSpec arguments size.
+	builder pushNewArrayStackInit: functionSpec arguments size.
 	builder addTemp: #argumentsArray.
 	builder storeTemp: #argumentsArray.
 

--- a/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
+++ b/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
@@ -114,7 +114,7 @@ FFICalloutMethodBuilder >> generateFFICallout: builder spec: functionSpec ffiLib
 	"iterate arguments in order (in the function) to create the function call"
 	functionSpec arguments do: [ :each | each emitArgument: builder context: sender inCallout: self requestor ].
 	"create the array"
-	builder pushConsArray: functionSpec arguments size.
+	builder pushNewArrayStackInit: functionSpec arguments size.
 	"send call and store into result"
 	builder send: #invokeWithArguments:.
 	functionSpec arguments do: [ :each | each emitReturnArgument: builder context: sender ].


### PR DESCRIPTION
This breaks all `InstructionClient` implementations.

Done at the dojo with @PalumboN / @jordanmontt / @FedeLoch / (don't remember the handles for the rest, sorry 😢)