### PR TITLE
Fix minimize bug on windows

### DIFF
--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -432,8 +432,10 @@ TaskbarMorph >> updateTasks [
 	wm := self windows.
 	taskbarTasksFromWorldMorph := (wm collect: [ :m | m taskbarTask ])
 		                              reject: [ :task |
-		                              task isNil or: [
-			                              task morph visible not ] ].
+			                              task isNil or: [
+				                              SpClosedWindowListPresenter 
+					                              lastClosedWindows includes:
+					                              task morph  ] ] .
 
 	self tasks: taskbarTasksFromWorldMorph.
 	deadTasks := self orderedTasks difference: self tasks.

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -433,9 +433,7 @@ TaskbarMorph >> updateTasks [
 	taskbarTasksFromWorldMorph := (wm collect: [ :m | m taskbarTask ])
 		                              reject: [ :task |
 			                              task isNil or: [
-				                              SpClosedWindowListPresenter 
-					                              lastClosedWindows includes:
-					                              task morph  ] ] .
+				                              task morph extension otherProperties includes: 'isClosed' ] ] .
 
 	self tasks: taskbarTasksFromWorldMorph.
 	deadTasks := self orderedTasks difference: self tasks.

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -433,7 +433,7 @@ TaskbarMorph >> updateTasks [
 	taskbarTasksFromWorldMorph := (wm collect: [ :m | m taskbarTask ])
 		                              reject: [ :task |
 			                              task isNil or: [
-				                              task morph extension otherProperties includes: 'isClosed' ] ] .
+				                              task morph hasProperty: #isClosed] ] .
 
 	self tasks: taskbarTasksFromWorldMorph.
 	deadTasks := self orderedTasks difference: self tasks.

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -276,11 +276,16 @@ SystemWindow class >> closeBoxImage [
 
 { #category : 'top window' }
 SystemWindow class >> closeTopWindow [
+
+	| announcement |
 	"Try to close the top window.  It may of course decline"
 	TopWindow ifNotNil: [ :window |
 		TopWindow := nil.
-		window delete.
-	]
+		window hide.
+		announcement := WindowClosed new
+			                window: window;
+			                yourself.
+		self currentWorld announcer announce: announcement ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Minimised windows are hidden same as the "fake closed windows" so I was removing all hidden windows from the taskbar, now its only the closed windows.