### PR TITLE
Backport addition of discardBuffer to ZnBufferedReadStream>>#readInto:startingAt:count in the case that the buffer is bypassed to Pharo 11

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
@@ -261,15 +261,14 @@ ZnBufferedReadStream >> peekFor: object [
 
 { #category : #accessing }
 ZnBufferedReadStream >> position [
-
 	"If the buffer advanced, we need to check the original stream position, minus what we have read.
 	The -1 is because the buffer is base 1"
+
 	^ stream position - limit + position - 1
 ]
 
 { #category : #accessing }
 ZnBufferedReadStream >> position: anInteger [
-
 	| bufferEnd bufferStart |
 	bufferEnd := stream position.
 	bufferStart := bufferEnd - limit.
@@ -277,8 +276,7 @@ ZnBufferedReadStream >> position: anInteger [
 		ifTrue: [ position := anInteger - bufferStart + 1 ]
 		ifFalse: [
 			"We reset the buffer and update the position in the underlying stream"
-			limit := 0.
-			position := 1.
+			self discardBuffer.
 			stream position: anInteger ]
 ]
 
@@ -301,7 +299,7 @@ ZnBufferedReadStream >> readFromBufferInto: collection startingAt: offset count:
 	^ read
 ]
 
-{ #category : #accessing }
+{ #category : #private }
 ZnBufferedReadStream >> readInto: collection startingAt: offset count: requestedCount [
 	"Read requestedCount elements into collection starting at offset,
 	answering the number of elements read, there could be fewer elements available."
@@ -315,12 +313,13 @@ ZnBufferedReadStream >> readInto: collection startingAt: offset count: requested
 			| newOffset |
 			newOffset := offset + countRead.
 			(self shouldBufferReadOfCount: countYetToRead)
-				ifTrue: [ self nextBuffer.
+				ifTrue: [
+					self nextBuffer.
 					limit > 0
-						ifTrue:
-							[ countRead := countRead + (self readInto: collection startingAt: newOffset count: countYetToRead) ] ]
-				ifFalse:
-					[ countRead := countRead + (stream readInto: collection startingAt: newOffset count: countYetToRead) ] ].
+						ifTrue: [ countRead := countRead + (self readInto: collection startingAt: newOffset count: countYetToRead) ] ]
+				ifFalse: [
+					self discardBuffer.
+					countRead := countRead + (stream readInto: collection startingAt: newOffset count: countYetToRead) ] ].
 	^ countRead
 ]
 

--- a/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnBufferedReadStreamTest.class.st
@@ -34,6 +34,29 @@ ZnBufferedReadStreamTest >> testPeek [
 ]
 
 { #category : #tests }
+ZnBufferedReadStreamTest >> testPositioning [
+	| byteArray stream |
+
+	byteArray := (1 to: 255) as: ByteArray.
+
+	stream := ZnBufferedReadStream on: byteArray readStream.
+	stream sizeBuffer: 32.
+
+	self assert: stream position equals: 0.
+	self assert: stream next equals: 1.
+	self assert: stream position equals: 1.
+
+	self assert: (stream next: 100) equals: ((2 to: 101) as: ByteArray).
+	self assert: stream position equals: 101.
+
+	stream position: 99.
+	self assert: stream position equals: 99.
+	
+	self assert: stream next equals: 100.
+	self assert: stream position equals: 100
+]
+
+{ #category : #tests }
 ZnBufferedReadStreamTest >> testReadInto [
 	| stream buffer count |
 	stream := ZnBufferedReadStream on: '0123456789' readStream.


### PR DESCRIPTION
This pull request backports the changes of pull request #17055 to Pharo 11.

Note that the most recent build (730), as well as the three previous ones (727–729), of the [Jenkins ‘Pharo11’ job](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/Pharo11/) failed at the ‘Full Image-64’ stage.