### PR TITLE
Fix Duplicate class refactoring if there are spaces in package or package tag

### DIFF
--- a/src/Refactoring-UI-Tests/StClassAndMethodsSelectionPresenterTest.class.st
+++ b/src/Refactoring-UI-Tests/StClassAndMethodsSelectionPresenterTest.class.st
@@ -1,0 +1,21 @@
+"
+A StClassAndMethodsSelectionPresenterTest is a test class for testing the behavior of StClassAndMethodsSelectionPresenter
+"
+Class {
+	#name : 'StClassAndMethodsSelectionPresenterTest',
+	#superclass : 'StRequestClassPresenterTest',
+	#category : 'Refactoring-UI-Tests-UI',
+	#package : 'Refactoring-UI-Tests',
+	#tag : 'UI'
+}
+
+{ #category : 'accessing' }
+StClassAndMethodsSelectionPresenterTest >> newPresenter [
+
+	^ StClassAndMethodsSelectionPresenter on: (ReDuplicateClassDriver new
+			   className: 'Class';
+			   scopes: { (RBClassEnvironment classes: {
+							    ReClassToBeDuplicated.
+							    ReClassToBeDuplicated superclass }) };
+			   yourself)
+]

--- a/src/Refactoring-UI-Tests/StRefactoringAddClassPresenterTest.class.st
+++ b/src/Refactoring-UI-Tests/StRefactoringAddClassPresenterTest.class.st
@@ -1,0 +1,18 @@
+"
+A StRefactoringAddClassPresenterTest is a test class for testing the behavior of StRefactoringAddClassPresenter
+"
+Class {
+	#name : 'StRefactoringAddClassPresenterTest',
+	#superclass : 'StRequestClassPresenterTest',
+	#category : 'Refactoring-UI-Tests-UI',
+	#package : 'Refactoring-UI-Tests',
+	#tag : 'UI'
+}
+
+{ #category : 'accessing' }
+StRefactoringAddClassPresenterTest >> newPresenter [
+
+	^ StRefactoringAddClassPresenter on: (ReAddSubclassDriver basicNew
+			   superclass: Object;
+			   yourself)
+]

--- a/src/Refactoring-UI-Tests/StRequestClassPresenterTest.class.st
+++ b/src/Refactoring-UI-Tests/StRequestClassPresenterTest.class.st
@@ -24,7 +24,7 @@ StRequestClassPresenterTest >> newPresenter [
 	^ self subclassResponsibility
 ]
 
-{ #category : 'accessing' }
+{ #category : 'running' }
 StRequestClassPresenterTest >> setUp [
 	super setUp.
 	presenter := self newPresenter

--- a/src/Refactoring-UI-Tests/StRequestClassPresenterTest.class.st
+++ b/src/Refactoring-UI-Tests/StRequestClassPresenterTest.class.st
@@ -1,0 +1,61 @@
+"
+A StRequestClassPresenterTest is a test class for testing the behavior of StRequestClassPresenter
+"
+Class {
+	#name : 'StRequestClassPresenterTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'presenter'
+	],
+	#category : 'Refactoring-UI-Tests-UI',
+	#package : 'Refactoring-UI-Tests',
+	#tag : 'UI'
+}
+
+{ #category : 'testing' }
+StRequestClassPresenterTest class >> isAbstract [
+
+	^ self = StRequestClassPresenterTest
+]
+
+{ #category : 'accessing' }
+StRequestClassPresenterTest >> newPresenter [
+
+	^ self subclassResponsibility
+]
+
+{ #category : 'accessing' }
+StRequestClassPresenterTest >> setUp [
+	super setUp.
+	presenter := self newPresenter
+]
+
+{ #category : 'tests' }
+StRequestClassPresenterTest >> testValidateAnswerBlock [
+
+	self assert: (presenter validateAnswerBlock value: 'ClassName' value: 'PackageName' value: 'PackageTagName')
+]
+
+{ #category : 'tests' }
+StRequestClassPresenterTest >> testValidateAnswerBlockWithEmptyStrings [
+
+	self deny: (presenter validateAnswerBlock value: '' value: 'PackageName' value: 'PackageTagName').
+	self deny: (presenter validateAnswerBlock value: 'ClassName' value: '' value: 'PackageTagName').
+	self deny: (presenter validateAnswerBlock value: 'ClassName' value: 'PackageName' value: '')
+]
+
+{ #category : 'tests' }
+StRequestClassPresenterTest >> testValidateAnswerBlockWithNils [
+
+	self deny: (presenter validateAnswerBlock value: nil value: 'PackageName' value: 'PackageTagName').
+	self deny: (presenter validateAnswerBlock value: 'ClassName' value: nil value: 'PackageTagName').
+	self deny: (presenter validateAnswerBlock value: 'ClassName' value: 'PackageName' value: nil)
+]
+
+{ #category : 'tests' }
+StRequestClassPresenterTest >> testValidateAnswerBlockWithSpaces [
+
+	self deny: (presenter validateAnswerBlock value: 'Class Name' value: 'PackageName' value: 'PackageTagName').
+	self assert: (presenter validateAnswerBlock value: 'ClassName' value: 'Package Name' value: 'PackageTagName').
+	self assert: (presenter validateAnswerBlock value: 'ClassName' value: 'PackageName' value: 'Package Tag Name')
+]

--- a/src/Refactoring-UI/StRefactoringAddClassPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringAddClassPresenter.class.st
@@ -31,9 +31,9 @@ StRefactoringAddClassPresenter >> defaultLayout [
 
 	^ SpGridLayout new
 		  add: 'New class name' atPoint: 1 @ 1;
-		  add: textInput at: 2 @ 1 span: 2 @ 1;
-		  add: 'Package' at: 1 @ 2;
-		  add: packagePresenter at: 2 @ 2 span: 2 @ 1;
+		  add: textInput atPoint: 2 @ 1 span: 2 @ 1;
+		  add: 'Package' atPoint: 1 @ 2;
+		  add: packagePresenter atPoint: 2 @ 2 span: 2 @ 1;
 		  add: 'Tag' at: 1 @ 3;
 		  add: tagPresenter at: 2 @ 3 span: 2 @ 1;
 		  add: 'Comment' at: 1 @ 4;

--- a/src/Refactoring-UI/StRequestClassPresenter.class.st
+++ b/src/Refactoring-UI/StRequestClassPresenter.class.st
@@ -123,20 +123,22 @@ StRequestClassPresenter >> validateAnswer [
 { #category : 'private' }
 StRequestClassPresenter >> validateAnswerBlock [
 
-	^ [ : newClassName : packageName : tagName |
+	^ [ :newClassName :packageName :tagName |
 		  | isValid |
-		  isValid := (self validateNameBlock value: newClassName) and: [ (self validateNameBlock value: packageName) and: [ self validateNameBlock value: tagName ] ].
-		  isValid 
-			ifFalse: [ self inform: 'Name can''t be empty or contain spaces' ].
+		  isValid := (self validateClassNameBlock value: newClassName) and: [
+			             (self validatePackageNameBlock value: packageName) and: [ self validatePackageNameBlock value: tagName ] ].
+		  isValid ifFalse: [ self inform: 'Name can''t be empty or contain spaces' ].
 		  isValid ]
 ]
 
 { #category : 'private' }
-StRequestClassPresenter >> validateNameBlock [
+StRequestClassPresenter >> validateClassNameBlock [
 
-	^ [ :txt |
-	  | isValid |
-	  isValid := txt isNotNil and: [
-		             txt isNotEmpty and: [ (txt includesSubstring: ' ') not ] ].
-	  isValid ]
+	^ [ :txt | txt isNotNil and: [ txt isNotEmpty and: [ (txt includesSubstring: ' ') not ] ] ]
+]
+
+{ #category : 'private' }
+StRequestClassPresenter >> validatePackageNameBlock [
+
+	^ [ :txt | txt isNotNil and: [ txt isNotEmpty ] ]
 ]


### PR DESCRIPTION
Currently StRequestClassPresenter is checking if the name of a class, package and package tag are right. But is expects that we have no space in the package name or package tag name. But it is possible to have spaces there in Pharo!

Update the check.

Fixes #18287

@balsa-sarenac I added tests but I find it hard to setup the presenters. For one I had to use a #basicNew because the initialize is opening a modal which make it really tricky to test. I think some cleaning is necessary to make it easier to test