### PR TITLE
Fixed SystemEnvironment tests by creating TestObject class using ShiftClassBuilder

### DIFF
--- a/src/System-Support-Tests/SystemEnvironmentTest.class.st
+++ b/src/System-Support-Tests/SystemEnvironmentTest.class.st
@@ -51,8 +51,13 @@ SystemEnvironmentTest >> setUp [
 	super setUp.
 	
 	testingEnvironment := SystemEnvironment new.
-	Smalltalk globals keysAndValuesDo: [ :key :value |
-		testingEnvironment at: key put: value ].
+
+	ShiftClassBuilder new
+		name: #TestObject;
+		superclass: nil;
+		installingEnvironment: testingEnvironment;
+		package: 'System-Support-Tests';
+		install.
 
 	associationNotIn := GlobalVariable key: keyNotIn value: valueNotIn
 ]
@@ -94,8 +99,12 @@ SystemEnvironmentTest >> testAtUpdateInitial [
 { #category : 'tests' }
 SystemEnvironmentTest >> testClassOrTraitNamedReturnsClassForClasses [
 
-	self assert: Object identicalTo: (testingEnvironment classOrTraitNamed: 'Object').
-	self assert: Object identicalTo: (testingEnvironment classOrTraitNamed: #Object)
+	self
+		assert: (testingEnvironment at: #TestObject)
+		identicalTo: (testingEnvironment classOrTraitNamed: 'TestObject').
+	self
+		assert: (testingEnvironment at: #TestObject)
+		identicalTo: (testingEnvironment classOrTraitNamed: #TestObject)
 ]
 
 { #category : 'tests' }

--- a/src/System-Support-Tests/SystemEnvironmentTest.class.st
+++ b/src/System-Support-Tests/SystemEnvironmentTest.class.st
@@ -4,6 +4,9 @@ SUnit tests for SystemEnvironment
 Class {
 	#name : 'SystemEnvironmentTest',
 	#superclass : 'DictionaryTest',
+	#instVars : [
+		'testingEnvironment'
+	],
 	#category : 'System-Support-Tests-Utilities',
 	#package : 'System-Support-Tests',
 	#tag : 'Utilities'
@@ -46,6 +49,10 @@ SystemEnvironmentTest >> elementToAdd [
 SystemEnvironmentTest >> setUp [
 
 	super setUp.
+	
+	testingEnvironment := SystemEnvironment new.
+	Smalltalk globals keysAndValuesDo: [ :key :value |
+		testingEnvironment at: key put: value ].
 
 	associationNotIn := GlobalVariable key: keyNotIn value: valueNotIn
 ]


### PR DESCRIPTION
Fixes: #18006 

### Description
This PR fixes failing tests in `SystemEnvironmentTest` by creating an isolated `TestObject` class in the `testingEnvironment` using `ShiftClassBuilder`.

### Changes
- Added `testingEnvironment` as instancVariable & updated `setUp` method.
- Update Tests 
- Verified that all tests now pass locally.