### PR TITLE
Fix Rename temp refactoring

### DIFF
--- a/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
@@ -81,9 +81,8 @@ RBRenameArgumentOrTemporaryRefactoring >> class: aClass selector: aSelector inte
 
 { #category : 'initialization' }
 RBRenameArgumentOrTemporaryRefactoring >> class: aClass selector: aSelector interval: anInterval newName: aString [
-	class := self classObjectFor: aClass.
-	selector := aSelector.
-	interval := anInterval.
+
+	self class: aClass selector: aSelector interval: anInterval.
 	newName := aString
 ]
 

--- a/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
+++ b/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
@@ -59,6 +59,7 @@ ReRenameArgumentOrTemporaryDriver >> runRefactoring [
 
 	| cancelled |
 	self configureRefactoring.
+	refactoring prepareForExecution. "This is needed to set some info in the refactoring such as the parse tree or the defining node."
 	(refactoring applicabilityPreconditionsIndependentOfTheNewName reject: [ :condition | condition check ]) ifNotEmpty: [
 		^ self inform: 'The interval selected is not right to rename a temporary variable.' ].
 


### PR DESCRIPTION
Rename temp refactoring needs #prepareForExecution to be called to be able to work and that was not the case.

@Ducasse @balsa-sarenac 
I have the impression that #prepareForExecution is something common in refactorings but I see no driver that call it already. Is it something missing in the drivers or is this refactoring "special"? Maybe there is a fix more generic than what we did to improve other refactorings as well but I don't know enough the refactoring architecture to be sure :)

There is also a small factorization of code

Co-authored-by: AlexisCnockaert <uzzelekbeatspro@gmail.com>

Fixes #17418