### PR TITLE
Update version in #spec for BaselineOfPharo for Pharo 12 to ‘v1.3.5’

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -129,7 +129,7 @@ BaselineOfPharo class >> spec [
 		newName: 'Spec2' 
 		owner: 'pharo-spec' 
 		project:'Spec' 
-		version: 'v1.3.4'
+		version: 'v1.3.5'
 ]
 
 { #category : 'repository urls' }


### PR DESCRIPTION
This pull request updates the version in `#spec` for BaselineOfPharo for Pharo 12 to ‘v1.3.5’. Before this can be merged, a corresponding tag referring to [commit 02ebd1ba50562961](https://github.com/pharo-spec/Spec/commit/02ebd1ba5056296157d793f5a97eaa7827058ab3) needs to be added.