### PR TITLE
Move (OC)DoItVariable to the compiler

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -238,6 +238,8 @@ BaselineOfBasicTools >> postload: loader package: packageSpec [
 	 OCPatternPragmaNode deprecatedAliases:
 		 { #RBPatternPragmaNode. #ASTPatternPragmaNode }.
 
+	OCDoItVariable deprecatedAliases: { #DoItVariable }.
+
 	 CompletionSorter register.
 	 RubSmalltalkEditor completionEngineClass: CompletionEngine.
 

--- a/src/Kernel-CodeModel/PseudoVariable.class.st
+++ b/src/Kernel-CodeModel/PseudoVariable.class.st
@@ -33,11 +33,6 @@ PseudoVariable class >> variableName [
 ]
 
 { #category : 'converting' }
-PseudoVariable >> asDoItVariableFrom: aContext [
-	^ DoItVariable fromContext: aContext variable: self
-]
-
-{ #category : 'converting' }
 PseudoVariable >> asString [
 
 	^ self name

--- a/src/OpalCompiler-Core/LocalVariable.class.st
+++ b/src/OpalCompiler-Core/LocalVariable.class.st
@@ -56,7 +56,7 @@ LocalVariable >> analyzeWrite: aVariableNode by: aSemanticAnalyzer [
 
 { #category : 'converting' }
 LocalVariable >> asDoItVariableFrom: aContext [
-	^ DoItVariable fromContext: aContext variable: self
+	^ OCDoItVariable fromContext: aContext variable: self
 ]
 
 { #category : 'converting' }

--- a/src/OpalCompiler-Core/OCDoItVariable.class.st
+++ b/src/OpalCompiler-Core/OCDoItVariable.class.st
@@ -33,19 +33,19 @@ Internal Representation and Key Implementation Points.
 	doItContext:		<Context>
 "
 Class {
-	#name : 'DoItVariable',
+	#name : 'OCDoItVariable',
 	#superclass : 'Variable',
 	#instVars : [
 		'actualVariable',
 		'doItContext'
 	],
-	#category : 'Kernel-CodeModel-Variables',
-	#package : 'Kernel-CodeModel',
-	#tag : 'Variables'
+	#category : 'OpalCompiler-Core-Semantics',
+	#package : 'OpalCompiler-Core',
+	#tag : 'Semantics'
 }
 
 { #category : 'instance creation' }
-DoItVariable class >> fromContext: aContext variable: aVariable [
+OCDoItVariable class >> fromContext: aContext variable: aVariable [
 
 	^self new
 		doItContext: aContext;
@@ -53,40 +53,40 @@ DoItVariable class >> fromContext: aContext variable: aVariable [
 ]
 
 { #category : 'instance creation' }
-DoItVariable class >> named: aString fromContext: aContext [
+OCDoItVariable class >> named: aString fromContext: aContext [
 	^self
 		fromContext: aContext
 		variable: (aContext lookupVar: aString)
 ]
 
 { #category : 'accessing' }
-DoItVariable >> actualVariable [
+OCDoItVariable >> actualVariable [
 	^ actualVariable
 ]
 
 { #category : 'accessing' }
-DoItVariable >> actualVariable: aVariable [
+OCDoItVariable >> actualVariable: aVariable [
 	actualVariable := aVariable.
 	name := actualVariable name
 ]
 
 { #category : 'testing' }
-DoItVariable >> allowsShadowing [
+OCDoItVariable >> allowsShadowing [
 	^true
 ]
 
 { #category : 'accessing' }
-DoItVariable >> doItContext [
+OCDoItVariable >> doItContext [
 	^ doItContext
 ]
 
 { #category : 'accessing' }
-DoItVariable >> doItContext: anObject [
+OCDoItVariable >> doItContext: anObject [
 	doItContext := anObject
 ]
 
 { #category : 'code generation' }
-DoItVariable >> emitStore: aMethodBuilder [
+OCDoItVariable >> emitStore: aMethodBuilder [
 	"generate bytecode to call the reflective write method of the Slot"
 	| tempName |
 	tempName := '0slotTempForStackManipulation'.
@@ -100,94 +100,94 @@ DoItVariable >> emitStore: aMethodBuilder [
 ]
 
 { #category : 'code generation' }
-DoItVariable >> emitValue: aMethodBuilder [
+OCDoItVariable >> emitValue: aMethodBuilder [
 	aMethodBuilder
 		pushLiteral: self;
 		send: #read
 ]
 
 { #category : 'testing' }
-DoItVariable >> isArgumentVariable [
+OCDoItVariable >> isArgumentVariable [
 	^actualVariable isArgumentVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isClassVariable [
+OCDoItVariable >> isClassVariable [
 	^actualVariable isClassVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isGlobalVariable [
+OCDoItVariable >> isGlobalVariable [
 	^actualVariable isGlobalVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isInstanceVariable [
+OCDoItVariable >> isInstanceVariable [
 	^actualVariable isInstanceVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isLiteralVariable [
+OCDoItVariable >> isLiteralVariable [
 	^actualVariable isLiteralVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isLocalVariable [
+OCDoItVariable >> isLocalVariable [
 	^actualVariable isLocalVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isPseudoVariable [
+OCDoItVariable >> isPseudoVariable [
 	^actualVariable isPseudoVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isSelfVariable [
+OCDoItVariable >> isSelfVariable [
 	^actualVariable isSelfVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isSuperVariable [
+OCDoItVariable >> isSuperVariable [
 	^actualVariable isSuperVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isTempVariable [
+OCDoItVariable >> isTempVariable [
 	^actualVariable isTempVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isThisContextVariable [
+OCDoItVariable >> isThisContextVariable [
 	^actualVariable isThisContextVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isThisProcessVariable [
+OCDoItVariable >> isThisProcessVariable [
 	^actualVariable isThisProcessVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isUndeclaredVariable [
+OCDoItVariable >> isUndeclaredVariable [
 	^actualVariable isUndeclaredVariable
 ]
 
 { #category : 'testing' }
-DoItVariable >> isUninitialized [
+OCDoItVariable >> isUninitialized [
 	^actualVariable isUninitialized
 ]
 
 { #category : 'testing' }
-DoItVariable >> isWorkspaceVariable [
+OCDoItVariable >> isWorkspaceVariable [
 	^actualVariable isWorkspaceVariable
 ]
 
 { #category : 'accessing' }
-DoItVariable >> key [
+OCDoItVariable >> key [
 	^self name
 ]
 
 { #category : 'printing' }
-DoItVariable >> printOn: aStream [
+OCDoItVariable >> printOn: aStream [
 	super printOn: aStream.
 
 	aStream nextPut: $(.
@@ -196,31 +196,31 @@ DoItVariable >> printOn: aStream [
 ]
 
 { #category : 'meta-object-protocol' }
-DoItVariable >> read [
+OCDoItVariable >> read [
 	^actualVariable readInContext: doItContext
 ]
 
 { #category : 'debugging' }
-DoItVariable >> readInContext: aContext [
+OCDoItVariable >> readInContext: aContext [
 	^self read
 ]
 
 { #category : 'accessing' }
-DoItVariable >> scope [
+OCDoItVariable >> scope [
 	^ actualVariable scope
 ]
 
 { #category : 'queries' }
-DoItVariable >> usingMethods [
+OCDoItVariable >> usingMethods [
 	^actualVariable usingMethods
 ]
 
 { #category : 'meta-object-protocol' }
-DoItVariable >> write: aValue [
+OCDoItVariable >> write: aValue [
 	^actualVariable write: aValue inContext: doItContext
 ]
 
 { #category : 'debugging' }
-DoItVariable >> write: aValue inContext: aContext [
+OCDoItVariable >> write: aValue inContext: aContext [
 	self write: aValue
 ]

--- a/src/OpalCompiler-Core/PseudoVariable.extension.st
+++ b/src/OpalCompiler-Core/PseudoVariable.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'PseudoVariable' }
+
+{ #category : '*OpalCompiler-Core' }
+PseudoVariable >> asDoItVariableFrom: aContext [
+	^ OCDoItVariable fromContext: aContext variable: self
+]

--- a/src/OpalCompiler-Tests/OCDoItVariableTest.class.st
+++ b/src/OpalCompiler-Tests/OCDoItVariableTest.class.st
@@ -1,16 +1,16 @@
 Class {
-	#name : 'DoItVariableTest',
+	#name : 'OCDoItVariableTest',
 	#superclass : 'TestCase',
 	#instVars : [
 		'instVarForTest'
 	],
-	#category : 'Slot-Tests-VariablesAndSlots',
-	#package : 'Slot-Tests',
-	#tag : 'VariablesAndSlots'
+	#category : 'OpalCompiler-Tests-Semantic',
+	#package : 'OpalCompiler-Tests',
+	#tag : 'Semantic'
 }
 
 { #category : 'helpers' }
-DoItVariableTest >> readVarInDifferentContext: aVar [
+OCDoItVariableTest >> readVarInDifferentContext: aVar [
 	| temp |
 	self assert: aVar name equals: #temp.
 
@@ -19,32 +19,32 @@ DoItVariableTest >> readVarInDifferentContext: aVar [
 ]
 
 { #category : 'tests' }
-DoItVariableTest >> testConvertingToDoItVariable [
+OCDoItVariableTest >> testConvertingToDoItVariable [
 
 	| temp var |
 	temp := 100.
-	var := DoItVariable named: #temp fromContext: thisContext.
+	var := OCDoItVariable named: #temp fromContext: thisContext.
 
 	self assert: (var asDoItVariableFrom: #anyContext) identicalTo: var
 ]
 
 { #category : 'tests' }
-DoItVariableTest >> testCreationFromAnotherVariable [
+OCDoItVariableTest >> testCreationFromAnotherVariable [
 	| temp var targetTemp |
 	temp := 100.
 	targetTemp := thisContext lookupVar: #temp.
 	var := targetTemp asDoItVariableFrom: thisContext.
 
-	self assert: var class equals: DoItVariable.
+	self assert: var class equals: OCDoItVariable.
 	self assert: var doItContext identicalTo: thisContext.
 	self assert: var actualVariable identicalTo: targetTemp
 ]
 
 { #category : 'tests' }
-DoItVariableTest >> testDoItCompilation [
+OCDoItVariableTest >> testDoItCompilation [
 	| temp var doIt |
 	temp := 100.
-	var := DoItVariable named: #temp fromContext: thisContext.
+	var := OCDoItVariable named: #temp fromContext: thisContext.
 	doIt := thisContext compiler
 		source: 'temp + 2';
 		isScripting: true;
@@ -54,11 +54,11 @@ DoItVariableTest >> testDoItCompilation [
 ]
 
 { #category : 'tests' }
-DoItVariableTest >> testFromInstVarVariable [
+OCDoItVariableTest >> testFromInstVarVariable [
 
 	| var |
 	instVarForTest := 100.
-	var := DoItVariable named: #instVarForTest fromContext: thisContext.
+	var := OCDoItVariable named: #instVarForTest fromContext: thisContext.
 
 	self assert: var name equals: #instVarForTest.
 	self assert: var read equals: 100.
@@ -68,11 +68,11 @@ DoItVariableTest >> testFromInstVarVariable [
 ]
 
 { #category : 'tests' }
-DoItVariableTest >> testFromTempVariable [
+OCDoItVariableTest >> testFromTempVariable [
 
 	| temp var |
 	temp := 100.
-	var := DoItVariable named: #temp fromContext: thisContext.
+	var := OCDoItVariable named: #temp fromContext: thisContext.
 
 	self assert: var name equals: #temp.
 	self assert: var read equals: 100.
@@ -82,10 +82,10 @@ DoItVariableTest >> testFromTempVariable [
 ]
 
 { #category : 'tests' }
-DoItVariableTest >> testReadCompilation [
+OCDoItVariableTest >> testReadCompilation [
 	| temp var ast doIt |
 	temp := 100.
-	var := DoItVariable named: #temp fromContext: thisContext.
+	var := OCDoItVariable named: #temp fromContext: thisContext.
 	ast := [ temp + 2 ] sourceNode body asDoit doSemanticAnalysis.
 	ast variableNodes first variable: var.
 	doIt := ast generateMethod.
@@ -94,30 +94,30 @@ DoItVariableTest >> testReadCompilation [
 ]
 
 { #category : 'tests' }
-DoItVariableTest >> testReadInGivenContextShouldIgnoreIt [
+OCDoItVariableTest >> testReadInGivenContextShouldIgnoreIt [
 	| temp var actual |
 	temp := 100.
-	var := DoItVariable named: #temp fromContext: thisContext.
+	var := OCDoItVariable named: #temp fromContext: thisContext.
 
 	actual := self readVarInDifferentContext: var.
 	self assert: actual equals: 100
 ]
 
 { #category : 'tests' }
-DoItVariableTest >> testUsingMethods [
+OCDoItVariableTest >> testUsingMethods [
 
 	| temp var |
 	temp := 100.
-	var := DoItVariable named: #temp fromContext: thisContext.
+	var := OCDoItVariable named: #temp fromContext: thisContext.
 
 	self assert: var usingMethods equals: { thisContext method }
 ]
 
 { #category : 'tests' }
-DoItVariableTest >> testWriteCompilation [
+OCDoItVariableTest >> testWriteCompilation [
 	| temp var ast doIt |
 	temp := 100.
-	var := DoItVariable named: #temp fromContext: thisContext.
+	var := OCDoItVariable named: #temp fromContext: thisContext.
 	ast := [ temp := 500 ] sourceNode body asDoit doSemanticAnalysis.
 	ast variableNodes first variable: var.
 	doIt := ast generateMethod.
@@ -127,17 +127,17 @@ DoItVariableTest >> testWriteCompilation [
 ]
 
 { #category : 'tests' }
-DoItVariableTest >> testWriteInGivenContextShouldIgnoreIt [
+OCDoItVariableTest >> testWriteInGivenContextShouldIgnoreIt [
 	| temp var |
 	temp := 100.
-	var := DoItVariable named: #temp fromContext: thisContext.
+	var := OCDoItVariable named: #temp fromContext: thisContext.
 
 	self writeVarInDifferentContext: var value: 200.
 	self assert: temp equals: 200
 ]
 
 { #category : 'helpers' }
-DoItVariableTest >> writeVarInDifferentContext: aVar value: aValue [
+OCDoItVariableTest >> writeVarInDifferentContext: aVar value: aValue [
 	| temp |
 	self assert: aVar name equals: #temp.
 

--- a/src/Shout/DoItVariable.extension.st
+++ b/src/Shout/DoItVariable.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'DoItVariable' }
-
-{ #category : '*Shout' }
-DoItVariable >> styleNameIn: aVariableNode [
-
-	^ self actualVariable styleNameIn: aVariableNode
-]

--- a/src/Shout/OCDoItVariable.extension.st
+++ b/src/Shout/OCDoItVariable.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'OCDoItVariable' }
+
+{ #category : '*Shout' }
+OCDoItVariable >> styleNameIn: aVariableNode [
+
+	^ self actualVariable styleNameIn: aVariableNode
+]


### PR DESCRIPTION
DoItVariable can exists only if the compiler is here. I propose to rename it OCDoItVariable and to move it to the compiler