### PR TITLE
Push up #classInstaller

### DIFF
--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -275,15 +275,6 @@ Class >> classBuilder [
 		^ self classInstaller new builder
 ]
 
-{ #category : 'subclass creation' }
-Class >> classInstaller [
-	"Answer the class responsible of creating subclasses of myself in the system."
-
-	^ self isAnonymous
-		  ifTrue: [ Smalltalk anonymousClassInstaller ]
-		  ifFalse: [ Smalltalk classInstaller ]
-]
-
 { #category : 'accessing' }
 Class >> classPool [
 	"Answer the dictionary of class variables.

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -217,6 +217,15 @@ Internal Representation and Key Implementation Points.'.
 	^ stream contents
 ]
 
+{ #category : 'subclass creation' }
+ClassDescription >> classInstaller [
+	"Answer the class responsible of creating subclasses of myself in the system."
+
+	^ self isAnonymous
+		  ifTrue: [ Smalltalk anonymousClassInstaller ]
+		  ifFalse: [ Smalltalk classInstaller ]
+]
+
 { #category : 'accessing - parallel hierarchy' }
 ClassDescription >> classSide [
 	"Return the metaclass of the couple class/metaclass. Useful to avoid explicit test."


### PR DESCRIPTION
Sometimes we have random falilures because we ask a class installer to a metaclass.  We can just push up #classInstaller because metaclasses have all the infos needed to give this class installer. This can fix some random failures we have

Goal: even greener CI