### PR TITLE
Branch: 17277-StringasInteger-has-not-defined-behavior,  Fixes #17277

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -449,9 +449,9 @@ StringTest >> testAsInteger [
 
 	self assert: '1796exportFixes-tkMX' asInteger equals: 1796.
 	self assert: 'donald' asInteger isNil.
-	self assert: 'abc234def567' asInteger equals: 234.
+	self assert: 'abc234def567' asInteger equals: nil.
 	self assert: '-94' asInteger equals: -94.
-	self assert: 'foo-bar-92' asInteger equals: -92
+	self assert: 'foo-bar-92' asInteger equals: nil
 ]
 
 { #category : 'tests' }

--- a/src/Collections-Strings-Tests/WideStringTest.class.st
+++ b/src/Collections-Strings-Tests/WideStringTest.class.st
@@ -22,9 +22,9 @@ WideStringTest >> classToBeTested [
 WideStringTest >> testAsInteger [
 	self assert: '1796exportFixes-tkMX' asWideString asInteger equals: 1796.
 	self assert: 'donald' asWideString asInteger isNil.
-	self assert: 'abc234def567' asWideString asInteger equals: 234.
+	self assert: 'abc234def567' asWideString asInteger equals: nil.
 	self assert: '-94' asWideString asInteger equals: -94.
-	self assert: 'foo-bar-92' asWideString asInteger equals: -92.
+	self assert: 'foo-bar-92' asWideString asInteger equals: nil.
 
 	self assert: '1796exportFixes-tkMX' asWideString asSignedInteger equals: 1796.
 	self assert: 'donald' asWideString asSignedInteger isNil.

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -702,7 +702,7 @@ String >> asInteger [
 	"'10' asInteger >>> 10"
 	"'a' asInteger >>> nil"
 	"'1.234' asInteger >>> 1"
-	^self asSignedInteger
+	^ NumberParser parse: self onError: [ nil ]
 ]
 
 { #category : 'converting' }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -702,7 +702,7 @@ String >> asInteger [
 	"'10' asInteger >>> 10"
 	"'a' asInteger >>> nil"
 	"'1.234' asInteger >>> 1"
-	^ NumberParser parse: self onError: [ nil ]
+	^ (NumberParser parse: self onError: [ ^ nil ]) asInteger
 ]
 
 { #category : 'converting' }


### PR DESCRIPTION
String>>#asInteger uses NumberParser

Later, we should deprecate `asSignedInteger`