### PR TITLE
Improve OCClassBuilderTest>>#testUseUndefinedClass

### DIFF
--- a/src/ClassParser-Tests/OCClassBuilderTest.class.st
+++ b/src/ClassParser-Tests/OCClassBuilderTest.class.st
@@ -321,5 +321,7 @@ OCClassBuilderTest >> testUseUndefinedClass [
 			buildEnvironment: self class environment;
 			buildFromAST: ast ].
 	self assert: [ (self class environment at: #PoPouet) isUndefined ] ] ensure: [
-		self class environment at: #PoPouet ifPresent: [ :class | class removeFromSystem ] ]
+		self class environment at: #PoPouet ifPresent: [ :class | "We first need to remove TestClass before removing PoPouet."
+			class subclassesDo: [ :subclass | subclass removeFromSystem ].
+			class removeFromSystem ] ]
 ]


### PR DESCRIPTION
I'm improving the cleanup of this test because it was leaving an unpackaged class (TestClass) and this subclass was causing its superclass (PoPouet) to end up as an Obsolete

Problem detected while working on https://github.com/pharo-project/pharo/pull/17783