### PR TITLE
Fixing browse in KMDescriptionPresenter

### DIFF
--- a/src/Keymapping-Tools-Spec/KMDescriptionPresenter.class.st
+++ b/src/Keymapping-Tools-Spec/KMDescriptionPresenter.class.st
@@ -143,7 +143,7 @@ KMDescriptionPresenter >> initializePresenters [
 	actionBar := self newActionBar.
 	actionBar
 		addLast: (SpButtonPresenter new
-				 action: [ "self application tools browser openOn:" shortcutTable selectedItem action browser ];
+				 action: [ self application tools browser openOnClass:  shortcutTable selectedItem action methodClass selector: shortcutTable selectedItem action selector ];
 				 label: 'Browse';
 				 yourself);
 		addLast: (SpButtonPresenter new


### PR DESCRIPTION
It was leading to opening the class CompiledMethod instead of the right location,