### PR TITLE
Load roassal before NewTools

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -127,12 +127,12 @@ BaselineOfIDE >> baseline: spec [
 			group: 'Tool-DependencyAnalyser-UI-Tab'
 			spec: spec.
 		self specCode: spec.
+		self roassal: spec.
 		self newTools: spec.
 		self drTests: spec.
 		self microdown: spec.
 		spec package: #'BeautifulComments'  with: [ spec requires:  #( 'Microdown') ].
 		self welcomeBrowser: spec.
-		self roassal: spec.
 		
 		spec package: 'IconPacks'.
 


### PR DESCRIPTION
We are working on the packaging of tools and some tools that needs to be in NewTools are depending on roassal (such as ColorPicker). 

I propose to load Roassal before NewTools. 

Next steps:
- Move inspctors of Roassal to NewTools
- Merge ColorPicker in NewTools