### PR TITLE
Cleaning the benchmarks

### DIFF
--- a/src/HeuristicCompletion-Benchmarks/CoBenchmarkVariableContext.class.st
+++ b/src/HeuristicCompletion-Benchmarks/CoBenchmarkVariableContext.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : 'CoBenchmarkVariableContext',
+	#superclass : 'CoBenchmarkContext',
+	#category : 'HeuristicCompletion-Benchmarks',
+	#package : 'HeuristicCompletion-Benchmarks'
+}
+
+{ #category : 'accessing' }
+CoBenchmarkVariableContext >> completionToken [
+
+	^ callsite name
+]

--- a/src/HeuristicCompletion-Benchmarks/CoStaticBenchmarks.class.st
+++ b/src/HeuristicCompletion-Benchmarks/CoStaticBenchmarks.class.st
@@ -56,59 +56,37 @@ Class {
 	#package : 'HeuristicCompletion-Benchmarks'
 }
 
-{ #category : 'running' }
-CoStaticBenchmarks class >> customHeuristics: aBuilder [
+{ #category : 'examples' }
+CoStaticBenchmarks class >> messageBenchmarksOnNECompletion [
+	<script>
+	
+	(CoStaticBenchmarksMessage new
+    	scope: (CoBenchmarkPackage on: CompletionSorter package);
+    	builder: CoASTHeuristicsResultSetBuilder new;
+    	run) inspect
 
-	self subclassResponsibility
+
+
 ]
 
 { #category : 'running' }
-CoStaticBenchmarks class >> defaultHeuristics: aBuilder [
+CoStaticBenchmarks class >> onPackage: aPackage heuristics: aHeuristicsBlock [
 
-	self subclassResponsibility
+	| benchmark builder |
+	builder := CoASTHeuristicsResultSetBuilder new.
+	aHeuristicsBlock value: builder.
+
+	benchmark := self new
+		             scope: (CoBenchmarkPackage on: aPackage);
+		             builder: builder;
+		             yourself.
+
+	benchmark run.
+	^ benchmark
 ]
 
-{ #category : 'running' }
-CoStaticBenchmarks class >> runAllOnClass: aPackage [
-    "Runs the CoStaticBenchmarks for every sorter class in sorterClasses,
-    all using the given package as the scope. 
-    Answers a Dictionary from sorter class symbols to the resulting CoStaticBenchmarks instance 
-    so you can inspect or retrieve results later."
-    
-    | results |
-    results := Dictionary new.
-    
-    self sorterClasses do: [ :sorterSymbol |
-        | sorterClass benchmark |
-        
-        "Retrieve the actual class object for the symbol"
-        sorterClass := Smalltalk at: sorterSymbol ifAbsent: [ 
-            self error: (String streamContents: [ :s | 
-    				s nextPutAll: 'Sorter class '.
-    				s nextPutAll: sorterSymbol asString.
-    				s nextPutAll: ' not found in Smalltalk image.'
-			])
-        ].
-
-        "Create and run a new benchmark for that sorter"
-        benchmark := self new
-            scope: (CoBenchmarkPackage on: aPackage);
-            builder: (CoGlobalSorterResultSetBuilder new
-                sorterClass: sorterClass;
-                yourself);
-            yourself.
-
-        benchmark run.
-
-        "Store the instance so we can retrieve/inspect it later"
-        results at: sorterSymbol put: benchmark
-    ].
-
-    ^ results
-]
-
-{ #category : 'running' }
-CoStaticBenchmarks class >> runAllOnPackage: aPackageIdentifier [
+{ #category : 'running sorters' }
+CoStaticBenchmarks class >> runAllSortersOnPackage: aPackageIdentifier [
     "Runs the CoStaticBenchmarks for every sorter class in sorterClasses using the given package as the scope.
     Returns a Dictionary mapping sorter class symbols to their benchmark instances."
 
@@ -122,10 +100,7 @@ CoStaticBenchmarks class >> runAllOnPackage: aPackageIdentifier [
     self sorterClasses do: [ :sorterSymbol |
         | sorterClass benchmark |
         
-        sorterClass := Smalltalk at: sorterSymbol ifAbsent: [
-            self error: 'Sorter class ', sorterSymbol asString, ' not found in Smalltalk image.'
-        ].
-    
+        sorterClass := Smalltalk at: sorterSymbol.
         benchmark := self new
             scope: (CoBenchmarkPackage on: pkg);
             builder: (CoGlobalSorterResultSetBuilder new
@@ -141,40 +116,48 @@ CoStaticBenchmarks class >> runAllOnPackage: aPackageIdentifier [
     ^ results
 ]
 
+{ #category : 'examples' }
+CoStaticBenchmarks class >> runMessageAllSortersOnNeCompletionPackage [
+	<script>
+	
+	^ (CoStaticBenchmarksMessage runAllSortersOnPackage: (PackageOrganizer default packageNamed: 'NECompletion')) inspect. 
+]
+
+{ #category : 'examples' }
+CoStaticBenchmarks class >> runMessageOnNeCompletionPackage [
+	<script>
+	
+	^ (CoStaticBenchmarksMessage 
+			runOnPackage: (PackageOrganizer default packageNamed: 'NECompletion')
+			heuristics: [:b | b]) inspect. 
+]
+
 { #category : 'running' }
-CoStaticBenchmarks class >> runAllOnPackage: aPackageOrName heuristics: aHeuristicsBlock [
+CoStaticBenchmarks class >> runOnPackage: aPackage heuristics: aHeuristicsBlock [
 
-	| benchmark builder package |
-	package := aPackageOrName isString
-		           ifTrue: [
-		           PackageOrganizer default packageNamed: aPackageOrName ]
-		           ifFalse: [ aPackageOrName ].
-
-	package ifNil: [
-		^ self error: 'Package not found: ' , aPackageOrName printString ].
-
-	builder := CoASTHeuristicsResultSetBuilder new.
-	aHeuristicsBlock value: builder.
-
-	"Create and run the benchmark"
-	benchmark := self new
-		             scope: (CoBenchmarkPackage on: package);
-		             builder: builder;
-		             yourself.
-
+	| benchmark |
+	benchmark := self onPackage: aPackage heuristics: aHeuristicsBlock.
 	benchmark run.
 	^ benchmark
 ]
 
-{ #category : 'running' }
-CoStaticBenchmarks class >> runFor: aClass [
-
-	^ self new
-		scope: aClass;
-		run
+{ #category : 'examples' }
+CoStaticBenchmarks class >> runVariableAllSortersOnNeCompletionPackage [
+	<script>
+	
+	^ (CoStaticBenchmarksVariables runAllSortersOnPackage: (PackageOrganizer default packageNamed: 'NECompletion')) inspect. 
 ]
 
-{ #category : 'running' }
+{ #category : 'examples' }
+CoStaticBenchmarks class >> runVariableOnNeCompletionPackage [
+	<script>
+	
+	^ (CoStaticBenchmarksVariables 
+			runOnPackage: (PackageOrganizer default packageNamed: 'NECompletion')
+			heuristics: [:b | b]) inspect. 
+]
+
+{ #category : 'running sorters' }
 CoStaticBenchmarks class >> sorterClasses [
 
     "Answers an array of the symbols of all sorter classes to be run."

--- a/src/HeuristicCompletion-Benchmarks/CoStaticBenchmarksMessage.class.st
+++ b/src/HeuristicCompletion-Benchmarks/CoStaticBenchmarksMessage.class.st
@@ -4,22 +4,13 @@
 
 ## Typical Usage:
 
-
-
-
-### First way (We recommand to use this one :):
+### First way (We recommand to use this one):
 
 
 ```smalltalk
-global := CoStaticBenchmarksMessage runAllOnClass: CompletionSorter package.
+global := CoStaticBenchmarksMessage runAllSortersOnPackage: CompletionSorter package.
 
-global := CoStaticBenchmarksMessage runAllOnPackage: 'NECompletion'.
-
-""To add the which templates of heurisitcs you want to use""
-
-global := CoStaticBenchmarksMessage runAllOnPackage: 'NECompletion' heuristics: [ :b | CoStaticBenchmarksMessage defaultHeuristics: b ].
-
-global := CoStaticBenchmarksMessage runAllOnPackage: 'NECompletion' heuristics: [ :b | CoStaticBenchmarksMessage customHeuristics: b ].
+global := CoStaticBenchmarksMessage runAllSortersOnPackage: 'NECompletion'
 
 ```
 
@@ -155,8 +146,7 @@ CoStaticBenchmarksMessage >> fetchTopCandidatesFrom: completion usingPrefix: pre
 { #category : 'benchmarks' }
 CoStaticBenchmarksMessage >> findCompletionIndexFor: originalSelector inCandidates: candidates [
 
-	^ (candidates collect: [ :each | each contents ]) indexOf:
-		  originalSelector
+	^ (candidates collect: [ :each | each contents ]) indexOf: originalSelector
 ]
 
 { #category : 'benchmarks' }

--- a/src/HeuristicCompletion-Benchmarks/CoStaticBenchmarksVariables.class.st
+++ b/src/HeuristicCompletion-Benchmarks/CoStaticBenchmarksVariables.class.st
@@ -88,83 +88,57 @@ Class {
 	#package : 'HeuristicCompletion-Benchmarks'
 }
 
-{ #category : 'running' }
-CoStaticBenchmarksVariables class >> customHeuristics: aBuilder [
-
-" For now `CoPackageScopedGlobalVariableFetcher` is NOT implemented, there will be another PR where `CoPackageScopedGlobalVariableFetcher` is implement, then you can use this template.
-	aBuilder variablesHeuristic: (aBuilder newHeuristicBuilder
-			 add: CoLocalScopeVariablesHeuristic new;
-			 add: CoWorkspaceVariablesHeuristic new;
-			 add: CoInstanceAccessibleVariablesHeuristic new;
-			 add: (CoGlobalVariablesHeuristic new globalVariableFetcherClass:
-						  CoPackageScopedGlobalVariableFetcher);
-			 build)
-"
-]
-
-{ #category : 'running' }
-CoStaticBenchmarksVariables class >> defaultHeuristics: aBuilder [
-
-	aBuilder variablesHeuristic: (aBuilder newHeuristicBuilder
-			 add: CoLocalScopeVariablesHeuristic new;
-			 add: CoWorkspaceVariablesHeuristic new;
-			 add: CoInstanceAccessibleVariablesHeuristic new;
-			 add: CoGlobalVariablesHeuristic new;
-			 build)
-]
-
 { #category : 'benchmarks' }
-CoStaticBenchmarksVariables >> benchCallsite: aMessageNode atPosition: aPosition [
+CoStaticBenchmarksVariables >> benchCallsite: aVariable atPosition: aPosition [
 
-	| receiver |
-	receiver := aMessageNode receiver.
-
-	2 to: (self maxPrefixSizeFor: receiver) do: [ :index |
+	| oldName |
+	oldName := aVariable name.
+	2 to: (self maxPrefixSizeFor: aVariable) do: [ :index |
 		| prefix startTime startMemory completion candidates completionIndex |
 		startTime := self startTimeMeasurement.
 		startMemory := self startMemoryMeasurement.
-
-		prefix := self extractPrefixFrom: receiver at: index.
-		aMessageNode receiver: (OCVariableNode named: prefix).
+		prefix := self extractPrefixFrom: oldName at: index.
+		aVariable name: prefix.
 
 		completion := self
-			              buildCompletionFor: aMessageNode
+			              buildCompletionFor: aVariable
 			              atPosition: aPosition.
 
 		candidates := self
 			              fetchTopCandidatesFrom: completion
 			              usingPrefix: prefix.
 		completionIndex := self
-			                   findCompletionIndexFor: receiver
+			                   findCompletionIndexFor: oldName
 			                   inCandidates: candidates.
 
 		self
-			trackCompletionResultsFor: receiver
+			trackCompletionResultsFor: oldName
 			atIndex: completionIndex
 			withPrefix: prefix.
 
 		self logMemoryUsageSince: startMemory forPrefixSize: prefix size.
 		self logExecutionTimeSince: startTime forPrefixSize: prefix size ].
+	
+		aVariable name: oldName 
 
-	aMessageNode receiver: receiver
 ]
 
 { #category : 'benchmarks' }
-CoStaticBenchmarksVariables >> buildCompletionFor: aMessageNode atPosition: aPosition [
+CoStaticBenchmarksVariables >> buildCompletionFor: variable atPosition: aPosition [
 
 	^ builder
-		  node: aMessageNode receiver;
-		  completionContext: (CoBenchmarkContext new
-				   callsite: aMessageNode;
+		  node: variable ;
+		  completionContext: (CoBenchmarkVariableContext new
+				   callsite: variable;
 				   position: aPosition;
 				   yourself);
 		  buildCompletion
 ]
 
 { #category : 'benchmarks' }
-CoStaticBenchmarksVariables >> extractPrefixFrom: receiver at: index [
+CoStaticBenchmarksVariables >> extractPrefixFrom: name at: index [
 
-	^ receiver name copyFrom: 1 to: index
+	^ name copyFrom: 1 to: index
 ]
 
 { #category : 'benchmarks' }
@@ -176,10 +150,10 @@ CoStaticBenchmarksVariables >> fetchTopCandidatesFrom: completion usingPrefix: p
 ]
 
 { #category : 'benchmarks' }
-CoStaticBenchmarksVariables >> findCompletionIndexFor: receiver inCandidates: candidates [
+CoStaticBenchmarksVariables >> findCompletionIndexFor: variableName inCandidates: candidates [
 
 	^ (candidates collect: [ :each | each contents ]) indexOf:
-		  receiver name
+		  variableName
 ]
 
 { #category : 'benchmarks' }
@@ -199,9 +173,9 @@ CoStaticBenchmarksVariables >> logMemoryUsageSince: startMemory forPrefixSize: p
 ]
 
 { #category : 'benchmarks' }
-CoStaticBenchmarksVariables >> maxPrefixSizeFor: receiver [
+CoStaticBenchmarksVariables >> maxPrefixSizeFor: variable [
 
-	^ receiver name size min: 8
+	^ variable name size min: 8
 ]
 
 { #category : 'running' }
@@ -209,10 +183,8 @@ CoStaticBenchmarksVariables >> run [
 
 	scope methodsDo: [ :method |
 		method parseTree nodesDo: [ :node |
-			(node isMessage and: [
-				 node receiver isVariable and: [
-					 node receiver name first isUppercase ] ]) ifTrue: [
-				self benchCallsite: node atPosition: node keywordsIntervals first ] ] ]
+			(node isVariable and: [ node name first isUppercase ]) 
+					ifTrue: [ self benchCallsite: node atPosition: node start ] ] ]
 ]
 
 { #category : 'benchmarks' }

--- a/src/HeuristicCompletion-Model/CoVariableValueMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoVariableValueMessageHeuristic.class.st
@@ -42,7 +42,9 @@ CoVariableValueMessageHeuristic >> valueOfVariable: aName inContext: completionC
 	If we find in the requestor a binding with the given name, use it, otherwise ignore it."
 
 	"We check using hasBindingOf: to not create bindings that are not there"
-	(completionContext doItRequestor hasBindingOf: aName) ifFalse:  [ ^ self ].
+	completionContext doItRequestor 
+		ifNotNil: [ :re | (re hasBindingOf: aName) ifFalse:  [ ^ self ]]
+		ifNil: [ ^ self ].
 
 	binding := completionContext doItRequestor bindingOf: aName.
 	^ aBlock value: binding value


### PR DESCRIPTION
Now 
(CoStaticBenchmarksVariables 
			runOnPackage: (PackageOrganizer default packageNamed: 'NECompletion')
			heuristics: [:b | b]) inspect. 
is working as well as 

CoStaticBenchmarksMessage  new
    scope: (CoBenchmarkPackage on: CompletionSorter package);
    builder: CoASTHeuristicsResultSetBuilder new;
    run.