### PR TITLE
Displaying a collection name with the size with string with commas

### DIFF
--- a/src/Collections-Abstract/Collection.class.st
+++ b/src/Collections-Abstract/Collection.class.st
@@ -708,7 +708,7 @@ Collection >> displayStringOn: stream [
 	stream
 		space;
 		nextPut: $[;
-		print: self size;
+		nextPutAll: self size asStringWithCommas;
 		nextPutAll: (' item' asPluralBasedOn: self size);
 		nextPut: $];
 		space.


### PR DESCRIPTION
Sometimes, especially with large collections, reading the size of the collection from the displaying string is impossible. This PR adds a better fomatting  using string with commas. See the below pictures

Before:

<img width="596" alt="Capture d’écran 2025-06-05 à 10 45 35" src="https://github.com/user-attachments/assets/37652075-5ce4-42c3-a1a3-0df12d309b4a" />

After:

<img width="593" alt="Capture d’écran 2025-06-05 à 10 46 57" src="https://github.com/user-attachments/assets/7c818f39-6950-4f60-9f5e-1d001cb8fe62" />
