### PR TITLE
Fixes of two cases on shortcut block indentation

### DIFF
--- a/src/EnlumineurFormatter-Tests/EFAssignmentExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFAssignmentExpressionTest.class.st
@@ -119,9 +119,9 @@ EFAssignmentExpressionTest >> testExtraIndentationWhenMultiline2 [
 		assert: source
 		equals:
 '1 to: 4 do: [
-	a := p2 - x - p0 - x * ( p3 - y - p0 - y )
-	     - ( p3 - x - p0 - x * ( p2 - y - p0 - y ) ) * b0
-	]'
+		a := p2 - x - p0 - x * ( p3 - y - p0 - y )
+		     - ( p3 - x - p0 - x * ( p2 - y - p0 - y ) ) * b0
+		]'
 ]
 
 { #category : 'tests' }

--- a/src/EnlumineurFormatter-Tests/EFBlockExpressionOnlyTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFBlockExpressionOnlyTest.class.st
@@ -59,8 +59,8 @@ EFBlockExpressionOnlyTest >> testDontFormatCommentWithStatement2 [
 	configurationSelector := #dontFormatCommentWithStatementConfiguration.
 	source := self formatExpression: '[ "aComment" 1 factorial.  2 factorial]'.
 	self assert: source equals: '[ "aComment"
-1 factorial.
-2 factorial ]'
+	1 factorial.
+	2 factorial ]'
 ]
 
 { #category : 'tests' }
@@ -70,8 +70,8 @@ EFBlockExpressionOnlyTest >> testNewLineAfterComment [
 	configurationSelector := #dontFormatCommentWithStatementConfiguration.
 	source := self formatExpression: '["aComment"1. 2]'.
 	self assert: source equals: '[ "aComment"
-1.
-2 ]'
+	1.
+	2 ]'
 ]
 
 { #category : 'tests' }

--- a/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFBlockExpressionTest.class.st
@@ -436,10 +436,10 @@ EFBlockExpressionTest >> testDoNotKeepBlockInMessageConfiguration [
 	
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i. Transcript show: j]'
 		isFormattedAs: ' :i |
-i to: 10 do:
-	[ :j |
-	Transcript show: i.
-	Transcript show: j ] '
+	i to: 10 do:
+		[ :j |
+			Transcript show: i.
+			Transcript show: j ] '
 	with: #doNotKeepBlockInMessageConfiguration.
 ]
 
@@ -449,8 +449,8 @@ EFBlockExpressionTest >> testDontFormatCommentWithStatement [
 		validate: '1 factorial. "aComment" 2 factorial'
 		isFormattedAs:
 '
-1 factorial "aComment".
-2 factorial '
+	1 factorial "aComment".
+	2 factorial '
 		with: #dontFormatCommentWithStatementConfiguration
 ]
 
