### PR TITLE
Update version in #spec for BaselineOfPharo for Pharo 11 to ‘v1.2.7’

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -143,7 +143,7 @@ BaselineOfPharo class >> spec [
 		newName: 'Spec2' 
 		owner: 'pharo-spec' 
 		project:'Spec' 
-		version: 'v1.2.6'
+		version: 'v1.2.7'
 ]
 
 { #category : #'repository urls' }


### PR DESCRIPTION
This pull request updates the version in #spec for BaselineOfPharo for Pharo 11 to ‘v1.2.7’. This is intended to include the changes of [Spec pull request #1714](https://github.com/pharo-spec/Spec/pull/1714), which needs to be merged first. The merge commit needs to be tagged as ‘v1.2.7’ before this pull request can be merged.