### PR TITLE
FilePresenter: Fix cancelling of FilePresenter via UIManager

### DIFF
--- a/src/Polymorph-Widgets/UITheme.class.st
+++ b/src/Polymorph-Widgets/UITheme.class.st
@@ -814,18 +814,22 @@ UITheme >> chooseForSaveFileReferenceIn: aThemedMorph title: title extensions: e
 
 	| dialog directory |
 	dialog := self fileSaveDialogWindowClass new.
-	exts ifNotNil: [
-		dialog filter: (StCustomExtensionsFilter extensions: exts) ].
-	path ifNotNil: [
-		dialog nameText: path asFileReference nextVersion basename ].
+	exts ifNotNil: [ dialog filter: (StCustomExtensionsFilter extensions: exts) ].
+	path ifNotNil: [ dialog nameText: path asFileReference nextVersion basename ].
 	directory := path
 		             ifNil: [ StFileSystemModel defaultDirectory ]
 		             ifNotNil: [ path parent ].
-	^ dialog
-		  defaultFolder: directory;
-		  title: (title ifNil: [ 'Save as' translated ] ifNotNil: [ title ]);
-		  openModal;
-		  selectedEntry
+
+	dialog
+		defaultFolder: directory;
+		title: (title
+				 ifNil: [ 'Save as' translated ]
+				 ifNotNil: [ title ]);
+		openModal.
+
+	^ dialog cancelled
+		  ifTrue: [ nil ]
+		  ifFalse: [ dialog selectedEntry ]
 ]
 
 { #category : 'services' }

--- a/src/Polymorph-Widgets/WorldState.extension.st
+++ b/src/Polymorph-Widgets/WorldState.extension.st
@@ -19,12 +19,7 @@ WorldState class >> quitSession [
 WorldState class >> saveAs [
 
 	| reference |
-	reference := MorphicUIManager new
-		             chooseForSaveFileReference: 'Save Image as?'
-		             extensions: #( 'image' )
-		             path: Smalltalk imageFile nextVersion.
+	reference := self uiManager chooseForSaveFileReference: 'Save Image as?' extensions: #( 'image' ) path: Smalltalk imageFile nextVersion.
 
-	reference ifNotNil: [
-		Smalltalk saveAs:
-			reference parent / (reference basenameWithoutExtension: 'image') ]
+	reference ifNotNil: [ Smalltalk saveAs: reference parent / (reference basenameWithoutExtension: 'image') ]
 ]


### PR DESCRIPTION
If you request a filename via the UIManager and cancel, the name is still returned. This causes bugs. For example, when cancelling a "Save as...", it is still saved. I also removed a hardcoded ref to MorphicUIManager.

Fixes #18221

This is an improvement but we have multiple problems here. 
1) To me the "Save as..." should be in NewTools and not directly in Pharo since it has UI interactions and is part of the IDE. 
2) MorphicUIManager is using the FilePresenter from NewTools. This is a bad dependency
3) We should not use the UIManager at all

But this will be for future works