### PR TITLE
Branch: 17225-Progress-Bar-in-Dark-Theme-does-not-have-a-good-contras…

### DIFF
--- a/src/DarkBlueTheme/DarkBlueTheme.class.st
+++ b/src/DarkBlueTheme/DarkBlueTheme.class.st
@@ -42,6 +42,12 @@ DarkBlueTheme >> defaultSettings [
 		  yourself
 ]
 
+{ #category : 'fill-styles' }
+DarkBlueTheme >> progressBarProgressFillColor [
+
+	^ self lightSelectionColor twiceLighter 
+]
+
 { #category : 'accessing' }
 DarkBlueTheme >> shStyleTableName [
 


### PR DESCRIPTION
…t2,  Fixes #17225

The issue is with the Dark Blue theme, regular Dark theme has good contrast

```smalltalk
m := ProgressBarMorph new.
m value: 50.
m openInWindow.
```` 

with the fix:

![image](https://github.com/user-attachments/assets/818ea4c4-bca4-49ed-a0b6-26762504c5e5)

before:

![image](https://github.com/user-attachments/assets/c823f35d-0bea-4208-b338-cea81e207089)
