### PR TITLE
Fix dependency test

### DIFF
--- a/src/Graphics-Display Objects/Form.class.st
+++ b/src/Graphics-Display Objects/Form.class.st
@@ -346,13 +346,6 @@ Form >> asSourceForm [
 	^self
 ]
 
-{ #category : 'converting' }
-Form >> asText [
-	"I return a text with myself embedded - Similar to Morph>>asText"
-	
-	^ (String value: 1) asText addAttribute: (TextAnchor new anchoredMorph: self)
-]
-
 { #category : 'color mapping' }
 Form >> balancedPatternFor: aColor [
 	"Return the pixel word for representing the given color on the receiver"

--- a/src/Text-Core/Form.extension.st
+++ b/src/Text-Core/Form.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'Form' }
+
+{ #category : '*Text-Core' }
+Form >> asText [
+	"I return a text with myself embedded - Similar to Morph>>asText"
+	
+	^ (String value: 1) asText addAttribute: (TextAnchor new anchoredMorph: self)
+]

--- a/src/Text-Core/TextAnchor.class.st
+++ b/src/Text-Core/TextAnchor.class.st
@@ -17,9 +17,9 @@ Class {
 	#instVars : [
 		'anchoredMorph'
 	],
-	#category : 'Morphic-Base-Text Support',
-	#package : 'Morphic-Base',
-	#tag : 'Text Support'
+	#category : 'Text-Core-Attributes',
+	#package : 'Text-Core',
+	#tag : 'Attributes'
 }
 
 { #category : 'comparing' }
@@ -31,6 +31,7 @@ TextAnchor >> = other [
 
 { #category : 'accessing' }
 TextAnchor >> anchoredMorph [
+	"I should probably be renamed #anchoredImage since I can take forms also. And I guess I'll also be used with Bloc. But it is not so easy since I'm subclassed by microdown."
 
 	^ anchoredMorph
 ]


### PR DESCRIPTION
We have a dependency test failing because Form has the method #asText that adds a TextAnchor attribute to a string.  This TextAnchor is in Morphic but in fact it can also be used with forms instead of morphs. 

I'm proposing to move the attribute to Text-Core since it does not necessarily depend on Morphic and I also moved Form>>#asText to Text-Core.

This will fix the dependency test