### PR TITLE
Fix off-by-one in `Color>>#isContrastCompliantFor*` 

### DIFF
--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -1314,9 +1314,9 @@ Color >> colorForInsets [
 
 { #category : 'accessing' }
 Color >> contrast: aColor [
-	"Get a constrast ratio between to colors. 
-	Constrast is computed from luminance value of these colors.
-	Formula L1/L2 is based on ISO-9241-3 and ANSI-HFES-100-1988.
+	"Get the contrast ratio between the given color and me. 
+	Contrast is computed from the luminance values of these colors.
+	The L1/L2 formula is based on ISO 9241-3 and ANSI/HFES 100-1988.
 	https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests"
 
 	| l1 l2 a |
@@ -1333,10 +1333,10 @@ Color >> contrast: aColor [
 Color >> contrastingBlackAndWhiteColor [
 	"Answer black or white depending on the luminance."
 
-	self isTransparent ifTrue: [ ^ self class black].
-	^self luminance > 0.5
-		ifTrue: [self class black]
-		ifFalse: [self class white]
+	self isTransparent ifTrue: [ ^ self class black ].
+	^ self luminance > 0.5
+		ifTrue: [ self class black ]
+		ifFalse: [ self class white ]
 ]
 
 { #category : 'converting' }
@@ -1344,10 +1344,9 @@ Color >> contrastingColorAdjustment [
 	"Answer darker or lighter color depending on the luminance."
 
 	self isTransparent ifTrue: [ ^ self ].
-
 	^ self luminance > 0.5
 		ifTrue: [ self darker ]
-		ifFalse:  [ self lighter ]
+		ifFalse: [ self lighter ]
 ]
 
 { #category : 'transformations' }
@@ -2015,7 +2014,9 @@ Color >> red [
 
 { #category : 'accessing' }
 Color >> relativeLuminance [
-	"Return the relative luminance Y of this color, a derivation of luminance signal from ITU-R BT.709-6 to considere human eye colors different sensitivity.
+	"Return the relative luminance (Y) of this color.
+	Unlike absolute luminance, Y is based on the luminance signal defined in ITU-R BT.709-6
+	that accounts for the varying sensitivity of the human eye to colors.
 	https://www.w3.org/WAI/GL/wiki/Relative_luminance"
 
 	| r g b a |

--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -1700,25 +1700,26 @@ Color >> isColor [
 
 { #category : 'testing' }
 Color >> isContrastCompliantForISO92413: aColor [
-	"Return true if the ISO92413 stardard consider myself and the given color with enough contrast to be used in an UI."
+	"Return true if the ISO 9241-3 standard considers the given color and myself to have sufficient contrast to be used in a UI.
+	Failing to achieve this level of contrast can result in reduced readability and poor visual clarity."
 
-	^ (self contrast: aColor) > 3
+	^ (self contrast: aColor) >= 3
 ]
 
 { #category : 'testing' }
 Color >> isContrastCompliantForWCAG2AA: aColor [
-	"Return true if the WCAG2AA stardard consider myself and the given color with enough contrast to be used in an UI.
-	With this standard respecrted, your UI is considered good for the majority of population"
+	"Return true if the WCAG 2 AA standard considers the given color and myself to have sufficient contrast to be used in a UI.
+	With this standard respected, your UI is considered suitable for the majority of the population."
 
-	^ (self contrast: aColor) > 4.5
+	^ (self contrast: aColor) >= 4.5
 ]
 
 { #category : 'testing' }
 Color >> isContrastCompliantForWCAG2AAA: aColor [
-	"Return true if the WCAG2AA stardard consider myself and the given color with enough contrast to be used in an UI.
-	With this standard respecrted, your UI is considered good for people of 80yo"
+	"Return true if the WCAG 2 AAA standard considers the given color and myself to have sufficient contrast to be used in a UI.
+	With this standard respected, your UI is considered suitable for people aged 80 and older."
 
-	^ (self contrast: aColor) > 7
+	^ (self contrast: aColor) >= 7
 ]
 
 { #category : 'testing' }

--- a/src/Graphics-Tests/ColorTest.class.st
+++ b/src/Graphics-Tests/ColorTest.class.st
@@ -99,6 +99,20 @@ ColorTest >> testColorFrom [
 ]
 
 { #category : 'tests' }
+ColorTest >> testContrast [
+
+	self assert: (Color white contrast: Color black) identicalTo: 21.0.
+
+	"Commutativity"
+	self
+		assert: (Color blue contrast: Color red)
+		identicalTo: (Color red contrast: Color blue).
+
+	"Identity"
+	self assert: (Color green contrast: Color green) identicalTo: 1.0
+]
+
+{ #category : 'tests' }
 ColorTest >> testFromHexString [
 
 	| color |
@@ -133,6 +147,54 @@ ColorTest >> testFromString [
 	self
 		assert: (Color fromString: 'DARKGRAY') = Color darkGray description: 'Color can be specified with a case insensitive color name';
 		assert: (Color fromString: '#blue') = Color blue description: 'Color can be specified with a leading literal sharp'
+]
+
+{ #category : 'tests' }
+ColorTest >> testIsContrastCompliantForISO92413 [
+
+	| darkColor edgeColor |
+	darkColor := Color black.
+	edgeColor := Color r: 0.7155 g: 0.01 b: 0.022. "Relative luminance around 0.1"
+
+	self
+		assert: (darkColor contrast: edgeColor)
+		closeTo: 3.0
+		precision: 0.001.
+	self assert: (darkColor isContrastCompliantForISO92413: edgeColor).
+	self deny: (darkColor isContrastCompliantForISO92413:
+			 (edgeColor adjustBrightness: -0.01))
+]
+
+{ #category : 'tests' }
+ColorTest >> testIsContrastCompliantForWCAG2AA [
+
+	| darkColor edgeColor |
+	darkColor := Color black.
+	edgeColor := Color r: 0.918 g: 0.0 b: 0.02. "Relative luminance around 0.175"
+
+	self
+		assert: (darkColor contrast: edgeColor)
+		closeTo: 4.5
+		precision: 0.001.
+	self assert: (darkColor isContrastCompliantForWCAG2AA: edgeColor).
+	self deny: (darkColor isContrastCompliantForWCAG2AA:
+			 (edgeColor adjustBrightness: -0.01))
+]
+
+{ #category : 'tests' }
+ColorTest >> testIsContrastCompliantForWCAG2AAA [
+
+	| darkColor edgeColor |
+	darkColor := Color black.
+	edgeColor := Color r: 0.05 g: 0.68 b: 0.05. "Relative luminance around 0.3"
+
+	self
+		assert: (darkColor contrast: edgeColor)
+		closeTo: 7.0
+		precision: 0.001.
+	self assert: (darkColor isContrastCompliantForWCAG2AAA: edgeColor).
+	self deny: (darkColor isContrastCompliantForWCAG2AAA:
+			 (edgeColor adjustBrightness: -0.01))
 ]
 
 { #category : 'tests - multiply' }
@@ -172,4 +234,15 @@ ColorTest >> testMultiplyByNumber [
 	self assert: (1 - newColor red) abs < tolerance.
 	self assert: (1 - newColor green) abs < tolerance.
 	self assert: (0.5 - newColor blue) abs < tolerance
+]
+
+{ #category : 'tests' }
+ColorTest >> testRelativeLuminance [
+	"Reference values from the WCAG definition: https://www.w3.org/TR/WCAG21/#dfn-relative-luminance"
+
+	self assert: Color black relativeLuminance equals: 0.0.
+	self assert: Color white relativeLuminance equals: 1.0.
+	self assert: Color red relativeLuminance equals: 0.2126.
+	self assert: Color green relativeLuminance equals: 0.7152.
+	self assert: Color blue relativeLuminance equals: 0.0722
 ]


### PR DESCRIPTION
`Color` has some useful methods to check standard compliance for contrast ratios.
However, they currently use a greater-than (>) comparison, whereas the standards define minimum acceptable contrast ratios, which implies a greater-than-or-equal-to (>=) comparison.

For example, [WCAG 2.x](https://www.w3.org/TR/WCAG21/#contrast-minimum) about the AA level:
> The visual presentation of text and images of text has a contrast ratio of at least 4.5:1.

The same phrasing applies to the AAA level, with a threshold of at least 7:1.
ISO 9241-3 does not define a specific ratio, but 3:1 is commonly accepted as the minimum.

Additionally, there are a few comment and formatting adjustments to related methods.