### PR TITLE
Backport changes making #cascadeFor:initialExtent:world: for RealEstateAgent use integral positions when using the world’s center to Pharo 11

### DIFF
--- a/src/Morphic-Core/RealEstateAgent.class.st
+++ b/src/Morphic-Core/RealEstateAgent.class.st
@@ -74,7 +74,7 @@ RealEstateAgent class >> cascadeFor: aView initialExtent: initialExtent world: a
 	| position allowedArea |
 	allowedArea := self maximumUsableAreaInWorld: aWorld.
 	position := aWorld currentWindow isMorph
-		ifFalse: [ aWorld center - (initialExtent / 2)]
+		ifFalse: [ aWorld center - (initialExtent // 2)]
 		ifTrue: [ aWorld currentWindow position + 20].
 	^ (position extent: initialExtent)
 		translatedAndSquishedToBeWithin: allowedArea


### PR DESCRIPTION
This pull request backports the change(s) of pull request #16390 to Pharo 11.