### PR TITLE
Pull up check

### DIFF
--- a/src/SystemCommands-VariableCommands/SycPushUpVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycPushUpVariableCommand.class.st
@@ -32,10 +32,17 @@ SycPushUpVariableCommand >> defaultMenuItemName [
 { #category : 'accessing' }
 SycPushUpVariableCommand >> executeRefactorings [
 
+	"Move this validation to the driver"
+	toolContext selectedVariables size > 1 ifTrue: [
+			SpAlertDialog new
+				label: 'Cannot pull up many variables at the same time';
+				openModal.
+			^ CmdCommandAborted signal ].
+
 	(RePushUpVariableDriver new
-		scopes: refactoringScopes
-		variable: variable actualVariable name
-		to: variable definingClass superclass) runRefactoring
+		 scopes: refactoringScopes
+		 variable: variable actualVariable name
+		 to: variable definingClass superclass) runRefactoring
 ]
 
 { #category : 'accessing' }
@@ -44,12 +51,11 @@ SycPushUpVariableCommand >> isComplexRefactoring [
 	^ false
 ]
 
-{ #category : 'accessing' }
+{ #category : 'execution' }
 SycPushUpVariableCommand >> prepareFullExecutionInContext: aToolContext [
 
 	super prepareFullExecutionInContext: aToolContext.
 	refactoringScopes := aToolContext refactoringScopes.
 	toolContext := aToolContext.
-	variable := toolContext lastSelectedVariable.
-	
+	variable := toolContext lastSelectedVariable
 ]


### PR DESCRIPTION
Right now, the pull up driver does not support pulling up many variables at the same time.

Instead of use the last selected variable and silently ignoring all other variables, raise an error