### PR TITLE
New test for File system saveas

### DIFF
--- a/src/Morphic-Tests/UIThemeTest.class.st
+++ b/src/Morphic-Tests/UIThemeTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : 'UIThemeTest',
+	#superclass : 'TestCase',
+	#category : 'Morphic-Tests-Widgets',
+	#package : 'Morphic-Tests',
+	#tag : 'Widgets'
+}
+
+{ #category : 'tests' }
+UIThemeTest >> testCanUseFileInChooseForSaveFileReference [
+
+    | fs file |
+    fs := FileSystem memory.
+    file := (fs root / 'a.image') ensureCreateFile.
+
+    MorphicUIManager new
+    chooseForSaveFileReference: 'save image as.?' extensions: #('image') path: file.
+    
+    self assert: (fs root / 'a.1.image') exists
+]

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -797,32 +797,22 @@ UITheme >> chooseFileIn: aThemedMorph title: title extensions: exts path: path p
 
 { #category : 'services' }
 UITheme >> chooseForSaveFileReferenceIn: aThemedMorph title: title extensions: exts path: path preview: preview [
-    "Answer the result of a file name chooser dialog with the given title, extensions
-    path and preview type.
-    Answer nil or a filename."
+	"Answer the result of a file name chooser dialog with the given title, extensions
+	path and preview type.
+	Answer nil or a filename."
 
-    | dialog |
-	"| dialog defaultFolder |"	
-    
-    dialog := self fileSaveDialogWindowClass new.
-    exts 
-        ifNotNil: [ dialog filter: (StCustomExtensionsFilter extensions: exts) ].
-    path 
-        ifNotNil: [ dialog nameText: path asFileReference basename ].
-        
-    "defaultFolder := path 
-        ifNil: [ StFileSystemModel defaultDirectory ]
-         ifNotNil: [ path 
-            ifFile: [ path parent ]
-             ifDirectory: [ path ] 
-            ifAbsent: [ path path parent asFileReference ] ]."
-        
-    ^ dialog
-		  defaultFolder: (path ifNil: [ StFileSystemModel defaultDirectory ]);
-        "defaultFolder: defaultFolder;"
-        title: (title ifNil: [ 'Save as' translated ] ifNotNil: [ title ]);
-        openModal;
-        selectedEntry
+	| dialog |
+	
+	dialog := self fileSaveDialogWindowClass new.
+	exts 
+		ifNotNil: [ dialog filter: (StCustomExtensionsFilter extensions: exts) ].
+	path 
+		ifNotNil: [ dialog nameText: path asFileReference basename ].
+	^ dialog
+		defaultFolder: (path ifNil: [ StFileSystemModel defaultDirectory ]);
+		title: (title ifNil: [ 'Save as' translated ] ifNotNil: [ title ]);
+		openModal;
+		selectedEntry
 ]
 
 { #category : 'services' }

--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -797,22 +797,32 @@ UITheme >> chooseFileIn: aThemedMorph title: title extensions: exts path: path p
 
 { #category : 'services' }
 UITheme >> chooseForSaveFileReferenceIn: aThemedMorph title: title extensions: exts path: path preview: preview [
-	"Answer the result of a file name chooser dialog with the given title, extensions
-	path and preview type.
-	Answer nil or a filename."
+    "Answer the result of a file name chooser dialog with the given title, extensions
+    path and preview type.
+    Answer nil or a filename."
 
-	| dialog |
-	
-	dialog := self fileSaveDialogWindowClass new.
-	exts 
-		ifNotNil: [ dialog filter: (StCustomExtensionsFilter extensions: exts) ].
-	path 
-		ifNotNil: [ dialog nameText: path asFileReference basename ].
-	^ dialog
-		defaultFolder: (path ifNil: [ StFileSystemModel defaultDirectory ]);
-		title: (title ifNil: [ 'Save as' translated ] ifNotNil: [ title ]);
-		openModal;
-		selectedEntry
+    | dialog |
+	"| dialog defaultFolder |"	
+    
+    dialog := self fileSaveDialogWindowClass new.
+    exts 
+        ifNotNil: [ dialog filter: (StCustomExtensionsFilter extensions: exts) ].
+    path 
+        ifNotNil: [ dialog nameText: path asFileReference basename ].
+        
+    "defaultFolder := path 
+        ifNil: [ StFileSystemModel defaultDirectory ]
+         ifNotNil: [ path 
+            ifFile: [ path parent ]
+             ifDirectory: [ path ] 
+            ifAbsent: [ path path parent asFileReference ] ]."
+        
+    ^ dialog
+		  defaultFolder: (path ifNil: [ StFileSystemModel defaultDirectory ]);
+        "defaultFolder: defaultFolder;"
+        title: (title ifNil: [ 'Save as' translated ] ifNotNil: [ title ]);
+        openModal;
+        selectedEntry
 ]
 
 { #category : 'services' }


### PR DESCRIPTION
Hello,

This Is referencing issue #17549,

We tried to fix this issue with @demarey during sprint and here is what we understood and tried to implement :

The first error says a directory does not exist so we tried to ensure that if the fileReference passed through the code corresponds to a file, its parent directory will be returned. This is done in UITheme>>chooseForSaveFileReferenceIn:title:extensions:path:preview:
This was recently fixed in merge #17767

We then wrote a test (#testCanUseFileInChooseForSaveFileReference) to save a file as a a name already used, and check if a new file with a 'duplicated' name existed.

We figured that the widget opening when doing the 'save as' operation is linked to the machine file system although we used an artificial file system for our test, that's why we added a little snippet to ensure the widget is correctly linked to the artificial file system if we use one. This is added as a suggestion on what could be done although this might break some thing if implemented as such, comment can be seen in StDirectoryTreePresenter>>expandPath: of [this PR on NewTools](https://github.com/pharo-spec/NewTools/pull/984), also this fix is needed for the test to pass so this test might be modified later when a correct implementation is found. 

After those changes, we can see the widget works fine for the test although the name suggested for the new file saved is the same as the current image so this might need to be changed by default to have something like 'a.1.image' for example.


**Attention, the code suggested in [this PR](https://github.com/pharo-spec/NewTools/pull/984) is required for the 'save as' widget when launching the test**

**Also, for now the test doesn't pass automatically as it waits for an answer from the widget, take this PR as a suggestion we can discuss**