### PR TITLE
Fix: OpalCompilerTest and others should not hard code Smalltalk compiler

### DIFF
--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -147,7 +147,7 @@ OpalCompilerTest >> testCompilerUsingCleanBlockClosureHasBlockAsLiteral [
 { #category : 'tests - bindings' }
 OpalCompilerTest >> testEvaluateWithBindings [
 	| result |
-	result := Smalltalk compiler
+	result := OpalCompiler new 
 		bindings: {(#a -> 3)} asDictionary;
 		evaluate: '1+a'.
 	self assert: result equals: 4


### PR DESCRIPTION
Fixes #17891