### PR TITLE
Update error message for FFICalloutAPI class >> new

### DIFF
--- a/src/UnifiedFFI/FFICalloutAPI.class.st
+++ b/src/UnifiedFFI/FFICalloutAPI.class.st
@@ -52,7 +52,7 @@ FFICalloutAPI class >> inUFFIContext: aContext [
 
 { #category : 'instance creation' }
 FFICalloutAPI class >> new [
-	self error: 'use #inFFIContext:'
+	self error: 'use #inUFFIContext:'
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
`FFICalloutAPI class >> new` properly asks to use `#inUFFIContext` instead of non-existent `#inFFIContext`.