### PR TITLE
Cleanup scale factor methods

### DIFF
--- a/src/Morphic-Base/PolygonMorph.class.st
+++ b/src/Morphic-Base/PolygonMorph.class.st
@@ -1920,6 +1920,12 @@ PolygonMorph >> scale: scaleFactor [
 	super scale: scaleFactor
 ]
 
+{ #category : 'geometry' }
+PolygonMorph >> scaleFactor [
+
+	^ 1.0
+]
+
 { #category : 'cubic support' }
 PolygonMorph >> segmentedSlopesOf: knots [
 	"For a collection of floats. Returns the slopes for straight

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -5418,11 +5418,6 @@ Morph >> scale: newScale [
 	"Backstop for morphs that don't have to do something special to set their scale"
 ]
 
-{ #category : 'accessing' }
-Morph >> scaleFactor [
-	^self valueOfProperty: #scaleFactor ifAbsent: [ 1.0 ]
-]
-
 { #category : 'geometry' }
 Morph >> screenLocation [
 	"For compatibility only"

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -578,8 +578,15 @@ WorldMorph >> runStepMethods [
 ]
 
 { #category : 'accessing' }
-WorldMorph >> scaleFactor: newScaleFactor [
-	self setProperty: #scaleFactor toValue: newScaleFactor
+WorldMorph >> scaleFactor: newZoomFactor [
+
+	self
+		deprecated: 'Use #zoomFactor: instead'
+		on: '01/01/1970'
+		in: #Pharo13
+		transformWith:
+		'`@receiver scaleFactor: `@arg' -> '`@receiver zoomFactor: `@arg'.
+	self zoomFactor: newZoomFactor
 ]
 
 { #category : 'stepping' }

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -582,7 +582,7 @@ WorldMorph >> scaleFactor: newZoomFactor [
 
 	self
 		deprecated: 'Use #zoomFactor: instead'
-		on: '01/01/1970'
+		on: '20/12/2024'
 		in: #Pharo13
 		transformWith:
 		'`@receiver scaleFactor: `@arg' -> '`@receiver zoomFactor: `@arg'.

--- a/src/Rubric/RubFloatingEditorBuilder.class.st
+++ b/src/Rubric/RubFloatingEditorBuilder.class.st
@@ -117,6 +117,7 @@ RubFloatingEditorBuilder >> autoAccept: aBoolean [
 
 { #category : 'private' }
 RubFloatingEditorBuilder >> buildEditor [
+
 	editor := RubScrolledTextMorph new forbidMenu.
 	editor
 		autoAccept: autoAccept;
@@ -130,11 +131,18 @@ RubFloatingEditorBuilder >> buildEditor [
 	editor
 		beWrapped;
 		font: font;
-		margins: (Margin left: 2 right: 2 top: 0 bottom: 1);
+		margins: (Margin
+				 left: 2
+				 right: 2
+				 top: 0
+				 bottom: 1);
 		selectFrom: initialContents size + 1 to: initialContents size.
 
 	"until we have better a rub text editor for text field like components"
-	editor textArea on: PharoShortcuts current findShortcut do:[:x | "nothing, we don't need a search within a floating editor widget"].
+	editor textArea
+		bindKeyCombination: PharoShortcuts current findShortcut
+		toAction: [ :x | "nothing, we don't need a search within a floating editor widget"
+			 ].
 	editor textArea withoutSelectionBar.
 	^ self customizedEditor
 ]


### PR DESCRIPTION
- Move down `scaleFactor` to its sole user
- deprecate `WorldMorph>>scaleFactor:` and redirect to the new `zoomFactor:`