### PR TITLE
Fix the logic of the extra commands on methods

### DIFF
--- a/src/SystemCommands-MethodCommands/SycClassifyMethodsCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycClassifyMethodsCommand.class.st
@@ -2,7 +2,7 @@
 Classify the selected methods
 "
 Class {
-	#name : 'SycClassifyMthCommand',
+	#name : 'SycClassifyMethodsCommand',
 	#superclass : 'SycMethodExtraCmCommand',
 	#instVars : [
 		'protocol'
@@ -12,45 +12,39 @@ Class {
 }
 
 { #category : 'execution' }
-SycClassifyMthCommand >> applyCommandResult [
-
-	context showProtocol: protocol
-]
-
-{ #category : 'executing' }
-SycClassifyMthCommand >> execute [
+SycClassifyMethodsCommand >> applyCommandResult [
 
 	self methods do: [ :aMethod | aMethod protocol: self protocol ].
-
+	context showProtocol: self protocol
 ]
 
 { #category : 'accessing' }
-SycClassifyMthCommand >> icon [
+SycClassifyMethodsCommand >> icon [
 
 	^ self iconNamed: #browse
 ]
 
 { #category : 'accessing' }
-SycClassifyMthCommand >> name [
+SycClassifyMethodsCommand >> name [
 
 	^ 'Classify methods'
 ]
 
 { #category : 'preparation' }
-SycClassifyMthCommand >> prepareFullExecution [
+SycClassifyMethodsCommand >> prepareFullExecution [
 
 	super prepareFullExecution.
 	protocol := StProtocolNameChooserPresenter requestProtocolNameConfiguring: [ :presenter | presenter concernedClass: context lastSelectedClass ]
 ]
 
 { #category : 'accessing' }
-SycClassifyMthCommand >> protocol [
+SycClassifyMethodsCommand >> protocol [
 
 	^ protocol
 ]
 
 { #category : 'accessing' }
-SycClassifyMthCommand >> protocol: anObject [
+SycClassifyMethodsCommand >> protocol: anObject [
 
 	protocol := anObject
 ]

--- a/src/SystemCommands-MethodCommands/SycCopyMethodNameToClipboardCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycCopyMethodNameToClipboardCommand.class.st
@@ -8,20 +8,19 @@ Class {
 	#package : 'SystemCommands-MethodCommands'
 }
 
+{ #category : 'executing' }
+SycCopyMethodNameToClipboardCommand >> applyCommandResult [
+
+	| text |
+	text := (self methods collect: #displayString) joinUsing: String cr.
+	Clipboard clipboardText: text.
+	self inform: 'Copied methods:' , String cr , text
+]
+
 { #category : 'accessing' }
 SycCopyMethodNameToClipboardCommand >> description [
 
 	^ 'Copy selected methods into Clipboard as class>>selector'
-]
-
-{ #category : 'executing' }
-SycCopyMethodNameToClipboardCommand >> execute [
-
-	| text |
-
-	text := (self methods collect: #displayString) joinUsing: String cr.
-	Clipboard clipboardText: text.
-	self inform: 'Copied methods:' , String cr , text
 ]
 
 { #category : 'accessing' }

--- a/src/SystemCommands-MethodCommands/SycCopyTestMethodNameToClipboardCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycCopyTestMethodNameToClipboardCommand.class.st
@@ -8,18 +8,18 @@ Class {
 	#package : 'SystemCommands-MethodCommands'
 }
 
-{ #category : 'accessing' }
-SycCopyTestMethodNameToClipboardCommand >> description [
-	^ 'Copy selected methods selector into Clipboard as testXXX'
-]
-
 { #category : 'executing' }
-SycCopyTestMethodNameToClipboardCommand >> execute [
-	| text |
+SycCopyTestMethodNameToClipboardCommand >> applyCommandResult [
 
+	| text |
 	text := (self methods collect: [ :each | each selector asTestSelector ]) joinUsing: String cr.
 	Clipboard clipboardText: text.
 	self inform: 'Copied methods:' , String cr , text
+]
+
+{ #category : 'accessing' }
+SycCopyTestMethodNameToClipboardCommand >> description [
+	^ 'Copy selected methods selector into Clipboard as testXXX'
 ]
 
 { #category : 'accessing' }

--- a/src/SystemCommands-MethodCommands/SycFileOutMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycFileOutMethodCommand.class.st
@@ -8,16 +8,16 @@ Class {
 	#package : 'SystemCommands-MethodCommands'
 }
 
+{ #category : 'executing' }
+SycFileOutMethodCommand >> applyCommandResult [
+
+	self methods do: [ :each | each fileOut ]
+]
+
 { #category : 'accessing' }
 SycFileOutMethodCommand >> description [
 
 	^ 'Requests to save a textual version of the selected class to a new file in chunk format and .st extension. Instance and class side methods are both saved'
-]
-
-{ #category : 'executing' }
-SycFileOutMethodCommand >> execute [
-
-	self methods do: [ :each | each fileOut ]
 ]
 
 { #category : 'accessing' }

--- a/src/SystemCommands-MethodCommands/SycInspectMethodCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycInspectMethodCommand.class.st
@@ -8,16 +8,16 @@ Class {
 	#package : 'SystemCommands-MethodCommands'
 }
 
+{ #category : 'executing' }
+SycInspectMethodCommand >> applyCommandResult [
+
+	self methods do: #inspect
+]
+
 { #category : 'accessing' }
 SycInspectMethodCommand >> description [
 
 	^ 'Inspect the selected methods'
-]
-
-{ #category : 'executing' }
-SycInspectMethodCommand >> execute [
-
-	self methods do: #inspect
 ]
 
 { #category : 'accessing' }

--- a/src/SystemCommands-MethodCommands/SycMethodExtraCmCommand.class.st
+++ b/src/SystemCommands-MethodCommands/SycMethodExtraCmCommand.class.st
@@ -14,9 +14,9 @@ SycMethodExtraCmCommand class >> activationStrategy [
 ]
 
 { #category : 'testing' }
-SycMethodExtraCmCommand >> canBeExecuted [ 
+SycMethodExtraCmCommand >> canBeExecuted [
 
-	^ self methods notNil and: [ self methods notEmpty ]
+	^ self methods isNotNil and: [ self methods isNotEmpty ]
 ]
 
 { #category : 'accessing' }
@@ -28,6 +28,7 @@ SycMethodExtraCmCommand >> methods [
 
 { #category : 'preparation' }
 SycMethodExtraCmCommand >> prepareFullExecution [
+
 	super prepareFullExecution.
 	self setUpModelFromContext: context
 ]


### PR DESCRIPTION
In Calypso Hernan started to migrate commands from Commander1 to Commander2. This brought a change in the logic but the commands in the extra group on methods lost the ability to execute the #prepareFullExecution method which cause some commands to fail.

I'm fixing this + I renamed a class to have a better name

Fixes #17506