### PR TITLE
Fix lock DNU on P12 and on

### DIFF
--- a/src/Metacello-Core/MetacelloProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectSpec.class.st
@@ -713,6 +713,12 @@ MetacelloProjectSpec >> projectPackage: aProjectPackage [
     projectPackage := aProjectPackage
 ]
 
+{ #category : 'querying' }
+MetacelloProjectSpec >> projectReference [
+	
+	^ self
+]
+
 { #category : 'scripting' }
 MetacelloProjectSpec >> registration [
     ^ MetacelloProjectRegistration


### PR DESCRIPTION
Attempt to fix the following issues in Pharo 12:

https://github.com/pharo-project/pharo/issues/14130
https://github.com/pharo-project/pharo/issues/17645

@marschall would you mind testing?
If this is ok, we can propose ports for Pharo 13 and 14.

## What I tested
I tested myself the following configs:

 - loading grease then locking
 - locking directly (should load also)
 - register/unregister and unlock also because they went through similar paths

## What I found

Turns out that calling `load` and `lock` in separate steps does not behave exactly the same as just `lock`ing.
I worked it around by making project references polymorphic to specs.

Cheers,