### PR TITLE
Update version in #iceberg for BaselineOfPharo for Pharo 12 to ‘v2.3.3’

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -60,7 +60,7 @@ BaselineOfPharo class >> iceberg [
 		newName: 'Iceberg' 
 		owner: 'pharo-vcs' 
 		project: 'iceberg'
-		version: 'v2.3.2' 
+		version: 'v2.3.3' 
 		sourceDir: nil
 ]
 


### PR DESCRIPTION
This pull request updates the version in #iceberg for BaselineOfPharo for Pharo 12 to ‘v2.3.3’.

Before merging this please:
* Merge Iceberg pull request [#1900](https://github.com/pharo-vcs/iceberg/pull/1900), [#1902](https://github.com/pharo-vcs/iceberg/pull/1902) and [#1903](https://github.com/pharo-vcs/iceberg/pull/1903). Note that these require fixing the Iceberg ‘Pharo12’ branch first.
* Tag the resulting Iceberg ‘Pharo12’ commit as ‘v2.3.3’.