### PR TITLE
Improve error on File deletion failure

### DIFF
--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -499,15 +499,11 @@ File class >> deleteFile: fullPathString [
 	"Delete the supplied UTF8 encoded path.  Answer nil on failure."
 
 	| utf8Path |
-
 	utf8Path := fullPathString utf8Encoded.
-	self
-		retryWithGC: [ self primDeleteFile: utf8Path ]
-		until: [ :result | result isNotNil ]
-		forFileNamed: fullPathString.
-	(self primExists: utf8Path) ifTrue:
-		[ (CannotDeleteFileException new messageText: 'Could not delete file ' , name,
-			'. Check the file is not open.') signal ]
+	self retryWithGC: [ self primDeleteFile: utf8Path ] until: [ :result | result isNotNil ] forFileNamed: fullPathString.
+
+	(self primExists: utf8Path) ifTrue: [
+		(CannotDeleteFileException new messageText: 'Could not delete file "' , fullPathString , '". Check the file is not open.') signal ]
 ]
 
 { #category : 'primitives - path' }


### PR DESCRIPTION
The file deletion failure uses the #name variable to give info on which file is been deleted. But the method is on the class side, so in reality it returns "File" all the time instead of the file name... On the CI I end up with this kind of failures: `Could not delete file File. Check the file is not open.`. 

I propose to update the error to use the path of the file instead to have a better log and have an easier time to debug things when we have test failures in the CI.