### PR TITLE
Adding fallback code in the allocation primitives `basicNewTenured`, `basicNewTenured:`

### DIFF
--- a/src/Kernel-CodeModel/Behavior.class.st
+++ b/src/Kernel-CodeModel/Behavior.class.st
@@ -414,7 +414,10 @@ Behavior >> basicNewTenured [
 	See more information in the newTenured method comment."
 
 	<primitive: 596 error: ec>
-	self error: 'Could not allocated object in the old space. Primitive error'
+	ec == #'insufficient object memory' ifTrue: [
+		^ self handleFailingBasicNew ].
+	self isVariable ifTrue: [ ^ self basicNew: 0 ].
+	self primitiveFailed
 ]
 
 { #category : 'instance creation' }
@@ -424,7 +427,12 @@ Behavior >> basicNewTenured: sizeRequested [
 	See more information in the newTenured method comment."
 
 	<primitive: 597 error: ec>
-	self error: 'Could not allocated object in the old space. Primitive error'
+	ec == #'insufficient object memory' ifTrue: [
+		^ self handleFailingBasicNew: sizeRequested ].
+	self isVariable ifFalse: [
+		self error:
+			self printString , ' cannot have variable sized instances' ].
+	self primitiveFailed
 ]
 
 { #category : 'obsolete subclasses' }


### PR DESCRIPTION
This fallback code is necessary since the allocation can fail when there is no space. When there is no more space, *Pharo*, nor the VM, should launch a full gc and if that is not enough it should allocate a new segment. This needs to be in the fallback of the primitive.