### PR TITLE
Calypso: Fix remove protocol when there is no method in the protocol

### DIFF
--- a/src/Calypso-SystemQueries/ClyMethodGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyMethodGroup.class.st
@@ -213,6 +213,13 @@ ClyMethodGroup >> printOn: aStream [
 ]
 
 { #category : 'operations' }
+ClyMethodGroup >> removeProtocolFrom: aCollectionOfClasses [
+	"Do nothing at this level."
+
+	
+]
+
+{ #category : 'operations' }
 ClyMethodGroup >> removeWithMethods [
 	self methods do: [ :each | each removeFromSystem ]
 ]

--- a/src/Calypso-SystemQueries/ClyMethodsInProtocolGroup.class.st
+++ b/src/Calypso-SystemQueries/ClyMethodsInProtocolGroup.class.st
@@ -46,3 +46,9 @@ ClyMethodsInProtocolGroup >> protocol [
 
 	^ methodQuery protocol
 ]
+
+{ #category : 'operations' }
+ClyMethodsInProtocolGroup >> removeProtocolFrom: aCollectionOfClasses [
+
+	aCollectionOfClasses do: [ :class | class removeProtocol: self protocol ]
+]

--- a/src/Calypso-SystemTools-FullBrowser/ClyRemoveMethodGroupCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyRemoveMethodGroupCommand.class.st
@@ -4,6 +4,9 @@ I am a command to remove method group with containing methods
 Class {
 	#name : 'ClyRemoveMethodGroupCommand',
 	#superclass : 'ClyMethodGroupCommand',
+	#instVars : [
+		'selectedClasses'
+	],
 	#category : 'Calypso-SystemTools-FullBrowser-Commands-MethodGroups',
 	#package : 'Calypso-SystemTools-FullBrowser',
 	#tag : 'Commands-MethodGroups'
@@ -36,18 +39,22 @@ ClyRemoveMethodGroupCommand >> defaultMenuItemName [
 { #category : 'execution' }
 ClyRemoveMethodGroupCommand >> execute [
 
-	methodGroups do: [ :each | each removeWithMethods ]
+	methodGroups do: [ :group |
+		group
+			removeWithMethods;
+			removeProtocolFrom: selectedClasses ]
 ]
 
 { #category : 'execution' }
 ClyRemoveMethodGroupCommand >> prepareFullExecutionInContext: aToolContext [
+
 	| tagsString confirmed |
 	super prepareFullExecutionInContext: aToolContext.
-
-	tagsString := ', ' join: (methodGroups collect: [:each | each name]).
-	(methodGroups anySatisfy: [ :each | each methodsSize > 0])
-		ifTrue: [
-			confirmed := self
-					confirm: 'Are you sure you want to remove methods tagged with ', tagsString, '?'.
-			confirmed ifFalse: [CmdCommandAborted signal]]
+	selectedClasses := aToolContext  selectedClasses.
+	
+	tagsString := ', ' join: (methodGroups collect: [ :each | each name ]).
+	(methodGroups anySatisfy: [ :each | each methodsSize > 0 ]) ifFalse: [ ^ self ].
+	
+	confirmed := self confirm: 'Are you sure you want to remove methods from ' , tagsString , '?'.
+	confirmed ifFalse: [ CmdCommandAborted signal ]
 ]


### PR DESCRIPTION
When there is no method in a protocol it is not possible to remove a protocol in Calypso because it removes it by removing all methods from it.

FIxes #17624