### PR TITLE
Fixes #17459: Remove "Declare new Global" feature from the undeclared variable dialogue

### DIFF
--- a/src/OpalCompiler-UI/OCCodeReparator.class.st
+++ b/src/OpalCompiler-UI/OCCodeReparator.class.st
@@ -133,7 +133,6 @@ OCCodeReparator >> openMenu [
 	* Return fail if the user cancel"
 
 	| alternatives labels actions lines caption choice name interval |
-
 	interval := node sourceInterval.
 	name := node name.
 	alternatives := self possibleVariablesFor: name.
@@ -151,33 +150,30 @@ OCCodeReparator >> openMenu [
 			actions add: [ ^ nil ].
 			lines add: labels size.
 			labels add: 'Define new class'.
-			actions
-				add: [
-					[ self defineClass: name asSymbol ]
-						on: Abort
-						do: [ self openMenu ] ].
-			labels add: 'Declare new global'.
-			actions add: [ self declareGlobal ].
-			requestor isScripting ifFalse:
-				[labels add: 'Declare new class variable'.
-				actions add: [ self declareClassVar ]].
+			actions add: [
+				[ self defineClass: name asSymbol ]
+					on: Abort
+					do: [ self openMenu ] ].
+			requestor isScripting ifFalse: [
+				labels add: 'Declare new class variable'.
+				actions add: [ self declareClassVar ] ].
 			labels add: 'Define new trait'.
-			actions
-				add: [
-					[ self defineTrait: name asSymbol ]
-						on: Abort
-						do: [ self openMenu ] ] ].
+			actions add: [
+				[ self defineTrait: name asSymbol ]
+					on: Abort
+					do: [ self openMenu ] ] ].
 	lines add: labels size.
-	alternatives
-		do: [ :each |
-			labels add: each.
-			actions
-				add: [
-					self substituteVariable: each atInterval: interval ] ].
+	alternatives do: [ :each |
+		labels add: each.
+		actions add: [ self substituteVariable: each atInterval: interval ] ].
 	lines add: labels size.
 	labels add: 'Cancel'.
-	caption := 'Unknown variable: ' , name , ' please correct, or cancel:'.
-	choice := MorphicUIManager new chooseFrom: labels lines: lines title: caption.
+	caption := 'Unknown variable: ' , name
+	           , ' please correct, or cancel:'.
+	choice := MorphicUIManager new
+		          chooseFrom: labels
+		          lines: lines
+		          title: caption.
 	(actions at: choice ifAbsent: [ ^ false ]) value.
 	^ true
 ]


### PR DESCRIPTION
removed "Declare new global" option from unknown variable menu Morphic