### PR TITLE
Update version in #iceberg for BaselineOfPharo for Pharo 11 to ‘v2.2.3’

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -74,7 +74,7 @@ BaselineOfPharo class >> iceberg [
 		newName: 'Iceberg' 
 		owner: 'pharo-vcs' 
 		project: 'iceberg' 
-		version: 'v2.2.2' 
+		version: 'v2.2.3' 
 		sourceDir: nil
 ]
 


### PR DESCRIPTION
This pull request updates the version in `#iceberg` for BaselineOfPharo for Pharo 11 to ‘v2.2.3’. Before this can be merged, a corresponding tag referring to [commit 283403745e94a1d3](https://github.com/pharo-vcs/iceberg/commit/283403745e94a1d3e6450369f98f4f6d804f6eb6) needs to be added.