### PR TITLE
17435 introduce backward compatible rewriting

### DIFF
--- a/src/Kernel/AutomaticRewriting.class.st
+++ b/src/Kernel/AutomaticRewriting.class.st
@@ -1,7 +1,199 @@
 Class {
 	#name : 'AutomaticRewriting',
 	#superclass : 'Warning',
+	#instVars : [
+		'context',
+		'explanationString',
+		'deprecationDate',
+		'versionString',
+		'rule',
+		'condition'
+	],
+	#classInstVars : [
+		'log',
+		'raiseWarning',
+		'showWarning',
+		'active'
+	],
 	#category : 'Kernel-Exceptions',
 	#package : 'Kernel',
 	#tag : 'Exceptions'
 }
+
+{ #category : 'logging' }
+AutomaticRewriting class >> activateTransformations [
+
+	^ active ifNil: [ active := true ]
+]
+
+{ #category : 'logging' }
+AutomaticRewriting class >> activateTransformations: aBoolean [
+
+	active := aBoolean
+]
+
+{ #category : 'logging' }
+AutomaticRewriting class >> addLog: anElement [ 
+
+	self log add: anElement
+]
+
+{ #category : 'class initialization' }
+AutomaticRewriting class >> initialize [
+	self reset
+]
+
+{ #category : 'class initialization' }
+AutomaticRewriting class >> log [ 
+
+	^ log ifNil: [ log := OrderedCollection new. log ]
+]
+
+{ #category : 'settings' }
+AutomaticRewriting class >> raiseWarning [
+	"If true, then a dialog is popup for each method invocation"
+	^ raiseWarning ifNil: [ raiseWarning := false ]
+]
+
+{ #category : 'settings' }
+AutomaticRewriting class >> raiseWarning: aBoolean [
+	raiseWarning := aBoolean
+]
+
+{ #category : 'class initialization' }
+AutomaticRewriting class >> reset [
+	<script>
+	log := nil.
+	raiseWarning := nil.
+	showWarning := nil.
+	active := nil
+]
+
+{ #category : 'settings' }
+AutomaticRewriting class >> showWarning [
+	"If true, then a message is send to the Transcript for each deprecated method invocation"
+	
+	^ showWarning ifNil: [ showWarning := true ]
+]
+
+{ #category : 'settings' }
+AutomaticRewriting class >> showWarning: aBoolean [
+	
+	showWarning := aBoolean
+]
+
+{ #category : 'comparing' }
+AutomaticRewriting >> = anObject [
+	^self class == anObject class
+	  and: [context = anObject contextOfDeprecatedMethod
+	  and: [context
+			ifNil: [explanationString = anObject explanationString]
+			ifNotNil: [true]]]
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> condition: aBlock [
+	condition := aBlock
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> context: aContext [
+	context := aContext
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> contextOfDeprecatedMethod [
+	^context
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> contextOfSender [
+	^context home sender
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> date: aDate [
+	deprecationDate := aDate
+]
+
+{ #category : 'private' }
+AutomaticRewriting >> deprecatedMethodName [
+	^self contextOfDeprecatedMethod homeMethod printString
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> deprecationDate [
+
+	^ deprecationDate ifNil: [ 'unknown' ]
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> explanation: aString [
+	explanationString := aString
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> explanationString [
+
+	^ explanationString
+]
+
+{ #category : 'comparing' }
+AutomaticRewriting >> hash [
+	^(context ifNil: [explanationString]) hash
+]
+
+{ #category : 'settings' }
+AutomaticRewriting >> raiseWarning [
+	^ self class raiseWarning
+]
+
+{ #category : 'private' }
+AutomaticRewriting >> rewriterClass [
+	^ self class environment at: #ASTParseTreeRewriter ifAbsent: [ nil ]
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> rule: aRule [
+	rule := aRule
+]
+
+{ #category : 'private' }
+AutomaticRewriting >> sendingMethodName [
+	^self contextOfSender homeMethod printString
+]
+
+{ #category : 'handling' }
+AutomaticRewriting >> shouldTransform [
+
+	self class activateTransformations ifFalse: [ ^false  ].
+	(condition isNil or: [ condition cull: self ]) ifFalse: [ ^false ].
+	^rule isNotNil
+]
+
+{ #category : 'settings' }
+AutomaticRewriting >> showWarning [
+	^ self class showWarning
+]
+
+{ #category : 'signaling' }
+AutomaticRewriting >> signal [
+	| pragma homeMethod |
+	homeMethod := context homeMethod.
+	(homeMethod hasPragmaNamed: #transform:to:) ifFalse: [ ^super signal ].
+
+	pragma := homeMethod pragmaAt: #transform:to:.
+	self rule: pragma arguments first -> pragma arguments second.
+	self transform
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> version: aString [
+	versionString := aString
+]
+
+{ #category : 'accessing' }
+AutomaticRewriting >> versionString [
+
+	^ versionString ifNil: [ 'unknown' ]
+]

--- a/src/Kernel/AutomaticRewriting.class.st
+++ b/src/Kernel/AutomaticRewriting.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'AutomaticRewriting',
+	#superclass : 'Warning',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
+}

--- a/src/Kernel/BackwardCompatibility.class.st
+++ b/src/Kernel/BackwardCompatibility.class.st
@@ -17,14 +17,16 @@ foo
 		backwardCompatible:  'The method #foo was not good. Use Bar>>newFoo instead.'
 		on:  'here add date'
 		in:  'here add version'
-		 transformWith:   '`@receiver foo' -> '`@receiver newFoo'.	
+		transformWith: '`@receiver foo' -> '`@receiver newFoo'.	
 	^ self newFoo
 ```
 
 You are done the system will rewrite the callers to this foo method (and not other potential implementations) when it is executed. 
 	
 The `transformWith:`  allows one to transform the backard compatible method calls automatically when called.
-When the transformation is defined, the Warning will not signalled.
+The Warning will not signalled.
+
+Check class side for posible configurations. You can ignore, raise warning, log or rewrite.
 
 
 "

--- a/src/Kernel/BackwardCompatibility.class.st
+++ b/src/Kernel/BackwardCompatibility.class.st
@@ -23,7 +23,7 @@ If the transformation is defined, the Warning will not signalled.
 
 "
 Class {
-	#name : 'Deprecation',
+	#name : 'BackwardCompatibility',
 	#superclass : 'AutomaticRewriting',
 	#instVars : [
 		'context',
@@ -45,19 +45,19 @@ Class {
 }
 
 { #category : 'logging' }
-Deprecation class >> activateTransformations [
+BackwardCompatibility class >> activateTransformations [
 
 	^ Active ifNil: [ Active := true ]
 ]
 
 { #category : 'logging' }
-Deprecation class >> activateTransformations: aBoolean [
+BackwardCompatibility class >> activateTransformations: aBoolean [
 
 	Active := aBoolean
 ]
 
 { #category : 'logging' }
-Deprecation class >> deprecationsWhile: aBlock [
+BackwardCompatibility class >> deprecationsWhile: aBlock [
 	"returns a log of all deprecated methods seen while executing aBlock"
 	| oldLog result |
 	oldLog := Log.
@@ -70,23 +70,23 @@ Deprecation class >> deprecationsWhile: aBlock [
 ]
 
 { #category : 'class initialization' }
-Deprecation class >> initialize [
+BackwardCompatibility class >> initialize [
 	self reset
 ]
 
 { #category : 'settings' }
-Deprecation class >> raiseWarning [
+BackwardCompatibility class >> raiseWarning [
 	"If true, then a dialog is popup for each deprecated method invocation"
 	^ RaiseWarning ifNil: [RaiseWarning := false]
 ]
 
 { #category : 'settings' }
-Deprecation class >> raiseWarning: aBoolean [
+BackwardCompatibility class >> raiseWarning: aBoolean [
 	RaiseWarning := aBoolean
 ]
 
 { #category : 'class initialization' }
-Deprecation class >> reset [
+BackwardCompatibility class >> reset [
 	<script>
 	Log := nil.
 	RaiseWarning := nil.
@@ -95,18 +95,18 @@ Deprecation class >> reset [
 ]
 
 { #category : 'settings' }
-Deprecation class >> showWarning [
+BackwardCompatibility class >> showWarning [
 	"If true, then a message is send to the Transcript for each deprecated method invocation"
 	^ ShowWarning ifNil: [ShowWarning := true]
 ]
 
 { #category : 'settings' }
-Deprecation class >> showWarning: aBoolean [
+BackwardCompatibility class >> showWarning: aBoolean [
 	ShowWarning := aBoolean
 ]
 
 { #category : 'comparing' }
-Deprecation >> = anObject [
+BackwardCompatibility >> = anObject [
 	^self class == anObject class
 	  and: [context = anObject contextOfDeprecatedMethod
 	  and: [context
@@ -115,32 +115,32 @@ Deprecation >> = anObject [
 ]
 
 { #category : 'accessing' }
-Deprecation >> condition: aBlock [
+BackwardCompatibility >> condition: aBlock [
 	condition := aBlock
 ]
 
 { #category : 'accessing' }
-Deprecation >> context: aContext [
+BackwardCompatibility >> context: aContext [
 	context := aContext
 ]
 
 { #category : 'accessing' }
-Deprecation >> contextOfDeprecatedMethod [
+BackwardCompatibility >> contextOfDeprecatedMethod [
 	^context
 ]
 
 { #category : 'accessing' }
-Deprecation >> contextOfSender [
+BackwardCompatibility >> contextOfSender [
 	^context home sender
 ]
 
 { #category : 'accessing' }
-Deprecation >> date: aDate [
+BackwardCompatibility >> date: aDate [
 	deprecationDate := aDate
 ]
 
 { #category : 'handling' }
-Deprecation >> defaultAction [
+BackwardCompatibility >> defaultAction [
 
 	Log ifNotNil: [ :log | log add: self ].
 	self showWarning ifTrue: [ self logTranscript ].
@@ -149,39 +149,39 @@ Deprecation >> defaultAction [
 ]
 
 { #category : 'private' }
-Deprecation >> deprecatedMethodName [
+BackwardCompatibility >> deprecatedMethodName [
 	^self contextOfDeprecatedMethod homeMethod printString
 ]
 
 { #category : 'accessing' }
-Deprecation >> deprecationDate [
+BackwardCompatibility >> deprecationDate [
 
 	^ deprecationDate ifNil: [ 'unknown' ]
 ]
 
 { #category : 'accessing' }
-Deprecation >> explanation: aString [
+BackwardCompatibility >> explanation: aString [
 	explanationString := aString
 ]
 
 { #category : 'accessing' }
-Deprecation >> explanationString [
+BackwardCompatibility >> explanationString [
 
 	^ explanationString
 ]
 
 { #category : 'comparing' }
-Deprecation >> hash [
+BackwardCompatibility >> hash [
 	^(context ifNil: [explanationString]) hash
 ]
 
 { #category : 'private' }
-Deprecation >> logTranscript [
+BackwardCompatibility >> logTranscript [
 	DeprecationPerformedNotification signal: self messageText
 ]
 
 { #category : 'accessing' }
-Deprecation >> messageText [
+BackwardCompatibility >> messageText [
 	^String streamContents: [ :str |
 		self shouldTransform ifTrue: [
 			str nextPutAll:  'Automatic deprecation code rewrite: '].
@@ -195,39 +195,39 @@ Deprecation >> messageText [
 ]
 
 { #category : 'settings' }
-Deprecation >> raiseWarning [
+BackwardCompatibility >> raiseWarning [
 	^ self class raiseWarning
 ]
 
 { #category : 'private' }
-Deprecation >> rewriterClass [
+BackwardCompatibility >> rewriterClass [
 	^ self class environment at: #ASTParseTreeRewriter ifAbsent: [ nil ]
 ]
 
 { #category : 'accessing' }
-Deprecation >> rule: aRule [
+BackwardCompatibility >> rule: aRule [
 	rule := aRule
 ]
 
 { #category : 'private' }
-Deprecation >> sendingMethodName [
+BackwardCompatibility >> sendingMethodName [
 	^self contextOfSender homeMethod printString
 ]
 
 { #category : 'handling' }
-Deprecation >> shouldTransform [
+BackwardCompatibility >> shouldTransform [
 	self class activateTransformations ifFalse: [ ^false  ].
 	(condition isNil or: [ condition cull: self ]) ifFalse: [ ^false ].
 	^rule isNotNil
 ]
 
 { #category : 'settings' }
-Deprecation >> showWarning [
+BackwardCompatibility >> showWarning [
 	^ self class showWarning
 ]
 
 { #category : 'handling' }
-Deprecation >> signal [
+BackwardCompatibility >> signal [
 	| pragma homeMethod |
 	homeMethod := context homeMethod.
 	(homeMethod hasPragmaNamed: #transform:to:) ifFalse: [ ^super signal ].
@@ -238,7 +238,7 @@ Deprecation >> signal [
 ]
 
 { #category : 'handling' }
-Deprecation >> transform [
+BackwardCompatibility >> transform [
 
 	| node rewriteRule aMethod |
 
@@ -264,12 +264,12 @@ Deprecation >> transform [
 ]
 
 { #category : 'accessing' }
-Deprecation >> version: aString [
+BackwardCompatibility >> version: aString [
 	versionString := aString
 ]
 
 { #category : 'accessing' }
-Deprecation >> versionString [
+BackwardCompatibility >> versionString [
 
 	^ versionString ifNil: [ 'unknown' ]
 ]

--- a/src/Kernel/BackwardCompatibility.class.st
+++ b/src/Kernel/BackwardCompatibility.class.st
@@ -31,12 +31,6 @@ When the transformation is defined, the Warning will not signalled.
 Class {
 	#name : 'BackwardCompatibility',
 	#superclass : 'AutomaticRewriting',
-	#classVars : [
-		'Active',
-		'Log',
-		'RaiseWarning',
-		'ShowWarning'
-	],
 	#category : 'Kernel-Exceptions',
 	#package : 'Kernel',
 	#tag : 'Exceptions'

--- a/src/Kernel/BackwardCompatibility.class.st
+++ b/src/Kernel/BackwardCompatibility.class.st
@@ -1,38 +1,36 @@
 "
-This Warning is signalled by methods which are deprecated.
+This Warning is signalled by methods which are kept for backward compatible concerns.
+Now you should not call them, and we nicely propose you that the system rewrite your messages to invoke the correct ones. 
 
-Idiom: Imagine I want to deprecate the message #foo.
+Idiom: Imagine that you want to declare that a method is just kept around for backward compatibility.
 
+```
 foo
 	^ 'foo'
+```
 
-I can replace it with:
+For this we introduce the following call in the definition of the `foo` method:
 
+```
 foo
 	self 
-		deprecated:   'The method #foo was not good. Use Bar>>newFoo instead.'
+		backwardCompatible:  'The method #foo was not good. Use Bar>>newFoo instead.'
 		on:  'here add date'
 		in:  'here add version'
 		 transformWith:   '`@receiver foo' -> '`@receiver newFoo'.	
-	^self newFoo
+	^ self newFoo
+```
+
+You are done the system will rewrite the callers to this foo method (and not other potential implementations) when it is executed. 
 	
-	
-The  transformWith:  part is optional. It allows to transform the deprecated method automatically when called.
-If the transformation is defined, the Warning will not signalled.
+The `transformWith:`  allows one to transform the backard compatible method calls automatically when called.
+When the transformation is defined, the Warning will not signalled.
 
 
 "
 Class {
 	#name : 'BackwardCompatibility',
 	#superclass : 'AutomaticRewriting',
-	#instVars : [
-		'context',
-		'explanationString',
-		'deprecationDate',
-		'versionString',
-		'rule',
-		'condition'
-	],
 	#classVars : [
 		'Active',
 		'Log',
@@ -45,196 +43,47 @@ Class {
 }
 
 { #category : 'logging' }
-BackwardCompatibility class >> activateTransformations [
+BackwardCompatibility class >> backwardsCompatibilityWhile: aBlock [
+	"Returns a log of all backward compatible methods seen while executing aBlock"
 
-	^ Active ifNil: [ Active := true ]
-]
-
-{ #category : 'logging' }
-BackwardCompatibility class >> activateTransformations: aBoolean [
-
-	Active := aBoolean
-]
-
-{ #category : 'logging' }
-BackwardCompatibility class >> deprecationsWhile: aBlock [
-	"returns a log of all deprecated methods seen while executing aBlock"
 	| oldLog result |
-	oldLog := Log.
-	Log := Set new.
+	oldLog := log.
+	log := Set new.
 	aBlock value.
-	result := Log.
-	oldLog ifNotNil: [oldLog addAll: result].
-	Log := oldLog.
-	^result
-]
-
-{ #category : 'class initialization' }
-BackwardCompatibility class >> initialize [
-	self reset
-]
-
-{ #category : 'settings' }
-BackwardCompatibility class >> raiseWarning [
-	"If true, then a dialog is popup for each deprecated method invocation"
-	^ RaiseWarning ifNil: [RaiseWarning := false]
-]
-
-{ #category : 'settings' }
-BackwardCompatibility class >> raiseWarning: aBoolean [
-	RaiseWarning := aBoolean
-]
-
-{ #category : 'class initialization' }
-BackwardCompatibility class >> reset [
-	<script>
-	Log := nil.
-	RaiseWarning := nil.
-	ShowWarning := nil.
-	Active := nil
-]
-
-{ #category : 'settings' }
-BackwardCompatibility class >> showWarning [
-	"If true, then a message is send to the Transcript for each deprecated method invocation"
-	^ ShowWarning ifNil: [ShowWarning := true]
-]
-
-{ #category : 'settings' }
-BackwardCompatibility class >> showWarning: aBoolean [
-	ShowWarning := aBoolean
-]
-
-{ #category : 'comparing' }
-BackwardCompatibility >> = anObject [
-	^self class == anObject class
-	  and: [context = anObject contextOfDeprecatedMethod
-	  and: [context
-			ifNil: [explanationString = anObject explanationString]
-			ifNotNil: [true]]]
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> condition: aBlock [
-	condition := aBlock
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> context: aContext [
-	context := aContext
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> contextOfDeprecatedMethod [
-	^context
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> contextOfSender [
-	^context home sender
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> date: aDate [
-	deprecationDate := aDate
+	result := log.
+	oldLog ifNotNil: [ oldLog addAll: result ].
+	log := oldLog.
+	^ result
 ]
 
 { #category : 'handling' }
 BackwardCompatibility >> defaultAction [
 
-	Log ifNotNil: [ :log | log add: self ].
+	self class addLog: self.
 	self showWarning ifTrue: [ self logTranscript ].
 	self raiseWarning ifTrue: [ super defaultAction ].
 	self shouldTransform ifTrue: [ self transform ]
 ]
 
 { #category : 'private' }
-BackwardCompatibility >> deprecatedMethodName [
-	^self contextOfDeprecatedMethod homeMethod printString
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> deprecationDate [
-
-	^ deprecationDate ifNil: [ 'unknown' ]
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> explanation: aString [
-	explanationString := aString
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> explanationString [
-
-	^ explanationString
-]
-
-{ #category : 'comparing' }
-BackwardCompatibility >> hash [
-	^(context ifNil: [explanationString]) hash
-]
-
-{ #category : 'private' }
 BackwardCompatibility >> logTranscript [
-	DeprecationPerformedNotification signal: self messageText
+
+	BackwardCompatibleRewritingCallPerformedNotification signal: self messageText
 ]
 
 { #category : 'accessing' }
 BackwardCompatibility >> messageText [
-	^String streamContents: [ :str |
+	
+	^ String streamContents: [ :str |
 		self shouldTransform ifTrue: [
-			str nextPutAll:  'Automatic deprecation code rewrite: '].
+			str nextPutAll:  'Automatic backward compatible senders rewrite: '].
 		str
 			nextPutAll: 'The method ';
 			nextPutAll: self deprecatedMethodName;
 			nextPutAll: ' called from ';
 			nextPutAll: self sendingMethodName;
-			nextPutAll: ' has been deprecated. ';
+			nextPutAll: ' is kept for backward compatible concerns.';
 		 	nextPutAll: explanationString]
-]
-
-{ #category : 'settings' }
-BackwardCompatibility >> raiseWarning [
-	^ self class raiseWarning
-]
-
-{ #category : 'private' }
-BackwardCompatibility >> rewriterClass [
-	^ self class environment at: #ASTParseTreeRewriter ifAbsent: [ nil ]
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> rule: aRule [
-	rule := aRule
-]
-
-{ #category : 'private' }
-BackwardCompatibility >> sendingMethodName [
-	^self contextOfSender homeMethod printString
-]
-
-{ #category : 'handling' }
-BackwardCompatibility >> shouldTransform [
-	self class activateTransformations ifFalse: [ ^false  ].
-	(condition isNil or: [ condition cull: self ]) ifFalse: [ ^false ].
-	^rule isNotNil
-]
-
-{ #category : 'settings' }
-BackwardCompatibility >> showWarning [
-	^ self class showWarning
-]
-
-{ #category : 'handling' }
-BackwardCompatibility >> signal [
-	| pragma homeMethod |
-	homeMethod := context homeMethod.
-	(homeMethod hasPragmaNamed: #transform:to:) ifFalse: [ ^super signal ].
-
-	pragma := homeMethod pragmaAt: #transform:to:.
-	self rule: pragma arguments first -> pragma arguments second.
-	self transform
 ]
 
 { #category : 'handling' }
@@ -260,16 +109,5 @@ BackwardCompatibility >> transform [
 		aMethod origin
 			compile: aMethod ast formattedCode
 			classified: aMethod protocol.
-		Log ifNotNil: [ :log | log add: self ] ]
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> version: aString [
-	versionString := aString
-]
-
-{ #category : 'accessing' }
-BackwardCompatibility >> versionString [
-
-	^ versionString ifNil: [ 'unknown' ]
+		self class addLog: self ]
 ]

--- a/src/Kernel/BackwardCompatibleRewritingCallPerformedNotification.class.st
+++ b/src/Kernel/BackwardCompatibleRewritingCallPerformedNotification.class.st
@@ -1,0 +1,10 @@
+"
+I am a notificaton about an operation that was performed as reaction of a Deprecation warning. I inform user about a method rewrite and so on. Usual reaction is to write related description to Transcript.
+"
+Class {
+	#name : 'BackwardCompatibleRewritingCallPerformedNotification',
+	#superclass : 'SystemNotification',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
+}

--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -3,22 +3,29 @@ This Warning is signalled by methods which are deprecated.
 
 Idiom: Imagine I want to deprecate the message #foo.
 
+```
 foo
 	^ 'foo'
+```
 
 I can replace it with:
 
+```
 foo
 	self 
 		deprecated:   'The method #foo was not good. Use Bar>>newFoo instead.'
 		on:  'here add date'
 		in:  'here add version'
-		 transformWith:   '`@receiver foo' -> '`@receiver newFoo'.	
+		transformWith:   '`@receiver foo' -> '`@receiver newFoo'.	
 	^self newFoo
 	
+```
 	
 The  transformWith:  part is optional. It allows to transform the deprecated method automatically when called.
 If the transformation is defined, the Warning will not signalled.
+
+
+Check the class side for configurations. You can raise, ignore, log and rewrite callers. 
 
 
 "

--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -25,14 +25,6 @@ If the transformation is defined, the Warning will not signalled.
 Class {
 	#name : 'Deprecation',
 	#superclass : 'AutomaticRewriting',
-	#instVars : [
-		'context',
-		'explanationString',
-		'deprecationDate',
-		'versionString',
-		'rule',
-		'condition'
-	],
 	#classVars : [
 		'Active',
 		'Log',
@@ -45,134 +37,25 @@ Class {
 }
 
 { #category : 'logging' }
-Deprecation class >> activateTransformations [
-
-	^ Active ifNil: [ Active := true ]
-]
-
-{ #category : 'logging' }
-Deprecation class >> activateTransformations: aBoolean [
-
-	Active := aBoolean
-]
-
-{ #category : 'logging' }
 Deprecation class >> deprecationsWhile: aBlock [
 	"returns a log of all deprecated methods seen while executing aBlock"
 	| oldLog result |
-	oldLog := Log.
-	Log := Set new.
+	oldLog := log.
+	log := Set new.
 	aBlock value.
-	result := Log.
+	result := log.
 	oldLog ifNotNil: [oldLog addAll: result].
-	Log := oldLog.
+	log := oldLog.
 	^result
-]
-
-{ #category : 'class initialization' }
-Deprecation class >> initialize [
-	self reset
-]
-
-{ #category : 'settings' }
-Deprecation class >> raiseWarning [
-	"If true, then a dialog is popup for each deprecated method invocation"
-	^ RaiseWarning ifNil: [RaiseWarning := false]
-]
-
-{ #category : 'settings' }
-Deprecation class >> raiseWarning: aBoolean [
-	RaiseWarning := aBoolean
-]
-
-{ #category : 'class initialization' }
-Deprecation class >> reset [
-	<script>
-	Log := nil.
-	RaiseWarning := nil.
-	ShowWarning := nil.
-	Active := nil
-]
-
-{ #category : 'settings' }
-Deprecation class >> showWarning [
-	"If true, then a message is send to the Transcript for each deprecated method invocation"
-	^ ShowWarning ifNil: [ShowWarning := true]
-]
-
-{ #category : 'settings' }
-Deprecation class >> showWarning: aBoolean [
-	ShowWarning := aBoolean
-]
-
-{ #category : 'comparing' }
-Deprecation >> = anObject [
-	^self class == anObject class
-	  and: [context = anObject contextOfDeprecatedMethod
-	  and: [context
-			ifNil: [explanationString = anObject explanationString]
-			ifNotNil: [true]]]
-]
-
-{ #category : 'accessing' }
-Deprecation >> condition: aBlock [
-	condition := aBlock
-]
-
-{ #category : 'accessing' }
-Deprecation >> context: aContext [
-	context := aContext
-]
-
-{ #category : 'accessing' }
-Deprecation >> contextOfDeprecatedMethod [
-	^context
-]
-
-{ #category : 'accessing' }
-Deprecation >> contextOfSender [
-	^context home sender
-]
-
-{ #category : 'accessing' }
-Deprecation >> date: aDate [
-	deprecationDate := aDate
 ]
 
 { #category : 'handling' }
 Deprecation >> defaultAction [
 
-	Log ifNotNil: [ :log | log add: self ].
+	self class addLog: self.
 	self showWarning ifTrue: [ self logTranscript ].
 	self raiseWarning ifTrue: [ super defaultAction ].
 	self shouldTransform ifTrue: [ self transform ]
-]
-
-{ #category : 'private' }
-Deprecation >> deprecatedMethodName [
-	^self contextOfDeprecatedMethod homeMethod printString
-]
-
-{ #category : 'accessing' }
-Deprecation >> deprecationDate [
-
-	^ deprecationDate ifNil: [ 'unknown' ]
-]
-
-{ #category : 'accessing' }
-Deprecation >> explanation: aString [
-	explanationString := aString
-]
-
-{ #category : 'accessing' }
-Deprecation >> explanationString [
-
-	^ explanationString
-]
-
-{ #category : 'comparing' }
-Deprecation >> hash [
-	^(context ifNil: [explanationString]) hash
 ]
 
 { #category : 'private' }
@@ -184,7 +67,7 @@ Deprecation >> logTranscript [
 Deprecation >> messageText [
 	^String streamContents: [ :str |
 		self shouldTransform ifTrue: [
-			str nextPutAll:  'Automatic deprecation code rewrite: '].
+			str nextPutAll:  'Automatic deprecation caller rewrite: '].
 		str
 			nextPutAll: 'The method ';
 			nextPutAll: self deprecatedMethodName;
@@ -192,49 +75,6 @@ Deprecation >> messageText [
 			nextPutAll: self sendingMethodName;
 			nextPutAll: ' has been deprecated. ';
 		 	nextPutAll: explanationString]
-]
-
-{ #category : 'settings' }
-Deprecation >> raiseWarning [
-	^ self class raiseWarning
-]
-
-{ #category : 'private' }
-Deprecation >> rewriterClass [
-	^ self class environment at: #ASTParseTreeRewriter ifAbsent: [ nil ]
-]
-
-{ #category : 'accessing' }
-Deprecation >> rule: aRule [
-	rule := aRule
-]
-
-{ #category : 'private' }
-Deprecation >> sendingMethodName [
-	^self contextOfSender homeMethod printString
-]
-
-{ #category : 'handling' }
-Deprecation >> shouldTransform [
-	self class activateTransformations ifFalse: [ ^false  ].
-	(condition isNil or: [ condition cull: self ]) ifFalse: [ ^false ].
-	^rule isNotNil
-]
-
-{ #category : 'settings' }
-Deprecation >> showWarning [
-	^ self class showWarning
-]
-
-{ #category : 'handling' }
-Deprecation >> signal [
-	| pragma homeMethod |
-	homeMethod := context homeMethod.
-	(homeMethod hasPragmaNamed: #transform:to:) ifFalse: [ ^super signal ].
-
-	pragma := homeMethod pragmaAt: #transform:to:.
-	self rule: pragma arguments first -> pragma arguments second.
-	self transform
 ]
 
 { #category : 'handling' }
@@ -260,16 +100,5 @@ Deprecation >> transform [
 		aMethod origin
 			compile: aMethod ast formattedCode
 			classified: aMethod protocol.
-		Log ifNotNil: [ :log | log add: self ] ]
-]
-
-{ #category : 'accessing' }
-Deprecation >> version: aString [
-	versionString := aString
-]
-
-{ #category : 'accessing' }
-Deprecation >> versionString [
-
-	^ versionString ifNil: [ 'unknown' ]
+		self class addLog: self ]
 ]

--- a/src/Kernel/Deprecation.class.st
+++ b/src/Kernel/Deprecation.class.st
@@ -25,12 +25,6 @@ If the transformation is defined, the Warning will not signalled.
 Class {
 	#name : 'Deprecation',
 	#superclass : 'AutomaticRewriting',
-	#classVars : [
-		'Active',
-		'Log',
-		'RaiseWarning',
-		'ShowWarning'
-	],
 	#category : 'Kernel-Exceptions',
 	#package : 'Kernel',
 	#tag : 'Exceptions'

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -390,6 +390,19 @@ Object >> attemptToAssign: value withIndex: index [
 	"CAN'T REACH"
 ]
 
+{ #category : 'deprecation' }
+Object >> backwardCompatible: anExplanationString on: date in: version transformWith: aRule [
+	"Automatically transform the backward compatible calls to this method"
+
+	BackwardCompatibility new
+		context: thisContext sender;
+		explanation: anExplanationString;
+		date: date;
+		version: version;
+		rule: aRule;
+		signal
+]
+
 { #category : 'accessing' }
 Object >> basicAt: index [
 	"Primitive. Assumes receiver is indexable. Answer the value of an
@@ -640,7 +653,7 @@ It doesn't handle cycles, #veryDeepCopy does. In the future we will make it hand
 
 { #category : 'deprecation' }
 Object >> deprecated: anExplanationString [
-	"Warn that the sending method has been deprecated"
+	"Warn that the sending method has been deprecated."
 
 	Deprecation new
 		context: thisContext sender;
@@ -650,7 +663,7 @@ Object >> deprecated: anExplanationString [
 
 { #category : 'deprecation' }
 Object >> deprecated: anExplanationString on: date in: version [
-	"Warn that the sending method has been deprecated"
+	"Warn that the sending method has been deprecated."
 
 	Deprecation new
 		context: thisContext sender;
@@ -661,8 +674,11 @@ Object >> deprecated: anExplanationString on: date in: version [
 ]
 
 { #category : 'deprecation' }
-Object >> deprecated: anExplanationString on: date in: version transformWith: aRule [
-	"Automatically tranform the deprecated call"
+Object >> deprecated: anExplanationString 
+	on: date 
+	in: version 
+	transformWith: aRule [
+	"Automatically transform the deprecated calls."
 
 	Deprecation new
 		context: thisContext sender;
@@ -674,8 +690,12 @@ Object >> deprecated: anExplanationString on: date in: version transformWith: aR
 ]
 
 { #category : 'deprecation' }
-Object >> deprecated: anExplanationString on: date in: version transformWith: aRule when: conditionBlock [
-	"Automatically tranform the deprecated call if it matches the condition"
+Object >> deprecated: anExplanationString 
+	on: date 
+	in: version 
+	transformWith: aRule 
+	when: conditionBlock [
+	"Automatically transform the deprecated call if it matches the condition."
 
 	Deprecation new
 		context: thisContext sender;
@@ -689,7 +709,7 @@ Object >> deprecated: anExplanationString on: date in: version transformWith: aR
 
 { #category : 'deprecation' }
 Object >> deprecated: anExplanationString transformWith: aRule [
-	"Automatically tranform the deprecated call"
+	"Automatically transform the deprecated call."
 
 	Deprecation new
 		context: thisContext sender;
@@ -700,7 +720,7 @@ Object >> deprecated: anExplanationString transformWith: aRule [
 
 { #category : 'deprecation' }
 Object >> deprecated: anExplanationString transformWith: aRule when: conditionBlock [
-	"Automatically tranform the deprecated call if it matches the condition"
+	"Automatically transform the deprecated call if it matches the condition."
 
 	Deprecation new
 		context: thisContext sender;

--- a/src/SUnit-Core/BackwardCompatibility.extension.st
+++ b/src/SUnit-Core/BackwardCompatibility.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : 'BackwardCompatibility' }
+
+{ #category : '*SUnit-Core' }
+BackwardCompatibility >> manageTestProcessBy: aProcessMonitorTestService [
+	"Deprecation is not considered as a test failure.
+	So we are ignoring it here just like any other notification"
+]
+
+{ #category : '*SUnit-Core' }
+BackwardCompatibility >> sunitAnnounce: aTestCase toResult: aTestResult [
+
+	self pass
+]

--- a/src/SUnit-Core/TestResult.class.st
+++ b/src/SUnit-Core/TestResult.class.st
@@ -112,7 +112,7 @@ TestResult class >> updateTestHistoryFor: aTestCase status: aSymbol [
 { #category : 'exceptions' }
 TestResult class >> warning [
 	"Warning that should be treated as test failure"
-	^Deprecation
+	^{ Deprecation . BackwardCompatibility }
 ]
 
 { #category : 'adding' }


### PR DESCRIPTION
- read the commit comments. 
- Why this user interface does not do it automatically?
- added a common superclass
- move shared variables to metaclass instance variables
- Integrate it into Sunit
- Only provide a single method with transform: we only support backward compatibility in presence of existing replacement!