### PR TITLE
use UIManager default in OCCodeReparator instead of a direct access to MorphicUIManager

### DIFF
--- a/src/OpalCompiler-UI/OCCodeReparator.class.st
+++ b/src/OpalCompiler-UI/OCCodeReparator.class.st
@@ -170,7 +170,7 @@ OCCodeReparator >> openMenu [
 	labels add: 'Cancel'.
 	caption := 'Unknown variable: ' , name
 	           , ' please correct, or cancel:'.
-	choice := MorphicUIManager new
+	choice := UIManager default
 		          chooseFrom: labels
 		          lines: lines
 		          title: caption.


### PR DESCRIPTION
... is  already bad that there is UI interactions so deep in the system, but at least let's not hardcode morphic there :/