### PR TITLE
Do not restore ffi methods if they are not installed

### DIFF
--- a/src/ThreadedFFI-UFFI-Tests/TFFITraitForTest.trait.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFFITraitForTest.trait.st
@@ -1,0 +1,9 @@
+Trait {
+	#name : 'TFFITraitForTest',
+	#category : 'ThreadedFFI-UFFI-Tests',
+	#package : 'ThreadedFFI-UFFI-Tests'
+}
+
+{ #category : 'accessing - structure variables' }
+TFFITraitForTest >> x [
+]

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIMethodRegistryTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIMethodRegistryTest.class.st
@@ -10,7 +10,7 @@ TFUFFIMethodRegistryTest >> testRegistryDoesNotRestoreUninstalledMethods [
 
 	"Call the method to force installation"
 	| ffiMethod |
-	TFUFFITestClassWithTrait new pidfortest.
+	TFUFFITestClassWithTrait uniqueInstance pidfortest.
 	
 	ffiMethod := TFUFFITestClassWithTrait >> #pidfortest.
 	ffiMethod recompile.

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIMethodRegistryTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIMethodRegistryTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : 'TFUFFIMethodRegistryTest',
+	#superclass : 'TFUFFITestCase',
+	#category : 'ThreadedFFI-UFFI-Tests',
+	#package : 'ThreadedFFI-UFFI-Tests'
+}
+
+{ #category : 'tests' }
+TFUFFIMethodRegistryTest >> testRegistryDoesNotRestoreUninstalledMethods [
+
+	"Call the method to force installation"
+	| ffiMethod |
+	TFUFFITestClassWithTrait new pidfortest.
+	
+	ffiMethod := TFUFFITestClassWithTrait >> #pidfortest.
+	ffiMethod recompile.
+	FFIMethodRegistry uniqueInstance resetMethod: ffiMethod.
+
+	self assert: TFUFFITestClassWithTrait localMethods first isInstalled.
+]

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFITestClassWithTrait.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFITestClassWithTrait.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : 'TFUFFITestClassWithTrait',
+	#superclass : 'Object',
+	#traits : 'TFFITraitForTest',
+	#classTraits : 'TFFITraitForTest classTrait',
+	#category : 'ThreadedFFI-UFFI-Tests',
+	#package : 'ThreadedFFI-UFFI-Tests'
+}
+
+{ #category : 'accessing' }
+TFUFFITestClassWithTrait >> pidfortest [
+
+	self ffiCall: #(size_t getpid()) library: 'libc.dylib'
+]

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFITestClassWithTrait.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFITestClassWithTrait.class.st
@@ -1,14 +1,30 @@
 Class {
 	#name : 'TFUFFITestClassWithTrait',
-	#superclass : 'Object',
+	#superclass : 'FFILibrary',
 	#traits : 'TFFITraitForTest',
 	#classTraits : 'TFFITraitForTest classTrait',
 	#category : 'ThreadedFFI-UFFI-Tests',
 	#package : 'ThreadedFFI-UFFI-Tests'
 }
 
+{ #category : 'accessing - platform' }
+TFUFFITestClassWithTrait >> macLibraryName [
+	^ 'libc.dylib'
+]
+
 { #category : 'accessing' }
 TFUFFITestClassWithTrait >> pidfortest [
 
-	self ffiCall: #(size_t getpid()) library: 'libc.dylib'
+	self ffiCall: #(size_t getpid())
+]
+
+{ #category : 'accessing - platform' }
+TFUFFITestClassWithTrait >> unixLibraryName [
+	^ 'libc.so.6'
+]
+
+{ #category : 'accessing - platform' }
+TFUFFITestClassWithTrait >> win32LibraryName [
+	"While this is not a 'libc' properly, msvcrt has the functions we are defining here"
+	^ 'msvcrt.dll'
 ]

--- a/src/UnifiedFFI/FFIMethodRegistry.class.st
+++ b/src/UnifiedFFI/FFIMethodRegistry.class.st
@@ -84,20 +84,30 @@ FFIMethodRegistry >> registerMethod: aCompiledMethod [
 	compiledMethods add: aCompiledMethod
 ]
 
-{ #category : 'accessing' }
-FFIMethodRegistry >> removeMethod: aMethod [
-
-	aMethod methodClass methodDict
-		at: aMethod selector
-		put: (aMethod propertyAt: #ffiNonCompiledMethod)
-]
-
 { #category : 'initialization' }
 FFIMethodRegistry >> reset [
 	"FFI compiled methods will keep the old method as a property, making easy to replace it
 	 when changing platforms."
-	self compiledMethods do: [ :each | self removeMethod: each].
+	self compiledMethods do: [ :each | 
+		self resetMethod: each ].
 	self compiledMethods removeAll
+]
+
+{ #category : 'accessing' }
+FFIMethodRegistry >> resetMethod: ffiMethod [
+
+	"Only restore methods that are still installed.
+	Otherwise, it may happen that the method has been replaced 
+	and thus not yet GC'd and we will restore a wrong method."
+
+	| originalMethod |
+	
+	ffiMethod isInstalled ifFalse: [ ^ self ].
+	
+	originalMethod := ffiMethod propertyAt: #ffiNonCompiledMethod.
+	ffiMethod methodClass methodDict
+		at: ffiMethod selector
+		put: originalMethod
 ]
 
 { #category : 'reseting' }
@@ -106,6 +116,6 @@ FFIMethodRegistry >> resetSingleClass: aClass [
 	self compiledMethods
 		select: [ :m | m methodClass = aClass ]
 		thenDo: [ :aMethod |
-			self removeMethod: aMethod.
+			self resetMethod: aMethod.
 			compiledMethods remove: aMethod ]
 ]


### PR DESCRIPTION
There is an edge case when mixing traits and FFI.
In this case methods appear both in the method dictionary and in the localMethod collection.
And when recompiling, the new method is installed in both, ok.

But when the image is shut down, the methods that have been recompiled by FFI are restored to their original version.
It could happen that a method is recompiled (and thus replaced) and the FFI registry retores the old version.

=> thus, only restore a method if the FFI method is the currenty installed version

Note: this is causing the test `testNoShadowedVariablesInMethods` fail in the CI with the following error

```
MessageNotUnderstood
receiver of "contents" is nil
UndefinedObject(Object)>>doesNotUnderstand: #contents
OpalCompiler>>source:
CompiledMethod>>parseTree
RFReflectivityASTCacheStrategy>>getASTFor:
OCASTCache>>getASTFor:
[ self getASTFor: aCompiledMethod ] in OCASTCache>>at:
OCASTCache>>at:ifAbsentPut:
OCASTCache>>at:
OCASTCache class>>at:
CompiledMethod>>ast
[ :m |
		m isQuick not and: [ "quick methods do not define variables"
			m ast variableDefinitionNodes anySatisfy: [ :node | node variable isShadowing ] ]] in ReleaseTest>>testNoShadowedVariablesInMethods
OrderedCollection>>select:
ReleaseTest>>testNoShadowedVariablesInMethods
```

Because that test looks for all methods and finds those old methods with a wrong source pointer (that was probably invalidated when condensing sources)