### PR TITLE
Rename temp var; remove dot after comment

### DIFF
--- a/src/AST-Core/RBParser.class.st
+++ b/src/AST-Core/RBParser.class.st
@@ -294,7 +294,7 @@ RBParser >> parseAssignment [
 	currentToken isAssignment ifTrue: [
 		err := self parseErrorNode: 'variable expected in assigment'.
 		self step. "Consume the :="
-		node := self parseAssignment. "parse the right side".
+		node := self parseAssignment. "parse the right side"
 		node := ASTAssignmentErrorNode from: err contents: { node }.
 		node value: ':='.
 		^ node

--- a/src/Kernel/MessageSend.class.st
+++ b/src/Kernel/MessageSend.class.st
@@ -201,17 +201,17 @@ MessageSend >> valueWithArguments: anArray [
 MessageSend >> valueWithEnoughArguments: anArray [
 	"call the selector with enough arguments from arguments and anArray"
 	<reflection: 'Message sending and code execution - Runtime and Evaluation'>
-	| args |
-	args := Array new: selector numArgs.
-	args replaceFrom: 1
-		to: (arguments size min: args size)
+	| newArgs |
+	newArgs := Array new: selector numArgs.
+	newArgs replaceFrom: 1
+		to: (arguments size min: newArgs size)
 		with: arguments
 		startingAt: 1.
-	args size > arguments size ifTrue: [
-		args replaceFrom: arguments size + 1
-			to: (arguments size + anArray size min: args size)
+	newArgs size > arguments size ifTrue: [
+		newArgs replaceFrom: arguments size + 1
+			to: (arguments size + anArray size min: newArgs size)
 			with: anArray
 			startingAt: 1.
 	].
-	^ receiver perform: selector withArguments: args
+	^ receiver perform: selector withArguments: newArgs
 ]

--- a/src/Kernel/WeakMessageSend.class.st
+++ b/src/Kernel/WeakMessageSend.class.st
@@ -281,21 +281,21 @@ WeakMessageSend >> valueWithArguments: anArray [
 WeakMessageSend >> valueWithEnoughArguments: anArray [
 	"call the selector with enough arguments from arguments and anArray"
 	<reflection: 'Message sending and code execution - Runtime and Evaluation'>
-	| args strongReceiver |
+	| newArgs strongReceiver |
 
 	strongReceiver := self receiver.
 
 	(self ensureReceiverAndArguments: strongReceiver) ifFalse: [ ^nil ].
-	args := Array new: selector numArgs.
-	args replaceFrom: 1
-		to: ( arguments size min: args size)
+	newArgs := Array new: selector numArgs.
+	newArgs replaceFrom: 1
+		to: ( arguments size min: newArgs size)
 		with: arguments
 		startingAt: 1.
-	args size > arguments size ifTrue: [
-		args replaceFrom: arguments size + 1
-			to: (arguments size + anArray size min: args size)
+	newArgs size > arguments size ifTrue: [
+		newArgs replaceFrom: arguments size + 1
+			to: (arguments size + anArray size min: newArgs size)
 			with: anArray
 			startingAt: 1.
 	].
-	^ strongReceiver perform: selector withArguments: args
+	^ strongReceiver perform: selector withArguments: newArgs
 ]

--- a/src/NumberParser/NumberParser.class.st
+++ b/src/NumberParser/NumberParser.class.st
@@ -513,7 +513,7 @@ NumberParser >> readExponent [
 			sourceStream skip: ((eneg or: [ epos ]) ifTrue: [ -2 ] ifFalse: [ -1 ]).
 			^ false ].
 		
-	"If the exponent is bigger than our max exponent, we return an error".
+	"If the exponent is bigger than our max exponent, we return an error"
 	exponent > self maxExponent
 		ifTrue: [ 
 				self expected: 'Exponent is larger than ' , self maxExponent printString , ' (Check Settings)'.

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1193,7 +1193,7 @@ SmalltalkImage >> newSpecialObjectsArray [
 	newArray at: 26 put: #mustBeBoolean.
 	newArray at: 27 put: ByteArray.
 	newArray at: 28 put: nil. "was Process."
-	newArray at: 29 put: nil. "was compact classes".
+	newArray at: 29 put: nil. "was compact classes"
 	newArray at: 30 put: ((self primitiveGetSpecialObjectsArray at: 30) ifNil: [Semaphore new]). "delay Semaphore"
 	newArray at: 31 put: ((self primitiveGetSpecialObjectsArray at: 31) ifNil: [Semaphore new]). "user interrupt Semaphore"
 	newArray at: 32 put: Float32Array. "was the prototype Float"


### PR DESCRIPTION
* GemStone has an instance var named `args` so I'd like to rename a method temp var to `newArgs`.
* Remove dots following comments.