### PR TITLE
Fix #isDeprecated logic of CompiledMethod

### DIFF
--- a/src/Kernel-CodeModel/CompiledMethod.class.st
+++ b/src/Kernel-CodeModel/CompiledMethod.class.st
@@ -337,13 +337,9 @@ CompiledMethod >> isConflict [
 { #category : 'testing' }
 CompiledMethod >> isDeprecated [
 
-	^ self sendsAnySelectorOf: #(
-			#deprecated:
-			#deprecated:transformWith:
-			#deprecated:transformWith:when:
-			#deprecated:on:in:
-			#deprecated:on:in:transformWith:
-			#deprecated:on:in:transformWith:when:)
+	^ (self sendsAnySelectorOf:
+		   #( #deprecated: #deprecated:transformWith: #deprecated:transformWith:when: #deprecated:on:in: #deprecated:on:in:transformWith:
+		      #deprecated:on:in:transformWith:when: )) or: [ self methodClass isDeprecated or: [ self package ifNotNil: [ :package | package isDeprecated ] ] ]
 ]
 
 { #category : 'testing' }

--- a/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
+++ b/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
@@ -716,6 +716,38 @@ CompiledMethodTest >> testMethodClass [
 	self assert: method methodClass equals: class
 ]
 
+{ #category : 'tests - testing' }
+CompiledMethodTest >> testMethodInDeprecatedClassIsDeprecated [
+
+	class := self class classInstaller make: [ :aBuilder |
+		         aBuilder
+			         name: #Derg;
+			         package: self packageNameForTests ].
+	class compile: 'method ^ 1'.
+
+	self deny: class isDeprecated.
+	self deny: (class >> #method) isDeprecated.
+
+	class class compile: 'isDeprecated ^ true'.
+	self assert: class isDeprecated.
+	self assert: (class >> #method) isDeprecated
+]
+
+{ #category : 'tests - testing' }
+CompiledMethodTest >> testMethodInDeprecatedPackageIsDeprecated [
+
+	self class compile: 'method ^1' classified: '*' , self packageNameForTests.
+
+	self deny: self packageNameForTests asPackage isDeprecated.
+	self deny: (self class >> #method) isDeprecated.
+
+	class := self packageNameForTests asPackage packageManifest.
+	class class compile: 'isDeprecated ^ true'.
+
+	self assert: self packageNameForTests asPackage isDeprecated.
+	self assert: (self class >> #method) isDeprecated
+]
+
 { #category : 'tests - comparing' }
 CompiledMethodTest >> testMethodsThatHaveOnlyDifferentSelectorsShouldBeDifferent [
 	| method1 method2 |


### PR DESCRIPTION
When a class is in a deprecated package, we consider it as deprecated. But if a method is in a deprecated package or class, it is not considered deprecated. 

To me this mixed behavior is not good. After talking with people, they seems to expect the deprecation to be passed on so I'm updating CompileMethod>>#isDeprecated to take the class and package state into account for deprecations.