### PR TITLE
Make Zinc tests open a random port

### DIFF
--- a/src/Zodiac-Tests/ZdcAbstractSocketStreamTest.class.st
+++ b/src/Zodiac-Tests/ZdcAbstractSocketStreamTest.class.st
@@ -6,6 +6,9 @@ This is an abstract class, subclasses should implement #socketStreamClass
 Class {
 	#name : 'ZdcAbstractSocketStreamTest',
 	#superclass : 'TestCase',
+	#instVars : [
+		'port'
+	],
 	#category : 'Zodiac-Tests',
 	#package : 'Zodiac-Tests'
 }
@@ -48,7 +51,7 @@ ZdcAbstractSocketStreamTest >> openConnectionToHostNamed: host port: port [
 
 { #category : 'accessing' }
 ZdcAbstractSocketStreamTest >> port [
-	^ 1701
+	^ port
 ]
 
 { #category : 'private' }
@@ -70,9 +73,10 @@ ZdcAbstractSocketStreamTest >> runClient: block [
 { #category : 'private' }
 ZdcAbstractSocketStreamTest >> runServer: block [
 	| serverSocket semaphore |
-	serverSocket := self serverSocketOn: self port.
+	serverSocket := self serverSocketOn: 0.
 	self assert: serverSocket notNil.
-	self assert: serverSocket localPort equals: self port.
+	port := serverSocket port.
+	
 	semaphore := Semaphore new.
 	[
 	semaphore signal.

--- a/src/Zodiac-Tests/ZdcAbstractSocketStreamTest.class.st
+++ b/src/Zodiac-Tests/ZdcAbstractSocketStreamTest.class.st
@@ -38,15 +38,15 @@ ZdcAbstractSocketStreamTest >> listenBacklogSize [
 ]
 
 { #category : 'private' }
-ZdcAbstractSocketStreamTest >> openConnectionToHost: host port: port [
+ZdcAbstractSocketStreamTest >> openConnectionToHost: host port: aPort [
 	^ self socketStreamClass
-		openConnectionToHost: host port: port
+		openConnectionToHost: host port: aPort
 ]
 
 { #category : 'private' }
-ZdcAbstractSocketStreamTest >> openConnectionToHostNamed: host port: port [
+ZdcAbstractSocketStreamTest >> openConnectionToHostNamed: host port: aPort [
 	^ self socketStreamClass
-		openConnectionToHostNamed: host port: port
+		openConnectionToHostNamed: host port: aPort
 ]
 
 { #category : 'accessing' }
@@ -94,15 +94,15 @@ ZdcAbstractSocketStreamTest >> serverPriority [
 ]
 
 { #category : 'private' }
-ZdcAbstractSocketStreamTest >> serverSocketOn: port [
+ZdcAbstractSocketStreamTest >> serverSocketOn: aPort [
 	| socket |
 	(socket := Socket newTCP)
 		setOption: 'TCP_NODELAY' value: 1;
 		setOption: 'SO_SNDBUF' value: self socketBufferSize;
 		setOption: 'SO_RCVBUF' value: self socketBufferSize .
-	socket listenOn: port backlogSize: self listenBacklogSize.
+	socket listenOn: aPort backlogSize: self listenBacklogSize.
 	socket isValid
-		ifFalse: [ self error: 'Cannot create socket on port ', port printString ].
+		ifFalse: [ self error: 'Cannot create socket on port ', aPort printString ].
 	^ socket
 ]
 

--- a/src/Zodiac-Tests/ZdcReferenceSocketStreamTest.class.st
+++ b/src/Zodiac-Tests/ZdcReferenceSocketStreamTest.class.st
@@ -22,9 +22,9 @@ ZdcReferenceSocketStreamTest >> openConnectionToHost: host port: aPort [
 ]
 
 { #category : 'private' }
-ZdcReferenceSocketStreamTest >> openConnectionToHostNamed: host port: port [
+ZdcReferenceSocketStreamTest >> openConnectionToHostNamed: host port: aPort [
 	| stream |
-	stream := super openConnectionToHostNamed: host port: port.
+	stream := super openConnectionToHostNamed: host port: aPort.
 	self setReferenceSocketStreamOptions: stream.
 	^ stream
 ]

--- a/src/Zodiac-Tests/ZdcReferenceSocketStreamTest.class.st
+++ b/src/Zodiac-Tests/ZdcReferenceSocketStreamTest.class.st
@@ -14,9 +14,9 @@ ZdcReferenceSocketStreamTest class >> isAbstract [
 ]
 
 { #category : 'private' }
-ZdcReferenceSocketStreamTest >> openConnectionToHost: host port: port [
+ZdcReferenceSocketStreamTest >> openConnectionToHost: host port: aPort [
 	| stream |
-	stream := super openConnectionToHost: host port: port.
+	stream := super openConnectionToHost: host port: aPort.
 	self setReferenceSocketStreamOptions: stream.
 	^ stream
 ]


### PR DESCRIPTION
Redo https://github.com/pharo-project/pharo/pull/17873

Zn tests should open a server with a random port (binding to 0).
Then that port is stored and used to connect to that server.

This will make the server a bit more robust and allow concurrent run of the tests in the same machine.