### PR TITLE
Use `Color>>#relativeLuminance` in contrast methods

### DIFF
--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -1334,7 +1334,7 @@ Color >> contrastingBlackAndWhiteColor [
 	"Answer black or white depending on the luminance."
 
 	self isTransparent ifTrue: [ ^ self class black ].
-	^ self luminance > 0.5
+	^ self relativeLuminance > 0.5
 		ifTrue: [ self class black ]
 		ifFalse: [ self class white ]
 ]
@@ -1344,7 +1344,7 @@ Color >> contrastingColorAdjustment [
 	"Answer darker or lighter color depending on the luminance."
 
 	self isTransparent ifTrue: [ ^ self ].
-	^ self luminance > 0.5
+	^ self relativeLuminance > 0.5
 		ifTrue: [ self darker ]
 		ifFalse: [ self lighter ]
 ]

--- a/src/Graphics-Tests/ColorTest.class.st
+++ b/src/Graphics-Tests/ColorTest.class.st
@@ -113,6 +113,38 @@ ColorTest >> testContrast [
 ]
 
 { #category : 'tests' }
+ColorTest >> testContrastingBlackAndWhiteColor [
+
+	self
+		assert: Color transparent contrastingBlackAndWhiteColor
+		identicalTo: Color black.
+
+	self
+		assert: (Color gray: 0.7) contrastingBlackAndWhiteColor
+		identicalTo: Color white.
+
+	self
+		assert: (Color gray: 0.8) contrastingBlackAndWhiteColor
+		identicalTo: Color black
+]
+
+{ #category : 'tests' }
+ColorTest >> testContrastingColorAdjustment [
+
+	self
+		assert: Color transparent contrastingColorAdjustment
+		identicalTo: Color transparent.
+
+	self
+		assert: (Color gray: 0.7) contrastingColorAdjustment
+		equals: (Color gray: 0.7) lighter.
+
+	self
+		assert: (Color gray: 0.8) contrastingColorAdjustment
+		equals: (Color gray: 0.8) darker
+]
+
+{ #category : 'tests' }
 ColorTest >> testFromHexString [
 
 	| color |


### PR DESCRIPTION
Follow-up to #18250 where @jecisc commented that `relativeLuminance` should be used instead of `luminance` for methods based on contrast.
This concerns `contrastingBlackAndWhiteColor` and `contrastingColorAdjustment`.
Also added tests.