### PR TITLE
Improve the selection color of the dark theme

### DIFF
--- a/src/DarkBlueTheme/DarkBlueTheme.class.st
+++ b/src/DarkBlueTheme/DarkBlueTheme.class.st
@@ -34,6 +34,14 @@ DarkBlueTheme >> buttonNormalBorderStyleFor: aButton [
 		baseColor: self buttonColor darker
 ]
 
+{ #category : 'initialization' }
+DarkBlueTheme >> defaultSettings [
+
+	^ super defaultSettings
+		  menuSelectionTextColor: Color white twiceDarker;
+		  yourself
+]
+
 { #category : 'accessing' }
 DarkBlueTheme >> shStyleTableName [
 


### PR DESCRIPTION
It's hard to see in the world menu the text that is been hovered. Here is an improvement of the theme

Old:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/91012b31-2584-4425-84eb-4f75834636d6" />

New: 
<img width="338" alt="image" src="https://github.com/user-attachments/assets/64c1eca0-8a01-492a-93c0-aef3aaa07631" />


