### PR TITLE
Migrate about window to Spec

### DIFF
--- a/src/Morphic-Base/SmalltalkImage.extension.st
+++ b/src/Morphic-Base/SmalltalkImage.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : 'SmalltalkImage' }
-
-{ #category : '*Morphic-Base' }
-SmalltalkImage >> aboutThisSystem [
-	"Identify software version"
-
-	AboutDialogWindow openForPharo
-]

--- a/src/Morphic-Core/WorldState.class.st
+++ b/src/Morphic-Core/WorldState.class.st
@@ -123,6 +123,7 @@ WorldState class >> easySelectingWorld: aBoolean [
 
 { #category : 'world menu items' }
 WorldState class >> helpOn: aBuilder [
+
 	<worldMenu>
 	(aBuilder item: #Help)
 		order: 99;
@@ -130,12 +131,7 @@ WorldState class >> helpOn: aBuilder [
 		with: [
 			(aBuilder group: #PharoHelp)
 				order: 2;
-				withSeparatorAfter.
-			(aBuilder item: #'About...')
-				order: 99;
-				iconName: #smallInfo;
-				help: 'Informations about this version of Pharo.';
-				action: [ Smalltalk aboutThisSystem ] ]
+				withSeparatorAfter ]
 ]
 
 { #category : 'class initialization' }

--- a/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
@@ -157,7 +157,7 @@ SDLOSXPharoMenu >> allocatePharoMenuTarget [
 { #category : 'menu options' }
 SDLOSXPharoMenu >> doAbout [
 
-	UIManager default defer: [ Smalltalk aboutThisSystem ]
+	UIManager default defer: [ StPharoSettings openPharoAbout ]
 ]
 
 { #category : 'private' }

--- a/src/OSWindow-SDL2/SDL_Window.class.st
+++ b/src/OSWindow-SDL2/SDL_Window.class.st
@@ -37,14 +37,6 @@ SDL_Window >> createAcceleratedRenderer [
 ]
 
 { #category : 'rendering' }
-SDL_Window >> createDefaultRenderer [
-
-	^ self
-		  createRenderer: -1 "Find the first available rendering driver with the matching options"
-		  flags: OSPlatform current sdlPlatform defaultRendererFlags
-]
-
-{ #category : 'rendering' }
 SDL_Window >> createRenderer: driverIndex flags: flags [
 
 	^ (self primCreateRenderer: driverIndex flags: flags) initialize

--- a/src/Polymorph-Widgets/AboutDialogWindow.class.st
+++ b/src/Polymorph-Widgets/AboutDialogWindow.class.st
@@ -18,26 +18,6 @@ AboutDialogWindow class >> open [
 		yourself
 ]
 
-{ #category : 'instance creation' }
-AboutDialogWindow class >> openForPharo [
-	<script>
-	| text dialog width |
-	text := Smalltalk systemInformationString withCRs.
-	width := 0.
-	text
-		linesDo: [ :l |
-			width := width
-				max: (self theme textFont widthOfStringOrText: l) ].
-	dialog := self new entryText: text.
-	dialog iconMorph formSet: (self iconFormSetNamed: #pharo).
-	dialog title: 'About Pharo'.
-	dialog open.
-	dialog textMorph
-		minWidth: 20;
-		minHeight: 20.
-	dialog position: 25 @ 25
-]
-
 { #category : 'defaults' }
 AboutDialogWindow >> defaultLabel [
 	"Answer the default label for the receiver."


### PR DESCRIPTION
Requires https://github.com/pharo-spec/NewTools/pull/965

This change is moving the About window from Morphic to Spec

Fixes #17551