### PR TITLE
Backport fix-SDL-default-renderer-by-platform to Pharo 11

### DIFF
--- a/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
@@ -26,6 +26,13 @@ SDLAbstractPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 	self subclassResponsibility
 ]
 
+{ #category : #configuration }
+SDLAbstractPlatform >> defaultRendererFlags [
+	"We have no special flags for the renderer.
+	SDL_RENDERER_PRESENTVSYNC was shown to crash on certain windows machines with external screens"
+	^ 0
+]
+
 { #category : #initialization }
 SDLAbstractPlatform >> initPlatformSpecific [
 

--- a/src/OSWindow-SDL2/SDLOSXPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatform.class.st
@@ -27,6 +27,13 @@ SDLOSXPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 	self release: aParam
 ]
 
+{ #category : #configuration }
+SDLOSXPlatform >> defaultRendererFlags [ 
+
+	"SDL_RENDERER_PRESENTVSYNC is required on MacOS for certain screens to avoid rendering issues"
+	^ super defaultRendererFlags | SDL_RENDERER_PRESENTVSYNC
+]
+
 { #category : #'ffi-calls' }
 SDLOSXPlatform >> ffiLibraryName [
 

--- a/src/OSWindow-SDL2/SDL_Window.class.st
+++ b/src/OSWindow-SDL2/SDL_Window.class.st
@@ -36,7 +36,10 @@ SDL_Window >> createAcceleratedRenderer [
 
 { #category : #rendering }
 SDL_Window >> createDefaultRenderer [
-	^ self createRenderer: -1 flags: 0
+
+	^ self
+		  createRenderer: -1 "Find the first available rendering driver with the matching options"
+		  flags: OSPlatform current sdlPlatform defaultRendererFlags
 ]
 
 { #category : #rendering }


### PR DESCRIPTION
This pull request backports the changes of pull request #17517 (and #17496) to Pharo 11 (see pull request #17579 for the Pharo 12 backport).