### PR TITLE
Remove dependency of Network-Mail to Morphic

### DIFF
--- a/src/Network-Mail/MailMessage.class.st
+++ b/src/Network-Mail/MailMessage.class.st
@@ -922,21 +922,3 @@ MailMessage >> to [
 MailMessage >> to: aStringOrCollection [
 	self setField: 'to' toString: aStringOrCollection asEmailHeaderString
 ]
-
-{ #category : 'printing/formatting' }
-MailMessage >> viewBody [
-	"open a viewer on the body of this message"
-	self containsViewableImage
-		ifTrue: [^ self viewImageInBody].
-	MorphicUIManager new
-		longMessage: self bodyTextFormatted
-		title: (self name ifNil: ['(a message part)'])
-]
-
-{ #category : 'printing/formatting' }
-MailMessage >> viewImageInBody [
-	| stream image |
-	stream := self body contentStream.
-	image := Form fromBinaryStream: stream.
-	(ImageMorph withForm: image) openInWorld
-]


### PR DESCRIPTION
MailMessage has some dependencies over Morphic and UIManager to be able to view a MailMessage content. 

I propose to move those methods to NewTools and to use Spec instead of Morphic to view the content. 

I already did a PR to NewTools so we can just remove those two methods from Pharo.

https://github.com/pharo-spec/NewTools/pull/1104