### PR TITLE
Remove String>>isValidSelector

### DIFF
--- a/src/AST-Core-Tests/OCScannerTest.class.st
+++ b/src/AST-Core-Tests/OCScannerTest.class.st
@@ -85,6 +85,12 @@ OCScannerTest >> testCommentTokenStopAtLastQuote [
 	self assert: token stop equals: (str findString: comment) + comment size - 1
 ]
 
+{ #category : 'tests - isSelector' }
+OCScannerTest >> testIsValidSelector [
+	self assert: (OCScanner isSelector: 'class').
+	self deny: (OCScanner isSelector: '0class')
+]
+
 { #category : 'tests - Comment' }
 OCScannerTest >> testMultipleCommentTokensAreWellSeparated [
 	| scanner token comments |

--- a/src/AST-Core/OCLiteralToken.class.st
+++ b/src/AST-Core/OCLiteralToken.class.st
@@ -80,7 +80,7 @@ OCLiteralToken >> storeOn: aStream [
 	value isSymbol
 		ifTrue:
 			[aStream nextPut: $#.
-			(value isValidSelector and: [value ~~ #'||'])
+			((OCScanner isSelector: value) and: [value ~~ #'||'])
 				ifTrue: [aStream nextPutAll: value]
 				ifFalse: [value asString printOn: aStream].
 			^self].

--- a/src/AST-Core/OCScanner.class.st
+++ b/src/AST-Core/OCScanner.class.st
@@ -160,8 +160,11 @@ OCScanner class >> patternVariableCharacter [
 OCScanner class >> scanTokenObjects: aStringOrStream [
 	"Return the tokens objects."
 
-	self deprecated: 'Use scanTokens:' on: '18/12/2024'  in: #pharo13  transformWith:  '`@receiver scanTokenObjects: `@arg '
-						-> '`@receiver scanTokens: `@arg '.
+	self deprecated: 'Use scanTokens:' 
+		on: '18/12/2024'  
+		in: 'pharo13'
+		transformWith:  '`@receiver scanTokenObjects: `@arg '
+			-> '`@receiver scanTokens: `@arg '.
 	^ self scanTokens: aStringOrStream
 ]
 

--- a/src/AST-Core/String.extension.st
+++ b/src/AST-Core/String.extension.st
@@ -4,5 +4,10 @@ Extension { #name : 'String' }
 String >> isValidSelector [
 	"check I could be a valid selector (name of method).
 	 For checking if there is symbol like me used as a selector, see #isSelectorSymbol on Symbol"
+
+	self deprecated: 'Use OCScanner isSelector: ' 
+		on: '02/02/2025'  
+		in: 'pharo13' 
+		transformWith: '`@rec isValidSelector' -> 'OCScanner isSelector: `@arg'.
 	^ OCScanner isSelector: self
 ]

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1452,12 +1452,6 @@ StringTest >> testIsPatternVariable [
 	self deny: 'notAPattern' isPatternVariable
 ]
 
-{ #category : 'tests - testing' }
-StringTest >> testIsValidSelector [
-	self assert: 'class' isValidSelector.
-	self deny: '0class' isValidSelector
-]
-
 { #category : 'tests' }
 StringTest >> testIsWideString [
 

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -483,6 +483,8 @@ Symbol >> isOrientedFill [
 
 { #category : 'testing' }
 Symbol >> isSelectorSymbol [
+	"Returns whether the receiving symbol is used as a method selector."
+	
 	^ self class selectorTable includes: self
 ]
 

--- a/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
+++ b/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
@@ -73,7 +73,7 @@ CompiledMethodTest >> deprecatedMethod4 [
 
 		deprecated: 'Example of a deprecated method with transform'
 		on: '01/01/1970'
-		in: #Pharo6
+		in: 'pharoX'
 		transformWith: '`@receiver deprecatedMethod4'
 						-> '`@receiver deprecatedMethod4'
 ]

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -4475,7 +4475,7 @@ Morph >> on: aShortcut do: anAction [
 	self
 		deprecated: 'Use bindKeyCombination:toAction:'
 		on: '16/11/2024'
-		in: #Pharo13
+		in: 'pharo13'
 		transformWith: '`@receiver on: `@aShortcut do: `@anAction'
 						-> '`@receiver bindKeyCombination: `@aShortcut toAction: `@anAction'.
 						

--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -583,7 +583,7 @@ WorldMorph >> scaleFactor: newZoomFactor [
 	self
 		deprecated: 'Use #zoomFactor: instead'
 		on: '20/12/2024'
-		in: #Pharo13
+		in: 'pharo13'
 		transformWith:
 		'`@receiver scaleFactor: `@arg' -> '`@receiver zoomFactor: `@arg'.
 	self zoomFactor: newZoomFactor

--- a/src/Refactoring-Core-Tests/RBConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/RBConditionTest.class.st
@@ -54,19 +54,19 @@ RBConditionTest >> testCheckFailEarlyAndDoesNotCoverEveryConditions [
 RBConditionTest >> testCheckInvalidMethodName [
 	"Usually used to validate input."
 
-	self deny: (RBCondition checkMethodName: 'fofo fo').
-	self deny: (RBCondition checkMethodName: '123fofo').
-	self deny: (RBCondition checkMethodName: 'foo::').
-	self deny: (RBCondition checkMethodName: 'agr:goo:aa').
-	self deny: (RBCondition checkMethodName: 'foo:123:').
-	self deny: (RBCondition checkMethodName: 'foo[arg]').
-	self deny: (RBCondition checkMethodName: 'foo:=arg').
-	self deny: (RBCondition checkMethodName: 'foo:arg)').
-	self deny: (RBCondition checkMethodName: 'foo:(arg)').
-	self deny: (RBCondition checkMethodName: 'foo:+arg)').
-	self deny: (RBCondition checkMethodName: '<<foo:<<arg)').
-	self deny: (RBCondition checkMethodName: 'foo:agr^:').
-	self deny: (RBCondition checkMethodName: 'foo:agr')
+	self deny: (RBCondition isValidSelector: 'fofo fo') check.
+	self deny: (RBCondition isValidSelector: '123fofo') check.
+	self deny: (RBCondition isValidSelector: 'foo::') check.
+	self deny: (RBCondition isValidSelector: 'agr:goo:aa') check.
+	self deny: (RBCondition isValidSelector: 'foo:123:') check.
+	self deny: (RBCondition isValidSelector: 'foo[arg]') check.
+	self deny: (RBCondition isValidSelector: 'foo:=arg') check.
+	self deny: (RBCondition isValidSelector: 'foo:arg)') check.
+	self deny: (RBCondition isValidSelector: 'foo:(arg)') check.
+	self deny: (RBCondition isValidSelector: 'foo:+arg)') check.
+	self deny: (RBCondition isValidSelector: '<<foo:<<arg)') check.
+	self deny: (RBCondition isValidSelector: 'foo:agr^:') check.
+	self deny: (RBCondition isValidSelector: 'foo:agr') check
 ]
 
 { #category : 'tests' }
@@ -118,10 +118,10 @@ RBConditionTest >> testCheckThatOnlyFailingConditionErrorIsReportedTrueCaseFirst
 { #category : 'tests' }
 RBConditionTest >> testCheckValidMethodName [
 	"Usually used to validate input."
-	self assert: (RBCondition checkMethodName: 'foo').
-	self assert: (RBCondition checkMethodName: #foo).
-
-	self assert: (RBCondition checkMethodName: #+)
+	
+	self assert: (RBCondition isValidSelector: 'foo') check.
+	self assert: (RBCondition isValidSelector: #foo) check.
+	self assert: (RBCondition isValidSelector: #+) check
 ]
 
 { #category : 'tests - references' }

--- a/src/Refactoring-Core/RBAbstractCondition.class.st
+++ b/src/Refactoring-Core/RBAbstractCondition.class.st
@@ -22,6 +22,17 @@ Class {
 	#tag : 'Conditions'
 }
 
+{ #category : 'testing' }
+RBAbstractCondition class >> isValidSelector: aString [
+	"Check that aString is a valid selector (name of method).
+	 For checking if there is symbol like me used as a selector, see Symbol>>#isSelectorSymbol"
+
+	^ self new
+		  block: [ OCScanner isSelector: aString ]
+		  errorString:
+		  aString printString , ' is <1?:not >a valid method name'
+]
+
 { #category : 'logical operations' }
 RBAbstractCondition >> & aCondition [
 	^RBConjunctiveCondition new left: self right: aCondition
@@ -51,6 +62,14 @@ RBAbstractCondition >> errorString [
 { #category : 'private' }
 RBAbstractCondition >> errorStringFor: aBoolean [
 	^self errorMacro expandMacrosWith: aBoolean
+]
+
+{ #category : 'testing' }
+RBAbstractCondition >> isValidSelector: aString [
+	"Check that aString is a valid selector (name of method).
+	 For checking if there is symbol like me used as a selector, see Symbol>>#isSelectorSymbol"
+
+	^ OCScanner isSelector: aString 
 ]
 
 { #category : 'logical operations' }

--- a/src/Refactoring-Core/RBAbstractCondition.class.st
+++ b/src/Refactoring-Core/RBAbstractCondition.class.st
@@ -22,17 +22,6 @@ Class {
 	#tag : 'Conditions'
 }
 
-{ #category : 'testing' }
-RBAbstractCondition class >> isValidSelector: aString [
-	"Check that aString is a valid selector (name of method).
-	 For checking if there is symbol like me used as a selector, see Symbol>>#isSelectorSymbol"
-
-	^ self new
-		  block: [ OCScanner isSelector: aString ]
-		  errorString:
-		  aString printString , ' is <1?:not >a valid method name'
-]
-
 { #category : 'logical operations' }
 RBAbstractCondition >> & aCondition [
 	^RBConjunctiveCondition new left: self right: aCondition
@@ -62,14 +51,6 @@ RBAbstractCondition >> errorString [
 { #category : 'private' }
 RBAbstractCondition >> errorStringFor: aBoolean [
 	^self errorMacro expandMacrosWith: aBoolean
-]
-
-{ #category : 'testing' }
-RBAbstractCondition >> isValidSelector: aString [
-	"Check that aString is a valid selector (name of method).
-	 For checking if there is symbol like me used as a selector, see Symbol>>#isSelectorSymbol"
-
-	^ OCScanner isSelector: aString 
 ]
 
 { #category : 'logical operations' }

--- a/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
+++ b/src/Refactoring-Core/RBChangeMethodNameRefactoring.class.st
@@ -78,7 +78,7 @@ RBChangeMethodNameRefactoring >> implementorsCanBePrimitives [
 
 { #category : 'preconditions' }
 RBChangeMethodNameRefactoring >> isValidMethodNamePrecondition [
-	^ (RBCondition isValidMethodName: newSelector for: class)
+	^ RBCondition isValidSelector: newSelector
 
 	
 ]

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -320,11 +320,13 @@ RBCondition class >> isValidInstanceVariableName: aString for: aClass [
 		  aString , ' is <1?:not >a valid instance variable name'
 ]
 
-{ #category : 'instance creation' }
-RBCondition class >> isValidMethodName: aString for: aClass [
+{ #category : 'testing' }
+RBCondition class >> isValidSelector: aString [
+	"Check that aString is a valid selector (name of method).
+	 For checking if there is symbol like me used as a selector, see Symbol>>#isSelectorSymbol"
 
 	^ self new
-		  block: [ self isValidSelector: aString ]
+		  block: [ OCScanner isSelector: aString ]
 		  errorString:
 		  aString printString , ' is <1?:not >a valid method name'
 ]

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -56,21 +56,6 @@ RBCondition class >> checkInstanceVariableName: aName in: aClass [
 	^ OCScanner isVariable: string
 ]
 
-{ #category : 'utilities' }
-RBCondition class >> checkMethodName: aString [
-	"Return whether the argument aName is can represent a selector"
-
-	^ aString isString and: [ aString isValidSelector ]
-]
-
-{ #category : 'utilities' }
-RBCondition class >> checkMethodName: aString in: aClass [
-	"Return whether the argument aName is can represent a selector"
-	"You probably look for checkMethodName: since the second argument is ignored"
-
-	^aString isString and: [ aString isValidSelector ]
-]
-
 { #category : 'instance creation' }
 RBCondition class >> definesClassVariable: aString in: aClass [
 	^self new
@@ -339,7 +324,7 @@ RBCondition class >> isValidInstanceVariableName: aString for: aClass [
 RBCondition class >> isValidMethodName: aString for: aClass [
 
 	^ self new
-		  block: [ self checkMethodName: aString in: aClass ]
+		  block: [ self isValidSelector: aString ]
 		  errorString:
 		  aString printString , ' is <1?:not >a valid method name'
 ]

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -322,9 +322,12 @@ RBCondition class >> isValidInstanceVariableName: aString for: aClass [
 
 { #category : 'testing' }
 RBCondition class >> isValidSelector: aString [
-	"Check that aString is a valid selector (name of method).
-	 For checking if there is symbol like me used as a selector, see Symbol>>#isSelectorSymbol"
-
+	"Returns a Condition that checks that aString is a valid selector (name of method)."
+	
+	"Pay attention this class side method returns an RBCondition object,
+	while Refactoring>> isValidSelector: retuns a boolean. 
+	In the future we may want to have two different names for this two methods."
+	
 	^ self new
 		  block: [ OCScanner isSelector: aString ]
 		  errorString:

--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -306,7 +306,7 @@ RBExtractMethodRefactoring >> getNewMethodName [
 	[newMethodName := self requestMethodNameFor: methodName.
 	newMethodName ifNil: [self refactoringError: 'Did not extract code'].
 	newSelector := newMethodName selector.
-	(self checkMethodName: newSelector in: class)
+	(self isValidSelector: newSelector)
 		ifFalse:
 			[self refactoringWarning: newSelector , ' is not a valid selector name.'.
 			newSelector := nil].

--- a/src/Refactoring-Core/RBMethod.class.st
+++ b/src/Refactoring-Core/RBMethod.class.st
@@ -207,7 +207,7 @@ RBMethod >> refersToSymbol: aSymbol [
 		matches: '`#literal'
 			do:
 				[ :node :answer | answer or: [ self literal: node value containsReferenceTo: aSymbol ] ].
-	aSymbol isValidSelector
+	(OCScanner isSelector: aSymbol)
 		ifTrue: [ searcher
 				matches:
 					'`@object '

--- a/src/Refactoring-Core/RBMethodName.class.st
+++ b/src/Refactoring-Core/RBMethodName.class.st
@@ -56,7 +56,7 @@ RBMethodName >> initialize [
 RBMethodName >> isValid [
 	"Return whether the receiver looks like a method with a selector in sync with the arguments in a possible class"
 
-	^ 	selector isString and: [ selector isValidSelector
+	^ 	selector isString and: [ (OCScanner isSelector: selector)
 			and: [ selector numArgs = arguments size ]]
 ]
 

--- a/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBMoveMethodRefactoring.class.st
@@ -267,7 +267,7 @@ RBMoveMethodRefactoring >> getNewMethodName [
 		ifTrue: [ newSelector := newMethodName selector ]
 		ifFalse: [ self refactoringWarning: 'Invalid method name' ].
 	parameters := newMethodName arguments.
-	( self checkMethodName: newSelector in: class )
+	( self isValidSelector: newSelector )
 		ifFalse: [ self refactoringWarning: newSelector , ' is not a valid selector name.'.
 			newSelector := nil
 			].

--- a/src/Refactoring-Core/ReAbstractTransformation.class.st
+++ b/src/Refactoring-Core/ReAbstractTransformation.class.st
@@ -178,11 +178,6 @@ ReAbstractTransformation >> checkInstanceVariableName: aName in: aClass [
 	^RBCondition checkInstanceVariableName: aName in: aClass
 ]
 
-{ #category : 'condition definitions' }
-ReAbstractTransformation >> checkMethodName: aName in: aClass [
-	^RBCondition checkMethodName: aName in: aClass
-]
-
 { #category : 'scripting api - conditions' }
 ReAbstractTransformation >> checkPreconditions [
 
@@ -280,6 +275,22 @@ ReAbstractTransformation >> generateChangesFor: aRefactoring [
 	aRefactoring copyOptionsFrom: self options.
 	aRefactoring model: self model.
 	aRefactoring generateChanges
+]
+
+{ #category : 'testing' }
+ReAbstractTransformation >> isValidSelector [
+	"Check I could be a valid selector (name of method).
+	 For checking if there is symbol like me used as a selector, see Symbol>>#isSelectorSymbol"
+
+	^ OCScanner isSelector: self
+]
+
+{ #category : 'testing' }
+ReAbstractTransformation >> isValidSelector: aString [
+	"Check that aString is a valid selector (name of method).
+	 For checking if there is symbol like me used as a selector, see Symbol>>#isSelectorSymbol"
+
+	^ OCScanner isSelector: aString
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-Core/ReAbstractTransformation.class.st
+++ b/src/Refactoring-Core/ReAbstractTransformation.class.st
@@ -287,9 +287,10 @@ ReAbstractTransformation >> isValidSelector [
 
 { #category : 'testing' }
 ReAbstractTransformation >> isValidSelector: aString [
-	"Check that aString is a valid selector (name of method).
+	"Returns the boolean true if aString is a valid selector (name of method).
 	 For checking if there is symbol like me used as a selector, see Symbol>>#isSelectorSymbol"
 
+	"Pay attention RBCondition >> #isValidSelector is returning an Condition object."
 	^ OCScanner isSelector: aString
 ]
 

--- a/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
+++ b/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
@@ -191,7 +191,7 @@ ReRenameMethodRefactoring >> storeOn: aStream [
 ReRenameMethodRefactoring >> validSelectorCondition [
 
 	^ (ReBlockCondition new 
-			block: [ newSelector asString isValidSelector. ];
+			block: [ self isValidSelector: newSelector ];
 			violatorErrorString: newSelector ,' is not a valid selector').
 ]
 

--- a/src/Refactoring-Transformations/RBChangeMethodNameTransformation.class.st
+++ b/src/Refactoring-Transformations/RBChangeMethodNameTransformation.class.st
@@ -21,7 +21,7 @@ RBChangeMethodNameTransformation >> applicabilityPreconditions [
 
 	^ {
 		  (RBCondition definesSelector: oldSelector in: class).
-		  (RBCondition isValidMethodName: newSelector for: class) }
+		  (RBCondition isValidSelector: newSelector) }
 ]
 
 { #category : 'support' }

--- a/src/Refactoring-Transformations/RBDeprecateMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBDeprecateMethodTransformation.class.st
@@ -97,8 +97,7 @@ RBDeprecateMethodTransformation >> applicabilityPreconditions [
 
 	^ {
 		  (RBCondition withBlock: [ selector ~= newSelector ]).
-		  (RBCondition withBlock: [
-			   RBCondition checkMethodName: newSelector ]).
+		 	(RBCondition isValidSelector: newSelector).
 		  (RBCondition definesSelector: selector in: class) }
 ]
 

--- a/src/Refactoring-Transformations/RBMoveMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBMoveMethodTransformation.class.st
@@ -287,7 +287,7 @@ RBMoveMethodTransformation >> getNewMethodName [
 		ifTrue: [ newSelector := newMethodName selector ]
 		ifFalse: [ self refactoringWarning: 'Invalid method name' ].
 	parameters := newMethodName arguments.
-	( self checkMethodName: newSelector in: class )
+	( self isValidSelector: newSelector )
 		ifFalse: [ self refactoringWarning: newSelector , ' is not a valid selector name.'.
 			newSelector := nil
 			].

--- a/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
@@ -384,7 +384,7 @@ ReCompositeExtractMethodRefactoring >> newMethodName [
 				newAttempt := newSelector isNil.
 
 				"it's a valid selector"
-				(newSelector isString and: [newSelector isValidSelector])
+				(newSelector isString and: [ self isValidSelector: newSelector])
 					ifFalse: [ self inform: newSelector asString, ' is not a valid selector.'.
 								  newSelector := nil ].
 

--- a/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringPreviewPresenter.class.st
@@ -29,7 +29,10 @@ Class {
 
 { #category : 'instance creation' }
 StRefactoringPreviewPresenter class >> changes: aCompositeRefactoring [
-	self deprecated: 'Use `for:` instead.' on: '2024-01-20' in: 'Pharo13' transformWith: '`@receiver changes: `@arg' -> '`@receiver for: `@arg'.
+	self deprecated: 'Use `for:` instead.' 
+		on: '2024/01/20' 
+		in: 'pharo13' 
+		transformWith: '`@receiver changes: `@arg' -> '`@receiver for: `@arg'.
 	
 	^ self new
 		  changesFrom: aCompositeRefactoring scopes: { RBBrowserEnvironment new };
@@ -46,7 +49,11 @@ StRefactoringPreviewPresenter class >> for: aCompositeRefactoring [
 
 { #category : 'instance creation' }
 StRefactoringPreviewPresenter class >> for: aCompositeRefactoring scopes: scopes [
-	self deprecated: 'Use `for:scopes:` instead.' on: '2024-01-20' in: 'Pharo13' transformWith: '`@receiver changes: `@arg1 scopes: `@arg2' -> '`@receiver for: `@arg1 scopes: `@arg2'.
+	self deprecated: 'Use `for:scopes:` instead.' 
+		on: '2024-01-20' 
+		in: 'pharo13' 
+		transformWith: '`@receiver changes: `@arg1 scopes: `@arg2' 
+			-> '`@receiver for: `@arg1 scopes: `@arg2'.
 
 	^ self new
 		  changesFrom: aCompositeRefactoring scopes: scopes;

--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
@@ -35,7 +35,7 @@ SpRubFindReplaceDialog class >> defaultLayout [
 				   add: #regExpCheckBox atPoint: 1 @ 1;
 				   add: #backwardsCheckBox atPoint: 2 @ 1;
 				   add: #caseCheckBox atPoint: 1 @ 2;
-				   add: #wrapCheckBox at: 2 @ 2;
+				   add: #wrapCheckBox atPoint: 2 @ 2;
 				   add: #entireCheckBox at: 1 @ 3;
 				   yourself);
 		  addLast: (SpBoxLayout newHorizontal

--- a/src/Tool-Registry/ToolRegistry.class.st
+++ b/src/Tool-Registry/ToolRegistry.class.st
@@ -177,7 +177,7 @@ ToolRegistry >> remove: aName [
 	self 
 		deprecated: 'Use unregisterToolWithRole:' 
 		on: '17/11/2024'  
-		in: #pharo13 
+		in: 'pharo13' 
 		transformWith:  '`@receiver remove: `@arg'
 						-> '`@receiver unregisterToolWithRole: `@arg'.
 	self unregisterToolWithRole: aName


### PR DESCRIPTION
Fixes #17670 
- Remove checkMethodName:, checkMethodName:in: and friends
- introduce isValidSelector: in refactoring root superclass and RBCondition