### PR TITLE
Update versions in #beautifulComments, #documentBrowser and #welcomeBrowser for BaselineOfPharo for Pharo 11 to ‘v1.0.1’, ‘v1.0.3’ and ‘v1.0.2’

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -15,7 +15,7 @@ BaselineOfPharo class >> beautifulComments [
 		newName: 'BeautifulComments' 
 		owner: 'pillar-markup' 
 		project: 'BeautifulComments' 
-		version: 'v1.0.0'
+		version: 'v1.0.1'
 ]
 
 { #category : #'repository urls' }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -43,7 +43,7 @@ BaselineOfPharo class >> documentBrowser [
 		newName: 'DocumentBrowser' 
 		owner: 'pharo-spec' 
 		project: 'NewTools-DocumentBrowser' 
-		version: 'v1.0.2'
+		version: 'v1.0.3'
 ]
 
 { #category : #'repository urls' }

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -160,7 +160,7 @@ BaselineOfPharo class >> welcomeBrowser [
 		newName: 'WelcomeBrowser' 
 		owner: 'pharo-spec' 
 		project: 'NewTools-WelcomeBrowser' 
-		version: 'v1.0.1'
+		version: 'v1.0.2'
 ]
 
 { #category : #'repository urls' }


### PR DESCRIPTION
This pull request updates the versions in `#documentBrowser` and `#welcomeBrowser` for BaselineOfPharo for Pharo 11 to ‘v1.0.3’ and ‘v1.0.2’ respectively. The tags need to be added first, I cannot do that; for NewTools-DocumentBrowser, ‘v1.0.3’ should refer to [commit 7d3996762a13](https://github.com/pharo-spec/NewTools-DocumentBrowser/commit/7d3996762a13), and for NewTools-WelcomeBrowser, ‘v1.0.2’ should refer to [commit ed5c5339466e](https://github.com/pharo-spec/NewTools-WelcomeBrowser/commit/ed5c5339466e).