### PR TITLE
Make compiled block class parametrizable

### DIFF
--- a/src/OpalCompiler-Core/OCCompilationContext.class.st
+++ b/src/OpalCompiler-Core/OCCompilationContext.class.st
@@ -28,7 +28,8 @@ Class {
 		'requestorScopeClass',
 		'bindings',
 		'compiledMethodClass',
-		'semanticScope'
+		'semanticScope',
+		'compiledBlockClass'
 	],
 	#classVars : [
 		'DefaultOptions',
@@ -422,6 +423,22 @@ OCCompilationContext >> bytecodeGeneratorClass: anObject [
 { #category : 'accessing' }
 OCCompilationContext >> class: aClass [
 	self semanticScope: (OCMethodSemanticScope targetingClass: aClass)
+]
+
+{ #category : 'accessing' }
+OCCompilationContext >> compiledBlockClass [
+	"Return the class used to instantiate the compiled method created by the compiler"
+	^ compiledBlockClass ifNil: [
+		self productionEnvironment
+			at: #CompiledBlock
+			ifAbsent: [ CompiledBlock ] ]
+]
+
+{ #category : 'accessing' }
+OCCompilationContext >> compiledBlockClass: aCompiledMethodClass [
+	"Return the class used to instantiate the compiled blocks created by the compiler"
+
+	compiledBlockClass := aCompiledMethodClass
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
@@ -166,7 +166,8 @@ OCIRBytecodeGenerator >> compiledBlock [
 
 	"Compiled blocks never call primitives"
 	header := self spurVMHeader: lits size hasPrimitive: false.
-	cb := CompiledBlock basicNew: self bytecodes size header: header.
+	cb := self compilationContext compiledBlockClass
+		basicNew: self bytecodes size header: header.
 	(WriteStream with: cb)
 		position: cb initialPC - 1;
 		nextPutAll: self bytecodes.

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -388,6 +388,12 @@ OpalCompiler >> compile: textOrString [
 ]
 
 { #category : 'accessing' }
+OpalCompiler >> compiledBlockClass: aClass [
+
+	self compilationContext compiledBlockClass: aClass
+]
+
+{ #category : 'accessing' }
 OpalCompiler >> compiledMethodClass: aClass [
 
 	self compilationContext compiledMethodClass: aClass


### PR DESCRIPTION
subject.

Like the compiled method class can be passed as argument, do the same with the compiled block class.