### PR TITLE
Improvements on StartUpPreferences menu

### DIFF
--- a/src/StartupPreferences/StartupPreferencesLoader.class.st
+++ b/src/StartupPreferences/StartupPreferencesLoader.class.st
@@ -280,10 +280,13 @@ StartupPreferencesLoader >> addAtStartupInPreferenceVersionFolder: aCollection n
 
 { #category : 'private' }
 StartupPreferencesLoader >> addTemplateForStartupInDirectory: aFileReference named: fileName [
-	
-	aFileReference ensureCreateDirectory.
-	aFileReference / fileName writeStreamDo: [ :stream | 
-		stream nextPutAll: self templateString ].
+
+	(aFileReference / fileName) exists
+		ifFalse: [
+				aFileReference ensureCreateDirectory.
+				aFileReference / fileName writeStreamDo: [ :stream |
+					stream nextPutAll: self templateString ] ]
+		ifTrue: [ self inform: 'This file already exists' ].
 	(aFileReference / fileName) inspect
 ]
 

--- a/src/StartupPreferences/StartupPreferencesLoader.class.st
+++ b/src/StartupPreferences/StartupPreferencesLoader.class.st
@@ -283,7 +283,8 @@ StartupPreferencesLoader >> addTemplateForStartupInDirectory: aFileReference nam
 	
 	aFileReference ensureCreateDirectory.
 	aFileReference / fileName writeStreamDo: [ :stream | 
-		stream nextPutAll: self templateString ]
+		stream nextPutAll: self templateString ].
+	(aFileReference / fileName) inspect
 ]
 
 { #category : 'private' }

--- a/src/System-Settings-Browser/StartupPreferencesLoader.extension.st
+++ b/src/System-Settings-Browser/StartupPreferencesLoader.extension.st
@@ -1,16 +1,37 @@
 Extension { #name : 'StartupPreferencesLoader' }
 
 { #category : '*System-Settings-Browser' }
-StartupPreferencesLoader class >> defineStartUpActionMenuOn: aBuilder [
+StartupPreferencesLoader class >> defineStartUpGlobalActionMenuOn: aBuilder [
+
 	<worldMenu>
-	
 	(aBuilder item: #SystemStartupCreator)
-		action: [ self default 
-						addTemplateForStartupInDirectory: self preferencesGeneralFolder named: 'PharoPreferences.st' ];
-		label: 'Define a preference file';
+		action: [
+				self default
+					addTemplateForStartupInDirectory: self preferencesGeneralFolder
+					named: 'PharoPreferences.st' ];
+		label: 'Define a global preference file';
 		parent: #SystemStartup;
-		order: 2;
-		help: 'Propose and define a startup action file for the current version of Pharo.';
+		order: 5;
+		help:
+			'Propose and define a startup action file in general preferences folder for the current version of Pharo.';
+		iconName: #scriptManager.
+
+]
+
+{ #category : '*System-Settings-Browser' }
+StartupPreferencesLoader class >> defineStartUpVersionActionMenuOn: aBuilder [
+
+	<worldMenu>
+	(aBuilder item: #SystemStartupCreator)
+		action: [
+				self default
+					addTemplateForStartupInDirectory: self preferencesVersionFolder
+					named: 'PharoPreferences.st' ];
+		label: 'Define a version preference file';
+		parent: #SystemStartup;
+		order: 3;
+		help:
+			'Propose and define a startup action file in version preferences folder for the current version of Pharo.';
 		iconName: #scriptManager.
 	aBuilder withSeparatorAfter
 ]
@@ -22,13 +43,14 @@ StartupPreferencesLoader class >> startupGeneralPrefererencesFolderMenuOn: aBuil
 		action: [ self preferencesGeneralFolder inspect ];
 		label: 'General Preferences folder';
 		parent: #SystemStartup;
-		order: 3;
+		order: 4;
 		help: 'Open the folder with general preferences.';
 		iconName: #smallOpen
 ]
 
 { #category : '*System-Settings-Browser' }
 StartupPreferencesLoader class >> startupLoaderMenuOn: aBuilder [
+
 	<worldMenu>
 	(aBuilder item: #SystemStartupLoader)
 		action: [ self default loadFromDefaultLocations ];
@@ -37,21 +59,24 @@ StartupPreferencesLoader class >> startupLoaderMenuOn: aBuilder [
 		order: 1;
 		help: 'Run startup scripts.';
 		iconName: #scriptManager.
-
+	aBuilder withSeparatorAfter
 ]
 
 { #category : '*System-Settings-Browser' }
 StartupPreferencesLoader class >> startupPreferencesVersionFolderMenuOn: aBuilder [
+
 	<worldMenu>
 	(aBuilder item: #SystemStartupFolder)
-		action: [ self preferencesVersionFolder
-				ensureCreateDirectory;
-				inspect ];
+		action: [
+				self preferencesVersionFolder
+					ensureCreateDirectory;
+					inspect ];
 		label: 'Version Preferences folder';
 		parent: #SystemStartup;
 		order: 2;
 		help: 'Open the preferences per version folder.';
-		iconName: #smallOpen
+		iconName: #smallOpen.
+	
 ]
 
 { #category : '*System-Settings-Browser' }


### PR DESCRIPTION
- Precision on define preference file: there was no distinction between general/version preferences folder
- Added the same behaviour to generate preference file in version folder
- When creating a file, now it inspects it right after and the user can edit/delete the file directly when generating it: for me it is very logic to do that