### PR TITLE
Fix : Improved mutator

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -362,8 +362,7 @@ Symbol >> asMethodSignature [
 { #category : 'converting' }
 Symbol >> asMutator [
 	"Return a setter message from a getter message.
-	Return self if it is already a setter.
-	Pay attention the implementation should be improved to return valid selector."
+	Return self if it is already a setter."
 
 	"#name asMutator >>> #name:"
 	"#name: asMutator >>> #name:"
@@ -371,6 +370,7 @@ Symbol >> asMutator [
 	"#_ asMutator >>> #_:"
 	"#foo:: asMutator >>> #'foo::'"
 
+	(self isSelector & self isBinary not) ifFalse: [ ^ self ].
 	self endsWithAColon ifTrue:[ ^ self ].
 	^ (self copyWith: $:) asSymbol
 ]


### PR DESCRIPTION
issue : https://github.com/pharo-project/pharo/issues/4599

I've improved the Symbol >> asMutator method by adding an explicit precondition check that ensures the method only operates on valid selectors that are not binary selectors. The updated implementation now properly checks that the receiver is a valid selector and not a binary selector before attempting to convert it to a setter method name