### PR TITLE
Fix: use correct method to find method

### DIFF
--- a/src/Refactoring-UI/ReRenameMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRenameMethodDriver.class.st
@@ -33,7 +33,7 @@ ReRenameMethodDriver >> browseOverrides [
 	| overrides |
 	overrides := refactoring violations.
 	StMessageBrowser
-		browse: (overrides collect: [ :ref | ref realClass methodNamed: newMessage selector ])
+		browse: (overrides collect: [ :ref | ref realClass lookupSelector: newMessage selector ])
 		asImplementorsOf: newMessage selector
 ]
 


### PR DESCRIPTION
This is port to Pharo14 of this fix:
- https://github.com/pharo-project/pharo/pull/18363

It also builds upon this PR that did first part of the fix:
- https://github.com/pharo-project/pharo/pull/18315