### PR TITLE
17409-Improving-FFI-Marshalling-of-Constants

### DIFF
--- a/src/ThreadedFFI-UFFI-Tests/BenchTFFI.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/BenchTFFI.class.st
@@ -21,6 +21,14 @@ BenchTFFI >> doCallWith: aFloat another: aDouble [
 	^ self ffiCall: #(float sumAFloatAndADouble(float aFloat, double aDouble))
 ]
 
+{ #category : 'private' }
+BenchTFFI >> doSumWithPointers [
+
+	^ self ffiCall: #(int64 sum_int64_t(void* 1, void* 0))
+
+	
+]
+
 { #category : 'accessing' }
 BenchTFFI >> ffiLibrary [
 

--- a/src/ThreadedFFI-UFFI-Tests/BenchTFFISameThread.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/BenchTFFISameThread.class.st
@@ -15,6 +15,30 @@ BenchTFFISameThread >> doCallWith: aFloat another: aDouble [
 	^ self ffiCall: #(float sumAFloatAndADouble(float aFloat, double aDouble))
 ]
 
+{ #category : 'private' }
+BenchTFFISameThread >> doSumWithConstants [
+
+	^ self ffiCall: #(int64 sum_int64_t(int 1, int 2))
+
+	
+]
+
+{ #category : 'private' }
+BenchTFFISameThread >> doSumWithPointers [
+
+	^ self ffiCall: #(int64 sum_int64_t(void* 1, void* 0))
+
+	
+]
+
+{ #category : 'private' }
+BenchTFFISameThread >> doSumWithPointers2 [
+
+	^ self ffiCall: #(int64 sum_int64_t(void* 1, nil))
+
+	
+]
+
 { #category : 'accessing' }
 BenchTFFISameThread >> ffiLibrary [
 
@@ -26,4 +50,40 @@ BenchTFFISameThread >> runCall [
 	<script: 'self new runCall traceCr'>
 
 	^ super runCall
+]
+
+{ #category : 'running' }
+BenchTFFISameThread >> runCallWithOptimizedIntegerConstants [
+	<script: 'self new runCallWithOptimizedIntegerConstants traceCr'>
+
+	| return |
+	^ [ return := self doSumWithPointers2. 
+		 self assert: return = 1 ] bench
+]
+
+{ #category : 'running' }
+BenchTFFISameThread >> runCallWithOptimizedLiterals [
+	<script: 'self new runCallWithOptimizedLiterals traceCr'>
+
+	| return |
+	^ [ return := self doSumWithPointers. 
+		 self assert: return = 1 ] bench
+]
+
+{ #category : 'running' }
+BenchTFFISameThread >> runCallWithOptimizedLiterals2 [
+	<script: 'self new runCallWithOptimizedLiterals2 traceCr'>
+
+	| return |
+	^ [ return := self doSumWithPointers2. 
+		 self assert: return = 1 ] bench
+]
+
+{ #category : 'running' }
+BenchTFFISameThread >> runDoSumWithConstants [
+	<script: 'self new runDoSumWithConstants traceCr'>
+
+	| return |
+	^ [ return := self doSumWithConstants. 
+		 self assert: return = 3 ] bench
 ]

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIDerivedTypeMarshallingTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIDerivedTypeMarshallingTest.class.st
@@ -27,6 +27,12 @@ TFUFFIDerivedTypeMarshallingTest >> intToBoolean: int [
 ]
 
 { #category : 'ffi-calls' }
+TFUFFIDerivedTypeMarshallingTest >> pointerConstantToInt [
+
+	^ self ffiCall: #(int id_int(void* 0))
+]
+
+{ #category : 'ffi-calls' }
 TFUFFIDerivedTypeMarshallingTest >> pointerToString: cString [
 
 	^ self ffiCall: #(String dup_string(char *cString))
@@ -198,6 +204,12 @@ TFUFFIDerivedTypeMarshallingTest >> testMarshallingTrueArgument [
 TFUFFIDerivedTypeMarshallingTest >> testMarshallingTrueReturnValue [
 
 	self assert: (self intToBoolean: 17) equals: true
+]
+
+{ #category : 'tests' }
+TFUFFIDerivedTypeMarshallingTest >> testPointerConstantCorrectlyMarshalled [
+
+	self assert: (self pointerConstantToInt) equals: 0
 ]
 
 { #category : 'tests' }

--- a/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
+++ b/src/ThreadedFFI-UFFI/TFCalloutMethodBuilder.class.st
@@ -95,6 +95,23 @@ TFCalloutMethodBuilder >> createFFICalloutLiteralFromSpec: functionSpec [
 ]
 
 { #category : 'private' }
+TFCalloutMethodBuilder >> emitArgument: anFFIFunctionArgument optimizingIn: builder [
+
+	| tfExternalTypeWithArity |
+	tfExternalTypeWithArity := anFFIFunctionArgument resolvedType tfExternalTypeWithArity.
+
+	tfExternalTypeWithArity
+		optimizeFor: anFFIFunctionArgument
+		in: builder
+		ifCannot: [
+			anFFIFunctionArgument
+				emitResolvedTypeArgument: builder
+				context: sender
+				inCallout: self requestor.
+			tfExternalTypeWithArity emitMarshallToPrimitive: builder ]
+]
+
+{ #category : 'private' }
 TFCalloutMethodBuilder >> generateFFICallout: builder spec: functionSpec ffiLibrary: ffiLibrary [
 
 	TFCalloutAPI isTracing ifTrue: [
@@ -112,9 +129,7 @@ TFCalloutMethodBuilder >> generateFFICallout: builder spec: functionSpec ffiLibr
 	"iterate arguments in order (in the function) to create the function call"
 
 	functionSpec arguments
-		do: [ :each |
-			each emitArgument: builder context: sender inCallout: self requestor.
-			each resolvedType tfExternalTypeWithArity emitMarshallToPrimitive: builder ].
+		do: [ :each | self emitArgument: each optimizingIn:builder ].
 
 	"create the array"
 	builder pushConsArray: functionSpec arguments size.

--- a/src/ThreadedFFI/TFAbstractType.class.st
+++ b/src/ThreadedFFI/TFAbstractType.class.st
@@ -34,6 +34,13 @@ TFAbstractType >> isValid [
 	^ handle isNull not
 ]
 
+{ #category : 'marshalling' }
+TFAbstractType >> optimizeFor: aFFIFunctionArgument in: anIRBuilder ifCannot: aFullBlockClosure [ 
+	
+	"Just doing the non-optimized version"
+	aFullBlockClosure value
+]
+
 { #category : 'reading' }
 TFAbstractType >> readReturnValue: anExternalAddress [
 

--- a/src/ThreadedFFI/TFCharType.class.st
+++ b/src/ThreadedFFI/TFCharType.class.st
@@ -26,3 +26,23 @@ TFCharType >> marshallToPrimitive: aValue [
 
 	^ aValue asInteger
 ]
+
+{ #category : 'marshalling' }
+TFCharType >> optimizeFor: aFFIFunctionArgument in: anIRBuilder ifCannot: aFullBlockClosure [
+
+	| literalValue |
+	
+	aFFIFunctionArgument loader isLiteralArgument 
+		ifTrue: [
+			literalValue := aFFIFunctionArgument loader value.
+
+			((literalValue isKindOf: Character) or: [ literalValue isKindOf: Integer ])
+				ifTrue: [ 
+					anIRBuilder pushLiteral: literalValue asCharacter.
+					^ self ]].
+
+	super
+		optimizeFor: aFFIFunctionArgument
+		in: anIRBuilder
+		ifCannot: aFullBlockClosure
+]

--- a/src/ThreadedFFI/TFDerivedType.class.st
+++ b/src/ThreadedFFI/TFDerivedType.class.st
@@ -97,6 +97,13 @@ TFDerivedType >> marshallToPrimitive: aValue [
 	^ aValue
 ]
 
+{ #category : 'marshalling' }
+TFDerivedType >> optimizeFor: aFFIFunctionArgument in: anIRBuilder ifCannot: aFullBlockClosure [ 
+	
+	"Just doing the non-optimized version"
+	aFullBlockClosure value
+]
+
 { #category : 'reading-writing' }
 TFDerivedType >> readReturnValue: anExternalAddress [
 

--- a/src/ThreadedFFI/TFDoubleType.class.st
+++ b/src/ThreadedFFI/TFDoubleType.class.st
@@ -18,6 +18,26 @@ TFDoubleType >> emitMarshallToPrimitive: builder [
 	builder send: #asFloat
 ]
 
+{ #category : 'marshalling' }
+TFDoubleType >> optimizeFor: aFFIFunctionArgument in: anIRBuilder ifCannot: aFullBlockClosure [
+
+	| literalValue |
+	
+	aFFIFunctionArgument loader isLiteralArgument 
+		ifTrue: [
+			literalValue := aFFIFunctionArgument loader value.
+
+			(literalValue isKindOf: Number)
+				ifTrue: [ 
+					anIRBuilder pushLiteral: literalValue asFloat.
+					^ self ]].
+
+	super
+		optimizeFor: aFFIFunctionArgument
+		in: anIRBuilder
+		ifCannot: aFullBlockClosure
+]
+
 { #category : 'reading' }
 TFDoubleType >> readValue: anExternalAddress offset: offset [
 

--- a/src/ThreadedFFI/TFFloatType.class.st
+++ b/src/ThreadedFFI/TFFloatType.class.st
@@ -18,6 +18,26 @@ TFFloatType >> emitMarshallToPrimitive: builder [
 	builder send: #asFloat
 ]
 
+{ #category : 'marshalling' }
+TFFloatType >> optimizeFor: aFFIFunctionArgument in: anIRBuilder ifCannot: aFullBlockClosure [
+
+	| literalValue |
+	
+	aFFIFunctionArgument loader isLiteralArgument 
+		ifTrue: [
+			literalValue := aFFIFunctionArgument loader value.
+
+			(literalValue isKindOf: Number)
+				ifTrue: [ 
+					anIRBuilder pushLiteral: literalValue asFloat.
+					^ self ]].
+
+	super
+		optimizeFor: aFFIFunctionArgument
+		in: anIRBuilder
+		ifCannot: aFullBlockClosure
+]
+
 { #category : 'reading' }
 TFFloatType >> readValue: anExternalAddress offset: offset [
 

--- a/src/ThreadedFFI/TFIntType.class.st
+++ b/src/ThreadedFFI/TFIntType.class.st
@@ -21,6 +21,26 @@ TFIntType >> emitMarshallToPrimitive: builder [
 	builder send: #asInteger
 ]
 
+{ #category : 'marshalling' }
+TFIntType >> optimizeFor: aFFIFunctionArgument in: anIRBuilder ifCannot: aFullBlockClosure [
+
+	| literalValue |
+	
+	aFFIFunctionArgument loader isLiteralArgument 
+		ifTrue: [
+			literalValue := aFFIFunctionArgument loader value.
+
+			((literalValue isKindOf: Boolean) or: [ (literalValue isKindOf: Number) or: [ literalValue isKindOf: Character ] ])
+				ifTrue: [ 
+					anIRBuilder pushLiteral: literalValue asInteger.
+					^ self ]].
+
+	super
+		optimizeFor: aFFIFunctionArgument
+		in: anIRBuilder
+		ifCannot: aFullBlockClosure
+]
+
 { #category : 'reading' }
 TFIntType >> readValue: anExternalAddress offset: offset [
 

--- a/src/ThreadedFFI/TFPointerType.class.st
+++ b/src/ThreadedFFI/TFPointerType.class.st
@@ -18,6 +18,32 @@ TFPointerType >> emitMarshallToPrimitive: builder [
 	builder send: #tfPointerAddress
 ]
 
+{ #category : 'marshalling' }
+TFPointerType >> optimizeFor: aFFIFunctionArgument in: anIRBuilder ifCannot: aFullBlockClosure [
+
+	| literalValue |
+	
+	aFFIFunctionArgument loader isLiteralArgument 
+		ifTrue: [
+			literalValue := aFFIFunctionArgument loader value.
+
+			"If I have a SmallInteger literal I can directly to the tfPointerAddress"			
+			(literalValue isKindOf: SmallInteger)
+				ifTrue: [ 
+					anIRBuilder pushLiteral: literalValue tfPointerAddress.
+					^ self ].
+
+			"If I have already a Null external address I can avoid the message send"			
+			(literalValue = ExternalAddress null) 
+				ifTrue: [ anIRBuilder pushLiteral: literalValue. 
+					^ self]].
+
+	super
+		optimizeFor: aFFIFunctionArgument
+		in: anIRBuilder
+		ifCannot: aFullBlockClosure
+]
+
 { #category : 'reading' }
 TFPointerType >> readValue: anExternalAddress offset: offset [
 

--- a/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTest.class.st
+++ b/src/UnifiedFFI-Tests/FFICalloutMethodBuilderTest.class.st
@@ -155,6 +155,27 @@ FFICalloutMethodBuilderTest >> testCallWithConstant [
 ]
 
 { #category : 'tests' }
+FFICalloutMethodBuilderTest >> testCallWithIntegerConstantAsPointerIsOptimized [
+
+	| result pushInstruction |
+	result := self builder build: [ :builder |
+		builder requestor requestor: FFICalloutObjectForTest.
+		builder
+			signature: #( void method1 ( void* 0 ) );
+			sender: (FFICalloutMethodBuilderTestContext new
+				selector: #method1:value:;
+				argumentNames: #();
+				methodClass: FFICalloutObjectForTest;
+				yourself )].
+
+	pushInstruction := result decompileIR startSequence at: 3.
+	
+	self assert: pushInstruction isPushLiteral.
+	self assert: pushInstruction literal equals: 0 tfPointerAddress 
+	
+]
+
+{ #category : 'tests' }
 FFICalloutMethodBuilderTest >> testCallWithObject [
 	| result tfFunction |
 

--- a/src/UnifiedFFI-Tests/FFIFunctionResolutionTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIFunctionResolutionTest.class.st
@@ -173,7 +173,7 @@ FFIFunctionResolutionTest >> testResolveConstantFalseShouldSetConstantZeroLoader
 		yourself.
 
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil inCallout: nil.
+	argument emitArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . 0 }
 ]
@@ -200,7 +200,7 @@ FFIFunctionResolutionTest >> testResolveConstantIntegerShouldSetConstantLoader [
 		yourself.
 
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil inCallout: nil.
+	argument  emitResolvedTypeArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . 1}
 ]
@@ -228,7 +228,7 @@ FFIFunctionResolutionTest >> testResolveConstantNULLShouldSetConstantNullLoader 
 		yourself.
 
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil inCallout: nil.
+	argument emitArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . ExternalAddress null}
 ]
@@ -256,7 +256,7 @@ FFIFunctionResolutionTest >> testResolveConstantNilShouldSetConstantNullLoader [
 		yourself.
 
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil inCallout: nil.
+	argument emitArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . ExternalAddress null }
 ]
@@ -326,14 +326,16 @@ FFIFunctionResolutionTest >> testResolveConstantSelfStringInStrictResolverFails 
 { #category : 'tests' }
 FFIFunctionResolutionTest >> testResolveConstantSelfStringShouldSetConstantLoader [
 
-	| argument |
+	| argument callout |
 	argument := FFIConstantArgument new
 		value: 'self';
 		type: (FFITypeDeclaration typeName: 'char' arity: 1);
 		yourself.
 
-	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil inCallout: nil.
+	callout := FFICallout new.
+
+	argument resolveUsing: callout.
+	argument emitArgument: self context: nil inCallout: callout.
 
 	self assert: stack pop equals: { #literal . 'self' }
 ]
@@ -364,7 +366,7 @@ FFIFunctionResolutionTest >> testResolveConstantTrueShouldSetConstantOneLoader [
 		yourself.
 
 	argument resolveUsing: FFICallout new.
-	argument loader emitArgument: self context: nil inCallout: nil.
+	argument emitArgument: self context: nil inCallout: nil.
 
 	self assert: stack pop equals: { #literal . 1 }
 ]

--- a/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
+++ b/src/UnifiedFFI/FFICalloutMethodBuilder.class.st
@@ -112,7 +112,7 @@ FFICalloutMethodBuilder >> generateFFICallout: builder spec: functionSpec ffiLib
 	"save ffi call as literal"
 	builder pushLiteral: (self createFFICalloutLiteralFromSpec: functionSpec).
 	"iterate arguments in order (in the function) to create the function call"
-	functionSpec arguments do: [ :each | each emitArgument: builder context: sender inCallout: self requestor ].
+	functionSpec arguments do: [ :each | each emitResolvedTypeArgument: builder context: sender inCallout: self requestor ].
 	"create the array"
 	builder pushConsArray: functionSpec arguments size.
 	"send call and store into result"

--- a/src/UnifiedFFI/FFIExternalType.class.st
+++ b/src/UnifiedFFI/FFIExternalType.class.st
@@ -242,6 +242,12 @@ FFIExternalType >> isFloatType [
 ]
 
 { #category : 'testing' }
+FFIExternalType >> isLiteralArgument [
+
+	^ false
+]
+
+{ #category : 'testing' }
 FFIExternalType >> isPointer [
 	^ self pointerArity > 0
 ]

--- a/src/UnifiedFFI/FFIFunctionArgument.class.st
+++ b/src/UnifiedFFI/FFIFunctionArgument.class.st
@@ -33,6 +33,12 @@ FFIFunctionArgument >> emitArgument: anIRBuilder context: aContext inCallout: aC
 	self resolvedType emitArgument: anIRBuilder context: aContext inCallout: aCallout
 ]
 
+{ #category : 'emitting code' }
+FFIFunctionArgument >> emitResolvedTypeArgument: anIRBuilder context: aContext inCallout: aCallout [
+
+	self resolvedType emitArgument: anIRBuilder context: aContext inCallout: aCallout
+]
+
 { #category : 'resolution' }
 FFIFunctionArgument >> emitReturnArgument: anIRBuilder context: aContext [
 

--- a/src/UnifiedFFI/FFIFunctionArgumentLoader.class.st
+++ b/src/UnifiedFFI/FFIFunctionArgumentLoader.class.st
@@ -26,12 +26,6 @@ FFIFunctionArgumentLoader >> emitArgument: aBuilder context: aContext [
 ]
 
 { #category : 'emitting code' }
-FFIFunctionArgumentLoader >> emitArgument: aBuilder context: aContext inCallout: aCallout [
-
-	self emitArgument: aBuilder context: aContext
-]
-
-{ #category : 'emitting code' }
 FFIFunctionArgumentLoader >> emitArgument: aBuilder context: aContext objectClass: objectClass instVarName: aName [
 	self subclassResponsibility
 ]
@@ -119,6 +113,12 @@ FFIFunctionArgumentLoader >> emitPointerArityUnpack: aBuilder type: aType contex
 		objectClass: objectClass
 		instVarName: aName
 		arity: aType pointerArity
+]
+
+{ #category : 'testing' }
+FFIFunctionArgumentLoader >> isLiteralArgument [
+
+	^ false
 ]
 
 { #category : 'private' }

--- a/src/UnifiedFFI/FFILiteralArgument.class.st
+++ b/src/UnifiedFFI/FFILiteralArgument.class.st
@@ -72,6 +72,12 @@ FFILiteralArgument >> externalTypeSize [
 	^ self externalType byteSize
 ]
 
+{ #category : 'testing' }
+FFILiteralArgument >> isLiteralArgument [
+	
+	^ true
+]
+
 { #category : 'accessing' }
 FFILiteralArgument >> loader [
 	^ self


### PR DESCRIPTION
- Adding an optimization point for the types so we can identify literals and handle them as literals avoiding to convert them in each FFI call, just doing it in the compilation of the method.
- This makes the marshalling of this constants 3 times faster when converting integers to External addreses and 10% faster when using other literals (as it avoids the conversion messages e.g., asInteger).
- Also, when using ExternalAddresses does not create a new object in every marshalling

Fix #17409 