### PR TITLE
Update version in #iceberg for BaselineOfPharo for Pharo 12 to ‘v2.3.4’

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -60,7 +60,7 @@ BaselineOfPharo class >> iceberg [
 		newName: 'Iceberg' 
 		owner: 'pharo-vcs' 
 		project: 'iceberg'
-		version: 'v2.3.3' 
+		version: 'v2.3.4' 
 		sourceDir: nil
 ]
 


### PR DESCRIPTION
This pull request updates the version in #iceberg for BaselineOfPharo for Pharo 12 to ‘v2.3.4’.

Before merging this please:
* Merge [Iceberg pull request #1949](https://github.com/pharo-vcs/iceberg/pull/1949)
* Tag the resulting Iceberg ‘Pharo12’ commit as ‘v2.3.4’