### PR TITLE
Update version in #documentBrowser for BaselineOfPharo for Pharo 11 to ‘v1.0.4’

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -43,7 +43,7 @@ BaselineOfPharo class >> documentBrowser [
 		newName: 'DocumentBrowser' 
 		owner: 'pharo-spec' 
 		project: 'NewTools-DocumentBrowser' 
-		version: 'v1.0.3'
+		version: 'v1.0.4'
 ]
 
 { #category : #'repository urls' }


### PR DESCRIPTION
This pull request updates the version in `#documentBrowser` for BaselineOfPharo for Pharo 11 to ‘v1.0.4’. Before this can be merged, a corresponding tag referring to [commit 5a30e17694acc023](https://github.com/pharo-spec/NewTools-DocumentBrowser/commit/5a30e17694acc023d17894578a1f3ba13455b5f5) needs to be added.