### PR TITLE
Edited two rules to implement that #initializeWindow: has to call super and can't override preferredExtent

### DIFF
--- a/src/General-Rules/ReMissingSuperSendsRule.class.st
+++ b/src/General-Rules/ReMissingSuperSendsRule.class.st
@@ -27,6 +27,12 @@ ReMissingSuperSendsRule class >> ruleName [
 ]
 
 { #category : 'accessing' }
+ReMissingSuperSendsRule class >> severity [
+
+	^ #error
+]
+
+{ #category : 'accessing' }
 ReMissingSuperSendsRule class >> uniqueIdentifierName [
 	"This number should be unique and should change only when the rule completely change semantics"
 
@@ -57,5 +63,5 @@ ReMissingSuperSendsRule >> basicCheck: aMethod [
 ReMissingSuperSendsRule >> methodsRequiringSuper [
 
 	^ #( #release #postCopy #postBuildWith: #preBuildWith: #postOpenWith:
-	     #noticeOfWindowClose: #initialize )
+	     #noticeOfWindowClose: #initialize #initializeWindow: ) 
 ]

--- a/src/General-Rules/ReOverridesSpecialMessageRule.class.st
+++ b/src/General-Rules/ReOverridesSpecialMessageRule.class.st
@@ -26,7 +26,7 @@ ReOverridesSpecialMessageRule class >> group [
 
 { #category : 'private' }
 ReOverridesSpecialMessageRule class >> metaclassShouldNotOverride [
-	^ #( #basicNew #basicNew #class #comment #name )
+	^ #( #basicNew #basicNew #class #comment #name #preferredExtent )
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
also changed severity of the ReMissingSuperSendsRule, makes sense to me.
@Ducasse @jecisc 