### PR TITLE
Fix failing tests about #print:delimiterOn:

### DIFF
--- a/src/AST-Core/OCDumpVisitor.class.st
+++ b/src/AST-Core/OCDumpVisitor.class.st
@@ -126,15 +126,13 @@ OCDumpVisitor >> visitEnglobingErrorNode: anEnglobingErrorNode [
 { #category : 'visiting' }
 OCDumpVisitor >> visitLiteralArrayNode: aLiteralArrayNode [
 
-	stream nextPutAll: aLiteralArrayNode class name;
+	stream
+		nextPutAll: aLiteralArrayNode class name;
 		nextPutAll: ' value: ';
-		nextPutAll: (
-	aLiteralArrayNode isForByteArray
-		ifTrue: [ '#['  ]
-		ifFalse: [ '#(' ]).
-	(aLiteralArrayNode contents collect: [ :each | each value ])
-		do: [ :e | stream print: e ]
-		separatedBy: [ stream print: ' ' ].
+		nextPutAll: (aLiteralArrayNode isForByteArray
+				 ifTrue: [ '#[' ]
+				 ifFalse: [ '#(' ]).
+	(aLiteralArrayNode contents collect: [ :each | each value ]) do: [ :e | stream print: e ] separatedBy: [ stream nextPutAll: ' ' ].
 	stream nextPutAll: (aLiteralArrayNode isForByteArray
 			 ifTrue: [ ']' ]
 			 ifFalse: [ ')' ])

--- a/src/Collections-Abstract-Tests/TPrintTest.trait.st
+++ b/src/Collections-Abstract-Tests/TPrintTest.trait.st
@@ -81,32 +81,3 @@ TPrintTest >> testPrintOn [
 			self prefix.
 			self nonEmpty class name } , allElementsAsString
 ]
-
-{ #category : 'tests - printing' }
-TPrintTest >> testPrintOnDelimiter [
-
-	| result allElementsAsString expectedelements |
-	result := String streamContents: [ :aStream |
-		          self nonEmpty
-			          do: [ :e | aStream print: e ]
-			          separatedBy: [ aStream print: ', ' ] ].
-
-	allElementsAsString := result findBetweenSubstrings: ', '.
-	expectedelements := self nonEmpty
-		                    collect: [ :e |
-		                    String streamContents: [ :aStream |
-			                    e printOn: aStream ] ]
-		                    as: OrderedCollection.
-
-	self assert: allElementsAsString equals: expectedelements
-]
-
-{ #category : 'tests - printing' }
-TPrintTest >> testPrintOnDelimiterLast [
-
-	| result |
-	result := String streamContents: [ :aStream |
-		          self nonEmpty printOn: aStream delimiter: ', ' last: ' and ' ].
-
-	self assert: (result occurrencesOf: $,) equals: self elements size - 2
-]

--- a/src/EmergencyDebugger/EDDebuggingAPI.class.st
+++ b/src/EmergencyDebugger/EDDebuggingAPI.class.st
@@ -102,9 +102,7 @@ EDDebuggingAPI >> dumpStack [
 
 	| str |
 	str := String new writeStream.
-	self stack
-		do: [ :e | str print: e ]
-		separatedBy: [ str print: String cr ].
+	self stack do: [ :e | str print: e ] separatedBy: [ str nextPutAll: String cr ].
 	^ str contents
 ]
 


### PR DESCRIPTION
The method was deprecated so I'm removing the tests about this method + I'm fixing some methods that got a wrong replacement for this code. Using #print: instead of #nextPutAll: was adding extra quotes