### PR TITLE
Adding restart world option

### DIFF
--- a/src/OSWindow-Core/OSWindowDriver.class.st
+++ b/src/OSWindow-Core/OSWindowDriver.class.st
@@ -146,6 +146,10 @@ OSWindowDriver >> afterMainPharoWindowCreated: aWindow [
 OSWindowDriver >> afterSetWindowTitle: windowTitle onWindow: osWindow [
 ]
 
+{ #category : 'events' }
+OSWindowDriver >> beforeMainPharoWindowClosed: aWindow [
+]
+
 { #category : 'window creation' }
 OSWindowDriver >> createWindowWithAttributes: anOSWindowAttributes osWindow: osWindow [
 	self subclassResponsibility

--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -62,6 +62,19 @@ OSWorldRenderer class >> priority [
 	^ 2
 ]
 
+{ #category : 'start' }
+OSWorldRenderer class >> restart [
+
+	UIManager default deactivate.
+	self shutDown: true.
+	OSSDL2Driver shutDown: true.
+
+	self startUp: true.
+	UIManager default activate.
+	
+	self inform: self class name , ' restarted'
+]
+
 { #category : 'settings' }
 OSWorldRenderer class >> settingsOn: aBuilder [
 
@@ -171,10 +184,12 @@ OSWorldRenderer >> copyRectangle: aRectangle into: aForm [
 	^ aForm
 ]
 
-{ #category : 'private' }
+{ #category : 'activation' }
 OSWorldRenderer >> deactivate [
 
-	osWindow ifNotNil: [ osWindow destroy. osWindow := nil ].
+	osWindow ifNotNil: [ 
+		driver beforeMainPharoWindowClosed: osWindow.
+		osWindow destroy. osWindow := nil ].
 	display := nil
 ]
 

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -769,6 +769,10 @@ OSSDL2BackendWindow >> visitMouseWheelEvent: sdlEvent [
 { #category : 'event handling' }
 OSSDL2BackendWindow >> visitSystemWindowEvent: systemWindowEvent [
 
+	systemWindowEvent isWindows ifFalse: [ ^ nil ].
+	
+	systemWindowEvent windowsMessage isDisplayChanged ifFalse: [ ^ nil ].
+
 	self fetchDPI.
 	(OSWindowResolutionChangeEvent for: osWindow)
 		horizontalDPI: horizontalDPI;

--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -55,6 +55,13 @@ OSSDL2Driver >> afterSetWindowTitle: windowTitle onWindow: osWindow [
 		afterSetWindowTitle: windowTitle onWindow: osWindow
 ]
 
+{ #category : 'events' }
+OSSDL2Driver >> beforeMainPharoWindowClosed: osWindow [
+
+	OSPlatform current sdlPlatform
+		beforeMainPharoWindowClosed: osWindow
+]
+
 { #category : 'private' }
 OSSDL2Driver >> closeRemovedController: index [
 	"TODO: What should I do here?"
@@ -537,5 +544,23 @@ OSSDL2Driver >> visitJoyDeviceRemovedEvent: joyEvent [
 
 { #category : 'global events' }
 OSSDL2Driver >> visitQuitEvent: quitEvent [
+	^ nil
+]
+
+{ #category : 'global events' }
+OSSDL2Driver >> visitSystemWindowEvent: systemWindowEvent [
+
+	systemWindowEvent isWindows ifFalse: [ ^ nil ].	
+
+	systemWindowEvent windowsMessage isWTSessionChange 
+		ifTrue: [ 
+			^ OSPlatform current sdlPlatform handleWTSessionChange: 
+				systemWindowEvent windowsMessage].
+
+
+	systemWindowEvent windowsMessage isSysCommand ifTrue: [
+			^ OSPlatform current sdlPlatform handleSystemCommand:
+				systemWindowEvent windowsMessage ].
+
 	^ nil
 ]

--- a/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2FormRenderer.class.st
@@ -83,7 +83,7 @@ OSSDL2FormRenderer >> primitiveUpdateRectangle: rectangle externalForm: external
 	"We need to do this ugly hack because the Mutex that is used in the renderer is not correctly liberated when there is an exception. Issue #10156. Once it is fixed, we can signal the exception as normal people."
 
 	[externalForm copy: rectangle from: form to: rectangle origin rule: Form over]
-		on:Exception do: [ :e | ('There was an error during copy, we should not throw an exception here:' , e printString) traceCr ]
+		on:Exception do: [ :e | Stdio stdout << ('There was an error during copy, we should not throw an exception here:' , e printString); crlf; flush. ]
 ]
 
 { #category : 'updating screen' }

--- a/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLAbstractPlatform.class.st
@@ -28,6 +28,12 @@ SDLAbstractPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 	self subclassResponsibility
 ]
 
+{ #category : 'operations' }
+SDLAbstractPlatform >> beforeMainPharoWindowClosed: aOSSDLWindow [
+
+	self subclassResponsibility
+]
+
 { #category : 'configuration' }
 SDLAbstractPlatform >> defaultRendererFlags [
 	"We have no special flags for the renderer.

--- a/src/OSWindow-SDL2/SDLNullPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLNullPlatform.class.st
@@ -17,6 +17,10 @@ SDLNullPlatform >> afterMainPharoWindowCreated: aOSSDLWindow [
 SDLNullPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 ]
 
+{ #category : 'operations' }
+SDLNullPlatform >> beforeMainPharoWindowClosed: aOSSDLWindow [
+]
+
 { #category : 'initialization' }
 SDLNullPlatform >> initPlatformSpecific [
 

--- a/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
@@ -230,7 +230,7 @@ SDLOSXPharoMenu >> doQuit [
 { #category : 'menu options' }
 SDLOSXPharoMenu >> doRestartWorld [
 
-	UIManager default defer: [ UIManager default restart ]
+	UIManager default defer: [ OSWorldRenderer restart ]
 ]
 
 { #category : 'api' }

--- a/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPharoMenu.class.st
@@ -11,7 +11,8 @@ Class {
 		'doAboutCallback',
 		'pharoTargetObject',
 		'doQuitCallback',
-		'doPreferencesCallback'
+		'doPreferencesCallback',
+		'doRestartWorldCallback'
 	],
 	#classVars : [
 		'UniqueInstance'
@@ -76,18 +77,36 @@ SDLOSXPharoMenu >> addMenuItemTo: menu title: aTitle withSubMenu: aNSMenu [
 { #category : 'private' }
 SDLOSXPharoMenu >> addPharoMenuOptions [
 
-	| selDoAbout selDoQuit selRemoveAllItems selDoPreferences |
+	| selDoAbout selDoQuit selRemoveAllItems selDoPreferences selDoRestartWorld |
+
 	selDoAbout := ObjCLibrary uniqueInstance lookupSelector: 'doAbout'.
 	selDoQuit := ObjCLibrary uniqueInstance lookupSelector: 'doQuit'.
 	selDoPreferences := ObjCLibrary uniqueInstance lookupSelector: 'doPreferences'.
+	selDoRestartWorld := ObjCLibrary uniqueInstance lookupSelector: 'doRestartWorld'.
 
 	selRemoveAllItems := ObjCLibrary uniqueInstance lookupSelector: 'removeAllItems'.
 	ObjCLibrary uniqueInstance sendMessage: selRemoveAllItems to: self pharoMenu.
 
-	self addMenuItemTo: self pharoMenu title: 'About Pharo' shortcut: '' selector: selDoAbout.
+	self
+		addMenuItemTo: self pharoMenu
+		title: 'About Pharo'
+		shortcut: ''
+		selector: selDoAbout.
+
 	self addSeparatorTo: self pharoMenu.
 
-	self addMenuItemTo: self pharoMenu title: 'Preferences' shortcut: ',' selector: selDoPreferences.
+	self
+		addMenuItemTo: self pharoMenu
+		title: 'Preferences'
+		shortcut: ','
+		selector: selDoPreferences.
+	
+	self
+		addMenuItemTo: self pharoMenu
+		title: 'Restart World Window'
+		shortcut: ''
+		selector: selDoRestartWorld.
+		
 	self addSeparatorTo: self pharoMenu.
 	
 	self addServicesMenuTo: self pharoMenu.
@@ -144,14 +163,31 @@ SDLOSXPharoMenu >> allocatePharoMenuTarget [
 		name: 'PharoMenuTargetClass' 
 		extraBytes: 0.
 	
-	doAboutCallback := self addCallbackForSelector: 'doAbout' withBlock: [ self doAbout ] toTargetClass: pharoMenuTargetClass.
-	doPreferencesCallback := self addCallbackForSelector: 'doPreferences' withBlock: [ self doPreferences ] toTargetClass: pharoMenuTargetClass.
-	doQuitCallback := self addCallbackForSelector: 'doQuit' withBlock: [ self doQuit ] toTargetClass: pharoMenuTargetClass.
-			
-	ObjCLibrary uniqueInstance objc_registerClassPair: pharoMenuTargetClass.
-	
-	pharoTargetObject := ObjCLibrary uniqueInstance sendMessage: selAlloc to: pharoMenuTargetClass.
+	doAboutCallback := self
+		                   addCallbackForSelector: 'doAbout'
+		                   withBlock: [ self doAbout ]
+		                   toTargetClass: pharoMenuTargetClass.
 
+	doPreferencesCallback := self
+		                         addCallbackForSelector: 'doPreferences'
+		                         withBlock: [ self doPreferences ]
+		                         toTargetClass: pharoMenuTargetClass.
+
+	doQuitCallback := self
+		                  addCallbackForSelector: 'doQuit'
+		                  withBlock: [ self doQuit ]
+		                  toTargetClass: pharoMenuTargetClass.
+	
+	doRestartWorldCallback := self
+		                  addCallbackForSelector: 'doRestartWorld'
+		                  withBlock: [ self doRestartWorld ]
+		                  toTargetClass: pharoMenuTargetClass.
+
+	ObjCLibrary uniqueInstance objc_registerClassPair: pharoMenuTargetClass.
+
+	pharoTargetObject := ObjCLibrary uniqueInstance
+		                     sendMessage: selAlloc
+		                     to: pharoMenuTargetClass
 ]
 
 { #category : 'menu options' }
@@ -189,6 +225,12 @@ SDLOSXPharoMenu >> doPreferences [
 SDLOSXPharoMenu >> doQuit [
 
 	UIManager default defer: [WorldState quitSession] 
+]
+
+{ #category : 'menu options' }
+SDLOSXPharoMenu >> doRestartWorld [
+
+	UIManager default defer: [ UIManager default restart ]
 ]
 
 { #category : 'api' }

--- a/src/OSWindow-SDL2/SDLOSXPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLOSXPlatform.class.st
@@ -56,6 +56,10 @@ SDLOSXPlatform >> allowTouchpadInertia [
 	ObjCLibrary uniqueInstance release: key.
 ]
 
+{ #category : 'operations' }
+SDLOSXPlatform >> beforeMainPharoWindowClosed: aOSSDLWindow [
+]
+
 { #category : 'configuration' }
 SDLOSXPlatform >> defaultRendererFlags [ 
 

--- a/src/OSWindow-SDL2/SDLUnixPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLUnixPlatform.class.st
@@ -18,6 +18,10 @@ SDLUnixPlatform >> afterMainPharoWindowCreated: aOSSDLWindow [
 SDLUnixPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
 ]
 
+{ #category : 'operations' }
+SDLUnixPlatform >> beforeMainPharoWindowClosed: aOSSDLWindow [
+]
+
 { #category : 'initialization' }
 SDLUnixPlatform >> initPlatformSpecific [
 

--- a/src/OSWindow-SDL2/SDLWindowsPlatform.class.st
+++ b/src/OSWindow-SDL2/SDLWindowsPlatform.class.st
@@ -16,22 +16,114 @@ SDLWindowsPlatform class >> enableDebugWindowMenu: hwnd [
 ]
 
 { #category : 'operations' }
+SDLWindowsPlatform >> addRestartUIManagerOption: handle [
+
+    | windowMenu | 
+
+	windowMenu := self getSystemMenu: handle.
+	self 
+		appendMenu: windowMenu 
+		flags: 0 "MF_STRING" 
+		idNewItem: self restartUIManagerMenuID 
+		newItemString: 'Restart World Window' asWin32WideString
+
+]
+
+{ #category : 'operations' }
 SDLWindowsPlatform >> afterMainPharoWindowCreated: aOSSDLWindow [
 
 	| sdlWindowInfo handle |
-	[	sdlWindowInfo := aOSSDLWindow backendWindow getWMInfo.
-		handle := sdlWindowInfo info win window.
+	sdlWindowInfo := aOSSDLWindow backendWindow getWMInfo.
+	handle := sdlWindowInfo info win window.
+	self enableDebugWindowMenu: handle. 
 
-		self class enableDebugWindowMenu: handle ]
-	onErrorDo: [
-		"There was an error installing the support for debug Window, the VM is not new enough." ].
+	self addRestartUIManagerOption: handle.
 
 	"I want to receive the System Windows events"
-	SDL2 eventType: SDL_SYSWMEVENT state: 1
+	SDL2 eventType: SDL_SYSWMEVENT state: 1.
+	
+	self wtsRegisterSessionNotification: handle.
+
 ]
 
 { #category : 'operations' }
 SDLWindowsPlatform >> afterSetWindowTitle: aString onWindow: aOSSDLWindow [
+]
+
+{ #category : 'operations' }
+SDLWindowsPlatform >> appendMenu: hMenu flags: uFlags idNewItem: uIDNewItem newItemString: lpNewItem [
+
+	self 
+			ffiCall: #(bool AppendMenuW(void* hMenu, uint uFlags, uint uIDNewItem, Win32WideString lpNewItem))
+			module: 'User32.dll'
+
+]
+
+{ #category : 'operations' }
+SDLWindowsPlatform >> beforeMainPharoWindowClosed: aOSSDLWindow [
+
+	| sdlWindowInfo handle |
+	sdlWindowInfo := aOSSDLWindow backendWindow getWMInfo.
+	handle := sdlWindowInfo info win window.
+ 
+	self wtsUnRegisterSessionNotification: handle.
+
+]
+
+{ #category : 'initialization' }
+SDLWindowsPlatform >> enableDebugWindowMenu: handle [
+
+	^ [ self class enableDebugWindowMenu: handle ] 
+		onErrorDo: [ 
+			"There was an error installing the support for debug Window, the VM is not new enough."
+		   ]
+]
+
+{ #category : 'operations' }
+SDLWindowsPlatform >> getActiveConsoleSessionId [
+
+	self ffiCall: #(int32 WTSGetActiveConsoleSessionId()) module: 'Kernel32.dll'
+]
+
+{ #category : 'operations' }
+SDLWindowsPlatform >> getRemoteSessionId [
+
+	^ (self getSystemMetrics: "SM_REMOTESESSION" 16r1000) = 0 
+		ifTrue: [ nil ]
+		ifFalse: [ self getActiveConsoleSessionId ]
+]
+
+{ #category : 'operations' }
+SDLWindowsPlatform >> getSystemMenu: handle [
+
+	self ffiCall: #(void* GetSystemMenu(void* handle, bool false)) module: 'User32.dll'
+]
+
+{ #category : 'operations' }
+SDLWindowsPlatform >> getSystemMetrics: nIndex [
+
+	self
+		ffiCall: #( int GetSystemMetrics #( int nIndex ) )
+		module: 'User32.dll'
+]
+
+{ #category : 'event handling' }
+SDLWindowsPlatform >> handleSystemCommand: aWindowMessage [
+
+	aWindowMessage wParam = self restartUIManagerMenuID ifTrue: [
+		UIManager default defer: [ OSWorldRenderer restart ] ].
+	
+	^ nil
+]
+
+{ #category : 'event handling' }
+SDLWindowsPlatform >> handleWTSessionChange: aWindowMessage [
+
+	"WTS_SESSION_UNLOCK"
+	aWindowMessage wParam = 8 ifTrue: [
+		UIManager default defer: [ OSWorldRenderer restart ] ]. 
+
+	^ nil
 ]
 
 { #category : 'initialization' }
@@ -41,6 +133,12 @@ SDLWindowsPlatform >> initPlatformSpecific [
 	This does not work properly on OSX with retina display, blurrying the rendering"
 
 	SDL2 setHint: SDL_HINT_RENDER_SCALE_QUALITY value: '1'
+]
+
+{ #category : 'operations' }
+SDLWindowsPlatform >> restartUIManagerMenuID [
+
+	^ 16rE002 "Next Value for menu item"
 ]
 
 { #category : 'initialization' }
@@ -65,4 +163,17 @@ SDLWindowsPlatform >> systemCursorConversionTable [
        #webLink -> #SDL_SYSTEM_CURSOR_HAND.
 
 		}
+]
+
+{ #category : 'operations' }
+SDLWindowsPlatform >> wtsRegisterSessionNotification: handle [
+
+	"Notify for this session NOTIFY_FOR_THIS_SESSION = 0"
+	self ffiCall: #(bool WTSRegisterSessionNotification(void* handle, int32 0)) module: 'Wtsapi32.dll'
+]
+
+{ #category : 'operations' }
+SDLWindowsPlatform >> wtsUnRegisterSessionNotification: handle [
+	
+	self ffiCall: #(bool WTSUnRegisterSessionNotification(void* handle)) module: 'Wtsapi32.dll'
 ]

--- a/src/OSWindow-SDL2/SDL_SysWMEvent.class.st
+++ b/src/OSWindow-SDL2/SDL_SysWMEvent.class.st
@@ -39,9 +39,6 @@ SDL_SysWMEvent class >> fieldsDesc [
 { #category : 'visitor' }
 SDL_SysWMEvent >> accept: aVisitor [
 
-	self isWindows ifFalse: [ ^ nil ].
-	self windowsMessage isDisplayChanged ifFalse: [ ^ nil ].
-
 	^ aVisitor visitSystemWindowEvent: self
 ]
 

--- a/src/OSWindow-SDL2/SDL_SysWMmsg_Windows.class.st
+++ b/src/OSWindow-SDL2/SDL_SysWMmsg_Windows.class.st
@@ -44,9 +44,27 @@ SDL_SysWMmsg_Windows >> hwnd: anObject [
 ]
 
 { #category : 'testing' }
+SDL_SysWMmsg_Windows >> isDeviceChange [
+
+	^ self msg = WM_DEVICECHANGE
+]
+
+{ #category : 'testing' }
 SDL_SysWMmsg_Windows >> isDisplayChanged [
 
 	^ self msg = WM_DISPLAYCHANGE
+]
+
+{ #category : 'testing' }
+SDL_SysWMmsg_Windows >> isSysCommand [
+
+	^ self msg = WM_SYSCOMMAND
+]
+
+{ #category : 'testing' }
+SDL_SysWMmsg_Windows >> isWTSessionChange [
+
+	^ self msg = WM_WTSSESSION_CHANGE
 ]
 
 { #category : 'accessing - structure variables' }

--- a/src/UIManager/UIManager.class.st
+++ b/src/UIManager/UIManager.class.st
@@ -618,6 +618,15 @@ UIManager >> requestPassword: queryString [
 	^self subclassResponsibility
 ]
 
+{ #category : 'start' }
+UIManager >> restart [
+
+	self
+		deactivate;
+		activate.
+	self inform: self class name , ' restarted'
+]
+
 { #category : 'display' }
 UIManager >> showWaitCursorWhile: aBlock [
 	| process |

--- a/src/UIManager/UIManager.class.st
+++ b/src/UIManager/UIManager.class.st
@@ -618,15 +618,6 @@ UIManager >> requestPassword: queryString [
 	^self subclassResponsibility
 ]
 
-{ #category : 'start' }
-UIManager >> restart [
-
-	self
-		deactivate;
-		activate.
-	self inform: self class name , ' restarted'
-]
-
 { #category : 'display' }
 UIManager >> showWaitCursorWhile: aBlock [
 	| process |


### PR DESCRIPTION

When connecting to a RDP session, we recreate the main Morphic world. 

Adding an option to force the restart of the morphic world, in case the SDL rendering is broken

In Windows: 

<img width="324" height="286" alt="image" src="https://github.com/user-attachments/assets/7fc26401-bc33-46ec-9bd6-c74285217733" />


In Mac:

<img width="325" height="264" alt="image" src="https://github.com/user-attachments/assets/22a7c03e-593d-49b5-a736-5a94fae762fe" />


# Detailled Changes:

- Adding restart message to the UIManager to force the restart, restarting Morphic or the UI handler that we are using
- Adding a menu option in MacOS for restarting the UIManager.
- Adding event to handle beforeMainPharoWindowClosed
- Adding operation to the OSWorldRenderer to restart
- Adding a menu entry for the main window (in Windows) to reset the OSWorldRenderer
- Better handling of SystemWindowEvents
- Get information about the RemoteTerminal
- Handle logon of RemoteDesktop to force the OSWorldRenderer restarting 

Fix https://github.com/pharo-project/pharo-vm/issues/983
as it is an issue in the image side, as SDL does not handle well reconecting to a RDP session.
