### PR TITLE
Remove a usage of an old icon name

### DIFF
--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -517,7 +517,7 @@ SystemWindow class >> windowMenuOn: aBuilder [
 		                 ifFalse: [ #Maximize ].
 	(aBuilder item: maximizeLabel)
 		action: [ aBuilder model expandBoxHit ];
-		iconName: #windowMaximizeForm
+		iconName: #windowMaximize
 ]
 
 { #category : 'top window' }


### PR DESCRIPTION
Icon names should not have "Form" as suffix anymore.