### PR TITLE
Fix timestamp parsing in SourceFileArray

### DIFF
--- a/src/System-Sources-Tests/SourceFileArrayTest.class.st
+++ b/src/System-Sources-Tests/SourceFileArrayTest.class.st
@@ -131,6 +131,48 @@ SourceFileArrayTest >> testForkedWrite [
 ]
 
 { #category : 'tests' }
+SourceFileArrayTest >> testParseStampWithConflict [
+
+	| sourceFiles timestamp preamble |
+	sourceFiles := SourceFileArray new.
+
+	preamble := 'SourceFileArray methodsFor: ''public - stamp: reading'' stamp: ''1/14/2025 10:16'' prior: 62647896'.
+	timestamp := sourceFiles
+		             timeStampFromPreamble: preamble
+		             for: sourceFiles sourceDataPointers.
+
+	self assert: timestamp equals: '1/14/2025 10:16'
+]
+
+{ #category : 'tests' }
+SourceFileArrayTest >> testParseStampWithNoStamp [
+
+	| sourceFiles timestamp preamble |
+	sourceFiles := SourceFileArray new.
+
+	preamble := 'AeBenchBlurConvexPolygonRunner methodsFor: ''running'''.
+	timestamp := sourceFiles
+		             timeStampFromPreamble: preamble
+		             for: sourceFiles sourceDataPointers.
+
+	self assert: timestamp equals: ''
+]
+
+{ #category : 'tests' }
+SourceFileArrayTest >> testParseStampWithoutConflict [
+
+	| sourceFiles timestamp preamble |
+	sourceFiles := SourceFileArray new.
+
+	preamble := 'SourceFileArray methodsFor: ''public - string reading'' stamp: ''1/14/2025 10:16'' prior: 62647896'.
+	timestamp := sourceFiles
+		             timeStampFromPreamble: preamble
+		             for: sourceFiles sourceDataPointers.
+
+	self assert: timestamp equals: '1/14/2025 10:16'
+]
+
+{ #category : 'tests' }
 SourceFileArrayTest >> testProtocol [
 	"Test that we can access protocol correctly"
 

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -425,7 +425,7 @@ SourceFileArray >> timeStampAt: sourcePointer for: sourceDataPointers [
 	flushChanges ifFalse: [ ^ stamp ].
 	preamble := self sourcedDataAt: sourcePointer.
 	(preamble includesSubstring: sourceDataPointers key) ifTrue: [
-		| stream |
+		| index stream |
 		" Extract the timestamp string from the preamble.
 		This can be a method or a class comment preamble.
 		A method Preamble is a string of the shape:
@@ -438,13 +438,17 @@ SourceFileArray >> timeStampAt: sourcePointer for: sourceDataPointers [
 		
 		
 		Lookup for the key stamp/commentStamp:, then take the string coming after that"
-		stream := preamble readStream.
-		[
-		| soFar |
-		soFar := stream upTo: $'.
-		soFar includesSubstring: sourceDataPointers value ] whileFalse.
-		stream atEnd ifTrue: [ ^ nil ].
-		stamp := stream upTo: $' ].
+
+		index := preamble findLastOccurrenceOfString: sourceDataPointers value startingAt: 1.
+		index = 0 ifFalse: [
+			stream :=
+				ReadStream
+					on: preamble
+					from: index + sourceDataPointers value size
+					to: preamble size.
+			stream upTo: $'.
+			stamp := stream upTo: $' ] ].
+
 	^ stamp
 ]
 

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -420,12 +420,20 @@ SourceFileArray >> timeStampAt: sourcePointer [
 SourceFileArray >> timeStampAt: sourcePointer for: sourceDataPointers [
 	"Answer the authoring time-stamp for the given method, retrieved from the sources or changes file. Answer the empty string if no time stamp is available."
 
-	| preamble stamp |
-	stamp := ''.
-	flushChanges ifFalse: [ ^ stamp ].
+	| preamble |
+	flushChanges ifFalse: [ ^ '' ].
 	preamble := self sourcedDataAt: sourcePointer.
+	^ self timeStampFromPreamble: preamble for: sourceDataPointers
+]
+
+{ #category : 'public - string reading' }
+SourceFileArray >> timeStampFromPreamble: preamble for: sourceDataPointers [
+	"Answer the authoring time-stamp for the given method, retrieved from the sources or changes file. Answer the empty string if no time stamp is available."
+
+	| stamp index |
+	stamp := ''.
 	(preamble includesSubstring: sourceDataPointers key) ifTrue: [
-		| index stream |
+		| stream |
 		" Extract the timestamp string from the preamble.
 		This can be a method or a class comment preamble.
 		A method Preamble is a string of the shape:
@@ -438,7 +446,7 @@ SourceFileArray >> timeStampAt: sourcePointer for: sourceDataPointers [
 		
 		
 		Lookup for the key stamp/commentStamp:, then take the string coming after that"
-
+		
 		index := preamble findLastOccurrenceOfString: sourceDataPointers value startingAt: 1.
 		index = 0 ifFalse: [
 			stream :=
@@ -448,7 +456,6 @@ SourceFileArray >> timeStampAt: sourcePointer for: sourceDataPointers [
 					to: preamble size.
 			stream upTo: $'.
 			stamp := stream upTo: $' ] ].
-
 	^ stamp
 ]
 


### PR DESCRIPTION
the goal is to add support for:
- method preambles that do not include stamp
- protocols that include stamp:

Fixes #17631