### PR TITLE
Move System-SourcesCondenser later in the loading order

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -147,7 +147,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform  --save SystemVers
 
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes InitializePackagesCommandLineHandler.hermes --save
 
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Collections-Atomic.hermes AST-Core.hermes Collections-Arithmetic.hermes ClassDefinitionPrinters.hermes System-SourcesCondenser.hermes System-NumberPrinting.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Collections-Atomic.hermes AST-Core.hermes Collections-Arithmetic.hermes ClassDefinitionPrinters.hermes System-NumberPrinting.hermes --save --no-fail-on-undeclared
 
 echo $(date -u) "[Compiler] Initializing the packages in the Kernel"
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" initializePackages --protocols=protocolsKernel.txt --packages --save

--- a/src/BaselineOfMisc/BaselineOfMisc.class.st
+++ b/src/BaselineOfMisc/BaselineOfMisc.class.st
@@ -7,11 +7,13 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfMisc >> baseline: spec [
+
 	<baseline>
-	spec for: #'common' do: [
-		spec 
+	spec for: #common do: [
+		spec
 			package: 'PharoDocComment';
 			package: 'STON-Text support';
 			package: 'System-CommandLine-TextSupport';
-			package: 'Files-Prompt'. ]
+			package: 'Files-Prompt';
+			package: 'System-SourcesCondenser' ]
 ]

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -117,7 +117,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		spec package: 'System-Platforms'.
 		spec package: 'System-SessionManager'.
 		spec package: 'System-Sources'.
-		spec package: 'System-SourcesCondenser'.
 		spec package: 'System-Support'.
 
 		spec package: 'UIManager'.
@@ -207,7 +206,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'CodeImport'.
 			'CodeImportCommandLineHandlers'.
 			'ClassDefinitionPrinters'.
-			'System-SourcesCondenser'.
 			'Debugging-Utils'.
 			'OpalCompiler-Core'}.
 		

--- a/src/System-SourcesCondenser/ManifestSystemSourcesCondenser.class.st
+++ b/src/System-SourcesCondenser/ManifestSystemSourcesCondenser.class.st
@@ -1,0 +1,12 @@
+"
+I an a package containing utils to condense source code in Pharo.
+
+Mostly I'm allowing to condence a .sources or .chances files to keep only the latest version of the code.
+"
+Class {
+	#name : 'ManifestSystemSourcesCondenser',
+	#superclass : 'PackageManifest',
+	#category : 'System-SourcesCondenser-Manifest',
+	#package : 'System-SourcesCondenser',
+	#tag : 'Manifest'
+}

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -89,6 +89,8 @@ PharoChangesCondenser >> fileIndex [
 
 { #category : 'initialization' }
 PharoChangesCondenser >> initialize [
+
+	super initialize.
 	self reset
 ]
 


### PR DESCRIPTION
System-SourcesCondenser is currently loaded by Hermes but is not used before the end of the bootstrap. I'm proposing to move this package to BaselineOfMisc in order to reduce the quantity of code loaded by hermes and increase the amount of code to load in the normal way,

I also added a missing super call and a package comment