### PR TITLE
DrTest second pane displayed as a tree

### DIFF
--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -38,8 +38,12 @@ DTDefaultPluginPresenter class >> buildContextualPackageGroupWith: presenterInst
 DTDefaultPluginPresenter class >> buildItemsListGroupWith: presenterInstance [
 
 	^ (CmCommandGroup named: 'List items menu') asSpecGroup
-		register: (DTBrowseSelectedItemCommand forSpec context: presenterInstance);
-		yourself
+		  register:
+			  (DTInspectSelectedItemCommand forSpecContext: presenterInstance)
+				  beHiddenWhenCantBeRun;
+		  register:
+			  (DTBrowseSelectedItemCommand forSpec context: presenterInstance);
+		  yourself
 ]
 
 { #category : 'private - commands' }
@@ -59,21 +63,24 @@ DTDefaultPluginPresenter class >> buildPackageGroupWith: presenterInstance [
 
 { #category : 'private - commands' }
 DTDefaultPluginPresenter class >> buildResultGroupWith: presenterInstance [
-	| commandGroup pluginCommands plugin |
 
+	| commandGroup pluginCommands plugin |
 	commandGroup := (CmCommandGroup named: 'Results tools') asSpecGroup
-		description: 'Commands related to result.';
-		register: (DTResultBrowseCommand forSpecContext: presenterInstance) beHiddenWhenCantBeRun;
-		yourself.
+		                description: 'Commands related to result.';
+		                register:
+			                (DTResultBrowseCommand forSpecContext:
+					                 presenterInstance) beHiddenWhenCantBeRun;
+		                yourself.
 
 	plugin := presenterInstance plugin.
 	plugin ifNil: [ ^ commandGroup ].
 
-	pluginCommands := plugin buildContextualMenuGroupWith: presenterInstance.
+	pluginCommands := plugin buildContextualMenuGroupWith:
+		                  presenterInstance.
 	pluginCommands entries ifEmpty: [ ^ commandGroup ].
 	^ commandGroup
-		register: pluginCommands beDisplayedAsGroup;
-		yourself
+		  register: pluginCommands beDisplayedAsGroup;
+		  yourself
 ]
 
 { #category : 'actions' }
@@ -83,6 +90,12 @@ DTDefaultPluginPresenter >> browseSelectedItem [
 	"
 
 	self selectedItems first drTestsBrowse
+]
+
+{ #category : 'actions' }
+DTDefaultPluginPresenter >> browseSelectedPackage [
+
+	self selectedPackage browse
 ]
 
 { #category : 'actions' }
@@ -213,6 +226,18 @@ DTDefaultPluginPresenter >> initializeResultsTreeAndLabel [
 			(DTResultBrowseCommand forSpecContext: self) execute ]
 ]
 
+{ #category : 'actions' }
+DTDefaultPluginPresenter >> inspectSelectedItem [
+
+	self selectedItems first inspect
+]
+
+{ #category : 'actions' }
+DTDefaultPluginPresenter >> inspectSelectedPackage [
+
+	self selectedPackage inspect
+]
+
 { #category : 'accessing' }
 DTDefaultPluginPresenter >> itemsList [
 	^ itemsList
@@ -292,6 +317,12 @@ DTDefaultPluginPresenter >> selectNoneInPackageList [
 DTDefaultPluginPresenter >> selectedItems [
 
 	^ itemsList selectedItems
+]
+
+{ #category : 'accessing' }
+DTDefaultPluginPresenter >> selectedPackage [
+
+	^ packagesList selectedItem
 ]
 
 { #category : 'accessing' }

--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -402,11 +402,26 @@ DTDefaultPluginPresenter >> whenItemsSelectionChanged: itemsSelected [
 { #category : 'private' }
 DTDefaultPluginPresenter >> whenPackagesSelectionChanged: packagesSelected [
 
+	| allPaths getPaths |
 	itemsList
 		roots: ((plugin itemsToBeAnalysedFor: packagesSelected) sorted:
 					 #name ascending);
 		children: [ :aClass | aClass subclasses sorted: #name ascending ];
-		expandAll;
-		selectAll.
+		expandAll.
+	itemsList roots: itemsList items.
+	allPaths := OrderedCollection new.
+	getPaths := [ :items :currentPath |
+		                     items withIndexDo: [ :item :index |
+				                     | itemPath |
+				                     itemPath := currentPath , { index }.
+				                     allPaths add: itemPath.
+				                     item subclasses ifNotEmpty: [
+					                     getPaths
+						                     value: item subclasses
+						                     value: itemPath ] ] ].
+
+	getPaths value: itemsList items value: #(  ).
+	itemsList selectPaths: allPaths.
+	itemsList selectAll.
 	self updatePackagesListLabel
 ]

--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -422,6 +422,5 @@ DTDefaultPluginPresenter >> whenPackagesSelectionChanged: packagesSelected [
 
 	getPaths value: itemsList items value: #(  ).
 	itemsList selectPaths: allPaths.
-	itemsList selectAll.
 	self updatePackagesListLabel
 ]

--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -142,22 +142,23 @@ DTDefaultPluginPresenter >> drTests [
 { #category : 'initialization' }
 DTDefaultPluginPresenter >> initializeItemsListAndLabel [
 
-	itemsList := self newFilterableListPresenter.
+	itemsList := self newFilterableTreePresenter.
 	itemsList
-		displayIcon: [ :aClass | self iconNamed: aClass systemIconName  ];
+		displayIcon: [ :aClass | self iconNamed: aClass systemIconName ];
 		displayColor: [ :aClass |
-			(self packagesSelected includes: aClass package)
-				ifTrue: [ self theme textColor ]
-				ifFalse: [ self theme classExtensionColor ] ];
-		help: 'Select the classes to analyze. Cmd+A or Ctrl+A to select all classes.';
-		sortingBlock: #name ascending;
+				(self packagesSelected includes: aClass package)
+					ifTrue: [ self theme textColor ]
+					ifFalse: [ self theme classExtensionColor ] ];
+		help:
+			'Select the classes to analyze. Cmd+A or Ctrl+A to select all classes.';
 		displayBlock: [ :item | item name ];
-		whenSelectionChangedDo: [ self whenItemsSelectionChanged: self selectedItems ];
+		whenSelectionChangedDo: [
+			self whenItemsSelectionChanged: self selectedItems ];
 		beMultipleSelection;
 		actions: (self rootCommandsGroup / 'List items menu') beRoot.
 
-	packagesList
-		whenSelectionChangedDo: [ self whenPackagesSelectionChanged: self packagesSelected ]
+	packagesList whenSelectionChangedDo: [
+		self whenPackagesSelectionChanged: self packagesSelected ]
 ]
 
 { #category : 'initialization' }
@@ -221,6 +222,12 @@ DTDefaultPluginPresenter >> itemsList [
 DTDefaultPluginPresenter >> newFilterableListPresenter [
 
 	^ self instantiate: DTFilterableListPresenter
+]
+
+{ #category : 'widgets' }
+DTDefaultPluginPresenter >> newFilterableTreePresenter [
+
+	^ self instantiate: DTFilterableTreePresenter
 ]
 
 { #category : 'accessing' }
@@ -396,7 +403,10 @@ DTDefaultPluginPresenter >> whenItemsSelectionChanged: itemsSelected [
 DTDefaultPluginPresenter >> whenPackagesSelectionChanged: packagesSelected [
 
 	itemsList
-		items: (plugin itemsToBeAnalysedFor: packagesSelected);
+		roots: ((plugin itemsToBeAnalysedFor: packagesSelected) sorted:
+					 #name ascending);
+		children: [ :aClass | aClass subclasses sorted: #name ascending ];
+		expandAll;
 		selectAll.
 	self updatePackagesListLabel
 ]

--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -402,25 +402,16 @@ DTDefaultPluginPresenter >> whenItemsSelectionChanged: itemsSelected [
 { #category : 'private' }
 DTDefaultPluginPresenter >> whenPackagesSelectionChanged: packagesSelected [
 
-	| allPaths getPaths |
 	itemsList
 		roots: ((plugin itemsToBeAnalysedFor: packagesSelected) sorted:
 					 #name ascending);
-		children: [ :aClass | aClass subclasses sorted: #name ascending ];
+		children: [ :aClass |
+				aClass subclasses
+				& (packagesSelected flatCollect: [ :package | package classes ])
+					sorted: #name ascending ];
 		expandAll.
 	itemsList roots: itemsList items.
-	allPaths := OrderedCollection new.
-	getPaths := [ :items :currentPath |
-		                     items withIndexDo: [ :item :index |
-				                     | itemPath |
-				                     itemPath := currentPath , { index }.
-				                     allPaths add: itemPath.
-				                     item subclasses ifNotEmpty: [
-					                     getPaths
-						                     value: item subclasses
-						                     value: itemPath ] ] ].
 
-	getPaths value: itemsList items value: #(  ).
-	itemsList selectPaths: allPaths.
+	itemsList selectAll.
 	self updatePackagesListLabel
 ]

--- a/src/DrTests/DTFilterableListPresenter.class.st
+++ b/src/DrTests/DTFilterableListPresenter.class.st
@@ -213,6 +213,12 @@ DTFilterableListPresenter >> selectItems: aBlock [
 ]
 
 { #category : 'accessing' }
+DTFilterableListPresenter >> selectedItem [
+
+	^ listPresenter selectedItem
+]
+
+{ #category : 'accessing' }
 DTFilterableListPresenter >> selectedItems [
 
 	^ self listPresenter selectedItems

--- a/src/DrTests/DTFilterableTreePresenter.class.st
+++ b/src/DrTests/DTFilterableTreePresenter.class.st
@@ -1,0 +1,250 @@
+"
+I am a list presenter that can be filtered.
+
+I also have a label.
+"
+Class {
+	#name : 'DTFilterableTreePresenter',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'treePresenter',
+		'filterTextInput',
+		'initialItems',
+		'labelPresenter'
+	],
+	#category : 'DrTests-Spec',
+	#package : 'DrTests',
+	#tag : 'Spec'
+}
+
+{ #category : 'api - actions' }
+DTFilterableTreePresenter >> actions [
+
+	^ self treePresenter actions
+]
+
+{ #category : 'api - actions' }
+DTFilterableTreePresenter >> actions: aCommandGroup [
+
+	self treePresenter actions: aCommandGroup
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> allItems [
+
+	^ initialItems
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> beEmpty [
+
+	self roots: #()
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> beMultipleSelection [
+
+	^ self treePresenter beMultipleSelection
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> beSingleSelection [
+
+	^ self treePresenter beSingleSelection
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> children [
+
+	^ self treePresenter children
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> children: aBlock [
+
+	self treePresenter children: aBlock
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> contextMenu: aBlock [
+
+	^ self treePresenter contextMenu: aBlock
+]
+
+{ #category : 'layout' }
+DTFilterableTreePresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		spacing: 5;
+		add: labelPresenter expand: false;
+		add: treePresenter;
+		add: filterTextInput expand: false;
+		yourself
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> displayBlock: aBlock [
+
+	^ self treePresenter display: aBlock
+]
+
+{ #category : 'api' }
+DTFilterableTreePresenter >> displayColor: aBlock [
+
+	self treePresenter displayColor: aBlock
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> displayIcon: aFullBlockClosure [
+
+	self treePresenter displayIcon: aFullBlockClosure
+]
+
+{ #category : 'private - actions' }
+DTFilterableTreePresenter >> ensureActions [
+
+	^ self treePresenter ensureActions
+]
+
+{ #category : 'expanding-collapsing' }
+DTFilterableTreePresenter >> expandAll [
+
+	self treePresenter expandAll
+]
+
+{ #category : 'private' }
+DTFilterableTreePresenter >> filterList [
+	"Filters the list according to the filterTextInput."
+
+	self unselectAll.
+	self filterStrings ifEmpty: [
+			self roots: initialItems.
+			^ self ].
+	self roots: (initialItems select: [ :each |
+				 self filterStrings anySatisfy: [ :any |
+					 any match: (self treePresenter display value: each) ] ])
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> filterStrings [
+
+	^ (self filterTextInput text splitOn: $|)
+		  reject: #isEmpty
+		  thenCollect: [ :pattern | '*' , pattern , '*' ]
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> filterTextInput [
+
+	^ filterTextInput
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> help [
+
+	^ labelPresenter help
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> help: aString [
+
+	labelPresenter help: aString
+]
+
+{ #category : 'initialization' }
+DTFilterableTreePresenter >> initialize [
+
+	super initialize.
+	initialItems := #()
+]
+
+{ #category : 'initialization' }
+DTFilterableTreePresenter >> initializePresenters [
+
+	labelPresenter := self newLabel.
+	treePresenter := self newTree.
+	filterTextInput := self newTextInput
+		                   placeholder: 'Filter...';
+		                   whenTextChangedDo: [ self filterList ];
+		                   yourself
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> items [
+
+	^ self visibleItems
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> label [
+
+	^ labelPresenter label
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> label: aString [
+
+	labelPresenter label: aString
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> labelPresenter [
+
+	^ labelPresenter
+]
+
+{ #category : 'actions' }
+DTFilterableTreePresenter >> resetFilter [
+
+	self filterTextInput text: ''.
+	self treePresenter roots: initialItems
+]
+
+{ #category : 'api' }
+DTFilterableTreePresenter >> roots: aBlock [
+
+	initialItems := aBlock.
+	self treePresenter roots: aBlock
+]
+
+{ #category : 'actions' }
+DTFilterableTreePresenter >> selectAll [
+
+	^ self treePresenter selectItems: self treePresenter roots
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> selectItems: aBlock [
+
+	^ self treePresenter selectItems: aBlock
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> selectedItems [
+
+	^ self treePresenter selectedItems
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> treePresenter [
+
+	^ treePresenter
+]
+
+{ #category : 'actions' }
+DTFilterableTreePresenter >> unselectAll [
+
+	^ self treePresenter unselectAll
+]
+
+{ #category : 'accessing' }
+DTFilterableTreePresenter >> visibleItems [
+
+	^ self treePresenter roots
+]
+
+{ #category : 'events' }
+DTFilterableTreePresenter >> whenSelectionChangedDo: aBlock [
+
+	^ self treePresenter whenSelectionChangedDo: aBlock
+]

--- a/src/DrTests/DTFilterableTreePresenter.class.st
+++ b/src/DrTests/DTFilterableTreePresenter.class.st
@@ -219,6 +219,12 @@ DTFilterableTreePresenter >> selectItems: aBlock [
 	^ self treePresenter selectItems: aBlock
 ]
 
+{ #category : 'api - selection' }
+DTFilterableTreePresenter >> selectPaths: aPathArray [
+
+	self treePresenter selectPaths: aPathArray
+]
+
 { #category : 'accessing' }
 DTFilterableTreePresenter >> selectedItems [
 

--- a/src/DrTests/DTFilterableTreePresenter.class.st
+++ b/src/DrTests/DTFilterableTreePresenter.class.st
@@ -210,7 +210,7 @@ DTFilterableTreePresenter >> roots: aBlock [
 { #category : 'actions' }
 DTFilterableTreePresenter >> selectAll [
 
-	^ self treePresenter selectItems: self treePresenter roots
+	^ self treePresenter selectAll
 ]
 
 { #category : 'accessing' }

--- a/src/DrTests/DTInspectSelectedItemCommand.class.st
+++ b/src/DrTests/DTInspectSelectedItemCommand.class.st
@@ -1,0 +1,22 @@
+"
+I browse the selected result in the results list of DrTests.
+"
+Class {
+	#name : 'DTInspectSelectedItemCommand',
+	#superclass : 'DTMiddleListCommand',
+	#category : 'DrTests-Commands',
+	#package : 'DrTests',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+DTInspectSelectedItemCommand class >> defaultName [
+
+	^ 'Inspect'
+]
+
+{ #category : 'executing' }
+DTInspectSelectedItemCommand >> execute [
+
+	self context inspectSelectedItem
+]

--- a/src/DrTests/DTPackagesBrowseCommand.class.st
+++ b/src/DrTests/DTPackagesBrowseCommand.class.st
@@ -1,0 +1,22 @@
+"
+I browse the selected package in the package list of DrTests.
+"
+Class {
+	#name : 'DTPackagesBrowseCommand',
+	#superclass : 'DTPackagesCommand',
+	#category : 'DrTests-Commands',
+	#package : 'DrTests',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+DTPackagesBrowseCommand class >> defaultName [
+
+	^ 'Browse'
+]
+
+{ #category : 'executing' }
+DTPackagesBrowseCommand >> execute [
+
+	self context browseSelectedPackage
+]

--- a/src/DrTests/DTPackagesInspectCommand.class.st
+++ b/src/DrTests/DTPackagesInspectCommand.class.st
@@ -1,0 +1,22 @@
+"
+I inspect the selected package in the package list of DrTests.
+"
+Class {
+	#name : 'DTPackagesInspectCommand',
+	#superclass : 'DTPackagesCommand',
+	#category : 'DrTests-Commands',
+	#package : 'DrTests',
+	#tag : 'Commands'
+}
+
+{ #category : 'default' }
+DTPackagesInspectCommand class >> defaultName [
+
+	^ 'Inspect'
+]
+
+{ #category : 'executing' }
+DTPackagesInspectCommand >> execute [
+
+	self context inspectSelectedPackage 
+]


### PR DESCRIPTION
- Improvement for the displayed classes in DrTest
- User had too search for subclasses tests hardly if a test class was abstract (now everything is displayed)
- Addition of new commands for context menu in drtest too
@jecisc 