### PR TITLE
17903-Using-Windows-key--click-to-find-implementors-has-side-effects

### DIFF
--- a/src/Calypso-Browser/ClyBrowserToolMorph.class.st
+++ b/src/Calypso-Browser/ClyBrowserToolMorph.class.st
@@ -427,7 +427,7 @@ ClyBrowserToolMorph >> isExtraSelectionRequested [
 	| lastEvent |
 	lastEvent := (self activeHand ifNil: [ ^ false ])lastEvent.
 	^ lastEvent isMouse and: [ lastEvent isMouseDown
-		and: [lastEvent commandKeyPressed or: [ lastEvent controlKeyPressed ]]]
+		and: [lastEvent metaKeyPressed ]]
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Widgets-FastTable/FTMultipleSelectionStrategy.class.st
+++ b/src/Morphic-Widgets-FastTable/FTMultipleSelectionStrategy.class.st
@@ -30,9 +30,7 @@ FTMultipleSelectionStrategy >> selectAppendingIndex: index [
 { #category : 'accessing' }
 FTMultipleSelectionStrategy >> selectIndex: index event: event [
 	event shiftPressed ifTrue: [ ^ self selectIndexesUpTo: index ].
-	OSPlatform current isMacOS
-		ifTrue: [ event commandKeyPressed ifTrue: [ ^ self selectAppendingIndex: index ] ]
-		ifFalse: [ event controlKeyPressed ifTrue: [ ^ self selectAppendingIndex: index ] ].
+	event metaKeyPressed ifTrue: [ ^ self selectAppendingIndex: index ].
 	self toggleIndex: index
 ]
 

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -676,9 +676,7 @@ FTTableMorph >> isYellowButtonReallyPressed: anEvent [
 	then you will got right mouse button event.
 	Interesting that it is not a problem in case of external SDL2 window.
 	Try check it from OSWindowWorldMorph new open"
-	^ (Smalltalk os isMacOS)
-		ifTrue: [ anEvent commandKeyPressed not]
-		ifFalse: [ anEvent controlKeyPressed not]
+	^ anEvent metaKeyPressed not
 ]
 
 { #category : 'event handling' }

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -134,11 +134,9 @@ CompletionEngine >> handleKeyDownBefore: aKeyboardEvent editor: anEditor [
 
 	This method would be cleaner if splitted."
 
-	| key controlKeyPressed commandKeyPressed |
+	| key |
 	self setEditor: anEditor.
 	key := aKeyboardEvent key.
-	controlKeyPressed := aKeyboardEvent controlKeyPressed.
-	commandKeyPressed := aKeyboardEvent commandKeyPressed.
 
 	(self isMenuOpen not and: [
 		 self editor atCompletionPosition and: [

--- a/src/Rubric/TextLink.extension.st
+++ b/src/Rubric/TextLink.extension.st
@@ -2,5 +2,5 @@ Extension { #name : 'TextLink' }
 
 { #category : '*Rubric-Editing-Core' }
 TextLink >> rubMayActOnEvent: anEvent [
-	^ anEvent isMouseDown and: [ anEvent commandKeyPressed ]
+	^ anEvent isMouseDown and: [ anEvent metaKeyPressed ]
 ]

--- a/src/Text-Edition/TextLink.extension.st
+++ b/src/Text-Edition/TextLink.extension.st
@@ -2,5 +2,5 @@ Extension { #name : 'TextLink' }
 
 { #category : '*Text-Edition' }
 TextLink >> mayActOnEvent: anEvent [
-	^ anEvent isMouseUp and: [ anEvent commandKeyPressed ]
+	^ anEvent isMouseUp and: [ anEvent metaKeyPressed ]
 ]


### PR DESCRIPTION
#Branch: 17903-Using-Windows-key--click-to-find-implementors-has-side-effects
Fixes #17903
Using metaKeyPressed instead of commandKeyPressed