### PR TITLE
Completion improvements: do not skip closing characters

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -564,20 +564,18 @@ CompletionEngine >> smartNeedExtraRemoveIn: currentText for: opposite [
 
 { #category : 'private' }
 CompletionEngine >> smartNeedExtraRemoveIn: currentText for: smartCharacter opposite: opposite at: position [
-	"Test if we need to remove an extra character when removing a smart character (any kind of smart character)"
+	"Test if we need to remove an extra character when removing a smart character (any kind of smart character)
+	 Do not consider literal characters to be smart characters"
 
-	smartCharacter = opposite
-		ifTrue: [
-			(self smartNeedExtraRemoveIn: currentText for: opposite)
-				ifFalse: [ ^ false ] ]
-		ifFalse: [
-			(self
-				smartNeedExtraRemovePairedIn: currentText
-				for: smartCharacter
-				opposite: opposite
-				at: position)
-					ifFalse: [ ^false ] ].
-	^ true
+	^ (position <= 2 or: [ (currentText at: position - 2) ~= $$ ]) and: [
+		  smartCharacter = opposite
+			  ifTrue: [ self smartNeedExtraRemoveIn: currentText for: opposite ]
+			  ifFalse: [
+				  self
+					  smartNeedExtraRemovePairedIn: currentText
+					  for: smartCharacter
+					  opposite: opposite
+					  at: position ] ]
 ]
 
 { #category : 'private' }

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -208,7 +208,7 @@ CompletionEngine >> handleKeystrokeBefore: aKeyboardEvent editor: anEditor [
 	keyCharacter := aKeyboardEvent keyCharacter.
 	controlKeyPressed := aKeyboardEvent controlKeyPressed.
 
-	(self smartInputWithEvent: aKeyboardEvent )
+	(self smartInputWithEvent: aKeyboardEvent)
 		ifNotNil: [ ^ true ].
 
 	self isMenuOpen
@@ -438,7 +438,7 @@ CompletionEngine >> smartBackspace [
 	currentText := currentEditor text.
 	smartCharacter := currentText at: currentEditor startIndex - 1 ifAbsent: [ ^ false ].	"take the opposite"
 
-	opposite := self smartCharacterOppositeOf: smartCharacter ifAbsent: [ ^false ].	"test if the next char is opposite"
+	opposite := self smartCharacterOppositeOf: smartCharacter ifAbsent: [ ^ false ].	"test if the next char is opposite"
 
 	opposite = (currentText at: currentEditor stopIndex ifAbsent: [ ^ false ])
 		ifFalse: [ ^ false ].	"test if there is an extra opposite to remove"
@@ -448,7 +448,7 @@ CompletionEngine >> smartBackspace [
 		for: smartCharacter
 		opposite: opposite
 		at: currentEditor startIndex)
-			ifFalse: [  ^ false ].
+			ifFalse: [ ^ false ].
 
 	currentEditor closeTypeIn.
 
@@ -566,7 +566,7 @@ CompletionEngine >> smartNeedExtraRemoveIn: currentText for: opposite [
 
 	(currentText select: [ :char | char = opposite ]) size odd
 		ifTrue: [ ^ false ].
-	^true
+	^ true
 ]
 
 { #category : 'private' }
@@ -589,11 +589,10 @@ CompletionEngine >> smartNeedExtraRemoveIn: currentText for: smartCharacter oppo
 
 { #category : 'private' }
 CompletionEngine >> smartNeedExtraRemovePairedIn: currentText for: smartCharacter opposite: opposite at: position [
-	"Test if we need to remove an extra character when removed a paired smart character.
+	"Test if we need to remove an extra character when removing a paired smart character.
 	 A paired smart character is any smart character who has an opposite who is diferent to itself: [], ()"
 
 	| startIndex countSmart countOpposite |
-
 	countSmart := 0.
 	countOpposite := 0.
 	startIndex := self
@@ -609,21 +608,17 @@ CompletionEngine >> smartNeedExtraRemovePairedIn: currentText for: smartCharacte
 			char = opposite
 				ifTrue: [ countOpposite := countOpposite + 1 ] ].
 
-	(countSmart > countOpposite and: [ (countOpposite - countSmart) odd ])
-		ifTrue: [ ^ false ].
-
-	^true
+	^ (countSmart > countOpposite and: [ (countOpposite - countSmart) odd ]) not
 ]
 
 { #category : 'private' }
-CompletionEngine >> smartStartIndexIn: currentText for: smartCharacter  opposite: opposite  at: position [
+CompletionEngine >> smartStartIndexIn: currentText for: smartCharacter opposite: opposite at: position [
 
 	(position - 1) to: 1 by: -1 do: [ :index | | char |
 		char := currentText at: index.
-		(char = smartCharacter or: [ char = opposite])
-			 ifFalse: [ ^index ] ].
-
-	^0
+		(char = smartCharacter or: [ char = opposite ])
+			 ifFalse: [ ^ index ] ].
+	^ 0
 ]
 
 { #category : 'private' }

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -493,35 +493,28 @@ CompletionEngine >> smartCharacterWithEvent: anEvent [
 	char := anEvent keyCharacter.
 	editor hasSelection
 		ifTrue: [
-			"we selected a piece of text and we type the same character that previously, so
-		we unwrap it"
-			"we selected a piece of text if the character is not a special one we do nothing."
-			matchingPair := self smartCharacterPairFor: char ifAbsent: [  ^nil ].	"else we wrap the selection"	"editor replaceSelectionWith: (String with: char) , (editor selection) , (String with: opposite)."	"ugly logic it should be encapsulated in the editor "
+			"We selected a piece of text and we type the same character that previously, so we unwrap it"
+			"We selected a piece of text if the character is not a special one we do nothing."
+			matchingPair := self smartCharacterPairFor: char ifAbsent: [ ^ nil ].	"else we wrap the selection"	"editor replaceSelectionWith: (String with: char) , (editor selection) , (String with: opposite)."	"ugly logic it should be encapsulated in the editor "
 
 			editor encloseWith: matchingPair.
 			self invalidateEditorMorph.
-			^ true ].	"we are not in a selection"
+			^ true ].	
+	"We are not in a selection"
 
 	(self smartCharacterShouldClose: char)
-		ifFalse: [
-			"if the character is not a special character"
-			self smartInverseMapping at: char ifAbsent: [ ^ nil ].	"if the character is not a closing special character do nothing"	"The character is special"
-			editor blinkPrevParen: char.
-			(editor nextCharacterIfAbsent: [ ^ nil ]) = char
-				ifFalse: [ ^ nil ].	"do not get this test but if we comment it out we cannot type closing ) anymore"
-			editor selectFrom: editor startIndex + 1 to: editor startIndex.
-			self invalidateEditorMorph.
-			^ true ].
+		ifFalse: [ "It is a closing smart character. Do not ignore it: if the user typed it, then assume the user wants it."
+			^ nil ].
 
-	opposite := self smartCharacterOppositeOf: char ifAbsent: [ ^nil ].
+	"Check if we are typing an opening smart character, and if so, add the matching closing string."
+	opposite := self smartCharacterOppositeOf: char ifAbsent: [ ^ nil ].
 	previous := editor previousCharacterIfAbsent: [ Character space ].
 	next := editor nextCharacterIfAbsent: [ Character space ].
-	insertion := next isSeparator
-				ifFalse: [ char asString ]
-				ifTrue: [
-					previous isSeparator
-						ifFalse: [ char asString ]
-						ifTrue: [ self newSmartCharacterInsertionStringForLeft: char right: opposite ]].
+	(previous ~= $$ and: [ "char literals are not smart"
+		 (next isSeparator and: [ previous isSeparator ]) or: [
+			 char = previous or: [ next = opposite ] ] ]) ifFalse: [ ^ nil ].
+
+	insertion := self newSmartCharacterInsertionStringForLeft: char right: opposite.
 	editor replaceSelectionWith: insertion.
 	insertionCenter := insertion size // 2 max: 1.
 	editor selectFrom: editor startIndex + insertionCenter to: editor startIndex + (insertionCenter - 1).

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -889,6 +889,35 @@ CompletionEngineTest >> testSmartCharacterWithEventAndSelection [
 ]
 
 { #category : 'tests - keyboard' }
+CompletionEngineTest >> testSmartCharacterWithEventDontWritePairAfterDifferentCharacter [
+	"Triggering a smart character inside the same smart character pair still works."
+
+	self setEditorTextWithCaret: '$|'.
+	editor keystroke: (self keyboardPressFor: $().
+	self assert: editor text equals: '$('.
+
+	self setEditorTextWithCaret: '(|'.
+	editor keystroke: (self keyboardPressFor: $").
+	self assert: editor text equals: '("'.
+
+	self setEditorTextWithCaret: 'foo:|'.
+	editor keystroke: (self keyboardPressFor: $[).
+	self assert: editor text equals: 'foo:['
+]
+
+{ #category : 'tests' }
+CompletionEngineTest >> testSmartCharacterWithEventNoPairWhenCharLiteral [
+
+	self setEditorTextWithCaret: '[$|]'.
+	editor keystroke: (self keyboardEventFor: $[).
+	self assert: editor text equals: '[$[]'.
+
+	self setEditorTextWithCaret: '(1 > $|)'.
+	editor keystroke: (self keyboardEventFor: $().
+	self assert: editor text equals: '(1 > $()'
+]
+
+{ #category : 'tests - keyboard' }
 CompletionEngineTest >> testSmartCharacterWithEventSelfClosing [
 
 	self setEditorTextWithCaret: ' |'.
@@ -902,6 +931,70 @@ CompletionEngineTest >> testSmartCharacterWithEventSelfClosing [
 	self setEditorTextWithCaret: ' |'.
 	controller smartCharacterWithEvent: (self keyboardEventFor: $<).
 	self assert: editor text equals: ' '
+]
+
+{ #category : 'tests - keyboard' }
+CompletionEngineTest >> testSmartCharacterWithEventWriteClosingBeforeSameCharacter [
+	"Triggering a smart character inside the same smart character pair still works."
+
+	self setEditorTextWithCaret: '|)'.
+	editor keystroke: (self keyboardPressFor: $)).
+	self assert: editor text equals: '))'.
+
+	self setEditorTextWithCaret: '|]'.
+	editor keystroke: (self keyboardPressFor: $]).
+	self assert: editor text equals: ']]'.
+
+	self setEditorTextWithCaret: '|}'.
+	editor keystroke: (self keyboardPressFor: $}).
+	self assert: editor text equals: '}}'.
+
+	self setEditorTextWithCaret: '|"'.
+	editor keystroke: (self keyboardPressFor: $").
+	self assert: editor text equals: '"""'.
+
+	self setEditorTextWithCaret: '|'''.
+	editor keystroke: (self keyboardPressFor: $').
+	self assert: editor text equals: ''''''''
+]
+
+{ #category : 'tests - keyboard' }
+CompletionEngineTest >> testSmartCharacterWithEventWritePairAfterSameCharacter [
+	"Triggering a smart character inside the same smart character pair still works."
+
+	self setEditorTextWithCaret: '"|'.
+	editor keystroke: (self keyboardPressFor: $").
+	self assert: editor text equals: '"""'.
+
+	self setEditorTextWithCaret: '''|'.
+	editor keystroke: (self keyboardPressFor: $').
+	self assert: editor text equals: ''''''''
+]
+
+{ #category : 'tests - keyboard' }
+CompletionEngineTest >> testSmartCharacterWithEventWritePairInsideExistingPair [
+	"Triggering a smart character inside the same smart character pair still works."
+
+	self setEditorTextWithCaret: '(|)'.
+	controller smartCharacterWithEvent: (self keyboardPressFor: $().
+	self assert: editor text equals: '(())'.
+
+	self setEditorTextWithCaret: '[|]'.
+	controller smartCharacterWithEvent: (self keyboardPressFor: $[).
+	self assert: editor text equals: '[[  ]]'.
+
+	self setEditorTextWithCaret: '{|}'.
+	editor keystroke: (self keyboardPressFor: ${).
+	self assert: editor text equals: '{{  }}'.
+
+	self setEditorTextWithCaret: '"|"'.
+	controller smartCharacterWithEvent: (self keyboardPressFor: $").
+	self assert: editor text equals: '""""'.
+
+	"initial string: '' (two quotes) ; typing $' ; final string: ''' (three quotes, and the inserted quote is escaped)"
+	self setEditorTextWithCaret: '''|'''.
+	controller smartCharacterWithEvent: (self keyboardPressFor: $').
+	self assert: editor text equals: ''''''''''
 ]
 
 { #category : 'tests - keyboard' }
@@ -1041,4 +1134,17 @@ nextLine'.
 	editor undo.
 	
 	self assert: editor text asString equals: text
+]
+
+{ #category : 'tests - keyboard' }
+CompletionEngineTest >> testWriteSmartCharacterPairInsideExistingPair [
+	"Triggering a smart character inside the same smart character pair still works."
+
+	self setEditorTextWithCaret: '(|)'.
+	controller smartCharacterWithEvent: (self keyboardPressFor: $().
+	self assert: editor text equals: '(())'.
+
+	self setEditorTextWithCaret: '[|]'.
+	controller smartCharacterWithEvent: (self keyboardPressFor: $[).
+	self assert: editor text equals: '[[  ]]'
 ]

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -890,24 +890,16 @@ CompletionEngineTest >> testSmartCharacterWithEventAndSelection [
 
 { #category : 'tests - keyboard' }
 CompletionEngineTest >> testSmartCharacterWithEventSelfClosing [
-	self
-		setEditorText: ' ';
-		selectAt: 2.
 
+	self setEditorTextWithCaret: ' |'.
 	controller smartCharacterWithEvent: (self keyboardEventFor: $().
 	self assert: editor text equals: ' ()'.
 
-	self
-		setEditorText: ' ';
-		selectAt: 2.
-
+	self setEditorTextWithCaret: ' |'.
 	controller smartCharacterWithEvent: (self keyboardEventFor: $)).
 	self assert: editor text equals: ' '.
 
-	self
-		setEditorText: ' ';
-		selectAt: 2.
-
+	self setEditorTextWithCaret: ' |'.
 	controller smartCharacterWithEvent: (self keyboardEventFor: $<).
 	self assert: editor text equals: ' '
 ]

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -1049,14 +1049,54 @@ CompletionEngineTest >> testSmartDoubleQuoteSurroundsSelection [
 
 { #category : 'tests - keyboard' }
 CompletionEngineTest >> testSmartNeedExtraRemoveInForOppositeAt [
+	"index of cursor = 1 + index of character to remove"
 
-	self assert: (controller smartNeedExtraRemoveIn: '()' for: $( opposite:$) at:1).
-	self deny: (controller smartNeedExtraRemoveIn: '(()' for: $( opposite:$) at:2).
-	self assert: (controller smartNeedExtraRemoveIn: '(1()' for: $( opposite:$) at:3).
-	self assert: (controller smartNeedExtraRemoveIn: '(1(1())' for: $( opposite:$) at:5).
-	self assert: (controller smartNeedExtraRemoveIn: '((1)1())))' for: $( opposite:$) at:6).
-	self deny: (controller smartNeedExtraRemoveIn: '()(()' for: $( opposite:$) at:3).
-	self assert: (controller smartNeedExtraRemoveIn: '(foobar()' for: $( opposite:$) at:8)
+	self setEditorTextWithCaret: '(|)'.
+	self assert: controller smartBackspace. "result: ''"
+
+	self setEditorTextWithCaret: '(()|'.
+	self deny: controller smartBackspace. "result: '(('"
+
+	self setEditorTextWithCaret: '(1(|)'.
+	self assert: controller smartBackspace. "result: '(1'"
+
+	self setEditorTextWithCaret: '(1(1(|))'.
+	self assert: controller smartBackspace. "result: '(1(1)'"
+
+	self setEditorTextWithCaret: '((1)1(|)))'.
+	self assert: controller smartBackspace. "result: '((1)1))'"
+
+	self setEditorTextWithCaret: '()((|)'.
+	self deny: controller smartBackspace. "result: '()()'"
+
+	self setEditorTextWithCaret: '(foobar(|)'.
+	self assert: controller smartBackspace. "result: '(foobar'"
+
+	self setEditorTextWithCaret: '[|]'.
+	self assert: controller smartBackspace. "result: ''"
+
+	self setEditorTextWithCaret: '{|}'.
+	self assert: controller smartBackspace. "result: ''"
+
+	self setEditorTextWithCaret: '"|"'.
+	self assert: controller smartBackspace. "result: ''"
+
+	self setEditorTextWithCaret: '''|'''.
+	self assert: controller smartBackspace "result: ''"
+]
+
+{ #category : 'tests - keyboard' }
+CompletionEngineTest >> testSmartNeedExtraRemoveInForOppositeAtNoRemoveForLiterals [
+	"index of cursor = 1 + index of character to remove"
+
+	self setEditorTextWithCaret: '($(|)'.
+	self deny: controller smartBackspace. "result: '($)'"
+
+	self setEditorTextWithCaret: '$[|]'.
+	self deny: controller smartBackspace. "result: '$]'"
+
+	self setEditorTextWithCaret: '$"|"'.
+	self deny: controller smartBackspace
 ]
 
 { #category : 'tests - keyboard' }

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -362,9 +362,9 @@ RubSmalltalkEditor >> completionAround: aBlock keyDown: anEvent [
 RubSmalltalkEditor >> completionAround: aBlock keyStroke: anEvent [
 	"I'm a editor for Smalltalk, so, do completion around"
 
-	self isCompletionEnabled ifFalse: [  ^aBlock value ].
+	self isCompletionEnabled ifFalse: [ ^ aBlock value ].
 
-	(completionEngine handleKeystrokeBefore: anEvent editor: self) ifTrue:  [^ self ].
+	(completionEngine handleKeystrokeBefore: anEvent editor: self) ifTrue: [ ^ self ].
 
 	aBlock value.
 	completionEngine handleKeystrokeAfter: anEvent editor: self

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -288,11 +288,6 @@ RubTextEditor >> backspace: aKeyboardEvent [
 ]
 
 { #category : 'obsolete - parenblinking' }
-RubTextEditor >> blinkParenAt: parenLocation [
-	"kept because NECController is sending it to me"
-]
-
-{ #category : 'obsolete - parenblinking' }
 RubTextEditor >> blinkPrevParen: aCharacter [
 	"kept because NECController is sending it to me"
 ]


### PR DESCRIPTION
Fixes #6528.
Originally based on #16542, but @Ducasse and @guillep agreed not to make it an option. The more I delved into the code, the more I wanted to change it, so I'm stopping here for now.
The way `CompletionEngine>>#smartBackspace` is implemented definitely needs a good review, the current behavior is strange...

# Changes
When typing a closing characters, it no longer gets skipped.
For example, the vertical bar respresents the cursor position before and after typing `)`:
```diff
 (|)
-()|
+()|)
```
Typing an opening *smart* character allows inserting a new pair in more contexts:
```diff
 (|)
-((|)
+((|))
```
Removing an opening *smart* character which is a literal does not remove the matching closing character:
```diff
 $(|)
-$|
+$|)
```