### PR TITLE
Move some AST visitor methods to AST-Core

### DIFF
--- a/src/AST-Core/ClassVariable.extension.st
+++ b/src/AST-Core/ClassVariable.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'ClassVariable' }
+
+{ #category : '*AST-Core' }
+ClassVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitClassVariableNode: aNode
+]

--- a/src/AST-Core/GlobalVariable.extension.st
+++ b/src/AST-Core/GlobalVariable.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'GlobalVariable' }
+
+{ #category : '*AST-Core' }
+GlobalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitGlobalVariableNode: aNode
+]

--- a/src/AST-Core/LiteralVariable.extension.st
+++ b/src/AST-Core/LiteralVariable.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'LiteralVariable' }
+
+{ #category : '*AST-Core' }
+LiteralVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitLiteralVariableNode: aNode
+]

--- a/src/AST-Core/SelfVariable.extension.st
+++ b/src/AST-Core/SelfVariable.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'SelfVariable' }
+
+{ #category : '*AST-Core' }
+SelfVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+
+	^ aProgramNodeVisitor visitSelfNode: aNode
+]

--- a/src/AST-Core/Slot.extension.st
+++ b/src/AST-Core/Slot.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'Slot' }
+
+{ #category : '*AST-Core' }
+Slot >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitInstanceVariableNode: aNode
+]

--- a/src/AST-Core/SuperVariable.extension.st
+++ b/src/AST-Core/SuperVariable.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'SuperVariable' }
+
+{ #category : '*AST-Core' }
+SuperVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitSuperNode: aNode
+]

--- a/src/AST-Core/ThisContextVariable.extension.st
+++ b/src/AST-Core/ThisContextVariable.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'ThisContextVariable' }
+
+{ #category : '*AST-Core' }
+ThisContextVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitThisContextNode: aNode
+]

--- a/src/AST-Core/Variable.extension.st
+++ b/src/AST-Core/Variable.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'Variable' }
+
+{ #category : '*AST-Core' }
+Variable >> acceptVisitor: aProgramNodeVisitor node: aNode [
+	^ aProgramNodeVisitor visitVariableNode: aNode
+]

--- a/src/Kernel-CodeModel/ClassVariable.class.st
+++ b/src/Kernel-CodeModel/ClassVariable.class.st
@@ -20,11 +20,6 @@ Class {
 	#tag : 'Variables'
 }
 
-{ #category : 'visiting' }
-ClassVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-	^ aProgramNodeVisitor visitClassVariableNode: aNode
-]
-
 { #category : 'accessing' }
 ClassVariable >> definingClass [
 	"if a Variable is from a Trait is installed in a class, we store the orginal class of the trait here"

--- a/src/Kernel-CodeModel/GlobalVariable.class.st
+++ b/src/Kernel-CodeModel/GlobalVariable.class.st
@@ -11,11 +11,6 @@ Class {
 	#tag : 'Variables'
 }
 
-{ #category : 'visiting' }
-GlobalVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-	^ aProgramNodeVisitor visitGlobalVariableNode: aNode
-]
-
 { #category : 'queries' }
 GlobalVariable >> definingClass [
 	"The class defining the variable. For Globals, return nil"

--- a/src/Kernel-CodeModel/LiteralVariable.class.st
+++ b/src/Kernel-CodeModel/LiteralVariable.class.st
@@ -44,11 +44,6 @@ LiteralVariable >> = anAssociation [
 	^ super = anAssociation and: [value = anAssociation value]
 ]
 
-{ #category : 'visiting' }
-LiteralVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-	^ aProgramNodeVisitor visitLiteralVariableNode: aNode
-]
-
 { #category : 'testing' }
 LiteralVariable >> analogousCodeTo: anAssociation [
 	^ self = anAssociation

--- a/src/Kernel-CodeModel/SelfVariable.class.st
+++ b/src/Kernel-CodeModel/SelfVariable.class.st
@@ -14,12 +14,6 @@ SelfVariable class >> variableName [
 	^#self
 ]
 
-{ #category : 'visiting' }
-SelfVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-
-	^ aProgramNodeVisitor visitSelfNode: aNode
-]
-
 { #category : 'code generation' }
 SelfVariable >> emitValue: methodBuilder [
 

--- a/src/Kernel-CodeModel/Slot.class.st
+++ b/src/Kernel-CodeModel/Slot.class.st
@@ -62,11 +62,6 @@ Slot class >> slotUsers [
 		select:  [ :class | class slots anySatisfy: [ :slot | slot class == self ] ]
 ]
 
-{ #category : 'visiting' }
-Slot >> acceptVisitor: aProgramNodeVisitor node: aNode [
-	^ aProgramNodeVisitor visitInstanceVariableNode: aNode
-]
-
 { #category : 'private' }
 Slot >> addAdditionalSlotsTo: slots [
 	"Some slots internal behavior are relying one other slots. This method should add them in order to build the class with them."

--- a/src/Kernel-CodeModel/SuperVariable.class.st
+++ b/src/Kernel-CodeModel/SuperVariable.class.st
@@ -14,11 +14,6 @@ SuperVariable class >> variableName [
 	^#super
 ]
 
-{ #category : 'visiting' }
-SuperVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-	^ aProgramNodeVisitor visitSuperNode: aNode
-]
-
 { #category : 'code generation' }
 SuperVariable >> emitValue: methodBuilder [
 	"super references the receiver, send that follows is a super send (the message lookup starts in the superclass, see OCASTTranslator>>#emitMessageNode:)"

--- a/src/Kernel-CodeModel/ThisContextVariable.class.st
+++ b/src/Kernel-CodeModel/ThisContextVariable.class.st
@@ -14,11 +14,6 @@ ThisContextVariable class >> variableName [
 	^#thisContext
 ]
 
-{ #category : 'visiting' }
-ThisContextVariable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-	^ aProgramNodeVisitor visitThisContextNode: aNode
-]
-
 { #category : 'code generation' }
 ThisContextVariable >> emitValue: methodBuilder [
 

--- a/src/Kernel-CodeModel/Variable.class.st
+++ b/src/Kernel-CodeModel/Variable.class.st
@@ -68,11 +68,6 @@ Variable >> = other [
 			and: [ name = other name ]
 ]
 
-{ #category : 'visiting' }
-Variable >> acceptVisitor: aProgramNodeVisitor node: aNode [
-	^ aProgramNodeVisitor visitVariableNode: aNode
-]
-
 { #category : 'testing' }
 Variable >> allowsShadowing [
 	^false


### PR DESCRIPTION
We have multiple #acceptVisitor:node: methods in Kernel-CodeModel. This methods are part of an AST visitor.  I propose to package them in AST-Core instead of the Kernel