### PR TITLE
AST-Core-Tests should not depend on Monticello

### DIFF
--- a/src/AST-Core-Tests/OCCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/OCCodeSnippetTest.class.st
@@ -103,45 +103,6 @@ OCCodeSnippetTest >> testFormattedCode [
 ]
 
 { #category : 'tests' }
-OCCodeSnippetTest >> testMonticello [
-
-	| definition |
-
-	self flag: 'Should be an extention method in Monticello-Test, but package dependency is garbage.'.
-
-	"Force non method to be inside a method"
-	snippet isScripting ifTrue: [
-		snippet := snippet copy.
-		snippet source: 'foo ' , snippet source ].
-
-	definition := MCMethodDefinition
-		className: #MCMockClassE
-		classIsMeta: false
-		selector: #'' "do not care, load will repear it"
-		category: nil
-		timeStamp: nil
-		source: snippet source.
-
-	"MCMockClassE should have no method. cleanup if some previous failed tests invalidated that"
-	MCMockClassE methods copy do: [ :m | MCMockClassE removeSelector: m selector ].
-	self assert: MCMockClassE methods size equals: 0.
-
-	snippet isFaultyMinusUndeclared ifTrue: [
-			self should: [ 	[ definition load ] on: Warning do: [ :e | e resume ]. "Ignore Selector missmatches" ] raise: OCCodeError.
-			self assert: MCMockClassE methods size equals: 0.
-			^ self ].
-
-	[ definition load ] on: Warning do: [ :e | e resume ]. "Ignore Selector missmatches"
-	self assert: MCMockClassE methods size equals: 1.
-
-	"forced methods cannot be executed, because no return (pharo language is weird)"
-	snippet isScripting ifFalse: [ self testExecute: MCMockClassE >> definition selector ].
-
-	definition unload.
-	self assert: MCMockClassE methods size equals: 0
-]
-
-{ #category : 'tests' }
 OCCodeSnippetTest >> testParse [
 
 	| ast |

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -75,6 +75,7 @@ BaselineOfBasicTools >> baseline: spec [
 
 		spec package: 'Kernel-CodeModel-Tests'.
 		spec package: 'Monticello-Tests'.
+		spec package: 'MonticelloMocks'.
 		spec package: 'Network-Mail'.
 		spec package: 'Network-Mail-Tests'.
 		spec package: 'ProfStef-Core'.

--- a/src/Monticello-Tests/OCCodeSnippetTest.extension.st
+++ b/src/Monticello-Tests/OCCodeSnippetTest.extension.st
@@ -1,0 +1,40 @@
+Extension { #name : 'OCCodeSnippetTest' }
+
+{ #category : '*Monticello-Tests' }
+OCCodeSnippetTest >> testMonticello [
+
+	| definition |
+
+	self flag: 'Should be an extention method in Monticello-Test, but package dependency is garbage.'.
+
+	"Force non method to be inside a method"
+	snippet isScripting ifTrue: [
+		snippet := snippet copy.
+		snippet source: 'foo ' , snippet source ].
+
+	definition := MCMethodDefinition
+		className: #MCMockClassE
+		classIsMeta: false
+		selector: #'' "do not care, load will repear it"
+		category: nil
+		timeStamp: nil
+		source: snippet source.
+
+	"MCMockClassE should have no method. cleanup if some previous failed tests invalidated that"
+	MCMockClassE methods copy do: [ :m | MCMockClassE removeSelector: m selector ].
+	self assert: MCMockClassE methods size equals: 0.
+
+	snippet isFaultyMinusUndeclared ifTrue: [
+			self should: [ 	[ definition load ] on: Warning do: [ :e | e resume ]. "Ignore Selector missmatches" ] raise: OCCodeError.
+			self assert: MCMockClassE methods size equals: 0.
+			^ self ].
+
+	[ definition load ] on: Warning do: [ :e | e resume ]. "Ignore Selector missmatches"
+	self assert: MCMockClassE methods size equals: 1.
+
+	"forced methods cannot be executed, because no return (pharo language is weird)"
+	snippet isScripting ifFalse: [ self testExecute: MCMockClassE >> definition selector ].
+
+	definition unload.
+	self assert: MCMockClassE methods size equals: 0
+]

--- a/src/Monticello-Tests/OCCodeSnippetTest.extension.st
+++ b/src/Monticello-Tests/OCCodeSnippetTest.extension.st
@@ -5,8 +5,6 @@ OCCodeSnippetTest >> testMonticello [
 
 	| definition |
 
-	self flag: 'Should be an extention method in Monticello-Test, but package dependency is garbage.'.
-
 	"Force non method to be inside a method"
 	snippet isScripting ifTrue: [
 		snippet := snippet copy.

--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -171,6 +171,7 @@ SystemDependenciesTest >> testExternalBasicToolsDependencies [
 	dependencies := self externalDependendiesOf: (
 		self metacelloPackageNames,
 		self tonelCorePackageNames,
+		BaselineOfKernelTests withAllPackageNames,
 		BaselineOfTraits corePackages,
 		BaselineOfSUnit withAllPackageNames, "ALL"
 		BaselineOfDisplay withAllPackageNames,


### PR DESCRIPTION
OCCodeSnippetTest is depending on Monticello but Monticello is loaded only later.  I propose to repackage this test in Monticello to cut this unwanted dependency