### PR TITLE
Fix block compilation

### DIFF
--- a/src/Kernel-CodeModel/CompiledBlock.class.st
+++ b/src/Kernel-CodeModel/CompiledBlock.class.st
@@ -153,6 +153,15 @@ CompiledBlock >> methodNode [
 	^ self outerCode methodNode
 ]
 
+{ #category : 'initialization' }
+CompiledBlock >> needsFrameSize: newFrameSize [
+	"Set the largeFrameBit to accomodate the newFrameSize"
+
+	self numTemps + newFrameSize > LargeFrame ifTrue: [
+		^ self error: 'Cannot compile -- stack including temps is too deep' ].
+	self setFrameBit: self numTemps + newFrameSize > SmallFrame
+]
+
 { #category : 'accessing' }
 CompiledBlock >> outerCode [
 	"answer the compiled code that I am installed in, or nil if none."
@@ -198,12 +207,6 @@ CompiledBlock >> pcInOuter [
 CompiledBlock >> pragmas [
 	<reflection: 'Class structural inspection - Pragma'>
 	^ #()
-]
-
-{ #category : 'accessing' }
-CompiledBlock >> primitive [
-	"for now we do not compile Quick CompiedBlocks, see IRBytecodeGenerator>>#compiledBlockWith:"
-	^0
 ]
 
 { #category : 'printing' }

--- a/src/Kernel-CodeModel/CompiledCode.class.st
+++ b/src/Kernel-CodeModel/CompiledCode.class.st
@@ -386,8 +386,7 @@ CompiledCode >> hasPragmaNamed: arg1 [
 
 { #category : 'accessing' }
 CompiledCode >> hasPrimitive [
-	"Answer the primitive index associated with the receiver.
-	 Zero indicates that this is not a primitive method."
+	"Answer a boolean indicated if the method is marked as having a primitive"
 
 	^ self header anyMask: 65536
 ]

--- a/src/Kernel-CodeModel/CompiledCode.class.st
+++ b/src/Kernel-CodeModel/CompiledCode.class.st
@@ -384,6 +384,14 @@ CompiledCode >> hasPragmaNamed: arg1 [
 	^ self subclassResponsibility
 ]
 
+{ #category : 'accessing' }
+CompiledCode >> hasPrimitive [
+	"Answer the primitive index associated with the receiver.
+	 Zero indicates that this is not a primitive method."
+
+	^ self header anyMask: 65536
+]
+
 { #category : 'literals' }
 CompiledCode >> hasSelector: selector [
 	"Answers true if the method refers to the selector"
@@ -797,10 +805,13 @@ CompiledCode >> pragmas [
 CompiledCode >> primitive [
 	"Answer the primitive index associated with the receiver.
 	 Zero indicates that this is not a primitive method."
+
 	| initialPC |
-	^(self header anyMask: 65536) "Is the hasPrimitive? flag set?"
-		ifTrue: [(self at: (initialPC := self initialPC) + 1) + ((self at: initialPC + 2) bitShift: 8)]
-		ifFalse: [0]
+	^ self hasPrimitive
+		  ifTrue: [
+			  (self at: (initialPC := self initialPC) + 1)
+			  + ((self at: initialPC + 2) bitShift: 8) ]
+		  ifFalse: [ 0 ]
 ]
 
 { #category : 'printing' }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -446,21 +446,6 @@ OCASTTranslator >> subTranslator [
 ]
 
 { #category : 'visitor - double dispatching' }
-OCASTTranslator >> translateConstantBlock: aBlockNode [
-	| ir |
-	"even though we never execute the compiledBlock, we create it so that the BlockClosure can use e.g. to query on the bytecode level"
-	ir := OCIRBuilder new
-				mapToNode: aBlockNode;
-				numArgs: aBlockNode arguments size;
-				pushLiteral: aBlockNode constantValue;
-				blockReturnTop;
-				ir.
-	aBlockNode ir: ir.
-	aBlockNode resetBcToASTCache.
-	^ ir compiledBlock: aBlockNode scope
-]
-
-{ #category : 'visitor - double dispatching' }
 OCASTTranslator >> translateFullBlock: aBlockNode [
 
 	methodBuilder mapToNode: aBlockNode.
@@ -568,7 +553,7 @@ OCASTTranslator >> visitConstantBlockNode: anBlockNode [
 	constantBlock := ConstantBlockClosure
 							  numArgs: anBlockNode numArgs
 		                 literal: anBlockNode constantValue.
-	compiledBlock := self translateConstantBlock: anBlockNode.
+	compiledBlock := self subTranslator translateFullBlock: anBlockNode.
 	constantBlock compiledBlock: compiledBlock.
 	methodBuilder pushLiteral: constantBlock
 ]

--- a/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
@@ -163,14 +163,9 @@ OCIRBytecodeGenerator >> compiledBlock [
 	| lits quickPrimitive header cb |
 	lits := self literals allButLast "1 free only for compiledBlock".
 	quickPrimitive := self quickMethodPrim.
-	"disabled for now"
-	"(primNumber = 0 and: [quickPrimitive > 0]) ifTrue: [
-		""if we are a quick method we need to add a bytecode at the beginning. #bytecodes
-		takes primitiveBytes into account""
-		primitiveBytes := (ByteArray new: 4) writeStream.
-		encoder stream: primitiveBytes.
-		encoder genCallPrimitive: quickPrimitive.
-	]."
+
+	"Compiled blocks never call primitives"
+	primNumber := 0.
 	header := self spurVMHeader: lits size.
 	cb := CompiledBlock basicNew: self bytecodes size header: header.
 	(WriteStream with: cb)

--- a/src/OpalCompiler-Tests/OCClosureTest.class.st
+++ b/src/OpalCompiler-Tests/OCClosureTest.class.st
@@ -102,7 +102,10 @@ OCClosureTest >> testConstantBlockClosure [
 	"this is a test that enales optionCleanBlockClosure and check that clean blocks work"
 	block := [1].
 	self assert: block isClean.
+	self deny: block hasPrimitive.
 	self assert: block class equals: ConstantBlockClosure.
+	self assert: block compiledBlock numTemps equals: 0.
+	self assert: block compiledBlock numArgs equals: 0.
 	self assert: block outerContext isNil.
 	self assert: block value equals: 1.
 	self assert: (block valueWithArguments: #()) equals: 1.
@@ -117,7 +120,10 @@ OCClosureTest >> testConstantBlockClosure [
 
 	block := [:arg | 1].
 	self assert: block isClean.
+	self deny: block hasPrimitive.
 	self assert: block class equals: ConstantBlockClosure1Arg.
+	self assert: block compiledBlock numTemps equals: 1.
+	self assert: block compiledBlock numArgs equals: 1.
 	self assert: block outerContext isNil.
 	self assert: (block value: nil) equals: 1.
 	self assert: (block valueWithArguments: #(2)) equals: 1.
@@ -129,7 +135,10 @@ OCClosureTest >> testConstantBlockClosure [
 
 	block := [:arg1 :arg2 | 1].
 	self assert: block isClean.
+	self deny: block hasPrimitive.
 	self assert: block class equals: ConstantBlockClosure2Arg.
+	self assert: block compiledBlock numTemps equals: 2.
+	self assert: block compiledBlock numArgs equals: 2.
 	self assert: block outerContext isNil.
 	self assert: (block value: nil value: nil) equals: 1.
 	self assert: (block valueWithArguments: #(2 2)) equals: 1.
@@ -143,8 +152,11 @@ OCClosureTest >> testConstantBlockClosure [
 
 	block := [:arg1 :arg2 :arg3 | 1].
 	self assert: block isClean.
+	self deny: block hasPrimitive.
 	self assert: block sourceNode isConstant.
 	self assert: block class equals: ConstantBlockClosure3Arg.
+	self assert: block compiledBlock numTemps equals: 3.
+	self assert: block compiledBlock numArgs equals: 3.
 	self assert: block outerContext isNil.
 	self assert: (block value: nil value: nil value: nil) equals: 1.
 	self assert: (block valueWithArguments: #(2 2 2)) equals: 1.
@@ -157,9 +169,12 @@ OCClosureTest >> testConstantBlockClosure [
 
 	block := [:arg1 :arg2 :arg3 :arg4 | 1].
 	self assert: block isClean.
+	self deny: block hasPrimitive.
 	self assert: block sourceNode isConstant.
 	"but we do not compile it as a ConstantBLockCloure for now"
 	self assert: block class equals: CleanBlockClosure.
+	self assert: block compiledBlock numTemps equals: 4.
+	self assert: block compiledBlock numArgs equals: 4.
 
 	self should: [block value] raise: ArgumentsCountMismatch.
 	self should: [block value: nil] raise: ArgumentsCountMismatch.
@@ -170,8 +185,11 @@ OCClosureTest >> testConstantBlockClosure [
 
 	block := [:arg1 :arg2 :arg3 :arg4 :arg5 | 1].
 	self assert: block isClean.
+	self deny: block hasPrimitive.
 	self assert: block sourceNode isConstant.
 	self assert: block class equals: CleanBlockClosure.
+	self assert: block compiledBlock numTemps equals: 5.
+	self assert: block compiledBlock numArgs equals: 5.
 
  	self should: [block value] raise: ArgumentsCountMismatch.
  	self should: [block value: nil] raise: ArgumentsCountMismatch.


### PR DESCRIPTION
 - constant blocks have a wrong number of temps. Use normal full block translation and remove duplicated and ill-implemented translation
 - blocks should not have the primitive flag set in their header (and it should not be worked around in the `primitive` method)

Introduce `hasPrimitive` as a testing method for testing