### PR TITLE
Branch: TurnOffUncloseWindow,  Fixes # 17820

### DIFF
--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -453,7 +453,7 @@ SystemWindow class >> topWindow [
 { #category : 'accessing' }
 SystemWindow class >> useHideForClose [
 
-	^ UseHideForClose ifNil: [ UseHideForClose := true ]
+	^ UseHideForClose ifNil: [ UseHideForClose := false ]
 ]
 
 { #category : 'setting' }

--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -282,11 +282,14 @@ SystemWindow class >> closeTopWindow [
 	"Try to close the top window.  It may of course decline"
 	TopWindow ifNotNil: [ :window |
 		TopWindow := nil.
-		window hide.
-		announcement := WindowClosed new
-			                window: window;
-			                yourself.
-		self currentWorld announcer announce: announcement ]
+		self useHideForClose
+			ifTrue: [
+				window hide.
+				announcement := WindowClosed new
+					                window: window;
+					                yourself.
+				self currentWorld announcer announce: announcement ]
+			ifFalse: [ window delete ] ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
-Put the shared variable at false by default to turn off the logic of unclose window
-It was like that before, no need to test.
-Also changed closeTopWindow because windows were not handled if SpClosedWindowListPresenter was off
Fixes #17820