@@ -469,8 +469,8 @@ EFBlockExpressionTest >> testFormatBody [
 		validate: ' [1]. [ a:=1] '
 		isFormattedAs:
 '
-[ 1 ].
-[ a := 1 ] '
+	[ 1 ].
+	[ a := 1 ] '
 ]
 
 { #category : 'tests' }
@@ -479,8 +479,8 @@ EFBlockExpressionTest >> testFormatCommentWithStatement [
 		validate: '1 factorial. "aComment" 2 factorial'
 		isFormattedAs:
 '
-1 factorial. "aComment"
-2 factorial '
+	1 factorial. "aComment"
+	2 factorial '
 		with: #formatCommentWithStatementConfiguration
 ]
 
@@ -490,10 +490,10 @@ EFBlockExpressionTest >> testFourSpaceIndent [
 		validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
 		isFormattedAs:
 ' :i |
-i to: 10 do: [ :j |
-    Transcript
-        show: i;
-        show: j ] '
+    i to: 10 do: [ :j |
+            Transcript
+                show: i;
+                show: j ] '
 		with: #fourSpaceIndentConfiguration
 ]
 
@@ -504,9 +504,9 @@ EFBlockExpressionTest >> testLongMultipleArguments [
 		validate: ' :superlong :longlong :long | Transcript show: longlong ; show: long'
 		isFormattedAs: 
 ' :superlong :longlong :long |
-Transcript
-	show: longlong;
-	show: long '
+	Transcript
+		show: longlong;
+		show: long '
 		with: #numberOfSpaceChangedAfterIndentCharacterConfiguration
 ]
 
@@ -517,10 +517,10 @@ EFBlockExpressionTest >> testLongSingleArgument [
 		validate: ' [:superlonglonglong | Transcript show:i; show: j]'
 		isFormattedAs: 
 '
-[ :superlonglonglong |
-Transcript
-	show: i;
-	show: j ] '
+	[ :superlonglonglong |
+		Transcript
+			show: i;
+			show: j ] '
 		with: #numberOfSpaceChangedAfterIndentCharacterConfiguration
 ]
 
@@ -531,8 +531,8 @@ EFBlockExpressionTest >> testMultiline [
 		validate: '1+3. 6 factorial '
 		isFormattedAs: 
 '
-1 + 3.
-6 factorial '
+	1 + 3.
+	6 factorial '
 ]
 
 { #category : 'tests' }
@@ -542,8 +542,8 @@ EFBlockExpressionTest >> testNewLineAfterFirstBracketWhenMultilineWithArguments 
 		validate: ':i | i+3. i factorial '
 		isFormattedAs: 
 ' :i |
-i + 3.
-i factorial '
+	i + 3.
+	i factorial '
 ]
 
 { #category : 'tests' }
@@ -553,9 +553,9 @@ EFBlockExpressionTest >> testNewLineAfterFirstBracketWhenMultilineWithTemporarie
 		validate: '| tmp | 1+3. 6 factorial '
 		isFormattedAs: 
 '
-| tmp |
-1 + 3.
-6 factorial '
+	| tmp |
+	1 + 3.
+	6 factorial '
 with: #blockWithTemporariesConfiguration
 ]
 
@@ -566,9 +566,9 @@ EFBlockExpressionTest >> testNewLineBeforeEndBrackets [
 		validate:'3. 4'  
 		isFormattedAs:
 '
-3.
-4
-'  		with: #newLineBeforeEndBracketConfiguration.
+	3.
+	4
+	'  		with: #newLineBeforeEndBracketConfiguration.
 ]
 
 { #category : 'tests' }
@@ -600,8 +600,8 @@ EFBlockExpressionTest >> testNoNewLineBeforeEndBrackets [
 		validate: '3. 4'  
 		isFormattedAs:
 '
-3.
-4 '  with: #noNewLineBeforeEndBracketConfiguration.
+	3.
+	4 '  with: #noNewLineBeforeEndBracketConfiguration.
 ]
 
 { #category : 'tests' }
@@ -620,10 +620,10 @@ EFBlockExpressionTest >> testOneSpaceIndent [
 	
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
 	isFormattedAs: ' :i |
-i to: 10 do: [ :j |
- Transcript
-  show: i;
-  show: j ] '
+ i to: 10 do: [ :j |
+   Transcript
+    show: i;
+    show: j ] '
 	with: #oneSpaceIndentConfiguration.
 ]
 
@@ -657,10 +657,10 @@ x doSomethingExceptional doSomethingExceptional '
 EFBlockExpressionTest >> testTabIndent [
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
 	isFormattedAs: ' :i |
-i to: 10 do: [ :j |
-	Transcript
-		show: i;
-		show: j ] '
+	i to: 10 do: [ :j |
+			Transcript
+				show: i;
+				show: j ] '
 	 with: #tabIndentConfiguration
 ]
 
@@ -669,10 +669,10 @@ EFBlockExpressionTest >> testTabIndentIsNotAffectedByNumberOfSpace [
 
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
 	 isFormattedAs: ' :i |
-i to: 10 do: [ :j |
-	Transcript
-		show: i;
-		show: j ] '
+	i to: 10 do: [ :j |
+			Transcript
+				show: i;
+				show: j ] '
 	 with: #tabIndentIsnotAffectedConfiguration
 ]
 
@@ -695,10 +695,10 @@ EFBlockExpressionTest >> testTwoSpaceIndent [
 
 	self validate: ':i | i to: 10 do: [:j | Transcript show:i; show: j]'
 	isFormattedAs: ' :i |
-i to: 10 do: [ :j |
-  Transcript
-    show: i;
-    show: j ] '
+  i to: 10 do: [ :j |
+      Transcript
+        show: i;
+        show: j ] '
 	with: #twoSpacesIndentConfiguration
 ]
 

--- a/src/EnlumineurFormatter-Tests/EFCascadeExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFCascadeExpressionTest.class.st
@@ -228,8 +228,8 @@ EFCascadeExpressionTest >> testFormatMultilineMessage [
 '1
 	between: 2 and: 5;
 	to: 4 do: [ :each |
-		each factorial.
-		each + 1 ]'
+			each factorial.
+			each + 1 ]'
 ]
 
 { #category : 'tests' }

--- a/src/EnlumineurFormatter-Tests/EFFormatterTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFFormatterTest.class.st
@@ -1,0 +1,71 @@
+Class {
+	#name : 'EFFormatterTest',
+	#superclass : 'EFTest',
+	#category : 'EnlumineurFormatter-Tests',
+	#package : 'EnlumineurFormatter-Tests'
+}
+
+{ #category : 'tests' }
+EFFormatterTest >> format: aProgram [
+
+	^ EFFormatter format: (OCParser parseExpression: aProgram)
+]
+
+{ #category : 'tests' }
+EFFormatterTest >> testFormattingABlockWithAnInlineCodeKeepItInAsingleLine [
+
+	self assert: (self format: 'emptyBlock:=[1 halt]') equals: 'emptyBlock := [ 1 halt ]'
+]
+
+{ #category : 'tests' }
+EFFormatterTest >> testFormattingABlockWithSeveralLinesInsertAnIdentationIntheCurrentLayout [
+
+	| source |
+	source := 'block := [logger logAnalysisStart.
+               self initialTestRun.
+               self startBudget]'.
+
+	self assert: (self format: source) equals:
+'block := [
+	         logger logAnalysisStart.
+	         self initialTestRun.
+	         self startBudget ]'
+]
+
+{ #category : 'tests' }
+EFFormatterTest >> testFormattingABlockWithSeveralLinesInsertAnIdentationIntheCurrentLayoutAndDeleteItAfter [
+
+	| source |
+	source := '[
+	               line a.
+	               line bb.
+	               line c.
+	               [
+		               line d.
+		               line e ].
+	               [
+		               line f.
+		               line g.
+		               line h ] ]'.
+
+	self assert: (self format: source) equals:
+'[
+	line a.
+	line bb.
+	line c.
+	[
+		line d.
+		line e ].
+	[
+		line f.
+		line g.
+		line h ] ]'
+]
+
+{ #category : 'tests' }
+EFFormatterTest >> testFormattingAnEmptyBlockKeepItWithoutlayoutTabs [
+
+	self
+		assert: (self format: 'emptyBlock := []')
+		equals: 'emptyBlock := [ ]'
+]

--- a/src/EnlumineurFormatter-Tests/EFMessageExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFMessageExpressionTest.class.st
@@ -504,9 +504,9 @@ EFMessageExpressionTest >> testBlockParameterOnTheMethodLineWhenMultiline [
 		assert: source
 		equals:
 '1 to: 10 do: [ :i |
-	Transcript show: i.
-	Transcript cr.
-	Transcript cr ]'
+		Transcript show: i.
+		Transcript cr.
+		Transcript cr ]'
 ]
 
 { #category : 'tests - block arg' }
@@ -554,8 +554,8 @@ EFMessageExpressionTest >> testDontKeepBlockInMessage [
 		equals:
 'aBoolean ifTrue:
 	[ :i |
-	i := i factorial.
-	Transcript show: i ]'
+		i := i factorial.
+		Transcript show: i ]'
 ]
 
 { #category : 'tests' }
@@ -583,7 +583,7 @@ EFMessageExpressionTest >> testDontKeepBlockInMessage3 [
 		equals:
 'aBoolean ifTrue:
 	[ Transcript cr.
-	Transcript cr ]'
+		Transcript cr ]'
 ]
 
 { #category : 'tests' }
@@ -593,9 +593,9 @@ EFMessageExpressionTest >> testExtraIndentInParentheses [
 	source := self formatExpression: '( [ :i | 	i factorial; +3 ] value: 15 )*3'.
 	self assert: source equals:
 '( [ :i |
-  i
-	  factorial;
-	  + 3 ] value: 15 ) * 3'
+	  i
+		  factorial;
+		  + 3 ] value: 15 ) * 3'
 ]
 
 { #category : 'tests' }
@@ -605,9 +605,9 @@ EFMessageExpressionTest >> testExtraIndentInParenthesesWhenThreeSpacesInsidePare
 	source := self formatExpression:'( [ :i | 	i factorial; +3 ] value: 15 )*3'.
 	self assert: source equals:
 '(   [ :i |
-    i
-	    factorial;
-	    + 3 ] value: 15   ) * 3'
+	    i
+		    factorial;
+		    + 3 ] value: 15   ) * 3'
 ]
 
 { #category : 'tests' }
@@ -649,8 +649,8 @@ EFMessageExpressionTest >> testKeepBlockInMessage [
 		assert: source
 		equals:
 'aBoolean ifTrue: [ :i |
-	i := i factorial.
-	Transcript show: i ]'
+		i := i factorial.
+		Transcript show: i ]'
 ]
 
 { #category : 'tests' }
@@ -663,9 +663,9 @@ EFMessageExpressionTest >> testKeepBlockInMessageMutlilineNewLine [
 		assert: source
 		equals:
 'aBoolean ifTrue: [
-	Transcript cr.
-	Transcript cr.
-	Transcript cr ]'
+		Transcript cr.
+		Transcript cr.
+		Transcript cr ]'
 ]
 
 { #category : 'tests' }
@@ -680,9 +680,9 @@ EFMessageExpressionTest >> testKeepBlockInMessageMutlilineSpace [
 		assert: source
 		equals:
 'aBoolean ifTrue: [
-	12 factorial.
-	12 factorial.
-	3 factorial ]'
+		12 factorial.
+		12 factorial.
+		3 factorial ]'
 ]
 
 { #category : 'tests' }
@@ -798,10 +798,10 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine [
 	source := self formatExpression: '1 to: 100 by: 2 do: [ :i | transcript show: i;cr; cr]'.
 	self assert: source equals:
 '1 to: 100 by: 2 do: [ :i |
-	transcript
-		show: i;
-		cr;
-		cr ]'
+		transcript
+			show: i;
+			cr;
+			cr ]'
 ]
 
 { #category : 'tests - keyword' }
@@ -817,8 +817,8 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine10 [
 	self assert: source equals:
 'foo
 	bar: [
-		1 + 2.
-		2 + 2 ]
+			1 + 2.
+			2 + 2 ]
 	bar3: 5'
 ]
 
