### PR TITLE
Backport changes to not restore ffi methods if they are not installed

### DIFF
--- a/src/ThreadedFFI-UFFI-Tests/TFFITraitForTest.trait.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFFITraitForTest.trait.st
@@ -1,0 +1,9 @@
+Trait {
+	#name : 'TFFITraitForTest',
+	#category : 'ThreadedFFI-UFFI-Tests',
+	#package : 'ThreadedFFI-UFFI-Tests'
+}
+
+{ #category : 'accessing - structure variables' }
+TFFITraitForTest >> x [
+]

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIMethodRegistryTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIMethodRegistryTest.class.st
@@ -10,9 +10,9 @@ TFUFFIMethodRegistryTest >> testRegistryDoesNotRestoreUninstalledMethods [
 
 	"Call the method to force installation"
 	| ffiMethod |
-	TFUFFITestClassWithTrait uniqueInstance pidfortest.
+	TFUFFITestClassWithTrait uniqueInstance shortCallout.
 	
-	ffiMethod := TFUFFITestClassWithTrait >> #pidfortest.
+	ffiMethod := TFUFFITestClassWithTrait >> #shortCallout.
 	ffiMethod recompile.
 	FFIMethodRegistry uniqueInstance resetMethod: ffiMethod.
 

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFIMethodRegistryTest.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFIMethodRegistryTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : 'TFUFFIMethodRegistryTest',
+	#superclass : 'TFUFFITestCase',
+	#category : 'ThreadedFFI-UFFI-Tests',
+	#package : 'ThreadedFFI-UFFI-Tests'
+}
+
+{ #category : 'tests' }
+TFUFFIMethodRegistryTest >> testRegistryDoesNotRestoreUninstalledMethods [
+
+	"Call the method to force installation"
+	| ffiMethod |
+	TFUFFITestClassWithTrait uniqueInstance pidfortest.
+	
+	ffiMethod := TFUFFITestClassWithTrait >> #pidfortest.
+	ffiMethod recompile.
+	FFIMethodRegistry uniqueInstance resetMethod: ffiMethod.
+
+	self assert: TFUFFITestClassWithTrait localMethods first isInstalled.
+]

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFITestClassWithTrait.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFITestClassWithTrait.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : 'TFUFFITestClassWithTrait',
+	#superclass : 'FFILibrary',
+	#traits : 'TFFITraitForTest',
+	#classTraits : 'TFFITraitForTest classTrait',
+	#category : 'ThreadedFFI-UFFI-Tests',
+	#package : 'ThreadedFFI-UFFI-Tests'
+}
+
+{ #category : 'accessing - platform' }
+TFUFFITestClassWithTrait >> macLibraryName [
+	^ 'libc.dylib'
+]
+
+{ #category : 'accessing' }
+TFUFFITestClassWithTrait >> pidfortest [
+
+	self ffiCall: #(size_t getpid())
+]
+
+{ #category : 'accessing - platform' }
+TFUFFITestClassWithTrait >> unixLibraryName [
+	^ 'libc.so.6'
+]
+
+{ #category : 'accessing - platform' }
+TFUFFITestClassWithTrait >> win32LibraryName [
+	"While this is not a 'libc' properly, msvcrt has the functions we are defining here"
+	^ 'msvcrt.dll'
+]

--- a/src/ThreadedFFI-UFFI-Tests/TFUFFITestClassWithTrait.class.st
+++ b/src/ThreadedFFI-UFFI-Tests/TFUFFITestClassWithTrait.class.st
@@ -9,22 +9,24 @@ Class {
 
 { #category : 'accessing - platform' }
 TFUFFITestClassWithTrait >> macLibraryName [
-	^ 'libc.dylib'
+
+	^ 'libTestLibrary.dylib'
 ]
 
 { #category : 'accessing' }
-TFUFFITestClassWithTrait >> pidfortest [
+TFUFFITestClassWithTrait >> shortCallout [
 
-	self ffiCall: #(size_t getpid())
+	^ self ffiCall: #(int shortCallout())
 ]
 
 { #category : 'accessing - platform' }
 TFUFFITestClassWithTrait >> unixLibraryName [
-	^ 'libc.so.6'
+
+	^ 'libTestLibrary.so'
 ]
 
 { #category : 'accessing - platform' }
 TFUFFITestClassWithTrait >> win32LibraryName [
-	"While this is not a 'libc' properly, msvcrt has the functions we are defining here"
-	^ 'msvcrt.dll'
+
+	^ 'TestLibrary.dll'
 ]

--- a/src/UnifiedFFI/FFIMethodRegistry.class.st
+++ b/src/UnifiedFFI/FFIMethodRegistry.class.st
@@ -84,20 +84,30 @@ FFIMethodRegistry >> registerMethod: aCompiledMethod [
 	compiledMethods add: aCompiledMethod
 ]
 
-{ #category : 'accessing' }
-FFIMethodRegistry >> removeMethod: aMethod [
-
-	aMethod methodClass methodDict
-		at: aMethod selector
-		put: (aMethod propertyAt: #ffiNonCompiledMethod)
-]
-
 { #category : 'initialization' }
 FFIMethodRegistry >> reset [
 	"FFI compiled methods will keep the old method as a property, making easy to replace it
 	 when changing platforms."
-	self compiledMethods do: [ :each | self removeMethod: each].
+	self compiledMethods do: [ :each | 
+		self resetMethod: each ].
 	self compiledMethods removeAll
+]
+
+{ #category : 'accessing' }
+FFIMethodRegistry >> resetMethod: ffiMethod [
+
+	"Only restore methods that are still installed.
+	Otherwise, it may happen that the method has been replaced 
+	and thus not yet GC'd and we will restore a wrong method."
+
+	| originalMethod |
+	
+	ffiMethod isInstalled ifFalse: [ ^ self ].
+	
+	originalMethod := ffiMethod propertyAt: #ffiNonCompiledMethod.
+	ffiMethod methodClass methodDict
+		at: ffiMethod selector
+		put: originalMethod
 ]
 
 { #category : 'reseting' }
@@ -106,6 +116,6 @@ FFIMethodRegistry >> resetSingleClass: aClass [
 	self compiledMethods
 		select: [ :m | m methodClass = aClass ]
 		thenDo: [ :aMethod |
-			self removeMethod: aMethod.
+			self resetMethod: aMethod.
 			compiledMethods remove: aMethod ]
 ]


### PR DESCRIPTION
This pull request backports the changes of pull request #17686 to Pharo 12.