### PR TITLE
17727-Fix-the-two-skipped-tests-in-DrTests

### DIFF
--- a/src/DrTests-Tests/DrTestsUITest.class.st
+++ b/src/DrTests-Tests/DrTestsUITest.class.st
@@ -73,7 +73,6 @@ DrTestsUITest >> testInitialStatusIsInitialStatusPluginName [
 { #category : 'tests' }
 DrTestsUITest >> testInitialWindowTitleIsInitialPluginWindowTitle [
 
-	self skip.
 	self
 		assert: drTestsUI title
 		equals: 'Dr Tests - ' , drTestsUI currentPlugin pluginName
@@ -131,9 +130,6 @@ DrTestsUITest >> testSelectingPluginWillUpdateCurrentPluginInstanceVariable [
 { #category : 'tests' }
 DrTestsUITest >> testSelectingPluginWillUpdatePackagesList [
 
-	"this test do not has sense anymore (since we do not change package list all the time)"
-	self skip.
-
 	drTestsUI pluginsDropList selectItem: plugin2.
 	self
 		assertCollection: drTestsUI pluginPresenter packagesList items
@@ -143,7 +139,6 @@ DrTestsUITest >> testSelectingPluginWillUpdatePackagesList [
 
 { #category : 'tests' }
 DrTestsUITest >> testSelectingPluginWillUpdateWindowTitle [
-	self skip. 
 	
 	drTestsUI pluginsDropList selectItem: plugin2.
 	self

--- a/src/DrTests/AbstractDrTestsPresenter.class.st
+++ b/src/DrTests/AbstractDrTestsPresenter.class.st
@@ -51,7 +51,7 @@ AbstractDrTestsPresenter >> currentPlugin: anObject [
 		send: #handlePluginResultUpdate:
 		to: self.
 
-	self withWindowDo: [ :aWindow | aWindow title: self windowTitle ]
+	titleHolder := self windowTitle.
 ]
 
 { #category : 'events' }


### PR DESCRIPTION
#Branch: 17727-Fix-the-two-skipped-tests-in-DrTests Fixes #17727
- Removing skipped tests from DrTest. 
- Fixing the title holder to set it even if there is no window.