### PR TITLE
Update version in #spec for BaselineOfPharo for Pharo 11 to ‘v1.2.6’

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -143,7 +143,7 @@ BaselineOfPharo class >> spec [
 		newName: 'Spec2' 
 		owner: 'pharo-spec' 
 		project:'Spec' 
-		version: 'v1.2.5'
+		version: 'v1.2.6'
 ]
 
 { #category : #'repository urls' }


### PR DESCRIPTION
This pull request updates the version in #spec for BaselineOfPharo for Pharo 11 to ‘v1.2.6’. Before this can be merged, a corresponding tag referring to [commit f8c9b76fb5672ae5](https://github.com/pharo-spec/Spec/commit/f8c9b76fb5672ae5c514a12c9412c8d16b2eee81) (which the [‘Pharo11’ branch](https://github.com/pharo-spec/Spec/tree/Pharo11) currently refers to) needs to added.