### PR TITLE
Fix: #17531: We can use string instead of symbols in slot in class definition #17531

### DIFF
--- a/src/Kernel-CodeModel/Slot.class.st
+++ b/src/Kernel-CodeModel/Slot.class.st
@@ -232,9 +232,15 @@ Slot >> isWrittenIn: aCompiledCode [
 ]
 
 { #category : 'accessing' }
+Slot >> name: aSymbol [
+
+	super name: aSymbol asSymbol
+]
+
+{ #category : 'accessing' }
 Slot >> named: aSymbol [
 	"to be polymorhic with slot class"
-	self name: aSymbol
+	self name: aSymbol asSymbol
 ]
 
 { #category : 'accessing' }

--- a/src/Shift-ClassBuilder-Tests/ShCreateClassTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShCreateClassTest.class.st
@@ -58,6 +58,25 @@ ShCreateClassTest >> testClassWithSlots [
 ]
 
 { #category : 'tests' }
+ShCreateClassTest >> testClassWithSlotsWithStringShouldBeTurnedIntoSymbols [
+	"This test check that we do not give string as slot names."
+	
+	builder
+		name: #SHTestClassWithSlots;
+		slots: #( 'anSlot' 'anotherSlot' ).
+
+	result := builder build.
+
+	self validateResult.
+	self validateSuperclass: Object.
+	self validateSlots: {
+			(#anSlot => InstanceVariableSlot).
+			(#anotherSlot => InstanceVariableSlot) }.
+	self assert: result allSlots first name class equals: ByteSymbol.
+	self assert: result allSlots second name class equals: ByteSymbol
+]
+
+{ #category : 'tests' }
 ShCreateClassTest >> testClassWithSuperclassNameAsString [
 
 	builder


### PR DESCRIPTION
now if the user gives a string we store a symnbol.