### PR TITLE
Space keypress in Rubric does not ignore previous dead characters

### DIFF
--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -2434,12 +2434,7 @@ RubTextEditor >> space: aKeyboardEvent [
 	"Append a space to the stream of characters and commit the undo/redo transaction.
 	This allows to manage undo/redo at a per-word granularity"
 
-	"We are consuming the space keydown event, do not send a keypress for it"
-	aKeyboardEvent supressNextKeyPress:  true.
-
 	self closeTypeIn.
-	self addString: String space.
-	self unselect.
 	^false
 ]
 

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -2431,8 +2431,7 @@ RubTextEditor >> shouldEscapeCharacter: aCharacter [
 
 { #category : 'typing/selecting keys' }
 RubTextEditor >> space: aKeyboardEvent [
-	"Append a space to the stream of characters and commit the undo/redo transaction.
-	This allows to manage undo/redo at a per-word granularity"
+	"Close the undo/redo transaction. This undo/redo at a per-word granularity"
 
 	self closeTypeIn.
 	^false


### PR DESCRIPTION
fixes #17338