### PR TITLE
Properly update the AST when the method editor gets its text changed

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyMethodEditorToolMorph.class.st
@@ -229,8 +229,9 @@ ClyMethodEditorToolMorph >> textChanged: aTextChanged [
 
 	super textChanged: aTextChanged.
 	textMorph segments copy do: #delete.
+	ast := self currentEditedAST.
 	IconStyler new
 	   stylerClasses: {ErrorNodeStyler . SemanticMessageIconStyler . SemanticWarningIconStyler };
-		styleText: textModel withAst: self currentEditedAST.
+		styleText: textModel withAst: ast.
 	^ ast
 ]


### PR DESCRIPTION
Currently we were only updating the AST when doing applying changes (see ClyMethodCodeEditorToolMorph>>#applyChanges). This is not the only way the text may be changed (for example: a refactoring may also change it). The other ways to update the text break the AST putting the method editor in a weird state where it shows the new code and does structural edits stuff using the old one.

An example of this issue can be experiencied by trying to do "extract temp" multiple times on the same method editor.

Reported-by: Andrzej Prochyra <andrzej@prochyra.io>