### PR TITLE
Add subclass fix

### DIFF
--- a/src/Refactoring-UI/StRefactoringAddClassPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringAddClassPresenter.class.st
@@ -104,6 +104,34 @@ StRefactoringAddClassPresenter >> open [
 		centered
 ]
 
+{ #category : 'callbacks' }
+StRefactoringAddClassPresenter >> updateTagItems: item [
+	"Note that as it seems there is no Spec drop list with editable text, we provide a 'Core' tag by default if the package has no tags"
+
+	| pkg superclassTag |
+	superclassTag := driver superclass packageTag name.
+	item
+		ifNil: [
+				superclassTag
+					ifNotNil: [ tagPresenter items: { superclassTag } ]
+					ifNil: [ tagPresenter items: { 'Core' } ] ]
+		ifNotNil: [
+				(pkg := PackageOrganizer default packageNamed: item) tagNames
+					ifEmpty: [
+							superclassTag
+								ifNotNil: [ tagPresenter items: { superclassTag } ]
+								ifNil: [ tagPresenter items: { 'Core' } ] ]
+					ifNotEmpty: [ :tagNames |
+							| orderedTags |
+							orderedTags := tagNames asOrderedCollection.
+							superclassTag ifNotNil: [
+									(orderedTags includes: superclassTag) ifTrue: [
+											orderedTags remove: superclassTag.
+											orderedTags addFirst: superclassTag ] ].
+							tagPresenter items: orderedTags ] ].
+	tagPresenter selectIndex: 1
+]
+
 { #category : 'accessing' }
 StRefactoringAddClassPresenter >> windowIcon [
 

--- a/src/Refactoring-UI/StRequestClassPresenter.class.st
+++ b/src/Refactoring-UI/StRequestClassPresenter.class.st
@@ -92,15 +92,29 @@ StRequestClassPresenter >> tagName [
 { #category : 'callbacks' }
 StRequestClassPresenter >> updateTagItems: item [
 	"Note that as it seems there is no Spec drop list with editable text, we provide a 'Core' tag by default if the package has no tags"
-	| pkg |
-	
-	item 
-		ifNil: [ tagPresenter items: { 'Core' } ]
-		ifNotNil: [ 
-			(pkg := PackageOrganizer default packageNamed: item)  tagNames
-				ifEmpty: [ tagPresenter items: { 'Core' }  ]
-				ifNotEmpty: [ : tagNames | tagPresenter items: tagNames asOrderedCollection ] ].
-	tagPresenter selectIndex: 1
+
+	| pkg superclassTag |
+	superclassTag := driver superclass packageTag name.
+	item
+		ifNil: [
+				superclassTag
+					ifNotNil: [ tagPresenter items: { superclassTag } ]
+					ifNil: [ tagPresenter items: { 'Core' } ] ]
+		ifNotNil: [
+				(pkg := PackageOrganizer default packageNamed: item) tagNames
+					ifEmpty: [
+							superclassTag
+								ifNotNil: [ tagPresenter items: { superclassTag } ]
+								ifNil: [ tagPresenter items: { 'Core' } ] ]
+					ifNotEmpty: [ :tagNames |
+							| orderedTags |
+							orderedTags := tagNames asOrderedCollection.
+							superclassTag ifNotNil: [
+									(orderedTags includes: superclassTag) ifTrue: [
+											orderedTags remove: superclassTag.
+											orderedTags addFirst: superclassTag ] ].
+							tagPresenter items: orderedTags ] ].
+	tagPresenter selectIndex: 1 
 ]
 
 { #category : 'callbacks' }

--- a/src/Refactoring-UI/StRequestClassPresenter.class.st
+++ b/src/Refactoring-UI/StRequestClassPresenter.class.st
@@ -93,28 +93,13 @@ StRequestClassPresenter >> tagName [
 StRequestClassPresenter >> updateTagItems: item [
 	"Note that as it seems there is no Spec drop list with editable text, we provide a 'Core' tag by default if the package has no tags"
 
-	| pkg superclassTag |
-	superclassTag := driver superclass packageTag name.
-	item
-		ifNil: [
-				superclassTag
-					ifNotNil: [ tagPresenter items: { superclassTag } ]
-					ifNil: [ tagPresenter items: { 'Core' } ] ]
-		ifNotNil: [
-				(pkg := PackageOrganizer default packageNamed: item) tagNames
-					ifEmpty: [
-							superclassTag
-								ifNotNil: [ tagPresenter items: { superclassTag } ]
-								ifNil: [ tagPresenter items: { 'Core' } ] ]
-					ifNotEmpty: [ :tagNames |
-							| orderedTags |
-							orderedTags := tagNames asOrderedCollection.
-							superclassTag ifNotNil: [
-									(orderedTags includes: superclassTag) ifTrue: [
-											orderedTags remove: superclassTag.
-											orderedTags addFirst: superclassTag ] ].
-							tagPresenter items: orderedTags ] ].
-	tagPresenter selectIndex: 1 
+	| pkg |
+	item ifNil: [ tagPresenter items: { 'Core' } ] ifNotNil: [
+			(pkg := PackageOrganizer default packageNamed: item) tagNames
+				ifEmpty: [ tagPresenter items: { 'Core' } ]
+				ifNotEmpty: [ :tagNames |
+				tagPresenter items: tagNames asOrderedCollection ] ].
+	tagPresenter selectIndex: 1
 ]
 
 { #category : 'callbacks' }


### PR DESCRIPTION
Fixes #18295.
Add subclass refactoring tag fix
-Select by default the superclass package tag if it exists
-More intuitive for the user