### PR TITLE
18253-ProcessorScheduler--nextReadyProcess-should-return-a-process-not-the-suspended-context

### DIFF
--- a/src/Kernel/ProcessorScheduler.class.st
+++ b/src/Kernel/ProcessorScheduler.class.st
@@ -224,7 +224,7 @@ ProcessorScheduler >> nextReadyProcess [
 
 	quiescentProcessLists reverseDo: [ :list |
 		list ifNotEmpty: [
-			list first suspendedContext ifNotNil: [:proc | ^ proc ] ] ].
+			list first ifNotNil: [:proc | ^ proc ] ] ].
 	^ nil
 ]
 


### PR DESCRIPTION
ProcessorScheduler >> nextReadyProcess should return a process
Fix #18253