### PR TITLE
Improve FLBasicSerializationTest>>#testWideStringClassName

### DIFF
--- a/src/Fuel-Core-Tests/FLBasicSerializationTest.class.st
+++ b/src/Fuel-Core-Tests/FLBasicSerializationTest.class.st
@@ -821,20 +821,15 @@ FLBasicSerializationTest >> testWideString [
 
 { #category : 'tests-strings' }
 FLBasicSerializationTest >> testWideStringClassName [
-	| class className |	
+
+	| class className |
 	className := 'Foox' asWideString
-		at: 4 put: (Character value: 265);
-		yourself.
-	class := self classFactory silentlyNewClass
-		setName: className;
-		yourself.
-	self environmentOfTest
-		at: class name
-		put: class.
-		
-	self
-		shouldnt: [ self resultOfSerializeAndMaterialize: class ]
-		raise: FLClassNotFound
+		             at: 4 put: (Character value: 265);
+		             yourself.
+	class := self classFactory silentlyMake: [ :builder | builder name: className ].
+	self environmentOfTest at: class name put: class.
+
+	self shouldnt: [ self resultOfSerializeAndMaterialize: class ] raise: FLClassNotFound
 ]
 
 { #category : 'tests-strings' }


### PR DESCRIPTION
This test change the name of a class after creating it but this seems to create a problem that this class ends up been an obsolete class once we cleanup after the test.

To not let any leftover I propose to create it directly with the right name from the start. With this, no obsolete class stays in the system afterward