### PR TITLE
Update version in #newTools for BaselineOfPharo for Pharo 12 to ‘v0.9.1’

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -95,7 +95,7 @@ BaselineOfPharo class >> newTools [
 		newName: 'NewTools' 
 		owner: 'pharo-spec' 
 		project: 'NewTools' 
-		version: 'v0.9.0'
+		version: 'v0.9.1'
 ]
 
 { #category : 'repository urls' }


### PR DESCRIPTION
This pull request updates the version in `#newTools` for BaselineOfPharo for Pharo 12 to ‘v0.9.1’. Before this can be merged, a corresponding tag referring to [commit 2d5f4518a2c36eea](https://github.com/pharo-spec/NewTools/commit/2d5f4518a2c36eea7aca2ec11fcb28df44d7dffc) (which the [‘Pharo12’ branch](https://github.com/pharo-spec/NewTools/tree/Pharo12) currently refers to) needs to added.