### PR TITLE
Improving implementation of Random >> next

### DIFF
--- a/src/Random-Core/Random.class.st
+++ b/src/Random-Core/Random.class.st
@@ -142,7 +142,7 @@ Random >> maxValue [
 Random >> next [
 	"Answer a random Float in the interval [0 to 1)."
 
-	^ (self privateNextValue / (self maxValue + 1) ) asFloat 
+	^ (self privateNextValue asFloat / (self maxValue + 1) ) 
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Converting to float before the operation makes it 1.5 times faster, and does not allocate a fraction.