### PR TITLE
Set to true because we want to use pres by default

### DIFF
--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -453,7 +453,7 @@ SystemWindow class >> topWindow [
 { #category : 'accessing' }
 SystemWindow class >> useHideForClose [
 
-	^ UseHideForClose ifNil: [ UseHideForClose := false ]
+	^ UseHideForClose ifNil: [ UseHideForClose := true ]
 ]
 
 { #category : 'setting' }


### PR DESCRIPTION
- Changing lazy initialization of SystemWindow shared variable to use SpClosedWindowListPresenter by default
- The logic of "unclose window" wasn't use by default before
- Lazy initialization is an implementation detail, testing the initialization mechanism itself is redundant.