### PR TITLE
Removed reference of GT package from Beacon baseline

### DIFF
--- a/src/BaselineOfBeacon/BaselineOfBeacon.class.st
+++ b/src/BaselineOfBeacon/BaselineOfBeacon.class.st
@@ -10,23 +10,32 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfBeacon >> baseline: spec [
-	<baseline>
 
-	spec for: #'common' do: [
-		spec 
-			package: #'Beacon-Core';
-			package: #'Beacon-Core-GT' with: [
-				spec requires: #('Beacon-Core' #'Beacon-ExtraSignals'). ];
-			package: #'Beacon-Core-Tests' with: [
-				spec requires: #('Beacon-Core' ). ];
-			package: #'Beacon-SerializingLoggers' with: [ spec requires: #('Beacon-Core') ];
-			package: #'Beacon-ExtraSignals' with: [ spec requires: #('Beacon-Core') ];
-			package: #'Beacon-Extra-Tests' with: [ spec requires: #('Beacon-SerializingLoggers' 'Beacon-ExtraSignals') ];
-			package: #'Beacon-Syslog' with: [ spec requires: #('Beacon-SerializingLoggers') ];
-			package: #'Beacon-File' with: [ spec requires: #('Beacon-SerializingLoggers') ];
-			package: #'Beacon-Zinc' with: [ spec requires: #(#'Beacon-Core') ].
-		spec 
-			group: 'Core' with: #('Beacon-Core' );
-			group: 'CoreTests' with: #('Beacon-Core' 'Beacon-Core-Tests');
-			group: 'default' with: #('Beacon-Core' 'Beacon-Core-Tests' 'Beacon-SerializingLoggers' 'Beacon-Core-GT' 'Beacon-ExtraSignals' 'Beacon-Extra-Tests' 'Beacon-Syslog' 'Beacon-File' 'Beacon-Zinc'). ].
+	<baseline>
+	spec for: #common do: [
+			spec
+				package: #'Beacon-Core';
+				package: #'Beacon-Core-Tests'
+				with: [ spec requires: #( 'Beacon-Core' ) ];
+				package: #'Beacon-SerializingLoggers'
+				with: [ spec requires: #( 'Beacon-Core' ) ];
+				package: #'Beacon-ExtraSignals'
+				with: [ spec requires: #( 'Beacon-Core' ) ];
+				package: #'Beacon-Extra-Tests' with: [
+						spec requires:
+								#( 'Beacon-SerializingLoggers' 'Beacon-ExtraSignals' ) ];
+				package: #'Beacon-Syslog'
+				with: [ spec requires: #( 'Beacon-SerializingLoggers' ) ];
+				package: #'Beacon-File'
+				with: [ spec requires: #( 'Beacon-SerializingLoggers' ) ];
+				package: #'Beacon-Zinc'
+				with: [ spec requires: #( #'Beacon-Core' ) ].
+			spec
+				group: 'Core' with: #( 'Beacon-Core' );
+				group: 'CoreTests' with: #( 'Beacon-Core' 'Beacon-Core-Tests' );
+				group: 'default'
+				with:
+					#( 'Beacon-Core' 'Beacon-Core-Tests' 'Beacon-SerializingLoggers'
+					   'Beacon-ExtraSignals' 'Beacon-Extra-Tests'
+					   'Beacon-Syslog' 'Beacon-File' 'Beacon-Zinc' ) ]
 ]


### PR DESCRIPTION
Fixes #18055 

This PR removes the GT package reference from Beacon baseline as we do not have GT package