### PR TITLE
Fix #17471: custom Job interruption

### DIFF
--- a/src/Jobs/Job.class.st
+++ b/src/Jobs/Job.class.st
@@ -23,7 +23,8 @@ Class {
 		'parent',
 		'process',
 		'owner',
-		'announcer'
+		'announcer',
+		'interruptBlock'
 	],
 	#classInstVars : [
 		'jobAnnouncer'
@@ -232,6 +233,7 @@ Job >> initialize [
 	title := ''.
 	isRunning := false.
 	children := OrderedCollection new.
+	interruptBlock := [ process debug ]
 ]
 
 { #category : 'accessing' }
@@ -239,6 +241,24 @@ Job >> installOn: aPresenter [
 	"this method is provider for compatibility"
 	
 	announcer := aPresenter announcer
+]
+
+{ #category : 'running' }
+Job >> interrupt [
+
+	self isRunning ifTrue: [ interruptBlock cull: self ]
+]
+
+{ #category : 'accessing' }
+Job >> interruptBlock [
+
+	^ interruptBlock
+]
+
+{ #category : 'accessing' }
+Job >> interruptBlock: aBlock [
+
+	interruptBlock := aBlock
 ]
 
 { #category : 'testing' }
@@ -362,6 +382,12 @@ Job >> run [
 		during: [ ^ block cull: self ] ]
 	ensure: [ 
 		self cleanupAfterRunning ]
+]
+
+{ #category : 'running' }
+Job >> terminate [
+
+	process terminate
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Base/JobProgressMorph.class.st
+++ b/src/Morphic-Base/JobProgressMorph.class.st
@@ -63,12 +63,6 @@ JobProgressMorph >> current: aNumber [
 	self changed
 ]
 
-{ #category : 'action' }
-JobProgressMorph >> debug [
-
-	job isRunning ifTrue: [ job debug ]
-]
-
 { #category : 'API' }
 JobProgressMorph >> decrement [
 
@@ -125,7 +119,7 @@ JobProgressMorph >> initializeJob: aJob [
 		font: StandardFonts defaultFont.
 	bar := JobProgressBarMorph new.
 	bar
-		on: #mouseUp send: #debug to: self;
+		on: #mouseUp send: #interrupt to: aJob;
 		hResizing: #spaceFill.
 	self updateLayout
 ]


### PR DESCRIPTION
Job now has an `interruptBlock` instance variable which by default calls `debug` on its process (original behavior).
Added `terminate` method to the Job so that it can be called to stop the process without exposing it.
Removed `JobProgressMorph>>#debug` because it's the only Morph with this method, and to me it does not make sense to debug the Job by asking the Morph, feel free to put it back if it is truly needed.