### PR TITLE
Fixes: 17680 RB-Rename-class-from-in-text-editor-select-the-class-of-…

### DIFF
--- a/src/SystemCommands-ClassCommands/SycRenameClassCommand.class.st
+++ b/src/SystemCommands-ClassCommands/SycRenameClassCommand.class.st
@@ -24,21 +24,26 @@ SycRenameClassCommand >> defaultMenuItemName [
 
 { #category : 'execution' }
 SycRenameClassCommand >> execute [
-	"Pay attention when you specify a model that is a selection of the full environment. 
-	Indeed imagine that you have a model of just one package, 
-	the precondition may say that the new name is not the one of an already existing global 
-	that is defined outside of your model (think of OrderedCollection) in this case
-	when the refactoring will check then it will say that the name is ok, and you will destroy the system
-	by creating a new class with the same name as an existing one.
-	
-	So this is we pass the model of the full environment and not a scope selected by the user."
-	
-	
-	
-	(ReRenameClassDriver
-		rename: targetClass name) 
-		model: RBBrowserEnvironment new;
-		scopes: toolContext refactoringScopes; runRefactoring
+
+	toolContext class = ClyFullBrowserClassContext
+		ifTrue: [
+			(ReRenameClassDriver rename: targetClass name)
+				model: RBBrowserEnvironment new;
+				scopes: toolContext refactoringScopes;
+				runRefactoring ]
+		ifFalse: [
+			toolContext class = ClyClassDefinitionContext
+				ifTrue: [
+					(ReRenameClassDriver rename: toolContext selectedSourceNode value)
+						model: RBBrowserEnvironment new;
+						scopes: toolContext refactoringScopes;
+						runRefactoring ]
+				ifFalse: [ "we are in selection in a method "
+					(ReRenameClassDriver rename:
+							 toolContext selectedSourceNode value name)
+						model: RBBrowserEnvironment new;
+						scopes: toolContext refactoringScopes;
+						runRefactoring ] ]
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
…the-method-and-not-the-selected-class

Ugly but it works for 
	- menu selection
	- selection in class definition
	- selection in method

Fixes #17680