### PR TITLE
Improve extension methods

### DIFF
--- a/src/Kernel-CodeModel/AdditionalMethodState.class.st
+++ b/src/Kernel-CodeModel/AdditionalMethodState.class.st
@@ -53,7 +53,7 @@ AdditionalMethodState class >> persistProperty: aSymbol [
 AdditionalMethodState class >> propertiesToPersist [
 	"See class comment."
 
-	^ PropertiesToPersist ifNil: [ PropertiesToPersist := Set <- #( #extensionPackage #extendedMethod #traitSource ) ]
+	^ PropertiesToPersist ifNil: [ PropertiesToPersist := Set <- #( #extensionPackage #beforeExtensionMethod #traitSource ) ]
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel-CodeModel/AdditionalMethodState.class.st
+++ b/src/Kernel-CodeModel/AdditionalMethodState.class.st
@@ -53,7 +53,7 @@ AdditionalMethodState class >> persistProperty: aSymbol [
 AdditionalMethodState class >> propertiesToPersist [
 	"See class comment."
 
-	^ PropertiesToPersist ifNil: [ PropertiesToPersist := Set <- #( #extensionPackage #traitSource ) ]
+	^ PropertiesToPersist ifNil: [ PropertiesToPersist := Set <- #( #extensionPackage #extendedMethod #traitSource ) ]
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -988,8 +988,11 @@ ClassDescription >> removeSelector: selector [
 	self removeFromProtocols: selector.
 
 	super removeSelector: selector.
-
-	self codeChangeAnnouncer methodRemoved: method origin: origin
+	self codeChangeAnnouncer methodRemoved: method origin: origin.
+	
+	method isExtension ifTrue: [ 
+		(method propertyAt: #extendedMethod) ifNotNil: [ :originalMethod |
+			self addSelector: selector withMethod: originalMethod ] ]
 ]
 
 { #category : 'instance variables' }

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -34,11 +34,19 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 			priorMethod := method.
 			priorOrigin := method origin ].
 
+
+	priorMethod ifNotNil: [  
+		(protocol asString beginsWith: '*') ifTrue: [ 
+			compiledMethod propertyAt: #extendedMethod put: priorMethod.
+			"See Package >> #addMethod:"
+		]
+	].
+
+	self addSelectorSilently: selector withMethod: compiledMethod.
+
 	oldProtocol := self protocolOfSelector: selector.
 	self codeChangeAnnouncer prevent: MethodRecategorized during: [ self classify: selector under: protocol ].
 	newProtocol := self protocolOfSelector: selector.
-
-	self addSelectorSilently: selector withMethod: compiledMethod.
 
 	self isAnonymous ifTrue: [ ^ self ].
 

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -37,7 +37,8 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 
 	priorMethod ifNotNil: [  
 		(protocol asString beginsWith: '*') ifTrue: [ 
-			compiledMethod propertyAt: #extendedMethod put: priorMethod.
+			protocol asString = priorMethod protocol name ifFalse: [ 
+				compiledMethod propertyAt: #extendedMethod put: priorMethod ].
 			"See Package >> #addMethod:"
 		]
 	].

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -38,7 +38,7 @@ ClassDescription >> addAndClassifySelector: selector withMethod: compiledMethod 
 	priorMethod ifNotNil: [  
 		(protocol asString beginsWith: '*') ifTrue: [ 
 			protocol asString = priorMethod protocol name ifFalse: [ 
-				compiledMethod propertyAt: #extendedMethod put: priorMethod ].
+				compiledMethod propertyAt: #beforeExtensionMethod put: priorMethod ].
 			"See Package >> #addMethod:"
 		]
 	].
@@ -992,7 +992,7 @@ ClassDescription >> removeSelector: selector [
 	self codeChangeAnnouncer methodRemoved: method origin: origin.
 	
 	method isExtension ifTrue: [ 
-		(method propertyAt: #extendedMethod) ifNotNil: [ :originalMethod |
+		(method propertyAt: #beforeExtensionMethod) ifNotNil: [ :originalMethod |
 			self addSelector: selector withMethod: originalMethod ] ]
 ]
 

--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -120,7 +120,7 @@ Package >> addMethod: aCompiledMethod [
 	(self includesClass: methodClass)
 		ifTrue: [ "We want to make sure the method is not considered an extension." aCompiledMethod removeProperty: #extensionPackage ]
 		ifFalse: [
-			aCompiledMethod propertyAt: #extensionPackage put: self. "We tag the method as an extension method."
+			aCompiledMethod propertyAt: #extensionPackage put: self.
 			(extensionSelectors at: methodClass ifAbsentPut: [ IdentitySet new ]) add: aCompiledMethod selector ].
 
 	^ aCompiledMethod

--- a/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
+++ b/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
@@ -437,6 +437,61 @@ CompiledMethodTest >> testEqualityInstanceSideMethod [
 ]
 
 { #category : 'tests - testing' }
+CompiledMethodTest >> testExtensionEditedPresistOriginalMethod [
+
+	[
+	| original extension |
+	self class compile: 'isExtensionTestMethod ^ 1' classified: 'protocol'.
+	original := self class >> #isExtensionTestMethod.
+	self deny: original isExtension.
+
+	self class compile: 'isExtensionTestMethod ^ 2' classified: '*Kernel-Tests-Generated-Package'.
+	extension := self class >> #isExtensionTestMethod.
+	self assert: extension isExtension.
+	self assert: (extension propertyAt: #extendedMethod) equals: original.
+
+	self class compile: 'isExtensionTestMethod ^ 3' classified: '*Kernel-Tests-Generated-Package'.
+	extension := self class >> #isExtensionTestMethod.
+	self assert: extension isExtension.
+	self assert: (extension propertyAt: #extendedMethod) equals: original.
+	
+	"The old method is not extension!"
+	self deny: original isExtension ] ensure: [
+		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
+		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | 
+			method propertyAt: #extendedMethod put: nil.
+			method removeFromSystem ] ]
+]
+
+{ #category : 'tests - testing' }
+CompiledMethodTest >> testExtensionReplaceExtensionMethod [
+
+	[
+	| original extension  extension2 |
+	self class compile: 'isExtensionTestMethod ^ 1' classified: 'protocol'.
+	original := self class >> #isExtensionTestMethod.
+	self deny: original isExtension.
+
+	self class compile: 'isExtensionTestMethod ^ 2' classified: '*Kernel-Tests-Generated-Package'.
+	extension := self class >> #isExtensionTestMethod.
+	self assert: extension isExtension.
+	self assert: (extension propertyAt: #extendedMethod) equals: original.
+
+	self class compile: 'isExtensionTestMethod ^ 3' classified: '*Kernel-Tests-Generated-Package-2'.
+	extension2 := self class >> #isExtensionTestMethod.
+	self assert: extension2 isExtension.
+	self assert: (extension2 propertyAt: #extendedMethod) equals: extension.
+	
+	"The old method is not extension!"
+	self deny: original isExtension ] ensure: [
+		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
+		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package-2'.
+		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | 
+			method propertyAt: #extendedMethod put: nil.
+			method removeFromSystem ] ]
+]
+
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testExtensionReplaceOriginalMethod [
 
 	[
@@ -453,7 +508,9 @@ CompiledMethodTest >> testExtensionReplaceOriginalMethod [
 	"The old method is not extension!"
 	self deny: original isExtension ] ensure: [
 		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
-		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
+		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | 
+			method propertyAt: #extendedMethod put: nil.
+			method removeFromSystem ] ]
 ]
 
 { #category : 'tests - testing' }

--- a/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
+++ b/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
@@ -448,18 +448,18 @@ CompiledMethodTest >> testExtensionEditedPresistOriginalMethod [
 	self class compile: 'isExtensionTestMethod ^ 2' classified: '*Kernel-Tests-Generated-Package'.
 	extension := self class >> #isExtensionTestMethod.
 	self assert: extension isExtension.
-	self assert: (extension propertyAt: #extendedMethod) equals: original.
+	self assert: (extension propertyAt: #beforeExtensionMethod) equals: original.
 
 	self class compile: 'isExtensionTestMethod ^ 3' classified: '*Kernel-Tests-Generated-Package'.
 	extension := self class >> #isExtensionTestMethod.
 	self assert: extension isExtension.
-	self assert: (extension propertyAt: #extendedMethod) equals: original.
+	self assert: (extension propertyAt: #beforeExtensionMethod) equals: original.
 	
 	"The old method is not extension!"
 	self deny: original isExtension ] ensure: [
 		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | 
-			method propertyAt: #extendedMethod put: nil.
+			method propertyAt: #beforeExtensionMethod put: nil.
 			method removeFromSystem ] ]
 ]
 
@@ -475,19 +475,19 @@ CompiledMethodTest >> testExtensionReplaceExtensionMethod [
 	self class compile: 'isExtensionTestMethod ^ 2' classified: '*Kernel-Tests-Generated-Package'.
 	extension := self class >> #isExtensionTestMethod.
 	self assert: extension isExtension.
-	self assert: (extension propertyAt: #extendedMethod) equals: original.
+	self assert: (extension propertyAt: #beforeExtensionMethod) equals: original.
 
 	self class compile: 'isExtensionTestMethod ^ 3' classified: '*Kernel-Tests-Generated-Package-2'.
 	extension2 := self class >> #isExtensionTestMethod.
 	self assert: extension2 isExtension.
-	self assert: (extension2 propertyAt: #extendedMethod) equals: extension.
+	self assert: (extension2 propertyAt: #beforeExtensionMethod) equals: extension.
 	
 	"The old method is not extension!"
 	self deny: original isExtension ] ensure: [
 		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
 		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package-2'.
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | 
-			method propertyAt: #extendedMethod put: nil.
+			method propertyAt: #beforeExtensionMethod put: nil.
 			method removeFromSystem ] ]
 ]
 
@@ -503,13 +503,13 @@ CompiledMethodTest >> testExtensionReplaceOriginalMethod [
 	self class compile: 'isExtensionTestMethod ^ 2' classified: '*Kernel-Tests-Generated-Package'.
 	extension := self class >> #isExtensionTestMethod.
 	self assert: extension isExtension.
-	self assert: (extension propertyAt: #extendedMethod) equals: original.
+	self assert: (extension propertyAt: #beforeExtensionMethod) equals: original.
 	
 	"The old method is not extension!"
 	self deny: original isExtension ] ensure: [
 		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | 
-			method propertyAt: #extendedMethod put: nil.
+			method propertyAt: #beforeExtensionMethod put: nil.
 			method removeFromSystem ] ]
 ]
 

--- a/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
+++ b/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
@@ -961,6 +961,25 @@ CompiledMethodTest >> testRecompilingDoesNotRemoveExtensions [
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
 ]
 
+{ #category : 'tests - testing' }
+CompiledMethodTest >> testRemoveExtensionRecoverOriginalMethod [
+
+	[
+	| original extension |
+	self class compile: 'isExtensionTestMethod ^ 1' classified: 'protocol'.
+	original := self class >> #isExtensionTestMethod.
+
+	self class compile: 'isExtensionTestMethod ^ 2' classified: '*Kernel-Tests-Generated-Package'.
+	extension := self class >> #isExtensionTestMethod.
+
+	self class removeSelector: #isExtensionTestMethod.
+
+	self assert: (self class >> #isExtensionTestMethod) equals: original 
+	] ensure: [
+		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
+		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
+]
+
 { #category : 'tests - accessing' }
 CompiledMethodTest >> testSelector [
 

--- a/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
+++ b/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
@@ -437,6 +437,26 @@ CompiledMethodTest >> testEqualityInstanceSideMethod [
 ]
 
 { #category : 'tests - testing' }
+CompiledMethodTest >> testExtensionReplaceOriginalMethod [
+
+	[
+	| original extension |
+	self class compile: 'isExtensionTestMethod ^ 1' classified: 'protocol'.
+	original := self class >> #isExtensionTestMethod.
+	self deny: original isExtension.
+
+	self class compile: 'isExtensionTestMethod ^ 2' classified: '*Kernel-Tests-Generated-Package'.
+	extension := self class >> #isExtensionTestMethod.
+	self assert: extension isExtension.
+	self assert: (extension propertyAt: #extendedMethod) equals: original.
+	
+	"The old method is not extension!"
+	self deny: original isExtension ] ensure: [
+		self packageOrganizer removePackage: 'Kernel-Tests-Generated-Package'.
+		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
+]
+
+{ #category : 'tests - testing' }
 CompiledMethodTest >> testHasComment [
 	self assert: (CompiledMethod>>#hasComment) hasComment
 ]
@@ -503,10 +523,7 @@ CompiledMethodTest >> testIsExtension [
 
 	[
 	| method |
-	self class compile: 'isExtensionTestMethod ^ 1' classified: 'protocol'.
-	self deny: (self class >> #isExtensionTestMethod) isExtension.
-
-	self class compile: 'isExtensionTestMethod ^ 1' classified: '*Kernel-Tests-Generated-Package'.
+	self class compile: 'isExtensionTestMethod ^ 2' classified: '*Kernel-Tests-Generated-Package'.
 	method := self class >> #isExtensionTestMethod.
 	self assert: method isExtension.
 

--- a/src/Monticello-Tests/MCPackageTest.class.st
+++ b/src/Monticello-Tests/MCPackageTest.class.st
@@ -26,7 +26,7 @@ MCPackageTest >> testUnload [
 
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
-	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
+	self deny: (MCSnapshotTest lookupSelector: #mockClassExtension) isExtension.
 	self deny: (MCSnapshotTest hasProtocol: self mockExtensionProtocol).
 	testingEnvironment at: #MCMockClassA ifPresent: [ self fail ].
 	self assert: (Object subclasses
@@ -45,7 +45,7 @@ MCPackageTest >> testUnloadWithAdditionalTracking [
 	self assert: (announcer hasSubscriber: self).
 	self mockPackage unload.
 	self deny: (testingEnvironment hasClassNamed: #MCMockClassA).
-	self deny: (MCSnapshotTest includesSelector: #mockClassExtension).
+	self deny: (MCSnapshotTest lookupSelector: #mockClassExtension) isExtension.
 	self deny: (MCSnapshotTest hasProtocol: self mockExtensionProtocol).
 	testingEnvironment at: #MCMockClassA ifPresent: [ self fail ].
 	self assert: (Object subclasses

--- a/src/OpalCompiler-Core/OCIRBuilder.class.st
+++ b/src/OpalCompiler-Core/OCIRBuilder.class.st
@@ -345,6 +345,12 @@ OCIRBuilder >> pushLiteral: object [
 	self add: (OCIRInstruction pushLiteral: object)
 ]
 
+{ #category : 'accessing' }
+OCIRBuilder >> pushLiteralAt: index [
+
+	self add: (OCIRInstruction pushLiteralAt: index)
+]
+
 { #category : 'instructions' }
 OCIRBuilder >> pushLiteralVariable: object [
 

--- a/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
+++ b/src/OpalCompiler-Core/OCIRBytecodeGenerator.class.st
@@ -531,6 +531,13 @@ OCIRBytecodeGenerator >> pushLiteral: object [
 	encoder genPushLiteral: (self literalIndexOf: object)
 ]
 
+{ #category : 'accessing' }
+OCIRBytecodeGenerator >> pushLiteralAt: index [ 
+
+	stack push.
+	encoder genPushLiteral: index
+]
+
 { #category : 'instructions' }
 OCIRBytecodeGenerator >> pushLiteralVariable: object [
 	stack push.

--- a/src/OpalCompiler-Core/OCIRInstruction.class.st
+++ b/src/OpalCompiler-Core/OCIRInstruction.class.st
@@ -98,6 +98,14 @@ OCIRInstruction class >> pushLiteral: object [
 		literal: object
 ]
 
+{ #category : 'accessing' }
+OCIRInstruction class >> pushLiteralAt: index [ 
+
+	^ OCIRPushLiteralAt new
+		index: index;
+		yourself
+]
+
 { #category : 'instance creation' }
 OCIRInstruction class >> pushLiteralVariable: object [
 

--- a/src/OpalCompiler-Core/OCIRPushLiteralAt.class.st
+++ b/src/OpalCompiler-Core/OCIRPushLiteralAt.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'OCIRPushLiteralAt',
+	#superclass : 'OCIRInstruction',
+	#instVars : [
+		'index'
+	],
+	#category : 'OpalCompiler-Core-IR-Nodes',
+	#package : 'OpalCompiler-Core',
+	#tag : 'IR-Nodes'
+}
+
+{ #category : 'visiting' }
+OCIRPushLiteralAt >> accept: aVisitor [ 
+
+	^ aVisitor visitPushLiteralAt: self
+]
+
+{ #category : 'accessing' }
+OCIRPushLiteralAt >> index [
+	^ index
+]
+
+{ #category : 'accessing' }
+OCIRPushLiteralAt >> index: anInteger [ 
+	index := anInteger
+]

--- a/src/OpalCompiler-Core/OCIRTranslatorVisitor.class.st
+++ b/src/OpalCompiler-Core/OCIRTranslatorVisitor.class.st
@@ -217,6 +217,12 @@ OCIRTranslatorVisitor >> visitPushLiteral: lit [
 ]
 
 { #category : 'visiting' }
+OCIRTranslatorVisitor >> visitPushLiteralAt: literalVariableAt [
+
+	gen pushLiteralAt: literalVariableAt index
+]
+
+{ #category : 'visiting' }
 OCIRTranslatorVisitor >> visitPushLiteralVariable: var [
 
 	gen pushLiteralVariable: var association

--- a/src/OpalCompiler-Core/OCIRVisitor.class.st
+++ b/src/OpalCompiler-Core/OCIRVisitor.class.st
@@ -80,6 +80,10 @@ OCIRVisitor >> visitPushInstVar: pushInstVar [
 OCIRVisitor >> visitPushLiteral: pushLiteral [
 ]
 
+{ #category : 'accessing' }
+OCIRVisitor >> visitPushLiteralAt: pushLiteralVariableAt [ 
+]
+
 { #category : 'visiting' }
 OCIRVisitor >> visitPushLiteralVariable: pushLiteralVariable [
 ]


### PR DESCRIPTION
This PR changes the behaviour of installing/unistalling _extension methods_.

### The case I don't like

Now if you have a method in a package:
```st
"Package: MyPackage"
MyClass >> m
  ^ 'original'
```

And then you install another package with an extension method:
```st
"Package: *MyPackageExtension"
MyClass >> m
  ^ 'extension'
```

The original method **is lost forever**.

Then, for example, if you delete or unload the extension package, you object keeps without any method `#m` 👎 

-----

### What is done here?

This PR changes the compilation of extension methods to:
1. Save the original method into the compiled method literals
1. When it is removed, the original method is recovered


### Something cool that you can do with this:

We could define the extension method based on the replaced method.
We still need a syntax for this, but I could make this extension method using the IRBuilder support:
```st
m
	<opalBytecodeMethod>
	^ OCIRBuilder buildIR: [ :builder |
		builder
				pushLiteral: 'extension of ';
				
				pushLiteralAt: 5; "AdditionalMethodState"
				pushLiteral: #extendedMethod;
				send: #propertyAt:;
				pushLiteral: nil;
				send: #valueWithReceiver:;
				
				send: #,;
				returnTop
		 ]
```

With result:
```st
MyClass new m   "'extension of original'"
```

### Other stuff

- Also, the original method was configured as extension when it is replaced. I changed it (see tests)

### What is missing?

There are still some cases to test/support:
- [x] Editing the extended method make it lose the original method
- [x] We could have an "extension chain" of methods, we should think how it works
- [ ] What happen when an extended method is called and it uses `super`?


_Done in the sprint 🎉_