### PR TITLE
Add shortcut for closing windows

### DIFF
--- a/src/Morphic-Widgets-Windows/SystemWindow.class.st
+++ b/src/Morphic-Widgets-Windows/SystemWindow.class.st
@@ -1203,7 +1203,8 @@ SystemWindow >> initialize [
 	mustNotClose := false.
 	updatablePanes := Array new.
 	self bindKeyCombination: ($k meta shift alt ) toAction: [self taskbarMoveLeft ].
-	self bindKeyCombination: ($l meta shift alt) toAction: [self taskbarMoveRight ]
+	self bindKeyCombination: ($l meta shift alt) toAction: [self taskbarMoveRight ].
+	self bindKeyCombination: $w meta toAction: [ self class closeTopWindow ]
 ]
 
 { #category : 'keymapping' }


### PR DESCRIPTION
In order to stock windows in window uncloser.
@tesonep i know you moved the closeTopWindow method call in https://github.com/pharo-project/pharo/pull/18116 , my changes dont interfere with yours right? 