### PR TITLE
Fix: rename method violators are list and not single instance

### DIFF
--- a/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
+++ b/src/Refactoring-Core/ReRenameMethodRefactoring.class.st
@@ -198,5 +198,5 @@ ReRenameMethodRefactoring >> validSelectorCondition [
 { #category : 'accessing' }
 ReRenameMethodRefactoring >> violations [ 
 
-	^ self breakingChangePreconditions violators
+	^ self breakingChangePreconditions flatCollect: [ :each | each violators ]
 ]

--- a/src/Refactoring-UI/ReRenameMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRenameMethodDriver.class.st
@@ -33,7 +33,7 @@ ReRenameMethodDriver >> browseOverrides [
 	| overrides |
 	overrides := refactoring violations.
 	StMessageBrowser
-		browse: (overrides collect: [ :ref | ref realClass methodNamed: newMessage selector ])
+		browse: (overrides collect: [ :ref | ref realClass lookupSelector: newMessage selector ])
 		asImplementorsOf: newMessage selector
 ]
 


### PR DESCRIPTION
This has been fixed in Pharo14, this is just backport.