### PR TITLE
Show correct modifier for NEC item browsing on Linux/Win

### DIFF
--- a/src/NECompletion-Morphic/NECMenuMorph.class.st
+++ b/src/NECompletion-Morphic/NECMenuMorph.class.st
@@ -281,7 +281,9 @@ NECMenuMorph >> detailMessage [
 
 	^ self itemsCount isZero
 		  ifTrue: [ 'no entries' ]
-		  ifFalse: [ 'cmd+B browse entry' ]
+		  ifFalse: [
+			  (OSPlatform current defaultModifier + $b) asString
+			  , ' browse entry' ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
NEC list used to show "cmd + B" on all platforms, even on Windows and Linux where it is actually ctrl. This PR uses `OSPlatform current` to show the correct modifier.
Fixes https://github.com/pharo-project/pharo/issues/6169