@@ -832,8 +832,8 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine11 [
 	2 + 2 ]'.
 	self assert: source equals:
 'foo bar3: 5 bar2: [
-	1 + 1.
-	2 + 2 ]'
+		1 + 1.
+		2 + 2 ]'
 ]
 
 { #category : 'tests - keyword' }
@@ -851,8 +851,8 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine12 [
 'foo
 	bar3: 5
 	bar: [
-		1 + 2.
-		2 + 2 ]
+			1 + 2.
+			2 + 2 ]
 	bar3: 5'
 ]
 
@@ -866,8 +866,8 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine13 [
 	2 + 2 ]'.
 	self assert: source equals:
 'foo bar3: 5 bar3: 5 bar2: [
-	1 + 1.
-	2 + 2 ]'
+		1 + 1.
+		2 + 2 ]'
 ]
 
 { #category : 'tests - keyword' }
@@ -884,8 +884,8 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine14 [
 	self assert: source equals:
 'foo
 	bar: [
-		1 + 2.
-		2 + 2 ]
+			1 + 2.
+			2 + 2 ]
 	bar3: 5
 	bar3: 5'.
 ]
@@ -902,11 +902,11 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine15 [
 	self assert: source equals:
 'self
 	indent: (self do: [
-			 1.
-			 2 ])
+				 1.
+				 2 ])
 	around: [
-		1.
-		2 ]'
+			1.
+			2 ]'
 ]
 
 { #category : 'tests - keyword' }
@@ -918,8 +918,8 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine2 [
 'aBoolean
 	ifTrue: [ ^1 ]
 	ifFalse: [
-		tmp := tmp + a.
-		^tmp ]'
+			tmp := tmp + a.
+			^tmp ]'
 ]
 
 { #category : 'tests - keyword' }
@@ -930,8 +930,8 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine3 [
 	self assert: source equals:
 'aBoolean
 	ifTrue: [
-		tmp := tmp + a.
-		^ tmp ]
+			tmp := tmp + a.
+			^ tmp ]
 	ifFalse: [ ^ 0 ]'
 ]
 
