### PR TITLE
fix-SDL-default-renderer-by-platform

### DIFF
--- a/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
@@ -28,6 +28,12 @@ SDLAbstractPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 	self subclassResponsibility
 ]
 
+{ #category : 'configuration' }
+SDLAbstractPlatform >> defaultRendererFlags [
+	"We have no special flags for the renderer"
+	^ 0
+]
+
 { #category : 'initialization' }
 SDLAbstractPlatform >> initPlatformSpecific [
 

--- a/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
@@ -30,7 +30,8 @@ SDLAbstractPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 
 { #category : 'configuration' }
 SDLAbstractPlatform >> defaultRendererFlags [
-	"We have no special flags for the renderer"
+	"We have no special flags for the renderer.
+	SDL_RENDERER_PRESENTVSYNC was shown to crash on certain windows machines with external screens"
 	^ 0
 ]
 

--- a/src/OSWindow-SDL2/SDLOSXPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatform.class.st
@@ -59,6 +59,7 @@ SDLOSXPlatform >> allowTouchpadInertia [
 { #category : 'configuration' }
 SDLOSXPlatform >> defaultRendererFlags [ 
 
+	"SDL_RENDERER_PRESENTVSYNC is required on MacOS for certain screens to avoid rendering issues"
 	^ super defaultRendererFlags | SDL_RENDERER_PRESENTVSYNC
 ]
 

--- a/src/OSWindow-SDL2/SDLOSXPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatform.class.st
@@ -56,6 +56,12 @@ SDLOSXPlatform >> allowTouchpadInertia [
 	ObjCLibrary uniqueInstance release: key.
 ]
 
+{ #category : 'configuration' }
+SDLOSXPlatform >> defaultRendererFlags [ 
+
+	^ super defaultRendererFlags | SDL_RENDERER_PRESENTVSYNC
+]
+
 { #category : 'initialization' }
 SDLOSXPlatform >> initPlatformSpecific [
 

--- a/src/OSWindow-SDL2/SDL_Window.class.st
+++ b/src/OSWindow-SDL2/SDL_Window.class.st
@@ -38,10 +38,10 @@ SDL_Window >> createAcceleratedRenderer [
 
 { #category : 'rendering' }
 SDL_Window >> createDefaultRenderer [
-	"Flags was 0 previously but this caused crashes on Mac with 4k displays.
-	https://github.com/pharo-project/pharo/issues/17439"
 
-	^ self createRenderer: -1 flags: SDL_RENDERER_PRESENTVSYNC
+	^ self
+		  createRenderer: -1 "Find the first available rendering driver with the matching options"
+		  flags: OSPlatform current sdlPlatform defaultRendererFlags
 ]
 
 { #category : 'rendering' }


### PR DESCRIPTION
Default renderer flags should be different by platforms.
In MacOS, the SDL_RENDERER_PRESENTVSYNC is needed when using 4k monitors. https://github.com/pharo-project/pharo/issues/17439 In Windows having this flag produces crashes.