### PR TITLE
Fix bug with obsolete classes and extension methods

### DIFF
--- a/src/Kernel-CodeModel-Tests/PackageTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageTest.class.st
@@ -472,6 +472,28 @@ PackageTest >> testPropertyAtPut [
 	self assert: package properties isNil
 ]
 
+{ #category : 'tests - extensions' }
+PackageTest >> testRecompilingClassWithExtensionMethods [
+	"This is a regression test. In the past recompiling a class with extension methods was duplicating the entries in the extension map of the packages."
+
+	| class1 class2 |
+	class1 := self newClassNamed: #X in: self xPackageName.
+	class2 := self newClassNamed: #Y in: self yPackageName.
+
+	self createMethodNamed: 'extension' inClass: class1 asExtensionOf: self yPackageName.
+
+	class1 classInstaller update: class1 to: [ :builder | builder slots: { #slot } ].
+
+	"With the bug, we had 2 entries for the class1."
+	self assert: class2 package extendedClasses size equals: 1.
+	self assert: (class2 package instVarNamed: #extensionSelectors) size equals: 1.
+
+	class1 package removeFromSystem.
+
+	self assertEmpty: (class2 package instVarNamed: #extensionSelectors).
+	self assertEmpty: class2 package extendedClasses
+]
+
 { #category : 'tests' }
 PackageTest >> testRemoveClassRemovesExtensions [
 

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -44,8 +44,9 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 
 	"The old protocol should never be nil. But we are not in an ideal world sadly :( We got reported some cases where some code was loaded but had an error during the loading preventing a method that got added to the method dictionary to have an associated protocol. If this happens, we consider that we categorize it for the first time to avoid announcing a MethodRecategorized with an old protocol that is nil."
 	(priorMethod isNil or: [ priorOrigin ~= compiledMethod origin or: [ oldProtocol isNil ] ])
-		ifTrue: [
-			(self packageOrganizer packageForProtocol: newProtocol from: self) addMethod: compiledMethod.
+		ifTrue: [ "If we end up in this branch, it means the method is compiled for the first time in this class. BUT we have an edge case that is that during a class recompilation, we create a new instance of the class and add the methods from the old one to the new one. In that case, we should not add the new method to the package of the newProtocol because it is already present.
+			In order to know if we are in this edge case we can check if we have an old protocol already because we copy the protocols before the methods."
+			oldProtocol ifNil: [ (self packageOrganizer packageForProtocol: newProtocol from: self) addMethod: compiledMethod ].
 			self codeChangeAnnouncer announce: (MethodAdded method: compiledMethod) ]
 		ifFalse: [ "If protocol changed and someone is from different package, I need to throw a method recategorized"
 			newProtocol = oldProtocol ifFalse: [ self announceRecategorizationOf: compiledMethod oldProtocol: oldProtocol ].


### PR DESCRIPTION
If you recompile a class with extension methods and remove it afterward, then the class stays as obsolete. This happens because of a bug creating duplicated entries in the packages extension maps. 

I'm proposing a fix to not add new entries to the extension maps in case of recompilation. Coming with a comment and a regression test.

Fixes #17927