### PR TITLE
Prevent renaming the accessors when renaming an instance variable

### DIFF
--- a/src/Refactoring-UI/ReRenameInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/ReRenameInstanceVariableDriver.class.st
@@ -13,7 +13,7 @@ Class {
 ReRenameInstanceVariableDriver >> configureRefactoring [
 
 	super configureRefactoring.
-	refactoring renameAccessors: true
+	refactoring renameAccessors: false
 ]
 
 { #category : 'factory method' }


### PR DESCRIPTION
-Could break code potentially because it was removing previous accessors, so now it is still using the same accessors
Fixes: #18088 
Fixes: #17590