### PR TITLE
Improve ClassFactoryForTestCase cleanup

### DIFF
--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -125,7 +125,7 @@ ClassFactoryForTestCase >> delete: aBehavior [
 ClassFactoryForTestCase >> deletePackages [
 	"We remove all packages that we created while creating classes in this factory."
 
-	createdPackages do: [ :package | package removeFromSystem ]
+	createdPackages do: [ :package | self organization removePackage: package ]
 ]
 
 { #category : 'accessing' }
@@ -155,7 +155,7 @@ ClassFactoryForTestCase >> make: aBlock [
 	Once the test is finished, I'll remove the created class or trait."
 
 	| newClass numberOfPackages |
-	numberOfPackages := self environment packageOrganizer packages size.
+	numberOfPackages := self organization packages size.
 	newClass := self class classInstaller make: [ :aBuilder | "Let's but some default values."
 		            aBuilder
 			            name: self newBehaviorName;
@@ -169,7 +169,7 @@ ClassFactoryForTestCase >> make: aBlock [
 	self registerBehavior: newClass.
 
 	"If we created a package, we need to register it to be removed."
-	numberOfPackages = self environment packageOrganizer packages size ifFalse: [ createdPackages add: newClass package ].
+	numberOfPackages = self organization packages size ifFalse: [ createdPackages add: newClass package ].
 	^ newClass
 ]
 

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -29,6 +29,7 @@ Class {
 	#name : 'ClassFactoryForTestCase',
 	#superclass : 'Object',
 	#instVars : [
+		'createdPackages',
 		'createdBehaviors',
 		'createdSilently',
 		'environment'
@@ -53,7 +54,7 @@ ClassFactoryForTestCase class >> environment: aSystemEnvironment [
 ClassFactoryForTestCase >> cleanUp [
 
 	self createdBehaviors copy do: [ :behavior | self delete: behavior ].
-	self deletePackage
+	self deletePackages
 ]
 
 { #category : 'accessing' }
@@ -107,8 +108,7 @@ ClassFactoryForTestCase >> defaultSuperclass [
 { #category : 'cleaning' }
 ClassFactoryForTestCase >> delete: aBehavior [
 
-	| name package |
-	package := aBehavior package.
+	| name |
 	createdBehaviors remove: aBehavior ifAbsent: [  ].
 	aBehavior isObsolete ifTrue: [ ^ self ].
 	name := aBehavior name. "save it as it will be obsolete later"
@@ -118,14 +118,14 @@ ClassFactoryForTestCase >> delete: aBehavior [
 			aBehavior removeFromSystemUnlogged ]
 		ifFalse: [ aBehavior removeFromSystem ].
 	"We know that we can remove the key from the undeclared registry, as it was added by #removeFromSystem"
-	self class undeclaredRegistry removeKey: name ifAbsent: [ "might be an anonymous class" ].
-	package isEmpty ifTrue: [ package removeFromSystem ]
+	self class undeclaredRegistry removeKey: name ifAbsent: [ "might be an anonymous class" ]
 ]
 
 { #category : 'cleaning' }
-ClassFactoryForTestCase >> deletePackage [
+ClassFactoryForTestCase >> deletePackages [
+	"We remove all packages that we created while creating classes in this factory."
 
-	(self organization packages select: [ :package | package name beginsWith: self packageName ]) do: [ :package | package removeFromSystem ]
+	createdPackages do: [ :package | package removeFromSystem ]
 ]
 
 { #category : 'accessing' }
@@ -145,7 +145,8 @@ ClassFactoryForTestCase >> initialize [
 
 	super initialize.
 	createdBehaviors := IdentitySet new.
-	createdSilently := IdentitySet new
+	createdSilently := IdentitySet new.
+	createdPackages := IdentitySet new
 ]
 
 { #category : 'creating' }
@@ -153,7 +154,8 @@ ClassFactoryForTestCase >> make: aBlock [
 	"I return a new class or trait in the environment of the factory configured as the user specified in the make block.
 	Once the test is finished, I'll remove the created class or trait."
 
-	| newClass |
+	| newClass numberOfPackages |
+	numberOfPackages := self environment packageOrganizer packages size.
 	newClass := self class classInstaller make: [ :aBuilder | "Let's but some default values."
 		            aBuilder
 			            name: self newBehaviorName;
@@ -165,6 +167,9 @@ ClassFactoryForTestCase >> make: aBlock [
 		            aBlock value: aBuilder ].
 
 	self registerBehavior: newClass.
+
+	"If we created a package, we need to register it to be removed."
+	numberOfPackages = self environment packageOrganizer packages size ifFalse: [ createdPackages add: newClass package ].
 	^ newClass
 ]
 

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -107,7 +107,8 @@ ClassFactoryForTestCase >> defaultSuperclass [
 { #category : 'cleaning' }
 ClassFactoryForTestCase >> delete: aBehavior [
 
-	| name |
+	| name package |
+	package := aBehavior package.
 	createdBehaviors remove: aBehavior ifAbsent: [  ].
 	aBehavior isObsolete ifTrue: [ ^ self ].
 	name := aBehavior name. "save it as it will be obsolete later"
@@ -117,7 +118,8 @@ ClassFactoryForTestCase >> delete: aBehavior [
 			aBehavior removeFromSystemUnlogged ]
 		ifFalse: [ aBehavior removeFromSystem ].
 	"We know that we can remove the key from the undeclared registry, as it was added by #removeFromSystem"
-	self class undeclaredRegistry removeKey: name ifAbsent: [ "might be an anonymous class" ]
+	self class undeclaredRegistry removeKey: name ifAbsent: [ "might be an anonymous class" ].
+	package isEmpty ifTrue: [ package removeFromSystem ]
 ]
 
 { #category : 'cleaning' }

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -79,6 +79,20 @@ ClassFactoryForTestCaseTest >> testPackageCleanUp [
 ]
 
 { #category : 'testing' }
+ClassFactoryForTestCaseTest >> testPackageOfCreatedClassIsCleanedUp [
+
+	| class |
+	class := factory make: [ :aBuilder |
+		         aBuilder
+			         superclass: Object;
+			         package: 'ClassFactoryForTestCaseGeneratedPackage' ].
+	self assert: class package name equals: 'ClassFactoryForTestCaseGeneratedPackage'.
+	self assert: (self class packageOrganizer packages anySatisfy: [ :package | package name = 'ClassFactoryForTestCaseGeneratedPackage' ]).
+	factory cleanUp.
+	self deny: (self class packageOrganizer packages anySatisfy: [ :package | package name = 'ClassFactoryForTestCaseGeneratedPackage' ])
+]
+
+{ #category : 'testing' }
 ClassFactoryForTestCaseTest >> testSingleClassCreation [
 
 	| class |

--- a/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
+++ b/src/SUnit-Tests/ClassFactoryForTestCaseTest.class.st
@@ -87,9 +87,9 @@ ClassFactoryForTestCaseTest >> testPackageOfCreatedClassIsCleanedUp [
 			         superclass: Object;
 			         package: 'ClassFactoryForTestCaseGeneratedPackage' ].
 	self assert: class package name equals: 'ClassFactoryForTestCaseGeneratedPackage'.
-	self assert: (self class packageOrganizer packages anySatisfy: [ :package | package name = 'ClassFactoryForTestCaseGeneratedPackage' ]).
+	self assert: (self organization packages anySatisfy: [ :package | package name = 'ClassFactoryForTestCaseGeneratedPackage' ]).
 	factory cleanUp.
-	self deny: (self class packageOrganizer packages anySatisfy: [ :package | package name = 'ClassFactoryForTestCaseGeneratedPackage' ])
+	self deny: (self organization packages anySatisfy: [ :package | package name = 'ClassFactoryForTestCaseGeneratedPackage' ])
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
By default ClassFactoryForTestCase generates its classes in the same package and cleanup this package afterward.  The problem is that a user can define its own package for the classes to create and those are not cleanup up.

I propose to improve the cleanup to remove those packages if they are empty.