### PR TITLE
Fix equality between MCClassDefinition and MCTraitDefinition

### DIFF
--- a/src/Monticello-Model/MCDefinition.class.st
+++ b/src/Monticello-Model/MCDefinition.class.st
@@ -15,7 +15,8 @@ MCDefinition >> <= other [
 
 { #category : 'comparing' }
 MCDefinition >> = aDefinition [
-	^(aDefinition isKindOf: MCDefinition) and: [self isRevisionOf: aDefinition]
+
+	^ self class = aDefinition class and: [ self isRevisionOf: aDefinition ]
 ]
 
 { #category : 'accessing' }

--- a/src/Monticello-Model/MCTraitDefinition.class.st
+++ b/src/Monticello-Model/MCTraitDefinition.class.st
@@ -13,13 +13,13 @@ MCTraitDefinition >> = aDefinition [
 
 	self flag: #traits. "Ugly we harcoded the super superclass method.  We will have to refactor the definition hierarchy"
 
-	^ (aDefinition isKindOf: MCDefinition) and: [
-		  (self isRevisionOf: aDefinition) and: [
-			  self traitCompositionString = aDefinition traitCompositionString and: [
-				  self classTraitCompositionString = aDefinition classTraitCompositionString and: [
-					  self category = aDefinition category and: [
-						  self slotDefinitionString = aDefinition slotDefinitionString and: [
-							  self classInstVarNames = aDefinition classInstVarNames and: [ comment = aDefinition comment ] ] ] ] ] ] ]
+	^ self class = aDefinition class and: [
+			  (self isRevisionOf: aDefinition) and: [
+					  self traitCompositionString = aDefinition traitCompositionString and: [
+							  self classTraitCompositionString = aDefinition classTraitCompositionString and: [
+									  self category = aDefinition category and: [
+											  self slotDefinitionString = aDefinition slotDefinitionString and: [
+												  self classInstVarNames = aDefinition classInstVarNames and: [ comment = aDefinition comment ] ] ] ] ] ] ]
 ]
 
 { #category : 'visiting' }

--- a/src/Monticello-Tests/MCClassDefinitionTest.class.st
+++ b/src/Monticello-Tests/MCClassDefinitionTest.class.st
@@ -154,6 +154,28 @@ MCClassDefinitionTest >> testEqualsSensitivity [
 ]
 
 { #category : 'tests' }
+MCClassDefinitionTest >> testEqualsWithTraitDefinition [
+
+	| classDefinition traitDefinition |
+	classDefinition := (MCClassDefinition named: 'Test')
+		                   superclassName: 'SuperTest';
+		                   packageName: self packageForTestName;
+		                   comment: 'Comment';
+		                   commentStamp: (self commentStampForClass: 'Test');
+		                   yourself.
+
+	traitDefinition := (MCTraitDefinition named: 'Test')
+		                   superclassName: 'SuperTest';
+		                   packageName: self packageForTestName;
+		                   comment: 'Comment';
+		                   commentStamp: (self commentStampForClass: 'Test');
+		                   yourself.
+
+	self deny: classDefinition equals: traitDefinition.
+	self deny: traitDefinition equals: classDefinition
+]
+
+{ #category : 'tests' }
 MCClassDefinitionTest >> testKindOfSubclass [
 	| classes |
 	classes := {self mockClassA. String. Context. WeakArray. Float. CompiledMethod. DoubleByteArray . DoubleWordArray }.


### PR DESCRIPTION
Currently if you try to compare a TraitDefinition with a ClassDefinition you will get a DNU. I'm fixing it by stopping the comparison if the classes are not the same.

This will allow us to commit the change of a class to a trait of the same name. Currently we cannot commit with Iceberg this kind of changes 

Fixes #18035