### PR TITLE
Speedup Random initialization from seed

### DIFF
--- a/src/Random-Core/Random.class.st
+++ b/src/Random-Core/Random.class.st
@@ -100,6 +100,14 @@ more; go get coffee.
 						stream space ] ])
 ]
 
+{ #category : 'instance creation' }
+Random class >> new [
+
+	^ super new
+		  useClockBasedSeed;
+		  yourself
+]
+
 { #category : 'private' }
 Random class >> primitiveRandomNumber: stateArray [
 	"Answer a random Float in the interval [0 to 1)."
@@ -124,13 +132,18 @@ Random class >> primitiveRandomNumber: stateArray [
 
 { #category : 'instance creation' }
 Random class >> seed: anInteger [
-	^self new seed: anInteger
+	"We use the super to avoid a double initialization of the seed that would slow down the random instantiation."
+
+	^ super new
+		  seed: anInteger;
+		  yourself
 ]
 
 { #category : 'initialization' }
 Random >> initialize [
-	state := DoubleWordArray new: 1.
-	self useClockBasedSeed.
+
+	super initialize.
+	state := DoubleWordArray new: 1
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
When setting the seed, this change avoid to have a double initialization of the seed to speed it up.

```st
{ [ Random new ]. [ Random seed: 7 ] } collect: #bench.

"
Before:
an Array(
4,527,035 iterations in 5 seconds 2 milliseconds.905044.982 per second
2,578,191 iterations in 5 seconds 3 milliseconds. 515329.003 per second)"

 "
After:
an Array(
4,839,828 iterations in 5 seconds 1 millisecond. 967772.046 per second
5,454,942 iterations in 5 seconds 2 milliseconds. 1090552.179 per second)"
```

Fixes #17510