### PR TITLE
17403 test case  failure log should not refer to a globlal

### DIFF
--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -77,7 +77,10 @@ TestAsserter class >> isLogging [
 
 { #category : 'logging' }
 TestAsserter class >> logFailure: aString [
-
+	"It provides a way to log something at the class level.
+	Note that they are two levels of logging one at the class and other at instance. So isLogging should be defined in subclasses at the right place.
+	Clearly this duplication is strange."
+	
 	self isLogging ifTrue:
 		[ self failureLog 
 				cr; 

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -28,6 +28,9 @@ To have them appear elsewhere, also override my class-side `TestAsserter class>>
 Class {
 	#name : 'TestAsserter',
 	#superclass : 'Object',
+	#classVars : [
+		'LogFailureStream'
+	],
 	#category : 'SUnit-Core-Kernel',
 	#package : 'SUnit-Core',
 	#tag : 'Kernel'
@@ -55,7 +58,14 @@ TestAsserter class >> classForTestSuite [
 
 { #category : 'logging' }
 TestAsserter class >> failureLog [
-	^ Smalltalk tools transcript
+	^ LogFailureStream ifNil: [ self failureLog: String new writeStream. LogFailureStream ]
+]
+
+{ #category : 'logging' }
+TestAsserter class >> failureLog: aStream [ 
+	"So that we can pass a different stream if needed."
+	
+	LogFailureStream := aStream
 ]
 
 { #category : 'logging' }
@@ -67,8 +77,12 @@ TestAsserter class >> isLogging [
 
 { #category : 'logging' }
 TestAsserter class >> logFailure: aString [
+
 	self isLogging ifTrue:
-		[self failureLog cr; nextPutAll: aString; flush]
+		[ self failureLog 
+				cr; 
+				nextPutAll: aString; 
+				flush ]
 ]
 
 { #category : 'factory' }

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -707,7 +707,7 @@ TestCase >> expectedFailures [
 { #category : 'running' }
 TestCase >> failureLog [
 
-	^ Smalltalk tools transcript
+	^ self class failureLog
 ]
 
 { #category : 'private' }
@@ -732,11 +732,8 @@ TestCase >> isLogging [
 
 { #category : 'running' }
 TestCase >> logFailure: aString [
-	self isLogging ifTrue: [
-		self failureLog
-			cr;
-			nextPutAll: aString;
-			flush]
+
+	self class logFailure: aString
 ]
 
 { #category : 'accessing' }

--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -730,10 +730,15 @@ TestCase >> isLogging [
 	^false
 ]
 
-{ #category : 'running' }
+{ #category : 'logging' }
 TestCase >> logFailure: aString [
 
-	self class logFailure: aString
+	self isLogging 
+		ifTrue: [
+			self class failureLog
+				cr;
+				nextPutAll: aString;
+				flush]
 ]
 
 { #category : 'accessing' }

--- a/src/SUnit-Tests/SUnitExtensionsTest.class.st
+++ b/src/SUnit-Tests/SUnitExtensionsTest.class.st
@@ -32,7 +32,10 @@ SUnitExtensionsTest >> differentExceptionInShouldRaiseWithExceptionDoTest [
 	[ self
 		should: [ Error signal ]
 		raise: Halt
-		withExceptionDo: [ :anException | self assert: false description: 'should:raise:withExceptionDo: handled an exception that should not handle'] ]
+		withExceptionDo: [ :anException | 
+									self 
+										assert: false 
+										description: 'should:raise:withExceptionDo: handled an exception that should not handle'] ]
 	on: Error
 	do: [ :anException | anException return: nil ]
 ]
@@ -87,12 +90,16 @@ SUnitExtensionsTest >> shouldFixTest [
 
 { #category : 'real tests' }
 SUnitExtensionsTest >> shouldRaiseWithExceptionDoTest [
-	self should: [ Error signal: '1' ] raise: Error withExceptionDo: [ :anException | self assert: anException messageText equals: '1' ]
+	self 
+		should: [ Error signal: '1' ] 
+		raise: Error withExceptionDo: [ :anException | self assert: anException messageText equals: '1' ]
 ]
 
 { #category : 'real tests' }
 SUnitExtensionsTest >> shouldRaiseWithSignalDoTest [
-	self should: [ Error signal: '1' ] raise: Error withExceptionDo: [ :anException | self assert: anException messageText equals: '1' ]
+	self 
+		should: [ Error signal: '1' ] 
+		raise: Error withExceptionDo: [ :anException | self assert: anException messageText equals: '1' ]
 ]
 
 { #category : 'accessing' }

--- a/src/SUnit-Tests/SUnitExtensionsTest.class.st
+++ b/src/SUnit-Tests/SUnitExtensionsTest.class.st
@@ -49,11 +49,6 @@ SUnitExtensionsTest >> errorInRaiseWithExceptionDoTest [
 		withExceptionDo: [ :anException | Error signal: 'A forced error' ]
 ]
 
-{ #category : 'test support' }
-SUnitExtensionsTest >> failureLog [
-	^self stream
-]
-
 { #category : 'real tests' }
 SUnitExtensionsTest >> invalidShouldNotTakeMoreThan [
 
@@ -102,11 +97,6 @@ SUnitExtensionsTest >> shouldRaiseWithSignalDoTest [
 		raise: Error withExceptionDo: [ :anException | self assert: anException messageText equals: '1' ]
 ]
 
-{ #category : 'accessing' }
-SUnitExtensionsTest >> stream [
-	^stream ifNil: [stream := String new writeStream]
-]
-
 { #category : 'tests' }
 SUnitExtensionsTest >> testAssertionFailedInRaiseWithExceptionDo [
 	| testCase testResult |
@@ -121,11 +111,15 @@ SUnitExtensionsTest >> testAssertionFailedInRaiseWithExceptionDo [
 
 { #category : 'tests' }
 SUnitExtensionsTest >> testAutoAssertFalse [
-	| booleanCondition |
+	
 	self assert: self isLogging.
-	self should: [ self assert: 1 = 2 description: 'self assert: 1 = 2' ] raise: self defaultTestFailure.
-	booleanCondition := (self stream contents substrings: {Character cr}) last = 'self assert: 1 = 2'.
-	self assert: booleanCondition
+	self 
+		should: [ self assert: 1 = 2 description: 'self assert: 1 = 2' ] 
+		raise: self defaultTestFailure.
+	self 
+		assert: (self failureLog contents substrings: {Character cr}) last 
+		equals: 'self assert: 1 = 2'.
+
 ]
 
 { #category : 'tests' }
@@ -136,11 +130,15 @@ SUnitExtensionsTest >> testAutoAssertTrue [
 
 { #category : 'tests' }
 SUnitExtensionsTest >> testAutoDenyFalse [
-	| booleanCondition |
+
 	self assert: self isLogging.
-	self should: [ self deny: 1 = 1 description: 'self deny: 1 = 1'.] raise: self defaultTestFailure.
-	booleanCondition := (self stream contents substrings:  {Character cr}) last = 'self deny: 1 = 1'.
-	self assert: booleanCondition
+	self 
+		should: [ self deny: 1 = 1 description: 'self deny: 1 = 1' ] 
+		raise: self defaultTestFailure.
+	self 
+		assert: (self failureLog contents substrings:  {Character cr}) last 
+		equals: 'self deny: 1 = 1'.
+	
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
Check the comments of the different commit. 
In essence introduced a stream shared variable.


