### PR TITLE
Create a new package to place AST related functionality that are used…

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -83,6 +83,10 @@ BaselineOfBasicTools >> baseline: spec [
 		spec package: 'ProfStef-Core'.
 		spec package: 'StartupPreferences'.
 
+
+
+		spec package: 'OpalCompiler-ToolFeatures'.
+		spec package: 'OpalCompiler-ToolFeatures-Tests'.
 		spec baseline: 'Refactoring' with: [
 			spec
 				repository: repository;

--- a/src/OpalCompiler-ToolFeatures-Tests/OCReadBeforeWrittenTesterTest.class.st
+++ b/src/OpalCompiler-ToolFeatures-Tests/OCReadBeforeWrittenTesterTest.class.st
@@ -4,9 +4,8 @@ SUnit tests for ASTReadBeforeWrittenTester
 Class {
 	#name : 'OCReadBeforeWrittenTesterTest',
 	#superclass : 'OCParseTreeTest',
-	#category : 'AST-Core-Tests-Visitors',
-	#package : 'AST-Core-Tests',
-	#tag : 'Visitors'
+	#category : 'OpalCompiler-ToolFeatures-Tests',
+	#package : 'OpalCompiler-ToolFeatures-Tests'
 }
 
 { #category : 'tests' }

--- a/src/OpalCompiler-ToolFeatures-Tests/OCReturnNodeAdderVisitorTest.class.st
+++ b/src/OpalCompiler-ToolFeatures-Tests/OCReturnNodeAdderVisitorTest.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : 'OCReturnNodeAdderVisitorTest',
 	#superclass : 'OCParseTreeTest',
-	#category : 'AST-Core-Tests-Visitors',
-	#package : 'AST-Core-Tests',
-	#tag : 'Visitors'
+	#category : 'OpalCompiler-ToolFeatures-Tests',
+	#package : 'OpalCompiler-ToolFeatures-Tests'
 }
 
 { #category : 'tests' }

--- a/src/OpalCompiler-ToolFeatures-Tests/package.st
+++ b/src/OpalCompiler-ToolFeatures-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'OpalCompiler-ToolFeatures-Tests' }

--- a/src/OpalCompiler-ToolFeatures/OCReadBeforeWrittenTester.class.st
+++ b/src/OpalCompiler-ToolFeatures/OCReadBeforeWrittenTester.class.st
@@ -16,9 +16,8 @@ Class {
 		'checkNewTemps',
 		'scopeStack'
 	],
-	#category : 'AST-Core-Visitors',
-	#package : 'AST-Core',
-	#tag : 'Visitors'
+	#category : 'OpalCompiler-ToolFeatures',
+	#package : 'OpalCompiler-ToolFeatures'
 }
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-ToolFeatures/OCReturnNodeAdderVisitor.class.st
+++ b/src/OpalCompiler-ToolFeatures/OCReturnNodeAdderVisitor.class.st
@@ -4,9 +4,8 @@ I am a visitor that wraps a node in a return node. If the node is sequence it wi
 Class {
 	#name : 'OCReturnNodeAdderVisitor',
 	#superclass : 'OCProgramNodeVisitor',
-	#category : 'AST-Core-Visitors',
-	#package : 'AST-Core',
-	#tag : 'Visitors'
+	#category : 'OpalCompiler-ToolFeatures',
+	#package : 'OpalCompiler-ToolFeatures'
 }
 
 { #category : 'visiting' }

--- a/src/OpalCompiler-ToolFeatures/package.st
+++ b/src/OpalCompiler-ToolFeatures/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'OpalCompiler-ToolFeatures' }


### PR DESCRIPTION
… by tools but not by the compiler.

Since AST should be renamed OpalAST I named this new package OpalCompiler-ToolFeatures.  May be in a second step we should move the classes to the package of their users renraku and rb  but this is trickier for ParserTreeMatcher and ParseTreeRewriter.