### PR TITLE
Removed IRMethod (that got renamed to OCIRMethod)

### DIFF
--- a/src/OpalCompiler-Core/IRMethod.class.st
+++ b/src/OpalCompiler-Core/IRMethod.class.st
@@ -1,7 +1,0 @@
-Class {
-	#name : 'IRMethod',
-	#superclass : 'OCIRMethod',
-	#category : 'OpalCompiler-Core-IR-Nodes',
-	#package : 'OpalCompiler-Core',
-	#tag : 'IR-Nodes'
-}


### PR DESCRIPTION
Removed IRMethod (that got renamed to OCIRMethod), fixes #17722 (cleanup)