### PR TITLE
Move LocalProcessException and LocalRecursionStopper to debugger packages

### DIFF
--- a/src/Debugging-Core/LocalProcessException.class.st
+++ b/src/Debugging-Core/LocalProcessException.class.st
@@ -4,7 +4,6 @@ I store the execeptions silently raised when stepping a process execution to kee
 Class {
 	#name : 'LocalProcessException',
 	#superclass : 'ProcessLocalVariable',
-	#category : 'Kernel-Processes',
-	#package : 'Kernel',
-	#tag : 'Processes'
+	#category : 'Debugging-Core',
+	#package : 'Debugging-Core'
 }

--- a/src/Debugging-Utils/LocalRecursionStopper.class.st
+++ b/src/Debugging-Utils/LocalRecursionStopper.class.st
@@ -10,9 +10,8 @@ A LocalRecursionStopper value is a collection of active methods which are curren
 Class {
 	#name : 'LocalRecursionStopper',
 	#superclass : 'ProcessLocalVariable',
-	#category : 'Kernel-Processes',
-	#package : 'Kernel',
-	#tag : 'Processes'
+	#category : 'Debugging-Utils',
+	#package : 'Debugging-Utils'
 }
 
 { #category : 'private' }


### PR DESCRIPTION
Those classes are used only in the debugging packages so I propose to move them there instead of letting them in the Kernel and be loaded in the first bootstrap phases