### PR TITLE
17997-Control-Shift-Click-on-a-message-in-Windows-does-not-browse-senders

### DIFF
--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -2880,7 +2880,7 @@ Morph >> handleMouseDown: anEvent [
 	anEvent hand newMouseFocus: self event: anEvent.
 
 	"Check to open halo"
-	anEvent isSpecialGesture
+	(anEvent isSpecialGesture and: [self cmdGesturesEnabled])
 		ifTrue: [
 			^ self handleSpecialGesture: anEvent ].
 

--- a/src/Morphic-Core/Morph.class.st
+++ b/src/Morphic-Core/Morph.class.st
@@ -2871,8 +2871,7 @@ Morph >> handleMouseDown: anEvent [
 	anEvent hand removePendingBalloonFor: self.
 	anEvent wasHandled: true.
 
-	(anEvent controlKeyPressed and: [
-		 self cmdGesturesEnabled and: [ anEvent shiftPressed ] ]) ifTrue: [
+	(anEvent isSpecialMetaMenuGesture and: [ self cmdGesturesEnabled ]) ifTrue: [
 		self invokeMetaMenu: anEvent.
 		^ self eventHandler ifNotNil: [ :handler |
 			  handler mouseDown: anEvent fromMorph: self ] ].

--- a/src/Morphic-Core/MouseButtonEvent.class.st
+++ b/src/Morphic-Core/MouseButtonEvent.class.st
@@ -38,6 +38,13 @@ MouseButtonEvent >> isSpecialGesture [
 ]
 
 { #category : 'accessing' }
+MouseButtonEvent >> isSpecialMetaMenuGesture [
+	"This is the gesture to open the Halos"
+	^ (self blueButtonPressed & self controlKeyPressed) 
+	or: [self redButtonPressed & self altKeyPressed & self shiftPressed & self controlKeyPressed]
+]
+
+{ #category : 'accessing' }
 MouseButtonEvent >> redButtonChanged [
 	"Answer true if the red mouse button has changed. This is the first mouse button."
 

--- a/src/Settings-Polymorph/PolymorphSystemSettings.class.st
+++ b/src/Settings-Polymorph/PolymorphSystemSettings.class.st
@@ -284,6 +284,11 @@ PolymorphSystemSettings class >> morphicHaloSettingsOn: aBuilder [
 		description: 'All halo settings';
 		noOrdering;
 		with: [
+			(aBuilder setting: #cmdGesturesEnabled)
+				label: 'Enable Gesture to Open Halo';
+				target: Morph;
+				default: true;
+				description: 'Enables or Disables the gestures to open the Halo or the meta menu. The Halo is open with Alt+Shift+Click and the Menu with Ctrl+Alt+Shift+Click'.
 			(aBuilder setting: #cycleHalosBothDirections)
 				label: 'Cycle both directions';
 				target: Morph;


### PR DESCRIPTION
Fix #17997 

- Changing the gesture to open the meta menu from Ctrl + Shift + Click, to Ctrl + Alt + Shift + Click to be coherent with the other special gesture like that is Alt + Shift + Click.
- Adding a setting to disable the halos, also making it work for real