### PR TITLE
Transformations cleanup: better preview API and updated class comments

### DIFF
--- a/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st
+++ b/src/Refactoring-Changes/RBCompositeRefactoryChange.class.st
@@ -168,6 +168,11 @@ RBCompositeRefactoryChange >> initialize [
 	changes := OrderedCollection new
 ]
 
+{ #category : 'testing' }
+RBCompositeRefactoryChange >> isInScope: aRBBrowserEnvironment [ 
+	^ aRBBrowserEnvironment includesClass: self changeClass.
+]
+
 { #category : 'accessing' }
 RBCompositeRefactoryChange >> newName [
 

--- a/src/Refactoring-Changes/RBRefactoryChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryChange.class.st
@@ -77,6 +77,12 @@ RBRefactoryChange >> initialize [
 	changeFactory := RBRefactoryChangeManager changeFactory
 ]
 
+{ #category : 'testing' }
+RBRefactoryChange >> isInScope: anEnvironment [
+
+	^ self subclassResponsibility
+]
+
 { #category : 'accessing' }
 RBRefactoryChange >> name [
 

--- a/src/Refactoring-Changes/RBRefactoryClassChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryClassChange.class.st
@@ -105,6 +105,11 @@ RBRefactoryClassChange >> hash [
 	^ self changeClassName hash
 ]
 
+{ #category : 'testing' }
+RBRefactoryClassChange >> isInScope: aRBBrowserEnvironment [ 
+	^ aRBBrowserEnvironment includesClass: self changeClass.
+]
+
 { #category : 'private' }
 RBRefactoryClassChange >> isMeta [
 

--- a/src/Refactoring-Changes/RBRefactoryPackageChange.class.st
+++ b/src/Refactoring-Changes/RBRefactoryPackageChange.class.st
@@ -37,3 +37,8 @@ RBRefactoryPackageChange >> initialize [
 	super initialize.
 	browserEnvironment := RBBrowserEnvironment default
 ]
+
+{ #category : 'testing' }
+RBRefactoryPackageChange >> isInScope: aRBBrowserEnvironment [ 
+	^ aRBBrowserEnvironment includesPackage: self
+]

--- a/src/Refactoring-Core/RBRefactoryTyper.class.st
+++ b/src/Refactoring-Core/RBRefactoryTyper.class.st
@@ -11,35 +11,36 @@ I analyze message sends to the instance variables and try to guess the type by l
 
 If I can guess the type to be a collection, I'll try to investigate the types of the possible contained elements as well.
 You can ask for the guessed type of the variable: 
-typer guessTypeFor: 'variablename'
+`typer guessTypeFor: 'variablename'`
 and the contained elements: 
-typer guessTypeFor: '-variablename-'
+`typer guessTypeFor: '-variablename-'`
 
 Example usage: 
+```
 | typer |
 ""create and initialize for a class to analyze""
-typer := (RBRefactoryTyper new runOn: ASTMessageNode).
+typer := (RBRefactoryTyper new runOn: OCMessageNode).
 
 ""guess types for ASTMessageNodes instane var 'arguments' ""
 typer  guessTypesFor:'arguments'.  ""a Set(SequenceableCollection)""
 
 ""guess types for objects that may be put  into  'arguments' collection ""
-typer  guessTypesFor:'-arguments-' ""a Set(ASTBlockNode ASTMethodNode)""
-
+typer  guessTypesFor:'-arguments-' ""a Set(OCBlockNode OCMethodNode)""
+```
 
 You can print a full report on all results with #printString.
-
+```
 (RBRefactoryTyper new runOn: Point ) printString.
 ""'Point
 	x	<Integer>
 	y	<Integer>
 '""
-
+```
 There are two class side methods, one for creating an instance and setting the environment used to resolve names - a RBNamespace.
 
 And another one for guessing types in a parseTree:
 
-RBRefactoryTyper typesFor: 'var' in: (RBParser parseExpression: 'var squared') model: RBNamespace new ""a Set(Number Collection)""
+`RBRefactoryTyper typesFor: 'var' in: (RBParser parseExpression: 'var squared') model: RBNamespace new ""a Set(Number Collection)""`
 (Here, I can guess the types Number and Collections as these are the classes implementing the message #squared)
 
 

--- a/src/Refactoring-Transformations-Tests/RBRemoveMethodRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveMethodRefactoringTest.class.st
@@ -18,8 +18,7 @@ RBRemoveMethodRefactoringTest >> testFailureRemoveReferenced [
 { #category : 'failure tests' }
 RBRemoveMethodRefactoringTest >> testFailureRemoveSameMethodButSendsSuper [
 
-	<expectedFailure>
-	self shouldWarn: (RBRemoveMethodRefactoring
+	self shouldFail: (RBRemoveMethodRefactoring
 			 model: model
 			 selector: #new
 			 from: #'RBBasicLintRuleTestData class')

--- a/src/Refactoring-Transformations/RBAddAccessorsForClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddAccessorsForClassTransformation.class.st
@@ -2,11 +2,13 @@
 Adds accessors (getters and setters) for all the variables in a class, if each of them do not exist.
 
 Usage:
+```
+| transformation |
 transformation := (RBAddAccessorsForClassTransformation
 	className: #RBVariableTransformation)
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
-
+	generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 Preconditions:
 overridden from RBAddVariableAccessorRefactoring
 "

--- a/src/Refactoring-Transformations/RBAddAssignmentTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddAssignmentTransformation.class.st
@@ -1,15 +1,17 @@
 "
 I am responsible for adding an assignment statement (variable := anExpression) inside a method. Both variable and expression are passed as arguments separately.
 
-Usage: 
+Usage:
+```
 | transformation |
 transformation := (RBAddAssignmentTransformation
 				variable: 'variable'
 				value: '1 asString'
 				inMethod: #methodBefore
 				inClass: #RBAddAssignmentTransformationTest)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - Checks whether there is a variable in this environment with the given name.

--- a/src/Refactoring-Transformations/RBAddClassCommentTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddClassCommentTransformation.class.st
@@ -2,12 +2,14 @@
 Adds a comment to a class. It replaces the current comment for the new one (i.e., it does not append the given text to the existing class comment)
 
 Usage:
+```
 | transformation |
 transformation := (RBAddClassCommentTransformation
 		comment: 'New comment'
-		in: RBTransformationTest)
-		transform.
-(ChangesBrowser changes: transformation model changes changes) open
+		in: RBClassToRename)
+		generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 "
 Class {
 	#name : 'RBAddClassCommentTransformation',

--- a/src/Refactoring-Transformations/RBAddMessageSendTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddMessageSendTransformation.class.st
@@ -2,13 +2,15 @@
 I am responsible for adding a message send inside a method. In this implementation, all the message send, e.g., 'variable message: (arg)' shall be described as a string. It was implemented this way to avoid having another transformation just to add the receiver as a literal node.
 
 Usage:
+```
 | transformation |
 transformation := (RBAddMessageSendTransformation
 				messageSend: 'variable byteAt: 1'
 				inMethod: #methodBefore
 				inClass: #RBAddMessageSendTransformationTest)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - the method exists.

--- a/src/Refactoring-Transformations/RBAddMethodCommentTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddMethodCommentTransformation.class.st
@@ -2,13 +2,15 @@
 Adds a comment in the beginning of the method (after its signature).
 
 Usage:
+```
 | transformation |
 transformation := (RBAddMethodCommentTransformation
 		comment: 'New comment'
-		inMethod: #testTransform
-		inClass: #RBAddClassTransformationTest)
-		transform.
-(ChangesBrowser changes: transformation model changes changes) open
+		inMethod: #storeOn:
+		inClass: #RBAddMethodCommentTransformation)
+		generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 "
 Class {
 	#name : 'RBAddMethodCommentTransformation',

--- a/src/Refactoring-Transformations/RBAddMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddMethodTransformation.class.st
@@ -2,13 +2,15 @@
 Adds a method in a class. The source code of the method, as well as the protocol in which the method will be categorized, can be specified.
 
 Usage:
+```
 | transformation |
 transformation := (RBAddMethodTransformation
 		sourceCode: 'printString1 ^super printString'
-		in: RBTransformationTest
+		in: RBAddMethodTransformation
 		withProtocol: #accessing)
-		transform.
-(ChangesBrowser changes: transformation model changes changes) open
+		generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 The source code of the method must be syntactically valid.
@@ -21,9 +23,9 @@ Class {
 		'rbMethod',
 		'protocol'
 	],
-	#category : 'Refactoring-Transformations-Model-Unused',
+	#category : 'Refactoring-Transformations-Model',
 	#package : 'Refactoring-Transformations',
-	#tag : 'Model-Unused'
+	#tag : 'Model'
 }
 
 { #category : 'api' }

--- a/src/Refactoring-Transformations/RBAddPragmaTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddPragmaTransformation.class.st
@@ -2,13 +2,15 @@
 I am responsible for adding a pragma inside a method. In this implementation, all pragma definition, e.g., '<selector: args>' must be described.
 
 Usage:
+```
 | transformation |
 transformation := (RBAddPragmaTransformation
 				pragma: '<pragaForTesting: 213>'
 				inMethod: #methodBefore
 				inClass: #RBAddPragmaTransformationTest)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - the class exists,

--- a/src/Refactoring-Transformations/RBAddProtocolTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddProtocolTransformation.class.st
@@ -2,12 +2,14 @@
 I am responsible to add a protocol to a class.
 
 Usage:
+```
 | transformation |
 transformation := (RBAddProtocolTransformation
 				protocol: 'transforming'
 				inClass: #RBDummyEmptyClass)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - The class exists;

--- a/src/Refactoring-Transformations/RBAddReturnStatementTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddReturnStatementTransformation.class.st
@@ -2,13 +2,15 @@
 I am responsible for adding a return statement inside a method. In this implementation, all the return value (including the '^') shall be described.
 
 Usage: 
+```
 | transformation |
 transformation := (RBAddReturnStatementTransformation
 				return: '^ variable'
 				inMethod: #methodBefore
 				inClass: #RBAddReturnStatementTransformationTest)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - the method does not have a return statement

--- a/src/Refactoring-Transformations/RBAddSubtreeTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddSubtreeTransformation.class.st
@@ -2,14 +2,16 @@
 Adds a subtree inside a method. It is required an interval indicating where the subtree shall be added. If the interval is invalid, the new subtree will be added at the end of the mehtod body (or before the return node, if it exists).
 
 Usage:
+```
 | transformation |
 transformation := (RBAddSubtreeTransformation
 		interval: (0 to: 1)
 		with: '^ selector'
 		from: #selector:from:
 		in: #RBRemoveMethodTransformation)
-		transform. 
-(ChangesBrowser changes: transformation model changes changes) open
+		generateChanges. 
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - the class and method exist

--- a/src/Refactoring-Transformations/RBAddTemporaryVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddTemporaryVariableTransformation.class.st
@@ -1,14 +1,16 @@
 "
 I am responsible for adding a temporary variable inside a method. In Pharo, temporary variables can be declared inside blocks as well. By default, the container is the method itself.
 
-Usage: 
+Usage:
+```
 | transformation |
 transformation := (RBAddTemporaryVariableTransformation
 			variable: #newVariable
 			inMethod: #methodBefore
 			inClass: #RBAddReturnStatementTransformationTest)
-			transform.
-(ChangesBrowser changes: transformation model changes changes) open
+			generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - Check whether there is a variable inside the method with the same name.

--- a/src/Refactoring-Transformations/RBAddVariableAccessorTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddVariableAccessorTransformation.class.st
@@ -2,13 +2,15 @@
 Adds accessors (getter and setter) for a variable in a class, if they do not exist.
 
 Usage:
+```
 | transformation |
 transformation := (RBAddVariableAccessorTransformation
 	variable: 'variableName'
 	class: #RBVariableTransformation
 	classVariable: false)
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
+		generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - the variable with which the accessors will be created shall exist. The parameter isClassVariable indicates whether to look in the instance or class variables.

--- a/src/Refactoring-Transformations/RBAddVariableAccessorWithLazyInitializationTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddVariableAccessorWithLazyInitializationTransformation.class.st
@@ -7,11 +7,13 @@ Example
 --------
 Script
 ```
-(RBAddVariableAccessorWithLazyInitialization 
+| transformation |
+transformation := (RBAddVariableAccessorWithLazyInitializationTransformation 
 	variable: 'foo1' 
 	class: RBLintRuleTestData 
 	classVariable: false 
-	defaultValue: '123') execute
+	defaultValue: '123') generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
 ```
 
 After refactoring we get:

--- a/src/Refactoring-Transformations/RBAddVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddVariableTransformation.class.st
@@ -2,13 +2,15 @@
 Adds a variable in a class. It is necessary to indicate whether the variable is an instance or class variable.
 
 Usage:
+```
 | transformation |
 transformation := (RBAddVariableTransformation 
 	variable: 'asdf'
 	class: #RBVariableTransformation
 	classVariable: false)
-	transform. 
-(ChangesBrowser changes: transformation model changes changes) open
+	generateChanges. 
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - the variable name should not be a class name

--- a/src/Refactoring-Transformations/RBChangeMethodNameTransformation.class.st
+++ b/src/Refactoring-Transformations/RBChangeMethodNameTransformation.class.st
@@ -1,3 +1,6 @@
+"
+I am common superclass for transformations that modify method's name. I am storing common state and behavior that is shared among these refactorings.
+"
 Class {
 	#name : 'RBChangeMethodNameTransformation',
 	#superclass : 'RBMethodTransformation',

--- a/src/Refactoring-Transformations/RBCustomTransformation.class.st
+++ b/src/Refactoring-Transformations/RBCustomTransformation.class.st
@@ -1,7 +1,9 @@
 "
 Performs a custom transformation. With this class, the developer can manipulate the model (a RBNamespace) directly, i.e., adding classes, transforming them etc.
 
-Usage: 
+Usage:
+```
+| transformation |
 transformation := (RBCustomTransformation with: [ :model |
 	model defineClass: ('Object subclass: #Bla
 		instanceVariableNames: ''''
@@ -10,8 +12,9 @@ transformation := (RBCustomTransformation with: [ :model |
 		category: ',  'Refactoring2-Transformations' surroundedBySingleQuotes ).
 	(model classNamed: #Bla)
 		comment: 'Deprecated!!! Use super class' ])
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
+		generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 "
 Class {
 	#name : 'RBCustomTransformation',

--- a/src/Refactoring-Transformations/RBDeprecateClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBDeprecateClassTransformation.class.st
@@ -2,10 +2,13 @@
 Marks a class as deprecated and suggests the use of the superclass.
 
 Usage:
+```
+| transformation |
 transformation := (RBDeprecateClassTransformation 
-		class: #RBRemoveClassTransformation)
-		transform. 
-(ChangesBrowser changes: transformation model changes changes) open
+		className: #RBRemoveClassTransformation)
+		generateChanges. 
+(StRefactoringPreviewPresenter for: transformation) open
+```
 "
 Class {
 	#name : 'RBDeprecateClassTransformation',

--- a/src/Refactoring-Transformations/RBDeprecateMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBDeprecateMethodTransformation.class.st
@@ -10,10 +10,12 @@ Example
 
 Script:
 ```
-	(RBDeprecateMethodTransformation 
+| transformation |
+transformation :=  (RBDeprecateMethodTransformation 
 		deprecateMethod: #called:on: 
-		in: RBRefactoryTestDataApp 
-		using: #callFoo) asRefactoring; execute
+		in: RBClassDataForRefactoringTest 
+		using: #callFoo) generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
 ```
 
 Before

--- a/src/Refactoring-Transformations/RBInsertNewClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBInsertNewClassTransformation.class.st
@@ -4,13 +4,13 @@ Adds a class in the image, optionally inside an hierarchy (with superclass or su
 Usage:
 ```
 | transformation |
-transformation := (RBInsertClassTransformation
-	addClass: #InsertedClass
-	superclass: #RBTransformationTest
-	subclasses: (Array with: RBInsertClassTransformationTest)
-	category: #'Refactoring2-Transformations-Tests')
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
+transformation := RBInsertNewClassTransformation new
+	className: #InsertedClass;
+	superclass: #RBAbstractRefactoringTest;
+	subclasses: (Array with: RBInsertClassParametrizedTest);
+	packageName: #'Refactoring2-Transformations-Tests';
+	generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
 ```
 
 Preconditions:

--- a/src/Refactoring-Transformations/RBMethodProtocolTransformation.class.st
+++ b/src/Refactoring-Transformations/RBMethodProtocolTransformation.class.st
@@ -1,14 +1,16 @@
 "
 I am responsible for changing the protocol (or category) of a method. If the protocol does not exist in the class protocols list, the transformation will create it automatically.
 
-Usage: 
+Usage:
+```
 | transformation |
 transformation := (RBMethodProtocolTransformation
 				protocol: 'transforming'
 				inMethod: #someMethod
 				inClass: #RBDummyEmptyClass)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+		generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - the method exists.

--- a/src/Refactoring-Transformations/RBMoveClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBMoveClassTransformation.class.st
@@ -7,10 +7,10 @@ Usage:
 | transformation |
 transformation := (RBMoveClassTransformation
 	move: #RBMoveClassTransformation
-	toPackage: #'Refactoring2-Refactorings-Tests'
+	toPackage: #'Refactoring-Transformations-Tests'
 	inTag: #Utilities) ""The tag is optional""
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
+	generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
 ```
 
 Preconditions:

--- a/src/Refactoring-Transformations/RBMoveInstanceVariableToClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBMoveInstanceVariableToClassTransformation.class.st
@@ -2,13 +2,15 @@
 Moves an instance variable from a class to another. It does not check whether this variable is being referenced in the former class.
 
 Usage:
+```
 | transformation |
 transformation := (RBMoveInstanceVariableToClassTransformation
 				variable: 'methodBlock'
-				fromClass: #RBBasicLintRuleTest
-				toClass: #RBFooLintRuleTest)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				fromClass: #RBBasicLintRuleTestData
+				toClass: #RBFooLintRuleTestData)
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 overrides the preconditions from both RBAddVariableRefactoring and RBRemoveVariableRefactoring

--- a/src/Refactoring-Transformations/RBMoveMethodToClassSideTransformation.class.st
+++ b/src/Refactoring-Transformations/RBMoveMethodToClassSideTransformation.class.st
@@ -2,12 +2,14 @@
 I am responsible for moving a method to class side.
 
 Usage:
+```
 | transformation |
 transformation := (RBMoveMethodToClassSideTransformation
-				method: #method
-				class: #RBMoveMethodTransformationTest)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				method: RBMoveMethodParametrizedTest>>#testMoveMethodIntoClass
+				class: #RBMoveMethodParametrizedTest)
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - the method exists and belongs to instance side.

--- a/src/Refactoring-Transformations/RBMoveMethodToClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBMoveMethodToClassTransformation.class.st
@@ -2,12 +2,14 @@
 I am responsible for moving a method from one class to another existing class
 
 Usage:
+```
 | transformation |
 transformation := (RBMoveMethodToClassTransformation
-				method: #method
-				class: #RBMoveMethodTransformationTest)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				method: RBMoveMethodToClassTransformation>>#storeOn:
+				class: #RBMoveMethodParametrizedTest)
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 "
 Class {

--- a/src/Refactoring-Transformations/RBMoveMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBMoveMethodTransformation.class.st
@@ -351,12 +351,6 @@ RBMoveMethodTransformation >> needsToReplaceSelfReferences [
 ]
 
 { #category : 'executing' }
-RBMoveMethodTransformation >> prepareForExecution [ 
-
-	NautilusRefactoring new refactoringOptions: self
-]
-
-{ #category : 'executing' }
 RBMoveMethodTransformation >> privateTransform [
 	self
 		abstractVariables;

--- a/src/Refactoring-Transformations/RBMoveMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBMoveMethodTransformation.class.st
@@ -10,13 +10,16 @@ And an option for requesting the new method selector.
 For all selected classes a method implementing the original method is created, and if the original code uses some references to self, a parameter needs to be added to provided the former implementor.
 
 Usage:
+```
 | transformation |
 transformation := (RBMoveMethodTransformation
-				selector: aSelector
-				class: aClass
-				variable: aVariable)
-				transform.
-				
+				selector: #isBlack
+				class: Color
+				variable: #rbg)
+				privateTransform;
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```		
 For example, moving the method #isBlack from class Color to its instvar #rgb for the type ""Integer"" creates a method 
 
 
@@ -345,6 +348,12 @@ RBMoveMethodTransformation >> isMovingToInstVar [
 RBMoveMethodTransformation >> needsToReplaceSelfReferences [
 	^self hasSelfReferences
 		or: [self abstractVariablesRefactoring hasVariablesToAbstract]
+]
+
+{ #category : 'executing' }
+RBMoveMethodTransformation >> prepareForExecution [ 
+
+	NautilusRefactoring new refactoringOptions: self
 ]
 
 { #category : 'executing' }

--- a/src/Refactoring-Transformations/RBMoveTemporaryVariableDefinitionTransformation.class.st
+++ b/src/Refactoring-Transformations/RBMoveTemporaryVariableDefinitionTransformation.class.st
@@ -6,13 +6,15 @@ For a temporary variable defined in a method but only initialized and used withi
 The transformation automatically searches for the block(s) where the definition could be moved to.
 
 Usage:
+```
 | transformation |
 transformation := (RBMoveTemporaryVariableDefinitionTransformation
 				variable: #temp
 				inMethod: #moveDefinition
-				inClass: #RBDummyRefactoryTestDataApp)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				inClass: #RBClassDataForRefactoringTest)
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - there is a block where the variable definition can be moved to.

--- a/src/Refactoring-Transformations/RBProtectVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBProtectVariableTransformation.class.st
@@ -2,11 +2,14 @@
 Creates accessors for a variable in a class, then replaces all the direct accesses to this variable by invocation to the accessors.
 
 Usage:
+```
+| transformation |
 transformation := (RBProtectVariableTransformation
 	instanceVariable: 'class'
-	class: #RBTransformationRuleTest)
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
+	class: #RBTransformationDummyRuleTest)
+	generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 overriden from RBAddAccessorsForClassTransformation and RBRemoveDirectAccessToVariableTransformation

--- a/src/Refactoring-Transformations/RBPullUpVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPullUpVariableTransformation.class.st
@@ -2,11 +2,14 @@
 Removes this variable from all the subclasses of a class, then adds this variable in this class. If none of the subclasses define a variable with the given name, this transformation works as a RBAddVariableTransformation.
 
 Usage:
+```
+| transformation |
 transformation := (RBPullUpVariableTransformation
 		instanceVariable: 'result'
-		class: #RBLintRuleTest)
-		transform.
-(ChangesBrowser changes: transformation model changes changes) open
+		class: #RBBasicLintRuleTestData)
+		generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 overriden from RBRemoveVariableTransformation and RBAddVariableAccessorTransformation

--- a/src/Refactoring-Transformations/RBPushDownVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPushDownVariableTransformation.class.st
@@ -2,11 +2,14 @@
 Removes this variable from the given class, then adds this variable in all the subclasses of this class.
 
 Usage:
+```
+| transformation |
 transformation := (RBPushDownVariableTransformation 
 		instanceVariable: 'foo1'
-		class: #RBLintRuleTest)
-		transform.
-(ChangesBrowser changes: transformation model changes changes) open
+		class: #RBLintRuleTestData)
+		generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 overriden from RBAddVariableTransformation and RBRemoveVariableAccessorTransformation

--- a/src/Refactoring-Transformations/RBRemoveAllMessageSendsTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveAllMessageSendsTransformation.class.st
@@ -8,11 +8,11 @@ Usage:
 ```
 | transformation |
 transformation := (RBRemoveAllMessageSendsTransformation
-				messageSend: #byteAt:
-				inMethod: #methodBefore
-				inClass: #RBRemoveMessageSendTransformationTest)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				messageSend: #isMessage
+				inMethod: #privateTransform
+				inClass: #RBRemoveAllMessageSendsTransformation)
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
 ```
 
 Preconditions:

--- a/src/Refactoring-Transformations/RBRemoveAssignmentTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveAssignmentTransformation.class.st
@@ -2,14 +2,16 @@
 I am responsible for removing an assignment statement inside a method. In this implementation, the variable name and the expression value must be described separately.
 
 Usage:
+```
 | transformation |
 transformation := (RBRemoveAssignmentTransformation
 				variable: 'variable'
 				value: '1 asString'
 				inMethod: #methodBefore
 				inClass: #RBRemoveAssignmentTransformationTest)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - there is an assignment to the given variable.

--- a/src/Refactoring-Transformations/RBRemoveClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveClassTransformation.class.st
@@ -4,22 +4,24 @@ Removes a potential non empty class (to your own risk) and reparent its children
 ## Usage:
 
 ```
-(RBRemoveClassTransformation
+| transformation |
+transformation := (RBRemoveClassTransformation
 	className: #RBRemoveClassTransformationTest)
-	execute.
+	generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
 ```
 
 To get the changes
 
 ```
-| transf | 
+| transf |
 transf := (RBRemoveClassTransformation
 	className: #RBRemoveClassTransformationTest)
 	generateChanges.
 (StRefactoringPreviewPresenter changes: transf scopes: {RBBrowserEnvironment new}) open
 ```
 
-To view changes check `StRefactoringPreviewPresenter changes: aCompositeRefactoring scopes: scopes
+To view changes check `StRefactoringPreviewPresenter>>changes:scopes:`
 
 ## Preconditions:
 - class must exist
@@ -28,9 +30,9 @@ To view changes check `StRefactoringPreviewPresenter changes: aCompositeRefactor
 Class {
 	#name : 'RBRemoveClassTransformation',
 	#superclass : 'RBClassTransformation',
-	#category : 'Refactoring-Transformations-Model',
+	#category : 'Refactoring-Transformations-Model-Unused',
 	#package : 'Refactoring-Transformations',
-	#tag : 'Model'
+	#tag : 'Model-Unused'
 }
 
 { #category : 'private' }

--- a/src/Refactoring-Transformations/RBRemoveDirectAccessToVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveDirectAccessToVariableTransformation.class.st
@@ -3,11 +3,12 @@ Replaces all the direct accesses to this variable in this class (and its metacla
 
 Usage:
 ```
+| transformation |
 transformation := (RBRemoveDirectAccessToVariableTransformation
 	instanceVariable: 'environment'
 	class: #RBNamespace)
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
+	generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
 ```
 
 Preconditions:

--- a/src/Refactoring-Transformations/RBRemoveMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveMethodTransformation.class.st
@@ -2,12 +2,14 @@
 Removes a method from a class. Only the selector of the method is needed.
 
 Usage:
+```
 | transformation |
 transformation := (RBRemoveMethodTransformation 
-		selector: #transform
+		selector: #privateTransform
 		from: RBRemoveMethodTransformation)
-		transform. 
-(ChangesBrowser changes: transformation model changes changes) open
+		generateChanges. 
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 Checks whether there are any references to this method

--- a/src/Refactoring-Transformations/RBRemovePragmaTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemovePragmaTransformation.class.st
@@ -2,13 +2,15 @@
 I am responsible for removing a pragma definition in a method. In this implementation, all the pragma (i.e., selector and arguments) must be described.
 
 Usage:
+```
 | transformation |
 transformation := (RBRemovePragmaTransformation
 				pragma: '<pragmaForTesting: 34>'
 				inMethod: #methodBefore
 				inClass: #RBRemovePragmaTransformationTest)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - the class exists,

--- a/src/Refactoring-Transformations/RBRemoveProtocolTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveProtocolTransformation.class.st
@@ -2,12 +2,14 @@
 I am responsible for removing a protocol in a class
 
 Usage:
+```
 | transformation |
 transformation := (RBRemoveProtocolTransformation
-			protocol: 'empty protocol'
+			protocol: 'empty protocol 1'
 			inClass: #RBDummyEmptyClass)
-			transform.
-(ChangesBrowser changes: transformation model changes changes) open
+			generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 	
 Preconditions:
 - The class exists;

--- a/src/Refactoring-Transformations/RBRemoveReturnStatementTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveReturnStatementTransformation.class.st
@@ -2,13 +2,15 @@
 I am responsible for removing a return statement inside a method.
 
 Usage:
+```
 | transformation |
 transformation := (RBRemoveReturnStatementTransformation
 			return: '^ variable'
 			inMethod: #methodBefore
 			inClass: #RBRemoveReturnStatementTransformationTest)
-			transform.
-(ChangesBrowser changes: transformation model changes changes) open
+			generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - Checks whether the method has a return.

--- a/src/Refactoring-Transformations/RBRemoveSubtreeTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveSubtreeTransformation.class.st
@@ -2,13 +2,15 @@
 Removes a subtree from a method. This is a first step on providing small AST tranformations. It might replace the message send, assignment, return, etc. transformations proposed by other tools. This transformation can also be reused by more complex ones, such as Extract Method.
 
 Usage:
+```
 | transformation |
 transformation := (RBRemoveSubtreeTransformation
-		code: 'selector := aSelector'
-		from: #selector:from:
-		in: #RBRemoveMethodTransformation)
-		transform. 
-(ChangesBrowser changes: transformation model changes changes) open
+		remove: 'selector := aSelector'
+		fromMethod: #selector:from:
+		inClass: #RBRemoveMethodTransformation)
+			generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 - the class and method exist

--- a/src/Refactoring-Transformations/RBRemoveTemporaryVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveTemporaryVariableTransformation.class.st
@@ -1,14 +1,16 @@
 "
 RBRemoveTemporaryVariableRefactoring is responsible for removing temporary variables inside a method. In Pharo, temporary variables can be declared inside blocks as well.
 
-Example: 
+Example:
+```
 | transformation |
 transformation := (RBRemoveTemporaryVariableTransformation
-	variable: 'transformation'
-	inMethod: #testTransform
-	inClass: #RBAddTemporaryVariableTransformationTest)
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
+	variable: 'methodTree'
+	inMethod: #privateTransform
+	inClass: #RBRemoveTemporaryVariableTransformation)
+			generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 	
 Preconditions:
 - Check whether this method has a temporary variable with the given name.

--- a/src/Refactoring-Transformations/RBRemoveVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveVariableTransformation.class.st
@@ -4,12 +4,13 @@ Removes a variable from a class. It does not remove it if there is a direct acce
 Usage:
 
 ```
+| transformation |
 transformation := (RBRemoveVariableTransformation 
 	variable: 'isClassVariable'
 	class: #RBVariableTransformation
 	classVariable: false)
-	transform. 
-(ChangesBrowser changes: transformation model changes changes) open
+			generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
 ```
 
 Preconditions:

--- a/src/Refactoring-Transformations/RBRenameAndDeprecateClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRenameAndDeprecateClassTransformation.class.st
@@ -8,11 +8,14 @@ This way client code using A will be able to load and get all the behavior of An
 
 
 Usage:
+```
+| transformation |
 transformation := (RBRenameAndDeprecateClassTransformation 
 				rename: #DANode
 				to: #DANodePresenter)
-				transform. 
-(ChangesBrowser changes: transformation model changes changes) open
+			generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 
 "

--- a/src/Refactoring-Transformations/RBRenamePackageTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRenamePackageTransformation.class.st
@@ -6,11 +6,14 @@ My preconditions verify that the new name is different from the current package 
 I change all the references of the classes that are defined within the package, and if there is a manifest, it is updated with the new name of the package. 
 
 Usage:
+```
 | transformation |
 transformation := (RBRenamePackageTransformation
-				rename: (self getPackageNamed: #'Refactoring2-Transformations-Tests')
+				rename: #'Refactoring-Transformations-Tests'
 				to: #'Refactoring2-Transformations-Tests1')
-				transform.
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 "
 Class {
 	#name : 'RBRenamePackageTransformation',

--- a/src/Refactoring-Transformations/RBRenameTemporaryVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRenameTemporaryVariableTransformation.class.st
@@ -1,14 +1,16 @@
 "
 RBRenameTemporaryVariableTransformation is responsible for renaming temporary variables, including arguments, inside a method.
 
-Example: 
+Example:
+```
 | transformation |
 transformation := (RBRenameTemporaryVariableTransformation 
 				rename: #rules to: #asdf
-				in: #RBLintRuleTest
+				in: #RBDummyLintRuleTest
 				selector: #openEditor)
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+			generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 	
 Preconditions:
 - Check whether this method has a temporary variable with the given name.

--- a/src/Refactoring-Transformations/RBRenameVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRenameVariableTransformation.class.st
@@ -2,12 +2,15 @@
 Renames a variable in a class and all its direct accesses. It is necessary to indicate whether the variable is an instance or class variable. It is not implemented as a composite transformation because the rename is made internally in the model.
 
 Usage:
+```
+| transformation |
 transformation := (RBRenameVariableTransformation
 			rename: 'classBlock' to: 'asdf'
-			in: #RBBasicLintRuleTest
+			in: #RBBasicLintRuleTestData
 			classVariable: false)
-			transform.
-(ChangesBrowser changes: transformation model changes changes) open
+			generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Preconditions:
 overrides from RBAddVariableRefactoring and RBRemoveVariableRefactoring

--- a/src/Refactoring-Transformations/RBReplaceSubtreeTransformation.class.st
+++ b/src/Refactoring-Transformations/RBReplaceSubtreeTransformation.class.st
@@ -2,14 +2,16 @@
 Replaces a piece of code by another in a method. Internally, this transformation replaces the corresponding subtrees, so they have to be syntactically correct.
 
 Usage:
+```
 | transformation |
 transformation := (RBReplaceSubtreeTransformation
 		replace: 'selector := aSelector'
 		to: '^ selector'
 		inMethod: #selector:from:
 		inClass: #RBRemoveMethodTransformation)
-		transform.
-(ChangesBrowser changes: transformation model changes changes) open
+		generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 "
 Class {
 	#name : 'RBReplaceSubtreeTransformation',

--- a/src/Refactoring-Transformations/RBSplitClassTransformation.class.st
+++ b/src/Refactoring-Transformations/RBSplitClassTransformation.class.st
@@ -2,13 +2,15 @@
 Creates another class with a subset of instance variables from an existing class. References to instance variables in the original class will be replaced by invocations to getters and setters on the new class.
 
 Usage:
+```
+| transformation |
 transformation := (RBSplitClassTransformation
 	class: #RBRemoveDirectAccessToVariableTransformation
 	instanceVariables: #(receiver)
 	newClassName: #RBRemoveAccessWithReceiverTransformation
 	referenceVariableName: #newReceiver)
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
+			generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
 
 In this example,
 the class ""RBRemoveAccessWithReceiverTransformation"" will be created with the variable ""receiver"". The variable ""receiver"" will be removed from the original class ""RBRemoveDirectAccessToVariableTransformation"". All references to ""receiver"" in this class and its subclasses will be replaced by: ""newReceiver receiver ..."" or ""newReceiver receiver: ...""

--- a/src/Refactoring-Transformations/RBTemporaryToInstanceVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBTemporaryToInstanceVariableTransformation.class.st
@@ -12,14 +12,16 @@ The temporary variables with the same name in hierarchy will be removed, and rep
 Example
 --------------------
 
-Example: 
+Example:
+```
 | transformation |
 transformation := (RBTemporaryToInstanceVariableRefactoring 
-				class: MyClassA
+				class: RBDummyEmptyClass
     			selector: #someMethod
     			variable: 'log') 
-				transform.
-(ChangesBrowser changes: transformation model changes changes) open
+				generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 
 Script refactoring:
 ```

--- a/src/Refactoring-Transformations/ReAddSuperSendAsFirstStatementTransformation.class.st
+++ b/src/Refactoring-Transformations/ReAddSuperSendAsFirstStatementTransformation.class.st
@@ -3,7 +3,7 @@ I am a small transformation that adds super call to given method as a first stat
 
 You can use me like this:
 ```
-ReAddSuperSendAsFirstStatementTransformation 
+(ReAddSuperSendAsFirstStatementTransformation 
 	model: self model
 	methodTree: method
 	inClass: class) execute

--- a/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
@@ -5,17 +5,20 @@ If the name of the new method is not provided (i.e., nil), it prompts a dialog w
 Similarly, if the number of arguments in the new method provided by the developer is higher than the number of arguments as calculated by the transformation, it prompts a dialog window so the developer selects which values must be passed as arguments.
 
 Usage:
-transformation := (RBExtractMethodTransformation
-	extract: '(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
+```
+| transformation |
+transformation := (ReCompositeExtractMethodRefactoring
+	extractSource: '(RecursiveSelfRule executeTree: rewriteRule tree initialAnswer: false)
 		ifFalse: [builder
 					compile: rewriteRule tree printString
 					in: class
 					classified: aSmalllintContext protocols]'
 	from: #checkMethod:
 	to: #foo:
-	in: #RBTransformationRuleTest)
-	transform.
-(ChangesBrowser changes: transformation model changes changes) open
+	in: #RBTransformationDummyRuleTest)
+	generateChanges.
+(StRefactoringPreviewPresenter for: transformation) open
+```
 "
 Class {
 	#name : 'ReCompositeExtractMethodRefactoring',

--- a/src/Refactoring-UI-Tests/ReDuplicateClassDriverTest.class.st
+++ b/src/Refactoring-UI-Tests/ReDuplicateClassDriverTest.class.st
@@ -30,7 +30,7 @@ ReDuplicateClassDriverTest >> setUpMocksOn: driver [
 	
 	requestClass := MockObject new.
 	requestClass
-		on: #changes:scopes: respond: dialog;
+		on: #for:scopes: respond: dialog;
 		on: #application: respond: dialog;
 		on: #refactoring: respond: dialog;
 		on: #openModal respond: dialog.		

--- a/src/Refactoring-UI-Tests/StRefactoringPreviewPresenterMock.class.st
+++ b/src/Refactoring-UI-Tests/StRefactoringPreviewPresenterMock.class.st
@@ -10,8 +10,8 @@ Class {
 }
 
 { #category : 'instance creation' }
-StRefactoringPreviewPresenterMock class >> changes: aRBUpFrontPreconditionCheckingCompositeRefactoring scopes: aCollection [ 
-	^ self new changes: aRBUpFrontPreconditionCheckingCompositeRefactoring scopes: aCollection 
+StRefactoringPreviewPresenterMock class >> for: aRBUpFrontPreconditionCheckingCompositeRefactoring scopes: aCollection [ 
+	^ self new for: aRBUpFrontPreconditionCheckingCompositeRefactoring scopes: aCollection 
 ]
 
 { #category : 'accessing' }
@@ -20,7 +20,7 @@ StRefactoringPreviewPresenterMock >> application: aStPharoApplication [
 ]
 
 { #category : 'instance creation' }
-StRefactoringPreviewPresenterMock >> changes: aRBUpFrontPreconditionCheckingCompositeRefactoring scopes: aCollection [ 
+StRefactoringPreviewPresenterMock >> for: aRBUpFrontPreconditionCheckingCompositeRefactoring scopes: aCollection [ 
 	changes := aRBUpFrontPreconditionCheckingCompositeRefactoring
 ]
 

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -161,13 +161,11 @@ ReInteractionDriver >> model: aRBBrowserEnvironment [
 
 { #category : 'execution' }
 ReInteractionDriver >> openPreviewWithChanges: changes [
-	
-	^ (self previewPresenterClass
-		 changes: changes
-		 scopes: scopes)
-		application: self application;
-		refactoring: self refactoring;
-		openModal
+
+	^ (self previewPresenterClass for: changes scopes: scopes)
+		  application: self application;
+		  refactoring: self refactoring;
+		  openModal
 ]
 
 { #category : 'configuration' }

--- a/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
@@ -29,6 +29,7 @@ Class {
 
 { #category : 'instance creation' }
 StRefactoringPreviewPresenter class >> changes: aCompositeRefactoring [
+	self deprecated: 'Use `for:` instead.' on: '2024-01-20' in: 'Pharo13' transformWith: '`@receiver changes: `@arg' -> '`@receiver for: `@arg'.
 	
 	^ self new
 		  changesFrom: aCompositeRefactoring scopes: { RBBrowserEnvironment new };
@@ -37,6 +38,23 @@ StRefactoringPreviewPresenter class >> changes: aCompositeRefactoring [
 
 { #category : 'instance creation' }
 StRefactoringPreviewPresenter class >> changes: aCompositeRefactoring scopes: scopes [
+	self deprecated: 'Use `for:scopes:` instead.' on: '2024-01-20' in: 'Pharo13' transformWith: '`@receiver changes: `@arg1 scopes: `@arg2' -> '`@receiver for: `@arg1 scopes: `@arg2'.
+
+	^ self new
+		  changesFrom: aCompositeRefactoring scopes: scopes;
+		  yourself
+]
+
+{ #category : 'instance creation' }
+StRefactoringPreviewPresenter class >> for: aCompositeRefactoring [
+	
+	^ self new
+		  changesFrom: aCompositeRefactoring scopes: { RBBrowserEnvironment new };
+		  yourself
+]
+
+{ #category : 'instance creation' }
+StRefactoringPreviewPresenter class >> for: aCompositeRefactoring scopes: scopes [
 
 	^ self new
 		  changesFrom: aCompositeRefactoring scopes: scopes;

--- a/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
@@ -244,7 +244,7 @@ StRefactoringPreviewPresenter >> updateActiveScope [
 StRefactoringPreviewPresenter >> updateChanges [
 
 	changesInScope := changes select: [ :change |
-		                  activeScope includesClass: change changeClass ].
+							change isInScope: activeScope ].
 	selectedChanges := OrderedCollection withAll: changesInScope
 ]
 

--- a/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
@@ -104,14 +104,8 @@ StRefactoringPreviewPresenter >> changesFrom: aCompositeChange [
 { #category : 'initialization' }
 StRefactoringPreviewPresenter >> changesFrom: aCompositeChange scopes: aCollection [
 
-	compositeChange := aCompositeChange.
-	"we keep the composite because we want to use it for performing changes later on."
-	
-	changes := aCompositeChange whatToDisplayIn: self.
 	scopes := aCollection.
-	self updateScopeList.
-	self updateChanges.
-	self updateTablePresenter
+	self changesFrom: aCompositeChange.
 ]
 
 { #category : 'action' }

--- a/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
@@ -37,15 +37,6 @@ StRefactoringPreviewPresenter class >> changes: aCompositeRefactoring [
 ]
 
 { #category : 'instance creation' }
-StRefactoringPreviewPresenter class >> changes: aCompositeRefactoring scopes: scopes [
-	self deprecated: 'Use `for:scopes:` instead.' on: '2024-01-20' in: 'Pharo13' transformWith: '`@receiver changes: `@arg1 scopes: `@arg2' -> '`@receiver for: `@arg1 scopes: `@arg2'.
-
-	^ self new
-		  changesFrom: aCompositeRefactoring scopes: scopes;
-		  yourself
-]
-
-{ #category : 'instance creation' }
 StRefactoringPreviewPresenter class >> for: aCompositeRefactoring [
 	
 	^ self new
@@ -55,6 +46,7 @@ StRefactoringPreviewPresenter class >> for: aCompositeRefactoring [
 
 { #category : 'instance creation' }
 StRefactoringPreviewPresenter class >> for: aCompositeRefactoring scopes: scopes [
+	self deprecated: 'Use `for:scopes:` instead.' on: '2024-01-20' in: 'Pharo13' transformWith: '`@receiver changes: `@arg1 scopes: `@arg2' -> '`@receiver for: `@arg1 scopes: `@arg2'.
 
 	^ self new
 		  changesFrom: aCompositeRefactoring scopes: scopes;


### PR DESCRIPTION
This PR introduces some quality of life improvements to refactorings and transformations including:

- Improve class comments of refactorings to use new API and can be executed again
- [improve api of StRefactoringPreviewPresenter to be more fluent for all cases it supports](https://github.com/pharo-project/pharo/commit/7d2be6e75d6c53268a81230328b01890afa37ea0)
- [use double dispatch to check if a change is part of the scope](https://github.com/pharo-project/pharo/commit/c70f8329ca8a8dce6766b7c32712c5e6353cc6ea)