### PR TITLE
[P11] 18431-ZdcPluginSSLSession-leaks-SSLSession-information-if-the-connection-is-not-explicitly-closed

### DIFF
--- a/src/Zodiac-Core/ZdcPluginSSLSession.class.st
+++ b/src/Zodiac-Core/ZdcPluginSSLSession.class.st
@@ -85,7 +85,8 @@ ZdcPluginSSLSession >> destroy [
 
 	handle ifNil: [ ^ self ].
 	self primitiveSSLDestroy: handle.
-	handle := nil
+	handle := nil.
+	FinalizationRegistry default remove: self ifAbsent: [ ]
 ]
 
 { #category : #initialization }
@@ -102,6 +103,12 @@ ZdcPluginSSLSession >> encrypt: srcBuf from: start to: stop into: dstBuf [
 	^ self primitiveSSL: handle encrypt: srcBuf startingAt: start count: stop - start + 1 into: dstBuf
 ]
 
+{ #category : #finalization }
+ZdcPluginSSLSession >> finalize [ 
+	
+	self destroy
+]
+
 { #category : #initialization }
 ZdcPluginSSLSession >> initialize [
 	"Initialize the receiver"
@@ -111,6 +118,9 @@ ZdcPluginSSLSession >> initialize [
 		do: [ :exception |
 			"Give a more human friendly error message"
 			ZdcPluginMissing signal ].
+	
+	FinalizationRegistry default add: self.
+	
 	self logging: false
 ]
 

--- a/src/Zodiac-Tests/ManifestZodiacTests.class.st
+++ b/src/Zodiac-Tests/ManifestZodiacTests.class.st
@@ -1,0 +1,29 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestZodiacTests,
+	#superclass : #PackageManifest,
+	#category : #'Zodiac-Tests-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestZodiacTests class >> ruleEmptyExceptionHandlerRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGMethodDefinition #(#ZdcPluginSSLSessionFinalizationTest #tearDown #false)) #'2025-07-28T11:27:10.661654+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestZodiacTests class >> ruleLiteralArrayContainsSuspiciousTrueFalseOrNilRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGPackageDefinition #(#'Zodiac-Tests')) #'2025-07-28T11:27:56.910159+02:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestZodiacTests class >> ruleReClassNotCategorizedRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGPackageDefinition #(#'Zodiac-Tests')) #'2025-07-28T11:27:40.582327+02:00') )
+]

--- a/src/Zodiac-Tests/ZdcPluginSSLSessionFinalizationTest.class.st
+++ b/src/Zodiac-Tests/ZdcPluginSSLSessionFinalizationTest.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : #ZdcPluginSSLSessionFinalizationTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'client',
+		'clone'
+	],
+	#category : #'Zodiac-Tests'
+}
+
+{ #category : #running }
+ZdcPluginSSLSessionFinalizationTest >> tearDown [
+
+	client ifNotNil: [ client close ].
+	clone ifNotNil: [
+		[ clone destroy ]
+			on: PrimitiveFailed
+			do: [ "I ignore, because if the test works... it has been alread done"
+			 ] ].
+
+	super tearDown
+]
+
+{ #category : #tests }
+ZdcPluginSSLSessionFinalizationTest >> testPluginSSLSessionIsCorrectlyFinalized [
+
+	| previousState afterState |
+	client := ZnClient new.
+	client url: 'https://www.google.com'.
+	client method: #GET.
+	client execute.
+	client response.
+
+	clone := client connection sslSession clone.
+		
+	previousState := clone serverName.
+	
+ 	client := nil.
+	3 timesRepeat: [ Smalltalk garbageCollect ].
+	
+	afterState := clone serverName.
+	
+	self deny: previousState equals: afterState. 
+]


### PR DESCRIPTION
Fix #18431 for P11

We should destroy ZdcPluginSSLSessions when they are not used anymore. 
Just in case the ZnClient has been not closed correctly. Adding a test

Thanks so much @SabineMa for all your help to reproduce the issue.