### PR TITLE
Enable Full Blocks without outer context

### DIFF
--- a/src/OpalCompiler-Core/OCCompilationContext.class.st
+++ b/src/OpalCompiler-Core/OCCompilationContext.class.st
@@ -328,7 +328,7 @@ OCCompilationContext class >> optionsDescription [
 	(+ optionInlineRepeat 			'Inline repeat if specific conditions are met (See isInlineRepeat)')
 	(- optionInlineNone 				'To turn off all inlining options. Overrides the others')
 
-	(- optionBlockClosureOptionalOuter 			'Compiler compiles closure creation with outerContext only if it has a non-local return. Experimental')
+	(+ optionBlockClosureOptionalOuter 			'Compiler compiles closure creation with outerContext only if it has a non-local return. Experimental')
 	(+ optionConstantBlockClosure 			'Compiler compiles closure creation to use ConstantBlockClosure for constant with 0-3 arguments. Experimental')
 	(+ optionCleanBlockClosure 			'Compiler compiles closure creation to use CleanBlockClosure instead of FullBlockClosure for clean blocks. Experimental')
 	(- optionLongIvarAccessBytecodes 	'Specific inst var accesses to Maybe context objects')


### PR DESCRIPTION
This PR enables the option for Full Blocks ot not have an outerContext if it is not needed.

Let's see how many tests fail