### PR TITLE
Close windows from taskbar thumbnail

### DIFF
--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -87,15 +87,18 @@ SystemWindow >> taskbarButtonClicked [
 SystemWindow >> taskbarButtonEntered: aButton event: evt in: aMorph [
 	"The mouse has entered out taskbar button.
 	Show a thumbnail."
+	| taskbar |
+	taskbar := aButton owner.
 
-	aButton owner ifNotNil: [:buttonBar | |thumb|
+	taskbar ifNotNil: [:buttonBar | |thumb|
 		buttonBar showWindowPreview ifFalse: [^self].
-		thumb := self valueOfProperty: #taskbarThumbnail.
-		thumb
-			ifNil: [thumb := self theme newTaskbarThumbnailIn: self for: self]
-			ifNotNil: [^self].
-		self setProperty: #taskbarThumbnail toValue: thumb.
-		thumb bottomLeft: ((aButton left min: aButton owner right - thumb width)@ (aButton owner top - 4)).
+		thumb := taskbar valueOfProperty: #taskbarThumbnail.
+		thumb ifNotNil: [
+			thumb window = self ifTrue: [^self].
+			thumb delete ].
+		thumb := self theme newTaskbarThumbnailFor: self taskbarButton: aButton.
+		taskbar setProperty: #taskbarThumbnail toValue: thumb.
+		thumb bottomLeft: (aButton left min: taskbar right - thumb width)@ (taskbar top - 4).
 		thumb openInWorld]
 ]
 
@@ -113,12 +116,6 @@ SystemWindow >> taskbarButtonFor: aTaskbar [
 SystemWindow >> taskbarButtonLeft: aButton event: evt in: aMorph [
 	"The mouse has left our taskbar button.
 	Remove our thumbnail."
-
-	self
-		valueOfProperty: #taskbarThumbnail
-		ifPresentDo: [:thumb |
-			thumb delete.
-			self removeProperty: #taskbarThumbnail]
 ]
 
 { #category : '*Morphic-Widgets-Taskbar' }

--- a/src/Polymorph-Widgets/TaskbarThumbnailMorph.class.st
+++ b/src/Polymorph-Widgets/TaskbarThumbnailMorph.class.st
@@ -46,6 +46,13 @@ TaskbarThumbnailMorph >> button: aButton [
 		to: self
 ]
 
+{ #category : 'submorphs - add/remove' }
+TaskbarThumbnailMorph >> delete [
+	"NOTE: We should only remove it if we are the current thumbnail"
+	taskbar removeProperty: #taskbarThumbnail.
+	super delete
+]
+
 { #category : 'event handling' }
 TaskbarThumbnailMorph >> handlesMouseOver: evt [
 

--- a/src/Polymorph-Widgets/TaskbarThumbnailMorph.class.st
+++ b/src/Polymorph-Widgets/TaskbarThumbnailMorph.class.st
@@ -1,0 +1,131 @@
+"
+I am the helpful little window that appear when you hover a taskbar button. I show a recent screenshot of the window in question and an easy way to close that window.
+"
+Class {
+	#name : 'TaskbarThumbnailMorph',
+	#superclass : 'PanelMorph',
+	#instVars : [
+		'window',
+		'taskbarButton',
+		'deleteAt',
+		'taskbar'
+	],
+	#category : 'Polymorph-Widgets-Themes',
+	#package : 'Polymorph-Widgets',
+	#tag : 'Themes'
+}
+
+{ #category : 'instance creation' }
+TaskbarThumbnailMorph class >> for: aWindow taskbarButton: aButton theme: aTheme [
+	^ self new
+		window: aWindow;
+		button: aButton;
+		theme: aTheme;
+		initializeAppearance;
+		yourself.
+]
+
+{ #category : 'fading' }
+TaskbarThumbnailMorph >> aboutToBeDeleted [
+	deleteAt := DateAndTime now + 150 milliSeconds
+]
+
+{ #category : 'accessing' }
+TaskbarThumbnailMorph >> button: aButton [
+	self assert: taskbarButton isNil description: 'Do not change the taskbar button after creation'.
+	taskbarButton := aButton.
+	taskbar := aButton owner.
+
+	taskbarButton
+		on: #mouseEnter
+		send: #isNotBeingDeleted
+		to: self;
+	
+		on: #mouseLeave
+		send: #aboutToBeDeleted
+		to: self
+]
+
+{ #category : 'event handling' }
+TaskbarThumbnailMorph >> handlesMouseOver: evt [
+
+	^true
+]
+
+{ #category : 'initialization' }
+TaskbarThumbnailMorph >> initializeAppearance [
+	| thumb closeButton labelAndButton |
+	thumb := window taskbarThumbnail.
+	closeButton := (self theme
+		newCloseControlIn: window
+		for: window
+		action: [window closeBoxHit. self delete]
+		help: 'Close this window' translated)
+		extent: window boxExtent.
+	labelAndButton := PanelMorph new.
+	labelAndButton
+		layoutPolicy: RowLayout new;
+		hResizing: #shrinkWrap;
+		vResizing: #shrinkWrap;
+		addMorphBack: closeButton;
+		addMorphBack: (self theme
+			buttonLabelForText: (window labelString truncateWithElipsisTo: 50)).
+	self
+		hResizing: #shrinkWrap;
+		vResizing: #shrinkWrap;
+		changeTableLayout;
+		layoutInset: 8 scaledByDisplayScaleFactor;
+		cellInset: 4 scaledByDisplayScaleFactor;
+		addMorphBack: thumb;
+		addMorphBack: labelAndButton;
+		extent: self minExtent;
+		fillStyle: (self theme taskListFillStyleFor: self);
+		borderStyle: (self theme taskbarThumbnailNormalBorderStyleFor: self);
+		cornerStyle: (self theme taskbarThumbnailCornerStyleFor: self).
+]
+
+{ #category : 'fading' }
+TaskbarThumbnailMorph >> isNotBeingDeleted [ 
+	deleteAt := nil
+]
+
+{ #category : 'event handling' }
+TaskbarThumbnailMorph >> mouseEnter: evt [
+	self isNotBeingDeleted
+]
+
+{ #category : 'event handling' }
+TaskbarThumbnailMorph >> mouseLeave: evt [
+	self aboutToBeDeleted
+]
+
+{ #category : 'stepping and presenter' }
+TaskbarThumbnailMorph >> step [
+	deleteAt ifNil: [^self].
+
+	(self containsPoint: self activeHand position) ifTrue: [
+		self isNotBeingDeleted.
+		^self].
+
+	deleteAt < DateAndTime now ifTrue: [self delete]
+]
+
+{ #category : 'stepping and presenter' }
+TaskbarThumbnailMorph >> stepTime [
+	^ 50
+]
+
+{ #category : 'stepping and presenter' }
+TaskbarThumbnailMorph >> wantsSteps [
+	^ true
+]
+
+{ #category : 'accessing' }
+TaskbarThumbnailMorph >> window [
+	^ window
+]
+
+{ #category : 'accessing' }
+TaskbarThumbnailMorph >> window: aWindow [ 
+	window := aWindow
+]

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -3391,27 +3391,10 @@ UITheme >> newTaskbarButtonIn: aTaskbar for: aWindow [
 ]
 
 { #category : 'morph creation' }
-UITheme >> newTaskbarThumbnailIn: aThemedMorph for: aWindow [
+UITheme >> newTaskbarThumbnailFor: aWindow taskbarButton: aButton [
 	"Answer a taskbar thumbnail morph for the given window."
 
-	|answer thumb|
-	thumb := aWindow taskbarThumbnail.
-	answer := PanelMorph new
-		hResizing: #shrinkWrap;
-		vResizing: #shrinkWrap;
-		changeTableLayout;
-		layoutInset: 8 scaledByDisplayScaleFactor;
-		cellInset: 4 scaledByDisplayScaleFactor;
-		addMorphBack: thumb;
-		addMorphBack: ((self
-			buttonLabelForText: (aWindow labelString truncateWithElipsisTo: 50))
-				color: Color white).
-	answer
-		extent: answer minExtent;
-		fillStyle: (self taskListFillStyleFor: answer);
-		borderStyle: (self taskbarThumbnailNormalBorderStyleFor: aWindow);
-		cornerStyle: (self taskbarThumbnailCornerStyleFor: answer).
-	^answer
+	^ TaskbarThumbnailMorph for: aWindow taskbarButton: aButton theme: self
 ]
 
 { #category : 'morph creation' }


### PR DESCRIPTION
This PR is a sketch on adding a "close window" button to the taskbar thumbnail we show by default. This behavior is currently doable (just do right click on the corresponding taskbar button and click "close") but this is a bit easier when searching a window across the whole taskbar.

The implementation is not up to any decent standard so any suggestions wil be highly appreciated.

This was done on the last pharo sprint with help from @tesonep.

<img width="352" alt="The new thumbnail in action" src="https://github.com/user-attachments/assets/3d123538-ce57-4b02-b84a-6cd4dcd23df0">
