### PR TITLE
Replace DADependencyChecker with StDependencyChecker

### DIFF
--- a/src/Specific-Rules/PharoBootstrapRule.class.st
+++ b/src/Specific-Rules/PharoBootstrapRule.class.st
@@ -53,7 +53,7 @@ PharoBootstrapRule >> critiqueFor: aPackage [
 
 { #category : 'private' }
 PharoBootstrapRule >> dependencyChecker [
-	^ (DependencyChecker ifNil: [ DADependencyChecker ]) new
+	^ (DependencyChecker ifNil: [ StDependencyChecker ]) new
 ]
 
 { #category : 'instance creation' }


### PR DESCRIPTION
Fixes: #17998 

This PR replaces `DADependencyChecker` with `StDependencyChecker` in the `PharoBootstrapRule` class to ensure the correct dependency checker is used.