### PR TITLE
Fix Refactoring issue #18212

### DIFF
--- a/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
+++ b/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
@@ -196,7 +196,8 @@ ReRenameMethodRefactoring >> validSelectorCondition [
 ]
 
 { #category : 'accessing' }
-ReRenameMethodRefactoring >> violations [ 
+ReRenameMethodRefactoring >> violations [
 
-	^ self breakingChangePreconditions violators
+	^ self breakingChangePreconditions flatCollect: [ :each |
+		  each violators ]
 ]


### PR DESCRIPTION
Fix #18212 

An error occured when renaming a method that name exists already in the class.

The issue is a type error: breakingChangePreconditions returns a collection of RBConditions.
But in violations it was used as a single RBCondition.

Fixed with concatenating the violators on breakingChangePreconditions

