### PR TITLE
Add String>>withPlatformLineEndings

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -2102,6 +2102,30 @@ StringTest >> testWithNoLineLongerThan [
 		  equals: ('Sample text' , String cr , 'to line break' , String cr , 'at some point')
 ]
 
+{ #category : 'tests - internet' }
+StringTest >> testWithPlatformLineEndings [
+
+	| platformLineEnding |
+	platformLineEnding := OSPlatform current lineEnding.
+
+	{
+		('abc' -> 'abc').
+		('abc' , String cr -> ('abc' , platformLineEnding)).
+		('abc' , String lf -> ('abc' , platformLineEnding)).
+		('abc' , String crlf -> ('abc' , platformLineEnding)).
+		(String cr , 'abc' -> (platformLineEnding , 'abc')).
+		(String lf , 'abc' -> (platformLineEnding , 'abc')).
+		(String crlf , 'abc' -> (platformLineEnding , 'abc')).
+		('abc' , String cr , String cr , 'abc' -> ('abc' , platformLineEnding , platformLineEnding , 'abc')).
+		('abc' , String lf , String lf , 'abc' -> ('abc' , platformLineEnding , platformLineEnding , 'abc')).
+		('abc' , String crlf , String crlf , 'abc' -> ('abc' , platformLineEnding , platformLineEnding , 'abc')).
+		(String cr , 'abc' , String cr , String crlf , 'abc' , String lf
+		 -> (platformLineEnding , 'abc' , platformLineEnding , platformLineEnding , 'abc' , platformLineEnding)).
+		(String lf , 'abc' , String lf , String crlf , 'abc' , String cr
+		 -> (platformLineEnding , 'abc' , platformLineEnding , platformLineEnding , 'abc' , platformLineEnding)) } do: [ :each |
+		self assert: each key withPlatformLineEndings equals: each value ]
+]
+
 { #category : 'tests - converting' }
 StringTest >> testWithSeparatorsCompacted [
 	#(

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2849,6 +2849,13 @@ String >> withNoLineLongerThan: aNumber [
 				stream nextPutAll: (self copyFrom: pastEnd to: end) ] ]
 ]
 
+{ #category : 'platform conventions' }
+String >> withPlatformLineEndings [
+	"Answer a new instance where all occurrences of CRLF, CR and LF are substituted with the line ending used by default by the current platform."
+
+	^ self withLineEndings: OSPlatform current lineEnding
+]
+
 { #category : 'converting' }
 String >> withSeparatorsCompacted [
     "Returns a copy of the receiver with each sequence of whitespace (separator)


### PR DESCRIPTION
We already have some utility methods to replace all line return of a string by cr, lf or crlf but we have none using the platform line ending. I'm proposing to add this one withPlatformLineEndings