@@ -943,11 +943,11 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine4 [
 	self assert: source equals:
 'aBoolean
 	ifTrue: [
-		tmp := tmp + a.
-		^ tmp ]
+			tmp := tmp + a.
+			^ tmp ]
 	ifFalse: [
-		tmp := tmp + a.
-		^ tmp ]'
+			tmp := tmp + a.
+			^ tmp ]'
 ]
 
 { #category : 'tests - keyword' }
@@ -957,8 +957,8 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine5 [
 	source := self formatExpression: 'aBoolean ifTrue:[ ^ 1] ifFalse:[ tmp := tmp + a. ^tmp]'.
 	self assert: source equals:
 'aBoolean ifTrue: [ ^ 1 ] ifFalse: [
-	tmp := tmp + a.
-	^ tmp ]'
+		tmp := tmp + a.
+		^ tmp ]'
 ]
 
 { #category : 'tests - keyword' }
@@ -977,11 +977,11 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine6 [
 	self assert: source equals:
 'foo
 	bar: [
-		1 + 2.
-		2 + 2 ]
+			1 + 2.
+			2 + 2 ]
 	bar2: [
-		1 + 1.
-		2 + 2 ]
+			1 + 1.
+			2 + 2 ]
 	bar3: 5'
 ]
 
