### PR TITLE
Remove some methods with equivalent in superclass in Calypso

### DIFF
--- a/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
+++ b/src/Calypso-SystemQueries/ClyScopedSystemEnvironment.class.st
@@ -31,12 +31,6 @@ ClyScopedSystemEnvironment >> asRBEnvironment [
 ]
 
 { #category : 'class management' }
-ClyScopedSystemEnvironment >> classNamed: aString [
-	
-	^globals classNamed: aString
-]
-
-{ #category : 'class management' }
 ClyScopedSystemEnvironment >> classNamed: aString ifAbsent: aBlockClosure [
 
 	^ globals
@@ -49,15 +43,6 @@ ClyScopedSystemEnvironment >> classNamed: aString ifAbsent: aBlockClosure [
 						  ifFalse: aBlockClosure ]
 				  ifFalse: aBlockClosure ]
 		  ifAbsent: aBlockClosure
-]
-
-{ #category : 'class management' }
-ClyScopedSystemEnvironment >> classNamed: aString ifPresent: aBlockClosure ifAbsent: anotherBlockClosure [
-
-	^ globals
-		  at: aString
-		  ifPresent: aBlockClosure
-		  ifAbsent: anotherBlockClosure
 ]
 
 { #category : 'compiling' }

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -319,7 +319,7 @@ ReleaseTest >> testNoEquivalentSuperclassMethods [
 
 	methods := methods select: [ :method | method hasEquivalentMethodInSuperclass ].
 
-	self assert: methods size <= 88
+	self assert: methods size <= 79
 ]
 
 { #category : 'tests - variables' }

--- a/src/SystemCommands-ClassCommands/SycCmCopyClassNameCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmCopyClassNameCommand.class.st
@@ -9,11 +9,6 @@ Class {
 	#tag : 'Extra'
 }
 
-{ #category : 'execution' }
-SycCmCopyClassNameCommand class >> activationStrategy [
-	^ SycExtraMenuActivation
-]
-
 { #category : 'testing' }
 SycCmCopyClassNameCommand >> canBeExecuted [ 
 

--- a/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRemoveClassCommand.class.st
@@ -29,11 +29,6 @@ SycRemoveClassCommand >> execute [
 				 classes:  classes) runRefactoring
 ]
 
-{ #category : 'testing' }
-SycRemoveClassCommand >> isComplexRefactoring [
-	^ false
-]
-
 { #category : 'execution' }
 SycRemoveClassCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.

--- a/src/SystemCommands-MessageCommands/SycRemoveMessageArgumentCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycRemoveMessageArgumentCommand.class.st
@@ -99,11 +99,6 @@ SycRemoveMessageArgumentCommand >> prepareFullExecutionInContext: aToolContext [
 	self abort
 ]
 
-{ #category : 'accessing' }
-SycRemoveMessageArgumentCommand >> refactoredClass: aClass [ 
-	refactoredClass := aClass
-]
-
 { #category : 'execution' }
 SycRemoveMessageArgumentCommand >> resultMessageSelector [
 	^ self methodName selector

--- a/src/SystemCommands-MessageCommands/SycShowLocalSendersCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycShowLocalSendersCommand.class.st
@@ -32,12 +32,6 @@ SycShowLocalSendersCommand >> execute [
 	Smalltalk tools messageList browse: self searchInTheWholeHierarchy.
 ]
 
-{ #category : 'testing' }
-SycShowLocalSendersCommand >> isComplexRefactoring [
-
-	^ false
-]
-
 { #category : 'execution' }
 SycShowLocalSendersCommand >> searchInTheWholeHierarchy [
 

--- a/src/SystemCommands-MessageCommands/SycSuperclassImplementorsCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycSuperclassImplementorsCommand.class.st
@@ -27,12 +27,6 @@ SycSuperclassImplementorsCommand >> execute [
 ]
 
 { #category : 'execution' }
-SycSuperclassImplementorsCommand >> isComplexRefactoring [
-
-	^ false
-]
-
-{ #category : 'execution' }
 SycSuperclassImplementorsCommand >> searchInTheWholeHierarchy [
 
 	| mthImplementors |

--- a/src/SystemCommands-MethodCommands/SycRemoveMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycRemoveMethodCommand.class.st
@@ -41,12 +41,6 @@ SycRemoveMethodCommand >> execute [
 ]
 
 { #category : 'execution' }
-SycRemoveMethodCommand >> isComplexRefactoring [ 
-
-	^ false
-]
-
-{ #category : 'execution' }
 SycRemoveMethodCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 	toolContext := aToolContext.

--- a/src/SystemCommands-PackageCommands/SycPackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycPackageCommand.class.st
@@ -26,12 +26,6 @@ SycPackageCommand class >> isAbstract [
 	^self = SycPackageCommand
 ]
 
-{ #category : 'private' }
-SycPackageCommand >> morphicUIManager [
-
-	^ MorphicUIManager new
-]
-
 { #category : 'accessing' }
 SycPackageCommand >> packages [
 	^ packages


### PR DESCRIPTION
This cleans some methods from Calypso and SystemCommands