### PR TITLE
Update version in #newTools for BaselineOfPharo for Pharo 12 to ‘v0.9.2’

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -95,7 +95,7 @@ BaselineOfPharo class >> newTools [
 		newName: 'NewTools' 
 		owner: 'pharo-spec' 
 		project: 'NewTools' 
-		version: 'v0.9.1'
+		version: 'v0.9.2'
 ]
 
 { #category : 'repository urls' }


### PR DESCRIPTION
This pull request updates the version in `#newTools` for BaselineOfPharo for Pharo 12 to ‘v0.9.2’. Before this can be merged, a corresponding tag referring to [commit c74b203596f8ffd2](https://github.com/pharo-spec/NewTools/commit/c74b203596f8ffd27a6fb4a1439d47071ab88774) needs to added.