### PR TITLE
ffi value holder for multiple arities

### DIFF
--- a/src/UnifiedFFI-Tests/FFIValueHolderTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIValueHolderTest.class.st
@@ -24,6 +24,15 @@ FFIValueHolderTest >> ffiMethodInt: value [
 ]
 
 { #category : 'accessing' }
+FFIValueHolderTest >> ffiMethodIntPointer: value [
+
+	^ self 
+		ffiCall: #(int TestIntPointerValueHolder(int *value))
+		module: 'to-test'
+		options: #(+optCallbackCall)
+]
+
+{ #category : 'accessing' }
 FFIValueHolderTest >> ffiMethodStructure: value [
 
 	^ self 
@@ -107,6 +116,39 @@ FFIValueHolderTest >> testCallCharPointerPointerWithValueHolder [
 		assert: string utf8StringFromCString
 		equals: 'Hello, World'.
 	string free
+]
+
+{ #category : 'tests' }
+FFIValueHolderTest >> testCallIntPointerWithValueHolder [
+	| holder result resultIntegers |
+	
+	"since I will keep a list of integers (and not just one integer), 
+	 I will need a pointer holder (otherwise the buffer will have a wrong size)"
+	holder :=  FFIOop newValueHolder.
+
+	FFICallbackFunctionResolution 
+		registerCallback: (FFICallback 
+			signature: #(int (int *aValue)) 
+			block: [ :aValue |
+				| integers |
+				integers := ExternalAddress allocate: FFIInt32 externalTypeSize * 5.
+				integers signedLongAt: 1 put: 1.
+				integers signedLongAt: 5 put: 2.
+				integers signedLongAt: 9 put: 3.
+				integers signedLongAt: 13 put: 4.
+				integers signedLongAt: 17 put: 42.
+				aValue pointerAt: 1 put: integers.
+				1 ])
+		as: #TestIntPointerValueHolder.
+
+	result := self ffiMethodIntPointer: holder.
+
+	self assert: result equals: 1.
+	resultIntegers := holder arrayOf: #int size: 5.
+	self 
+		assert: resultIntegers
+		equals: #(1 2 3 4 42).
+	holder value free
 ]
 
 { #category : 'tests' }

--- a/src/UnifiedFFI-Tests/FFIValueHolderTest.class.st
+++ b/src/UnifiedFFI-Tests/FFIValueHolderTest.class.st
@@ -6,6 +6,15 @@ Class {
 }
 
 { #category : 'accessing' }
+FFIValueHolderTest >> ffiMethodCharPointerPointer: value [
+
+	^ self 
+		ffiCall: #(int TestCharPointerPointerValueHolder(char **value))
+		module: 'to-test'
+		options: #(+optCallbackCall)
+]
+
+{ #category : 'accessing' }
 FFIValueHolderTest >> ffiMethodInt: value [
 
 	^ self 
@@ -72,6 +81,32 @@ FFIValueHolderTest >> testCallBasicValueWithValueHolder [
 	self assert: result equals: 1.
 	resultValue := holder value.
 	self assert: resultValue equals: 42
+]
+
+{ #category : 'tests' }
+FFIValueHolderTest >> testCallCharPointerPointerWithValueHolder [
+	| holder result string |
+	
+	holder :=  FFIOop newValueHolder.
+	
+	FFICallbackFunctionResolution 
+		registerCallback: (FFICallback 
+			signature: #(int (char **aValue)) 
+			block: [ :aValue |
+				| externalString |
+				externalString := ExternalAddress fromString: 'Hello, World'.
+				aValue pointerAt: 1 put: externalString.
+				1 ])
+		as: #TestCharPointerPointerValueHolder.
+
+	result := self ffiMethodCharPointerPointer: holder.
+	
+	self assert: result equals: 1.
+	string := holder value.
+	self 
+		assert: string utf8StringFromCString
+		equals: 'Hello, World'.
+	string free
 ]
 
 { #category : 'tests' }

--- a/src/UnifiedFFI/FFIExternalType.class.st
+++ b/src/UnifiedFFI/FFIExternalType.class.st
@@ -254,6 +254,12 @@ FFIExternalType >> isLiteralArgument [
 ]
 
 { #category : 'testing' }
+FFIExternalType >> isOop [
+	
+	^ false
+]
+
+{ #category : 'testing' }
 FFIExternalType >> isPointer [
 	^ self pointerArity > 0
 ]

--- a/src/UnifiedFFI/FFIOop.class.st
+++ b/src/UnifiedFFI/FFIOop.class.st
@@ -44,6 +44,12 @@ FFIOop >> externalTypeSize [
 ]
 
 { #category : 'testing' }
+FFIOop >> isOop [
+
+	^ true
+]
+
+{ #category : 'testing' }
 FFIOop >> needsArityUnpacking [
 	"this represent kind of pointers, so it will be unpacked if they are also rolled."
 	^ self needsArityPacking

--- a/src/UnifiedFFI/FFIReferenceValueHolder.class.st
+++ b/src/UnifiedFFI/FFIReferenceValueHolder.class.st
@@ -9,6 +9,25 @@ Class {
 	#tag : 'Objects'
 }
 
+{ #category : 'as yet unclassified' }
+FFIReferenceValueHolder >> arrayOfSize: aNumber [ 
+	| first |
+
+	first := self getHandle pointerAt: 1.
+	^ Array streamContents: [ :stream |
+		0 to: aNumber - 1 do: [ :index |
+			| next value |
+			next := first + (index * FFIExternalType pointerSize).
+			value := self typeClass fromHandle: next.
+			stream nextPut: value ] ]
+]
+
+{ #category : 'private' }
+FFIReferenceValueHolder >> typeClass [
+
+	^ self type class
+]
+
 { #category : 'accessing' }
 FFIReferenceValueHolder >> value: anOpaqueObject [
 

--- a/src/UnifiedFFI/FFIReferenceValueHolder.class.st
+++ b/src/UnifiedFFI/FFIReferenceValueHolder.class.st
@@ -9,7 +9,7 @@ Class {
 	#tag : 'Objects'
 }
 
-{ #category : 'as yet unclassified' }
+{ #category : 'instance creation' }
 FFIReferenceValueHolder >> arrayOfSize: aNumber [ 
 	| first |
 

--- a/src/UnifiedFFI/FFIReferenceValueHolder.class.st
+++ b/src/UnifiedFFI/FFIReferenceValueHolder.class.st
@@ -9,12 +9,6 @@ Class {
 	#tag : 'Objects'
 }
 
-{ #category : 'converting' }
-FFIReferenceValueHolder >> tfPointerAddress [
-
-	^ self getHandle tfPointerAddress
-]
-
 { #category : 'accessing' }
 FFIReferenceValueHolder >> value: anOpaqueObject [
 

--- a/src/UnifiedFFI/FFIValueHolder.class.st
+++ b/src/UnifiedFFI/FFIValueHolder.class.st
@@ -81,6 +81,20 @@ FFIValueHolder >> adoptAddress: anExternalAddress [
 ]
 
 { #category : 'accessing' }
+FFIValueHolder >> arrayOf: aTypeOrClass size: aNumber [ 
+	| first arrayType |
+	
+	arrayType := FFIExternalType resolveType: aTypeOrClass.
+	first := self getHandle pointerAt: 1.
+	^ Array streamContents: [ :stream |
+		0 to: aNumber - 1 do: [ :index |
+			| next value |
+			next := first + (index * arrayType externalTypeSize).
+			value := arrayType handle: next at: 1.
+			stream nextPut: value ] ]
+]
+
+{ #category : 'accessing' }
 FFIValueHolder >> getHandle [
 	"for compatibility"
 

--- a/src/UnifiedFFI/FFIValueHolder.class.st
+++ b/src/UnifiedFFI/FFIValueHolder.class.st
@@ -74,6 +74,12 @@ FFIValueHolder class >> newType: aTypeClass handle: aHandle [
 	yourself
 ]
 
+{ #category : 'private' }
+FFIValueHolder >> adoptAddress: anExternalAddress [
+
+	handle := anExternalAddress getHandle
+]
+
 { #category : 'accessing' }
 FFIValueHolder >> getHandle [
 	"for compatibility"
@@ -95,6 +101,13 @@ FFIValueHolder >> initializeType: aType handle: aHandle [
 	self initialize
 ]
 
+{ #category : 'converting' }
+FFIValueHolder >> packToArity: aNumber [
+	"holders do not packarity"
+
+	^ self
+]
+
 { #category : 'private' }
 FFIValueHolder >> pointer [
 	"used for boxing/unboxing the typed pointers e.g. int* with take a pointer"
@@ -102,10 +115,23 @@ FFIValueHolder >> pointer [
 	^ self getHandle
 ]
 
+{ #category : 'converting' }
+FFIValueHolder >> tfPointerAddress [
+
+	^ self getHandle tfPointerAddress
+]
+
 { #category : 'accessing' }
 FFIValueHolder >> type [
 
 	^ type
+]
+
+{ #category : 'converting' }
+FFIValueHolder >> unpackFromArity: aNumber [
+	"holders do not pack arity"
+
+	^ self
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
from the point of view of the user of ffi value holders, is the same calling a function with an argument with an arity of 1 than an arity of many (e.g. `some_function(char **value)`, but the previous implementation was not able to respond to that for its basic types (char, int, etc.).

This change improves that. 