### PR TITLE
Do not resume running process

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -296,11 +296,10 @@ OSSDL2Driver >> setupEventLoop [
 			EventLoopProcess terminate.
 			EventLoopProcess := nil ] ].
 
-	EventLoopProcess := [ self eventLoop ] forkAt: Processor lowIOPriority.
+	EventLoopProcess := [ self eventLoop ] forkAt:
+		                    Processor lowIOPriority.
 
-	EventLoopProcess
-		name: 'SDL2 Event loop';
-		resume
+	EventLoopProcess name: 'SDL2 Event loop'
 ]
 
 { #category : 'system startup' }


### PR DESCRIPTION
SDL code calls `resume` on an already running/ready process (that was just created two lines above using `fork`).

This is undefined behavior right now in Pharo, and causes assertion failures on the VM code that performs context switch.
Interestingly, many process primitives have undefined/ill-defined-implementation-specific behavior.
For example, imaging resuming a process sleeping in a semaphore.

This PR removes the incorrect call to `resume`. In the future we should review all process primitives.