### PR TITLE
Fix closure tests

### DIFF
--- a/src/Kernel-CodeModel/CleanBlockClosure.class.st
+++ b/src/Kernel-CodeModel/CleanBlockClosure.class.st
@@ -47,6 +47,12 @@ CleanBlockClosure >> hasLiteralSuchThat: aLiteral [
 	^self compiledBlock hasLiteralSuchThat: aLiteral
 ]
 
+{ #category : 'testing' }
+CleanBlockClosure >> hasPrimitive [
+	
+	^ self compiledBlock hasPrimitive
+]
+
 { #category : 'accessing' }
 CleanBlockClosure >> innerCompiledBlocksAnySatisfy: aBlock [
 	^self compiledBlock innerCompiledBlocksAnySatisfy: aBlock

--- a/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
@@ -165,8 +165,7 @@ OCIRBytecodeGenerator >> compiledBlock [
 	quickPrimitive := self quickMethodPrim.
 
 	"Compiled blocks never call primitives"
-	primNumber := 0.
-	header := self spurVMHeader: lits size.
+	header := self spurVMHeader: lits size hasPrimitive: false.
 	cb := CompiledBlock basicNew: self bytecodes size header: header.
 	(WriteStream with: cb)
 		position: cb initialPC - 1;
@@ -189,7 +188,7 @@ OCIRBytecodeGenerator >> compiledMethod [
 		encoder stream: primitiveBytes.
 		encoder genCallPrimitive: quickPrimitive.
 	].
-	^ self compiledMethodHeader: (self spurVMHeader: lits size) literals: lits
+	^ self compiledMethodHeader: (self spurVMHeader: lits size hasPrimitive: self hasPrimitive) literals: lits
 ]
 
 { #category : 'results' }
@@ -281,7 +280,8 @@ OCIRBytecodeGenerator >> goto: seqId [
 
 { #category : 'results' }
 OCIRBytecodeGenerator >> hasPrimitive [
-	"do I have a primitive? Both normal primitive and quick return"
+	"Compute if the method is a primitive or quick method.
+	Invalid for closures"
 	primNumber > 0 ifTrue: [ ^true ].
 	^ self endPrimNumber > 0
 ]
@@ -663,12 +663,12 @@ OCIRBytecodeGenerator >> send: selector toSuperOf: behavior [
 ]
 
 { #category : 'results' }
-OCIRBytecodeGenerator >> spurVMHeader: literalsSize [
+OCIRBytecodeGenerator >> spurVMHeader: literalsSize hasPrimitive: hasPrimitive [
 	^ (CompiledMethod headerFlagForEncoder: self encoderClass) +
 		(self numArgs bitShift: 24) +
 		( self numTemps bitShift: 18) +
 		literalsSize +
-		(self hasPrimitive asBit bitShift: 16)
+		(hasPrimitive asBit bitShift: 16)
 ]
 
 { #category : 'results' }


### PR DESCRIPTION
- Remove the compiler quick primitive calculation for blocks.
- Add `hasPrimitive` on block closure objects delegating to their code