### PR TITLE
Removing misplaced browing methods,  Fixes # 17396

### DIFF
--- a/src/DebugPoints/DebugPoint.class.st
+++ b/src/DebugPoints/DebugPoint.class.st
@@ -111,12 +111,6 @@ DebugPoint >> behaviors [
 	^ checkBehaviors , sideEffectBehaviors
 ]
 
-{ #category : 'actions' }
-DebugPoint >> browse [
-
-	^ self target browse
-]
-
 { #category : 'accessing' }
 DebugPoint >> checkBehaviors [
 

--- a/src/DebugPoints/DebugPointInstanceVariableTarget.class.st
+++ b/src/DebugPoints/DebugPointInstanceVariableTarget.class.st
@@ -32,15 +32,6 @@ DebugPointInstanceVariableTarget >> accessStrategy: aSymbol [
 	accessStrategy := aSymbol
 ]
 
-{ #category : 'actions' }
-DebugPointInstanceVariableTarget >> browse [
-
-	((Smalltalk tools toolNamed: #browser) openOnClass:
-			 self instanceVariable owningClass)
-		switchToVariables;
-		selectVariableNamed: self instanceVariable name
-]
-
 { #category : 'announcements' }
 DebugPointInstanceVariableTarget >> hitAnnouncementOn: aDebugPoint inContext: aContext [
 

--- a/src/DebugPoints/DebugPointNodeTarget.class.st
+++ b/src/DebugPoints/DebugPointNodeTarget.class.st
@@ -15,12 +15,6 @@ DebugPointNodeTarget class >> hitAnnouncementClass [
 	^ DebugPointHit
 ]
 
-{ #category : 'actions' }
-DebugPointNodeTarget >> browse [
-
-	^ self method browse
-]
-
 { #category : 'private' }
 DebugPointNodeTarget >> install: aLink on: aClassOrObject [
 
@@ -73,5 +67,5 @@ DebugPointNodeTarget >> targetClass [
 { #category : 'description' }
 DebugPointNodeTarget >> targetString [
 
-	^ self method printString
+	^ [self method printString] on: Error do:['ERROR PARSING DEBUG POINT TARGET']
 ]

--- a/src/DebugPoints/DebugPointObjectTarget.class.st
+++ b/src/DebugPoints/DebugPointObjectTarget.class.st
@@ -20,12 +20,6 @@ DebugPointObjectTarget >> beForObject: anObject [
 		  yourself
 ]
 
-{ #category : 'description' }
-DebugPointObjectTarget >> browse [
-
-	^ self subTarget browse
-]
-
 { #category : 'announcements' }
 DebugPointObjectTarget >> hitAnnouncementOn: aDebugPoint inContext: aContext [
 

--- a/src/DebugPoints/DebugPointTarget.class.st
+++ b/src/DebugPoints/DebugPointTarget.class.st
@@ -23,12 +23,6 @@ DebugPointTarget >> beForObject: anObject [
 		  yourself
 ]
 
-{ #category : 'actions' }
-DebugPointTarget >> browse [
-
-	self subclassResponsibility 
-]
-
 { #category : 'announcements' }
 DebugPointTarget >> hitAnnouncementOn: aDebugPoint inContext: aContext [
 


### PR DESCRIPTION
The browsing will be correctly put back in place in NewTools, where it belongs.