### PR TITLE
Reduce usage of protocol initialize-release

### DIFF
--- a/src/HeuristicCompletion-Model/CoCompletionContext.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionContext.class.st
@@ -21,7 +21,7 @@ Class {
 	#tag : 'SystemIntegration'
 }
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 CoCompletionContext class >> engine: aCompletionEngine class: aClass source: aString position: anInteger [
 
 	^ self new

--- a/src/Keymapping-Core/KMBuffer.class.st
+++ b/src/Keymapping-Core/KMBuffer.class.st
@@ -18,7 +18,7 @@ Class {
 	#tag : 'Base'
 }
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 KMBuffer class >> resetUniqueInstance [
 	uniqueInstance := nil
 ]

--- a/src/Metacello-Core/MetacelloPlatform.class.st
+++ b/src/Metacello-Core/MetacelloPlatform.class.st
@@ -28,12 +28,12 @@ MetacelloPlatform class >> initialize [
 	self select
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 MetacelloPlatform class >> select [
   Current := self new
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 MetacelloPlatform class >> unselect [
   MetacelloPlatform current class = self
     ifTrue: [ Current := nil ]

--- a/src/Monticello/MCDataStream.class.st
+++ b/src/Monticello/MCDataStream.class.st
@@ -78,7 +78,7 @@ MCDataStream class >> initialize [
 	self initializeTypeMap 
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 MCDataStream class >> initializeTypeMap [
 	"TypeMap maps Smalltalk classes to type ID numbers which identify the data stream primitive formats.  nextPut: writes these IDs to the data stream.  NOTE: Changing these type ID numbers will invalidate all extant data stream files.  Adding new ones is OK.  
 	Classes named here have special formats in the file.  If such a class has a subclass, it will use type 9 and write correctly.  It will just be slow.  (Later write the class name in the special format, then subclasses can use the type also.)
@@ -201,25 +201,25 @@ MCDataStream class >> readOnlyFileNamed: fileName do: aBlock [
 	^ self detectFile: [ self readOnlyFileNamed: fileName ] do: aBlock
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 MCDataStream class >> readSelectors [
 	ReadSelectors ifNil: [ self initializeTypeMap ].
 	^ReadSelectors 
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 MCDataStream class >> registerClass: aClass atIndex: anIndex usingReadSelector: readSelector usingWriteSelector: writeSelector [
 	self typeMap at: aClass put: anIndex.
 	self readSelectors at: anIndex put: readSelector.
 	self writeSelectors at: anIndex put: writeSelector
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 MCDataStream class >> registerReaderSelector: aSelector atIndex: index [
 	self readSelectors at: index put: aSelector
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 MCDataStream class >> registerWriterSelector: aSelector atIndex: anIndex [
 	self writeSelectors at: anIndex put: aSelector
 ]
@@ -233,13 +233,13 @@ MCDataStream class >> streamedRepresentationOf: anObject [
 	^file contents
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 MCDataStream class >> typeMap [
 	TypeMap ifNil: [ self initializeTypeMap ].
 	^ TypeMap
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 MCDataStream class >> writeSelectors [
 	WriteSelectors ifNil: [ self initializeTypeMap ].
 	^ WriteSelectors

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -149,7 +149,7 @@ UITheme class >> newDefault [
 	^self new
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 UITheme class >> resetBuilder [
 	<script>
 

--- a/src/Renraku/ReRuleManager.class.st
+++ b/src/Renraku/ReRuleManager.class.st
@@ -261,7 +261,7 @@ ReRuleManager class >> uniqueInstance [
 	^ self default
 ]
 
-{ #category : 'initialize-release' }
+{ #category : 'class initialization' }
 ReRuleManager class >> unload [
 
 	self reset


### PR DESCRIPTION
Most of the pharo code is using "class initialization" so this is to improve the coherence.

Next step is to fix this in Roassal, Libgit and Iceberg