### PR TITLE
Removed reference to the shortcuts browser from the system settings

### DIFF
--- a/src/Commander-Activators-Shortcut/CmdShortcutActivation.class.st
+++ b/src/Commander-Activators-Shortcut/CmdShortcutActivation.class.st
@@ -33,29 +33,10 @@ Class {
 	#package : 'Commander-Activators-Shortcut'
 }
 
-{ #category : 'settings' }
-CmdShortcutActivation class >> buildSettingsOn: aBuilder [
-	<systemsettings>
-
-	(aBuilder button: #openShortcutsEditor)
-		order: 1;
-		parent: #tools;
-		buttonLabel: 'Open';
-		label: 'Shortcuts Editor';
-		description: 'All System Command Shortcuts';
-		target: self
-]
-
 { #category : 'instance creation' }
 CmdShortcutActivation class >> by: aKeyCombination for: anAnnotationUser [
 	^(self for: anAnnotationUser)
 		keyCombination: aKeyCombination
-]
-
-{ #category : 'settings' }
-CmdShortcutActivation class >> openShortcutsEditor [
-
-	KMDescriptionPresenter open
 ]
 
 { #category : 'well known shortcuts' }


### PR DESCRIPTION
Removed reference to the shortcuts browser from the settings. This was just a button inside the settings to open the shortcuts browser. An open button should not be in the settings.

Besides, it is already on the menu

<img width="270" alt="Capture d’écran 2025-02-11 à 16 51 37" src="https://github.com/user-attachments/assets/6d69b44f-703f-4d37-ac87-bb27afc8e8bc" />
