### PR TITLE
Avoid clean blocks for ED tests

### DIFF
--- a/src/EmergencyDebugger-Tests/EDTest.class.st
+++ b/src/EmergencyDebugger-Tests/EDTest.class.st
@@ -104,6 +104,8 @@ EDTest >> newEd [
 
 { #category : 'methods version' }
 EDTest >> prepareMethodVersionTest [
+	<compilerOptions: #(- #optionCleanBlockClosure)>
+
 	| context process |
 	EDMockObjectForTests compile: self sampleMethodSourceCodeVersion1.
 	EDMockObjectForTests compile: self sampleMethodSourceCodeVersion2.


### PR DESCRIPTION
Related to https://github.com/pharo-project/pharo/pull/18322

Activating the clean blocks in all the image causes failing tests on the ED.

This PR does not really fix the problem, but avoid the clean blocks in the guilty the method 🤷‍♂️ 