@@ -1002,11 +1002,11 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine7 [
 'foo
 	bar3: 5
 	bar: [
-		1 + 2.
-		2 + 2 ]
+			1 + 2.
+			2 + 2 ]
 	bar2: [
-		1 + 1.
-		2 + 2 ]'
+			1 + 1.
+			2 + 2 ]'
 ]
 
 { #category : 'tests - keyword' }
@@ -1025,12 +1025,12 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine8 [
 	self assert: source equals:
 'foo
 	bar: [
-		1 + 2.
-		2 + 2 ]
+			1 + 2.
+			2 + 2 ]
 	bar3: 5
 	bar2: [
-		1 + 1.
-		2 + 2 ]'.
+			1 + 1.
+			2 + 2 ]'.
 ]
 
 { #category : 'tests - keyword' }
@@ -1051,11 +1051,11 @@ EFMessageExpressionTest >> testKeywordOnMultipleLine9 [
 'foo
 	bar3: 5
 	bar: [
-		1 + 2.
-		2 + 2 ]
+			1 + 2.
+			2 + 2 ]
 	bar2: [
-		1 + 1.
-		2 + 2 ]
+			1 + 1.
+			2 + 2 ]
 	bar3: 5'
 ]
 
@@ -1142,8 +1142,8 @@ EFMessageExpressionTest >> testNewLineBeforeStatementsWhenMultilineBlock [
 		assert: source
 		equals:
 'x = 0 ifFalse: [
-	tan := y asFloat / x asFloat.
-	theta := tan arcCos ]'
+		tan := y asFloat / x asFloat.
+		theta := tan arcCos ]'
 ]
 
 { #category : 'tests' }
@@ -1186,11 +1186,11 @@ EFMessageExpressionTest >> testNoNewLineBetweenVariableAndIfTrue [
 				  ungammaTable: gammaInverseTable ]'.
 	self assert: source equals: 
 'x ifTrue: [
-	aBitBlt
-		copyBitsColor: foreColorVal
-		alpha: foreColorAlpha
-		gammaTable: gammaTable
-		ungammaTable: gammaInverseTable ]'
+		aBitBlt
+			copyBitsColor: foreColorVal
+			alpha: foreColorAlpha
+			gammaTable: gammaTable
+			ungammaTable: gammaInverseTable ]'
 ]
 
 { #category : 'tests' }

--- a/src/EnlumineurFormatter-Tests/EFMethodExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFMethodExpressionTest.class.st
@@ -337,11 +337,11 @@ EFMethodExpressionTest >> testBigMethod [
 	| tmp |
 	tmp := 1.
 	tmp to: 10 do: [:i |
-		Transcript
-			show: i;
-			cr;
-			cr
-		]'
+			Transcript
+				show: i;
+				cr;
+				cr
+			]'
 ]
 
 { #category : 'tests' }
@@ -409,11 +409,11 @@ EFMethodExpressionTest >> testMethodWithMessageArgument [
 	self assert: source equals:
 'aMethod
 	1 to: 10 do: [:i |
-		Transcript
-			show: i;
-			cr;
-			cr
-		]'
+			Transcript
+				show: i;
+				cr;
+				cr
+			]'
 ]
 
 { #category : 'tests' }

--- a/src/EnlumineurFormatter-Tests/EFSequenceExpressionTest.class.st
+++ b/src/EnlumineurFormatter-Tests/EFSequenceExpressionTest.class.st
@@ -379,11 +379,11 @@ EFSequenceExpressionTest >> testNoNewLineBetweenVariableAndIfTrue [
 			ungammaTable: gammaInverseTable ]		
 "
 x ifTrue: [
-	aBitBlt
-		copyBitsColor: foreColorVal
-		alpha: foreColorAlpha
-		gammaTable: gammaTable
-		ungammaTable: gammaInverseTable ]'
+		aBitBlt
+			copyBitsColor: foreColorVal
+			alpha: foreColorAlpha
+			gammaTable: gammaTable
+			ungammaTable: gammaInverseTable ]'
 ]
 
 { #category : 'tests' }

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1576,7 +1576,9 @@ EFFormatter >> installNewContext: aContext [
 { #category : 'private - formatting' }
 EFFormatter >> isEmptyBlock: aBlockNode [
 
-	^ (aBlockNode arguments isEmpty) and: [ aBlockNode body statements isEmpty ]
+	^ (aBlockNode arguments isEmpty and: [
+		   aBlockNode body statements isEmpty ]) and: [
+		  aBlockNode comments isEmpty ]
 ]
 
 { #category : 'accessing' }

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1082,6 +1082,12 @@ EFFormatter >> currentLineLength [
 ]
 
 { #category : 'private - formatting' }
+EFFormatter >> decrementIdentation [
+
+	 indent := indent - 1
+]
+
+{ #category : 'private - formatting' }
 EFFormatter >> firstSeparatorShouldNotPassLine: aMessageNode [
 	"predicate that tells if the keyword should be forced to be on the same line."
 
@@ -1181,14 +1187,16 @@ EFFormatter >> formatBlock2: aBlockNode [
 { #category : 'private - formatting' }
 EFFormatter >> formatBlock: aBlockNode [
 	" see formatBlock2: for a possible alternate and faster definition."
-
 	| isMultiline |
+	
 	isMultiline := self willBeMultiline: aBlockNode body.
-
-	codeStream nextPutAll: self spacesInsideBlocksString.
+	isMultiline ifTrue: [ self incrementIdentation ].
+	
+	aBlockNode body statements ifNotEmpty: [ codeStream nextPutAll: self spacesInsideBlocksString ]. 
 
 	self formatBlockArgumentsFor: aBlockNode.
 	self formatBlockCommentFor: aBlockNode.
+
 	((isMultiline or: [ self isLineTooLongWithNode: aBlockNode body ])
 		 and: [ self shouldPassNewLineAfterHeadOfBlock: aBlockNode ])
 		ifTrue: [ self newLine ].
@@ -1197,7 +1205,8 @@ EFFormatter >> formatBlock: aBlockNode [
 
 	(self lineUpBlockBrackets and: [ isMultiline ])
 		ifTrue: [ self newLine ]
-		ifFalse: [ codeStream nextPutAll: self spacesInsideBlocksString ]
+		ifFalse: [ codeStream nextPutAll: self spacesInsideBlocksString ].
+	isMultiline ifTrue: [ self decrementIdentation ].
 ]
 
 { #category : 'private - formatting' }
@@ -1439,6 +1448,12 @@ EFFormatter >> hasAMultiLineMessageArgument: anArgumentsCollection [
 EFFormatter >> headOfBlockNotEmpty: aBlockNode [
 
 	^ aBlockNode arguments isNotEmpty or: [aBlockNode comments isNotEmpty]
+]
+
+{ #category : 'private - formatting' }
+EFFormatter >> incrementIdentation [
+
+	 indent := indent + 1
 ]
 
 { #category : 'accessing' }

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1191,8 +1191,8 @@ EFFormatter >> formatBlock: aBlockNode [
 	
 	isMultiline := self willBeMultiline: aBlockNode body.
 	isMultiline ifTrue: [ self incrementIdentation ].
-	
-	aBlockNode body statements ifNotEmpty: [ codeStream nextPutAll: self spacesInsideBlocksString ]. 
+
+	(self isEmptyBlock: aBlockNode) ifFalse: [ codeStream nextPutAll: self spacesInsideBlocksString ].
 
 	self formatBlockArgumentsFor: aBlockNode.
 	self formatBlockCommentFor: aBlockNode.
@@ -1571,6 +1571,12 @@ EFFormatter >> initializeTemporaryLookAheadCode [
 EFFormatter >> installNewContext: aContext [
 	
 	context := aContext
+]
+
+{ #category : 'private - formatting' }
+EFFormatter >> isEmptyBlock: aBlockNode [
+
+	^ (aBlockNode arguments isEmpty) and: [ aBlockNode body statements isEmpty ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
### Fixing format shortcut block indentation

- In the case of blocks with empty content, it was inserting 3 spaces instead of just one.
- In the Case of block layout indentation, the block content is now inserted, adding one to the indentation level.