### PR TITLE
Fix Message not understood when opening Full Environment on Calypso

### DIFF
--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -265,6 +265,11 @@ RBBrowserEnvironment >> defaultPlugins [
 	^ OrderedCollection new
 ]
 
+{ #category : 'accessing' }
+RBBrowserEnvironment >> definedClasses [
+	^ self allClasses
+]
+
 { #category : 'testing' }
 RBBrowserEnvironment >> definesClass: aClass [
 	^ true


### PR DESCRIPTION
Fix issue [#17730](https://github.com/pharo-project/pharo/issues/17730#issuecomment-2629078319) produced when opening `Full environment` on Calypso from the Scopes Editor.