### PR TITLE
17440 refactorings reserved names should not be duplicated

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -199,7 +199,7 @@ Symbol class >> rehash [
 { #category : 'accessing' }
 Symbol class >> reservedLiterals [
 
-	^ PseudoVariable lookupDictionary keys
+	^ PseudoVariable lookupDictionary keys union: #( #nil #true #false )
 ]
 
 { #category : 'cleanup' }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -196,6 +196,12 @@ Symbol class >> rehash [
 	self resetSelectorTable
 ]
 
+{ #category : 'as yet unclassified' }
+Symbol class >> reservedLiterals [
+
+	^ PseudoVariable lookupDictionary keys
+]
+
 { #category : 'cleanup' }
 Symbol class >> resetSelectorTable [
 	^ SelectorTable := nil

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -196,7 +196,7 @@ Symbol class >> rehash [
 	self resetSelectorTable
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 Symbol class >> reservedLiterals [
 
 	^ PseudoVariable lookupDictionary keys

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -38,7 +38,7 @@ RBCondition class >> checkClassVarName: aName in: aClass [
 	| string |
 	aName isString ifFalse: [^false].
 	string := aName asString.
-	(self reservedNames includes: string) ifTrue: [^false].
+	(Symbol reservedLiterals includes: string) ifTrue: [^false].
 	string isEmpty ifTrue: [^false].
 	string first isUppercase ifFalse: [^false].
 	^RBScanner isVariable: string
@@ -51,7 +51,7 @@ RBCondition class >> checkInstanceVariableName: aName in: aClass [
 	aName isString ifFalse: [ ^ false ].
 	string := aName.
 	string ifEmpty: [ ^ false ].
-	(self reservedNames includes: string) ifTrue: [ ^ false ].
+	(Symbol reservedLiterals includes: string) ifTrue: [ ^ false ].
 	string first isUppercase ifTrue: [ ^ false ].
 	^ RBScanner isVariable: string
 ]
@@ -381,11 +381,6 @@ RBCondition class >> referencesInstanceVariable: aString in: aClass [
 		  (aClass whichSelectorsReferToInstanceVariable: aString) isNotEmpty ]
 		  errorString: aClass printString
 			  , ' <1?:does not >reference<1?s:> instance variable ' , aString
-]
-
-{ #category : 'utilities' }
-RBCondition class >> reservedNames [
-	^#('self' 'true' 'false' 'nil' 'thisContext' 'super')
 ]
 
 { #category : 'instance creation' }

--- a/src/Refactoring-Core/ReIsValidInstanceVariableName.class.st
+++ b/src/Refactoring-Core/ReIsValidInstanceVariableName.class.st
@@ -20,7 +20,7 @@ ReIsValidInstanceVariableName >> check [
 	string isEmpty ifTrue: [
 		violator := name.
 		^ false ].
-	(self class reservedNames includes: string) ifTrue: [
+	(Symbol reservedLiterals includes: string) ifTrue: [
 		violator := name.
 		^ false ].
 	string first isUppercase ifTrue: [

--- a/src/Refactoring-Core/ReIsValidSharedVariableName.class.st
+++ b/src/Refactoring-Core/ReIsValidSharedVariableName.class.st
@@ -17,7 +17,7 @@ ReIsValidSharedVariableName >> check [
 		violator := name.
 		^ false ].
 	string := name asString.
-	(self class reservedNames includes: string) ifTrue: [
+	(Symbol reservedLiterals includes: string) ifTrue: [
 		violator := name.
 		^ false ].
 	string isEmpty ifTrue: [

--- a/src/Refactoring-Core/ReVariableNameCondition.class.st
+++ b/src/Refactoring-Core/ReVariableNameCondition.class.st
@@ -19,12 +19,6 @@ ReVariableNameCondition class >> name: aString [
 	^ self new name: aString
 ]
 
-{ #category : 'utilities' }
-ReVariableNameCondition class >> reservedNames [
-
-	^ PseudoVariable lookupDictionary keys
-]
-
 { #category : 'accessing' }
 ReVariableNameCondition >> errorString [
 

--- a/src/Refactoring-Core/ReVariableNameCondition.class.st
+++ b/src/Refactoring-Core/ReVariableNameCondition.class.st
@@ -21,7 +21,8 @@ ReVariableNameCondition class >> name: aString [
 
 { #category : 'utilities' }
 ReVariableNameCondition class >> reservedNames [
-	^#('self' 'true' 'false' 'nil' 'thisContext' 'super')
+
+	^ PseudoVariable lookupDictionary keys
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Fixes #17440
updated the methods that called RBCondition class>>#reservedNames.
and like @jecisc said, we can add missing literals by hand (here such as "true", "false" or "nil" that were in reservedNames but not in Symbol lookupdictionnaryl keys).
Tell me if I should add them 