### PR TITLE
Ineffective method reformatting stops confusing code editor

### DIFF
--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -2170,23 +2170,16 @@ RubAbstractTextArea >> updateTextWith: aStringOrText [
 			s := self validateTextFrom: aStringOrText.
 			"Text can = String, but String never = Text"
 			s = self text asString ifFalse: [
-				| markIndex pointIndex wasAtEnd |
-				markIndex := self markIndex.
-				pointIndex := self pointIndex.
-				wasAtEnd := pointIndex > self text size.
-
+				| wasAtEnd |
+				wasAtEnd := self hasSelection not and: [
+					            self markIndex > self text size ].
 				self selectAll.
 				self editor replaceSelectionWith: s.
 				self deselect.
-
-				"Restore selections only, otherwise the cursor could be anywhere
-				after formatting, so keep it at the beginning. Unless it was
-				already at the end, then we can at least keep it there."
-				markIndex = pointIndex
-					ifFalse: [ self markIndex: markIndex pointIndex: pointIndex ]
-					ifTrue: [
-						wasAtEnd ifTrue: [
-							self markIndex: pointIndex pointIndex: pointIndex ] ] ] ] ]
+				wasAtEnd ifTrue: [ "Keep cursor at end if it was already there"
+					| atEnd |
+					atEnd := self text size + 1.
+					self markIndex: atEnd pointIndex: atEnd ] ] ] ]
 ]
 
 { #category : 'accessing - text' }

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -2164,15 +2164,30 @@ RubAbstractTextArea >> updateMarginsWith: aMargin [
 
 { #category : 'accessing - text' }
 RubAbstractTextArea >> updateTextWith: aStringOrText [
-	self
-		handleEdit: [ self
-				beEditableWhile: [
-					| s |
-					s := self validateTextFrom: aStringOrText.
-					s = self text
-						ifFalse: [ self selectAll.
-							self editor replaceSelectionWith: s.
-							self deselect ] ] ]
+
+	self handleEdit: [
+		self beEditableWhile: [
+			| s |
+			s := self validateTextFrom: aStringOrText.
+			"Text can = String, but String never = Text"
+			s = self text asString ifFalse: [
+				| markIndex pointIndex wasAtEnd |
+				markIndex := self markIndex.
+				pointIndex := self pointIndex.
+				wasAtEnd := pointIndex > self text size.
+
+				self selectAll.
+				self editor replaceSelectionWith: s.
+				self deselect.
+
+				"Restore selections only, otherwise the cursor could be anywhere
+				after formatting, so keep it at the beginning. Unless it was
+				already at the end, then we can at least keep it there."
+				markIndex = pointIndex
+					ifFalse: [ self markIndex: markIndex pointIndex: pointIndex ]
+					ifTrue: [
+						wasAtEnd ifTrue: [
+							self markIndex: pointIndex pointIndex: pointIndex ] ] ] ] ]
 ]
 
 { #category : 'accessing - text' }

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -826,7 +826,7 @@ RubAbstractTextArea >> editPrimarySelectionSeparately [
 { #category : 'accessing - im text input' }
 RubAbstractTextArea >> editing [
 
-	^ editing = true
+	^ editing
 ]
 
 { #category : 'accessing - editing mode' }
@@ -1057,7 +1057,7 @@ RubAbstractTextArea >> handleEdit: editBlock [
 { #category : 'event handling' }
 RubAbstractTextArea >> handleKeyDown: anEvent [
 
-	editing = true ifTrue: [ ^ self ].
+	editing ifTrue: [ ^ self ].
 	^ super handleKeyDown: anEvent
 ]
 
@@ -1240,12 +1240,11 @@ RubAbstractTextArea >> keyDown: anEvent [
 
 { #category : 'event handling' }
 RubAbstractTextArea >> keyStroke: anEvent [
-
 	"Handle a keystroke event."
 
 	anEvent hand anyButtonPressed ifTrue: [ ^ self ].
 	self handleEdit: [
-		editing = true
+		editing
 			ifTrue: [
 				editing := false.
 				self editor unselect ]
@@ -1266,7 +1265,7 @@ RubAbstractTextArea >> keyboardFocusChange: aBoolean [
 			self showOverEditableTextCursor ]
 		ifFalse: [
 			self hasFocus: false.
-			editing = true ifTrue: [ editing := false ].
+			editing ifTrue: [ editing := false ].
 			self hideOverEditableTextCursor ].
 	super keyboardFocusChange: aBoolean
 ]
@@ -2052,7 +2051,7 @@ RubAbstractTextArea >> textEdition: aTextEditionEvent [
 			self editor zapSelectionWith: editText.
 			editing := true ]
 		ifEmpty: [
-			editing = true ifTrue: [
+			editing ifTrue: [
 				self editor zapSelectionWith: ''.
 				editing := false ] ]
 ]

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -174,7 +174,8 @@ RubSmalltalkCodeMode >> formatMethodCode [
 	tree checkFaulty: [ :msg :pos |
 		^ self editor notify: msg at: pos + 1 in: source ].
 	formatted := tree formattedCodeIn: classOrMetaclass.
-	formatted = source ifTrue: [ ^ self ].
+	"Text can = String, but String never = Text"
+	formatted = source asString ifTrue: [ ^ self ].
 	self textArea hasSelection
 		ifTrue: [ self textArea replaceSelectionWith: formatted ]
 		ifFalse: [ self textArea updateTextWith: formatted ]


### PR DESCRIPTION
# Bug Origin
The bug described in #15183 was introduced in #14909 (specifically 8807faf) as part of Pharo 12.

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/7ae5e4f5-29af-4392-a499-17de08c75fc0" />

Before the change, `source` was a String, but after the change, it became a Text. The problem occurred when comparing `source` with `formatted`, which has the new source as a String. Since `formatted` is the receiver, it uses `String >> #=`, which does not know how to compare with Text, causing the equality to always return false.
Interestingly, if the operands were reversed, `Text >> #=` would have handled the comparison with a String correctly.

# Fix

Explicitly call `source asString` (the `=` argument) to ensure that the comparison works as expected. A comment has been added for clarity.
A proper test to check if the code editor correctly ignores ineffective reformatting would be ideal, but I'm not sure how to write it just yet.

## Cursor Restoration Improvement

I also added a small improvement for cursor positioning after formatting: if the cursor was at the end, it will stay at the end.
Otherwise, since accurately tracking the position post-formatting is tricky, we fall back to the previous behavior of moving it to the beginning.
This fix also means the cursor will not be sent to the beginning when the reformatting is ineffective, it will stay right where you left it 😄

I hope this makes formatting feel a bit smoother for users.