### PR TITLE
Branch: 17672-Rename-formatter-in-EFtests-to-avoid-spurious-sender-clash

### DIFF
--- a/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
@@ -583,7 +583,7 @@ EFBlockExpressionTest >> testNoExtraSpaceAroundBlock [
 	| expr source |
 	expr := self parserClass parseExpression: '   ', self openBracket, '2', self closeBracket, '   '.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: self openBracket, ' 2 ', self closeBracket
 ]
 
@@ -744,6 +744,6 @@ EFBlockExpressionTest >> validate: stringInsideBlock isFormattedAs: expectedStri
 	| expr source |
 	expr := self parserClass parseExpression: self openBracket , stringInsideBlock, self closeBracket.
 	configurationSelector := aConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: self openBracket , expectedStringInsideBlock , self closeBracket
 ]

--- a/src/EnlumineurFormatter-Tests/EFFFICallTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFFFICallTest.class.st
@@ -37,7 +37,7 @@ EFFFICallTest >> testOtherFFI [
 	'.
 	expr := OCParser parseMethod: originalSource.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: originalSource
 ]
 
@@ -50,7 +50,7 @@ EFFFICallTest >> testOtherFFI2 [
 	'.
 	expr := OCParser parseMethod: originalSource.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: originalSource
 ]
 
@@ -70,7 +70,7 @@ EFFFICallTest >> testOtherFFI3 [
 				double anOffset) )	'.
 	expr := OCParser parseMethod: originalSource.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: originalSource
 ]
 
@@ -83,7 +83,7 @@ EFFFICallTest >> testSimpleFFI [
 	'.
 	expr := OCParser parseMethod: originalSource. 
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: originalSource
 ]
 
@@ -99,7 +99,7 @@ EFFFICallTest >> testSimpleFFISafelyOptions [
 		options: #()'.
 	expr := OCParser parseMethod: originalSource. 
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: originalSource
 ]
 
@@ -117,6 +117,6 @@ EFFFICallTest >> testSimpleFFISafelyOptions2 [
 		options: #()'.
 	expr := OCParser parseMethod: originalSource. 
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: originalSource
 ]

--- a/src/EnlumineurFormatter-Tests/EFLiteralValueExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFLiteralValueExpressionTest.class.st
@@ -26,7 +26,7 @@ EFLiteralValueExpressionTest >> testNotLitteral [
 	| expr source |
 	expr := OCLiteralValueNode value: Object.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: '''<an unprintable nonliteral value>'''
 ]
 

