### PR TITLE
17839-Mismatch-between-Smalltalk-globals-method-allImplementorsOf-and-selectors

### DIFF
--- a/src/System-Support-Tests/SystemEnvironmentTest.class.st
+++ b/src/System-Support-Tests/SystemEnvironmentTest.class.st
@@ -68,6 +68,16 @@ SystemEnvironmentTest >> supportsNilKey [
 	^ false
 ]
 
+{ #category : 'tests' }
+SystemEnvironmentTest >> testAddFlushesCaches [
+	"we add to the environemnt with #add:"
+	testingEnvironment add: (GlobalVariable key: #Object value: Object).
+	"we can find it with at:"
+	self assert: (testingEnvironment at: #Object) equals: Object.
+	"and via #allBehavior, which uses the cache"
+	self assert: (testingEnvironment allBehaviors includes: Object).
+]
+
 { #category : 'tests - DictionaryIndexAccessing' }
 SystemEnvironmentTest >> testAtPutNil [
 

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -127,7 +127,7 @@ SystemEnvironment >> at: aKey put: anObject [
  	index := self findElementOrNil: aKey.
  	assoc := array at: index.
  	assoc
- 		ifNil: [self atNewIndex: index put: (GlobalVariable key: aKey value: anObject). self flushClassNameCache]
+ 		ifNil: [self atNewIndex: index put: (GlobalVariable key: aKey value: anObject).]
  		ifNotNil: [assoc value: anObject].
 		
 	registeredMethods do: [ :aMethod | aMethod isInstalled ifTrue: [aMethod recompile] ].		
@@ -142,10 +142,12 @@ SystemEnvironment >> at: key update: updateBlock initial: initBlocktOrValue [
 	self shouldNotImplement
 ]
 
-{ #category : 'adding' }
+{ #category : 'private' }
 SystemEnvironment >> atNewIndex: index put: aGlobalVariable [
 
 	aGlobalVariable isAssociation ifTrue: [ self error: 'Only global variables should be added to the SystemEnvironment and not associations.' ].
+	"make sure to fludh the caches"
+	self flushClassNameCache.
 	^ super atNewIndex: index put: aGlobalVariable
 ]
 


### PR DESCRIPTION
Move the #flushClassNameCache to the pviate method that does the change. this way we will flush the cache, too, when using #add: to add to the environment.

fixes #17839

Pharo13.0.0:
#Branch: 17839-Mismatch-between-Smalltalk-globals-method-allImplementorsOf-and-selectors Fixes # #Please use one of those
#feat:
#fix:
#refactor:
#chore:
#comment: