### PR TITLE
New rule to avoid ```Smalltalk tools``` reference in spec

### DIFF
--- a/src/General-Rules-Tests/ReSpecShouldNotReferenceToolsRuleTest.class.st
+++ b/src/General-Rules-Tests/ReSpecShouldNotReferenceToolsRuleTest.class.st
@@ -25,16 +25,18 @@ ReSpecShouldNotReferenceToolsRuleTest >> tearDown [
 
 { #category : 'tests' }
 ReSpecShouldNotReferenceToolsRuleTest >> testRule [
- 
+
 	| class |
-	class := classFactory make: [ :builder | builder slots: { } ].
+	class := classFactory make: [ :builder |
+		         builder superclass: StPresenter ].
+
 	class
-		superclass: StPresenter;
 		compile: 'method ^ Smalltalk tools inspector'
 		classified: 'initialization'.
+
 	self
 		assert: (self myCritiquesOnMethod: class >> #method) size
-		equals: 1 
+		equals: 1
 ]
 
 { #category : 'tests' }

--- a/src/General-Rules-Tests/ReSpecShouldNotReferenceToolsRuleTest.class.st
+++ b/src/General-Rules-Tests/ReSpecShouldNotReferenceToolsRuleTest.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : 'ReSpecShouldNotReferenceToolsRuleTest',
+	#superclass : 'ReAbstractRuleTestCase',
+	#instVars : [
+		'classFactory'
+	],
+	#category : 'General-Rules-Tests-Optimization',
+	#package : 'General-Rules-Tests',
+	#tag : 'Optimization'
+}
+
+{ #category : 'running' }
+ReSpecShouldNotReferenceToolsRuleTest >> setUp [
+
+	super setUp.
+	classFactory := ClassFactoryForTestCase new
+]
+
+{ #category : 'running' }
+ReSpecShouldNotReferenceToolsRuleTest >> tearDown [
+
+	classFactory cleanUp.
+	super tearDown
+]
+
+{ #category : 'tests' }
+ReSpecShouldNotReferenceToolsRuleTest >> testRule [
+ 
+	| class |
+	class := classFactory make: [ :builder | builder slots: { } ].
+	class
+		superclass: StPresenter;
+		compile: 'method ^ Smalltalk tools inspector'
+		classified: 'initialization'.
+	self
+		assert: (self myCritiquesOnMethod: class >> #method) size
+		equals: 1 
+]
+
+{ #category : 'tests' }
+ReSpecShouldNotReferenceToolsRuleTest >> testRuleNotViolated [
+
+	self generateMethod: 'method ^ Smalltalk tools workspace open '.
+	self assertEmpty: (self myCritiquesOnMethod: self class >> #method)
+]

--- a/src/General-Rules/ReSpecShouldNotReferenceToolsRule.class.st
+++ b/src/General-Rules/ReSpecShouldNotReferenceToolsRule.class.st
@@ -1,5 +1,5 @@
 "
-This rule warn the user if ```Smalltalk Tools``` is referenced in a Spec subclass, which should not indeed.
+This rule warn the user if `Smalltalk tools` is referenced in a Spec subclass. Presenters should access the tools via the application doing `self application tools` instead.
 "
 Class {
 	#name : 'ReSpecShouldNotReferenceToolsRule',
@@ -26,7 +26,7 @@ ReSpecShouldNotReferenceToolsRule >> basicCheck: aNode [
 
 	| class |
 	aNode isMessage ifFalse: [ ^ false ].
-	class := aNode methodNode compiledMethod methodClass. 
+	class := aNode methodNode methodClass.
 	(class inheritsFrom: StPresenter) ifFalse: [ ^ false ].
 	^ self isToolReference: aNode
 ]
@@ -38,11 +38,8 @@ ReSpecShouldNotReferenceToolsRule >> isToolReference: aMessageNode [
 			Smalltalk tools tools valuesDo: [ :toolClass |
 				toolClass name = aMessageNode receiver name ifTrue: [ ^ true ] ] ].
 
-	(aMessageNode receiver isMessage and: [
-			 aMessageNode receiver selector = #tools and: [ 
-					 aMessageNode receiver receiver isVariable and: [
-						 aMessageNode receiver receiver name = #Smalltalk ] ] ])
-		ifTrue: [ ^ true ].
+	(aMessageNode receiver isVariable and: [
+		 aMessageNode receiver name = 'Smalltalk' ]) ifFalse: [ ^ false ].
 
-	^ false
+	^ aMessageNode keywords = #( 'tools' )
 ]

--- a/src/General-Rules/ReSpecShouldNotReferenceToolsRule.class.st
+++ b/src/General-Rules/ReSpecShouldNotReferenceToolsRule.class.st
@@ -4,9 +4,9 @@ This rule warn the user if ```Smalltalk Tools``` is referenced in a Spec subclas
 Class {
 	#name : 'ReSpecShouldNotReferenceToolsRule',
 	#superclass : 'ReNodeBasedRule',
-	#category : 'Renraku-Rules',
-	#package : 'Renraku',
-	#tag : 'Rules'
+	#category : 'General-Rules-Optimization',
+	#package : 'General-Rules',
+	#tag : 'Optimization'
 }
 
 { #category : 'accessing' }
@@ -39,10 +39,10 @@ ReSpecShouldNotReferenceToolsRule >> isToolReference: aMessageNode [
 				toolClass name = aMessageNode receiver name ifTrue: [ ^ true ] ] ].
 
 	(aMessageNode receiver isMessage and: [
-			 aMessageNode receiver selector = #tools and: [
+			 aMessageNode receiver selector = #tools and: [ 
 					 aMessageNode receiver receiver isVariable and: [
 						 aMessageNode receiver receiver name = #Smalltalk ] ] ])
 		ifTrue: [ ^ true ].
 
-	^ false 
+	^ false
 ]

--- a/src/Renraku/ReSpecShouldNotReferenceToolsRule.class.st
+++ b/src/Renraku/ReSpecShouldNotReferenceToolsRule.class.st
@@ -1,0 +1,48 @@
+"
+This rule warn the user if ```Smalltalk Tools``` is referenced in a Spec subclass, which should not indeed.
+"
+Class {
+	#name : 'ReSpecShouldNotReferenceToolsRule',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'Renraku-Rules',
+	#package : 'Renraku',
+	#tag : 'Rules'
+}
+
+{ #category : 'accessing' }
+ReSpecShouldNotReferenceToolsRule class >> ruleName [
+
+	^ 'Spec subclasses should not reference Smalltalk tools'
+]
+
+{ #category : 'accessing' }
+ReSpecShouldNotReferenceToolsRule class >> severity [
+
+	^ #warning
+]
+
+{ #category : 'running' }
+ReSpecShouldNotReferenceToolsRule >> basicCheck: aNode [
+
+	| class |
+	aNode isMessage ifFalse: [ ^ false ].
+	class := aNode methodNode compiledMethod methodClass. 
+	(class inheritsFrom: StPresenter) ifFalse: [ ^ false ].
+	^ self isToolReference: aNode
+]
+
+{ #category : 'testing' }
+ReSpecShouldNotReferenceToolsRule >> isToolReference: aMessageNode [
+
+	aMessageNode receiver isVariable ifTrue: [
+			Smalltalk tools tools valuesDo: [ :toolClass |
+				toolClass name = aMessageNode receiver name ifTrue: [ ^ true ] ] ].
+
+	(aMessageNode receiver isMessage and: [
+			 aMessageNode receiver selector = #tools and: [
+					 aMessageNode receiver receiver isVariable and: [
+						 aMessageNode receiver receiver name = #Smalltalk ] ] ])
+		ifTrue: [ ^ true ].
+
+	^ false 
+]

--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -84,3 +84,9 @@ PharoCommonTools class >> worldMenuOn: aBuilder [
 			a model."
 			((Smalltalk at: #IceTipRepositoriesBrowser) new) open ]
 ]
+
+{ #category : 'accessing' }
+PharoCommonTools >> tools [
+
+	^ tools
+]


### PR DESCRIPTION
-in Spec subclasses we should call ```application toolNamed:``` instead of ```Smalltalk tools```, this is why I implemented a new rule that raises a warning in critiques if theres a reference to Smalltalk tools in an ```StPresenter``` subclass.
Fixes #18420
