### PR TITLE
Symbol should not depend on AST (Fix dependency test)

### DIFF
--- a/src/AST-Core/Symbol.extension.st
+++ b/src/AST-Core/Symbol.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'Symbol' }
+
+{ #category : '*AST-Core' }
+Symbol class >> readFrom: strm [
+	"Symbol readFromString: '#abc'"
+
+	strm peek = $# ifFalse: [
+		self error: 'Symbols must be introduced by #' ].
+	^ (OCParser parseLiterals: strm contents) first
+]

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -165,15 +165,6 @@ Symbol class >> rawIntern: aStringOrSymbol [
 		  NewSymbols add: aStringOrSymbol createSymbol ]
 ]
 
-{ #category : 'instance creation' }
-Symbol class >> readFrom: strm [
-	"Symbol readFromString: '#abc'"
-
-	strm peek = $# ifFalse: [
-		self error: 'Symbols must be introduced by #' ].
-	^ (OCParser parseLiterals: strm contents) first
-]
-
 { #category : 'selector table' }
 Symbol class >> rebuildSelectorTable [
 


### PR DESCRIPTION
This change moves the method Symbol class>>#readFrom: to AST-Core because it uses the OCParser to parse the symbol so this cannot work without the AST This should fix a failure of the dependency test