### PR TITLE
Fix 18350: DrTest: running doc comments sometimes fails

### DIFF
--- a/src/DrTests/DrTests.class.st
+++ b/src/DrTests/DrTests.class.st
@@ -230,8 +230,8 @@ DrTests >> reloadConfiguration: aDTPluginConfiguration withResults: aDTPluginRes
 
 { #category : 'accessing' }
 DrTests >> selectedItems [
-
-	^ pluginPresenter selectedItems
+	"selectedItems is sometimes an Array"
+	^ pluginPresenter selectedItems asOrderedCollection
 ]
 
 { #category : 'accessing - model' }


### PR DESCRIPTION
fixes #18350 by making sure we get an ordered collection