### PR TITLE
Commit undo transaction before formatting

### DIFF
--- a/src/Rubric-Tests/RubTextEditorLocalHistoryTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorLocalHistoryTest.class.st
@@ -65,15 +65,19 @@ RubTextEditorLocalHistoryTest >> testUndoAfterFormatShouldRestoreOriginalCode [
 
 	editor textArea beForSmalltalkCode.
 
-	"If the caret is at the end of a word, replace the entire word"
+	"Insert the start of the text and commit the transaction"
 	editor addString: 'method (to be formatted; but) maybe not nice'.
 	editor closeTypeIn.
-	editor unselect.
 
-	"let's replace the to be formatted by a shorter sequence"
+	"let's replace the to be formatted by a shorter sequence.
+	Do not commit the transaction here, simulating a text edition by a user.
+	When the transaction is committed, two entries will get created:
+	 - an entry with the removal of the selection
+	 - an entry with the addition of the new text in that place"
 	editor selectFrom: 'method (to ' size + 1 to: 'method (to be formatted' size.
 	editor addString: 'format'.
 	
+	"Unselect and format. This should not break the undo buffer"
 	editor unselect.
 	editor textArea formatMethodCode.
 
@@ -85,17 +89,14 @@ RubTextEditorLocalHistoryTest >> testUndoAfterFormatShouldRestoreOriginalCode [
 
 	"Undo the format"	
 	editor undo.
-
 	self expectText: 'method (to format; but) maybe not nice'.	
 	
-	"Undo the addition"
+	"Undo the addition of new text"
 	editor undo.
-	
 	self expectText: 'method (to ; but) maybe not nice'.
 	
 	"Undo the removal"
 	editor undo.
-	
 	self expectText: 'method (to be formatted; but) maybe not nice'
 ]
 

--- a/src/Rubric-Tests/RubTextEditorLocalHistoryTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorLocalHistoryTest.class.st
@@ -61,6 +61,45 @@ RubTextEditorLocalHistoryTest >> testRedoLeavesCursorInOriginalPosition [
 ]
 
 { #category : 'tests - undo' }
+RubTextEditorLocalHistoryTest >> testUndoAfterFormatShouldRestoreOriginalCode [
+
+	editor textArea beForSmalltalkCode.
+
+	"If the caret is at the end of a word, replace the entire word"
+	editor addString: 'method (to be formatted; but) maybe not nice'.
+	editor closeTypeIn.
+	editor unselect.
+
+	"let's replace the to be formatted by a shorter sequence"
+	editor selectFrom: 'method (to ' size + 1 to: 'method (to be formatted' size.
+	editor addString: 'format'.
+	
+	editor unselect.
+	editor textArea formatMethodCode.
+
+	self expectText: 'method
+
+	(to
+		 format;
+		 but) maybe not nice'.
+
+	"Undo the format"	
+	editor undo.
+
+	self expectText: 'method (to format; but) maybe not nice'.	
+	
+	"Undo the addition"
+	editor undo.
+	
+	self expectText: 'method (to ; but) maybe not nice'.
+	
+	"Undo the removal"
+	editor undo.
+	
+	self expectText: 'method (to be formatted; but) maybe not nice'
+]
+
+{ #category : 'tests - undo' }
 RubTextEditorLocalHistoryTest >> testUndoAfterTypeThenTabUndoesOnlyTheTab [
 
 	editor addString: 'self'.

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -164,6 +164,7 @@ RubSmalltalkCodeMode >> classOrMetaClass: aBehavior [
 RubSmalltalkCodeMode >> formatMethodCode [
 
 	| source tree formatted |
+	self editor closeTypeIn.
 	self textArea hasSelection
 		ifTrue: [
 			source := self textArea selection.

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -718,11 +718,6 @@ RubSmalltalkEditor >> findValidKeywordIn: sourceCode at: locationIndex ifFound: 
 ]
 
 { #category : 'do-its' }
-RubSmalltalkEditor >> format [
-	self model formatSourceCodeInView
-]
-
-{ #category : 'do-its' }
 RubSmalltalkEditor >> highlightEvaluateAndDo: aBlock [
 	"Treat the current selection as an expression; evaluate it and invoke aBlock with the result."
 


### PR DESCRIPTION
Fix #18034

Commit undo transaction before formatting.
Otherwise the formatting breaks the undo buffer.