### PR TITLE
Improve the default comparision value

### DIFF
--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -205,7 +205,7 @@ Float class >> initialize [
 
 	"Default precision used for comparing two float numbers.
 	Using value described in Numerical Recipes, 3rd edition, Section 5.7, which is pages 229-230 corresponding to the square root of the machine epsilon"
-	DefaultComparisonPrecision :=  1.4901161193847656e-8. "This is the result of `self machineEpsilon sqrt ` but the bootstrap does not work if we do not put the constant directly."
+	DefaultComparisonPrecision :=  1.4901161193847656e-8. "This is the result of `self machineEpsilon sqrt ` but the bootstrap does not work if we do not put the constant directly. This is due to the fact that #sqrt is loaded after this value is initialized."
 
 	MaxVal := 1.7976931348623157e308.
 	MaxValLn := 709.782712893384.

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -205,7 +205,7 @@ Float class >> initialize [
 
 	"Default precision used for comparing two float numbers.
 	Using value described in Numerical Recipes, 3rd edition, Section 5.7, which is pages 229-230 corresponding to the square root of the machine epsilon"
-	DefaultComparisonPrecision := 1.4901161193847656e-8. "This is the result of `self machineEpsilon sqrt ` but the bootstrap does not work if we do not put the constant directly."
+	DefaultComparisonPrecision :=  1.4901161193847656e-8. "This is the result of `self machineEpsilon sqrt ` but the bootstrap does not work if we do not put the constant directly."
 
 	MaxVal := 1.7976931348623157e308.
 	MaxValLn := 709.782712893384.

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -199,11 +199,13 @@ Float class >> initialize [
 	E := 2.718281828459045235360287471353.
 
 	"Defines precision of approximated mathematical functions such as trigonometric functions.
-	Use a small enough epsilon value to make approximations as good as possible."
+	Use a small enough epsilon value to make approximations as good as possible.
+	This one should probably be removed and we should use DefaultComparisionValue but I'm not sure it's that simple to remove a class var of Float."
 	MathApproximationEpsilon := 0.000000000001.
-	
-	"Default precision used for comparing two float numbers"
-	DefaultComparisonPrecision := 0.0001.
+
+	"Default precision used for comparing two float numbers.
+	Using value described in Numerical Recipes, 3rd edition, Section 5.7, which is pages 229-230 corresponding to the square root of the machine epsilon"
+	DefaultComparisonPrecision := 1.4901161193847656e-8. "This is the result of `self machineEpsilon sqrt ` but the bootstrap does not work if we do not put the constant directly."
 
 	MaxVal := 1.7976931348623157e308.
 	MaxValLn := 709.782712893384.

--- a/src/STON-Tests/STONReaderTest.class.st
+++ b/src/STON-Tests/STONReaderTest.class.st
@@ -265,7 +265,7 @@ STONReaderTest >> testFloat [
 	self assert: ((self materialize: '-1.5') closeTo: -1.5).
 	self assert: (self materialize: '0.0') isZero.
 	self assert: (Float pi closeTo: (self materialize: '3.14159') precision: 0.00001).
-	self assert: (1 / 3 closeTo: (self materialize: '0.333333')).
+	self assert: (1 / 3 closeTo: (self materialize: '0.3333333333')).
 	self assert: (self materialize: '1.0e100') equals: 1.0e100.
 	self assert: (self materialize: '1.0e-100') equals: 1.0e-100.
 	self assert: (self materialize: '-1.0e-100') equals: -1.0e-100.

--- a/src/System-Time-Tests/DurationTest.class.st
+++ b/src/System-Time-Tests/DurationTest.class.st
@@ -55,9 +55,10 @@ DurationTest >> testAsDay [
 
 { #category : 'tests' }
 DurationTest >> testAsDays [
+
 	self assert: (Duration days: 2) asDays equals: 2.
 	self assert: (Duration weeks: 1) asDays equals: 7.
-	self assert: (aDuration asDays closeTo: 1.08546)
+	self assert: aDuration asDays closeTo: 1.08546296296
 ]
 
 { #category : 'tests' }
@@ -87,9 +88,10 @@ DurationTest >> testAsHour [
 
 { #category : 'tests' }
 DurationTest >> testAsHours [
+
 	self assert: (Duration hours: 2) asHours equals: 2.
 	self assert: (Duration days: 1) asHours equals: 24.
-	self assert: (aDuration asHours closeTo: 26.0511)
+	self assert: aDuration asHours closeTo: 26.051111111
 ]
 
 { #category : 'tests' }
@@ -149,10 +151,11 @@ DurationTest >> testAsMinute [
 
 { #category : 'tests' }
 DurationTest >> testAsMinutes [
+
 	self assert: (Duration seconds: 60) asMinutes equals: 1.
 	self assert: (Duration hours: 1) asMinutes equals: 60.
-	self assert: (aDuration asMinutes closeTo: 1563.0666).
-	self assert: ((Duration milliSeconds: 100) asMinutes closeTo: 1 / 600)
+	self assert: aDuration asMinutes closeTo: 1563.06666666.
+	self assert: (Duration milliSeconds: 100) asMinutes closeTo: 1 / 600
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
Do not use a random precision but use one that proved itself

This value is the default used by Polymath and comes from Numerical Recipes, 3rd edition, Section 5.7, which is pages 229-230

Redo of https://github.com/pharo-project/pharo/pull/12984 because the CI seems to still take the Pharo 11 image instead of Pharo 13