### PR TITLE
Revert "Fix #17471: custom Job interruption"

### DIFF
--- a/src/Jobs/Job.class.st
+++ b/src/Jobs/Job.class.st
@@ -23,8 +23,7 @@ Class {
 		'parent',
 		'process',
 		'owner',
-		'announcer',
-		'interruptBlock'
+		'announcer'
 	],
 	#classInstVars : [
 		'jobAnnouncer'
@@ -233,7 +232,6 @@ Job >> initialize [
 	title := ''.
 	isRunning := false.
 	children := OrderedCollection new.
-	interruptBlock := [ process debug ]
 ]
 
 { #category : 'accessing' }
@@ -241,24 +239,6 @@ Job >> installOn: aPresenter [
 	"this method is provider for compatibility"
 	
 	announcer := aPresenter announcer
-]
-
-{ #category : 'running' }
-Job >> interrupt [
-
-	self isRunning ifTrue: [ interruptBlock cull: self ]
-]
-
-{ #category : 'accessing' }
-Job >> interruptBlock [
-
-	^ interruptBlock
-]
-
-{ #category : 'accessing' }
-Job >> interruptBlock: aBlock [
-
-	interruptBlock := aBlock
 ]
 
 { #category : 'testing' }
@@ -382,12 +362,6 @@ Job >> run [
 		during: [ ^ block cull: self ] ]
 	ensure: [ 
 		self cleanupAfterRunning ]
-]
-
-{ #category : 'running' }
-Job >> terminate [
-
-	process terminate
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Base/JobProgressMorph.class.st
+++ b/src/Morphic-Base/JobProgressMorph.class.st
@@ -63,6 +63,12 @@ JobProgressMorph >> current: aNumber [
 	self changed
 ]
 
+{ #category : 'action' }
+JobProgressMorph >> debug [
+
+	job isRunning ifTrue: [ job debug ]
+]
+
 { #category : 'API' }
 JobProgressMorph >> decrement [
 
@@ -119,7 +125,7 @@ JobProgressMorph >> initializeJob: aJob [
 		font: StandardFonts defaultFont.
 	bar := JobProgressBarMorph new.
 	bar
-		on: #mouseUp send: #interrupt to: aJob;
+		on: #mouseUp send: #debug to: self;
 		hResizing: #spaceFill.
 	self updateLayout
 ]


### PR DESCRIPTION
Reverts pharo-project/pharo#17474

We need to revert this PR, because we are having some issues .

@astares reported:

I typically use a Laptop and a second monitor as an additional extended screen. When I start and use current Pharo 13 on Windows with the Launcher it appears on the Laptop screen. When I move it to a second monitor screen it is not possible to click into the Pharo main window to open the world menu or any of the tools.
Pharo just hangs and I can only kill it using

taskkill -f /im Pharo.exe


In Pharo 12 I do not see this effect - it works properly.