### PR TITLE
fixed #17568: move #executedPC to be not an extension method

### DIFF
--- a/src/Kernel-CodeModel/Context.class.st
+++ b/src/Kernel-CodeModel/Context.class.st
@@ -740,6 +740,19 @@ Context >> exceptionsToCaptureWhenStepping [
 	^ exceptionsSet
 ]
 
+{ #category : 'accessing' }
+Context >> executedPC [
+	"Deeper in the stack the pc was already advanced one bytecode, so we need to go back
+	this one bytecode, which can consist of multiple bytes. But on IR, we record the *last*
+	bytecode offset as the offset of the IR instruction, which means we can just go back one"
+
+	"if we are at the start, return the startpc"
+	(pc == self startpc) ifTrue: [ ^self startpc ].
+
+	"we need to guard for dead contexts (pc is nil)"
+	^self isDead ifTrue: [ self endPC - 1] ifFalse: [ pc - 1]
+]
+
 { #category : 'system simulation' }
 Context >> failPrimitiveWith: maybePrimFailToken [
 	"The receiver is a freshly-created context on a primitive method.  Skip the callPrimitive:

--- a/src/OpalCompiler-Core/Context.extension.st
+++ b/src/OpalCompiler-Core/Context.extension.st
@@ -27,19 +27,6 @@ Context >> compiler [
 ]
 
 { #category : '*OpalCompiler-Core' }
-Context >> executedPC [
-	"Deeper in the stack the pc was already advanced one bytecode, so we need to go back
-	this one bytecode, which can consist of multiple bytes. But on IR, we record the *last*
-	bytecode offset as the offset of the IR instruction, which means we can just go back one"
-
-	"if we are at the start, return the startpc"
-	(pc == self startpc) ifTrue: [ ^self startpc ].
-
-	"we need to guard for dead contexts (pc is nil)"
-	^self isDead ifTrue: [ self endPC - 1] ifFalse: [ pc - 1]
-]
-
-{ #category : '*OpalCompiler-Core' }
 Context >> lookupVar: aSymbol [
 	^ self astScope lookupVar: aSymbol
 ]


### PR DESCRIPTION
I used accessing for now,  to be close to  #pc (and there are lots of methods that are not strict accessors already)