### PR TITLE
Fixed the duplicate class refactoring wrong message

### DIFF
--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -26,16 +26,6 @@ Class {
 }
 
 { #category : 'instance creation' }
-RBCondition class >> alreadyExistGlobal: aString in: aRBSmalltalk [
-
-	^ self new 
-		  block: [ aRBSmalltalk includesGlobal: aString asSymbol ]
-		  errorString:
-			  'A class or global variable with the name: ' , aString
-			  , ' already exists'
-]
-
-{ #category : 'instance creation' }
 RBCondition class >> canUnderstand: aSelector in: aClass [
 
 	^self new
@@ -267,7 +257,11 @@ RBCondition class >> isClassNamed: className definedIn: aModel [
 { #category : 'instance creation' }
 RBCondition class >> isGlobal: aString in: aRBSmalltalk [
 
-	^ self new block: [ aRBSmalltalk includesGlobal: aString asSymbol ] errorString: aString , ' is <1?:not >a class or global variable'
+	^ self new
+		  block: [ aRBSmalltalk includesGlobal: aString asSymbol ]
+		  errorString:
+			  'A class or global variable with the name: ' , aString
+			  , ' already exists'
 ]
 
 { #category : 'instance creation' }

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -25,7 +25,7 @@ Class {
 	#tag : 'Conditions'
 }
 
-{ #category : 'as yet unclassified' }
+{ #category : 'instance creation' }
 RBCondition class >> alreadyExistGlobal: aString in: aRBSmalltalk [
 
 	^ self new 

--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -25,6 +25,16 @@ Class {
 	#tag : 'Conditions'
 }
 
+{ #category : 'as yet unclassified' }
+RBCondition class >> alreadyExistGlobal: aString in: aRBSmalltalk [
+
+	^ self new 
+		  block: [ aRBSmalltalk includesGlobal: aString asSymbol ]
+		  errorString:
+			  'A class or global variable with the name: ' , aString
+			  , ' already exists'
+]
+
 { #category : 'instance creation' }
 RBCondition class >> canUnderstand: aSelector in: aClass [
 

--- a/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
@@ -42,7 +42,7 @@ RBInsertNewClassRefactoring >> applicabilityPreconditions [
 			        (RBCondition isImmediateSubclass: sub of: superclass) } ].
 	^ cond , { 
 			(RBCondition isValidClassName: className).
-			(RBCondition alreadyExistGlobal: className in: self model) not.
+			(RBCondition isGlobal: className in: self model) not.
 			(RBCondition isSymbol: packageName).
 			((RBCondition withBlock: [ packageName isNotEmpty ]) errorMacro:
 				 'Invalid package name') }

--- a/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
+++ b/src/Refactoring-Core/RBInsertNewClassRefactoring.class.st
@@ -40,9 +40,9 @@ RBInsertNewClassRefactoring >> applicabilityPreconditions [
 				 	((RBCondition isMetaclass: sub) errorMacro:
 				         'Subclass must <1?not :>be a metaclass') not.
 			        (RBCondition isImmediateSubclass: sub of: superclass) } ].
-	^ cond , {
+	^ cond , { 
 			(RBCondition isValidClassName: className).
-			(RBCondition isGlobal: className in: self model) not.
+			(RBCondition alreadyExistGlobal: className in: self model) not.
 			(RBCondition isSymbol: packageName).
 			((RBCondition withBlock: [ packageName isNotEmpty ]) errorMacro:
 				 'Invalid package name') }


### PR DESCRIPTION
Fixes #17518
- Indeed there is a  <1?:not > in #isGlobal: in: that was putting a "not" in the linked issue but because we evaluated 	```(RBCondition alreadyExistGlobal: className in: self model) not.``` the not was put in the wrong cases
- I created a new method to handle it to not change anything in #isGlobal: in: to not break something