### PR TITLE
Deprecate BlockClosure>>#sender

### DIFF
--- a/src/Kernel-CodeModel/BlockClosure.class.st
+++ b/src/Kernel-CodeModel/BlockClosure.class.st
@@ -599,7 +599,7 @@ BlockClosure >> repeatWithGCIf: testBlock [
 
 { #category : 'accessing' }
 BlockClosure >> sender [	
-	<reflection: 'Message sending and code execution - Message send reification'>
+	self deprecated: 'Blocks do not have senders. As the outerContext or home context instead, but take care: clean blocks do not know the context!'.
 	^ self subclassResponsibility
 ]
 

--- a/src/Kernel-CodeModel/CleanBlockClosure.class.st
+++ b/src/Kernel-CodeModel/CleanBlockClosure.class.st
@@ -145,7 +145,7 @@ CleanBlockClosure >> refersToLiteral: aLiteral [
 { #category : 'debugger access' }
 CleanBlockClosure >> sender [
 	" clean blocks do not know the sender"
-	<reflection: 'Message sending and code execution - Message send reification'>
+	self deprecated: 'Blocks do not have senders. As the outerContext or home context instead, but take care: clean blocks do not know the context!'.
 	^nil
 ]
 

--- a/src/Kernel-CodeModel/FullBlockClosure.class.st
+++ b/src/Kernel-CodeModel/FullBlockClosure.class.st
@@ -32,6 +32,6 @@ FullBlockClosure >> receiver: anObject [
 { #category : 'accessing' }
 FullBlockClosure >> sender [
 	"Answer the context that sent the message that created the receiver."
-	<reflection: 'Message sending and code execution - Message send reification'>
+	self deprecated: 'Blocks do not have senders. As the outerContext or home context instead, but take care: clean blocks do not know the context!'.
 	^outerContext sender
 ]


### PR DESCRIPTION
This PR deprecates #sender on BlockClosure. Closures do not have a #sender. 

This was a leftover from the ST80 closure model where closures are represented by the *context* of the closure.

fixes  #18384
