### PR TITLE
Calypso: Allow definition of shared variables when using the class definition tab as a regular code editor

### DIFF
--- a/src/Calypso-Browser/ClyTextEditingMode.class.st
+++ b/src/Calypso-Browser/ClyTextEditingMode.class.st
@@ -12,7 +12,6 @@ Class {
 	#name : 'ClyTextEditingMode',
 	#superclass : 'RubSmalltalkCodeMode',
 	#instVars : [
-		'isForScripting',
 		'browserTool'
 	],
 	#category : 'Calypso-Browser-TextEditors',
@@ -46,25 +45,13 @@ ClyTextEditingMode >> editorClass [
 	^ClyTextEditor
 ]
 
-{ #category : 'initialization' }
-ClyTextEditingMode >> initialize [
-	super initialize.
-
-	isForScripting := false
-]
-
 { #category : 'testing' }
 ClyTextEditingMode >> isScripting [
-	^ isForScripting
+	^ browserTool isScripting
 ]
 
-{ #category : 'accessing' }
-ClyTextEditingMode >> isScripting: anObject [
-	isForScripting := anObject
-]
-
-{ #category : 'initialization' }
+{ #category : 'update' }
 ClyTextEditingMode >> updateTextAreaWhenPlugged [
 	super updateTextAreaWhenPlugged.
-	isForScripting ifTrue: [ self textArea shoutStyler beForSmalltalkScripting]
+	self isScripting ifTrue: [ self textArea shoutStyler beForSmalltalkScripting ]
 ]

--- a/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
+++ b/src/Calypso-Browser/ClyTextEditorToolMorph.class.st
@@ -188,8 +188,7 @@ ClyTextEditorToolMorph >> editingMode [
 	| editingMode |
 	editingMode := ClyTextEditingMode browserTool: self.
 	editingMode
-		classOrMetaClass: self selectedClassOrMetaClass;
-		isScripting: self isScripting.
+		classOrMetaClass: self selectedClassOrMetaClass.
 	^editingMode
 ]
 

--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionEditorToolMorph.class.st
@@ -25,7 +25,7 @@ ClyClassDefinitionEditorToolMorph >> applyChanges [
 			'The class definition used is the old Pharo class definition. Now the Fluid class definition should be used. Check the comment of ShiftClassBuilder to know the syntax.'.
 		^ self applyChangesAsOldClassDefinition: ast ].
 
-	^ (code asString lines first includesSubstring: '<<')
+	^ (self codeLooksLikeAClassDefinition: code)
 		  ifTrue: [ self applyChangesAsClassDefinition ]
 		  ifFalse: [
 			  self pendingText: code copy. "no idea why we have to copy"
@@ -77,6 +77,12 @@ ClyClassDefinitionEditorToolMorph >> applyChangesAsOldClassDefinition: ast [
 	^ true
 ]
 
+{ #category : 'operations' }
+ClyClassDefinitionEditorToolMorph >> codeLooksLikeAClassDefinition: code [
+
+	^ code isEmpty or: [ code asString lines first includesSubstring: '<<' ]
+]
+
 { #category : 'to sort' }
 ClyClassDefinitionEditorToolMorph >> createTextContext [
 	^self selectedSourceNode
@@ -114,6 +120,11 @@ ClyClassDefinitionEditorToolMorph >> editingText [
 ClyClassDefinitionEditorToolMorph >> isCommandAvailable: aCommand [
 
 	^ aCommand canBeExecutedInClassEditor: self
+]
+
+{ #category : 'rubric interaction model' }
+ClyClassDefinitionEditorToolMorph >> isScripting [
+	^ self codeLooksLikeAClassDefinition: self pendingText.
 ]
 
 { #category : 'to sort' }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -276,16 +276,11 @@ SystemWindow class >> closeBoxImage [
 
 { #category : 'top window' }
 SystemWindow class >> closeTopWindow [
-
-	| announcement |
 	"Try to close the top window.  It may of course decline"
 	TopWindow ifNotNil: [ :window |
 		TopWindow := nil.
-		window hide.
-		announcement := WindowClosed new
-			                window: window;
-			                yourself.
-		self currentWorld announcer announce: announcement ]
+		window delete.
+	]
 ]
 
 { #category : 'accessing' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -1206,7 +1206,6 @@ UITheme >> createCloseBoxFor: aSystemWindow [
 			   self currentWorld announcer announce: announcement ]
 		   help: 'Close this window' translated) extent:
 		  aSystemWindow boxExtent
-
 ]
 
 { #category : 'label-styles' }


### PR DESCRIPTION
For this change we make ClyTextEditingMode ask the browser tool if it is in "scripting" or "method" mode. We also remove the cached `isForScripting` instance variable.

FInally we extract the current heuristic for wether the code of a class definition tab refers to a class defition or a method into `#codeLooksLikeAClassDefinition:`

Made during the january pharo sprint with @matijakljajic

This fixes #17716