### PR TITLE
[Backport] Fix bug when adding an extension method overriding a trait method

### DIFF
--- a/src/Kernel-CodeModel-Tests/PackageTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageTest.class.st
@@ -98,6 +98,22 @@ PackageTest >> testAddTraitSettingPackage [
 ]
 
 { #category : 'tests' }
+PackageTest >> testAddingAnExtensionMethodCrushingAMethodFromATrait [
+	"This is a regression test. In the past adding an extension methods that was crushing a method from a used trait was not marking the method as an extension."
+
+	| class trait |
+	class := self newClassNamed: #X in: self xPackageName.
+	trait := self newTraitNamed: #XT in: self xPackageName.
+
+	class classInstaller update: class to: [ :builder | builder traits: trait ].
+	trait compile: 'extension ^2'.
+
+	self createMethodNamed: 'extension' inClass: class asExtensionOf: self yPackageName.
+
+	self assert: (class >> #extension) isExtension
+]
+
+{ #category : 'tests' }
 PackageTest >> testAllUnsentMessages [
 
 	| package class1 class2 |
@@ -486,6 +502,25 @@ PackageTest >> testRecompilingClassWithExtensionMethods [
 
 	self assertEmpty: (class2 package instVarNamed: #extensionSelectors).
 	self assertEmpty: class2 package extendedClasses
+]
+
+{ #category : 'tests' }
+PackageTest >> testRecompilingClassWithExtensionMethodsCrushingMethodsFromATrait [
+	"This is a regression test. In the past recompiling a class  with extension methods that was crushing a method from a used trait was not marking the method as an extension."
+
+	| class1 class2 trait |
+	class1 := self newClassNamed: #X in: self xPackageName.
+	trait := self newTraitNamed: #XT in: self xPackageName.
+	class2 := self newClassNamed: #Y in: self yPackageName.
+
+	class1 classInstaller update: class1 to: [ :builder | builder traits: trait ].
+	trait compile: 'extension ^2'.
+
+	self createMethodNamed: 'extension' inClass: class1 asExtensionOf: self yPackageName.
+
+	class1 classInstaller update: class1 to: [ :builder | builder slots: { #slot } ].
+
+	self assert: (class1 >> #extension) isExtension
 ]
 
 { #category : 'tests' }

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -31,8 +31,8 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 	<reflection: 'Class structural modification - Selector/Method modification'>
 	| priorMethod priorOrigin oldProtocol newProtocol |
 	self compiledMethodAt: selector ifPresent: [ :method |
-		priorMethod := method.
-		priorOrigin := method origin ].
+			priorMethod := method.
+			priorOrigin := method origin ].
 
 	oldProtocol := self protocolOfSelector: selector.
 	self codeChangeAnnouncer prevent: MethodRecategorized during: [ self classify: selector under: protocol ].
@@ -45,12 +45,13 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 	"The old protocol should never be nil. But we are not in an ideal world sadly :( We got reported some cases where some code was loaded but had an error during the loading preventing a method that got added to the method dictionary to have an associated protocol. If this happens, we consider that we categorize it for the first time to avoid announcing a MethodRecategorized with an old protocol that is nil."
 	(priorMethod isNil or: [ priorOrigin ~= compiledMethod origin or: [ oldProtocol isNil ] ])
 		ifTrue: [ "If we end up in this branch, it means the method is compiled for the first time in this class. BUT we have an edge case that is that during a class recompilation, we create a new instance of the class and add the methods from the old one to the new one. In that case, we should not add the new method to the package of the newProtocol because it is already present.
-			In order to know if we are in this edge case we can check if we have an old protocol already because we copy the protocols before the methods."
-			oldProtocol ifNil: [ (self packageOrganizer packageForProtocol: newProtocol from: self) addMethod: compiledMethod ].
-			self codeChangeAnnouncer announce: (MethodAdded method: compiledMethod) ]
+			In order to know if we are in this edge case we can check if we have an old protocol already because we copy the protocols before the methods, but only in case the prior origin is the same as the origin. Else, it means that we are overrinding a method from a trait.."
+				((priorMethod isNotNil and: [ priorMethod isFromTrait ]) or: [ oldProtocol isNil ]) ifTrue: [
+					(self packageOrganizer packageForProtocol: newProtocol from: self) addMethod: compiledMethod ].
+				self codeChangeAnnouncer announce: (MethodAdded method: compiledMethod) ]
 		ifFalse: [ "If protocol changed and someone is from different package, I need to throw a method recategorized"
-			newProtocol = oldProtocol ifFalse: [ self announceRecategorizationOf: compiledMethod oldProtocol: oldProtocol ].
-			self codeChangeAnnouncer announce: (MethodModified methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol) ]
+				newProtocol = oldProtocol ifFalse: [ self announceRecategorizationOf: compiledMethod oldProtocol: oldProtocol ].
+				self codeChangeAnnouncer announce: (MethodModified methodChangedFrom: priorMethod to: compiledMethod oldProtocol: oldProtocol) ]
 ]
 
 { #category : 'instance variables' }


### PR DESCRIPTION
In case you have a class using a trait with a method #toto, if you add an extension method named #toto on this class, then the method is not considered as an extension.

I'm adding regression tests and fixing this problem in this change

Backport of https://github.com/pharo-project/pharo/pull/18137