### PR TITLE
```StChangesBrowser``` registered as an application tool

### DIFF
--- a/src/NautilusRefactoring/StChangesBrowserPresenter.class.st
+++ b/src/NautilusRefactoring/StChangesBrowserPresenter.class.st
@@ -20,6 +20,13 @@ StChangesBrowserPresenter class >> changes: aCollection [
 	^ self on: aCollection
 ]
 
+{ #category : 'tools registry' }
+StChangesBrowserPresenter class >> registerToolsOn: registry [
+	"Add ourselves to registry. See [Smalltalk tools]"
+
+	registry register: self as: #changesBrowser 
+]
+
 { #category : 'visiting' }
 StChangesBrowserPresenter >> accept [
 


### PR DESCRIPTION
Since there is references to a constructor of this presenter with ```newApplication:```, we should reference it as an application tool

So the references of this presenter pass by the application, 
Fixes https://github.com/pharo-spec/NewTools/issues/1210#event-18702342323