### PR TITLE
Fix ast mapping constant block

### DIFF
--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -33,8 +33,6 @@ CompiledBlock >> sourceNodeForPC: aPC [
 
 	| blockNode |
 	blockNode := self outerCode sourceNodeForPC: self pcInOuter.
-	"Bug in the cache? The mapping is returning Return node instead of Block"
-	blockNode isReturn ifTrue: [ blockNode := blockNode value ].
 	self method
 		propertyAt: self bcToASTCacheKey asSymbol
 		ifPresent: [ :bcToASTCache |

--- a/src/OpalCompiler-Core/OCIRPushLiteral.class.st
+++ b/src/OpalCompiler-Core/OCIRPushLiteral.class.st
@@ -21,7 +21,10 @@ OCIRPushLiteral >> accept: aVisitor [
 
 { #category : 'testing' }
 OCIRPushLiteral >> canBeQuickReturn [
-	^ true
+
+	"Put here whatever can be optimized as a ret literal or as a quick method.
+	Same contents as quickPrimSpecialConstants, but this should require passing the encoder as argument all the way down"
+	^ #( nil true false -1 0 1 2 ) includes: literal
 ]
 
 { #category : 'testing' }

--- a/src/OpalCompiler-Tests/MethodMapExamples.class.st
+++ b/src/OpalCompiler-Tests/MethodMapExamples.class.st
@@ -25,6 +25,12 @@ MethodMapExamples >> exampleAccessOuterFromCleanBlock [
 ]
 
 { #category : 'examples' }
+MethodMapExamples >> exampleConstantBlock [
+	
+	^ [ nil ]
+]
+
+{ #category : 'examples' }
 MethodMapExamples >> exampleCopiedVarFromDeadContext [
 	^ self defineCopiedVarBecomeDeadContext value
 ]

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -8,10 +8,18 @@ Class {
 
 { #category : 'utilities' }
 MethodMapTest >> compileAndRunExample: aSelector [
-	| oldMethod recompiledMethod |
-	oldMethod := MethodMapExamples>>aSelector.
-	recompiledMethod := oldMethod methodClass compiler compile: oldMethod sourceCode.
-	^recompiledMethod valueWithReceiver: MethodMapExamples new
+
+	| recompiledMethod |
+	recompiledMethod := self compileExample: aSelector.
+	^ recompiledMethod valueWithReceiver: MethodMapExamples new
+]
+
+{ #category : 'utilities' }
+MethodMapTest >> compileExample: aSelector [
+
+	| oldMethod |
+	oldMethod := MethodMapExamples >> aSelector.
+	^ oldMethod methodClass compiler compile: oldMethod sourceCode
 ]
 
 { #category : 'tests - ast mapping' }
@@ -77,6 +85,17 @@ MethodMapTest >> testCompiledBlockSourceNode [
 	method := OpalCompiler new compile: 'foo Object. [ self ]. ^ #bar'.
 	block := method literals detect: #isCompiledBlock.
 	self assert: block sourceNode equals: (self parseExpression: '[ self ]')
+]
+
+{ #category : 'tests - ast mapping' }
+MethodMapTest >> testConstantBlockIsMappedToBlockNode [
+
+	| method block |
+	method := self compileExample: #exampleConstantBlock.
+	block := method literalAt: 1.
+	self assert: block isBlock.
+	
+	self assert: block compiledBlock ast isBlock
 ]
 
 { #category : 'tests - temp access' }

--- a/src/OpalCompiler-Tests/OCIRPrinterTest.class.st
+++ b/src/OpalCompiler-Tests/OCIRPrinterTest.class.st
@@ -112,7 +112,8 @@ OCIRPrinterTest >> testLiteralArray [
 		equals:
 			'
 label: 1
-returnLiteral: #(#test 4 #you)
+pushLiteral: #(#test 4 #you)
+returnTop
 '
 ]
 


### PR DESCRIPTION
## The Bug

The following code returns a return node instead of a block node

```
((OpalCompiler new compile: 'x ^ [ "constant!" true ]') literalAt: 1) ast
 => OCReturnNode
```

We have even comments acknowledging and working around the bug:

```
"Bug in the cache? The mapping is returning Return node instead of Block"
	blockNode isReturn ifTrue: [ blockNode := blockNode value ].
```

## The cause

Returning constant blocks was causing a peephole optimization that transforms the IR sequence

```
push block
ret
```

to

```
ret block
```

Then, the AST mapping lost information because the new ret instruction cannot be mapped to two different nodes.

## The fix

We prevent the peephole optimization except for those constants that can be optimized.

Still, this means that the AST mapping is partial with those special constants, but this is a minor issue than constant blocks, for which you want to access the block internals.