### PR TITLE
[P13 Backport] Fix: Rubric error when jumping to previous word and string begins with separators

### DIFF
--- a/src/Rubric-Tests/RubTextEditorTest.class.st
+++ b/src/Rubric-Tests/RubTextEditorTest.class.st
@@ -327,6 +327,14 @@ RubTextEditorTest >> testNextWordManyUppercases [
 ]
 
 { #category : 'tests' }
+RubTextEditorTest >> testNextWordOnlySeparators [
+
+	self setString: '   '.
+
+	self assertNextWordFrom: '¶   ' to: '   ¶' equals: '   ¶'
+]
+
+{ #category : 'tests' }
 RubTextEditorTest >> testNextWordSkipsCurrentSpacesAndGoesToEndOfCurrentWord [
 
 	self setString: 'abc d'.
@@ -631,6 +639,14 @@ RubTextEditorTest >> testPreviousWordManyUppercases [
 		assertPreviousWordFrom:	'ABCdEFG¶'
 		to: 							'¶ABCdEFG'
 		equals: 						'¶ABCdEFG'
+]
+
+{ #category : 'tests' }
+RubTextEditorTest >> testPreviousWordOnlySeparators [
+
+	self setString: '   '.
+
+	self assertPreviousWordFrom: '   ¶' to: '¶   ' equals: '¶   '
 ]
 
 { #category : 'tests' }

--- a/src/Rubric/RubTextEditor.class.st
+++ b/src/Rubric/RubTextEditor.class.st
@@ -1900,14 +1900,14 @@ RubTextEditor >> previousWord: position stopOnUpperCase: stopOnUpperCase [
 	size := string size + 1.
 	index := initialPosition := size min: position.
 
-	position <= 2 ifTrue: [ ^ 1 ].
-
 	[ "Skip blanks"
-	index > 1 and: [
-		{
-			Character space.
-			Character tab } includes: (string at: index - 1) ] ] whileTrue: [
+		index > 1 and: [
+				{
+					Character space.
+					Character tab } includes: (string at: index - 1) ] ] whileTrue: [
 		index := index - 1 ].
+
+	index <= 2 ifTrue: [ ^ 1 ].
 
 	groupAtStart := self characterGroupAt: index - 1 in: string.
 
@@ -1916,22 +1916,22 @@ RubTextEditor >> previousWord: position stopOnUpperCase: stopOnUpperCase [
 
 	"Stop if we are in a lowercase->uppercase transition"
 	groupAtStart = #upper ifTrue: [
-		stopOnUpperCase
-			ifFalse: [ groupAtStart := #lower ]
-			ifTrue: [
-				(index < string size and: [
-					 (self characterGroupAt: index + 1 in: string) = #lower ])
-					ifTrue: [ ^ index ] ] ].
+			stopOnUpperCase
+				ifFalse: [ groupAtStart := #lower ]
+				ifTrue: [
+						(index < string size and: [
+							 (self characterGroupAt: index + 1 in: string) = #lower ])
+							ifTrue: [ ^ index ] ] ].
 
 	[ "Stop when we reach the end, a new line, or a different character group"
-	index <= 1 ifTrue: [ ^ 1 ].
-	(string at: index - 1) = Character cr ifTrue: [ ^ index ].
+		index <= 1 ifTrue: [ ^ 1 ].
+		(string at: index - 1) = Character cr ifTrue: [ ^ index ].
 
-	currentGroup := self characterGroupAt: index - 1 in: string.
-	(stopOnUpperCase not and: [ currentGroup = #upper ]) ifTrue: [
-		currentGroup := #lower ].
+		currentGroup := self characterGroupAt: index - 1 in: string.
+		(stopOnUpperCase not and: [ currentGroup = #upper ]) ifTrue: [
+			currentGroup := #lower ].
 
-	currentGroup = groupAtStart ] whileTrue: [ index := index - 1 ].
+		currentGroup = groupAtStart ] whileTrue: [ index := index - 1 ].
 
 	"Moving to the left from lower to upper, we want to stop left of the upper"
 	(stopOnUpperCase and: [


### PR DESCRIPTION
Backport of #18208.