### PR TITLE
Fix string parse literals

### DIFF
--- a/src/AST-Core/OCParser.class.st
+++ b/src/AST-Core/OCParser.class.st
@@ -58,14 +58,8 @@ OCParser class >> parseFaultyMethod: aString [
 { #category : 'parsing' }
 OCParser class >> parseLiterals: aString [
 
-	| scanner parser |
-	parser := self new.
-	scanner := parser scannerClass on: (ReadStream on: aString).
-	scanner state: #literalArray.
-	^ parser
-		  source: aString;
-		  scanner: scanner;
-		  parseLiterals
+	^ self new parseLiterals: aString
+
 ]
 
 { #category : 'parsing' }
@@ -771,6 +765,18 @@ OCParser >> parseLiterals [
 		node isError ifTrue: [ node checkFaulty: nil ].
 		stream nextPut: node value ].
 	^ stream contents
+]
+
+{ #category : 'parsing' }
+OCParser >> parseLiterals: aString [
+
+	| localScanner |
+	localScanner := self scannerClass on: (ReadStream on: aString).
+	localScanner state: #literalArray.
+	^ self
+		  source: aString;
+		  scanner: localScanner;
+		  parseLiterals
 ]
 
 { #category : 'private - parsing' }

--- a/src/CodeImport/ChunkFileFormatParser.class.st
+++ b/src/CodeImport/ChunkFileFormatParser.class.st
@@ -222,27 +222,27 @@ ChunkFileFormatParser >> parseMethodDeclarations: methodsPreamble [
 
 { #category : 'parsing' }
 ChunkFileFormatParser >> parseNextDeclaration [
+
 	| isMetadata nextChunk |
 	readStream skipSeparators.
-	readStream isNextStyleChunk
-		ifTrue:
-			[
-			self addDeclaration: (self styleChunkClass contents: readStream readUpToEndOfStyleChunk).
-			^ self ].
+	readStream isNextStyleChunk ifTrue: [
+		self addDeclaration:
+			(self styleChunkClass contents: readStream readUpToEndOfStyleChunk).
+		^ self ].
 	isMetadata := readStream isNextChunkMetaData.
 	nextChunk := readStream next.
 	isMetadata
-		ifFalse: [ self addDeclaration: (self doItChunkClass contents: nextChunk) ]
-		ifTrue:
-			[
+		ifFalse: [
+		self addDeclaration: (self doItChunkClass contents: nextChunk) ]
+		ifTrue: [
 			| substrings |
-			substrings := nextChunk parseLiterals.
-			(substrings includes: self methodsForSelector asString)
-				ifTrue: [ ^ self parseMethodDeclarations: substrings ].
-			(substrings includes: self commentStampSelector asString)
-				ifTrue: [ ^ self parseCommentDeclaration: substrings ].
-			(substrings includes: self reorganizeSelector asString)
-				ifTrue: [ ^ self parseClassOrganization: substrings ] ]
+			substrings := OCParser parseLiterals: nextChunk.
+			(substrings includes: self methodsForSelector asString) ifTrue: [
+				^ self parseMethodDeclarations: substrings ].
+			(substrings includes: self commentStampSelector asString) ifTrue: [
+				^ self parseCommentDeclaration: substrings ].
+			(substrings includes: self reorganizeSelector asString) ifTrue: [
+				^ self parseClassOrganization: substrings ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/CodeImport/ClassOrganizationChunk.class.st
+++ b/src/CodeImport/ClassOrganizationChunk.class.st
@@ -44,17 +44,23 @@ ClassOrganizationChunk >> description [
 ClassOrganizationChunk >> importFor: aRequestor logSource: logSource [
 
 	| targetClass protocolSpecs |
-	self existsBehavior ifFalse: [ self error: ('Cannot change organization of unexistent behavior {1}' format: { behaviorName asString }) ].
+	self existsBehavior ifFalse: [
+		self error:
+			('Cannot change organization of unexistent behavior {1}' format:
+				 { behaviorName asString }) ].
 
 	targetClass := self targetClass.
-	protocolSpecs := contents parseLiterals.
+	protocolSpecs := OCParser parseLiterals: contents.
 
 	targetClass resetProtocols.
 
 	"If nothing was scanned and I had no elements before, then default me"
-	(protocolSpecs isEmpty and: [ targetClass protocols isEmpty ]) ifTrue: [ ^ self ].
+	(protocolSpecs isEmpty and: [ targetClass protocols isEmpty ])
+		ifTrue: [ ^ self ].
 
-	protocolSpecs do: [ :spec | (targetClass addProtocol: (Protocol named: spec first)) methodSelectors: spec allButFirst asSet ]
+	protocolSpecs do: [ :spec |
+		(targetClass addProtocol: (Protocol named: spec first))
+			methodSelectors: spec allButFirst asSet ]
 ]
 
 { #category : 'testing' }

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -487,18 +487,22 @@ StringTest >> testAsSignedInteger [
 
 { #category : 'tests - converting' }
 StringTest >> testAsSmalltalkComment [
+
 	| exampleStrings |
-	exampleStrings := #('' ' ' '"' '""' '"""' 'abc"abc' 'abc""abc' 'abc"hello"abc' 'abc"' '"abc').
+	exampleStrings := #( '' ' ' '"' '""' '"""' 'abc"abc' 'abc""abc'
+	                     'abc"hello"abc' 'abc"' '"abc' ).
 
 	"check that the result of scanning the comment is empty"
-	exampleStrings
-		do: [ :s |
-			| tokens |
-			tokens := s asComment parseLiterals.
-			self assertEmpty: tokens ].
+	exampleStrings do: [ :s |
+		| tokens |
+		tokens := OCParser parseLiterals: s asComment.
+		self assertEmpty: tokens ].
 
 	"check that the result has the same non-quote characters as the original"
-	exampleStrings do: [ :s | self assert: (s copyWithout: $") equals: (s asComment copyWithout: $") ].
+	exampleStrings do: [ :s |
+		self
+			assert: (s copyWithout: $")
+			equals: (s asComment copyWithout: $") ].
 
 	"finnaly, test for some common kinds of inputs"
 	self assert: '' asComment equals: '""'.

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -169,8 +169,9 @@ Symbol class >> rawIntern: aStringOrSymbol [
 Symbol class >> readFrom: strm [
 	"Symbol readFromString: '#abc'"
 
-	strm peek = $# ifFalse: [self error: 'Symbols must be introduced by #'].
-    	^ strm contents parseLiterals first
+	strm peek = $# ifFalse: [
+		self error: 'Symbols must be introduced by #' ].
+	^ (OCParser parseLiterals: strm contents) first
 ]
 
 { #category : 'selector table' }

--- a/src/Monticello-BackwardCompatibility/MCClassTraitParser.class.st
+++ b/src/Monticello-BackwardCompatibility/MCClassTraitParser.class.st
@@ -19,7 +19,7 @@ MCClassTraitParser class >> pattern [
 MCClassTraitParser >> addDefinitionsTo: aCollection [
 
 	| tokens definition traitCompositionString |
-	tokens := source parseLiterals.
+	tokens := OCParser parseLiterals: source.
 	traitCompositionString := (source readStream
 		                           match: 'uses:';
 		                           upToEnd) trimBoth.

--- a/src/Monticello-BackwardCompatibility/MCSystemCategoryParser.class.st
+++ b/src/Monticello-BackwardCompatibility/MCSystemCategoryParser.class.st
@@ -30,7 +30,8 @@ MCSystemCategoryParser >> addDefinitionsTo: aCollection [
 MCSystemCategoryParser >> category [
 
 	| tokens |
-	tokens := source parseLiterals.
-	tokens size = 3 ifFalse: [ self error: 'Unrecognized category definition' ].
+	tokens := OCParser parseLiterals: source.
+	tokens size = 3 ifFalse: [
+		self error: 'Unrecognized category definition' ].
 	^ tokens at: 3
 ]

--- a/src/Monticello/MCMczReader.class.st
+++ b/src/Monticello/MCMczReader.class.st
@@ -168,9 +168,10 @@ MCMczReader >> loadVersionInfo [
 
 { #category : 'parsing' }
 MCMczReader >> parseMember: memberOrName [
+
 	| member tokens |
 	member := self zip member: memberOrName.
-	tokens := (self contentsForMember: member) parseLiterals first.
+	tokens := (OCParser parseLiterals: (self contentsForMember: member)) first.
 	^ self associate: tokens
 ]
 

--- a/src/Monticello/MCOrganizationParser.class.st
+++ b/src/Monticello/MCOrganizationParser.class.st
@@ -20,9 +20,10 @@ MCOrganizationParser >> addDefinitionsTo: aCollection [
 	| definition tokens packageName tags |
 	definition := aCollection
 		              detect: [ :ea | ea isOrganizationDefinition ]
-		              ifNone: [ aCollection add: MCOrganizationDefinition new ].
+		              ifNone: [
+		              aCollection add: MCOrganizationDefinition new ].
 
-	tokens := source parseLiterals.
+	tokens := OCParser parseLiterals: source.
 
 	packageName := tokens at: 4.
 	tags := tokens at: 6.

--- a/src/Monticello/MCScriptParser.class.st
+++ b/src/Monticello/MCScriptParser.class.st
@@ -16,11 +16,12 @@ MCScriptParser class >> pattern [
 
 { #category : 'actions' }
 MCScriptParser >> addDefinitionsTo: aCollection [
+
 	| tokens definition |
-	tokens := source parseLiterals.
+	tokens := OCParser parseLiterals: source.
 	definition := MCScriptDefinition
-		scriptSelector: tokens second allButLast
-		script: tokens third
-		packageName: tokens first third.
-	aCollection add: definition.
+		              scriptSelector: tokens second allButLast
+		              script: tokens third
+		              packageName: tokens first third.
+	aCollection add: definition
 ]

--- a/src/Monticello/MCStReader.class.st
+++ b/src/Monticello/MCStReader.class.st
@@ -40,15 +40,19 @@ MCStReader >> addDefinitionsFromDoit: aString [
 MCStReader >> classDefinitionFrom: aRingClass [
 
 	| tokens traitCompositionString lastIndex classTraitCompositionString converter |
-	tokens := aRingClass definitionSource parseLiterals.
+	tokens := OCParser parseLiterals: aRingClass definitionSource.
 	traitCompositionString := (aRingClass definitionSource readStream
 		                           match: 'uses:';
-		                           upToAll: 'instanceVariableNames:') trimBoth.
-	classTraitCompositionString := (aRingClass classSide definitionSource asString readStream
+		                           upToAll: 'instanceVariableNames:')
+		                          trimBoth.
+	classTraitCompositionString := (aRingClass classSide definitionSource
+		                                asString readStream
 		                                match: 'uses:';
-		                                upToAll: 'instanceVariableNames:') trimBoth.
+		                                upToAll: 'instanceVariableNames:')
+		                               trimBoth.
 	traitCompositionString ifEmpty: [ traitCompositionString := '{}' ].
-	classTraitCompositionString ifEmpty: [ classTraitCompositionString := '{}' ].
+	classTraitCompositionString ifEmpty: [
+		classTraitCompositionString := '{}' ].
 	lastIndex := tokens size.
 	converter := CategoryConverter category: (tokens at: lastIndex).
 	^ (MCClassDefinition named: (tokens at: 3))
@@ -69,11 +73,11 @@ MCStReader >> classDefinitionFrom: aRingClass [
 
 { #category : 'reading' }
 MCStReader >> classInstVarNamesFor: aRingClass [
+
 	| tokens |
-	
 	self flag: #traits.
-	aRingClass classSide hasDefinitionSource ifFalse: [^ #()].
-	tokens := aRingClass classSide definitionSource parseLiterals.
+	aRingClass classSide hasDefinitionSource ifFalse: [ ^ #(  ) ].
+	tokens := OCParser parseLiterals: aRingClass classSide definitionSource.
 	"tokens size = 4 ifFalse: [self error: 'Unrecognized metaclass definition']."
 	^ tokens last findTokens: ' '
 ]

--- a/src/OpalCompiler-Core/String.extension.st
+++ b/src/OpalCompiler-Core/String.extension.st
@@ -2,5 +2,12 @@ Extension { #name : 'String' }
 
 { #category : '*OpalCompiler-Core' }
 String >> parseLiterals [
-	^ self class compiler parseLiterals: self
+
+	self 
+		deprecated: 'Use OCParser parseLiterals: instead of String>>parseLiterals' 
+		on: '29/12/2024' 
+		in: 'pharo13' 
+		transformWith: 
+		'`@receiver parseLiterals' -> 'OCParser parseLiterals: `@receiver'.
+	^ OCParser parseLiterals: self
 ]

--- a/src/OpalCompiler-Tests/OCScanner2Test.class.st
+++ b/src/OpalCompiler-Tests/OCScanner2Test.class.st
@@ -8,12 +8,8 @@ Class {
 
 { #category : 'testing' }
 OCScanner2Test >> testAmbiguousSelector [
-	"Non regression test.
-	See http://code.google.com/p/pharo/issues/detail?id=2271
-	and http://bugs.squeak.org/view.php?id=7491"
 
-	'1@-1' parseLiterals.
-	self assert: ('1@-1' parseLiterals at: 2) asString equals: '@-'
+	self assert: ((OCParser parseLiterals: '1@-1') at: 2) asString equals: '@-'
 ]
 
 { #category : 'testing' }

--- a/src/Ring-Definitions-Core/RGBehaviorDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGBehaviorDefinition.class.st
@@ -539,10 +539,10 @@ RGBehaviorDefinition >> traitNames [
 	"Assuming that traits in a composition can be identified by
 	testing for the first character being an uppercase character
 	(and thus not a special character such as {, # etc.)"
-	| tokens |
 
-	tokens := self traitCompositionSource parseLiterals flattened.
-	^tokens select: [:each | each first isUppercase]
+	| tokens |
+	tokens := (OCParser parseLiterals: self traitCompositionSource) flattened.
+	^ tokens select: [ :each | each first isUppercase ]
 ]
 
 { #category : 'accessing' }

--- a/src/System-Changes/SourceFileArray.extension.st
+++ b/src/System-Changes/SourceFileArray.extension.st
@@ -53,86 +53,87 @@ SourceFileArray >> changeRecordsFrom: initialSourcePointer className: theNonMeta
 
 	| filePosition fileIndex |
 	fileIndex := self fileIndexFromSourcePointer: initialSourcePointer.
-	filePosition := self filePositionFromSourcePointer: initialSourcePointer.
+	filePosition := self filePositionFromSourcePointer:
+		                initialSourcePointer.
 
 	self readOnlyDo: [ :sourceFilesCopy |
 		| file previousFilePosition previousFileIndex preamble stamp protocol preambleTokens |
 		file := sourceFilesCopy fileAt: fileIndex ifAbsent: [ ^ self ].
 
-		[ filePosition isNotNil & file isNotNil ]
-			whileTrue: [
-				file position: (0 max: filePosition - 150).	"Skip back to before the preamble"
-				[ file position < (filePosition - 1) ] whileTrue: [
-					preamble := (ChunkReadStream on: file) next ].	"then pick it up from the front"
-					"Preamble is likely a linked method preamble, if we're in
+		[ filePosition isNotNil & file isNotNil ] whileTrue: [
+			file position: (0 max: filePosition - 150). "Skip back to before the preamble"
+			[ file position < (filePosition - 1) ] whileTrue: [
+				preamble := (ChunkReadStream on: file) next ]. "then pick it up from the front"
+			"Preamble is likely a linked method preamble, if we're in
 					a changes file (not the sources file).  Try to parse it
 					for prior source position and file index"
 
-				previousFilePosition := nil.
-				stamp := ''.
-				"method records"
-				(preamble includesSubstring: 'methodsFor:')
-					ifTrue: [ preambleTokens := preamble parseLiterals ]
-					ifFalse: [ preambleTokens := Array new	"ie cant be back ref" ].
-				((preambleTokens size between: 7 and: 8) and: [ (preambleTokens at: preambleTokens size - 5) = #methodsFor: ])
-					ifTrue: [
-						(preambleTokens at: preambleTokens size - 3) = #stamp:
-							ifTrue: [
-								"New format gives change stamp and unified prior pointer"
-								stamp := preambleTokens at: preambleTokens size - 2.
-								previousFilePosition := preambleTokens last.
-								previousFileIndex := self fileIndexFromSourcePointer: previousFilePosition.
-								previousFilePosition := self filePositionFromSourcePointer: previousFilePosition ]
-							ifFalse: [
-								"Old format gives no stamp; prior pointer in two parts"
-								previousFilePosition := preambleTokens at: preambleTokens size - 2.
-								previousFileIndex := preambleTokens last ].
-						(previousFilePosition = 0 or: [ previousFileIndex = 0 ])
-							ifTrue: [ previousFilePosition := nil ] ].
+			previousFilePosition := nil.
+			stamp := ''.
+			"method records"
+			(preamble includesSubstring: 'methodsFor:')
+				ifTrue: [ preambleTokens := OCParser parseLiterals: preamble ]
+				ifFalse: [ preambleTokens := Array new "ie cant be back ref" ].
+			((preambleTokens size between: 7 and: 8) and: [
+				 (preambleTokens at: preambleTokens size - 5) = #methodsFor: ])
+				ifTrue: [
+					(preambleTokens at: preambleTokens size - 3) = #stamp:
+						ifTrue: [ "New format gives change stamp and unified prior pointer"
+							stamp := preambleTokens at: preambleTokens size - 2.
+							previousFilePosition := preambleTokens last.
+							previousFileIndex := self fileIndexFromSourcePointer:
+								                     previousFilePosition.
+							previousFilePosition := self filePositionFromSourcePointer:
+								                        previousFilePosition ]
+						ifFalse: [ "Old format gives no stamp; prior pointer in two parts"
+							previousFilePosition := preambleTokens at:
+								                        preambleTokens size - 2.
+							previousFileIndex := preambleTokens last ].
+					(previousFilePosition = 0 or: [ previousFileIndex = 0 ]) ifTrue: [
+						previousFilePosition := nil ] ].
 
-				((preambleTokens size between: 5 and: 6) and: [ (preambleTokens at: preambleTokens size - 3) = #methodsFor: ])
-					ifTrue: [
-						(preambleTokens at: preambleTokens size - 1) = #stamp:
-							ifTrue: [
-								"New format gives change stamp and unified prior pointer"
-								stamp := preambleTokens at: preambleTokens size ] ].
-				"class comment records"
-				(preamble includesSubstring: 'commentStamp:')
-					ifTrue: [ preambleTokens := preamble parseLiterals ].
-				((preambleTokens size = 5 or: [ preambleTokens size = 3 ]) and: [ (preambleTokens at: 2) = #commentStamp: ])
-					ifTrue: [
-						stamp := preambleTokens at: 3.
-						preambleTokens size > 3
-							ifTrue: [
-								previousFilePosition := preambleTokens last.
-								previousFileIndex := self fileIndexFromSourcePointer: previousFilePosition.
-								previousFilePosition := self filePositionFromSourcePointer: previousFilePosition ].
-						aUnaryBlock
-							value:
-								(ChangeRecord new
-									file: file
-									position: filePosition
-									type: #classComment
-									class: theNonMetaClassName
-									protocol: nil
-									meta: classIsMeta
-									stamp: stamp) ]
-					ifFalse: [
-						protocol := preambleTokens after: #methodsFor: ifAbsent: [ Protocol unclassified ].
-						aUnaryBlock
-							value:
-								(ChangeRecord new
-									file: file
-									position: filePosition
-									type: #method
-									class: theNonMetaClassName
-									protocol: protocol
-									meta: classIsMeta
-									stamp: stamp) ].
+			((preambleTokens size between: 5 and: 6) and: [
+				 (preambleTokens at: preambleTokens size - 3) = #methodsFor: ])
+				ifTrue: [
+					(preambleTokens at: preambleTokens size - 1) = #stamp: ifTrue: [ "New format gives change stamp and unified prior pointer"
+						stamp := preambleTokens at: preambleTokens size ] ].
+			"class comment records"
+			(preamble includesSubstring: 'commentStamp:') ifTrue: [
+				preambleTokens := OCParser parseLiterals: preamble ].
+			((preambleTokens size = 5 or: [ preambleTokens size = 3 ]) and: [
+				 (preambleTokens at: 2) = #commentStamp: ])
+				ifTrue: [
+					stamp := preambleTokens at: 3.
+					preambleTokens size > 3 ifTrue: [
+						previousFilePosition := preambleTokens last.
+						previousFileIndex := self fileIndexFromSourcePointer:
+							                     previousFilePosition.
+						previousFilePosition := self filePositionFromSourcePointer:
+							                        previousFilePosition ].
+					aUnaryBlock value: (ChangeRecord new
+							 file: file
+							 position: filePosition
+							 type: #classComment
+							 class: theNonMetaClassName
+							 protocol: nil
+							 meta: classIsMeta
+							 stamp: stamp) ]
+				ifFalse: [
+					protocol := preambleTokens
+						            after: #methodsFor:
+						            ifAbsent: [ Protocol unclassified ].
+					aUnaryBlock value: (ChangeRecord new
+							 file: file
+							 position: filePosition
+							 type: #method
+							 class: theNonMetaClassName
+							 protocol: protocol
+							 meta: classIsMeta
+							 stamp: stamp) ].
 
-				filePosition := previousFilePosition.
-				previousFilePosition ifNotNil: [
-					file := sourceFilesCopy
-						fileAt: previousFileIndex
-						ifAbsent: [ ^ self ] ] ] ]
+			filePosition := previousFilePosition.
+			previousFilePosition ifNotNil: [
+				file := sourceFilesCopy
+					        fileAt: previousFileIndex
+					        ifAbsent: [ ^ self ] ] ] ]
 ]

--- a/src/System-Installers/MczInstaller.class.st
+++ b/src/System-Installers/MczInstaller.class.st
@@ -178,9 +178,10 @@ MczInstaller >> installMember: member [
 
 { #category : 'utilities' }
 MczInstaller >> parseMember: memberOrName [
+
 	| member tokens |
 	member := self zip member: memberOrName.
-	tokens := (self contentsForMember: member) parseLiterals first.
+	tokens := (OCParser parseLiterals: (self contentsForMember: member)) first.
 	^ self associate: tokens
 ]
 

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -218,18 +218,16 @@ SourceFileArray >> protocolAt: sourcePointer for: sourceDataPointers [
 	"Answer the protocol for a given method, retrieved from the sources or changes file. Answer unfound protocol if no protocol is available."
 
 	| preamble protocol tokens protocolPosition |
-	protocol := 'unfound protocol'.	"this is to indicate that the tagging in the source does not use the correct format.
+	protocol := 'unfound protocol'. "this is to indicate that the tagging in the source does not use the correct format.
 	We will have to fix that. For example some traits methods are wrongly tagged.
 	see http://code.google.com/p/pharo/issues/detail?id=4581"
 	preamble := self sourcedDataAt: sourcePointer.
 	preamble = 'Trait method' ifTrue: [ ^ nil ].
 	(preamble includesSubstring: sourceDataPointers key) ifTrue: [
-		tokens := preamble parseLiterals.
+		tokens := OCParser parseLiterals: preamble.
 		protocolPosition := tokens indexOf: sourceDataPointers key.
-		protocolPosition = 0
-			ifFalse: [
-				"New format gives change protocol and unified prior pointer"
-				protocol := tokens at: protocolPosition + 1 ] ].
+		protocolPosition = 0 ifFalse: [ "New format gives change protocol and unified prior pointer"
+			protocol := tokens at: protocolPosition + 1 ] ].
 	^ protocol
 ]
 
@@ -422,14 +420,11 @@ SourceFileArray >> timeStampAt: sourcePointer for: sourceDataPointers [
 	stamp := ''.
 	flushChanges ifFalse: [ ^ stamp ].
 	preamble := self sourcedDataAt: sourcePointer.
-	(preamble includesSubstring: sourceDataPointers key)
-		ifTrue: [
-			tokens := preamble parseLiterals.
-			stampPosition := tokens indexOf: sourceDataPointers value.
-			stampPosition = 0
-				ifFalse: [
-					"New format gives change stamp and unified prior pointer"
-					stamp := tokens at: stampPosition + 1 ] ].
+	(preamble includesSubstring: sourceDataPointers key) ifTrue: [
+		tokens := OCParser parseLiterals: preamble.
+		stampPosition := tokens indexOf: sourceDataPointers value.
+		stampPosition = 0 ifFalse: [ "New format gives change stamp and unified prior pointer"
+			stamp := tokens at: stampPosition + 1 ] ].
 	^ stamp
 ]
 


### PR DESCRIPTION
- define parseLiterals: on the instance side, make the class side parseLiterals: call the instance side method. 
- deprecate String>>parseLiterals
- fix all senders to use the version of OCParser 