### PR TITLE
Fix #loadVersionFromFileNamed: on MCRemoteFileBasedRepository to always answer the version

### DIFF
--- a/src/Monticello-Tests/MCSmalltalkhubRepositoryTest.class.st
+++ b/src/Monticello-Tests/MCSmalltalkhubRepositoryTest.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : 'MCSmalltalkhubRepositoryTest',
+	#superclass : 'MCTestCase',
+	#category : 'Monticello-Tests-Repository',
+	#package : 'Monticello-Tests',
+	#tag : 'Repository'
+}
+
+{ #category : 'tests' }
+MCSmalltalkhubRepositoryTest >> testVersionFromFileNamed [
+
+	| repository version |
+
+	repository := MCSmalltalkhubRepository owner: 'Pharo' project: 'Pharo10'.
+	version := repository versionFromFileNamed: 'Kernel-sd.152.mcz'.
+	self assert: (version info hasID: (UUID fromString: '085d31bf-e12f-4f0e-8b3f-a7aae927c7b8')).
+]

--- a/src/Monticello/MCCacheRepository.class.st
+++ b/src/Monticello/MCCacheRepository.class.st
@@ -142,6 +142,8 @@ MCCacheRepository >> versionWithInfo: aVersionInfo ifAbsent: errorBlock [
 MCCacheRepository >> writeStreamWithReplacingForFileNamed: aString do: aBlock [
 
 	| file |
+
+	cacheEnabled ifFalse: [ ^ self ].
 	file := directory / aString.
 	file ensureDelete.
 	file binaryWriteStreamDo: aBlock

--- a/src/MonticelloRemoteRepositories/MCRemoteFileBasedRepository.class.st
+++ b/src/MonticelloRemoteRepositories/MCRemoteFileBasedRepository.class.st
@@ -37,7 +37,7 @@ MCRemoteFileBasedRepository >> loadVersionFromFileNamed: aString [
 
 	(MCCacheRepository uniqueInstance includesFileNamed: aString) ifTrue: [ ^ MCCacheRepository uniqueInstance loadVersionFromFileNamed: aString ].
 
-	super loadVersionFromFileNamed: aString
+	^ super loadVersionFromFileNamed: aString
 ]
 
 { #category : 'interface' }


### PR DESCRIPTION
This pull request fixes `#loadVersionFromFileNamed:` on MCRemoteFileBasedRepository to always answer the version, which fixes issue #17586. It also makes `#writeStreamWithReplacingForFileNamed:do:` on MCCacheRepository take disablement of the cache into account, otherwise the test that is added would pass on a second run due to the cache disablement in `#runCase` inherited from MCTestCase being ignored.