### PR TITLE
Clean TransferMorph

### DIFF
--- a/src/Morphic-Base/TransferMorph.class.st
+++ b/src/Morphic-Base/TransferMorph.class.st
@@ -13,7 +13,6 @@ Class {
 		'passenger',
 		'draggedMorph',
 		'source',
-		'dropNotifyRecipient',
 		'accepted',
 		'copy',
 		'dragHand'
@@ -83,8 +82,7 @@ TransferMorph >> defaultColor [
 { #category : 'submorphs - add/remove' }
 TransferMorph >> delete [
 	"See also >>justDroppedInto:event:."
-	accepted ifFalse: [
-		self dropNotifyRecipient ifNotNil: [ self dropNotifyRecipient dropRejectedMorph: self ]].
+
 	self changed: #deleted.
 	self breakDependents.
 	super delete
@@ -121,16 +119,6 @@ TransferMorph >> draggedMorph [
 { #category : 'accessing' }
 TransferMorph >> draggedMorph: aMorph [
 	draggedMorph := aMorph
-]
-
-{ #category : 'accessing' }
-TransferMorph >> dropNotifyRecipient [
-	^dropNotifyRecipient
-]
-
-{ #category : 'accessing' }
-TransferMorph >> dropNotifyRecipient: anObject [
-	dropNotifyRecipient := anObject
 ]
 
 { #category : 'private' }
@@ -180,9 +168,6 @@ TransferMorph >> justDroppedInto: targetMorph event: anEvent [
 	self formerPosition: formerPosition.
 	accepted := targetMorph ~= self world.
 
-	accepted ifTrue: [
-		self dropNotifyRecipient ifNotNil: [
-			self dropNotifyRecipient dropAcceptedMorph: self from: targetMorph ] ].
 	self delete
 ]
 

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -533,52 +533,22 @@ ReleaseTest >> testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented 
 	 This test makes sure that we do not introduce new cases until we are down to one"
 
 	| knownFailures violations wantedAndValidViolations |
-
 	"String streamContents: [ :aStream | aStream << '#( '.  SystemNavigation default allSentButNotImplementedSelectors do: [ :m | .aStream << '''' << m printString  << ''' ' ]. aStream << ')' ]"
 	knownFailures := #( 'AthensCCWArcSegment>>#accept:' 'AthensCWArcSegment>>#accept:' 'AthensCairoCanvas>>#visitCubicSegment:'
 	                    'AthensCairoCanvas>>#visitQuadSegment:' 'AthensCloseSegment>>#accept:' 'AthensCubicSegment>>#accept:' 'AthensEllipticalArcSegment>>#accept:'
-	                    'AthensInteractiveScene>>#eventHandledByScene:' 'AthensLineSegment>>#accept:' 'AthensMoveSegment>>#accept:' 
-	                    'AthensParagraph>>#compose:style:from:in:'
-	                    'AthensPolygon>>#paintFillsUsing:on:' 
-	
-							'BalloonEdgeData>>#stepToFirstScanLine' 'BalloonEdgeData>>#stepToNextScanLine'
+	                    'AthensInteractiveScene>>#eventHandledByScene:' 'AthensLineSegment>>#accept:' 'AthensMoveSegment>>#accept:' 'AthensParagraph>>#compose:style:from:in:'
+	                    'AthensPolygon>>#paintFillsUsing:on:' 'BalloonEdgeData>>#stepToFirstScanLine' 'BalloonEdgeData>>#stepToNextScanLine'
 	                    'BalloonEngine>>#registerFills:' 'BalloonFillData>>#computeFill' 'ClyFullBrowserMorph>>#extendClassScopeForMethods:'
 	                    'ComplexBorderStyle>>#drawPolyPatchFrom:to:on:usingEnds:' 'ComplexBorderStyle>>#drawLineFrom:to:on:'
-	             			
-							  'Context>>#doPrimitive:method:receiver:args:'
-	                    'Context>>#failPrimitiveWith:' 
-								
-							'DTReRunConfiguration>>#items'
-	
-	                    'DebugSession>>#shouldDisplayContext:basedOnFilters:'
-	                	'EDTest>>#prepareMethodVersionTest' 
-							'ExternalDropHandler class>>#defaultHandler'
-	
-	                    'FFICallbackArgumentReader>>#stackPointer' 
-								'FFIFloat32>>#callbackReturnOn:for:' 
-								'FFIFloatType>>#callbackReturnOn:for:'
-	                    'FFIIndirectFunctionResolution>>#resolveFunction:' 
-	      
-	              		'OCIRReconstructor>>#fixPushNilsForTemps' 
-			
-			
-	                   'IceTipHiedraAltComponentHistoryBrowser>>#newCommitRow:commit:'
-	                    'IceTipHiedraAltHistoryBrowser>>#newCommitRow:commit:' 
-							'IceTipHiedraAltHistoryBrowser>>#initializeCommitList'
-	
-	
+	                    'Context>>#doPrimitive:method:receiver:args:' 'Context>>#failPrimitiveWith:' 'DTReRunConfiguration>>#items' 'DebugSession>>#shouldDisplayContext:basedOnFilters:'
+	                    'EDTest>>#prepareMethodVersionTest' 'ExternalDropHandler class>>#defaultHandler' 'FFICallbackArgumentReader>>#stackPointer'
+	                    'FFIFloat32>>#callbackReturnOn:for:' 'FFIFloatType>>#callbackReturnOn:for:' 'FFIIndirectFunctionResolution>>#resolveFunction:'
+	                    'OCIRReconstructor>>#fixPushNilsForTemps' 'IceTipHiedraAltComponentHistoryBrowser>>#newCommitRow:commit:'
+	                    'IceTipHiedraAltHistoryBrowser>>#newCommitRow:commit:' 'IceTipHiedraAltHistoryBrowser>>#initializeCommitList'
 	                    'InstructionStream>>#interpretNext3ByteSistaV1Instruction:for:extA:extB:startPC:'
-	                  
-							'KMMetaModifier>>#printOsRepresentationOn:'
-	
-								'LazyListMorph>>#drawOnAthensCanvas:'
-	
-							'MCFileTreeAbstractReader>>#packageProperties' 
-	
-	                    'MicrodownSpecComponentForTest class>>#open' 
-	
-							'MorphTreeMorph>>#nodeExpandRequest:'
-	                    'MorphTreeMorph>>#selectItemsRequest:' 'PSMCClassChangeWrapper>>#remoteChosen' 'PolygonMorph>>#intersects:' 'RBBasicDummyLintRuleTest class>>#createMatcherFor:method:'
+	                    'KMMetaModifier>>#printOsRepresentationOn:' 'LazyListMorph>>#drawOnAthensCanvas:' 'MCFileTreeAbstractReader>>#packageProperties'
+	                    'MicrodownSpecComponentForTest class>>#open' 'MorphTreeMorph>>#nodeExpandRequest:' 'MorphTreeMorph>>#selectItemsRequest:'
+	                    'PSMCClassChangeWrapper>>#remoteChosen' 'PolygonMorph>>#intersects:' 'RBBasicDummyLintRuleTest class>>#createMatcherFor:method:'
 	                    'RBBasicDummyLintRuleTest class>>#usesAdd' 'RBBasicDummyLintRuleTest class>>#unreferencedVariables'
 	                    'RBBasicDummyLintRuleTest class>>#classNotReferenced' 'RBBasicDummyLintRuleTest class>>#canCall:in:from:'
 	                    'RBBasicDummyLintRuleTest class>>#tempsReadBeforeWritten' 'RBBasicDummyLintRuleTest class>>#usesTrue'
@@ -589,21 +559,11 @@ ReleaseTest >> testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented 
 	                    'RBBasicLintRuleTestData class>>#sentNotImplementedInApplication' 'RBBasicLintRuleTestData class>>#utilityMethods'
 	                    'RBClassDataForRefactoringTest>>#inlineComponent' 'RBClassDataForRefactoringTest>>#textInput:name:symbol:'
 	                    'RBClassDataForRefactoringTest>>#inlineFailed' 'RBClassDataForRefactoringTest>>#renderContentOn:'
-	            
-								'OCIRReconstructorBuilder>>#fixPushNilsForTemps'
-			
-	                    'RBLintRuleTestData>>#runOnEnvironment:'
-	                    'RBTransformationDummyRuleTest class>>#initializeAfterLoad1'
+	                    'OCIRReconstructorBuilder>>#fixPushNilsForTemps' 'RBLintRuleTestData>>#runOnEnvironment:' 'RBTransformationDummyRuleTest class>>#initializeAfterLoad1'
 	                    'RBTransformationDummyRuleTest class>>#rewrite:methods:name:' 'RBTransformationRuleTestData class>>#initializeAfterLoad1'
-	                    'RBTransformationRuleTestData class>>#rewrite:methods:name:' 'RGChunkImporter>>#visitDoItChunk:' 
-							  'ReSentNotImplementedRuleTest>>#sampleMethod'
-	                    'RubSegmentMorph>>#intersects:' 
-	
-	                    'SpTreeColumn>>#rowMorphFor:' 'SpUIThemeDecoratorTest>>#testDoesNotUnderstand'
-	                    'SpWindowPresenter>>#notify:' 'SpMorphicBackend>>#executeSaveFileDialog:'
-	                  
-							  'StringMorph>>#launchEditor:'  'TransferMorph>>#justDroppedInto:event:'
-	                    'TransferMorph>>#delete').
+	                    'RBTransformationRuleTestData class>>#rewrite:methods:name:' 'RGChunkImporter>>#visitDoItChunk:' 'ReSentNotImplementedRuleTest>>#sampleMethod'
+	                    'RubSegmentMorph>>#intersects:' 'SpTreeColumn>>#rowMorphFor:' 'SpUIThemeDecoratorTest>>#testDoesNotUnderstand'
+	                    'SpWindowPresenter>>#notify:' 'SpMorphicBackend>>#executeSaveFileDialog:' 'StringMorph>>#launchEditor:' ).
 
 	violations := (SystemNavigation default allSentButNotImplementedSelectors collect: [ :method | method printString ]) asOrderedCollection.
 	"This next line is to ignore this for SmalltalkCI and not make external Pharo projects fail :("


### PR DESCRIPTION
This morph has dead code. This code is calling methods that do not exist so it should be safe to remove.