### PR TITLE
Add a retry in case of IceGenericError in the bootstrap

### DIFF
--- a/bootstrap/scripts/prepare_image.st
+++ b/bootstrap/scripts/prepare_image.st
@@ -9,8 +9,19 @@
 
   Transcript show: '    [+] Loading tonel code to dump files for the Pharo bootstrap process from ' , repositoryPathString; cr.
 
+
+"For now, it happens that we have an error from time to time when bootstraping with the next step (IceGenericError: error reading from the zlib stream).
+This error should be fixed in recent Pharo versions but for now the bootstrap runs on Pharo ~10. In the meantime I'm adding a catch of this error with a retry."
+[
   Metacello new
-	baseline: 'PharoBootstrapProcess';
-	repository: 'tonel://', repositoryPathString;
-	load.
+	  baseline: 'PharoBootstrapProcess';
+	  repository: 'tonel://', repositoryPathString;
+	  load ]
+      on: IceGenericError
+      do: [ :exception |
+        Metacello new
+	        baseline: 'PharoBootstrapProcess';
+	        repository: 'tonel://', repositoryPathString;
+	        load
+      ].
 ] on: Warning do: #resume.


### PR DESCRIPTION
It happens a lot that we get this during the bootstrap: `IceGenericError: error reading from the zlib stream`. 

I'm proposing to add a retry in case we get this error. I'm not sure it'll work since I cannot try with a random failure but it's worth a try