### PR TITLE
Move OpalCompiler-UI tests to OpalCompiler-UI-Tests

### DIFF
--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -69,6 +69,7 @@ BaselineOfIDE >> baseline: spec [
 		spec package: 'Rubric-SpecFindReplaceDialog'.
 
 		spec package: 'OpalCompiler-UI'.
+		spec package: 'OpalCompiler-UI-Tests'.
 
 		self load: 'Metacello' group: 'Tests' spec: spec.
 

--- a/src/OpalCompiler-UI-Tests/OCCodeReparatorTest.class.st
+++ b/src/OpalCompiler-UI-Tests/OCCodeReparatorTest.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : 'OCCodeReparatorTest',
 	#superclass : 'TestCase',
-	#category : 'OpalCompiler-Tests-FromOld',
-	#package : 'OpalCompiler-Tests',
-	#tag : 'FromOld'
+	#category : 'OpalCompiler-UI-Tests',
+	#package : 'OpalCompiler-UI-Tests'
 }
 
 { #category : 'tests' }

--- a/src/OpalCompiler-UI-Tests/package.st
+++ b/src/OpalCompiler-UI-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'OpalCompiler-UI-Tests' }


### PR DESCRIPTION
Currently OpalCompiler-Tests depends on OpalCompiler-UI, but this packages is loaded way later than OpalCompiler-Tests. This create a dependency problem.

I propose to have a package OpalCompiler-UI-Tests loaded alongside OpalCompiler-UI.