### PR TITLE
Update word navigation to handle different character groups

### DIFF
--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -272,6 +272,12 @@ Character class >> supportsNonASCII [
 		((self environment  at: #EncodedCharSet) charsetAt: 255) name = #Unicode ]
 ]
 
+{ #category : 'constants' }
+Character class >> syntaxCharacters [
+
+	^ '^"''|[](){}$#<>=;:.' copy
+]
+
 { #category : 'accessing - untypeable characters' }
 Character class >> tab [
 	"Answer the Character representing a tab."
@@ -779,14 +785,15 @@ Character >> isSpecial [
 ]
 
 { #category : 'testing' }
-Character >> isSpecialSyntaxValid [
-
-	^ '^"''[](){}#$:;.=' includes: self
+Character >> isSurrogateOther [
+^ self characterSet isSurrogateOther: self
 ]
 
 { #category : 'testing' }
-Character >> isSurrogateOther [
-^ self characterSet isSurrogateOther: self
+Character >> isSyntax [
+	"Answer whether the receiver is part of the Smalltalk syntax, i.e. ^""'|[](){}$#<>=;:."
+
+	^ self class syntaxCharacters includes: self
 ]
 
 { #category : 'testing' }

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -72,9 +72,20 @@ CompletionEngine >> completionToken [
 { #category : 'replacement' }
 CompletionEngine >> completionTokenStart [
 	"This is the position in the editor where the completion token starts"
+
+	| caret |
 	self editor caret <= 1 ifTrue: [ ^ self editor caret ].
-	(self editor isWordCharacterAt: self editor caret - 1 in: self editor text) ifFalse: [^ self editor caret ].	
-	^ self editor previousWord: self editor caret
+	(self editor
+		 isWordCharacterAt: self editor caret - 1
+		 in: self editor text) ifFalse: [ ^ self editor caret ].
+
+	"Look back.
+	If the caret is at the end of a keyword (i.e., just after a colon) go back twice"
+	caret := self editor caret.
+	(self editor characterAt: caret - 1) = $: ifTrue: [
+		caret := self editor previousWord: caret ].
+	caret := self editor previousWord: caret.
+	^ caret
 ]
 
 { #category : 'accessing' }
@@ -338,34 +349,52 @@ CompletionEngine >> replaceTokenInEditorWith: aString [
 
 	The completion context uses this API to insert text into the text editor"
 
-	| newString wordEnd doubleSpace wordStart oldSelectionInterval |
+	| newString doubleSpace oldSelectionInterval replacementInterval wordStart wordEnd |
 
 	newString := aString.
-	wordStart := self completionTokenStart.
+	oldSelectionInterval := self editor selectionInterval.
+	replacementInterval := self replacementInterval.
+	wordStart := replacementInterval first.
+	wordEnd := replacementInterval last.
 
-	"If completionToken is not empty, the end is the end of the whole word (according to the editor)"
-	wordEnd := wordStart = editor caret
-		ifTrue: [ wordStart ]
-		ifFalse: [ self editor nextWord: self editor caret - 1].
+	self editor
+		selectInvisiblyFrom: wordStart
+		to: wordEnd.
 
 	"Do not insert an aditional space if there is already one"
 	(newString last = $  and: [
 		wordEnd <= self editor text size and: [
-			(self editor text at: wordEnd) = $ ]]) ifTrue: [ newString := newString copyWithoutIndex: newString size ].
-	"If the returned index is the size of the text that means that the caret is at the end of the text and there is no more word after, so add 1 to the index to be out of range to select the entierely word because of the selectInvisiblyFrom:to: remove 1 just after to be at the end of then final word"
-	wordEnd > self editor text size ifTrue:[ wordEnd := wordEnd + 1 ].
-
-	oldSelectionInterval := self editor selectionInterval.
-	self editor
-		selectInvisiblyFrom: wordStart
-		to: wordEnd - 1.
+			(self editor text at: wordEnd + 1) = $ ]]) ifTrue: [ newString := newString copyWithoutIndex: newString size ].
 
 	self editor replaceSelectionWith: newString fromSelection: oldSelectionInterval.
-
 	doubleSpace := newString indexOfSubCollection: '  ' startingAt: 1 ifAbsent: [ newString size ].
 	self editor selectAt: wordStart + doubleSpace.
 
 	self editor morph invalidRect: self editor morph bounds
+]
+
+{ #category : 'replacement' }
+CompletionEngine >> replacementInterval [
+
+	| wordEnd wordStart |
+	wordStart := self completionTokenStart.
+
+	"If completionToken is not empty, the end is the end of the whole word (according to the editor)"
+	wordEnd := wordStart = editor caret
+		           ifTrue: [ wordStart ]
+		           ifFalse: [ self editor nextWord: wordStart ].
+
+	"If this is a keyword (i.e., ends with a : and not a :=), replace the colon too, as we want to replace selector parts"
+	(wordEnd <= self editor text size and: [
+		 (self editor characterAt: wordEnd) = $: ]) ifTrue: [
+		(wordEnd + 1 <= self editor text size and: [
+			 (self editor characterAt: wordEnd + 1) = $= ]) ifFalse: [
+			wordEnd := wordEnd + 1 ] ].
+
+	"If the returned index is the size of the text that means that the caret is at the end of the text and there is no more word after, so add 1 to the index to be out of range to select the entierely word because of the selectInvisiblyFrom:to: remove 1 just after to be at the end of then final word"
+	wordEnd > self editor text size ifTrue: [ wordEnd := wordEnd + 1 ].
+
+	^ wordStart to: wordEnd - 1
 ]
 
 { #category : 'private' }
@@ -602,6 +631,14 @@ CompletionEngine >> stopCompletionDelay [
 
     completionDelay ifNotNil: [
         completionDelay isTerminating ifFalse: [ completionDelay terminate ] ]
+]
+
+{ #category : 'replacement' }
+CompletionEngine >> tokenToReplace [
+
+	| interval |
+	interval := self replacementInterval.
+	^ self editor text copyFrom: interval first to: interval last
 ]
 
 { #category : 'keyboard' }

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -159,6 +159,7 @@ CompletionEngineTest >> testCompletionAfterKeyword [
 
 	self setEditorTextWithCaret: 'self"x"foo:|"x"baz'.
 	self assert: controller completionToken equals: 'foo:'.
+	self assert: controller tokenToReplace equals: 'foo:'.
 	controller context replaceTokenInEditorWith: 'bar'.
 	self assert: self editorTextWithCaret equals: 'self"x"bar|"x"baz'.
 
@@ -198,6 +199,7 @@ CompletionEngineTest >> testCompletionAfterWord [
 
 	self setEditorTextWithCaret: 'self:=foo|:=baz'.
 	self assert: controller completionToken equals: 'foo'.
+	self assert: controller tokenToReplace equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
 	self assert: self editorTextWithCaret equals: 'self:=bar|:=baz'.
 
@@ -295,6 +297,7 @@ CompletionEngineTest >> testCompletionOnFirstLetter [
 
 	self setEditorTextWithCaret: 'self:=f|oo:=baz'.
 	self assert: controller completionToken equals: 'f'.
+	self assert: controller tokenToReplace equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar'.
 	self assert: self editorTextWithCaret equals: 'self:=bar|:=baz'.
 
@@ -324,6 +327,7 @@ CompletionEngineTest >> testCompletionOnNoWord [
 
 	self setEditorTextWithCaret: 'self:=|:=baz'.
 	self assert: controller completionToken equals: ''.
+	self assert: controller tokenToReplace equals: ''.
 	controller context replaceTokenInEditorWith: 'bar'.
 	self assert: self editorTextWithCaret equals: 'self:=bar|:=baz'.
 
@@ -657,6 +661,7 @@ CompletionEngineTest >> testReplaceWithSpaces [
 
 	self setEditorTextWithCaret: 'self fo|o baz'.
 	self assert: controller completionToken equals: 'fo'.
+	self assert: controller tokenToReplace equals: 'foo'.
 	controller context replaceTokenInEditorWith: 'bar '.
 	self assert: self editorTextWithCaret equals: 'self bar| baz'.
 

--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -298,6 +298,37 @@ RubTextEditorTest >> testNextCharacterGroupWithSpecialCharacters [
 ]
 
 { #category : 'tests' }
+RubTextEditorTest >> testNextCharacterGroupWithSyntax [
+
+	string := '^"''|[](){}$#<>=;:.'.
+	editor addString: string.
+
+	self
+		assertNextCharGroupFrom:	'¶^"''|[](){}$#<>=;:.'
+		to: 							'^"¶''|[](){}$#<>=;:.'
+		equals: 						'^"''¶|[](){}$#<>=;:.'.
+
+	self
+		assertNextCharGroupOf:	'^"''¶|[](){}$#<>=;:.'
+		equals: 						'^"''|¶[](){}$#<>=;:.'.
+
+	self
+		assertNextCharGroupFrom:	'^"''|¶[](){}$#<>=;:.'
+		to: 							'^"''|[](){}$¶#<>=;:.'
+		equals: 						'^"''|[](){}$#¶<>=;:.'.
+
+	self
+		assertNextCharGroupFrom:	'^"''|[](){}$#¶<>=;:.'
+		to: 							'^"''|[](){}$#<>¶=;:.'
+		equals: 						'^"''|[](){}$#<>=¶;:.'.
+
+	self
+		assertNextCharGroupFrom:	'^"''|[](){}$#<>=¶;:.'
+		to: 							'^"''|[](){}$#<>=;:.¶'
+		equals: 						'^"''|[](){}$#<>=;:.¶'.
+]
+
+{ #category : 'tests' }
 RubTextEditorTest >> testNextWord [
 
 	| textSize |
@@ -594,6 +625,37 @@ RubTextEditorTest >> testPreviousCharacterGroupWithSpecialCharacters [
 		assertPreviousCharGroupFrom:	'^[:¶x|(''#eur'',$$asString)]'
 		to: 									'¶^[:x|(''#eur'',$$asString)]'
 		equals: 								'¶^[:x|(''#eur'',$$asString)]'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousCharacterGroupWithSyntax [
+
+	string := '^"''|[](){}$#<>=;:.'.
+	editor addString: string.
+
+	self
+		assertPreviousCharGroupFrom:	'^"''|[](){}$#<>=;:.¶'
+		to: 									'^"''|[](){}$#<>=;¶:.'
+		equals: 								'^"''|[](){}$#<>=¶;:.'.
+
+	self
+		assertPreviousCharGroupFrom:	'^"''|[](){}$#<>=¶;:.'
+		to: 									'^"''|[](){}$#<¶>=;:.'
+		equals: 								'^"''|[](){}$#¶<>=;:.'.
+
+	self
+		assertPreviousCharGroupFrom:	'^"''|[](){}$#¶<>=;:.'
+		to: 									'^"''|[¶](){}$#<>=;:.'
+		equals: 								'^"''|¶[](){}$#<>=;:.'.
+
+	self
+		assertPreviousCharGroupOf:		'^"''|¶[](){}$#<>=;:.'
+		equals: 								'^"''¶|[](){}$#<>=;:.'.
+
+	self
+		assertPreviousCharGroupFrom:	'^"''¶|[](){}$#<>=;:.'
+		to: 									'¶^"''|[](){}$#<>=;:.'
+		equals: 								'¶^"''|[](){}$#<>=;:.'.
 ]
 
 { #category : 'tests' }

--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -10,7 +10,33 @@ Class {
 }
 
 { #category : 'asserting' }
-RubTextEditorTest >> assertPreviousJumpPointFrom: actualFrom to: actualTo equals: expected [
+RubTextEditorTest >> assertNextCharGroupFrom: actualFrom to: actualTo equals: expected [
+
+	| actualIndexFrom actualIndexTo expectedIndex |
+	actualIndexFrom := actualFrom indexOf: $¶.
+	actualIndexTo := actualTo indexOf: $¶.
+	expectedIndex := expected indexOf: $¶.
+
+	actualIndexFrom to: actualIndexTo do: [ :i |
+		self
+			assert: (editor nextCharacterGroup: i)
+			equals: expectedIndex ]
+]
+
+{ #category : 'asserting' }
+RubTextEditorTest >> assertNextCharGroupOf: actual equals: expected [
+
+	| actualIndex expectedIndex |
+	actualIndex := actual indexOf: $¶.
+	expectedIndex := expected indexOf: $¶.
+
+	self
+		assert: (editor nextCharacterGroup: actualIndex)
+		equals: expectedIndex
+]
+
+{ #category : 'asserting' }
+RubTextEditorTest >> assertPreviousCharGroupFrom: actualFrom to: actualTo equals: expected [
 
 	| actualIndexFrom actualIndexTo expectedIndex |
 	actualIndexFrom := actualFrom indexOf: $¶.
@@ -21,6 +47,18 @@ RubTextEditorTest >> assertPreviousJumpPointFrom: actualFrom to: actualTo equals
 		self
 			assert: (editor previousWord: i stopOnUpperCase: true)
 			equals: expectedIndex ]
+]
+
+{ #category : 'asserting' }
+RubTextEditorTest >> assertPreviousCharGroupOf: actual equals: expected [
+
+	| actualIndex expectedIndex |
+	actualIndex := actual indexOf: $¶.
+	expectedIndex := expected indexOf: $¶.
+
+	self
+		assert: (editor previousCharacterGroup: actualIndex)
+		equals: expectedIndex
 ]
 
 { #category : 'running' }
@@ -63,6 +101,200 @@ RubTextEditorTest >> testLineStart [
 		assert: starts
 		equals:
 		#( 1 1 1 1 5 5 5 5 5 5 11 11 11 11 11 11 17 18 19 19 19 22 22 )
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testNextCharacterGroup [
+
+	string := 'loRem ipSum'.
+	editor addString: string.
+
+	self assert: (editor nextCharacterGroup: -999) equals: 3. "Out of range means end of text"
+	self assert: (editor nextCharacterGroup: 0) equals: 3. "Out of range means end of text"
+	self assert: (editor nextCharacterGroup: 999) equals: string size + 1. "Out of range"
+
+	self
+		assertNextCharGroupFrom:	'¶loRem ipSum'
+		to: 							'l¶oRem ipSum'
+		equals: 						'lo¶Rem ipSum'.
+
+	self
+		assertNextCharGroupFrom:	'lo¶Rem ipSum'
+		to: 							'loRe¶m ipSum'
+		equals: 						'loRem¶ ipSum'.
+
+	self
+		assertNextCharGroupOf:	'loRem¶ ipSum'
+		equals: 						'loRem ¶ipSum'.
+
+	self
+		assertNextCharGroupFrom:	'loRem ¶ipSum'
+		to: 							'loRem i¶pSum'
+		equals: 						'loRem ip¶Sum'.
+
+	self
+		assertNextCharGroupFrom:	'loRem ip¶Sum'
+		to: 							'loRem ipSum¶'
+		equals: 						'loRem ipSum¶'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testNextCharacterGroupComplex [
+
+	string := 'self loRem: [[ (1 + 2) // 100 ]]'.
+	editor addString: string.
+
+	self
+		assertNextCharGroupFrom:	'self lo¶Rem: [[ (1 + 2) // 100 ]]'
+		to: 							'self loRe¶m: [[ (1 + 2) // 100 ]]'
+		equals: 						'self loRem¶: [[ (1 + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem¶: [[ (1 + 2) // 100 ]]'
+		equals: 						'self loRem:¶ [[ (1 + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem:¶ [[ (1 + 2) // 100 ]]'
+		equals: 						'self loRem: ¶[[ (1 + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem: ¶[[ (1 + 2) // 100 ]]'
+		to: 							'self loRem: [¶[ (1 + 2) // 100 ]]'
+		equals: 						'self loRem: [[¶ (1 + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[¶ (1 + 2) // 100 ]]'
+		equals: 						'self loRem: [[ ¶(1 + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ ¶(1 + 2) // 100 ]]'
+		equals: 						'self loRem: [[ (¶1 + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (¶1 + 2) // 100 ]]'
+		equals: 						'self loRem: [[ (1¶ + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (1¶ + 2) // 100 ]]'
+		equals: 						'self loRem: [[ (1 ¶+ 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (1 ¶+ 2) // 100 ]]'
+		equals: 						'self loRem: [[ (1 +¶ 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (1 +¶ 2) // 100 ]]'
+		equals: 						'self loRem: [[ (1 + ¶2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (1 + ¶2) // 100 ]]'
+		equals: 						'self loRem: [[ (1 + 2¶) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (1 + 2¶) // 100 ]]'
+		equals: 						'self loRem: [[ (1 + 2)¶ // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (1 + 2)¶ // 100 ]]'
+		equals: 						'self loRem: [[ (1 + 2) ¶// 100 ]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem: [[ (1 + 2) ¶// 100 ]]'
+		to: 							'self loRem: [[ (1 + 2) /¶/ 100 ]]'
+		equals: 						'self loRem: [[ (1 + 2) //¶ 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (1 + 2) //¶ 100 ]]'
+		equals: 						'self loRem: [[ (1 + 2) // ¶100 ]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem: [[ (1 + 2) // ¶100 ]]'
+		to: 							'self loRem: [[ (1 + 2) // 10¶0 ]]'
+		equals: 						'self loRem: [[ (1 + 2) // 100¶ ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (1 + 2) // 100¶ ]]'
+		equals: 						'self loRem: [[ (1 + 2) // 100 ¶]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem: [[ (1 + 2) // 100 ¶]]'
+		to: 							'self loRem: [[ (1 + 2) // 100 ]¶]'
+		equals: 						'self loRem: [[ (1 + 2) // 100 ]]¶'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testNextCharacterGroupManyUppercases [
+
+	string := 'AAAb'.
+	editor addString: string.
+
+	self
+		assertNextCharGroupFrom:	'¶AAAb'
+		to: 							'A¶AAb'
+		equals: 						'AA¶Ab'.
+
+	self
+		assertNextCharGroupFrom:	'AA¶Ab'
+		to: 							'AAA¶b'
+		equals: 						'AAAb¶'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testNextCharacterGroupWithSpecialCharacters [
+
+	string := '^[:x|(''#eur'',$$asString)]'.
+	editor addString: string.
+
+	self
+		assertNextCharGroupFrom:	'¶^[:x|(''#eur'',$$asString)]'
+		to: 							'^[¶:x|(''#eur'',$$asString)]'
+		equals: 						'^[:¶x|(''#eur'',$$asString)]'.
+
+	self
+		assertNextCharGroupOf:	'^[:¶x|(''#eur'',$$asString)]'
+		equals: 						'^[:x¶|(''#eur'',$$asString)]'.
+
+	self
+		assertNextCharGroupOf:	'^[:x¶|(''#eur'',$$asString)]'
+		equals: 						'^[:x|¶(''#eur'',$$asString)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|¶(''#eur'',$$asString)]'
+		to: 							'^[:x|(''¶#eur'',$$asString)]'
+		equals: 						'^[:x|(''#¶eur'',$$asString)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|(''#¶eur'',$$asString)]'
+		to: 							'^[:x|(''#eu¶r'',$$asString)]'
+		equals: 						'^[:x|(''#eur¶'',$$asString)]'.
+
+	self
+		assertNextCharGroupOf:	'^[:x|(''#eur¶'',$$asString)]'
+		equals: 						'^[:x|(''#eur''¶,$$asString)]'.
+
+	self
+		assertNextCharGroupOf:	'^[:x|(''#eur''¶,$$asString)]'
+		equals: 						'^[:x|(''#eur'',¶$$asString)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|(''#eur'',¶$$asString)]'
+		to: 							'^[:x|(''#eur'',$¶$asString)]'
+		equals: 						'^[:x|(''#eur'',$$¶asString)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|(''#eur'',$$¶asString)]'
+		to: 							'^[:x|(''#eur'',$$a¶sString)]'
+		equals: 						'^[:x|(''#eur'',$$as¶String)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|(''#eur'',$$as¶String)]'
+		to: 							'^[:x|(''#eur'',$$asStrin¶g)]'
+		equals: 						'^[:x|(''#eur'',$$asString¶)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|(''#eur'',$$asString¶)]'
+		to: 							'^[:x|(''#eur'',$$asString)¶]'
+		equals: 						'^[:x|(''#eur'',$$asString)]¶'.
 ]
 
 { #category : 'tests' }
@@ -122,6 +354,7 @@ RubTextEditorTest >> testNextWordAtLineWithSpacesGoesToEndOfCurrentLine [
 	self assert: (editor nextWord: 2) equals: 4
 ]
 
+
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordAtStartOfEmptyLineGoesToStartOfNextLine [
 
@@ -156,6 +389,211 @@ RubTextEditorTest >> testNextWordSkipsCurrentSpacesAndGoesToEndOfCurrentWord [
 	editor addString: 'abc d'.
 
 	self assert: (editor nextWord: 4) equals: 6
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousCharacterGroup [
+
+    string := 'loRem ipSum'.
+    editor addString: string.
+	self assert: (editor previousCharacterGroup: -999) equals: 1. "Out of range means start of text"
+	self assert: (editor previousCharacterGroup: 0) equals: 1. "Out of range means start of text"
+
+	self
+		assertPreviousCharGroupFrom:	'loRem ipSum¶'
+		to: 									'loRem ipS¶um'
+		equals: 								'loRem ip¶Sum'.
+
+	self
+		assertPreviousCharGroupFrom:	'loRem ip¶Sum'
+		to: 									'loRem i¶pSum'
+		equals: 								'loRem ¶ipSum'.
+
+	self
+		assertPreviousCharGroupOf:		'loRem ¶ipSum'
+		equals: 								'loRem¶ ipSum'.
+
+	self
+		assertPreviousCharGroupFrom:	'loRem¶ ipSum'
+		to: 									'loR¶em ipSum'
+		equals: 								'lo¶Rem ipSum'.
+
+	self
+		assertPreviousCharGroupFrom:	'lo¶Rem ipSum'
+		to: 									'¶loRem ipSum'
+		equals: 								'¶loRem ipSum'
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousCharacterGroupComplex [
+
+	string := 'self loRem: [[ (1 + 2) // 100 ]]'.
+	editor addString: string.
+
+	self
+		assertPreviousCharGroupFrom:	'self loRem: [[ (1 + 2) // 100 ]]¶'
+		to: 									'self loRem: [[ (1 + 2) // 100 ]¶]'
+		equals: 								'self loRem: [[ (1 + 2) // 100 ¶]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ (1 + 2) // 100 ¶]]'
+		equals: 								'self loRem: [[ (1 + 2) // 100¶ ]]'.
+
+	self
+		assertPreviousCharGroupFrom:	'self loRem: [[ (1 + 2) // 100¶ ]]'
+		to: 									'self loRem: [[ (1 + 2) // 1¶00 ]]'
+		equals: 								'self loRem: [[ (1 + 2) // ¶100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ (1 + 2) // ¶100 ]]'
+		equals: 								'self loRem: [[ (1 + 2) //¶ 100 ]]'.
+
+	self
+		assertPreviousCharGroupFrom:	'self loRem: [[ (1 + 2) //¶ 100 ]]'
+		to: 									'self loRem: [[ (1 + 2) /¶/ 100 ]]'
+		equals: 								'self loRem: [[ (1 + 2) ¶// 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ (1 + 2) ¶// 100 ]]'
+		equals: 								'self loRem: [[ (1 + 2)¶ // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ (1 + 2)¶ // 100 ]]'
+		equals: 								'self loRem: [[ (1 + 2¶) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ (1 + 2¶) // 100 ]]'
+		equals: 								'self loRem: [[ (1 + ¶2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ (1 + ¶2) // 100 ]]'
+		equals: 								'self loRem: [[ (1 +¶ 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ (1 +¶ 2) // 100 ]]'
+		equals: 								'self loRem: [[ (1 ¶+ 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ (1 ¶+ 2) // 100 ]]'
+		equals: 								'self loRem: [[ (1¶ + 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ (1¶ + 2) // 100 ]]'
+		equals: 								'self loRem: [[ (¶1 + 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ (¶1 + 2) // 100 ]]'
+		equals: 								'self loRem: [[ ¶(1 + 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: [[ ¶(1 + 2) // 100 ]]'
+		equals: 								'self loRem: [[¶ (1 + 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupFrom:	'self loRem: [[¶ (1 + 2) // 100 ]]'
+		to: 									'self loRem: [¶[ (1 + 2) // 100 ]]'
+		equals: 								'self loRem: ¶[[ (1 + 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem: ¶[[ (1 + 2) // 100 ]]'
+		equals: 								'self loRem:¶ [[ (1 + 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self loRem:¶ [[ (1 + 2) // 100 ]]'
+		equals: 								'self loRem¶: [[ (1 + 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupFrom:	'self loRem¶: [[ (1 + 2) // 100 ]]'
+		to: 									'self loR¶em: [[ (1 + 2) // 100 ]]'
+		equals: 								'self lo¶Rem: [[ (1 + 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupFrom:	'self lo¶Rem: [[ (1 + 2) // 100 ]]'
+		to: 									'self l¶oRem: [[ (1 + 2) // 100 ]]'
+		equals: 								'self ¶loRem: [[ (1 + 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupOf:		'self ¶loRem: [[ (1 + 2) // 100 ]]'
+		equals: 								'self¶ loRem: [[ (1 + 2) // 100 ]]'.
+
+	self
+		assertPreviousCharGroupFrom:	'self¶ loRem: [[ (1 + 2) // 100 ]]'
+		to: 									'¶self loRem: [[ (1 + 2) // 100 ]]'
+		equals: 								'¶self loRem: [[ (1 + 2) // 100 ]]'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousCharacterGroupManyUppercases [
+	string := 'AAAb'.
+	editor addString: string.
+
+	self
+		assertPreviousCharGroupFrom:	'AAAb¶'
+		to: 									'AAA¶b'
+		equals: 								'AA¶Ab'.
+
+	self
+		assertPreviousCharGroupFrom:	'AA¶Ab'
+		to: 									'¶AAAb'
+		equals: 								'¶AAAb'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousCharacterGroupWithSpecialCharacters [
+
+	string := '^[:x|(''#eur'',$$asString)]'.
+	editor addString: string.
+
+	self
+		assertPreviousCharGroupFrom:	'^[:x|(''#eur'',$$asString)]¶'
+		to: 									'^[:x|(''#eur'',$$asString)¶]'
+		equals: 								'^[:x|(''#eur'',$$asString¶)]'.
+
+	self
+		assertPreviousCharGroupFrom:	'^[:x|(''#eur'',$$asString¶)]'
+		to: 									'^[:x|(''#eur'',$$asS¶tring)]'
+		equals: 								'^[:x|(''#eur'',$$as¶String)]'.
+
+	self
+		assertPreviousCharGroupFrom:	'^[:x|(''#eur'',$$as¶String)]'
+		to: 									'^[:x|(''#eur'',$$a¶sString)]'
+		equals: 								'^[:x|(''#eur'',$$¶asString)]'.
+
+	self
+		assertPreviousCharGroupFrom:	'^[:x|(''#eur'',$$¶asString)]'
+		to: 									'^[:x|(''#eur'',$¶$asString)]'
+		equals: 								'^[:x|(''#eur'',¶$$asString)]'.
+
+	self
+		assertPreviousCharGroupOf:		'^[:x|(''#eur'',¶$$asString)]'
+		equals: 								'^[:x|(''#eur''¶,$$asString)]'.
+
+	self
+		assertPreviousCharGroupOf:		'^[:x|(''#eur''¶,$$asString)]'
+		equals: 								'^[:x|(''#eur¶'',$$asString)]'.
+
+	self
+		assertPreviousCharGroupFrom:	'^[:x|(''#eur¶'',$$asString)]'
+		to: 									'^[:x|(''#e¶ur'',$$asString)]'
+		equals: 								'^[:x|(''#¶eur'',$$asString)]'.
+
+	self
+		assertPreviousCharGroupFrom:	'^[:x|(''#¶eur'',$$asString)]'
+		to: 									'^[:x|(¶''#eur'',$$asString)]'
+		equals: 								'^[:x|¶(''#eur'',$$asString)]'.
+
+	self
+		assertPreviousCharGroupOf:		'^[:x|¶(''#eur'',$$asString)]'
+		equals: 								'^[:x¶|(''#eur'',$$asString)]'.
+
+	self
+		assertPreviousCharGroupOf:		'^[:x¶|(''#eur'',$$asString)]'
+		equals: 								'^[:¶x|(''#eur'',$$asString)]'.
+
+	self
+		assertPreviousCharGroupFrom:	'^[:¶x|(''#eur'',$$asString)]'
+		to: 									'¶^[:x|(''#eur'',$$asString)]'
+		equals: 								'¶^[:x|(''#eur'',$$asString)]'.
 ]
 
 { #category : 'tests' }

--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -19,7 +19,7 @@ RubTextEditorTest >> assertNextCharGroupFrom: actualFrom to: actualTo equals: ex
 
 	actualIndexFrom to: actualIndexTo do: [ :i |
 		self
-			assert: (editor nextCharacterGroup: i)
+			assert: (editor nextWord: i stopOnUpperCase: true)
 			equals: expectedIndex ]
 ]
 
@@ -31,7 +31,7 @@ RubTextEditorTest >> assertNextCharGroupOf: actual equals: expected [
 	expectedIndex := expected indexOf: $¶.
 
 	self
-		assert: (editor nextCharacterGroup: actualIndex)
+		assert: (editor nextWord: actualIndex stopOnUpperCase: true)
 		equals: expectedIndex
 ]
 
@@ -57,7 +57,7 @@ RubTextEditorTest >> assertPreviousCharGroupOf: actual equals: expected [
 	expectedIndex := expected indexOf: $¶.
 
 	self
-		assert: (editor previousCharacterGroup: actualIndex)
+		assert: (editor previousWord: actualIndex stopOnUpperCase: true)
 		equals: expectedIndex
 ]
 
@@ -101,231 +101,6 @@ RubTextEditorTest >> testLineStart [
 		assert: starts
 		equals:
 		#( 1 1 1 1 5 5 5 5 5 5 11 11 11 11 11 11 17 18 19 19 19 22 22 )
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testNextCharacterGroup [
-
-	string := 'loRem ipSum'.
-	editor addString: string.
-
-	self assert: (editor nextCharacterGroup: -999) equals: 3. "Out of range means end of text"
-	self assert: (editor nextCharacterGroup: 0) equals: 3. "Out of range means end of text"
-	self assert: (editor nextCharacterGroup: 999) equals: string size + 1. "Out of range"
-
-	self
-		assertNextCharGroupFrom:	'¶loRem ipSum'
-		to: 							'l¶oRem ipSum'
-		equals: 						'lo¶Rem ipSum'.
-
-	self
-		assertNextCharGroupFrom:	'lo¶Rem ipSum'
-		to: 							'loRe¶m ipSum'
-		equals: 						'loRem¶ ipSum'.
-
-	self
-		assertNextCharGroupOf:	'loRem¶ ipSum'
-		equals: 						'loRem ¶ipSum'.
-
-	self
-		assertNextCharGroupFrom:	'loRem ¶ipSum'
-		to: 							'loRem i¶pSum'
-		equals: 						'loRem ip¶Sum'.
-
-	self
-		assertNextCharGroupFrom:	'loRem ip¶Sum'
-		to: 							'loRem ipSum¶'
-		equals: 						'loRem ipSum¶'.
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testNextCharacterGroupComplex [
-
-	string := 'self loRem: [[ (1 + 2) // 100 ]]'.
-	editor addString: string.
-
-	self
-		assertNextCharGroupFrom:	'self lo¶Rem: [[ (1 + 2) // 100 ]]'
-		to: 							'self loRe¶m: [[ (1 + 2) // 100 ]]'
-		equals: 						'self loRem¶: [[ (1 + 2) // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem¶: [[ (1 + 2) // 100 ]]'
-		equals: 						'self loRem:¶ [[ (1 + 2) // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem:¶ [[ (1 + 2) // 100 ]]'
-		equals: 						'self loRem: ¶[[ (1 + 2) // 100 ]]'.
-
-	self
-		assertNextCharGroupFrom:	'self loRem: ¶[[ (1 + 2) // 100 ]]'
-		to: 							'self loRem: [¶[ (1 + 2) // 100 ]]'
-		equals: 						'self loRem: [[¶ (1 + 2) // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[¶ (1 + 2) // 100 ]]'
-		equals: 						'self loRem: [[ ¶(1 + 2) // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[ ¶(1 + 2) // 100 ]]'
-		equals: 						'self loRem: [[ (¶1 + 2) // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[ (¶1 + 2) // 100 ]]'
-		equals: 						'self loRem: [[ (1¶ + 2) // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[ (1¶ + 2) // 100 ]]'
-		equals: 						'self loRem: [[ (1 ¶+ 2) // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[ (1 ¶+ 2) // 100 ]]'
-		equals: 						'self loRem: [[ (1 +¶ 2) // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[ (1 +¶ 2) // 100 ]]'
-		equals: 						'self loRem: [[ (1 + ¶2) // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[ (1 + ¶2) // 100 ]]'
-		equals: 						'self loRem: [[ (1 + 2¶) // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[ (1 + 2¶) // 100 ]]'
-		equals: 						'self loRem: [[ (1 + 2)¶ // 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[ (1 + 2)¶ // 100 ]]'
-		equals: 						'self loRem: [[ (1 + 2) ¶// 100 ]]'.
-
-	self
-		assertNextCharGroupFrom:	'self loRem: [[ (1 + 2) ¶// 100 ]]'
-		to: 							'self loRem: [[ (1 + 2) /¶/ 100 ]]'
-		equals: 						'self loRem: [[ (1 + 2) //¶ 100 ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[ (1 + 2) //¶ 100 ]]'
-		equals: 						'self loRem: [[ (1 + 2) // ¶100 ]]'.
-
-	self
-		assertNextCharGroupFrom:	'self loRem: [[ (1 + 2) // ¶100 ]]'
-		to: 							'self loRem: [[ (1 + 2) // 10¶0 ]]'
-		equals: 						'self loRem: [[ (1 + 2) // 100¶ ]]'.
-
-	self
-		assertNextCharGroupOf:	'self loRem: [[ (1 + 2) // 100¶ ]]'
-		equals: 						'self loRem: [[ (1 + 2) // 100 ¶]]'.
-
-	self
-		assertNextCharGroupFrom:	'self loRem: [[ (1 + 2) // 100 ¶]]'
-		to: 							'self loRem: [[ (1 + 2) // 100 ]¶]'
-		equals: 						'self loRem: [[ (1 + 2) // 100 ]]¶'.
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testNextCharacterGroupManyUppercases [
-
-	string := 'AAAb'.
-	editor addString: string.
-
-	self
-		assertNextCharGroupFrom:	'¶AAAb'
-		to: 							'A¶AAb'
-		equals: 						'AA¶Ab'.
-
-	self
-		assertNextCharGroupFrom:	'AA¶Ab'
-		to: 							'AAA¶b'
-		equals: 						'AAAb¶'.
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testNextCharacterGroupWithSpecialCharacters [
-
-	string := '^[:x|(''#eur'',$$asString)]'.
-	editor addString: string.
-
-	self
-		assertNextCharGroupFrom:	'¶^[:x|(''#eur'',$$asString)]'
-		to: 							'^[¶:x|(''#eur'',$$asString)]'
-		equals: 						'^[:¶x|(''#eur'',$$asString)]'.
-
-	self
-		assertNextCharGroupOf:	'^[:¶x|(''#eur'',$$asString)]'
-		equals: 						'^[:x¶|(''#eur'',$$asString)]'.
-
-	self
-		assertNextCharGroupOf:	'^[:x¶|(''#eur'',$$asString)]'
-		equals: 						'^[:x|¶(''#eur'',$$asString)]'.
-
-	self
-		assertNextCharGroupFrom:	'^[:x|¶(''#eur'',$$asString)]'
-		to: 							'^[:x|(''¶#eur'',$$asString)]'
-		equals: 						'^[:x|(''#¶eur'',$$asString)]'.
-
-	self
-		assertNextCharGroupFrom:	'^[:x|(''#¶eur'',$$asString)]'
-		to: 							'^[:x|(''#eu¶r'',$$asString)]'
-		equals: 						'^[:x|(''#eur¶'',$$asString)]'.
-
-	self
-		assertNextCharGroupOf:	'^[:x|(''#eur¶'',$$asString)]'
-		equals: 						'^[:x|(''#eur''¶,$$asString)]'.
-
-	self
-		assertNextCharGroupOf:	'^[:x|(''#eur''¶,$$asString)]'
-		equals: 						'^[:x|(''#eur'',¶$$asString)]'.
-
-	self
-		assertNextCharGroupFrom:	'^[:x|(''#eur'',¶$$asString)]'
-		to: 							'^[:x|(''#eur'',$¶$asString)]'
-		equals: 						'^[:x|(''#eur'',$$¶asString)]'.
-
-	self
-		assertNextCharGroupFrom:	'^[:x|(''#eur'',$$¶asString)]'
-		to: 							'^[:x|(''#eur'',$$a¶sString)]'
-		equals: 						'^[:x|(''#eur'',$$as¶String)]'.
-
-	self
-		assertNextCharGroupFrom:	'^[:x|(''#eur'',$$as¶String)]'
-		to: 							'^[:x|(''#eur'',$$asStrin¶g)]'
-		equals: 						'^[:x|(''#eur'',$$asString¶)]'.
-
-	self
-		assertNextCharGroupFrom:	'^[:x|(''#eur'',$$asString¶)]'
-		to: 							'^[:x|(''#eur'',$$asString)¶]'
-		equals: 						'^[:x|(''#eur'',$$asString)]¶'.
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testNextCharacterGroupWithSyntax [
-
-	string := '^"''|[](){}$#<>=;:.'.
-	editor addString: string.
-
-	self
-		assertNextCharGroupFrom:	'¶^"''|[](){}$#<>=;:.'
-		to: 							'^"¶''|[](){}$#<>=;:.'
-		equals: 						'^"''¶|[](){}$#<>=;:.'.
-
-	self
-		assertNextCharGroupOf:	'^"''¶|[](){}$#<>=;:.'
-		equals: 						'^"''|¶[](){}$#<>=;:.'.
-
-	self
-		assertNextCharGroupFrom:	'^"''|¶[](){}$#<>=;:.'
-		to: 							'^"''|[](){}$¶#<>=;:.'
-		equals: 						'^"''|[](){}$#¶<>=;:.'.
-
-	self
-		assertNextCharGroupFrom:	'^"''|[](){}$#¶<>=;:.'
-		to: 							'^"''|[](){}$#<>¶=;:.'
-		equals: 						'^"''|[](){}$#<>=¶;:.'.
-
-	self
-		assertNextCharGroupFrom:	'^"''|[](){}$#<>=¶;:.'
-		to: 							'^"''|[](){}$#<>=;:.¶'
-		equals: 						'^"''|[](){}$#<>=;:.¶'.
 ]
 
 { #category : 'tests' }
@@ -385,7 +160,6 @@ RubTextEditorTest >> testNextWordAtLineWithSpacesGoesToEndOfCurrentLine [
 	self assert: (editor nextWord: 2) equals: 4
 ]
 
-
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordAtStartOfEmptyLineGoesToStartOfNextLine [
 
@@ -423,12 +197,286 @@ RubTextEditorTest >> testNextWordSkipsCurrentSpacesAndGoesToEndOfCurrentWord [
 ]
 
 { #category : 'tests' }
-RubTextEditorTest >> testPreviousCharacterGroup [
+RubTextEditorTest >> testNextWordStopOnUpperCase [
+
+	string := 'loRem ipSum'.
+	editor addString: string.
+
+	self assert: (editor nextWord: -999 stopOnUpperCase: true) equals: 3. "Out of range means end of text"
+	self assert: (editor nextWord: 0 stopOnUpperCase: true) equals: 3. "Out of range means end of text"
+	self assert: (editor nextWord: 999 stopOnUpperCase: true) equals: string size + 1. "Out of range"
+
+	self
+		assertNextCharGroupFrom:	'¶loRem ipSum'
+		to: 							'l¶oRem ipSum'
+		equals: 						'lo¶Rem ipSum'.
+
+	self
+		assertNextCharGroupFrom:	'lo¶Rem ipSum'
+		to: 							'loRe¶m ipSum'
+		equals: 						'loRem¶ ipSum'.
+
+	self
+		assertNextCharGroupFrom:	'loRem¶ ipSum'
+		to: 							'loRem i¶pSum'
+		equals: 						'loRem ip¶Sum'.
+
+	self
+		assertNextCharGroupFrom:	'loRem ip¶Sum'
+		to: 							'loRem ipSum¶'
+		equals: 						'loRem ipSum¶'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testNextWordStopOnUpperCaseComplex [
+
+	string := 'self loRem: [[ (1 + 2) // 100 ]]'.
+	editor addString: string.
+
+	self
+		assertNextCharGroupFrom:	'self lo¶Rem: [[ (1 + 2) // 100 ]]'
+		to: 							'self loRe¶m: [[ (1 + 2) // 100 ]]'
+		equals: 						'self loRem¶: [[ (1 + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem¶: [[ (1 + 2) // 100 ]]'
+		equals: 						'self loRem:¶ [[ (1 + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem:¶ [[ (1 + 2) // 100 ]]'
+		to: 							'self loRem: [¶[ (1 + 2) // 100 ]]'
+		equals: 						'self loRem: [[¶ (1 + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem: [[¶ (1 + 2) // 100 ]]'
+		to: 							'self loRem: [[ ¶(1 + 2) // 100 ]]'
+		equals: 						'self loRem: [[ (¶1 + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (¶1 + 2) // 100 ]]'
+		equals: 						'self loRem: [[ (1¶ + 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem: [[ (1¶ + 2) // 100 ]]'
+		to: 							'self loRem: [[ (1 ¶+ 2) // 100 ]]'
+		equals: 						'self loRem: [[ (1 +¶ 2) // 100 ]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem: [[ (1 +¶ 2) // 100 ]]'
+		to: 							'self loRem: [[ (1 + ¶2) // 100 ]]'
+		equals: 						'self loRem: [[ (1 + 2¶) // 100 ]]'.
+
+	self
+		assertNextCharGroupOf:	'self loRem: [[ (1 + 2¶) // 100 ]]'
+		equals: 						'self loRem: [[ (1 + 2)¶ // 100 ]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem: [[ (1 + 2)¶ // 100 ]]'
+		to: 							'self loRem: [[ (1 + 2) /¶/ 100 ]]'
+		equals: 						'self loRem: [[ (1 + 2) //¶ 100 ]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem: [[ (1 + 2) //¶ 100 ]]'
+		to: 							'self loRem: [[ (1 + 2) // 10¶0 ]]'
+		equals: 						'self loRem: [[ (1 + 2) // 100¶ ]]'.
+
+	self
+		assertNextCharGroupFrom:	'self loRem: [[ (1 + 2) // 100¶ ]]'
+		to: 							'self loRem: [[ (1 + 2) // 100 ]¶]'
+		equals: 						'self loRem: [[ (1 + 2) // 100 ]]¶'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testNextWordStopOnUpperCaseManyUppercases [
+
+	string := 'AAAb'.
+	editor addString: string.
+
+	self
+		assertNextCharGroupFrom:	'¶AAAb'
+		to: 							'A¶AAb'
+		equals: 						'AA¶Ab'.
+
+	self
+		assertNextCharGroupFrom:	'AA¶Ab'
+		to: 							'AAA¶b'
+		equals: 						'AAAb¶'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testNextWordStopOnUpperCaseWithSpecialCharacters [
+
+	string := '^[:x|(''#eur'',$$asString)]'.
+	editor addString: string.
+
+	self
+		assertNextCharGroupFrom:	'¶^[:x|(''#eur'',$$asString)]'
+		to: 							'^[¶:x|(''#eur'',$$asString)]'
+		equals: 						'^[:¶x|(''#eur'',$$asString)]'.
+
+	self
+		assertNextCharGroupOf:	'^[:¶x|(''#eur'',$$asString)]'
+		equals: 						'^[:x¶|(''#eur'',$$asString)]'.
+
+	self
+		assertNextCharGroupOf:	'^[:x¶|(''#eur'',$$asString)]'
+		equals: 						'^[:x|¶(''#eur'',$$asString)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|¶(''#eur'',$$asString)]'
+		to: 							'^[:x|(''¶#eur'',$$asString)]'
+		equals: 						'^[:x|(''#¶eur'',$$asString)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|(''#¶eur'',$$asString)]'
+		to: 							'^[:x|(''#eu¶r'',$$asString)]'
+		equals: 						'^[:x|(''#eur¶'',$$asString)]'.
+
+	self
+		assertNextCharGroupOf:	'^[:x|(''#eur¶'',$$asString)]'
+		equals: 						'^[:x|(''#eur''¶,$$asString)]'.
+
+	self
+		assertNextCharGroupOf:	'^[:x|(''#eur''¶,$$asString)]'
+		equals: 						'^[:x|(''#eur'',¶$$asString)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|(''#eur'',¶$$asString)]'
+		to: 							'^[:x|(''#eur'',$¶$asString)]'
+		equals: 						'^[:x|(''#eur'',$$¶asString)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|(''#eur'',$$¶asString)]'
+		to: 							'^[:x|(''#eur'',$$a¶sString)]'
+		equals: 						'^[:x|(''#eur'',$$as¶String)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|(''#eur'',$$as¶String)]'
+		to: 							'^[:x|(''#eur'',$$asStrin¶g)]'
+		equals: 						'^[:x|(''#eur'',$$asString¶)]'.
+
+	self
+		assertNextCharGroupFrom:	'^[:x|(''#eur'',$$asString¶)]'
+		to: 							'^[:x|(''#eur'',$$asString)¶]'
+		equals: 						'^[:x|(''#eur'',$$asString)]¶'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testNextWordStopOnUpperCaseWithSyntax [
+
+	string := '^"''|[](){}$#<>=;:.'.
+	editor addString: string.
+
+	self
+		assertNextCharGroupFrom:	'¶^"''|[](){}$#<>=;:.'
+		to: 							'^"¶''|[](){}$#<>=;:.'
+		equals: 						'^"''¶|[](){}$#<>=;:.'.
+
+	self
+		assertNextCharGroupOf:	'^"''¶|[](){}$#<>=;:.'
+		equals: 						'^"''|¶[](){}$#<>=;:.'.
+
+	self
+		assertNextCharGroupFrom:	'^"''|¶[](){}$#<>=;:.'
+		to: 							'^"''|[](){}$¶#<>=;:.'
+		equals: 						'^"''|[](){}$#¶<>=;:.'.
+
+	self
+		assertNextCharGroupFrom:	'^"''|[](){}$#¶<>=;:.'
+		to: 							'^"''|[](){}$#<>¶=;:.'
+		equals: 						'^"''|[](){}$#<>=¶;:.'.
+
+	self
+		assertNextCharGroupFrom:	'^"''|[](){}$#<>=¶;:.'
+		to: 							'^"''|[](){}$#<>=;:.¶'
+		equals: 						'^"''|[](){}$#<>=;:.¶'.
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWord [
+
+	| textSize |
+	textSize := 'Lorem ipsum ' size.
+	self assert: (editor previousWord: -999) equals: 1. "Out of range"
+	self assert: (editor previousWord: 0) equals: 1. "Out of range"
+
+	1 to: 7 do: [ :i |
+		"From:   |Lorem ipsum
+		 To:     Lorem |ipsum
+		 Should be: |Lorem ipsum"
+		self assert: (editor previousWord: i) equals: 1 ].
+
+	8 to: 12 do: [ :i |
+		"From:   Lorem |ipsum
+		 To:     Lorem ipsum|
+		 Should be: Lorem |ipsum"
+		self assert: (editor previousWord: i) equals: 7 ].
+
+	self assert: (editor previousWord: 999) equals: 7. "Out of range"
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordAtEndOfFirstWordOfLineGoesToStartOfLine [
+
+	editor addString: 'a
+
+a'.
+
+	self assert: (editor previousWord: 5) equals: 4
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordAtLineWithSpacesGoesToStartOfCurrentLine [
+
+	editor addString: 'a
+
+  a'.
+
+	self assert: (editor previousWord: 6) equals: 4
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordAtStartOfLineGoesToEndOfLastWordOfPreviousLine [
+
+	editor addString: 'a	
+a'.
+
+	self assert: (editor previousWord: 4) equals: 1
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordAtStartOfLineGoesToPreviousLine [
+
+	editor addString: 'a
+
+a'.
+
+	self assert: (editor previousWord: 4) equals: 3
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordGoesToStartOfCurrentWord [
+
+	editor addString: 'abc def'.
+
+	self assert: (editor previousWord: 6) equals: 5
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordSkipsCurrentSpacesAndGoesToStartOfCurrentWord [
+
+	editor addString: 'abc def'.
+
+	self assert: (editor previousWord: 5) equals: 1
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordStopOnUpperCase [
 
     string := 'loRem ipSum'.
     editor addString: string.
-	self assert: (editor previousCharacterGroup: -999) equals: 1. "Out of range means start of text"
-	self assert: (editor previousCharacterGroup: 0) equals: 1. "Out of range means start of text"
+	self assert: (editor previousWord: -999 stopOnUpperCase: true) equals: 1. "Out of range means start of text"
+	self assert: (editor previousWord: 0 stopOnUpperCase: true) equals: 1. "Out of range means start of text"
 
 	self
 		assertPreviousCharGroupFrom:	'loRem ipSum¶'
@@ -441,11 +489,7 @@ RubTextEditorTest >> testPreviousCharacterGroup [
 		equals: 								'loRem ¶ipSum'.
 
 	self
-		assertPreviousCharGroupOf:		'loRem ¶ipSum'
-		equals: 								'loRem¶ ipSum'.
-
-	self
-		assertPreviousCharGroupFrom:	'loRem¶ ipSum'
+		assertPreviousCharGroupFrom:	'loRem ¶ipSum'
 		to: 									'loR¶em ipSum'
 		equals: 								'lo¶Rem ipSum'.
 
@@ -456,7 +500,7 @@ RubTextEditorTest >> testPreviousCharacterGroup [
 ]
 
 { #category : 'tests' }
-RubTextEditorTest >> testPreviousCharacterGroupComplex [
+RubTextEditorTest >> testPreviousWordStopOnUpperCaseComplex [
 
 	string := 'self loRem: [[ (1 + 2) // 100 ]]'.
 	editor addString: string.
@@ -467,29 +511,18 @@ RubTextEditorTest >> testPreviousCharacterGroupComplex [
 		equals: 								'self loRem: [[ (1 + 2) // 100 ¶]]'.
 
 	self
-		assertPreviousCharGroupOf:		'self loRem: [[ (1 + 2) // 100 ¶]]'
-		equals: 								'self loRem: [[ (1 + 2) // 100¶ ]]'.
-
-	self
-		assertPreviousCharGroupFrom:	'self loRem: [[ (1 + 2) // 100¶ ]]'
+		assertPreviousCharGroupFrom:	'self loRem: [[ (1 + 2) // 100 ¶]]'
 		to: 									'self loRem: [[ (1 + 2) // 1¶00 ]]'
 		equals: 								'self loRem: [[ (1 + 2) // ¶100 ]]'.
 
 	self
-		assertPreviousCharGroupOf:		'self loRem: [[ (1 + 2) // ¶100 ]]'
-		equals: 								'self loRem: [[ (1 + 2) //¶ 100 ]]'.
-
-	self
-		assertPreviousCharGroupFrom:	'self loRem: [[ (1 + 2) //¶ 100 ]]'
+		assertPreviousCharGroupFrom:	'self loRem: [[ (1 + 2) // ¶100 ]]'
 		to: 									'self loRem: [[ (1 + 2) /¶/ 100 ]]'
 		equals: 								'self loRem: [[ (1 + 2) ¶// 100 ]]'.
 
 	self
-		assertPreviousCharGroupOf:		'self loRem: [[ (1 + 2) ¶// 100 ]]'
-		equals: 								'self loRem: [[ (1 + 2)¶ // 100 ]]'.
-
-	self
-		assertPreviousCharGroupOf:		'self loRem: [[ (1 + 2)¶ // 100 ]]'
+		assertPreviousCharGroupFrom:	'self loRem: [[ (1 + 2) ¶// 100 ]]'
+		to: 									'self loRem: [[ (1 + 2)¶ // 100 ]]'
 		equals: 								'self loRem: [[ (1 + 2¶) // 100 ]]'.
 
 	self
@@ -497,19 +530,13 @@ RubTextEditorTest >> testPreviousCharacterGroupComplex [
 		equals: 								'self loRem: [[ (1 + ¶2) // 100 ]]'.
 
 	self
-		assertPreviousCharGroupOf:		'self loRem: [[ (1 + ¶2) // 100 ]]'
-		equals: 								'self loRem: [[ (1 +¶ 2) // 100 ]]'.
-
-	self
-		assertPreviousCharGroupOf:		'self loRem: [[ (1 +¶ 2) // 100 ]]'
+		assertPreviousCharGroupFrom:	'self loRem: [[ (1 + ¶2) // 100 ]]'
+		to: 									'self loRem: [[ (1 +¶ 2) // 100 ]]'
 		equals: 								'self loRem: [[ (1 ¶+ 2) // 100 ]]'.
 
 	self
-		assertPreviousCharGroupOf:		'self loRem: [[ (1 ¶+ 2) // 100 ]]'
-		equals: 								'self loRem: [[ (1¶ + 2) // 100 ]]'.
-
-	self
-		assertPreviousCharGroupOf:		'self loRem: [[ (1¶ + 2) // 100 ]]'
+		assertPreviousCharGroupFrom:	'self loRem: [[ (1 ¶+ 2) // 100 ]]'
+		to: 									'self loRem: [[ (1¶ + 2) // 100 ]]'
 		equals: 								'self loRem: [[ (¶1 + 2) // 100 ]]'.
 
 	self
@@ -517,20 +544,13 @@ RubTextEditorTest >> testPreviousCharacterGroupComplex [
 		equals: 								'self loRem: [[ ¶(1 + 2) // 100 ]]'.
 
 	self
-		assertPreviousCharGroupOf:		'self loRem: [[ ¶(1 + 2) // 100 ]]'
-		equals: 								'self loRem: [[¶ (1 + 2) // 100 ]]'.
-
-	self
-		assertPreviousCharGroupFrom:	'self loRem: [[¶ (1 + 2) // 100 ]]'
+		assertPreviousCharGroupFrom:	'self loRem: [[ ¶(1 + 2) // 100 ]]'
 		to: 									'self loRem: [¶[ (1 + 2) // 100 ]]'
 		equals: 								'self loRem: ¶[[ (1 + 2) // 100 ]]'.
 
 	self
-		assertPreviousCharGroupOf:		'self loRem: ¶[[ (1 + 2) // 100 ]]'
-		equals: 								'self loRem:¶ [[ (1 + 2) // 100 ]]'.
-
-	self
-		assertPreviousCharGroupOf:		'self loRem:¶ [[ (1 + 2) // 100 ]]'
+		assertPreviousCharGroupFrom:	'self loRem: ¶[[ (1 + 2) // 100 ]]'
+		to: 									'self loRem:¶ [[ (1 + 2) // 100 ]]'
 		equals: 								'self loRem¶: [[ (1 + 2) // 100 ]]'.
 
 	self
@@ -544,17 +564,31 @@ RubTextEditorTest >> testPreviousCharacterGroupComplex [
 		equals: 								'self ¶loRem: [[ (1 + 2) // 100 ]]'.
 
 	self
-		assertPreviousCharGroupOf:		'self ¶loRem: [[ (1 + 2) // 100 ]]'
-		equals: 								'self¶ loRem: [[ (1 + 2) // 100 ]]'.
-
-	self
-		assertPreviousCharGroupFrom:	'self¶ loRem: [[ (1 + 2) // 100 ]]'
+		assertPreviousCharGroupFrom:	'self ¶loRem: [[ (1 + 2) // 100 ]]'
 		to: 									'¶self loRem: [[ (1 + 2) // 100 ]]'
 		equals: 								'¶self loRem: [[ (1 + 2) // 100 ]]'.
 ]
 
 { #category : 'tests' }
-RubTextEditorTest >> testPreviousCharacterGroupManyUppercases [
+RubTextEditorTest >> testPreviousWordStopOnUpperCaseManyUpercases [
+
+	string := 'AAAb'.
+	editor addString: string.
+
+	self
+		assertPreviousCharGroupFrom: 	'AAAb¶'
+		to: 							  		'AAA¶b'
+		equals: 						  		'AA¶Ab'.
+
+	self
+		assertPreviousCharGroupFrom:	'AA¶Ab'
+		to: 							  		'¶AAAb'
+		equals: 						  		'¶AAAb'.	
+
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordStopOnUpperCaseManyUppercases [
 	string := 'AAAb'.
 	editor addString: string.
 
@@ -570,7 +604,7 @@ RubTextEditorTest >> testPreviousCharacterGroupManyUppercases [
 ]
 
 { #category : 'tests' }
-RubTextEditorTest >> testPreviousCharacterGroupWithSpecialCharacters [
+RubTextEditorTest >> testPreviousWordStopOnUpperCaseWithSpecialCharacters [
 
 	string := '^[:x|(''#eur'',$$asString)]'.
 	editor addString: string.
@@ -628,7 +662,7 @@ RubTextEditorTest >> testPreviousCharacterGroupWithSpecialCharacters [
 ]
 
 { #category : 'tests' }
-RubTextEditorTest >> testPreviousCharacterGroupWithSyntax [
+RubTextEditorTest >> testPreviousWordStopOnUpperCaseWithSyntax [
 
 	string := '^"''|[](){}$#<>=;:.'.
 	editor addString: string.
@@ -656,102 +690,6 @@ RubTextEditorTest >> testPreviousCharacterGroupWithSyntax [
 		assertPreviousCharGroupFrom:	'^"''¶|[](){}$#<>=;:.'
 		to: 									'¶^"''|[](){}$#<>=;:.'
 		equals: 								'¶^"''|[](){}$#<>=;:.'.
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testPreviousWord [
-
-	| textSize |
-	textSize := 'Lorem ipsum ' size.
-	self assert: (editor previousWord: -999) equals: 1. "Out of range"
-	self assert: (editor previousWord: 0) equals: 1. "Out of range"
-
-	1 to: 7 do: [ :i |
-		"From:   |Lorem ipsum
-		 To:     Lorem |ipsum
-		 Should be: |Lorem ipsum"
-		self assert: (editor previousWord: i) equals: 1 ].
-
-	8 to: 12 do: [ :i |
-		"From:   Lorem |ipsum
-		 To:     Lorem ipsum|
-		 Should be: Lorem |ipsum"
-		self assert: (editor previousWord: i) equals: 7 ].
-
-	self assert: (editor previousWord: 999) equals: 7. "Out of range"
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testPreviousWordAtEndOfFirstWordOfLineGoesToStartOfLine [
-
-	editor addString: 'a
-
-a'.
-
-	self assert: (editor previousWord: 5) equals: 4
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testPreviousWordAtLineWithSpacesGoesToStartOfCurrentLine [
-
-	editor addString: 'a
-
-  a'.
-
-	self assert: (editor previousWord: 6) equals: 4
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testPreviousWordAtStartOfLineGoesToEndOfLastWordOfPreviousLine [
-
-	editor addString: 'a	
-a'.
-
-	self assert: (editor previousWord: 4) equals: 2
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testPreviousWordAtStartOfLineGoesToPreviousLine [
-
-	editor addString: 'a
-
-a'.
-
-	self assert: (editor previousWord: 4) equals: 3
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testPreviousWordGoesToStartOfCurrentWord [
-
-	editor addString: 'abc def'.
-
-	self assert: (editor previousWord: 6) equals: 5
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testPreviousWordSkipsCurrentSpacesAndGoesToStartOfCurrentWord [
-
-	editor addString: 'abc def'.
-
-	self assert: (editor previousWord: 5) equals: 1
-]
-
-{ #category : 'tests' }
-RubTextEditorTest >> testPreviousWordStopOnUpperCaseManyUpercases [
-
-	string := 'AAAb'.
-	editor addString: string.
-
-	self
-		assertPreviousJumpPointFrom: 	'AAAb¶'
-		to: 							  		'AAA¶b'
-		equals: 						  		'AA¶Ab'.	
-
-	self
-		assertPreviousJumpPointFrom:	'AA¶Ab'
-		to: 							  		'¶AAAb'
-		equals: 						  		'¶AAAb'.	
-
 ]
 
 { #category : 'test-selection' }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -288,6 +288,12 @@ RubSmalltalkEditor >> browseIt: aKeyboardEvent [
 	^true
 ]
 
+{ #category : 'accessing' }
+RubSmalltalkEditor >> characterAt: anInteger [ 
+	
+	^ self text at: anInteger
+]
+
 { #category : 'menu messages' }
 RubSmalltalkEditor >> classCommentsContainingIt [
 	"Open a browser class comments which contain the current selection somewhere in them."

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -692,9 +692,9 @@ RubTextEditor >> cursorHome: aKeyboardEvent [
 { #category : 'nonediting/nontyping keys' }
 RubTextEditor >> cursorLeft: aKeyboardEvent [
 	"Private - Move cursor left one character if nothing selected, otherwise
-	move cursor to beginning of selection. If the shift key is down, start
-	selecting or extending current selection. Don't allow cursor past
-	beginning of text"
+    move cursor to beginning of selection. If the shift key is down, start
+    selecting or extending current selection. Don't allow cursor past
+    beginning of text"
 
 	textArea editing ifTrue: [ ^ false ].
 	self closeTypeIn.
@@ -744,9 +744,9 @@ RubTextEditor >> cursorPageUp: aKeyboardEvent [
 { #category : 'nonediting/nontyping keys' }
 RubTextEditor >> cursorRight: aKeyboardEvent [
 	"Private - Move cursor right one character if nothing selected,
-	otherwise move cursor to end of selection. If the shift key is down,
-	start selecting characters or extending already selected characters.
-	Don't allow cursor past end of text"
+    otherwise move cursor to end of selection. If the shift key is down,
+    start selecting characters or extending already selected characters.
+    Don't allow cursor past end of text"
 
 	textArea editing ifTrue: [ ^ false ].
 	self closeTypeIn.
@@ -1681,33 +1681,6 @@ RubTextEditor >> newDefaultKeymappingIndex [
 	^ defaultKeymappingIndex
 ]
 
-{ #category : 'private' }
-RubTextEditor >> nextCharacterGroup: position [
-	"Positions go from 1 to size + 1
-	Position N + 1 is after the Nth character"
-
-	| string index size initialGroup finalGroup |
-	string := self string.
-	size := string size + 1.
-	position >= size ifTrue: [ ^ size ].
-	index := 1 max: position.
-
-	initialGroup := self characterGroupAt: index in: string.
-	index := index + 1.
-	initialGroup = #upper ifTrue: [
-		(self characterGroupAt: index in: string) = #lower ifTrue: [ initialGroup := #lower ] ].
-
-	[
-	index < size and: [ (finalGroup := self characterGroupAt: index in: string) = initialGroup ] ]
-		whileTrue: [ index := index + 1 ].
-
-	"Moving to the right from upper to lower, we want to stop before the last upper"
-	(initialGroup = #upper and: [ finalGroup = #lower ]) ifTrue: [
-		index := index - 1 ].
-
-	^ index
-]
-
 { #category : 'accessing' }
 RubTextEditor >> nextCharacterIfAbsent: aBlock [
 
@@ -1725,36 +1698,42 @@ RubTextEditor >> nextWord: position stopOnUpperCase: stopOnUpperCase [
 	"Positions go from 1 to size + 1
 	Position N + 1 is after the Nth character"
 
-	| string index initialIsAlphaNumeric size initialPosition |
+	| string index characterGroupAtStart size initialPosition currentGroup |
 	index := initialPosition := 1 max: position.
 	string := self string.
 	size := string size + 1.
-	position >= size ifTrue: [ ^ size ].
+	position >= string size ifTrue: [ ^ size ].
 
-	[ index < string size and: [ 
-			{ Character space . Character tab }
-				includes: (string at: index)]
-	] whileTrue: [ index := index + 1 ].
+	[
+	index < string size and: [
+		{
+			Character space.
+			Character tab } includes: (string at: index) ] ] whileTrue: [
+		index := index + 1 ].
 
-	initialIsAlphaNumeric := self isWordCharacterAt: index in: string.
-	
-	
-	index = initialPosition
-		ifTrue: [ index := index + 1 ].
-	
-	[ | nextCharacterInDirection |
+	characterGroupAtStart := self characterGroupAt: index in: string.
+	index = initialPosition ifTrue: [ index := index + 1 ].
+	"Do not stop if we are in an uppercase->lowercase transition"
+	(characterGroupAtStart = #upper and: [
+		 (self characterGroupAt: index in: string) = #lower ]) ifTrue: [
+		characterGroupAtStart := #lower ].
+
+	[
+	| nextCharacterInDirection |
 	"If we reach the end"
 	index >= size ifTrue: [ ^ index ].
-	
+
 	nextCharacterInDirection := string at: index.
-	nextCharacterInDirection = Character cr
-		ifTrue: [ ^ index ].
-	
-		(self
-			 isWordCharacterAt: index
-			 in: string
-			 except: [ :char | stopOnUpperCase and: [ char isUppercase ] ]) = initialIsAlphaNumeric ]
-		whileTrue: [ index := index + 1 ].
+	nextCharacterInDirection = Character cr ifTrue: [ ^ index ].
+
+	currentGroup := self characterGroupAt: index in: string.
+	currentGroup = characterGroupAtStart or: [
+		(currentGroup = #upper and: [ characterGroupAtStart = #lower ])
+			and: [ stopOnUpperCase not ] ] ] whileTrue: [ index := index + 1 ].
+
+	"Moving to the right from upper to lower, we want to stop before the last upper"
+	(characterGroupAtStart = #upper and: [ currentGroup = #lower ])
+		ifTrue: [ index := index - 1 ].
 
 	^ index
 ]
@@ -1893,32 +1872,6 @@ RubTextEditor >> pointIndex [
 	^ textArea pointIndex
 ]
 
-{ #category : 'private' }
-RubTextEditor >> previousCharacterGroup: position [
-	"Positions go from 1 to size + 1
-	Position N + 1 is after the Nth character"
-
-	| string index size initialGroup finalGroup |
-	position <= 2 ifTrue: [ ^ 1 ].
-	string := self string.
-	size := string size.
-	index := position - 1.
-
-	initialGroup := self characterGroupAt: index in: string.
-	initialGroup = #upper ifTrue: [
-		(self characterGroupAt: index + 1 in: string) = #lower ifTrue: [ initialGroup := #lower ] ].
-
-	[
-	index > 0 and: [ (finalGroup := self characterGroupAt: index in: string) = initialGroup ] ]
-		whileTrue: [ index := index - 1 ].
-
-	"Moving to the left from lower to upper, we want to stop before the upper"
-	(initialGroup = #lower and: [ finalGroup = #upper ]) ifFalse: [
-		index := index + 1 ].
-
-	^ index
-]
-
 { #category : 'accessing' }
 RubTextEditor >> previousCharacterIfAbsent: aBlock [
 
@@ -1932,9 +1885,9 @@ RubTextEditor >> previousWord: position [
 ]
 
 { #category : 'private' }
-RubTextEditor >> previousWord: position stopOnUpperCase: stopOnUpperCase [ 
+RubTextEditor >> previousWord: position stopOnUpperCase: stopOnUpperCase [
 
-	| string index size initialPosition beforeCaretIsAlpha afterCaretIsAlpha nextCharacterInDirection |
+	| string index size initialPosition afterCaretIsAlpha nextCharacterInDirection characterGroupAtStart groupBeforeCaret groupAfterCaret |
 	"Positions go from 1 to size + 1
 	Position N + 1 is after the Nth character"
 	string := self string.
@@ -1945,34 +1898,47 @@ RubTextEditor >> previousWord: position stopOnUpperCase: stopOnUpperCase [
 
 	position <= 2 ifTrue: [ ^ 1 ].
 
+	(string at: index - 1) = Character cr ifTrue: [ index := index - 1 ].
+
+	[
+	| currentChar |
+	currentChar := string at: index - 1.
+	currentChar = Character cr ifTrue: [ ^ index ].
+	currentChar isSeparator ] whileTrue: [ index := index - 1 ].
+
 	"Go always at least once backwards to guarantee progress"
 	index := index - 1.
-	afterCaretIsAlpha := index = 1 or: [
-		self isWordCharacterAt: index in: string ].
 
-	index <= 1 ifTrue: [ ^ index ].	
+	characterGroupAtStart := self characterGroupAt: index in: string.
+
+	afterCaretIsAlpha := index = 1 or: [
+		                     #( #lower #upper ) includes:
+			                     characterGroupAtStart ].
+	index <= 1 ifTrue: [ ^ index ].
 	nextCharacterInDirection := string at: index - 1.
-	nextCharacterInDirection = Character cr
-		ifTrue: [ ^ index ].
-	
-	afterCaretIsAlpha ifFalse: [ index := index - 1 ].
+	nextCharacterInDirection = Character cr ifTrue: [ ^ index ].
 
 	[ "If we reach the end"
 	index <= 1 ifTrue: [ ^ index ].
 
 	nextCharacterInDirection := string at: index - 1.
-	nextCharacterInDirection = Character cr
-		ifTrue: [ ^ index ].
+	nextCharacterInDirection = Character cr ifTrue: [ ^ index ].
 
-	afterCaretIsAlpha := index = 1 or: [
-		                      self isWordCharacterAt: index in: string except: [ :char | stopOnUpperCase and: [ char isUppercase ] ] ].
-	beforeCaretIsAlpha := index = 1 or: [
-		                      self isWordCharacterAt: index - 1 in: string ].
+	groupBeforeCaret := self characterGroupAt: index in: string.
+	(stopOnUpperCase not and: [ groupBeforeCaret = #upper ]) ifTrue: [
+		groupBeforeCaret := #lower ].
+	groupAfterCaret := self characterGroupAt: index - 1 in: string.
+	(stopOnUpperCase not and: [ groupAfterCaret = #upper ]) ifTrue: [
+		groupAfterCaret := #lower ].
 
-	beforeCaretIsAlpha = afterCaretIsAlpha and: [ index > 1 ] ]
-		whileTrue: [ index := index - 1 ].
+	groupAfterCaret = groupBeforeCaret and: [ index > 1 ] ] whileTrue: [
+		index := index - 1 ].
 
-	^ index
+	"Moving to the left from lower to upper, we want to stop before the upper"
+	(groupBeforeCaret = #lower and: [ groupAfterCaret = #upper ])
+		ifFalse: [ index := index + 1 ].
+
+	^ index - 1
 ]
 
 { #category : 'accessing - selection' }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -457,8 +457,6 @@ RubTextEditor >> characterGroupAt: index in: aString [
 	(('^"''[](){}$#;:.' includes: character) or: [
 		 character = $= and: [ (aString at: (index - 1 max: 1)) = $: ] ]) 
 			ifTrue: [ ^ #syntax ].
-
-
 	^ #binary
 ]
 
@@ -1683,6 +1681,33 @@ RubTextEditor >> newDefaultKeymappingIndex [
 	^ defaultKeymappingIndex
 ]
 
+{ #category : 'private' }
+RubTextEditor >> nextCharacterGroup: position [
+	"Positions go from 1 to size + 1
+	Position N + 1 is after the Nth character"
+
+	| string index size initialGroup finalGroup |
+	string := self string.
+	size := string size + 1.
+	position >= size ifTrue: [ ^ size ].
+	index := 1 max: position.
+
+	initialGroup := self characterGroupAt: index in: string.
+	index := index + 1.
+	initialGroup = #upper ifTrue: [
+		(self characterGroupAt: index in: string) = #lower ifTrue: [ initialGroup := #lower ] ].
+
+	[
+	index < size and: [ (finalGroup := self characterGroupAt: index in: string) = initialGroup ] ]
+		whileTrue: [ index := index + 1 ].
+
+	"Moving to the right from upper to lower, we want to stop before the last upper"
+	(initialGroup = #upper and: [ finalGroup = #lower ]) ifTrue: [
+		index := index - 1 ].
+
+	^ index
+]
+
 { #category : 'accessing' }
 RubTextEditor >> nextCharacterIfAbsent: aBlock [
 
@@ -1866,6 +1891,32 @@ RubTextEditor >> pointBlock [
 { #category : 'accessing - selection' }
 RubTextEditor >> pointIndex [
 	^ textArea pointIndex
+]
+
+{ #category : 'private' }
+RubTextEditor >> previousCharacterGroup: position [
+	"Positions go from 1 to size + 1
+	Position N + 1 is after the Nth character"
+
+	| string index size initialGroup finalGroup |
+	position <= 2 ifTrue: [ ^ 1 ].
+	string := self string.
+	size := string size.
+	index := position - 1.
+
+	initialGroup := self characterGroupAt: index in: string.
+	initialGroup = #upper ifTrue: [
+		(self characterGroupAt: index + 1 in: string) = #lower ifTrue: [ initialGroup := #lower ] ].
+
+	[
+	index > 0 and: [ (finalGroup := self characterGroupAt: index in: string) = initialGroup ] ]
+		whileTrue: [ index := index - 1 ].
+
+	"Moving to the left from lower to upper, we want to stop before the upper"
+	(initialGroup = #lower and: [ finalGroup = #upper ]) ifFalse: [
+		index := index + 1 ].
+
+	^ index
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Navigating source code with Cmd/Ctrl+option now allows navigation of camel case and special characters