### PR TITLE
18075-cached-item-not-returned-in-CompiledBlocksourceNodeForPC 

### DIFF
--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -38,7 +38,7 @@ CompiledBlock >> sourceNodeForPC: aPC [
 	self method
 		propertyAt: self bcToASTCacheKey asSymbol
 		ifPresent: [ :bcToASTCache |
-			bcToASTCache nodeForPC: aPC ].
+			^ bcToASTCache nodeForPC: aPC ].
 	^ blockNode sourceNodeForPC: aPC
 ]
 


### PR DESCRIPTION
make sure to return the cached node if we find one

Pharo13.0.0:
#Branch: 18075-cached-item-not-returned-in-CompiledBlocksourceNodeForPC Fixes # #Please use one of those
#feat:
#fix:
#refactor:
#chore:
#comment: