### PR TITLE
17487-SignalLogger-should-unsubscribe-on-intance-reset

### DIFF
--- a/src/Beacon-Core/SignalLogger.class.st
+++ b/src/Beacon-Core/SignalLogger.class.st
@@ -94,9 +94,12 @@ SignalLogger class >> resetAllInstances [
 
 { #category : 'class initialization' }
 SignalLogger class >> resetInstance [
+
 	<script>
 
-	instance := nil
+	instance ifNotNil: [
+		Beacon instance unsubscribe: instance.
+		instance := nil ]
 ]
 
 { #category : 'registration' }


### PR DESCRIPTION
SignalLogger should unsubscribe it self before reseting the instance