### PR TITLE
Skip some socket tests on windows

### DIFF
--- a/src/Network-Tests/SocketStreamTest.class.st
+++ b/src/Network-Tests/SocketStreamTest.class.st
@@ -150,6 +150,8 @@ SocketStreamTest >> testUpToAfterCloseNonSignaling [
 	"Tests correct behavior of #upToAll"
 
 	| resp |
+	"Since we changed the machine for the CI this test is breaking on windows. Skipping it temporarily."
+	OSPlatform current isWindows ifTrue: [ self skip ].
 	clientStream nextPutAll: 'A line of text'.
 	clientStream close.
 	serverStream shouldSignal: false.
@@ -161,9 +163,12 @@ SocketStreamTest >> testUpToAfterCloseNonSignaling [
 SocketStreamTest >> testUpToAfterCloseSignaling [
 	"Tests correct behavior of #upToAll"
 
-	clientStream nextPutAll:'A line of text'.
+	"Since we changed the machine for the CI this test is breaking on windows. Skipping it temporarily."
+
+	OSPlatform current isWindows ifTrue: [ self skip ].
+	clientStream nextPutAll: 'A line of text'.
 	clientStream close.
-	self should: [serverStream upTo: Character cr] raise: ConnectionClosed
+	self should: [ serverStream upTo: Character cr ] raise: ConnectionClosed
 ]
 
 { #category : 'stream protocol' }
@@ -182,6 +187,8 @@ SocketStreamTest >> testUpToAllAfterCloseNonSignaling [
 	"Tests correct behavior of #upToAll"
 
 	| resp |
+	"Since we changed the machine for the CI this test is breaking on windows. Skipping it temporarily."
+	OSPlatform current isWindows ifTrue: [ self skip ].
 	clientStream nextPutAll: 'A line of text'.
 	clientStream close.
 	serverStream shouldSignal: false.
@@ -193,9 +200,12 @@ SocketStreamTest >> testUpToAllAfterCloseNonSignaling [
 SocketStreamTest >> testUpToAllAfterCloseSignaling [
 	"Tests correct behavior of #upToAll"
 
-	clientStream nextPutAll:'A line of text'.
+	"Since we changed the machine for the CI this test is breaking on windows. Skipping it temporarily."
+
+	OSPlatform current isWindows ifTrue: [ self skip ].
+	clientStream nextPutAll: 'A line of text'.
 	clientStream close.
-	self should: [serverStream upToAll: String crlf] raise: ConnectionClosed
+	self should: [ serverStream upToAll: String crlf ] raise: ConnectionClosed
 ]
 
 { #category : 'stream protocol' }


### PR DESCRIPTION
This PR disable some Socket tests on windows for now. I'll open an issue to say we should check this when we'll have the time so enable them again

Fixes #17244