### PR TITLE
Remove what seems to be a hack in runTest.st

### DIFF
--- a/bootstrap/scripts/testing/core/runTests.st
+++ b/bootstrap/scripts/testing/core/runTests.st
@@ -1,7 +1,3 @@
-ClassTestCase removeSelector: #testClassComment.
-HashTesterTest removeSelector: #testBasicBehaviour.
-
-
 (Package organizer packages collect: #name) logCr.
 
 HDTestReport runPackages: (Package organizer packages collect: #name).


### PR DESCRIPTION
Two selectors are removed in this file but one does not exist anymore and the second seems to pass in my image so I don't know why we are removing it? Let's try to remove those lines to see if the CI is happy

If it's not happy we should use some skip instead of removing the methods like this