### PR TITLE
Fix #isInteractive

### DIFF
--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -848,11 +848,8 @@ SmalltalkImage >> isInteractive [
 	"Check if vm were run with headless parameter.
 	Different VMs for different platform have different multiple way(s) to indicate that"
 
-	"non-headless mode is always interactive"
-	self isHeadless ifFalse: [ ^ true ].
-
 	-1000 to: 1000 do: [ :n |
-		(#('-interactive') includes: (self vm getSystemAttribute: n))
+		(#('--interactive') includes: (self vm getSystemAttribute: n))
 			ifTrue: [ ^ true ]].
 
 	^ false


### PR DESCRIPTION
Also, the interactive argument should have 2 dashes and not one.

In a future change I'll propose to deprecated #isHeadless