### PR TITLE
Make all Dictionary tests inheritable

### DIFF
--- a/src/Collections-Sequenceable/OrderedDictionary.class.st
+++ b/src/Collections-Sequenceable/OrderedDictionary.class.st
@@ -263,7 +263,7 @@ OrderedDictionary >> at: key update: updateBlock initial: initBlocktOrValue [
 	"I am used to update the value at a given key. The updateBlock is passed
 	the existing value, and the result of the block is stored back.
 	If the key does not exist, store the value of the initBlocktOrValue.
-	initBlocktOrValue can be a block in case the initial value is expencive to compute."
+	initBlocktOrValue can be a block in case the initial value is expensive to compute."
 	| val |
 	val := self at: key ifAbsent: [ nil ].
 	val

--- a/src/Collections-Unordered-Tests/DictionaryTest.class.st
+++ b/src/Collections-Unordered-Tests/DictionaryTest.class.st
@@ -286,41 +286,35 @@ DictionaryTest >> setUp [
 	emptyDict := self classToBeTested new.
 	nonEmptyDict := self classToBeTested new.
 	nonEmptyDict
-		at: #a
-			put: self elementTwiceIn;
-		at: #b
-			put: 30;
-		at: #c
-			put: self elementTwiceIn;
-		at: #d
-			put: -2.
+		at: #a put: self elementTwiceIn;
+		at: #b put: 30;
+		at: #c put: self elementTwiceIn;
+		at: #d put: -2.
 	nonEmpty5ElementsNoDuplicates := self classToBeTested new
-		at: #a
-			put: 5;
-		at: #b
-			put: 4;
-		at: #c
-			put: 7;
-		at: #d
-			put: 6;
-		at: #e
-			put: 9;
+		at: #a put: 5;
+		at: #b put: 4;
+		at: #c put: 7;
+		at: #d put: 6;
+		at: #e put: 9;
 		yourself.
 	valueNotIn := 666.
-	keyNotIn := #z .
-	associationNotIn := keyNotIn->valueNotIn.
-	dictionaryNotIncluded := Dictionary new add: associationNotIn ;yourself.
-	collectionNotIncluded := {  valueNotIn. valueNotIn  }.
-	collectionIncluded := {  (self elementTwiceIn)  }.
-	indexArray := #(2 3 1 ).
-	valueArray := #(5 5 5 ).
+	keyNotIn := #z.
+	associationNotIn := keyNotIn -> valueNotIn.
+	dictionaryNotIncluded := Dictionary new add: associationNotIn; yourself.
+	collectionNotIncluded := { valueNotIn. valueNotIn }.
+	collectionIncluded := { self elementTwiceIn }.
+	indexArray := #( 2 3 1 ).
+	valueArray := #( 5 5 5 ).
 	nonEmpty1Element := self classToBeTested new
-		at: #a
-			put: 5;
+		at: #a put: 5;
 		yourself.
-	nonEmptyWithString := Dictionary new add: #A->'foo'; add: #b->'bar' ; yourself.
+	nonEmptyWithString := Dictionary new add: #A->'foo'; add: #b->'bar'; yourself.
 	duplicateValue := 2.5.
-	dictionaryWithDuplicateValues := 	Dictionary new add: #A->duplicateValue ; add: #b->3.5 ; add: #C->duplicateValue  ; yourself
+	dictionaryWithDuplicateValues := Dictionary new
+		add: #A -> duplicateValue;
+		add: #b -> 3.5;
+		add: #C -> duplicateValue;
+		yourself
 ]
 
 { #category : 'requirements' }
@@ -372,7 +366,7 @@ DictionaryTest >> testAddWithKeyNotIn [
 DictionaryTest >> testAsSet [
 
 	| aDictionary aSet assoc0 assoc1 |
-	aDictionary := Dictionary new.
+	aDictionary := self classToBeTested new.
 	aSet := aDictionary asSet.
 	"Add two associations to it"
 	assoc0 := #first -> 0.
@@ -388,19 +382,21 @@ DictionaryTest >> testAsSet [
 
 { #category : 'tests' }
 DictionaryTest >> testAtUpdate [
+
 	| dict |
-	dict := {2->10. 100->5} asDictionary.
-	dict at: 2 update: [ :v | v+10 ].
+	dict := { 2 -> 10. 100 -> 5 } as: self classToBeTested.
+	dict at: 2 update: [ :v | v + 10 ].
 	self assert: (dict at: 2) equals: 20.
-	self should: [ dict at: 5 update: [ :v | v+1 ] ] raise: KeyNotFound
+	self should: [ dict at: 5 update: [ :v | v + 1 ] ] raise: KeyNotFound
 ]
 
 { #category : 'tests' }
 DictionaryTest >> testAtUpdateInitial [
+
 	| dict |
-	dict := {2->10. 100->5} asDictionary.
-	dict at: 5 update: [ :v | v+1 ] initial: [17].
-	dict at: 2 update: [ :v | v+10 ] initial: [0].
+	dict := { 2 -> 10. 100 -> 5 } as: self classToBeTested.
+	dict at: 5 update: [ :v | v + 1 ] initial: [ 17 ].
+	dict at: 2 update: [ :v | v + 10 ] initial: [ 0 ].
 	self assert: (dict at: 5) equals: 17.
 	self assert: (dict at: 2) equals: 20
 ]
@@ -411,11 +407,11 @@ DictionaryTest >> testCollectAsWithParenthesis [
 	| array dict |
 	array := { 1. 2. 3 }.
 	dict := (array collect: [ :each | each -> each asString ]) as:
-		        Dictionary.
-	self assert: dict equals: {
-			(1 -> '1').
-			(2 -> '2').
-			(3 -> '3') } asDictionary
+		        self classToBeTested.
+	self assert: dict equals: ({
+			 (1 -> '1').
+			 (2 -> '2').
+			 (3 -> '3') } as: self classToBeTested)
 ]
 
 { #category : 'tests' }
@@ -425,11 +421,11 @@ DictionaryTest >> testCollectAsWithoutParenthesis [
 	array := { 1. 2. 3 }.
 	dict := array
 		        collect: [ :each | each -> each asString ]
-		        as: Dictionary.
-	self assert: dict equals: {
-			(1 -> '1').
-			(2 -> '2').
-			(3 -> '3') } asDictionary
+		        as: self classToBeTested.
+	self assert: dict equals: ({
+			 (1 -> '1').
+			 (2 -> '2').
+			 (3 -> '3') } as: self classToBeTested)
 ]
 
 { #category : 'tests' }
@@ -458,7 +454,8 @@ DictionaryTest >> testDictionaryPublicProtocolCompatibility [
 DictionaryTest >> testFlatCollect [
 
 	| res |
- 	res := {#first -> -1. #second -> 5 . #three -> -33} asDictionary flatCollect: [:e | { e abs } ].
+ 	res := {#first -> -1. #second -> 5 . #three -> -33} as: self classToBeTested.
+	res := res flatCollect: [ :e | { e abs } ].
  	self assert: res asSet equals: #(1 5 33) asSet
 ]
 
@@ -466,7 +463,8 @@ DictionaryTest >> testFlatCollect [
 DictionaryTest >> testFlatCollect2 [
 
 	| res |
- 	res := {#first -> #(-2 3). #second -> #(-4 5)} asDictionary flatCollect: [:e | e collect: [:each | each abs]].
+ 	res := {#first -> #(-2 3). #second -> #(-4 5)} as: self classToBeTested.
+	res := res flatCollect: [ :e | e collect: [ :each | each abs ] ].
  	self assert: res asSet equals: #(2 3 4 5) asSet
 ]
 
@@ -474,7 +472,8 @@ DictionaryTest >> testFlatCollect2 [
 DictionaryTest >> testFlatCollect3 [
 
 	| res |
- 	res := {#first -> #(-2 3). #second -> #(-4 5)} asDictionary flatCollect: [:e | {e collect: [:each | each abs]}].
+ 	res := {#first -> #(-2 3). #second -> #(-4 5)} as: self classToBeTested.
+	res := res flatCollect: [ :e | { (e collect: [ :each | each abs ]) } ].
  	self assert: res asSet equals: #(#(2 3) #(4 5)) asSet
 ]
 

--- a/src/Collections-Unordered/Dictionary.class.st
+++ b/src/Collections-Unordered/Dictionary.class.st
@@ -461,7 +461,7 @@ Dictionary >> at: key update: updateBlock initial: initBlocktOrValue [
 	"I am used to update the value at a given key. The updateBlock is passed
 	the existing value, and the result of the block is stored back.
 	If the key does not exist, store the value of the initBlocktOrValue.
-	initBlocktOrValue can be a block in case the initial value is expencive to compute.
+	initBlocktOrValue can be a block in case the initial value is expensive to compute.
 	I use findElementOrNil: to avoid looking up the key twice."
 	| index |
 	index := self findElementOrNil: key.

--- a/src/Collections-Unordered/SmallDictionary.class.st
+++ b/src/Collections-Unordered/SmallDictionary.class.st
@@ -357,7 +357,7 @@ SmallDictionary >> at: key update: updateBlock initial: initBlocktOrValue [
 	"I am used to update the value at a given key. The updateBlock is passed
 	the existing value, and the result of the block is stored back.
 	If the key does not exist, store the value of the initBlocktOrValue.
-	initBlocktOrValue can be a block in case the initial value is expencive to compute.
+	initBlocktOrValue can be a block in case the initial value is expensive to compute.
 	I use findElementOrNil: to avoid looking up the key twice."
 	| index |
 	index := self findIndexForKey: key.

--- a/src/System-Support-Tests/SystemEnvironmentTest.class.st
+++ b/src/System-Support-Tests/SystemEnvironmentTest.class.st
@@ -87,6 +87,15 @@ SystemEnvironmentTest >> testAtUpdateInitial [
 	self assert: (dict at: #a) equals: 20
 ]
 
+{ #category : 'tests - DictionaryIndexAccessing' }
+SystemEnvironmentTest >> testAtUpdateInitialNil [
+	"Only symbols are accepted as keys in SystemEnvironment"
+
+	self
+		should: [ self collection at: nil update: nil initial: nil ]
+		raise: Error
+]
+
 { #category : 'tests' }
 SystemEnvironmentTest >> testClassOrTraitNamedReturnsClassForClasses [
 

--- a/src/System-Support-Tests/SystemEnvironmentTest.class.st
+++ b/src/System-Support-Tests/SystemEnvironmentTest.class.st
@@ -66,34 +66,22 @@ SystemEnvironmentTest >> testAtPutNil [
 SystemEnvironmentTest >> testAtUpdate [
 
 	| dict |
-	dict := {
-		        (GlobalVariable key: #a value: 10).
-		        (GlobalVariable key: #b value: 5) } as: self classToBeTested.
-	dict at: #a update: [ :v | v + 10 ].
-	self assert: (dict at: #a) equals: 20.
-	self should: [ dict at: #c update: [ :v | v + 1 ] ] raise: KeyNotFound
+	dict := { (GlobalVariable key: #a value: 10) } as:
+		        self classToBeTested.
+	self
+		should: [ dict at: #a update: [ :v | v + 10 ] ]
+		raise: ShouldNotImplement
 ]
 
 { #category : 'tests' }
 SystemEnvironmentTest >> testAtUpdateInitial [
 
 	| dict |
-	dict := {
-		        (GlobalVariable key: #a value: 10).
-		        (GlobalVariable key: #b value: 5) } as: self classToBeTested.
-	dict at: #c update: [ :v | v + 1 ] initial: [ 17 ].
-	dict at: #a update: [ :v | v + 10 ] initial: [ 0 ].
-	self assert: (dict at: #c) equals: 17.
-	self assert: (dict at: #a) equals: 20
-]
-
-{ #category : 'tests - DictionaryIndexAccessing' }
-SystemEnvironmentTest >> testAtUpdateInitialNil [
-	"Only symbols are accepted as keys in SystemEnvironment"
-
+	dict := { (GlobalVariable key: #a value: 10) } as:
+		        self classToBeTested.
 	self
-		should: [ self collection at: nil update: nil initial: nil ]
-		raise: Error
+		should: [ dict at: #c update: [ :v | v + 1 ] initial: [ 17 ] ]
+		raise: ShouldNotImplement
 ]
 
 { #category : 'tests' }

--- a/src/System-Support-Tests/SystemEnvironmentTest.class.st
+++ b/src/System-Support-Tests/SystemEnvironmentTest.class.st
@@ -63,6 +63,31 @@ SystemEnvironmentTest >> testAtPutNil [
 ]
 
 { #category : 'tests' }
+SystemEnvironmentTest >> testAtUpdate [
+
+	| dict |
+	dict := {
+		        (GlobalVariable key: #a value: 10).
+		        (GlobalVariable key: #b value: 5) } as: self classToBeTested.
+	dict at: #a update: [ :v | v + 10 ].
+	self assert: (dict at: #a) equals: 20.
+	self should: [ dict at: #c update: [ :v | v + 1 ] ] raise: KeyNotFound
+]
+
+{ #category : 'tests' }
+SystemEnvironmentTest >> testAtUpdateInitial [
+
+	| dict |
+	dict := {
+		        (GlobalVariable key: #a value: 10).
+		        (GlobalVariable key: #b value: 5) } as: self classToBeTested.
+	dict at: #c update: [ :v | v + 1 ] initial: [ 17 ].
+	dict at: #a update: [ :v | v + 10 ] initial: [ 0 ].
+	self assert: (dict at: #c) equals: 17.
+	self assert: (dict at: #a) equals: 20
+]
+
+{ #category : 'tests' }
 SystemEnvironmentTest >> testClassOrTraitNamedReturnsClassForClasses [
 
 	self assert: Object identicalTo: (testingEnvironment classOrTraitNamed: 'Object').
@@ -77,11 +102,76 @@ SystemEnvironmentTest >> testClassOrTraitNamedReturnsNilForGlobals [
 ]
 
 { #category : 'tests' }
+SystemEnvironmentTest >> testCollectAsWithParenthesis [
+
+	| array dict |
+	array := #( a b c ).
+	dict := (array collect: [ :each |
+		         GlobalVariable key: each value: each asString ]) as:
+		        self classToBeTested.
+	self assert: dict equals: ({
+			 (GlobalVariable key: #a value: 'a').
+			 (GlobalVariable key: #b value: 'b').
+			 (GlobalVariable key: #c value: 'c') } as: self classToBeTested)
+]
+
+{ #category : 'tests' }
+SystemEnvironmentTest >> testCollectAsWithoutParenthesis [
+
+	| array dict |
+	array := #( a b c ).
+	dict := array
+		        collect: [ :each | GlobalVariable key: each value: each asString ]
+		        as: self classToBeTested.
+	self assert: dict equals: ({
+			 (GlobalVariable key: #a value: 'a').
+			 (GlobalVariable key: #b value: 'b').
+			 (GlobalVariable key: #c value: 'c') } as: self classToBeTested)
+]
+
+{ #category : 'tests' }
 SystemEnvironmentTest >> testEnvironmentOfOrganization [
 
 	| aDictionary |
 	aDictionary := SystemEnvironment new.
 	self assert: aDictionary organization environment equals: aDictionary
+]
+
+{ #category : 'tests - flatCollect' }
+SystemEnvironmentTest >> testFlatCollect [
+
+	| res |
+	res := {
+		       (GlobalVariable key: #first value: -1).
+		       (GlobalVariable key: #second value: 5).
+		       (GlobalVariable key: #three value: -33) } as:
+		       self classToBeTested.
+	res := res flatCollect: [ :e | { e abs } ].
+	self assert: res asSet equals: #( 1 5 33 ) asSet
+]
+
+{ #category : 'tests - flatCollect' }
+SystemEnvironmentTest >> testFlatCollect2 [
+
+	| res |
+	res := {
+		       (GlobalVariable key: #first value: #( -2 3 )).
+		       (GlobalVariable key: #second value: #( -4 5 )) } as:
+		       self classToBeTested.
+	res := res flatCollect: [ :e | e collect: [ :each | each abs ] ].
+	self assert: res asSet equals: #( 2 3 4 5 ) asSet
+]
+
+{ #category : 'tests - flatCollect' }
+SystemEnvironmentTest >> testFlatCollect3 [
+
+	| res |
+	res := {
+		       (GlobalVariable key: #first value: #( -2 3 )).
+		       (GlobalVariable key: #second value: #( -4 5 )) } as:
+		       self classToBeTested.
+	res := res flatCollect: [ :e | { (e collect: [ :each | each abs ]) } ].
+	self assert: res asSet equals: #( #( 2 3 ) #( 4 5 ) ) asSet
 ]
 
 { #category : 'tests' }

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -137,21 +137,9 @@ SystemEnvironment >> at: aKey put: anObject [
 
 { #category : 'accessing' }
 SystemEnvironment >> at: key update: updateBlock initial: initBlocktOrValue [
-	"I am used to update the value at a given key. The updateBlock is passed
-	the existing value, and the result of the block is stored back.
-	If the key does not exist, store the value of the initBlocktOrValue.
-	initBlocktOrValue can be a block in case the initial value is expensive to compute.
-	I use findElementOrNil: to avoid looking up the key twice."
-	| index |
-	key isSymbol ifFalse: [ self error: 'Only symbols are accepted as keys in SystemEnvironment' ].
-	index := self findElementOrNil: key.
-	(array at: index)
-		ifNil: [
-			self
-				atNewIndex: index
-				put: (GlobalVariable key: key value: initBlocktOrValue value).
-			self flushClassNameCache ]
-		ifNotNil: [ :var | var value: (updateBlock value: var value) ]
+	"Unsupported API: SystemEnvironment is not intended to be used as a dictionary."
+
+	self shouldNotImplement
 ]
 
 { #category : 'adding' }

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -140,9 +140,10 @@ SystemEnvironment >> at: key update: updateBlock initial: initBlocktOrValue [
 	"I am used to update the value at a given key. The updateBlock is passed
 	the existing value, and the result of the block is stored back.
 	If the key does not exist, store the value of the initBlocktOrValue.
-	initBlocktOrValue can be a block in case the initial value is expencive to compute.
+	initBlocktOrValue can be a block in case the initial value is expensive to compute.
 	I use findElementOrNil: to avoid looking up the key twice."
 	| index |
+	key isSymbol ifFalse: [ self error: 'Only symbols are accepted as keys in SystemEnvironment' ].
 	index := self findElementOrNil: key.
 	(array at: index)
 		ifNil: [

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -135,6 +135,24 @@ SystemEnvironment >> at: aKey put: anObject [
  	^ anObject
 ]
 
+{ #category : 'accessing' }
+SystemEnvironment >> at: key update: updateBlock initial: initBlocktOrValue [
+	"I am used to update the value at a given key. The updateBlock is passed
+	the existing value, and the result of the block is stored back.
+	If the key does not exist, store the value of the initBlocktOrValue.
+	initBlocktOrValue can be a block in case the initial value is expencive to compute.
+	I use findElementOrNil: to avoid looking up the key twice."
+	| index |
+	index := self findElementOrNil: key.
+	(array at: index)
+		ifNil: [
+			self
+				atNewIndex: index
+				put: (GlobalVariable key: key value: initBlocktOrValue value).
+			self flushClassNameCache ]
+		ifNotNil: [ :var | var value: (updateBlock value: var value) ]
+]
+
 { #category : 'adding' }
 SystemEnvironment >> atNewIndex: index put: aGlobalVariable [
 


### PR DESCRIPTION
I found 8 tests in DictionaryTest that hardcoded the use of the Dictionary class. This meant that all subclasses of DictionaryTest also ran these tests using dictionaries instead of the class they were supposed to test. This fix replaces those hardcoded occurrences with the use of the `classToBeTested` method, just like all other tests.

Now about SystemEnvironment, which is a special cookie. This fix works for all classes except for this one. This required implementing `SystemEnvironment>>#at:update:initial:`, and also adjusting the tests for this class. @jecisc told me about the plans to no longer make this class inherit from Dictionary, so I guess this can be considered a *temporary* workaround. The API that is tested by these fixed tests is not used anywhere else anyway.