### PR TITLE
Backport fix making #loadVersionFromFileNamed: on MCRemoteFileBasedRepository always answer the version

### DIFF
--- a/src/Monticello-Tests/MCSmalltalkhubRepositoryTest.class.st
+++ b/src/Monticello-Tests/MCSmalltalkhubRepositoryTest.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : 'MCSmalltalkhubRepositoryTest',
+	#superclass : 'MCTestCase',
+	#category : 'Monticello-Tests-Repository',
+	#package : 'Monticello-Tests',
+	#tag : 'Repository'
+}
+
+{ #category : 'tests' }
+MCSmalltalkhubRepositoryTest >> testVersionFromFileNamed [
+
+	| repository version |
+
+	repository := MCSmalltalkhubRepository owner: 'Pharo' project: 'Pharo10'.
+	version := repository versionFromFileNamed: 'Kernel-sd.152.mcz'.
+	self assert: (version info hasID: (UUID fromString: '085d31bf-e12f-4f0e-8b3f-a7aae927c7b8')).
+]

--- a/src/MonticelloRemoteRepositories/MCRemoteFileBasedRepository.class.st
+++ b/src/MonticelloRemoteRepositories/MCRemoteFileBasedRepository.class.st
@@ -37,7 +37,7 @@ MCRemoteFileBasedRepository >> loadVersionFromFileNamed: aString [
 
 	(MCCacheRepository uniqueInstance includesFileNamed: aString) ifTrue: [ ^ MCCacheRepository uniqueInstance loadVersionFromFileNamed: aString ].
 
-	super loadVersionFromFileNamed: aString
+	^ super loadVersionFromFileNamed: aString
 ]
 
 { #category : 'interface' }


### PR DESCRIPTION
This pull request backports the changes of commit edcbd70e89a08112 (pull request #17613) to Pharo 12 which fixes issue #17586 and, presumably, issue #17081.