### PR TITLE
If outerContext is nil we do not return self sender anymore

### DIFF
--- a/src/Kernel-CodeModel/Context.class.st
+++ b/src/Kernel-CodeModel/Context.class.st
@@ -1244,9 +1244,9 @@ Context >> objectSize: anObject [
 { #category : 'accessing' }
 Context >> outerContext [
 	"Answer the context within which the receiver is nested."
+
 	<reflection: 'Stack Manipulation - Context'>
-	^closureOrNil ifNotNil:
-		[closureOrNil outerContext ifNil: ["if the outer is nil, this is a CleanBlock" self sender]]
+	^ closureOrNil ifNotNil: [ closureOrNil outerContext ]
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -143,8 +143,11 @@ OCAbstractMethodScope >> localTemps [
 OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aContext [
 	"Is this the definition context for var? If it not, we look in the outer context using the corresponding outer scope. If found, we return the context"
 
+	| nextContext |
+	nextContext := self nextOuterScopeContextOf: aContext.
+	nextContext ifNil: [ self error: var name, ' optimized out' ].
 	^self = var scope
-		ifFalse: [ self outerScope lookupDefiningContextForVariable: var startingFrom: (self nextOuterScopeContextOf: aContext) ]
+		ifFalse: [ self outerScope lookupDefiningContextForVariable: var startingFrom: nextContext ]
 		ifTrue: [ aContext ]
 ]
 

--- a/src/OpalCompiler-Core/OCBlockScope.class.st
+++ b/src/OpalCompiler-Core/OCBlockScope.class.st
@@ -41,5 +41,5 @@ OCBlockScope >> nextOuterScopeContextOf: aContext [
 	"Returns the next context to lookup a variable name from within outer scope.
 	If it is block context then we return outer context for lookup.
 	But if it is method context lookup will continue in same context but within outer scope"
-	^ aContext outerContext ifNil: [ aContext ]
+	^ aContext outerContext ifNil: [ self error: 'OuterContext is not available' ]
 ]

--- a/src/OpalCompiler-Core/OCBlockScope.class.st
+++ b/src/OpalCompiler-Core/OCBlockScope.class.st
@@ -41,5 +41,5 @@ OCBlockScope >> nextOuterScopeContextOf: aContext [
 	"Returns the next context to lookup a variable name from within outer scope.
 	If it is block context then we return outer context for lookup.
 	But if it is method context lookup will continue in same context but within outer scope"
-	^ aContext outerContext ifNil: [ self error: 'OuterContext is not available' ]
+	^ aContext outerContext
 ]

--- a/src/OpalCompiler-Tests/MethodMapExamples.class.st
+++ b/src/OpalCompiler-Tests/MethodMapExamples.class.st
@@ -25,6 +25,14 @@ MethodMapExamples >> exampleAccessOuterFromCleanBlock [
 ]
 
 { #category : 'examples' }
+MethodMapExamples >> exampleAccessOuterFromFullBlock [
+	<compilerOptions: #(- optionCleanBlockClosure)>
+	| b |
+	b := 1.
+	^[ thisContext tempNamed: 'b' ] value
+]
+
+{ #category : 'examples' }
 MethodMapExamples >> exampleConstantBlock [
 	
 	^ [ nil ]

--- a/src/OpalCompiler-Tests/MethodMapTest.class.st
+++ b/src/OpalCompiler-Tests/MethodMapTest.class.st
@@ -113,7 +113,16 @@ MethodMapTest >> testDeadContextSourceNode [
 
 { #category : 'tests - temp access' }
 MethodMapTest >> testExampleAccessOuterFromCleanBlock [
-	self assert: (self compileAndRunExample: #exampleAccessOuterFromCleanBlock) equals: 1
+"Should rise an exception since we are trying to access outerContext from a clean block"
+	self should: [(self compileAndRunExample: #exampleAccessOuterFromCleanBlock)] raise: Exception.
+
+]
+
+{ #category : 'tests - temp access' }
+MethodMapTest >> testExampleAccessOuterFromFullBLock [
+
+	self assert: (self compileAndRunExample: #exampleAccessOuterFromFullBlock) equals: 1
+
 ]
 
 { #category : 'tests - temp access' }

--- a/src/OpalCompiler-Tests/OCContextTempMappingTest.class.st
+++ b/src/OpalCompiler-Tests/OCContextTempMappingTest.class.st
@@ -33,7 +33,7 @@ OCContextTempMappingTest >> fetchArgFromOptimizedBlockInsideFullBlock: anArg ext
 
 { #category : 'tests' }
 OCContextTempMappingTest >> testAccessingArgOfOuterBlockFromAnotherDeepBlock [
-
+	<compilerOptions: #(- optionCleanBlockClosure)>
 	| actual |
 
 	"Check the source code availability to do not fail on images without sources"
@@ -41,7 +41,7 @@ OCContextTempMappingTest >> testAccessingArgOfOuterBlockFromAnotherDeepBlock [
 
 	actual := [:outerArg |
 		outerArg asString.
-		[ :innerArg | innerArg asString. thisContext tempNamed: #outerArg ] value: #innerValue.
+		[ :innerArg | innerArg asString.thisContext tempNamed: #outerArg ] value: #innerValue.
 		] value: #outerValue.
 
 	self assert: actual equals: #outerValue


### PR DESCRIPTION
Fix for #18387.
When trying to access a variable located in the outerContext of a block context if the block is clean it may happen that the value is not available. 

The current implementation traverse the stack trying to find the outerContext but it does not correctly works in many case. 

This PR proposes to remove the guessing and raise an exception if the block is clean, the UI traps that and shows it nicely.

<img width="427" height="87" alt="image" src="https://github.com/user-attachments/assets/bdbc0817-feba-4a33-8adb-6cef70cd381a" />
 

