### PR TITLE
Add support for underscore in numeric literals

### DIFF
--- a/src/NumberParser-Tests/NumberParserTest.class.st
+++ b/src/NumberParser-Tests/NumberParserTest.class.st
@@ -314,6 +314,25 @@ NumberParserTest >> testFloatmin [
 	self assert: moreThanHalfmin = Float fmin description: 'nearest Float of a Fraction > 0.5*Float fmin is Float fmin'
 ]
 
+{ #category : 'tests - Float' }
+NumberParserTest >> testIntegerParseUnderscore [
+
+	self assert: (NumberParser parse: '1234') equals: 1234.
+	self assert: (NumberParser parse: '1_234') equals: 1234.
+	self assert: (NumberParser parse: '1_1.1_1') equals: 11.11.
+	self assert: (NumberParser parse: '1_1r1_1.1_1e1_1') equals: 11r11.11e11.
+
+	self should: [NumberParser parse: '__'] raise: Error.
+	self should: [NumberParser parse: '_1'] raise: Error.
+	self should: [NumberParser parse: '1__1'] raise: Error.
+	self should: [NumberParser parse: '1_.1'] raise: Error.
+	self should: [NumberParser parse: '1._1'] raise: Error.
+	self should: [NumberParser parse: '1_e1'] raise: Error.
+	self should: [NumberParser parse: '1e_1'] raise: Error.
+	
+	self should: [NumberParser parse: '11_a' ] raise: Error.
+]
+
 { #category : 'tests - Integer' }
 NumberParserTest >> testIntegerReadFrom [
 	"Ensure remaining characters in a stream are not lost when parsing an integer."

--- a/src/NumberParser/NumberParser.class.st
+++ b/src/NumberParser/NumberParser.class.st
@@ -231,20 +231,32 @@ NumberParser >> nextElementaryLargeIntegerBase: aRadix [
 	Stop reading if end of digits or if a LargeInteger is formed.
 	Count the number of digits and the position of lastNonZero digit and store them in instVar."
 
-	| value digit char |
+	| value digit char lastWasUnderscore |
 	value := 0.
 	nDigits := 0.
 	lastNonZero := 0.
+	lastWasUnderscore := false.
+	
+	(sourceStream peekFor: $_)
+		ifTrue: [ self expected: 'No leading underscore in numeric token'].
+	
 	[value isLarge or: [(char := sourceStream next) isNil
 		or: [digit := char digitValue.
 			(0 > digit or: [digit >= aRadix])
 				and: [sourceStream skip: -1.
 					true]]]]
 		whileFalse: [
+			lastWasUnderscore := false.
 			nDigits := nDigits + 1.
 			0 = digit
 				ifFalse: [lastNonZero := nDigits].
-			value := value * aRadix + digit].
+			value := value * aRadix + digit.
+			
+			sourceStream peek = $_ ifTrue: [ 
+				lastWasUnderscore := true.
+				sourceStream next ] ].
+	lastWasUnderscore ifTrue: [ self expected: 'No trailing underscore in numeric token' ].
+	
 	^value
 ]
 


### PR DESCRIPTION
Redo of #12479

Follows the specification in https://github.com/pharo-project/pheps/pull/18