### PR TITLE
Improve simulation of suspend primitive

### DIFF
--- a/src/Kernel-CodeModel/Context.class.st
+++ b/src/Kernel-CodeModel/Context.class.st
@@ -631,8 +631,9 @@ Context >> doPrimitive: primitiveIndex method: meth receiver: aReceiver args: ar
 			ifFalse: [ ^self send: (arguments at: 2) to: (arguments at: 1) with: (arguments at: 3) lookupIn: (arguments at: 4) ]
 		].
 
-	primitiveIndex = 88 ifTrue: ["Process>>suspend"
-		"Simulation of suspend primitive should do nothing (with receiver return) by two reasons:
+	(primitiveIndex = 88 and: [ aReceiver == Processor activeProcess ])
+		ifTrue: ["Process>>suspend"
+			"Simulation of suspend primitive should do nothing (with receiver return) by two reasons:
 			- if by mistake the receiver is a simulating process itself
 				the suspend would stop it and the simulation would hang.
 				For example the debugger can hang during stepping over #suspend of real active process.


### PR DESCRIPTION
Do call the suspend primitive if the process to suspend is not the active process.

This guarantees that suspension semantics are kept: removing the process from the suspension list, niling the suspension lists from the process, etc.