### PR TITLE
[P12] Ineffective method reformatting stops confusing code editor

### DIFF
--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -2164,15 +2164,30 @@ RubAbstractTextArea >> updateMarginsWith: aMargin [
 
 { #category : 'accessing - text' }
 RubAbstractTextArea >> updateTextWith: aStringOrText [
-	self
-		handleEdit: [ self
-				beEditableWhile: [
-					| s |
-					s := self validateTextFrom: aStringOrText.
-					s = self text
-						ifFalse: [ self selectAll.
-							self editor replaceSelectionWith: s.
-							self deselect ] ] ]
+
+	self handleEdit: [
+		self beEditableWhile: [
+			| s |
+			s := self validateTextFrom: aStringOrText.
+			"Text can = String, but String never = Text"
+			s = self text asString ifFalse: [
+				| markIndex pointIndex wasAtEnd |
+				markIndex := self markIndex.
+				pointIndex := self pointIndex.
+				wasAtEnd := pointIndex > self text size.
+
+				self selectAll.
+				self editor replaceSelectionWith: s.
+				self deselect.
+
+				"Restore selections only, otherwise the cursor could be anywhere
+				after formatting, so keep it at the beginning. Unless it was
+				already at the end, then we can at least keep it there."
+				markIndex = pointIndex
+					ifFalse: [ self markIndex: markIndex pointIndex: pointIndex ]
+					ifTrue: [
+						wasAtEnd ifTrue: [
+							self markIndex: pointIndex pointIndex: pointIndex ] ] ] ] ]
 ]
 
 { #category : 'accessing - text' }

--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -2171,23 +2171,16 @@ RubAbstractTextArea >> updateTextWith: aStringOrText [
 			s := self validateTextFrom: aStringOrText.
 			"Text can = String, but String never = Text"
 			s = self text asString ifFalse: [
-				| markIndex pointIndex wasAtEnd |
-				markIndex := self markIndex.
-				pointIndex := self pointIndex.
-				wasAtEnd := pointIndex > self text size.
-
+				| wasAtEnd |
+				wasAtEnd := self hasSelection not and: [
+					            self markIndex > self text size ].
 				self selectAll.
 				self editor replaceSelectionWith: s.
 				self deselect.
-
-				"Restore selections only, otherwise the cursor could be anywhere
-				after formatting, so keep it at the beginning. Unless it was
-				already at the end, then we can at least keep it there."
-				markIndex = pointIndex
-					ifFalse: [ self markIndex: markIndex pointIndex: pointIndex ]
-					ifTrue: [
-						wasAtEnd ifTrue: [
-							self markIndex: pointIndex pointIndex: pointIndex ] ] ] ] ]
+				wasAtEnd ifTrue: [ "Keep cursor at end if it was already there"
+					| atEnd |
+					atEnd := self text size + 1.
+					self markIndex: atEnd pointIndex: atEnd ] ] ] ]
 ]
 
 { #category : 'accessing - text' }

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -174,7 +174,8 @@ RubSmalltalkCodeMode >> formatMethodCode [
 	tree checkFaulty: [ :msg :pos |
 		^ self editor notify: msg at: pos + 1 in: source ].
 	formatted := tree formattedCodeIn: classOrMetaclass.
-	formatted = source ifTrue: [ ^ self ].
+	"Text can = String, but String never = Text"
+	formatted = source asString ifTrue: [ ^ self ].
 	self textArea hasSelection
 		ifTrue: [ self textArea replaceSelectionWith: formatted ]
 		ifFalse: [ self textArea updateTextWith: formatted ]


### PR DESCRIPTION
Backport of #17884 (without de5f59f to be safe).