### PR TITLE
Fix bug: Changed #rowser to #browser in RubSmalltalkEditor

### DIFF
--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -791,7 +791,7 @@ RubSmalltalkEditor >> internalCallToBrowse: aSelector [
 		          classFromPattern: aSelector
 		          withCaption: 'choose a class to browse...'.
 	aClass ifNil: [ ^ self ].
-	(self tools toolNamed: #rowser) openOnClass: aClass
+	(self tools toolNamed: #browser) openOnClass: aClass
 ]
 
 { #category : 'menu messages' }


### PR DESCRIPTION
Fixes: #18096 

In the `internalCallToBrowse:` method, there was a typo where the browser tool was being referenced as `#rowser` instead of `#browser`. This PR changes `(self tools toolNamed: #rowser)` to `(self tools toolNamed: #browser)`