### PR TITLE
New methods to define window title for Pull up/down refactorings

### DIFF
--- a/src/Refactoring-UI-Tests/StMethodsSelectionPresenterMock.class.st
+++ b/src/Refactoring-UI-Tests/StMethodsSelectionPresenterMock.class.st
@@ -2,6 +2,7 @@ Class {
 	#name : 'StMethodsSelectionPresenterMock',
 	#superclass : 'Object',
 	#instVars : [
+		'title',
 		'label',
 		'items',
 		'selecting'
@@ -18,6 +19,16 @@ StMethodsSelectionPresenterMock class >> label: aString withItems: aCollection s
 		label: aString
 		withItems: aCollection
 		selecting: aCollection3
+]
+
+{ #category : 'initialization' }
+StMethodsSelectionPresenterMock class >> title: aTitle label: aString withItems: aCollection selecting: aCollection3 [
+
+	^ self new
+		  title: aTitle
+		  label: aString
+		  withItems: aCollection
+		  selecting: aCollection3
 ]
 
 { #category : 'testing' }
@@ -38,4 +49,13 @@ StMethodsSelectionPresenterMock >> label: aString withItems: aOrderedCollection 
 StMethodsSelectionPresenterMock >> selectedItems [
 
 	^ selecting 
+]
+
+{ #category : 'initialization' }
+StMethodsSelectionPresenterMock >> title: aTitle label: aString withItems: aOrderedCollection selecting: aOrderedCollectionToo [
+
+	title := aTitle.
+	label := 'Push down methods from a class'.
+	items := aOrderedCollection.
+	selecting := aOrderedCollectionToo
 ]

--- a/src/Refactoring-UI-Tests/StSelectClassAndMethodsPresenterMock.class.st
+++ b/src/Refactoring-UI-Tests/StSelectClassAndMethodsPresenterMock.class.st
@@ -2,6 +2,7 @@ Class {
 	#name : 'StSelectClassAndMethodsPresenterMock',
 	#superclass : 'Object',
 	#instVars : [
+		'title',
 		'label',
 		'dropLabel',
 		'items',
@@ -37,6 +38,19 @@ StSelectClassAndMethodsPresenterMock class >> selectedClass [
 	^ nil
 ]
 
+{ #category : 'initialization' }
+StSelectClassAndMethodsPresenterMock class >> title: aTitle label: aString dropLabel: aString2 withItems: aCollection selecting: aCollection4 dropItems: aCollection5 acceptBlock: aFullBlockClosure [
+
+	^ self new
+		  title: aTitle
+		  label: aString
+		  dropLabel: aString2
+		  withItems: aCollection5
+		  selecting: aCollection4
+		  dropItems: aCollection
+		  acceptBlock: aFullBlockClosure
+]
+
 { #category : 'testing' }
 StSelectClassAndMethodsPresenterMock >> cancelled [
 	^ false
@@ -61,4 +75,17 @@ StSelectClassAndMethodsPresenterMock >> selectedClass [
 { #category : 'initialization' }
 StSelectClassAndMethodsPresenterMock >> selectedMethods [
 	^ selecting
+]
+
+{ #category : 'initialization' }
+StSelectClassAndMethodsPresenterMock >> title: aTitle label: aString dropLabel: aString2 withItems: aCollection selecting: aCollection4 dropItems: aCollection5 acceptBlock: aFullBlockClosure [
+
+	title := aTitle.
+	label := aString. 
+	dropLabel := aString2.
+	items := aCollection.
+	selecting := aCollection4.
+	dropItems := aCollection4.
+	acceptBlock := aFullBlockClosure.
+	acceptBlock value: self selectedClass value: self selectedMethods
 ]

--- a/src/Refactoring-UI/RePullUpMethodDriver.class.st
+++ b/src/Refactoring-UI/RePullUpMethodDriver.class.st
@@ -231,6 +231,7 @@ RePullUpMethodDriver >> selectMethodsAndClass [
 	classes := class allSuperclasses removeAllSuchThat: [ :each |
 		           each == Object or: [ each == ProtoObject ] ].
 	dialog := self methodsAndSuperclassSelectionPresenterClass
+		          title: 'There are potential breaking changes!'
 		          label: 'Methods to be pulled up'
 		          dropLabel: 'Pull up methods from ' , class name , ' to:'
 		          withItems:
@@ -239,8 +240,8 @@ RePullUpMethodDriver >> selectMethodsAndClass [
 		          selecting: methods asOrderedCollection
 		          dropItems: classes
 		          acceptBlock: [ :selectedClass :selectedMethods |
-			          superclass := selectedClass.
-			          methods := selectedMethods ].
+				          superclass := selectedClass.
+				          methods := selectedMethods ].
 
 	dialog cancelled ifFalse: [ ^ self ].
 	superclass := nil.

--- a/src/Refactoring-UI/RePullUpMethodDriver.class.st
+++ b/src/Refactoring-UI/RePullUpMethodDriver.class.st
@@ -133,7 +133,7 @@ RePullUpMethodDriver >> configureRefactoring [
 { #category : 'execution' }
 RePullUpMethodDriver >> defaultSelectDialog [
 
-	^ self application newSelectMultiple
+	^ self defaultSelectDialog 
 		  title: 'There are potential breaking changes!';
 		  label: self labelBasedOnBreakingChanges;
 		  items: self breakingChoices;

--- a/src/Refactoring-UI/RePushDownMethodDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodDriver.class.st
@@ -163,6 +163,7 @@ RePushDownMethodDriver >> selectMethods [
 
 	| dialog |
 	dialog := self methodsSelectionPresenterClass 
+		          title: 'There are potential breaking changes!'
 		          label: 'Push down methods from ' , class name
 		          withItems:
 			          (class methods sort: [ :a :b | a asString < b asString ])

--- a/src/Refactoring-UI/StAbstractSelectionPresenter.class.st
+++ b/src/Refactoring-UI/StAbstractSelectionPresenter.class.st
@@ -39,6 +39,20 @@ StAbstractSelectionPresenter class >> label: aString dropLabel: aString2 withIte
 		openBlockedDialog
 ]
 
+{ #category : 'specs' }
+StAbstractSelectionPresenter class >> title: aTitle label: aString dropLabel: aString2 withItems: items selecting: selectedItems dropItems: dropItems acceptBlock: aBlock [
+
+	^ self new
+		  title: aTitle
+		  label: aString
+		  dropLabel: aString2
+		  withItems: items
+		  selecting: selectedItems
+		  dropItems: dropItems
+		  acceptBlock: aBlock;
+		  openBlockedDialog
+]
+
 { #category : 'actions' }
 StAbstractSelectionPresenter >> accept [
 	acceptBlock value: self selectedItem value: table selectedItems
@@ -76,4 +90,14 @@ StAbstractSelectionPresenter >> label: aString dropLabel: dropString withItems: 
 { #category : 'accessing' }
 StAbstractSelectionPresenter >> selectedItem [
 	^ dropList selectedItem
+]
+
+{ #category : 'initialization' }
+StAbstractSelectionPresenter >> title: aTitle label: aString dropLabel: dropString withItems: items selecting: selItems dropItems: dropItems acceptBlock: aBlock [
+
+	titleHolder := aTitle.
+	self label: aString withItems: items selecting: selItems.
+	dropLabel label: dropString.
+	dropList items: dropItems.
+	acceptBlock := aBlock
 ]

--- a/src/Refactoring-UI/StItemsSelectionPresenter.class.st
+++ b/src/Refactoring-UI/StItemsSelectionPresenter.class.st
@@ -124,3 +124,13 @@ StItemsSelectionPresenter >> label: aString withItems: coll1 selecting: coll2 [
 StItemsSelectionPresenter >> selectedItems [
 	^ selectedItems
 ]
+
+{ #category : 'initialization' }
+StItemsSelectionPresenter >> title: aTitle label: aString withItems: coll1 selecting: coll2 [
+
+	titleHolder := aTitle.
+	label label: aString.
+	table
+		items: coll1;
+		selectItems: coll2
+]

--- a/src/Refactoring-UI/StItemsSelectionPresenter.class.st
+++ b/src/Refactoring-UI/StItemsSelectionPresenter.class.st
@@ -48,6 +48,18 @@ StItemsSelectionPresenter class >> label: aString withItems: items selecting: se
 		yourself 
 ]
 
+{ #category : 'specs' }
+StItemsSelectionPresenter class >> title: aTitle label: aString withItems: items selecting: selectedItems [
+
+	^ self new
+		  title: aTitle
+		  label: aString
+		  withItems: items
+		  selecting: selectedItems; 
+		  openBlockedDialog;
+		  yourself
+]
+
 { #category : 'actions' }
 StItemsSelectionPresenter >> accept [
 

--- a/src/Refactoring-UI/StSelectClassAndMethodsPresenter.class.st
+++ b/src/Refactoring-UI/StSelectClassAndMethodsPresenter.class.st
@@ -14,7 +14,8 @@ StSelectClassAndMethodsPresenter class >> example [
 		withItems: self class methods
 		selecting: OrderedCollection new
 		dropItems: self class allSubclasses
-		acceptBlock: [ :item :items |  ] )
+		acceptBlock: [ :item :items |  ] ).
+
 ]
 
 { #category : 'specs' }


### PR DESCRIPTION
Windows were unnamed before, so we needed a new opening method for the presenters used for those refactorings.
Fixes #18294 