### PR TITLE
continue-to-generate-P30-artifacts

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -236,6 +236,6 @@ rm -f *.bak
 # delete Pharo60 sources files
 rm PharoV60.sources*
 
-PHARO_SOURCES_PREFIX=$(echo "${PHARO_NAME_PREFIX}" | cut -d'-' -f 1 | cut -d'.' -f 1-2)
+PHARO_SOURCES_PREFIX=$(echo "Pharo${PHARO_MAJOR}.${PHARO_MINOR}-${PHARO_SUFFIX}" | cut -d'-' -f 1 | cut -d'.' -f 1-2)
 zip "${PHARO_IMAGE_NAME}.zip" ${PHARO_IMAGE_NAME}.* ${PHARO_SOURCES_PREFIX}*.sources pharo.version
 

--- a/bootstrap/scripts/envversion.sh
+++ b/bootstrap/scripts/envversion.sh
@@ -55,10 +55,17 @@ function set_version_common() {
     PHARO_MINOR="$(git describe --tags --first-parent | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 2-2)"
     PHARO_PATCH="$(git describe --tags --first-parent | cut -d'-' -f 1 | cut -c 2- | cut -d'.' -f 3-3)"
 
+	# I am hardcoding here so we have Pharo13.0-PR and 130 as short version
+	# We want to make it transparent for the user so the file name and the zeroconf works with 130
+	# This is a hack and we should not push it to newer versions of the repository (it is for P13, and not for P14)
+
 	# This will answer "Pharo7.0-PR"
-	PHARO_NAME_PREFIX="Pharo${PHARO_MAJOR}.${PHARO_MINOR}-${PHARO_SUFFIX}"
+	# PHARO_NAME_PREFIX="Pharo${PHARO_MAJOR}.${PHARO_MINOR}-${PHARO_SUFFIX}"
+	PHARO_NAME_PREFIX="Pharo${PHARO_MAJOR}.0-${PHARO_SUFFIX}"
+
     # This will answer "70"
-	PHARO_SHORT_VERSION="${PHARO_MAJOR}${PHARO_MINOR}"
+	# PHARO_SHORT_VERSION="${PHARO_MAJOR}${PHARO_MINOR}"
+	PHARO_SHORT_VERSION="${PHARO_MAJOR}0"
 }
 
 # sets variables when we are in a release build

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -463,7 +463,7 @@ ReleaseTest >> testPharoVersionFileExists [
 	self assert: pharoVersionFile exists.
 	self
 		assert: pharoVersionFile readStream contents trimBoth
-		equals: SystemVersion current major asString,  SystemVersion current minor asString
+		equals: '130' "We need to hardcode it so it works well for Pharo13, as we have 13.1... in the future versions should not be hardcoded"
 ]
 
 { #category : 'tests - package' }


### PR DESCRIPTION
We need to continue generating the artifacts with P30, so the launcher and zero conf works transparently.