### PR TITLE
[WIP] Fix windows tab shortcut

### DIFF
--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -119,13 +119,15 @@ Morph class >> morphNavigationShortcutsOn: aBuilder [
 
 	<keymap>
 	(aBuilder shortcut: #navigateFocusForwardCtrl)
-		category: #MorphFocusCtrlNavigation
+		category: #MorphNavigation
 		default: Character tab ctrl asKeyCombination
-		do: [ :target :morph :event | morph navigateFocusForward ].
+		do: [ :target :morph :event |
+			morph world theme openTaskListIn: morph world from: event ].
 	(aBuilder shortcut: #navigateFocusBackwardCtrl)
-		category: #MorphFocusCtrlNavigation
+		category: #MorphNavigation
 		default: Character tab shift ctrl asKeyCombination
-		do: [ :target :morph :event | morph navigateFocusBackward ].
+		do: [ :target :morph :event |
+			morph world theme openTaskListIn: morph world from: event ].
 	(aBuilder shortcut: #navigateFocusForward)
 		category: #MorphFocusNavigation
 		default: Character tab asKeyCombination

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -605,6 +605,14 @@ WorldMorph >> stopStepping: aMorph selector: aSelector [
 	worldState stopStepping: aMorph selector: aSelector
 ]
 
+{ #category : 'accessing' }
+WorldMorph >> taskbarTasks [
+
+	^ self submorphs
+		  collect: [ :m | m taskbarTask ]
+		  thenSelect: [ :m | m isNotNil ]
+]
+
 { #category : 'menu & halo' }
 WorldMorph >> truncatedMenuLabelFor: aWindowLabel [
 	^ aWindowLabel truncateWithElipsisTo: 47

--- a/src/Morphic-Widgets-Taskbar-Tests/TaskListMorphTest.class.st
+++ b/src/Morphic-Widgets-Taskbar-Tests/TaskListMorphTest.class.st
@@ -1,0 +1,68 @@
+Class {
+	#name : 'TaskListMorphTest',
+	#superclass : 'TaskMorphTest',
+	#instVars : [
+		'taskList'
+	],
+	#category : 'Morphic-Widgets-Taskbar-Tests',
+	#package : 'Morphic-Widgets-Taskbar-Tests'
+}
+
+{ #category : 'tests' }
+TaskListMorphTest >> setUp [
+
+	super setUp.
+	self registerTaskFor: SystemWindow new.
+	self registerTaskFor: SystemWindow new.
+	self registerTaskFor: SystemWindow new.
+
+	taskList := TaskListMorph new tasks: tasks
+]
+
+{ #category : 'tests' }
+TaskListMorphTest >> testHasAllWindows [
+
+	| newTask |
+	self assert: (taskList hasCurrentWindows: tasks).
+
+	newTask := self newTaskFor: SystemWindow new.
+	self deny: (taskList hasCurrentWindows: tasks , { newTask }).
+
+	self deny: (taskList hasCurrentWindows: tasks allButLast)
+]
+
+{ #category : 'tests' }
+TaskListMorphTest >> testSelectNextTask [
+
+	self assert: taskList activeTask equals: nil.
+
+	self task1 state: #active.
+	self assert: taskList activeTask equals: self task1.
+
+	taskList selectNextTask.
+	self assert: taskList activeTask equals: self task2.
+	
+	taskList selectNextTask.
+	self assert: taskList activeTask equals: self task3.
+	
+	taskList selectNextTask. "cycle"
+	self assert: taskList activeTask equals: self task1.
+]
+
+{ #category : 'tests' }
+TaskListMorphTest >> testSelectPreviousTask [
+
+	self assert: taskList activeTask equals: nil.
+
+	self task3 state: #active.
+	self assert: taskList activeTask equals: self task3.
+
+	taskList selectPreviousTask.
+	self assert: taskList activeTask equals: self task2.
+	
+	taskList selectPreviousTask.
+	self assert: taskList activeTask equals: self task1.
+	
+	taskList selectPreviousTask. "cycle"
+	self assert: taskList activeTask equals: self task3.
+]

--- a/src/Morphic-Widgets-Taskbar-Tests/TaskMorphTest.class.st
+++ b/src/Morphic-Widgets-Taskbar-Tests/TaskMorphTest.class.st
@@ -1,0 +1,56 @@
+Class {
+	#name : 'TaskMorphTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'tasks',
+		'windows'
+	],
+	#category : 'Morphic-Widgets-Taskbar-Tests',
+	#package : 'Morphic-Widgets-Taskbar-Tests'
+}
+
+{ #category : 'mocking taskbar' }
+TaskMorphTest >> newTaskFor: window [
+
+	^ TaskbarTask
+		  morph: window
+		  state: #aNilState
+		  icon: nil
+		  label: 'a Label'
+]
+
+{ #category : 'mocking taskbar' }
+TaskMorphTest >> registerTaskFor: window [
+
+	| task |
+	task := self newTaskFor: window.
+	windows add: window.
+	tasks add: task.
+	^ task
+]
+
+{ #category : 'running' }
+TaskMorphTest >> setUp [
+
+	super setUp.
+	windows := OrderedCollection new.
+	tasks := OrderedCollection new
+]
+
+{ #category : 'acceas' }
+TaskMorphTest >> task1 [
+
+	^ tasks first
+]
+
+{ #category : 'accessing' }
+TaskMorphTest >> task2 [
+
+	^ tasks second
+]
+
+{ #category : 'accessing' }
+TaskMorphTest >> task3 [
+
+	^ tasks third
+]

--- a/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
+++ b/src/Morphic-Widgets-Taskbar-Tests/TaskbarMorphTest.class.st
@@ -3,12 +3,10 @@ A TaskbarMorphTest is a test class for testing the behavior of TaskbarMorph
 "
 Class {
 	#name : 'TaskbarMorphTest',
-	#superclass : 'TestCase',
+	#superclass : 'TaskMorphTest',
 	#instVars : [
 		'taskbar',
-		'world',
-		'windows',
-		'tasks'
+		'world'
 	],
 	#category : 'Morphic-Widgets-Taskbar-Tests',
 	#package : 'Morphic-Widgets-Taskbar-Tests'
@@ -19,8 +17,8 @@ TaskbarMorphTest >> addTaskWithWindow [
 
 	| newTask morph |
 	morph := SystemWindow new.
-	newTask := taskbar newTaskFor: morph.
-	self orderedTasks add: newTask.
+	newTask := self newTaskFor: morph.
+"	self orderedTasks add: newTask."
 	^ newTask
 ]
 
@@ -35,15 +33,6 @@ TaskbarMorphTest >> addWindowToWorld [
 	morph := Morph new.
 	windows add: morph.
 	^morph
-]
-
-{ #category : 'mocking taskbar' }
-TaskbarMorphTest >> newTaskFor: window [
-	^ TaskbarTask
-		morph: window
-		state: #aNilState
-		icon: nil
-		label: 'a Label'
 ]
 
 { #category : 'mocking taskbar' }
@@ -65,14 +54,6 @@ TaskbarMorphTest >> putOnTop: aMorph [
 { #category : 'mocking world' }
 TaskbarMorphTest >> removeWindow: aMorph [
 	windows remove: aMorph
-]
-
-{ #category : 'running' }
-TaskbarMorphTest >> setUp [
-	super setUp.
-	windows := OrderedCollection new.
-	tasks := OrderedCollection new.
-	self theMethodInProdThatShouldBeTested
 ]
 
 { #category : 'mocking taskbar' }

--- a/src/Morphic-Widgets-Taskbar/TaskListMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskListMorph.class.st
@@ -110,6 +110,13 @@ TaskListMorph >> handlesKeyboard: evt [
 	^true
 ]
 
+{ #category : 'testing' }
+TaskListMorph >> hasAllWindows [
+
+	^ self tasks includesAll: self currentWorld taskbarTasks
+
+]
+
 { #category : 'initialization' }
 TaskListMorph >> initialize [
 	"Initialize the receiver."
@@ -151,9 +158,7 @@ TaskListMorph >> initializeLayout [
 TaskListMorph >> initializeTasks [
 	"Set up the current tasks."
 
-	self tasks: ((self currentWorld submorphs
-		collect: [:m | m taskbarTask])
-		select: [:m | m isNotNil]) asOrderedCollection
+	self tasks: self currentWorld taskbarTasks
 ]
 
 { #category : 'settings' }

--- a/src/Morphic-Widgets-Taskbar/TaskListMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskListMorph.class.st
@@ -100,10 +100,10 @@ TaskListMorph >> handlesKeyboard: evt [
 ]
 
 { #category : 'testing' }
-TaskListMorph >> hasAllWindows [
+TaskListMorph >> hasCurrentWindows: currentTasks [
 
-	^ self tasks includesAll: self currentWorld taskbarTasks
-
+	^ (self tasks includesAll: currentTasks) and: [
+		  currentTasks includesAll: self tasks ]
 ]
 
 { #category : 'initialization' }

--- a/src/Morphic-Widgets-Taskbar/TaskListMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskListMorph.class.st
@@ -17,17 +17,6 @@ Class {
 	#package : 'Morphic-Widgets-Taskbar'
 }
 
-{ #category : 'instance creation' }
-TaskListMorph class >> from: aKeyboardEvent [
-
-	| instance |
-	instance := self new.
-	aKeyboardEvent shiftPressed
-		ifTrue: [ instance selectNextTask ]
-		ifFalse: [ instance selectPreviousTask ].
-	^ instance
-]
-
 { #category : 'testing' }
 TaskListMorph class >> isNavigationEvent: aKeyboardEvent [
 

--- a/src/Morphic-Widgets-Taskbar/UITheme.extension.st
+++ b/src/Morphic-Widgets-Taskbar/UITheme.extension.st
@@ -40,7 +40,15 @@ UITheme >> newBasicTaskbarButtonIn: aTaskbar for: aMorph [
 { #category : '*Morphic-Widgets-Taskbar' }
 UITheme >> openTaskListIn: world from: aKeyboardEvent [
 
-	| tasklistMorph |
-	tasklistMorph := TaskListMorph from: aKeyboardEvent.
+	tasklistMorph
+		ifNil: [ tasklistMorph := TaskListMorph new ]
+		ifNotNil: [
+			tasklistMorph hasAllWindows ifFalse: [
+				tasklistMorph := TaskListMorph new ] ].
+
+	aKeyboardEvent shiftPressed
+		ifTrue: [ tasklistMorph selectNextTask ]
+		ifFalse: [ tasklistMorph selectPreviousTask ].
+
 	tasklistMorph openInWorld: world
 ]

--- a/src/Morphic-Widgets-Taskbar/UITheme.extension.st
+++ b/src/Morphic-Widgets-Taskbar/UITheme.extension.st
@@ -43,8 +43,8 @@ UITheme >> openTaskListIn: world from: aKeyboardEvent [
 	tasklistMorph
 		ifNil: [ tasklistMorph := TaskListMorph new ]
 		ifNotNil: [
-			tasklistMorph hasAllWindows ifFalse: [
-				tasklistMorph := TaskListMorph new ] ].
+			(tasklistMorph hasCurrentWindows: self currentWorld taskbarTasks)
+				ifFalse: [ tasklistMorph := TaskListMorph new ] ].
 
 	aKeyboardEvent shiftPressed
 		ifTrue: [ tasklistMorph selectNextTask ]

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -23,7 +23,8 @@ Class {
 		'focusIndicator',
 		'windowActiveDropShadowStyle',
 		'useScrollbarThumbShadow',
-		'colorPalette'
+		'colorPalette',
+		'tasklistMorph'
 	],
 	#classVars : [
 		'Builder',


### PR DESCRIPTION
### This PR goes to pharo-12, I'll port it to pharo-13 also. But I need to reproduce this behaviour in a new image.

## Before

- `Ctrl + Tab` -> change the keyboard focus inside the windows (even from text boxes).
- `Option + Tab` -> change the window, _but_ it does not work from a text box (it writes a tab instead).

## Now

- `Tab` -> change the keyboard focus inside the windows, _except_ for text boxes (it writes a tab instead).
- `Ctrl + Tab` -> change the window, _always_ 🎉 
- `Option + Tab` -> Keep the same behaviour (I didn't want to change more things).

And everything works with the `Shift` button to control _next - previous_.
