### PR TITLE
Fix default behavior of literalEqual:

### DIFF
--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -264,6 +264,12 @@ ByteArray >> isLiteral [
 	^ self class == ByteArray
 ]
 
+{ #category : 'comparing' }
+ByteArray >> literalEqual: other [
+
+	^ self class == other class and: [self = other]
+]
+
 { #category : 'platform independent access' }
 ByteArray >> longAt: index bigEndian: aBool [
 	"Return a 32bit integer quantity starting from the given byte index"

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2201,6 +2201,12 @@ String >> linesDo: aBlock [
 ]
 
 { #category : 'comparing' }
+String >> literalEqual: other [
+
+	^ self class == other class and: [self = other]
+]
+
+{ #category : 'comparing' }
 String >> match: text [
 	"Answer whether text matches the pattern in this string.
 	Matching ignores upper/lower case differences.

--- a/src/Kernel/Number.class.st
+++ b/src/Kernel/Number.class.st
@@ -346,6 +346,12 @@ Number >> isZero [
 	^self = 0
 ]
 
+{ #category : 'comparing' }
+Number >> literalEqual: other [
+
+	^ self class == other class and: [self = other]
+]
+
 { #category : 'arithmetic' }
 Number >> negated [
 	"Answer a Number that is the negation of the receiver."

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1286,7 +1286,7 @@ Object >> isVariableBinding [
 { #category : 'comparing' }
 Object >> literalEqual: other [
 
-	^ self class == other class and: [self = other]
+	^ self == other
 ]
 
 { #category : 'printing' }

--- a/src/OpalCompiler-Tests/OCLiteralTest.class.st
+++ b/src/OpalCompiler-Tests/OCLiteralTest.class.st
@@ -1,0 +1,90 @@
+Class {
+	#name : 'OCLiteralTest',
+	#superclass : 'TestCase',
+	#category : 'OpalCompiler-Tests-Misc',
+	#package : 'OpalCompiler-Tests',
+	#tag : 'Misc'
+}
+
+{ #category : 'tests' }
+OCLiteralTest >> assertObject: anObject isLiteralIdenticalTo: anotherObject [
+
+	| literals |
+	literals := OCLiteralList new.
+
+	self
+		assert: (literals addLiteral: anObject)
+		equals: (literals addLiteral: anotherObject)
+]
+
+{ #category : 'tests' }
+OCLiteralTest >> assertObject: anObject isNotLiteralIdenticalTo: anotherObject [
+
+	| literals |
+	literals := OCLiteralList new.
+
+	self assert: anObject equals: anotherObject.
+	self
+		deny: (literals addLiteral: anObject)
+		equals: (literals addLiteral: anotherObject)
+]
+
+{ #category : 'tests' }
+OCLiteralTest >> testFloatAndIntegerDoNotShareSameEntryEvenIfEqual [
+
+	self
+		assertObject: 1
+		isNotLiteralIdenticalTo: 1 asFloat
+]
+
+{ #category : 'tests' }
+OCLiteralTest >> testRandomObjectsOfTheSameClassDoNotShareSameEntryEvenIfEqual [
+
+	"Use a copy to avoid any kind of compiler optimization"
+	self
+		assertObject: (1@2) copy
+		isNotLiteralIdenticalTo: (1@2) copy
+]
+
+{ #category : 'tests' }
+OCLiteralTest >> testScaleDecimalsWithDifferentScalesDoNotShareSameEntryEvenIfEqual [
+
+	self
+		assertObject: 1.01s2
+		isNotLiteralIdenticalTo: 1.01s5
+]
+
+{ #category : 'tests' }
+OCLiteralTest >> testTwoEqualFloatsShareSameLiteralEntry [
+
+	self
+		assertObject: 1 asFloat
+		isLiteralIdenticalTo: 1 asFloat
+]
+
+{ #category : 'tests' }
+OCLiteralTest >> testTwoEqualIntegersShareSameLiteralEntry [
+
+	self
+		assertObject: 1
+		isLiteralIdenticalTo: 1
+]
+
+{ #category : 'tests' }
+OCLiteralTest >> testTwoEqualStringsShareSameLiteralEntry [
+
+	"Use a string and force copy it to guarantee we have two different strings"
+	| theString |
+	theString := 'someString'.
+	self
+		assertObject: theString copy
+		isLiteralIdenticalTo: theString copy
+]
+
+{ #category : 'tests' }
+OCLiteralTest >> testTwoEqualSymbolsShareSameLiteralEntry [
+
+	self
+		assertObject: (Symbol intern: 'symbol')
+		isLiteralIdenticalTo: (Symbol intern: 'symbol')
+]


### PR DESCRIPTION
Do not share literals by default.
Instead, do it if users explicitly request so in their implementation of literalEqual:

Add tests

Fixes https://github.com/pharo-project/pharo/issues/17264
 => the reason is that reflectivity pushes AST nodes to the literal frame, and literal nodes are consireded equal if they have the same contents (regarless of their position in the tree). Thus, two similar nodes in different part of the trees were considered equals and shared, avoiding reflectivity to call the right method on the right node.