### PR TITLE
Push up #removeFromTree from MessageNode to ProgramNode

### DIFF
--- a/src/AST-Core/OCMessageNode.class.st
+++ b/src/AST-Core/OCMessageNode.class.st
@@ -330,12 +330,6 @@ OCMessageNode >> receiver: aValueNode selector: aSelector keywordsPositions: pos
 ]
 
 { #category : 'adding-removing' }
-OCMessageNode >> removeFromTree [
-
-	self parent removeNode: self
-]
-
-{ #category : 'adding-removing' }
 OCMessageNode >> removeNode: aNode [
 
 	self replaceNode: aNode withNode: aNode receiver

--- a/src/AST-Core/OCProgramNode.class.st
+++ b/src/AST-Core/OCProgramNode.class.st
@@ -1170,6 +1170,12 @@ OCProgramNode >> removeDeadCode [
 	self children do: [:each | each removeDeadCode]
 ]
 
+{ #category : 'removing' }
+OCProgramNode >> removeFromTree [
+
+	self parent removeNode: self
+]
+
 { #category : 'properties' }
 OCProgramNode >> removeProperty: aKey [
 	"Remove the property with aKey. Answer the property or raise an error if aKey isn't found."


### PR DESCRIPTION
In multiple projects I'm doing AST manipulation (fro example in Famix or in my project Chanel) and I need to remove some nodes from an AST. Currently it's possible only on MessageNodes but this should be possible on much more nodes.  I propose to push up this method on ProgramNodes