### PR TITLE
Fixes CI to have it green again on unix

### DIFF
--- a/src/Refactoring-Transformations/ReCompositeExtractSetUpMethodRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReCompositeExtractSetUpMethodRefactoring.class.st
@@ -66,15 +66,6 @@ ReCompositeExtractSetUpMethodRefactoring >> extractSetUpCode: sourceCodeString f
 	newSelector := #setUp
 ]
 
-{ #category : 'instance creation' }
-ReCompositeExtractSetUpMethodRefactoring >> extractSetUpInterval: anInterval fromMethod: aSelector inClass: aClassName [ 
-	
-	class := self model classNamed: aClassName.
-	selector := aSelector.
-	sourceCode := self getSourceFromInterval: anInterval.
-	newSelector := #setUp
-]
-
 { #category : 'storing' }
 ReCompositeExtractSetUpMethodRefactoring >> storeOn: aStream [
 

--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -60,15 +60,6 @@ SystemDependenciesTest >> knownCompilerDependencies [
 ]
 
 { #category : 'known dependencies' }
-SystemDependenciesTest >> knownIDEDependencies [
-	"ideally this list should be empty"
-
-	^ #( 'Spec2-CommonWidgets' #'Calypso-SystemPlugins-Traits-Queries-Tests-PWithTraits'
-	     #'AI-Algorithms-Graph' 'DebugPoints' 'Microdown' 'Microdown-RichTextComposer'
-	     #'NewTools-Scopes' #'Calypso-NavigationModel'  #'NewTools-Scopes-Editor' )
-]
-
-{ #category : 'known dependencies' }
 SystemDependenciesTest >> knownKernelDependencies [
 	"ideally this list should be empty"
 
@@ -238,77 +229,6 @@ SystemDependenciesTest >> testExternalFileSystemDependencies [
 		                , BaselineOfPharoBootstrap fileSystemPackageNames.
 
 	self assertEmpty: dependencies
-]
-
-{ #category : 'tests' }
-SystemDependenciesTest >> testExternalIDEDependencies [
-	| dependencies packages |
-	packages := self metacelloPackageNames , self tonelCorePackageNames , { BaselineOfPharoBootstrap name. BaselineOfMonticello name. BaselineOfMetacello name}.
-
-	{BaselineOfAthens.
-	BaselineOfBasicTools.
-	BaselineOfDisplay.
-	BaselineOfFlashback.
-	BaselineOfIDE.
-	BaselineOfMenuRegistration.
-	BaselineOfMorphic.
-	BaselineOfMorphicCore.
-	BaselineOfSlot.
-	BaselineOfSUnit.
-	BaselineOfShift.
-	BaselineOfTraits.
-	BaselineOfUI.
-	BaselineOfUnifiedFFI.
-	BaselineOfClassAnnotation.
-	BaselineOfSystemCommands.
-	BaselineOfClassParser.
-	BaselineOfReferenceFinder.
-	BaselineOfSortFunctions.
-	BaselineOfGeneralTests.
-	BaselineOfMisc.
-	BaselineOfEpicea.
-	BaselineOfRefactoring.
-	BaselineOfOSWindow.
-	BaselineOfQA.
-	BaselineOfManifest.
-	BaselineOfDependencyAnalyzer.
-	BaselineOfQualityAssistant.
-	BaselineOfReflectivity.
-	BaselineOfFuzzyMatcher.
-	BaselineOfZodiac.
-	BaselineOfReflectionMirrors.
-	BaselineOfShout.
-	BaselineOfKernelTests.
-	BaselineOfHeuristicCompletion.
-	 } do: [ :baseline | packages := packages , baseline withAllPackageNames ].
-
-	packages := packages ,  { BaselineOfFreeType name }, (self packagesOfGroupNamed: 'ui' on: BaselineOfFreeType ).
-	packages := packages ,  { BaselineOfKeymapping name }, (self packagesOfGroupNamed: 'ui' on: BaselineOfKeymapping ).
-	packages := packages ,  { BaselineOfNewValueHolder name }, (self packagesOfGroupNamed: 'core' on: BaselineOfNewValueHolder ).
-	packages := packages ,  { BaselineOfSpecCore name }, (self packagesOfGroupNamed: 'default' on: BaselineOfSpecCore ).
-	packages := packages ,  { BaselineOfSpec2 name }, (self packagesOfGroupNamed: 'default' on: BaselineOfSpec2 ).
-	packages := packages ,  { BaselineOfNewTools name }, (self packagesOfGroupNamed: 'Methods' on: BaselineOfNewTools ).
-	packages := packages ,  { BaselineOfCommander name} , (self packagesOfGroupNamed: 'default' on: BaselineOfCommander).
-	packages := packages ,  { BaselineOfCommander2 name} , (self packagesOfGroupNamed: 'default' on: BaselineOfCommander2).
-	packages := packages ,  { BaselineOfIceberg name. BaselineOfLibGit name. BaselineOfCalypso name}.
-
-	packages := packages ,  (self packagesOfGroupNamed: 'FullEnvironment' on: BaselineOfCalypso ).
-	packages := packages ,  (self packagesOfGroupNamed: 'SystemBrowser' on: BaselineOfCalypso ).
-	packages := packages ,  (self packagesOfGroupNamed: 'CoreBrowser' on: BaselineOfCalypso ).
-	packages := packages ,  (self packagesOfGroupNamed: 'CoreEnvironment' on: BaselineOfCalypso ).
-	packages := packages ,  #('Calypso-SystemTools-Core').
-	packages := packages ,  (BaselineOfMetacello packagesOfGroupNamed: 'Tests').
-
-	packages := packages ,  (self packagesOfGroupNamed: 'default' on: BaselineOfIceberg ).
-	packages := packages ,  (self packagesOfGroupNamed: 'default' on: BaselineOfLibGit ).
-	packages := packages , {BaselineOfThreadedFFI name} ,
-		(self packagesOfGroupNamed: 'default' on: BaselineOfThreadedFFI ).
-	packages := packages ,  #('TaskIt').
-	packages := packages , { BaselineOfFuel name } , (BaselineOfFuel packagesOfGroupNamed: #Core).
-	packages := packages ,  { BaselineOfNewTools name }, (self packagesOfGroupNamed: 'CritiqueBrowser' on: BaselineOfNewTools ).
-
-	dependencies := self externalDependendiesOf: packages.
-	self assertCollection: dependencies hasSameElements: self knownIDEDependencies
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
- Remove method calling an unimplemented method because it's dead code
- Remove testExternalIDEDependencies because the IDE already has almost all dependencies and the content of the test is broken already. We are missing a lot of dependencies