### PR TITLE
Simplify Calypso environment

### DIFF
--- a/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
@@ -77,23 +77,10 @@ ClyScopedSystemEnvironment >> compileANewClassFrom: newClassDefinitionString not
 	^ super compileANewClassFrom: newClassDefinitionString notifying: aController startingFrom: oldClass
 ]
 
-{ #category : 'package management' }
-ClyScopedSystemEnvironment >> createPackageNamed: packageName [
-	"ToDo: Should we allow new packages creation in calypso while displaying a scope?"
-	^ packageOrganizer addPackage: packageName
-]
-
 { #category : 'accessing' }
 ClyScopedSystemEnvironment >> definedClassesInPackage: aPackage [
 
 	^ scope definedClasses select: [ :class | class package = aPackage ]
-]
-
-{ #category : 'accessing' }
-ClyScopedSystemEnvironment >> ensurePackage: packageName [
-	"Should we allow creating new packages while calypso is displaying a scope?".
-	
-	^ packageOrganizer ensurePackage: packageName
 ]
 
 { #category : 'accessing' }
@@ -114,12 +101,6 @@ ClyScopedSystemEnvironment >> includesClassNamed: aSymbol [
 	
 	class := globals at: aSymbol ifAbsent: [^ false].
 	^ scope includesClass: class
-]
-
-{ #category : 'accessing' }
-ClyScopedSystemEnvironment >> packageNamed: aString [
-	
-	^packageOrganizer packageNamed: aString
 ]
 
 { #category : 'accessing' }

--- a/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClySystemEnvironment.class.st
@@ -1,5 +1,5 @@
 "
-I represent environment of Pharo system. I incapsulate globals (Smalltalk globals), packageOrganizer (PackageOrganizer  default) and changesAnnouncer (SystemAnnouncer uniqueInstance). I have class side #currentImage instance created with all corresponding globals of current image.
+I represent environment of Pharo system. I incapsulate globals (Smalltalk globals). I have class side #currentImage instance created with all corresponding globals of current image.
 
 I am used to navigate over system by ClyNavigationEnvironment.
 
@@ -15,11 +15,9 @@ Public API and Key Messages
 Internal Representation and Key Implementation Points.
 
     Instance Variables
-	changesAnnouncer:		<SystemAnnouncer>
 	globals:		<SmalltalkDictionary> ""Smalltalk globals class""
 	name:		<String>
-	packageOrganizer:		<PackageOrganizer>
-	projectManager:		<ClyProjectManager>
+	projectManager:		<ProjectManager>
 "
 Class {
 	#name : 'ClySystemEnvironment',
@@ -27,8 +25,6 @@ Class {
 	#instVars : [
 		'name',
 		'globals',
-		'changesAnnouncer',
-		'packageOrganizer',
 		'projectManager'
 	],
 	#classInstVars : [
@@ -41,12 +37,11 @@ Class {
 
 { #category : 'accessing' }
 ClySystemEnvironment class >> currentImage [
-	^currentImage ifNil: [
-		currentImage := self new
-			name: 'Current image';
-			globals: Smalltalk globals;
-			packageOrganizer: PackageOrganizer default;
-			changesAnnouncer: SystemAnnouncer uniqueInstance]
+
+	^ currentImage ifNil: [
+		  currentImage := self new
+			                  name: 'Current image';
+			                  globals: Smalltalk globals ]
 ]
 
 { #category : 'class initialization' }
@@ -79,12 +74,8 @@ ClySystemEnvironment >> bindingOf: aSymbol [
 
 { #category : 'accessing' }
 ClySystemEnvironment >> changesAnnouncer [
-	^ changesAnnouncer
-]
 
-{ #category : 'accessing' }
-ClySystemEnvironment >> changesAnnouncer: anObject [
-	changesAnnouncer := anObject
+	^ self globals codeChangeAnnouncer
 ]
 
 { #category : 'class compilation' }
@@ -170,7 +161,7 @@ Is this really what you want to do?') asText makeBoldFrom: 1 to: newClassName si
 { #category : 'package management' }
 ClySystemEnvironment >> createPackageNamed: packageName [
 
-	^ packageOrganizer addPackage: packageName
+	^ self packageOrganizer addPackage: packageName
 ]
 
 { #category : 'class compilation' }
@@ -188,7 +179,7 @@ ClySystemEnvironment >> definedClassesInPackage: aPackage [
 { #category : 'package management' }
 ClySystemEnvironment >> ensurePackage: packageName [
 
-	^ packageOrganizer ensurePackage: packageName
+	^ self packageOrganizer ensurePackage: packageName
 ]
 
 { #category : 'accessing' }
@@ -264,22 +255,20 @@ ClySystemEnvironment >> notifyErroInClassDefinition: anError [
 
 { #category : 'package management' }
 ClySystemEnvironment >> packageNamed: aString [
-	^packageOrganizer packageNamed: aString
+
+	^ self packageOrganizer packageNamed: aString
 ]
 
 { #category : 'accessing' }
 ClySystemEnvironment >> packageOrganizer [
-	^ packageOrganizer
-]
 
-{ #category : 'accessing' }
-ClySystemEnvironment >> packageOrganizer: anObject [
-	packageOrganizer := anObject
+	^ self globals packageOrganizer
 ]
 
 { #category : 'accessing' }
 ClySystemEnvironment >> packages [
-	^ packageOrganizer packages
+
+	^ self packageOrganizer packages
 ]
 
 { #category : 'printing' }
@@ -319,10 +308,12 @@ ClySystemEnvironment >> subscribe: anObject for: anAnnouncementClass [
 
 { #category : 'subscription' }
 ClySystemEnvironment >> unsubscribe: anObject [
-	changesAnnouncer unsubscribe: anObject
+
+	self changesAnnouncer unsubscribe: anObject
 ]
 
 { #category : 'subscription' }
 ClySystemEnvironment >> when: anAnnouncementClass send: aSelector to: anObject [
-	changesAnnouncer weak when: anAnnouncementClass send: aSelector to: anObject
+
+	self changesAnnouncer weak when: anAnnouncementClass send: aSelector to: anObject
 ]


### PR DESCRIPTION
Do not save a pharo environment, package manager and announcer. Instead get the package manager and the announcer directly from the Pharo environment