### PR TITLE
Implemented new menu to show pool users

### DIFF
--- a/src/Calypso-SystemTools-QueryBrowser/ClyShowClassRefCommand.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyShowClassRefCommand.class.st
@@ -94,7 +94,7 @@ ClyShowClassRefCommand >> defaultMenuItemName [
 { #category : 'execution' }
 ClyShowClassRefCommand >> execute [
 
-	browser spawnQueryBrowserOn: (ClyClassReferencesQuery toAny: classes)
+	browser spawnQueryBrowserOn: (ClyClassReferencesQuery toAny: classes) 
 ]
 
 { #category : 'execution' }

--- a/src/Calypso-SystemTools-QueryBrowser/ClyShowPoolUsersCommand.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyShowPoolUsersCommand.class.st
@@ -1,0 +1,55 @@
+"
+Retrieves the selected class pool users.
+"
+Class {
+	#name : 'ClyShowPoolUsersCommand',
+	#superclass : 'SycClassCommand',
+	#instVars : [
+		'browser'
+	],
+	#category : 'Calypso-SystemTools-QueryBrowser-Commands-Queries',
+	#package : 'Calypso-SystemTools-QueryBrowser',
+	#tag : 'Commands-Queries'
+}
+
+{ #category : 'activation' }
+ClyShowPoolUsersCommand class >> fullBrowserMenuActivation [
+
+	<classAnnotation>
+	^ CmdContextMenuActivation
+		  byItemOf: ClyQueryMenuGroup
+		  for: ClyFullBrowserClassContext
+]
+
+{ #category : 'accessing' }
+ClyShowPoolUsersCommand >> browser [
+
+	^ browser
+]
+
+{ #category : 'accessing' }
+ClyShowPoolUsersCommand >> browser: anObject [
+
+	browser := anObject
+]
+
+{ #category : 'accessing' }
+ClyShowPoolUsersCommand >> defaultMenuItemName [
+
+	^ 'Show pool users'
+]
+
+{ #category : 'execution' }
+ClyShowPoolUsersCommand >> execute [
+
+	browser spawnQueryBrowserOn:
+		(ClySharedPoolReferencesQuery to: classes first)
+]
+
+{ #category : 'execution' }
+ClyShowPoolUsersCommand >> prepareFullExecutionInContext: aToolContext [
+
+	super prepareFullExecutionInContext: aToolContext.
+
+	browser := aToolContext browser
+]


### PR DESCRIPTION
Branch: poolusers,  Fixes #17078
-New command class created to call the ClySharedPoolReferencesQuery browser to display the Pool Users of a class
-Added it in full browser context menu to use it .

@Ducasse fixed !