### PR TITLE
Added new method for class duplication + changes

### DIFF
--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -240,6 +240,17 @@ RBCondition class >> isClass: anObject [
 ]
 
 { #category : 'testing' }
+RBCondition class >> isClass: className alreadyExistIn: aModel [
+
+	^ self new 
+		  block: [
+			  | aClassOrTrait |
+			  aClassOrTrait := aModel classNamed: className.
+			  aClassOrTrait isNil ]
+		  errorString: 'Class ' , className , ' already exists'
+]
+
+{ #category : 'testing' }
 RBCondition class >> isClass: aRBClass definedIn: aRBNamespace [ 
 	^ self isClassNamed: aRBClass name definedIn: aRBNamespace 
 ]
@@ -247,11 +258,12 @@ RBCondition class >> isClass: aRBClass definedIn: aRBNamespace [
 { #category : 'instance creation' }
 RBCondition class >> isClassNamed: className definedIn: aModel [
 
-	^ self new 
-		block: [ | aClassOrTrait |
-				aClassOrTrait := aModel classNamed: className.
-				aClassOrTrait isNotNil ]
-		errorString: [ className , ' is <1?:not > defined' ]
+	^ self new
+		  block: [
+			  | aClassOrTrait |
+			  aClassOrTrait := aModel classNamed: className.
+			  aClassOrTrait isNotNil ]
+		  errorString: className , ' is <1?:not >defined'
 ]
 
 { #category : 'instance creation' }

--- a/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
@@ -36,16 +36,17 @@ RBInsertNewClassRefactoring >> applicabilityPreconditions [
 	cond := { ((RBCondition isMetaclass: superclass) errorMacro:
 		         'Superclass must not be a metaclass') not }.
 	subclasses do: [ :sub |
-		        cond := cond , {
-				 	((RBCondition isMetaclass: sub) errorMacro:
+		cond := cond , {
+			        ((RBCondition isMetaclass: sub) errorMacro:
 				         'Subclass must <1?not :>be a metaclass') not.
 			        (RBCondition isImmediateSubclass: sub of: superclass) } ].
 	^ cond , {
-			(RBCondition isValidClassName: className).
-			(RBCondition isGlobal: className in: self model) not.
-			(RBCondition isSymbol: packageName).
-			((RBCondition withBlock: [ packageName isNotEmpty ]) errorMacro:
-				 'Invalid package name') }
+		  (RBCondition isClass: className alreadyExistIn: self model).
+		  (RBCondition isValidClassName: className).
+		  (RBCondition isGlobal: className in: self model) .
+		  (RBCondition isSymbol: packageName).
+		  ((RBCondition withBlock: [ packageName isNotEmpty ]) errorMacro:
+			   'Invalid package name') }
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Fixes #17518 
-Added method #isClass:alreadyExistIn: to check if the class name is already taken before duplicating
-Removed block closure for one method because there was an error
-Changed the precondition for isGlobal because it was not used correctly