### PR TITLE
CodeImporter should close the stream it is reading after importing

### DIFF
--- a/src/CodeImport/CodeImporter.class.st
+++ b/src/CodeImport/CodeImporter.class.st
@@ -162,7 +162,10 @@ CodeImporter >> logSource: aBoolean [
 
 { #category : 'evaluating' }
 CodeImporter >> parseChunks [
-	^ codeDeclarations := (parserClass for: readStream) parseChunks
+
+	codeDeclarations := (parserClass for: readStream) parseChunks.
+	readStream close. "On windows we cannot manipulate a file if it is open, and this caused random failures in our CI depending on how things are garbage collected. So now I'm closing explicitly the stream after reading it."
+	^ codeDeclarations
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
I'm hoping this will fix some random failures we are having on Windows linked to the fact that we cannot delete an opened file. I guess the file is open because the CodeImporter is not always garbage collected in time and it keeps an open stream on the file