### PR TITLE
Fix cursor navigation

### DIFF
--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -36,6 +36,18 @@ RubTextEditorTest >> assertNextCharGroupOf: actual equals: expected [
 ]
 
 { #category : 'asserting' }
+RubTextEditorTest >> assertNextWordFrom: actualFrom to: actualTo equals: expected [
+
+	| actualIndexFrom actualIndexTo expectedIndex |
+	actualIndexFrom := actualFrom indexOf: $¶.
+	actualIndexTo := actualTo indexOf: $¶.
+	expectedIndex := expected indexOf: $¶.
+
+	actualIndexFrom to: actualIndexTo do: [ :i |
+		self assert: (editor nextWord: i) equals: expectedIndex ]
+]
+
+{ #category : 'asserting' }
 RubTextEditorTest >> assertPreviousCharGroupFrom: actualFrom to: actualTo equals: expected [
 
 	| actualIndexFrom actualIndexTo expectedIndex |
@@ -186,6 +198,18 @@ RubTextEditorTest >> testNextWordGoesToEndOfCurrentWord [
 	editor addString: 'abc d'.
 
 	self assert: (editor nextWord: 3) equals: 4
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testNextWordManyUppercases [
+
+	string := 'AAAb'.
+	editor addString: string.
+
+	self
+		assertNextWordFrom:	'¶AAAb'
+		to: 						'AAAb¶'
+		equals: 					'AAAb¶'.
 ]
 
 { #category : 'tests' }

--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -10,77 +10,167 @@ Class {
 }
 
 { #category : 'asserting' }
-RubTextEditorTest >> assertNextCharGroupFrom: actualFrom to: actualTo equals: expected [
+RubTextEditorTest >> assertNextCharGroupFrom: fromString to: toString equals: expected [
 
-	| actualIndexFrom actualIndexTo expectedIndex |
-	actualIndexFrom := actualFrom indexOf: $¶.
-	actualIndexTo := actualTo indexOf: $¶.
+	| fromIndex toIndex expectedIndex |
+	fromIndex := fromString indexOf: $¶.
+	toIndex := toString indexOf: $¶.
 	expectedIndex := expected indexOf: $¶.
 
-	actualIndexFrom to: actualIndexTo do: [ :i |
+	fromIndex to: toIndex do: [ :index |
+		| actualIndex |
+		actualIndex := editor nextWord: index stopOnUpperCase: true.
+
 		self
-			assert: (editor nextWord: i stopOnUpperCase: true)
-			equals: expectedIndex ]
+			assert: actualIndex = expectedIndex
+			description: [
+			self describe: actualIndex from: index comparedTo: expected ] ]
 ]
 
 { #category : 'asserting' }
-RubTextEditorTest >> assertNextCharGroupOf: actual equals: expected [
+RubTextEditorTest >> assertNextCharGroupOf: fromString equals: expected [
 
-	| actualIndex expectedIndex |
-	actualIndex := actual indexOf: $¶.
+	| fromIndex expectedIndex actualIndex |
+	fromIndex := fromString indexOf: $¶.
 	expectedIndex := expected indexOf: $¶.
+
+	actualIndex := editor nextWord: fromIndex stopOnUpperCase: true.
 
 	self
-		assert: (editor nextWord: actualIndex stopOnUpperCase: true)
-		equals: expectedIndex
+		assert: actualIndex = expectedIndex
+		description: [
+		self describe: actualIndex from: fromIndex comparedTo: expected ]
 ]
 
 { #category : 'asserting' }
-RubTextEditorTest >> assertNextWordFrom: actualFrom to: actualTo equals: expected [
+RubTextEditorTest >> assertNextWordFrom: fromString to: toString equals: expected [
 
-	| actualIndexFrom actualIndexTo expectedIndex |
-	actualIndexFrom := actualFrom indexOf: $¶.
-	actualIndexTo := actualTo indexOf: $¶.
+	| fromIndex toIndex expectedIndex |
+	fromIndex := fromString indexOf: $¶.
+	toIndex := toString indexOf: $¶.
 	expectedIndex := expected indexOf: $¶.
 
-	actualIndexFrom to: actualIndexTo do: [ :i |
-		self assert: (editor nextWord: i) equals: expectedIndex ]
-]
+	fromIndex to: toIndex do: [ :index |
+		| actualIndex |
+		actualIndex := editor nextWord: index.
 
-{ #category : 'asserting' }
-RubTextEditorTest >> assertPreviousCharGroupFrom: actualFrom to: actualTo equals: expected [
-
-	| actualIndexFrom actualIndexTo expectedIndex |
-	actualIndexFrom := actualFrom indexOf: $¶.
-	actualIndexTo := actualTo indexOf: $¶.
-	expectedIndex := expected indexOf: $¶.
-
-	actualIndexFrom to: actualIndexTo do: [ :i |
 		self
-			assert: (editor previousWord: i stopOnUpperCase: true)
-			equals: expectedIndex ]
+			assert: actualIndex = expectedIndex
+			description: [
+			self describe: actualIndex from: index comparedTo: expected ] ]
 ]
 
 { #category : 'asserting' }
-RubTextEditorTest >> assertPreviousCharGroupOf: actual equals: expected [
+RubTextEditorTest >> assertNextWordOf: fromString equals: expected [
 
-	| actualIndex expectedIndex |
-	actualIndex := actual indexOf: $¶.
+	| fromIndex expectedIndex actualIndex |
+	fromIndex := fromString indexOf: $¶.
 	expectedIndex := expected indexOf: $¶.
+
+	actualIndex := editor nextWord: fromIndex.
 
 	self
-		assert: (editor previousWord: actualIndex stopOnUpperCase: true)
-		equals: expectedIndex
+		assert: actualIndex = expectedIndex
+		description: [
+		self describe: actualIndex from: fromIndex comparedTo: expected ]
+]
+
+{ #category : 'asserting' }
+RubTextEditorTest >> assertPreviousCharGroupFrom: fromString to: toString equals: expected [
+
+	| fromIndex toIndex expectedIndex |
+	fromIndex := fromString indexOf: $¶.
+	toIndex := toString indexOf: $¶.
+	expectedIndex := expected indexOf: $¶.
+
+	fromIndex to: toIndex by: -1 do: [ :index |
+		| actualIndex |
+		actualIndex := editor previousWord: index stopOnUpperCase: true.
+
+		self
+			assert: actualIndex = expectedIndex
+			description: [
+			self describe: actualIndex from: index comparedTo: expected ] ]
+]
+
+{ #category : 'asserting' }
+RubTextEditorTest >> assertPreviousCharGroupOf: fromString equals: expected [
+
+	| fromIndex expectedIndex actualIndex |
+	fromIndex := fromString indexOf: $¶.
+	expectedIndex := expected indexOf: $¶.
+
+	actualIndex := editor previousWord: fromIndex stopOnUpperCase: true.
+
+	self
+		assert: actualIndex = expectedIndex
+		description: [
+		self describe: actualIndex from: fromIndex comparedTo: expected ]
+]
+
+{ #category : 'asserting' }
+RubTextEditorTest >> assertPreviousWordFrom: fromString to: toString equals: expected [
+
+	| fromIndex toIndex expectedIndex |
+	fromIndex := fromString indexOf: $¶.
+	toIndex := toString indexOf: $¶.
+	expectedIndex := expected indexOf: $¶.
+
+	fromIndex to: toIndex by: -1 do: [ :index |
+		| actualIndex |
+		actualIndex := editor previousWord: index.
+
+		self
+			assert: actualIndex = expectedIndex
+			description: [
+			self describe: actualIndex from: index comparedTo: expected ] ]
+]
+
+{ #category : 'asserting' }
+RubTextEditorTest >> assertPreviousWordOf: fromString equals: expected [
+
+	| fromIndex expectedIndex actualIndex |
+	fromIndex := fromString indexOf: $¶.
+	expectedIndex := expected indexOf: $¶.
+
+	actualIndex := editor previousWord: fromIndex.
+
+	self
+		assert: actualIndex = expectedIndex
+		description: [
+		self describe: actualIndex from: fromIndex comparedTo: expected ]
+]
+
+{ #category : 'asserting' }
+RubTextEditorTest >> describe: actualIndex from: fromIndex comparedTo: expected [
+
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: 'Got ''';
+			  next: actualIndex - 1 putAll: string startingAt: 1;
+			  nextPut: $¶;
+			  next: string size putAll: string startingAt: actualIndex;
+			  nextPutAll: ''' instead of ''';
+			  nextPutAll: expected;
+			  nextPutAll: ''' coming from ''';
+			  next: fromIndex - 1 putAll: string startingAt: 1;
+			  nextPut: $¶;
+			  next: string size putAll: string startingAt: fromIndex;
+			  nextPutAll: '''.' ]
+]
+
+{ #category : 'initialization' }
+RubTextEditorTest >> setString: aString [
+
+	string := aString.
+	editor addString: string
 ]
 
 { #category : 'running' }
 RubTextEditorTest >> setUp [
 
 	super setUp.
-	editor := RubTextEditor forTextArea: RubEditingArea new.
-	"Add text with a paragraph"
-	string := 'Lorem ipsum '.
-	editor addString: string
+	editor := RubTextEditor forTextArea: RubEditingArea new
 ]
 
 { #category : 'tests' }
@@ -118,113 +208,136 @@ RubTextEditorTest >> testLineStart [
 { #category : 'tests' }
 RubTextEditorTest >> testNextWord [
 
-	| textSize |
-	textSize := string size.
+	self setString: 'Lorem ipsum '.
+
 	self assert: (editor nextWord: -999) equals: 6. "Out of range means start of text"
 	self assert: (editor nextWord: 0) equals: 6. "Out of range means start of text"
 
-	1 to: 5 do: [ :i |
-		"From:   |Lorem ipsum
-		 To:     Lore|m ipsum
-		 Should be: Lorem| ipsum"
-		self assert: (editor nextWord: i) equals: 6 ].
+	self
+		assertNextWordFrom: '¶Lorem ipsum '
+		to: 'Lore¶m ipsum '
+		equals: 'Lorem¶ ipsum '.
 
-	6 to: 11 do: [ :i |
-		"From:   Lorem |ipsum
-		 To:     Lorem ipsu|m
-		 Should be: Lorem ipsum|"
-		self assert: (editor nextWord: i) equals: 12 ].
+	self
+		assertNextWordFrom: 'Lorem¶ ipsum '
+		to: 'Lorem ipsu¶m '
+		equals: 'Lorem ipsum¶ '.
 
-	"There is a space after ipsum:"
-	"Lorem ipsum| >> Lorem ipsum |"
-	self assert: (editor nextWord: 12) equals: 13.
+	self assertNextWordOf: 'Lorem ipsum¶ ' equals: 'Lorem ipsum ¶'.
 
-	self assert: (editor nextWord: 999) equals: textSize + 1. "Out of range"
+	self assert: (editor nextWord: 999) equals: string size + 1 "Out of range means end of text"
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordAtEndOfLineGoesToStartOfFirstWordOfNextLine [
 
-	editor addString: 'a
+	self setString: 'a
 	a
 a'.
 
-	self assert: (editor nextWord: 2) equals: 4
+	self
+		assertNextWordOf: 'a¶
+	a
+a'
+		equals: 'a
+	¶a
+a'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordAtEndOfLineGoesToStartOfNextLine [
 
-	editor addString: 'a
+	self setString: 'a
 
 a'.
 
-	self assert: (editor nextWord: 2) equals: 3
+	self
+		assertNextWordOf: 'a¶
+
+a'
+		equals: 'a
+¶
+a'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordAtLineWithSpacesGoesToEndOfCurrentLine [
 
-	editor addString: 'a  
+	self setString: 'a  
 
-  a'.
+  a'. "two trailing spaces at end of first line"
 
-	self assert: (editor nextWord: 2) equals: 4
+	self
+		assertNextWordOf: 'a¶  
+
+  a'
+		equals: 'a  ¶
+
+  a'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordAtStartOfEmptyLineGoesToStartOfNextLine [
 
-	editor addString: 'a
+	self setString: 'a
 
 a'.
 
-	self assert: (editor nextWord: 3) equals: 4
+	self
+		assertNextWordOf: 'a
+¶
+a'
+		equals: 'a
+
+¶a'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordAtStartOfFirstWordGoesToEndOfLine [
 
-	editor addString: 'a
+	self setString: 'a
 
 a'.
 
-	self assert: (editor nextWord: 4) equals: 5
+	self
+		assertNextWordOf: 'a
+
+¶a'
+		equals: 'a
+
+a¶'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordGoesToEndOfCurrentWord [
 
-	editor addString: 'abc d'.
+	self setString: 'abc d'.
 
-	self assert: (editor nextWord: 3) equals: 4
+	self assertNextWordOf: 'ab¶c d' equals: 'abc¶ d'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordManyUppercases [
 
-	string := 'AAAb'.
-	editor addString: string.
+	self setString: 'ABCdEFG'.
 
-	self
-		assertNextWordFrom:	'¶AAAb'
-		to: 						'AAAb¶'
-		equals: 					'AAAb¶'.
+	self assertNextWordFrom:	'¶ABCdEFG'
+	to:								'ABCdEFG¶'
+	equals:						'ABCdEFG¶'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordSkipsCurrentSpacesAndGoesToEndOfCurrentWord [
 
-	editor addString: 'abc d'.
+	self setString: 'abc d'.
 
-	self assert: (editor nextWord: 4) equals: 6
+	self assertNextWordOf: 'abc¶ d' equals: 'abc d¶'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordStopOnUpperCase [
 
-	string := 'loRem ipSum'.
-	editor addString: string.
+	self setString: 'loRem ipSum'.
 
 	self assert: (editor nextWord: -999 stopOnUpperCase: true) equals: 3. "Out of range means end of text"
 	self assert: (editor nextWord: 0 stopOnUpperCase: true) equals: 3. "Out of range means end of text"
@@ -248,14 +361,13 @@ RubTextEditorTest >> testNextWordStopOnUpperCase [
 	self
 		assertNextCharGroupFrom:	'loRem ip¶Sum'
 		to: 							'loRem ipSum¶'
-		equals: 						'loRem ipSum¶'.
+		equals: 						'loRem ipSum¶'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordStopOnUpperCaseComplex [
 
-	string := 'self loRem: [[ (1 + 2) // 100 ]]'.
-	editor addString: string.
+	self setString: 'self loRem: [[ (1 + 2) // 100 ]]'.
 
 	self
 		assertNextCharGroupFrom:	'self lo¶Rem: [[ (1 + 2) // 100 ]]'
@@ -307,31 +419,34 @@ RubTextEditorTest >> testNextWordStopOnUpperCaseComplex [
 	self
 		assertNextCharGroupFrom:	'self loRem: [[ (1 + 2) // 100¶ ]]'
 		to: 							'self loRem: [[ (1 + 2) // 100 ]¶]'
-		equals: 						'self loRem: [[ (1 + 2) // 100 ]]¶'.
+		equals: 						'self loRem: [[ (1 + 2) // 100 ]]¶'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordStopOnUpperCaseManyUppercases [
 
-	string := 'AAAb'.
-	editor addString: string.
+	self setString: 'ABCdEFG'.
 
 	self
-		assertNextCharGroupFrom:	'¶AAAb'
-		to: 							'A¶AAb'
-		equals: 						'AA¶Ab'.
+		assertNextCharGroupFrom:	'¶ABCdEFG'
+		to: 							'A¶BCdEFG'
+		equals: 						'AB¶CdEFG'.
 
 	self
-		assertNextCharGroupFrom:	'AA¶Ab'
-		to: 							'AAA¶b'
-		equals: 						'AAAb¶'.
+		assertNextCharGroupFrom:	'AB¶CdEFG'
+		to: 							'ABC¶dEFG'
+		equals: 						'ABCd¶EFG'.
+
+	self
+		assertNextCharGroupFrom:	'ABCd¶EFG'
+		to: 							'ABCdEFG¶'
+		equals: 						'ABCdEFG¶'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordStopOnUpperCaseWithSpecialCharacters [
 
-	string := '^[:x|(''#eur'',$$asString)]'.
-	editor addString: string.
+	self setString: '^[:x|(''#eur'',$$asString)]'.
 
 	self
 		assertNextCharGroupFrom:	'¶^[:x|(''#eur'',$$asString)]'
@@ -382,14 +497,13 @@ RubTextEditorTest >> testNextWordStopOnUpperCaseWithSpecialCharacters [
 	self
 		assertNextCharGroupFrom:	'^[:x|(''#eur'',$$asString¶)]'
 		to: 							'^[:x|(''#eur'',$$asString)¶]'
-		equals: 						'^[:x|(''#eur'',$$asString)]¶'.
+		equals: 						'^[:x|(''#eur'',$$asString)]¶'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testNextWordStopOnUpperCaseWithSyntax [
 
-	string := '^"''|[](){}$#<>=;:.'.
-	editor addString: string.
+	self setString: '^"''|[](){}$#<>=;:.'.
 
 	self
 		assertNextCharGroupFrom:	'¶^"''|[](){}$#<>=;:.'
@@ -413,92 +527,125 @@ RubTextEditorTest >> testNextWordStopOnUpperCaseWithSyntax [
 	self
 		assertNextCharGroupFrom:	'^"''|[](){}$#<>=¶;:.'
 		to: 							'^"''|[](){}$#<>=;:.¶'
-		equals: 						'^"''|[](){}$#<>=;:.¶'.
+		equals: 						'^"''|[](){}$#<>=;:.¶'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWord [
 
-	| textSize |
-	textSize := 'Lorem ipsum ' size.
+	self setString: 'Lorem ipsum '.
+
 	self assert: (editor previousWord: -999) equals: 1. "Out of range"
 	self assert: (editor previousWord: 0) equals: 1. "Out of range"
 
-	1 to: 7 do: [ :i |
-		"From:   |Lorem ipsum
-		 To:     Lorem |ipsum
-		 Should be: |Lorem ipsum"
-		self assert: (editor previousWord: i) equals: 1 ].
+	self
+		assertPreviousWordFrom: 'Lorem ¶ipsum '
+		to: '¶Lorem ipsum '
+		equals: '¶Lorem ipsum '.
 
-	8 to: 12 do: [ :i |
-		"From:   Lorem |ipsum
-		 To:     Lorem ipsum|
-		 Should be: Lorem |ipsum"
-		self assert: (editor previousWord: i) equals: 7 ].
+	self
+		assertPreviousWordFrom: 'Lorem ipsum ¶'
+		to: 'Lorem i¶psum '
+		equals: 'Lorem ¶ipsum '.
 
-	self assert: (editor previousWord: 999) equals: 7. "Out of range"
+	self
+		assert: (editor previousWord: 999)
+		equals: ('Lorem ¶ipsum ' indexOf: $¶) "Out of range"
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordAtEndOfFirstWordOfLineGoesToStartOfLine [
 
-	editor addString: 'a
+	self setString: 'a
 
 a'.
 
-	self assert: (editor previousWord: 5) equals: 4
+	self
+		assertPreviousWordOf: 'a
+
+a¶'
+		equals: 'a
+
+¶a'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordAtLineWithSpacesGoesToStartOfCurrentLine [
 
-	editor addString: 'a
+	self setString: 'a
 
   a'.
 
-	self assert: (editor previousWord: 6) equals: 4
+	self
+		assertPreviousWordOf: 'a
+
+  ¶a'
+		equals: 'a
+
+¶  a'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordAtStartOfLineGoesToEndOfLastWordOfPreviousLine [
 
-	editor addString: 'a	
-a'.
+	self setString: 'a	
+a'. "trailing tab at the end of the first line"
 
-	self assert: (editor previousWord: 4) equals: 1
+	self
+		assertPreviousWordOf: 'a	
+¶a'
+		equals: 'a¶	
+a'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordAtStartOfLineGoesToPreviousLine [
 
-	editor addString: 'a
+	self setString: 'a
 
 a'.
 
-	self assert: (editor previousWord: 4) equals: 3
+	self
+		assertPreviousWordOf: 'a
+
+¶a'
+		equals: 'a
+¶
+a'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordGoesToStartOfCurrentWord [
 
-	editor addString: 'abc def'.
+	self setString: 'abc def'.
 
-	self assert: (editor previousWord: 6) equals: 5
+	self assertPreviousWordOf: 'abc d¶ef' equals: 'abc ¶def'
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordManyUppercases [
+
+	self setString: 'ABCdEFG'.
+
+	self
+		assertPreviousWordFrom:	'ABCdEFG¶'
+		to: 							'¶ABCdEFG'
+		equals: 						'¶ABCdEFG'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordSkipsCurrentSpacesAndGoesToStartOfCurrentWord [
 
-	editor addString: 'abc def'.
+	self setString: 'abc def'.
 
-	self assert: (editor previousWord: 5) equals: 1
+	self assertPreviousWordOf: 'abc ¶def' equals: '¶abc def'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordStopOnUpperCase [
 
-    string := 'loRem ipSum'.
-    editor addString: string.
+	self setString: 'loRem ipSum'.
+
 	self assert: (editor previousWord: -999 stopOnUpperCase: true) equals: 1. "Out of range means start of text"
 	self assert: (editor previousWord: 0 stopOnUpperCase: true) equals: 1. "Out of range means start of text"
 
@@ -526,8 +673,7 @@ RubTextEditorTest >> testPreviousWordStopOnUpperCase [
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordStopOnUpperCaseComplex [
 
-	string := 'self loRem: [[ (1 + 2) // 100 ]]'.
-	editor addString: string.
+	self setString: 'self loRem: [[ (1 + 2) // 100 ]]'.
 
 	self
 		assertPreviousCharGroupFrom:	'self loRem: [[ (1 + 2) // 100 ]]¶'
@@ -590,30 +736,34 @@ RubTextEditorTest >> testPreviousWordStopOnUpperCaseComplex [
 	self
 		assertPreviousCharGroupFrom:	'self ¶loRem: [[ (1 + 2) // 100 ]]'
 		to: 									'¶self loRem: [[ (1 + 2) // 100 ]]'
-		equals: 								'¶self loRem: [[ (1 + 2) // 100 ]]'.
+		equals: 								'¶self loRem: [[ (1 + 2) // 100 ]]'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordStopOnUpperCaseManyUppercases [
-	string := 'AAAb'.
-	editor addString: string.
+
+	self setString: 'ABCdEFG'.
 
 	self
-		assertPreviousCharGroupFrom:	'AAAb¶'
-		to: 									'AAA¶b'
-		equals: 								'AA¶Ab'.
+		assertPreviousCharGroupFrom:	'ABCdEFG¶'
+		to: 									'ABCdE¶FG'
+		equals: 								'ABCd¶EFG'.
 
 	self
-		assertPreviousCharGroupFrom:	'AA¶Ab'
-		to: 									'¶AAAb'
-		equals: 								'¶AAAb'.
+		assertPreviousCharGroupFrom:	'ABCd¶EFG'
+		to: 									'ABC¶dEFG'
+		equals: 								'AB¶CdEFG'.
+
+	self
+		assertPreviousCharGroupFrom:	'AB¶CdEFG'
+		to: 									'¶ABCdEFG'
+		equals: 								'¶ABCdEFG'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordStopOnUpperCaseWithSpecialCharacters [
 
-	string := '^[:x|(''#eur'',$$asString)]'.
-	editor addString: string.
+	self setString: '^[:x|(''#eur'',$$asString)]'.
 
 	self
 		assertPreviousCharGroupFrom:	'^[:x|(''#eur'',$$asString)]¶'
@@ -664,14 +814,13 @@ RubTextEditorTest >> testPreviousWordStopOnUpperCaseWithSpecialCharacters [
 	self
 		assertPreviousCharGroupFrom:	'^[:¶x|(''#eur'',$$asString)]'
 		to: 									'¶^[:x|(''#eur'',$$asString)]'
-		equals: 								'¶^[:x|(''#eur'',$$asString)]'.
+		equals: 								'¶^[:x|(''#eur'',$$asString)]'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testPreviousWordStopOnUpperCaseWithSyntax [
 
-	string := '^"''|[](){}$#<>=;:.'.
-	editor addString: string.
+	self setString: '^"''|[](){}$#<>=;:.'.
 
 	self
 		assertPreviousCharGroupFrom:	'^"''|[](){}$#<>=;:.¶'
@@ -695,71 +844,66 @@ RubTextEditorTest >> testPreviousWordStopOnUpperCaseWithSyntax [
 	self
 		assertPreviousCharGroupFrom:	'^"''¶|[](){}$#<>=;:.'
 		to: 									'¶^"''|[](){}$#<>=;:.'
-		equals: 								'¶^"''|[](){}$#<>=;:.'.
+		equals: 								'¶^"''|[](){}$#<>=;:.'
 ]
 
-{ #category : 'test-selection' }
+{ #category : 'tests' }
 RubTextEditorTest >> testSelectFromBeginToEnd [
 
-	editor addString: 'a
+	self setString: 'a
 
 a'.
+	editor selectMark: 1 point: string size.
 
-	editor selectMark: 1 point: 5.
 	self assert: editor selection equals: 'a
 
-a'.
+a'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testSelectWord [
 
-	string := '#Lorem #ipsum #dolor #sit #amet'.
-	editor addString: string.
+	self setString: '#Lorem #ipsum #dolor #sit #amet'.
 
 	editor selectWordMark: 0 point: 0.
 	editor selectWord.
-	
+
 	self assert: editor hasSelection.
 	self assert: editor selection equals: 'Lorem'.
-	
+
 	editor selectWordMark: 2 point: 4. "Lorem ipsum dolor sit amet >> [Lorem ]ipsum dolor sit amet "
-	editor selectWord.	
+	editor selectWord.
 	self assert: editor selection equals: 'Lorem'.
-	
+
 	editor selectWordMark: 9 point: 11. "Lorem ipsum dolor sit amet >> Lorem [ipsum] dolor sit amet "
-	editor selectWord.		
+	editor selectWord.
 	self assert: editor selection equals: 'ipsum'.
-	
+
 	editor selectWordMark: 9 point: 12. "Lorem ipsum dolor sit amet >> Lorem [ipsum ]dolor sit amet "
-	editor selectWord.	
+	editor selectWord.
 	self assert: editor selection equals: 'ipsum'.
 
 	editor selectWordMark: 3 point: 24. "Lorem ipsum dolor sit amet >> [Lorem ipsum dolor sit amet ]"
-	editor selectWord.	
+	editor selectWord.
 	self assert: editor selection equals: 'sit'.
-	
+
 	editor selectWordMark: 1 point: 26. "Lorem ipsum dolor sit amet >> [Lorem ipsum dolor sit amet ]"
-	editor selectWord.	
+	editor selectWord.
 	self assert: editor selection equals: 'amet'.
-	
+
 	editor selectWordMark: 1 point: 1. "Lorem ipsum dolor sit amet >> [Lorem] ipsum dolor sit amet"
-	editor selectWord.	
+	editor selectWord.
 	self assert: editor selection equals: 'Lorem'.
 
 	editor selectWordMark: 26 point: 26. "Lorem ipsum dolor sit amet >> Lorem ipsum dolor sit [amet ]"
-	editor selectWord.	
-	self assert: editor selection equals: 'amet'.
-
+	editor selectWord.
+	self assert: editor selection equals: 'amet'
 ]
 
 { #category : 'tests' }
 RubTextEditorTest >> testSelectWordMarkPoint [
 
-	| textSize |
-	string := 'Lorem ipsum dolor sit amet'.
-	editor addString: string.
-	textSize := editor string size.
+	self setString: 'Lorem ipsum dolor sit amet'.
 
 	editor selectWordMark: 0 point: 0. "Lorem ipsum dolor sit amet >> [L]orem ipsum dolor sit amet "
 	self assert: editor markIndex equals: 1.

--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -570,24 +570,6 @@ RubTextEditorTest >> testPreviousWordStopOnUpperCaseComplex [
 ]
 
 { #category : 'tests' }
-RubTextEditorTest >> testPreviousWordStopOnUpperCaseManyUpercases [
-
-	string := 'AAAb'.
-	editor addString: string.
-
-	self
-		assertPreviousCharGroupFrom: 	'AAAb¶'
-		to: 							  		'AAA¶b'
-		equals: 						  		'AA¶Ab'.
-
-	self
-		assertPreviousCharGroupFrom:	'AA¶Ab'
-		to: 							  		'¶AAAb'
-		equals: 						  		'¶AAAb'.	
-
-]
-
-{ #category : 'tests' }
 RubTextEditorTest >> testPreviousWordStopOnUpperCaseManyUppercases [
 	string := 'AAAb'.
 	editor addString: string.

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -448,15 +448,17 @@ RubTextEditor >> characterGroupAt: index in: aString [
 	character := aString at: index.
 
 	character isSeparator ifTrue: [ ^ #separator ].
-	character isAlphaNumeric ifTrue: [
-		character isUppercase
-			ifTrue: [ ^ #upper ]
-			ifFalse: [ ^ #lower ] ].
 
-	"exclude '|<>=' from the syntax and consider them binary"
+	character isAlphaNumeric ifTrue: [
+		^ character isUppercase
+			  ifTrue: [ #upper ]
+			  ifFalse: [ #lower ] ].
+
+	"exclude '|<>=' from the syntax and consider them binary, except for ':='"
 	(('^"''[](){}$#;:.' includes: character) or: [
-		 character = $= and: [ (aString at: (index - 1 max: 1)) = $: ] ]) 
-			ifTrue: [ ^ #syntax ].
+		 character = $= and: [ (aString at: (index - 1 max: 1)) = $: ] ])
+		ifTrue: [ ^ #syntax ].
+
 	^ #binary
 ]
 
@@ -1695,13 +1697,14 @@ RubTextEditor >> nextWord: position [
 
 { #category : 'private' }
 RubTextEditor >> nextWord: position stopOnUpperCase: stopOnUpperCase [
+
+	| string index size initialPosition groupAtStart currentGroup |
 	"Positions go from 1 to size + 1
 	Position N + 1 is after the Nth character"
-
-	| string index characterGroupAtStart size initialPosition currentGroup |
-	index := initialPosition := 1 max: position.
 	string := self string.
 	size := string size + 1.
+	index := initialPosition := 1 max: position.
+
 	position >= string size ifTrue: [ ^ size ].
 
 	[ "Skip blanks"
@@ -1711,31 +1714,31 @@ RubTextEditor >> nextWord: position stopOnUpperCase: stopOnUpperCase [
 			Character tab } includes: (string at: index) ] ] whileTrue: [
 		index := index + 1 ].
 
-	characterGroupAtStart := self characterGroupAt: index in: string.
+	groupAtStart := self characterGroupAt: index in: string.
+
+	"Go at least once forward to guarantee progress"
 	index = initialPosition ifTrue: [ index := index + 1 ].
 
 	"Do not stop if we are in an uppercase->lowercase transition"
-	(characterGroupAtStart = #upper and: [
+	(groupAtStart = #upper and: [
 		 stopOnUpperCase not or: [
 			 (self characterGroupAt: index in: string) = #lower ] ]) ifTrue: [
-		characterGroupAtStart := #lower ].
+		groupAtStart := #lower ].
 
-	[ "If we reach the end"
+	[ "Stop when we reach the end, a new line, or a different character group"
 	index >= size ifTrue: [ ^ size ].
-
 	(string at: index) = Character cr ifTrue: [ ^ index ].
 
 	currentGroup := self characterGroupAt: index in: string.
 	(stopOnUpperCase not and: [ currentGroup = #upper ]) ifTrue: [
 		currentGroup := #lower ].
 
-	currentGroup = characterGroupAtStart ] whileTrue: [
-		index := index + 1 ].
+	currentGroup = groupAtStart ] whileTrue: [ index := index + 1 ].
 
-	"Moving to the right from upper to lower, we want to stop before the last upper"
+	"Moving to the right from upper to lower, we want to stop left of the upper"
 	(stopOnUpperCase and: [
-		 characterGroupAtStart = #upper and: [ currentGroup = #lower ] ])
-		ifTrue: [ index := index - 1 ].
+		 groupAtStart = #upper and: [ currentGroup = #lower ] ]) ifTrue: [
+		index := index - 1 ].
 
 	^ index
 ]
@@ -1889,58 +1892,52 @@ RubTextEditor >> previousWord: position [
 { #category : 'private' }
 RubTextEditor >> previousWord: position stopOnUpperCase: stopOnUpperCase [
 
-	| string index size initialPosition afterCaretIsAlpha nextCharacterInDirection characterGroupAtStart groupBeforeCaret groupAfterCaret |
+	| string index size initialPosition groupAtStart currentGroup |
 	"Positions go from 1 to size + 1
 	Position N + 1 is after the Nth character"
 	string := self string.
 	size := string size + 1.
-
-	initialPosition := size min: position.
-	index := initialPosition.
+	index := initialPosition := size min: position.
 
 	position <= 2 ifTrue: [ ^ 1 ].
 
-	(string at: index - 1) = Character cr ifTrue: [ index := index - 1 ].
-
-	[
-	| currentChar |
-	currentChar := string at: index - 1.
-	currentChar = Character cr ifTrue: [ ^ index ].
-	currentChar isSeparator ] whileTrue: [ index := index - 1 ].
-
-	"Go always at least once backwards to guarantee progress"
-	index := index - 1.
-
-	characterGroupAtStart := self characterGroupAt: index in: string.
-
-	afterCaretIsAlpha := index = 1 or: [
-		                     #( #lower #upper ) includes:
-			                     characterGroupAtStart ].
-	index <= 1 ifTrue: [ ^ index ].
-	nextCharacterInDirection := string at: index - 1.
-	nextCharacterInDirection = Character cr ifTrue: [ ^ index ].
-
-	[ "If we reach the end"
-	index <= 1 ifTrue: [ ^ index ].
-
-	nextCharacterInDirection := string at: index - 1.
-	nextCharacterInDirection = Character cr ifTrue: [ ^ index ].
-
-	groupBeforeCaret := self characterGroupAt: index in: string.
-	(stopOnUpperCase not and: [ groupBeforeCaret = #upper ]) ifTrue: [
-		groupBeforeCaret := #lower ].
-	groupAfterCaret := self characterGroupAt: index - 1 in: string.
-	(stopOnUpperCase not and: [ groupAfterCaret = #upper ]) ifTrue: [
-		groupAfterCaret := #lower ].
-
-	groupAfterCaret = groupBeforeCaret and: [ index > 1 ] ] whileTrue: [
+	[ "Skip blanks"
+	index > 1 and: [
+		{
+			Character space.
+			Character tab } includes: (string at: index - 1) ] ] whileTrue: [
 		index := index - 1 ].
 
-	"Moving to the left from lower to upper, we want to stop before the upper"
-	(groupBeforeCaret = #lower and: [ groupAfterCaret = #upper ])
-		ifFalse: [ index := index + 1 ].
+	groupAtStart := self characterGroupAt: index - 1 in: string.
 
-	^ index - 1
+	"Go at least once backward to guarantee progress"
+	index = initialPosition ifTrue: [ index := index - 1 ].
+
+	"Stop if we are in a lowercase->uppercase transition"
+	groupAtStart = #upper ifTrue: [
+		stopOnUpperCase
+			ifFalse: [ groupAtStart := #lower ]
+			ifTrue: [
+				(index < string size and: [
+					 (self characterGroupAt: index + 1 in: string) = #lower ])
+					ifTrue: [ ^ index ] ] ].
+
+	[ "Stop when we reach the end, a new line, or a different character group"
+	index <= 1 ifTrue: [ ^ 1 ].
+	(string at: index - 1) = Character cr ifTrue: [ ^ index ].
+
+	currentGroup := self characterGroupAt: index - 1 in: string.
+	(stopOnUpperCase not and: [ currentGroup = #upper ]) ifTrue: [
+		currentGroup := #lower ].
+
+	currentGroup = groupAtStart ] whileTrue: [ index := index - 1 ].
+
+	"Moving to the left from lower to upper, we want to stop left of the upper"
+	(stopOnUpperCase and: [
+		 groupAtStart = #lower and: [ currentGroup = #upper ] ]) ifTrue: [
+		index := index - 1 ].
+
+	^ index
 ]
 
 { #category : 'accessing - selection' }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1704,7 +1704,7 @@ RubTextEditor >> nextWord: position stopOnUpperCase: stopOnUpperCase [
 	size := string size + 1.
 	position >= string size ifTrue: [ ^ size ].
 
-	[
+	[ "Skip blanks"
 	index < string size and: [
 		{
 			Character space.
@@ -1713,26 +1713,28 @@ RubTextEditor >> nextWord: position stopOnUpperCase: stopOnUpperCase [
 
 	characterGroupAtStart := self characterGroupAt: index in: string.
 	index = initialPosition ifTrue: [ index := index + 1 ].
+
 	"Do not stop if we are in an uppercase->lowercase transition"
 	(characterGroupAtStart = #upper and: [
-		 (self characterGroupAt: index in: string) = #lower ]) ifTrue: [
+		 stopOnUpperCase not or: [
+			 (self characterGroupAt: index in: string) = #lower ] ]) ifTrue: [
 		characterGroupAtStart := #lower ].
 
-	[
-	| nextCharacterInDirection |
-	"If we reach the end"
-	index >= size ifTrue: [ ^ index ].
+	[ "If we reach the end"
+	index >= size ifTrue: [ ^ size ].
 
-	nextCharacterInDirection := string at: index.
-	nextCharacterInDirection = Character cr ifTrue: [ ^ index ].
+	(string at: index) = Character cr ifTrue: [ ^ index ].
 
 	currentGroup := self characterGroupAt: index in: string.
-	currentGroup = characterGroupAtStart or: [
-		(currentGroup = #upper and: [ characterGroupAtStart = #lower ])
-			and: [ stopOnUpperCase not ] ] ] whileTrue: [ index := index + 1 ].
+	(stopOnUpperCase not and: [ currentGroup = #upper ]) ifTrue: [
+		currentGroup := #lower ].
+
+	currentGroup = characterGroupAtStart ] whileTrue: [
+		index := index + 1 ].
 
 	"Moving to the right from upper to lower, we want to stop before the last upper"
-	(characterGroupAtStart = #upper and: [ currentGroup = #lower ])
+	(stopOnUpperCase and: [
+		 characterGroupAtStart = #upper and: [ currentGroup = #lower ] ])
 		ifTrue: [ index := index - 1 ].
 
 	^ index

--- a/src/SUnit-Core-Traits/TAssertable.trait.st
+++ b/src/SUnit-Core-Traits/TAssertable.trait.st
@@ -139,24 +139,24 @@ TAssertable >> comparingCollectionBetween: left and: right [
 { #category : 'private' }
 TAssertable >> comparingIdentityStringBetween: actual and: expected [
 
-	^ String streamContents: [:stream |
-			stream
-				nextPutAll: actual fullPrintString;
-				nextPutAll: ' is not identical to ';
-				nextPutAll: expected fullPrintString;
-				nextPutAll: '.']
+	^ String streamContents: [ :stream |
+		  stream
+			  print: actual;
+			  nextPutAll: ' is not identical to ';
+			  print: expected;
+			  nextPut: $. ]
 ]
 
 { #category : 'private' }
 TAssertable >> comparingStringBetween: actual and: expected [
 
-	^ String streamContents: [:stream |
-			stream
-				nextPutAll: 'Got ';
-				nextPutAll: actual fullPrintString;
-				nextPutAll: ' instead of ';
-				nextPutAll: expected fullPrintString;
-				nextPutAll: '.']
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: 'Got ';
+			  print: actual;
+			  nextPutAll: ' instead of ';
+			  print: expected;
+			  nextPut: $. ]
 ]
 
 { #category : 'asserting' }
@@ -399,23 +399,23 @@ TAssertable >> skipUnless: aBooleanOrBlock [
 { #category : 'private' }
 TAssertable >> unexpectedEqualityStringBetween: actual and: expected [
 
-	^ String streamContents: [:stream |
-			stream
-				nextPutAll: 'Unexpected equality of ';
-				nextPutAll: actual fullPrintString;
-				nextPutAll: ' and ';
-				nextPutAll: expected fullPrintString;
-				nextPutAll: '.']
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: 'Unexpected equality of ';
+			  print: actual;
+			  nextPutAll: ' and ';
+			  print: expected;
+			  nextPut: $. ]
 ]
 
 { #category : 'private' }
 TAssertable >> unexpectedIdentityEqualityStringBetween: actual and: expected [
 
-	^ String streamContents: [:stream |
-			stream
-				nextPutAll: 'Unexpected identity equality of ';
-				nextPutAll: actual fullPrintString;
-				nextPutAll: ' and ';
-				nextPutAll: expected fullPrintString;
-				nextPutAll: '.']
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: 'Unexpected identity equality of ';
+			  print: actual;
+			  nextPutAll: ' and ';
+			  print: expected;
+			  nextPut: $. ]
 ]

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -311,24 +311,24 @@ TestAsserter >> comparingCollectionBetween: left and: right [
 { #category : 'private' }
 TestAsserter >> comparingIdentityStringBetween: actual and: expected [
 
-	^ String streamContents: [:stream |
-			stream
-				nextPutAll: actual fullPrintString;
-				nextPutAll: ' is not identical to ';
-				nextPutAll: expected fullPrintString;
-				nextPutAll: '.']
+	^ String streamContents: [ :stream |
+		  stream
+			  print: actual;
+			  nextPutAll: ' is not identical to ';
+			  print: expected;
+			  nextPut: $. ]
 ]
 
 { #category : 'private' }
 TestAsserter >> comparingStringBetween: actual and: expected [
 
-	^ String streamContents: [:stream |
-			stream
-				nextPutAll: 'Got ';
-				nextPutAll: actual fullPrintString;
-				nextPutAll: ' instead of ';
-				nextPutAll: expected fullPrintString;
-				nextPutAll: '.']
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: 'Got ';
+			  print: actual;
+			  nextPutAll: ' instead of ';
+			  print: expected;
+			  nextPut: $. ]
 ]
 
 { #category : 'factory' }
@@ -699,23 +699,23 @@ TestAsserter >> tearDown [
 { #category : 'private' }
 TestAsserter >> unexpectedEqualityStringBetween: actual and: expected [
 
-	^ String streamContents: [:stream |
-			stream
-				nextPutAll: 'Unexpected equality of ';
-				nextPutAll: actual fullPrintString;
-				nextPutAll: ' and ';
-				nextPutAll: expected fullPrintString;
-				nextPutAll: '.']
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: 'Unexpected equality of ';
+			  print: actual;
+			  nextPutAll: ' and ';
+			  print: expected;
+			  nextPut: $. ]
 ]
 
 { #category : 'private' }
 TestAsserter >> unexpectedIdentityEqualityStringBetween: actual and: expected [
 
-	^ String streamContents: [:stream |
-			stream
-				nextPutAll: 'Unexpected identity equality of ';
-				nextPutAll: actual fullPrintString;
-				nextPutAll: ' and ';
-				nextPutAll: expected fullPrintString;
-				nextPutAll: '.']
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: 'Unexpected identity equality of ';
+			  print: actual;
+			  nextPutAll: ' and ';
+			  print: expected;
+			  nextPut: $. ]
 ]


### PR DESCRIPTION
Follow-up to #17476 and #17630 to fix two bugs:
- Going to the next word without considering uppercase (without ALT) incorrectly considered them
```diff
 ¶RBNamespace
-RB¶Namespace
+RBNamespace¶
```
- Going to the previous word and considering uppercase (with ALT) on a lower->upper transition incorrectly skipped it
```diff
 RBN¶amespace
-¶RBNamespace
+RB¶Namespace
```
I also took the opportunity to:
- homogenize the implementation of `previousWord:stopOnUpperCase:` with that of `nextWord:stopOnUpperCase:`, now the two methods are really similar which should make things easier to maintain,
- fix `previousWord:stopOnUpperCase:` rotten green tests that did not execute any assertion,
- make tests from `RubTextEditorTest` more readable both in code and assertion description,
- update assertion descriptions to reuse the current stream with `stream print: obj`, instead of using `stream nextPutAll: obj fullPrintString` which created a new stream just to put its contents into the current stream.