### PR TITLE
Improve ReRefersToClassRule name

### DIFF
--- a/src/General-Rules/ReRefersToClassRule.class.st
+++ b/src/General-Rules/ReRefersToClassRule.class.st
@@ -27,7 +27,7 @@ ReRefersToClassRule class >> rationale [
 
 { #category : 'accessing' }
 ReRefersToClassRule class >> ruleName [
-	^ 'Refers to class name instead of "self class"'
+	^ 'Refers to class name instead of "self class" (or "self" on the class side)'
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
It is weird that the rules says to use `self class` when we are on the class side. I'm updating the rule name to show this possibility

Fixes #17123