--- a/src/EnlumineurFormatter-Tests/EFMethodExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFMethodExpressionTest.class.st
@@ -279,7 +279,7 @@ EFMethodExpressionTest >> testBasic [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethod <pragma> "aComment" body'.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethod
 	"aComment"
@@ -292,7 +292,7 @@ EFMethodExpressionTest >> testBasic2 [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethod <pragma1> <pragma2> "aComment1" "aComment2"  body'.
 	configurationSelector := #newLineBetweenTopCommentsConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethod
 	"aComment1"
@@ -307,7 +307,7 @@ EFMethodExpressionTest >> testBasicSpaceIndent [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethod <pragma> "aComment" body'.
 	configurationSelector := #spaceIndentConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethod
           "aComment"
@@ -328,7 +328,7 @@ EFMethodExpressionTest >> testBigMethod [
 	tmp to: 10 do: [:i | Transcript show:i ; cr ;cr]
 	'.
 	configurationSelector := #bigMethodeConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	"aComment"
@@ -349,7 +349,7 @@ EFMethodExpressionTest >> testCommentBasicFormat [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode "   aComment   "'.
 	configurationSelector := #basicCommentFormatConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	"   aComment   "
@@ -361,7 +361,7 @@ EFMethodExpressionTest >> testCommentNotBasicFormat [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode "   aComment   "'.
 	configurationSelector := #notBasicCommentFormatConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	"aComment   "
@@ -373,7 +373,7 @@ EFMethodExpressionTest >> testFormatBody [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode a:=1'.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	a := 1'
@@ -384,7 +384,7 @@ EFMethodExpressionTest >> testIndentCascade [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode	Transcript cr; show: ''foo'';	cr. Transcript cr;cr'.
 	configurationSelector := #cascadeConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	Transcript
@@ -405,7 +405,7 @@ EFMethodExpressionTest >> testMethodWithMessageArgument [
 	1 to: 10 do: [:i | Transcript show:i ; cr ;cr]
 	'.
 	configurationSelector := #bigMethodeConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethod
 	1 to: 10 do: [:i |
@@ -421,7 +421,7 @@ EFMethodExpressionTest >> testNewLinesAfterComment [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode "aComment"'.
 	configurationSelector := #oneNewLineAfterCommentConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	"aComment"
@@ -434,7 +434,7 @@ EFMethodExpressionTest >> testNewLinesAfterComment2 [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode "aComment" "anotherComment"'.
 	configurationSelector := #oneNewLineAfterCommentConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	"aComment"
@@ -449,7 +449,7 @@ EFMethodExpressionTest >> testNewLinesAfterGluedComment [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode"aComment""anotherComment"'.
 	configurationSelector := #oneNewLineAfterCommentConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	"aComment""anotherComment"
@@ -462,7 +462,7 @@ EFMethodExpressionTest >> testNewLinesBetweenTopComments [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode "aComment" "anotherComment"'.
 	configurationSelector := #newLineBetweenTopCommentsConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	"aComment"
@@ -475,7 +475,7 @@ EFMethodExpressionTest >> testNoNewLinesAfterComment [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode "aComment"'.
 	configurationSelector := #basicCommentFormatConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	"aComment"
@@ -487,7 +487,7 @@ EFMethodExpressionTest >> testNoNewLinesAfterGluedComment [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode "aComment""anotherComment"'.
 	configurationSelector := #noNewLinesAfterCommentConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	"aComment""anotherComment"
@@ -499,7 +499,7 @@ EFMethodExpressionTest >> testNoNewLinesAfterSignature [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode'.
 	configurationSelector := #signatureConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	'
@@ -510,7 +510,7 @@ EFMethodExpressionTest >> testNoNewLinesBetweenTopComments [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode "aComment" "anotherComment"'.
 	configurationSelector := #noNewLineBetweenTopCommentsConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	"aComment"	"anotherComment"	'
@@ -521,7 +521,7 @@ EFMethodExpressionTest >> testOneNewLinesAfterSignature [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode'.
 	configurationSelector := #oneNewLineAfterCommentConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	'
@@ -532,7 +532,7 @@ EFMethodExpressionTest >> testPragma [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode <pragma>'.
 	configurationSelector := #notBasicCommentFormatConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	<pragma>
@@ -544,7 +544,7 @@ EFMethodExpressionTest >> testSignatureNotOnMultipleLines [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode:arg1 foo:arg2'.
 	configurationSelector := #signatureNotOnMultipleLinesConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode: arg1 foo: arg2
 	'
@@ -555,7 +555,7 @@ EFMethodExpressionTest >> testSignatureOnMultipleLines [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode: arg1 foo:arg2'.
 	configurationSelector := #signatureOnMultipleLinesConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode: arg1
 	foo: arg2
@@ -567,7 +567,7 @@ EFMethodExpressionTest >> testSignatureWithArgument [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode:arg'.
 	configurationSelector := #signatureNotOnMultipleLinesConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode: arg
 	'
@@ -578,7 +578,7 @@ EFMethodExpressionTest >> testSignatureWithoutArgument [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode'.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 	'
@@ -589,7 +589,7 @@ EFMethodExpressionTest >> testTwoNewLinesAfterSignature [
 	| expr source |
 	expr := OCParser parseMethod: 'aMethode'.
 	configurationSelector := #twoNewLinesAfterSignatureConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals:
 'aMethode
 

--- a/src/EnlumineurFormatter-Tests/EFParseErrorExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFParseErrorExpressionTest.class.st
@@ -22,7 +22,7 @@ EFParseErrorExpressionTest >> testParseError [
 	| expr source |
 	expr := OCParser parseFaultyExpression: '#(1 3 4'.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: '#( 1 3 4'
 ]
 
@@ -32,6 +32,6 @@ EFParseErrorExpressionTest >> testParseError2 [
 	| expr source |
 	expr := OCParser parseFaultyExpression: '1 := '.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: '1. := '
 ]

--- a/src/EnlumineurFormatter-Tests/EFPragmaExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFPragmaExpressionTest.class.st
@@ -19,7 +19,7 @@ EFPragmaExpressionTest >> testPragmaNoExtraSpace [
 	| expr source |
 	expr := OCParser parsePragma:'<   Pragma   >'.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: '<Pragma>'
 ]
 
@@ -28,7 +28,7 @@ EFPragmaExpressionTest >> testPragmaNoExtraSpace2 [
 	| expr source |
 	expr := OCParser parsePragma:'<func:     ''(3+4)''       res:      7>'.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: '<func: ''(3+4)'' res: 7>'
 ]
 
@@ -37,6 +37,6 @@ EFPragmaExpressionTest >> testPragmaNoExtraSpaceBetweenMethodeAndArgument [
 	| expr source |
 	expr := OCParser parsePragma:'<primitive:    41>'.
 	configurationSelector := #basicConfiguration.
-	source := self formatter format: expr.
+	source := self newFormatter format: expr.
 	self assert: source equals: '<primitive: 41>'
 ]

--- a/src/EnlumineurFormatter-Tests/EFTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFTest.class.st
@@ -38,14 +38,7 @@ EFTest >> formatExpression: anExpression [
 
 	| expr |
 	expr := self parseExpression: anExpression.
-	^ self formatter format: expr.
-]
-
-{ #category : 'hooks' }
-EFTest >> formatter [
-	^ self formatterClass new
-		installNewContext: (self perform: configurationSelector)
-		yourself
+	^ self newFormatter format: expr.
 ]
 
 { #category : 'hooks' }
@@ -57,6 +50,13 @@ EFTest >> formatterClass [
 { #category : 'hooks' }
 EFTest >> formatterClass: aFormatterClass [
 	formatterClass := aFormatterClass
+]
+
+{ #category : 'hooks' }
+EFTest >> newFormatter [
+	^ self formatterClass new
+		installNewContext: (self perform: configurationSelector)
+		yourself
 ]
 
 { #category : 'hooks' }


### PR DESCRIPTION
- formatter -> newFormatter to avoid clash with formatter message