### PR TITLE
Fix missing initialization for ‘zoomFactor’ of WorldMorph

### DIFF
--- a/src/Morphic-Core/WorldMorph.class.st
+++ b/src/Morphic-Core/WorldMorph.class.st
@@ -460,6 +460,7 @@ WorldMorph >> initialize [
 
 	worldState := WorldState new.
 	super initialize.
+	zoomFactor := 1.
 
 	self class codeSupportAnnouncer weak when: FullscreenAnnouncement send: #fullscreenChanged: to: self
 ]


### PR DESCRIPTION
This pull request fixes the missing initialization for the instance variable ‘zoomFactor’ of WorldMorph (which is what causes issue #17816).