### PR TITLE
Improval of auto pairing in code editor

### DIFF
--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -427,36 +427,38 @@ CompletionEngine >> showDetail [
 
 { #category : 'keyboard' }
 CompletionEngine >> smartBackspace [
-	| opposite currentText currentEditor smartCharacter |
 
+	| opposite currentText currentEditor smartCharacter index |
 	currentEditor := editor.
-	currentEditor hasSelection
-		ifTrue: [ ^ false ].
-
+	currentEditor hasSelection ifTrue: [ ^ false ].
 	currentText := currentEditor text.
-	smartCharacter := currentText at: currentEditor startIndex - 1 ifAbsent: [ ^ false ].	"take the opposite"
 
-	opposite := self smartCharacterOppositeOf: smartCharacter ifAbsent: [ ^ false ].	"test if the next char is opposite"
+	smartCharacter := currentText
+		                  at: currentEditor startIndex - 1
+		                  ifAbsent: [ ^ false ]. "take the opposite"
+	opposite := self
+		            smartCharacterOppositeOf: smartCharacter
+		            ifAbsent: [ ^ false ].
 
-	opposite = (currentText at: currentEditor stopIndex ifAbsent: [ ^ false ])
-		ifFalse: [ ^ false ].	"test if there is an extra opposite to remove"
+	index := currentEditor stopIndex.
+	[
+	index <= currentText size and: [ (currentText at: index) isSeparator ] ]
+		whileTrue: [ index := index + 1 ].
 
+	(index <= currentText size and: [ (currentText at: index) = opposite ])
+		ifFalse: [ ^ false ].
 	(self
-		smartNeedExtraRemoveIn: currentText
-		for: smartCharacter
-		opposite: opposite
-		at: currentEditor startIndex)
-			ifFalse: [ ^ false ].
+		 smartNeedExtraRemoveIn: currentText
+		 for: smartCharacter
+		 opposite: opposite
+		 at: currentEditor startIndex) ifFalse: [ ^ false ].
 
 	currentEditor closeTypeIn.
-
 	currentEditor
 		selectInvisiblyFrom: currentEditor startIndex - 1
-		to: currentEditor stopIndex.
+		to: index.
 	currentEditor replaceSelectionWith: currentEditor nullText.
-
 	self invalidateEditorMorph.
-
 	^ true
 ]
 

--- a/src/NECompletion-Morphic/CompletionEngine.class.st
+++ b/src/NECompletion-Morphic/CompletionEngine.class.st
@@ -428,36 +428,31 @@ CompletionEngine >> showDetail [
 { #category : 'keyboard' }
 CompletionEngine >> smartBackspace [
 
-	| opposite currentText currentEditor smartCharacter index |
-	currentEditor := editor.
-	currentEditor hasSelection ifTrue: [ ^ false ].
-	currentText := currentEditor text.
-
-	smartCharacter := currentText
-		                  at: currentEditor startIndex - 1
+	| opposite smartCharacter index |
+	editor hasSelection ifTrue: [ ^ false ].
+	smartCharacter := editor text
+		                  at: editor startIndex - 1
 		                  ifAbsent: [ ^ false ]. "take the opposite"
 	opposite := self
 		            smartCharacterOppositeOf: smartCharacter
 		            ifAbsent: [ ^ false ].
 
-	index := currentEditor stopIndex.
+	index := editor stopIndex.
 	[
-	index <= currentText size and: [ (currentText at: index) isSeparator ] ]
+	index <= editor text size and: [ (editor text at: index) isSeparator ] ]
 		whileTrue: [ index := index + 1 ].
 
-	(index <= currentText size and: [ (currentText at: index) = opposite ])
+	(index <= editor text size and: [ (editor text at: index) = opposite ])
 		ifFalse: [ ^ false ].
 	(self
-		 smartNeedExtraRemoveIn: currentText
+		 smartNeedExtraRemoveIn: editor text
 		 for: smartCharacter
 		 opposite: opposite
-		 at: currentEditor startIndex) ifFalse: [ ^ false ].
+		 at: editor startIndex) ifFalse: [ ^ false ].
 
-	currentEditor closeTypeIn.
-	currentEditor
-		selectInvisiblyFrom: currentEditor startIndex - 1
-		to: index.
-	currentEditor replaceSelectionWith: currentEditor nullText.
+	editor closeTypeIn.
+	editor selectInvisiblyFrom: editor startIndex - 1 to: index.
+	editor replaceSelectionWith: editor nullText.
 	self invalidateEditorMorph.
 	^ true
 ]

--- a/src/NECompletion-Tests/CompletionEngineTest.class.st
+++ b/src/NECompletion-Tests/CompletionEngineTest.class.st
@@ -828,6 +828,20 @@ CompletionEngineTest >> testSmartBackspaceOutsideSmartCharacters [
 		description: 'smartbackspace ignored if after smart character'
 ]
 
+{ #category : 'tests' }
+CompletionEngineTest >> testSmartBackspaceRemoveBothCharactersWithSpaces [
+	"Test that smart backspace removes both characters even with spaces between them"
+
+	self setEditorText: '(  )'.
+	self selectAt: 2.
+
+	self
+		assert: controller smartBackspace
+		description: 'Smart backspace should return true'.
+
+	self assert: editor text equals: ''
+]
+
 { #category : 'tests - keyboard' }
 CompletionEngineTest >> testSmartBackspaceWithSelection [
 


### PR DESCRIPTION
-Checks now until the next character encountered to remove smart character opposite so it is better for code editor UX
-Fixes a part of #18024, changing the logic of `smartBackspace` to know if we are in a comment or not would mean parsing the editor code into AST, looks like a lot of work to do 