### PR TITLE
Refactor OCMessageNode>>isInlineToDo to remove OCParseTreeSearcher

### DIFF
--- a/src/OpalCompiler-Core/OCMessageNode.extension.st
+++ b/src/OpalCompiler-Core/OCMessageNode.extension.st
@@ -108,10 +108,10 @@ OCMessageNode >> isInlineToDo [
 	block isBlock ifFalse: [^ false].
 	block arguments size = 1 ifFalse: [^ false].
 	self arguments first isVariable ifTrue: [
-		(OCParseTreeSearcher new
-			matches: self arguments first name , ' := `@object' do: [:n :a | true];
-			executeTree: block initialAnswer: false) ifTrue: [^ false].
-	].
+        (block allChildren anySatisfy: [:child | 
+            child isAssignment and: [
+                child variable = self arguments first]]) ifTrue: [^ false].
+    ].
 	self arguments size = 3 "to:by:do:" ifTrue: [
 		step := self arguments second.
 		(step isLiteralNode and: [step value isNumber])ifFalse: [^ false].

--- a/src/OpalCompiler-Core/OCMessageNode.extension.st
+++ b/src/OpalCompiler-Core/OCMessageNode.extension.st
@@ -108,10 +108,10 @@ OCMessageNode >> isInlineToDo [
 	block isBlock ifFalse: [^ false].
 	block arguments size = 1 ifFalse: [^ false].
 	self arguments first isVariable ifTrue: [
-        (block allChildren anySatisfy: [:child | 
-            child isAssignment and: [
-                child variable = self arguments first]]) ifTrue: [^ false].
-    ].
+		(block allChildren anySatisfy: [:child |
+			child isAssignment and: [
+				child variable = self arguments first ]]) ifTrue: [ ^false ].
+	].
 	self arguments size = 3 "to:by:do:" ifTrue: [
 		step := self arguments second.
 		(step isLiteralNode and: [step value isNumber])ifFalse: [^ false].


### PR DESCRIPTION
Fixes: #17752 

### Summary:
Replaced `OCParseTreeSearcher` in cases where the use of `OCParseTreeSearcher` lead to more complex code.

### Note:
I searched the codebase where `OCParseTreeSearcher` was used but I did not find any other code where it was overly complex or needed replacement.