### PR TITLE
Allow multiple package selection in DrTest coverage tool

### DIFF
--- a/src/DrTests-TestCoverage/DTTestCoveragePlugin.class.st
+++ b/src/DrTests-TestCoverage/DTTestCoveragePlugin.class.st
@@ -125,7 +125,7 @@ DTTestCoveragePlugin >> secondListLabel [
 { #category : 'api' }
 DTTestCoveragePlugin >> setSelectionModeOfItemsList: aListPresenter [
 	aListPresenter
-		beSingleSelection;
+		beMultipleSelection;
 		unselectAll
 ]
 


### PR DESCRIPTION
Fixes: #17278 

### Changes:
1. This PR fixes an issue in the DrTest coverage tool where only one package was allowed to be selected for run code coverage.
2. I have tested locally & it now selects multiple packages
