### PR TITLE
Move compiled method installation code from compile to install step

### DIFF
--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -86,16 +86,20 @@ Behavior >> recompile: selector from: oldClass [
 	"Compile the method associated with selector in the receiver's method dictionary."
 
 	| method newMethod |
-	method := oldClass compiledMethodAt: selector.
-	newMethod := oldClass compiler
-		             source: (oldClass sourceCodeAt: selector);
-		             priorMethod: method;
-		             class: self;
-		             permitFaulty: true;
-						"No need to log recompilation in the sources,
-						 We are going to reuse the original source pointer."
-		             logged: false; 
-		             install.
+
+	"Recompilation should be done silently, to avoid putting noise in the system"
+	self codeChangeAnnouncer suspendAllWhile: [
+		method := oldClass compiledMethodAt: selector.
+		newMethod := oldClass compiler
+			             source: (oldClass sourceCodeAt: selector);
+			             priorMethod: method;
+			             class: self;
+			             permitFaulty: true;
+			             "No need to log recompilation in the sources,
+						 	 We are going to reuse the original source pointer."
+			             logged: false;
+			             install ].
+
 	newMethod sourcePointer: method sourcePointer.
 	selector == newMethod selector ifFalse: [
 		self error: 'selector changed!' ]

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -85,28 +85,18 @@ Behavior >> recompile: selector [
 Behavior >> recompile: selector from: oldClass [
 	"Compile the method associated with selector in the receiver's method dictionary."
 
-	| newMethod |
-	newMethod := self recompileBasic: selector from: oldClass.
-	self addSelectorSilently: selector withMethod: newMethod
-]
-
-{ #category : '*OpalCompiler-Core' }
-Behavior >> recompileBasic: selector from: oldClass [
-	"Compile the method associated with selector in the receiver's context.
-	The resulting compiled method is not installed.
-	If the original method is faulty, the result will be also faulty (silently)."
-
 	| method newMethod |
 	method := oldClass compiledMethodAt: selector.
 	newMethod := oldClass compiler
-				source: (oldClass sourceCodeAt: selector);
-				priorMethod: method;
-				class: self;
-				permitFaulty: true;
-				logged: false; "No need to log recompilation in the sources."
-				compile.   "Assume OK after proceed from SyntaxError"
+		             source: (oldClass sourceCodeAt: selector);
+		             priorMethod: method;
+		             class: self;
+		             permitFaulty: true;
+						"No need to log recompilation in the sources,
+						 We are going to reuse the original source pointer."
+		             logged: false; 
+		             install.
 	newMethod sourcePointer: method sourcePointer.
-
-	selector == newMethod selector ifFalse: [self error: 'selector changed!'].
-	^ newMethod
+	selector == newMethod selector ifFalse: [
+		self error: 'selector changed!' ]
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -545,13 +545,6 @@ OpalCompiler >> generateMethod [
 	method propertyAt: #source put: source.
 	self isScripting ifTrue: [ method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"
 
-	"If the prior method was not set explicitly, we set it because we will need it if we are not in the first compilation"
-	self priorMethod ifNil: [
-		self methodClass ifNotNil: [ :class | "In case the method comes from a trait, we ignore it because it means we are overriding the trait method in the class"
-			class compiledMethodAt: method selector ifPresent: [ :aMethod | aMethod isFromTrait ifFalse: [ self priorMethod: aMethod ] ] ] ].
-
-	"In case we are not compiling the method for the first time, we want to ensure that some properties are kept."
-	self priorMethod ifNotNil: [ priorMethod migratePersistingPropertiesIn: method ].
 	^ method
 ]
 
@@ -564,6 +557,15 @@ OpalCompiler >> install [
 	self assert: class isNotNil.
 
 	method := self compile ifNil: [ ^ nil ].
+
+	"If the prior method was not set explicitly, we set it because we will need it if we are not in the first compilation"
+	self priorMethod ifNil: [ "In case the method comes from a trait, we ignore it because it means we are overriding the trait method in the class"
+		class compiledMethodAt: method selector ifPresent: [ :aMethod |
+			aMethod isFromTrait ifFalse: [ self priorMethod: aMethod ] ] ].
+
+	"In case we are not compiling the method for the first time, we want to ensure that some properties are kept."
+	self priorMethod ifNotNil: [
+		priorMethod migratePersistingPropertiesIn: method ].
 
 	changeStamp ifNil: [
 		changeStamp := Date today mmddyyyy , ' '

--- a/src/Reflectivity/ReflectiveMethod.class.st
+++ b/src/Reflectivity/ReflectiveMethod.class.st
@@ -228,6 +228,10 @@ ReflectiveMethod >> printOn: aStream [
 ReflectiveMethod >> recompileAST [
 
 	compiledMethod := self compileAST.
+	"This is bad.
+	Reflectivity has its own method installation process
+	This makes us duplicate behavior in here to pass the properties of old methods to ones"
+	ast compiledMethod migratePersistingPropertiesIn: compiledMethod.
 	ast compiledMethod: compiledMethod.
 	compiledMethod reflectiveMethod: self
 ]


### PR DESCRIPTION
The compile step tries to fill a method with metadata existing on installed methods.
Fetching this existing method and filling the meta-data should be done at the installation step and not the compilation step.

This is important for the bootstrap step, where no prior method exists, and no prior class to look for is there either.