### PR TITLE
Maximization fix for ```SystemWindow```

### DIFF
--- a/src/Polymorph-Widgets/SystemWindow.extension.st
+++ b/src/Polymorph-Widgets/SystemWindow.extension.st
@@ -474,24 +474,25 @@ SystemWindow >> drawDropShadowOn: aCanvas [
 SystemWindow >> expandBoxHit [
 	"The fullscreen expand box has been hit"
 
+	self canBeMaximized ifFalse: [ ^ self ].
 	self isCollapsed ifTrue: [
-		self
-			hide;
-			collapseOrExpand.
-		self unexpandedFrame ifNil: [ self unexpandedFrame: fullFrame ].
-		self
-			fullscreen;
-			setExpandBoxBalloonText.
-		^ self show ].
+			self
+				hide;
+				collapseOrExpand.
+			self unexpandedFrame ifNil: [ self unexpandedFrame: fullFrame ].
+			self
+				fullscreen;
+				setExpandBoxBalloonText.
+			^ self show ].
 	self unexpandedFrame
 		ifNil: [
-			self
-				unexpandedFrame: fullFrame;
-				fullscreen ]
+				self
+					unexpandedFrame: fullFrame;
+					fullscreen ]
 		ifNotNil: [
-			self
-				bounds: self unexpandedFrame;
-				unexpandedFrame: nil ].
+				self
+					bounds: self unexpandedFrame;
+					unexpandedFrame: nil ].
 	self setExpandBoxBalloonText
 ]
 


### PR DESCRIPTION
When a window was not resizable, the user could maximize it by a click on the box, which makes no sense
Fixes https://github.com/pharo-spec/Spec/issues/1744