### PR TITLE
Do not change the border color of an ImageMorph if it already has a color

### DIFF
--- a/src/Morphic-Base/ImageMorph.class.st
+++ b/src/Morphic-Base/ImageMorph.class.st
@@ -88,15 +88,6 @@ ImageMorph >> addCustomMenuItems: aMenu hand: aHand [
 	aMenu addUpdating: #opacityString selector: #changeOpacity
 ]
 
-{ #category : 'geometry' }
-ImageMorph >> adoptPaneColor: paneColor [
-	"Change our border color too."
-
-	super adoptPaneColor: paneColor.
-	paneColor ifNil: [^self].
-	self borderStyle baseColor: paneColor twiceDarker
-]
-
 { #category : 'testing' }
 ImageMorph >> areasRemainingToFill: aRectangle [
 


### PR DESCRIPTION
PR for https://github.com/pharo-spec/Spec/issues/1649. Please read https://github.com/pharo-spec/Spec/issues/1649#issuecomment-2507877634 for the analysis of the bug and the suggested change made in this PR.