### PR TITLE
Uses Clap for Hermes command-line handling

### DIFF
--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -56,7 +56,7 @@ export PHARO_CI_TESTING_ENVIRONMENT=1
 ./pharo bootstrap.image
 #Adding packages removed from the bootstrap
 ./pharo bootstrap.image loadHermes Hermes-Extensions.hermes --save
-./pharo bootstrap.image loadHermes System-Time.hermes AST-Core.hermes InitializePackagesCommandLineHandler.hermes Random-Core.hermes System-Model.hermes System-NumberPrinting.hermes --save --no-fail-on-undeclared --on-duplication=ignore
+./pharo bootstrap.image loadHermes System-Time.hermes AST-Core.hermes InitializePackagesCommandLineHandler.hermes Random-Core.hermes System-Model.hermes System-NumberPrinting.hermes --save --no-fail-on-undeclared --on-duplication ignore
 ./pharo bootstrap.image perform --save ChronologyConstants initialize
 ./pharo bootstrap.image perform --save DateAndTime initialize
 
@@ -67,7 +67,7 @@ export PHARO_CI_TESTING_ENVIRONMENT=1
 ./pharo bootstrap.image loadHermes Traits.hermes --save
 
 #Loading Tests
-./pharo bootstrap.image loadHermes Debugging-Utils.hermes SUnit-Core.hermes JenkinsTools-Core.hermes JenkinsTools-Core.hermes SUnit-Tests.hermes --save --no-fail-on-undeclared --on-duplication=ignore
+./pharo bootstrap.image loadHermes Debugging-Utils.hermes SUnit-Core.hermes JenkinsTools-Core.hermes JenkinsTools-Core.hermes SUnit-Tests.hermes --save --no-fail-on-undeclared --on-duplication ignore
 
 #Running tests
 ./pharo bootstrap.image test --junit-xml-output --stage-name=${2} SUnit-Core SUnit-Tests

--- a/src/Clap-CommandLine/ClapPharoApplication.class.st
+++ b/src/Clap-CommandLine/ClapPharoApplication.class.st
@@ -4,8 +4,8 @@ I am an abstract class providing some support to Pharo commands available from c
 Class {
 	#name : 'ClapPharoApplication',
 	#superclass : 'ClapApplication',
-	#category : 'Clap-Commands-Pharo',
-	#package : 'Clap-Commands-Pharo'
+	#category : 'Clap-CommandLine',
+	#package : 'Clap-CommandLine'
 }
 
 { #category : 'adding' }

--- a/src/Clap-Commands-Pharo/ClapHermesCommand.class.st
+++ b/src/Clap-Commands-Pharo/ClapHermesCommand.class.st
@@ -1,0 +1,146 @@
+"
+Class: HermesCommandLineHandler
+                                                                                                    
+This is the command line handler to load Hermes files in the image.
+The format is intented to export any of the objects. However, the command line expects to have a package as its root element.
+It loads the hermes files passed as parameter.
+They are loaded in the order of the parameters.
+
+Usage: loadHermes [--save] [extendedOptions] [<hermesFiles> ...]
+--save                		save after loading the packages if there is no error
+<hermesFiles>      	a list of .hermes files to load in the image.
+extendedOptions 	read the extension section.
+
+Examples:
+#Load the package Test-Package
+pharo Pharo.image loadHermes Test-Package.hermes
+
+#Load the package Test-Package and saving
+pharo Pharo.image loadHermes --save Test-Package.hermes
+
+
+Extensions
+=========
+
+When Hermes-Extensions is loaded additional options are present:
+no-fail-on-undeclared		It does not fail the loading if there are new undeclared variables. By default it fails.
+on-duplication=action	When there is a duplication in the loading package what is the action to take:
+fail		(default) Fail on a duplication
+ignore	Ignore the error and do not do nothing. Keeping the image version
+replace	Replace the image version with the one in the Hermes Package.
+
+Examples
+
+#Load the package Test-Package without failing on new undeclared variables.
+pharo Pharo.image loadHermes --save --no-fail-on-undeclared Test-Package.hermes
+
+#Load the package Test-Package replacing the image version with the ones in the hermes file.
+pharo Pharo.image loadHermes --save --on-duplication=replace Test-Package.hermes
+"
+Class {
+	#name : 'ClapHermesCommand',
+	#superclass : 'ClapPharoApplication',
+	#category : 'Clap-Commands-Pharo',
+	#package : 'Clap-Commands-Pharo'
+}
+
+{ #category : 'command line' }
+ClapHermesCommand class >> commandSpecification [
+
+	<commandline>
+	| spec |
+	spec := (ClapCommandSpec id: #loadHermes)
+		        description: 'Loads the hermes files passed as parameter';
+		        commandClass: self;
+		        addHelp;
+		        addPositional: #FILE spec: [ :positional |
+					positional
+						description: 'The Pharo expression to evaluate, joining successive arguments with spaces (if omitted, read the expression from stdin)';
+						multiple: true ];
+		        addFlag: #'no-fail-on-undeclared' description: 'Does not fail the loading if there are new undeclared variables.';
+		        addFlagWithPositional: #'on-duplication' description: 'When there is a duplication in the loading package what is the action to take:
+- fail			(default) Fail on a duplication
+- ignore		Ignore the error and do not do nothing. Keeping the image version
+- replace		Replace the image version with the one in the Hermes Package.';
+		        yourself.
+
+	self addSaveFlagTo: spec.
+	^ spec
+]
+
+{ #category : 'accessing' }
+ClapHermesCommand >> allHermesFiles [
+
+	^ (self positional: #FILE ifAbsent: [ #() ]) 
+		select: [ :arg | arg endsWith: '.hermes' ]
+]
+
+{ #category : 'execution' }
+ClapHermesCommand >> createInstaller [
+	"In the basic installation, the bootstraped version of Hermes,
+	there is only one Installer, the HEInstaller.
+	When the extensions are installed the new installer to use is the HEExtendedInstaller."
+
+	^ self class environment
+		at: #HEExtendedInstaller
+		ifPresent: [ :extendedInstallerClass |
+			extendedInstallerClass new
+				forOptions: self;
+				yourself ]
+		ifAbsent: [ HEInstaller new ]
+]
+
+{ #category : 'accessing' }
+ClapHermesCommand >> duplicationMode [
+
+	^ self
+		  positional: #'on-duplication'
+		  ifPresent: [ :action |
+				  (#( fail ignore replace ) includes: action asSymbol)
+					  ifTrue: [ action ]
+					  ifFalse: [ #fail ] ]
+		  ifAbsent: [ #fail ]
+]
+
+{ #category : 'execution' }
+ClapHermesCommand >> execute [ 
+
+	self validateParameters.
+	self processFiles.
+	self saveSessionIfAsked
+]
+
+{ #category : 'execution' }
+ClapHermesCommand >> processFile: aFileName [
+
+	"It loads the package and installs it in the image"
+	| installer reader readPackage |
+	installer := self createInstaller.
+	SystemNotification signal: ('[Hermes] Reading ' , aFileName).
+
+	reader := HEBinaryReader new
+		stream: (File named: aFileName) readStream;
+		yourself.
+
+	readPackage := HEPackage readFrom: reader.
+
+	SystemNotification signal: ('[Hermes] Installing ' , aFileName).
+	installer installPackage: readPackage
+]
+
+{ #category : 'execution' }
+ClapHermesCommand >> processFiles [
+
+	self allHermesFiles do: [ :name | self processFile: name ]
+]
+
+{ #category : 'testing' }
+ClapHermesCommand >> shouldFailOnUndeclared [
+
+	^ (self hasFlag: #'no-fail-on-undeclared') not
+]
+
+{ #category : 'validating' }
+ClapHermesCommand >> validateParameters [
+	self allHermesFiles ifEmpty: [ ^ self context exitFailure: 'Missing Hermes file as argument' ]
+]

--- a/src/Clap-Core/ClapApplication.class.st
+++ b/src/Clap-Core/ClapApplication.class.st
@@ -99,12 +99,26 @@ ClapApplication >> positional: aFlagIdentifier [
 ]
 
 { #category : 'accessing' }
+ClapApplication >> positional: anIdentifier ifAbsent: aBlock [
+
+	^ self
+		  positional: anIdentifier
+		  ifPresent: [ :positional | positional ]
+		  ifAbsent: aBlock
+]
+
+{ #category : 'accessing' }
 ClapApplication >> positional: anIdentifier ifPresent: aBlock [
-	"Execute aBlock if a positional with the identifier is found. The positional valu will be passed as first argument of the block"
 	
-	[ aBlock value: (self positional: anIdentifier) ]
+	^ self positional: anIdentifier ifPresent: aBlock ifAbsent: [ "ignore" ]
+]
+
+{ #category : 'accessing' }
+ClapApplication >> positional: anIdentifier ifPresent: presentBlock ifAbsent: absentBlock [
+	
+	^ [ presentBlock value: (self positional: anIdentifier) ]
 		on: NotFound 
-		do: [ "ignore" ]
+		do: absentBlock
 ]
 
 { #category : 'execution' }

--- a/src/Clap-Tests/ClapHermesCommandTest.class.st
+++ b/src/Clap-Tests/ClapHermesCommandTest.class.st
@@ -1,0 +1,95 @@
+Class {
+	#name : 'ClapHermesCommandTest',
+	#superclass : 'ClapPharoCommandsTest',
+	#category : 'Clap-Tests-Commands',
+	#package : 'Clap-Tests',
+	#tag : 'Commands'
+}
+
+{ #category : 'tests' }
+ClapHermesCommandTest >> testDuplicationModeIsFailWhenOptionNotSpecified [
+	| command |
+	context := ClapHermesCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes').
+	command := context command.
+	
+	self 
+		assert: command duplicationMode
+		equals: #fail
+]
+
+{ #category : 'tests' }
+ClapHermesCommandTest >> testDuplicationModeIsFailWhenOptionSpecifiedAsFail [
+	| command |
+	context := ClapHermesCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes' '--on-duplication' 'fail' ).
+	command := context command.
+	
+	self 
+		assert: command duplicationMode
+		equals: #fail
+]
+
+{ #category : 'tests' }
+ClapHermesCommandTest >> testDuplicationModeIsIgnoreWhenOptionSpecifiedAsIgnore [
+	| command |
+	context := ClapHermesCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes' '--on-duplication' 'ignore' ).
+	command := context command.
+	
+	self 
+		assert: command duplicationMode
+		equals: #ignore
+]
+
+{ #category : 'tests' }
+ClapHermesCommandTest >> testGetManyFilesToProcessWhenManyHermesFileGivenInArguments [
+
+	| command |
+	context := ClapHermesCommand commandSpecification activationWith:
+		           #( 'loadHermes' 'foo.hermes' 'bar.hermes' 'baz.hermes' ).
+	command := context command.
+
+	self
+		assertCollection: command allHermesFiles
+		hasSameElements: #( 'foo.hermes' 'bar.hermes' 'baz.hermes' )
+]
+
+{ #category : 'tests' }
+ClapHermesCommandTest >> testGetOneFileToProcessWheOneHermesFileGivenInArguments [
+
+	| command |
+	context := ClapHermesCommand commandSpecification activationWith:
+		           #( 'loadHermes' 'foo.hermes' ).
+	command := context command.
+
+	self
+		assertCollection: command allHermesFiles
+		hasSameElements: #( 'foo.hermes' )
+]
+
+{ #category : 'tests' }
+ClapHermesCommandTest >> testNoFailOnUndeclaredOption [
+	| command |
+	context := ClapHermesCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes' '--no-fail-on-undeclared' ).
+	command := context command.
+	
+	self deny: command shouldFailOnUndeclared
+]
+
+{ #category : 'tests' }
+ClapHermesCommandTest >> testRunningHermesWithoutFileExitsWithErrorMessage [
+	context := ClapHermesCommand commandSpecification activateWith: #('loadHermes').
+	
+	self assertFailure.
+	self
+		assert: context exitException messageText
+		equals: 'Missing Hermes file as argument'
+]
+
+{ #category : 'tests' }
+ClapHermesCommandTest >> testRunningHermesWithoutHermesFileExitsWithErrorMessage [
+	context := ClapHermesCommand commandSpecification activateWith: #('loadHermes' 'foo.txt').
+	
+	self assertFailure.
+	self
+		assert: context exitException messageText
+		equals: 'Missing Hermes file as argument'
+]

--- a/src/Clap-Tests/ClapHermesCommandTest.class.st
+++ b/src/Clap-Tests/ClapHermesCommandTest.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : 'tests' }
 ClapHermesCommandTest >> testDuplicationModeIsFailWhenOptionNotSpecified [
 	| command |
-	context := ClapHermesCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes').
+	context := HermesClapCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes').
 	command := context command.
 	
 	self 
@@ -20,7 +20,7 @@ ClapHermesCommandTest >> testDuplicationModeIsFailWhenOptionNotSpecified [
 { #category : 'tests' }
 ClapHermesCommandTest >> testDuplicationModeIsFailWhenOptionSpecifiedAsFail [
 	| command |
-	context := ClapHermesCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes' '--on-duplication' 'fail' ).
+	context := HermesClapCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes' '--on-duplication' 'fail' ).
 	command := context command.
 	
 	self 
@@ -31,7 +31,7 @@ ClapHermesCommandTest >> testDuplicationModeIsFailWhenOptionSpecifiedAsFail [
 { #category : 'tests' }
 ClapHermesCommandTest >> testDuplicationModeIsIgnoreWhenOptionSpecifiedAsIgnore [
 	| command |
-	context := ClapHermesCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes' '--on-duplication' 'ignore' ).
+	context := HermesClapCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes' '--on-duplication' 'ignore' ).
 	command := context command.
 	
 	self 
@@ -43,7 +43,7 @@ ClapHermesCommandTest >> testDuplicationModeIsIgnoreWhenOptionSpecifiedAsIgnore 
 ClapHermesCommandTest >> testGetManyFilesToProcessWhenManyHermesFileGivenInArguments [
 
 	| command |
-	context := ClapHermesCommand commandSpecification activationWith:
+	context := HermesClapCommand commandSpecification activationWith:
 		           #( 'loadHermes' 'foo.hermes' 'bar.hermes' 'baz.hermes' ).
 	command := context command.
 
@@ -56,7 +56,7 @@ ClapHermesCommandTest >> testGetManyFilesToProcessWhenManyHermesFileGivenInArgum
 ClapHermesCommandTest >> testGetOneFileToProcessWheOneHermesFileGivenInArguments [
 
 	| command |
-	context := ClapHermesCommand commandSpecification activationWith:
+	context := HermesClapCommand commandSpecification activationWith:
 		           #( 'loadHermes' 'foo.hermes' ).
 	command := context command.
 
@@ -68,7 +68,7 @@ ClapHermesCommandTest >> testGetOneFileToProcessWheOneHermesFileGivenInArguments
 { #category : 'tests' }
 ClapHermesCommandTest >> testNoFailOnUndeclaredOption [
 	| command |
-	context := ClapHermesCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes' '--no-fail-on-undeclared' ).
+	context := HermesClapCommand commandSpecification activationWith: #('loadHermes' 'foo.hermes' '--no-fail-on-undeclared' ).
 	command := context command.
 	
 	self deny: command shouldFailOnUndeclared
@@ -76,7 +76,7 @@ ClapHermesCommandTest >> testNoFailOnUndeclaredOption [
 
 { #category : 'tests' }
 ClapHermesCommandTest >> testRunningHermesWithoutFileExitsWithErrorMessage [
-	context := ClapHermesCommand commandSpecification activateWith: #('loadHermes').
+	context := HermesClapCommand commandSpecification activateWith: #('loadHermes').
 	
 	self assertFailure.
 	self
@@ -86,7 +86,7 @@ ClapHermesCommandTest >> testRunningHermesWithoutFileExitsWithErrorMessage [
 
 { #category : 'tests' }
 ClapHermesCommandTest >> testRunningHermesWithoutHermesFileExitsWithErrorMessage [
-	context := ClapHermesCommand commandSpecification activateWith: #('loadHermes' 'foo.txt').
+	context := HermesClapCommand commandSpecification activateWith: #('loadHermes' 'foo.txt').
 	
 	self assertFailure.
 	self

--- a/src/Clap-Tests/ClapPharoCommandsTest.class.st
+++ b/src/Clap-Tests/ClapPharoCommandsTest.class.st
@@ -20,8 +20,18 @@ ClapPharoCommandsTest class >> shouldInheritSelectors [
 ]
 
 { #category : 'asserting' }
+ClapPharoCommandsTest >> assertFailure [
+	self deny: context exitStatus equals: 0
+]
+
+{ #category : 'asserting' }
 ClapPharoCommandsTest >> assertSuccess [
 	self assert: context exitStatus equals: 0
+]
+
+{ #category : 'accessing' }
+ClapPharoCommandsTest >> errorString [
+	^ context stdio stderr contents utf8Decoded
 ]
 
 { #category : 'tests - fixture' }

--- a/src/Hermes-Extensions/HEExtendedInstaller.class.st
+++ b/src/Hermes-Extensions/HEExtendedInstaller.class.st
@@ -42,10 +42,9 @@ HEExtendedInstaller >> failOnUndeclared: anObject [
 ]
 
 { #category : 'initialization' }
-HEExtendedInstaller >> forOptions: aCommandLine [
-	failOnUndeclared := (aCommandLine hasOption: 'no-fail-on-undeclared') not.
-
-	duplicationMode := HEDuplicationModeStrategy forOption: (aCommandLine optionAt: 'on-duplication' ifAbsent: [ 'fail' ])
+HEExtendedInstaller >> forOptions: aClapHermesCommand [
+	failOnUndeclared := aClapHermesCommand shouldFailOnUndeclared.
+	duplicationMode := HEDuplicationModeStrategy forOption: aClapHermesCommand duplicationMode
 ]
 
 { #category : 'initialization' }

--- a/src/Hermes/HermesClapCommand.class.st
+++ b/src/Hermes/HermesClapCommand.class.st
@@ -35,17 +35,18 @@ Examples
 pharo Pharo.image loadHermes --save --no-fail-on-undeclared Test-Package.hermes
 
 #Load the package Test-Package replacing the image version with the ones in the hermes file.
-pharo Pharo.image loadHermes --save --on-duplication=replace Test-Package.hermes
+pharo Pharo.image loadHermes --save --on-duplication replace Test-Package.hermes
 "
 Class {
-	#name : 'ClapHermesCommand',
+	#name : 'HermesClapCommand',
 	#superclass : 'ClapPharoApplication',
-	#category : 'Clap-Commands-Pharo',
-	#package : 'Clap-Commands-Pharo'
+	#category : 'Hermes-CommandLineHandler',
+	#package : 'Hermes',
+	#tag : 'CommandLineHandler'
 }
 
 { #category : 'command line' }
-ClapHermesCommand class >> commandSpecification [
+HermesClapCommand class >> commandSpecification [
 
 	<commandline>
 	| spec |
@@ -69,14 +70,14 @@ ClapHermesCommand class >> commandSpecification [
 ]
 
 { #category : 'accessing' }
-ClapHermesCommand >> allHermesFiles [
+HermesClapCommand >> allHermesFiles [
 
 	^ (self positional: #FILE ifAbsent: [ #() ]) 
 		select: [ :arg | arg endsWith: '.hermes' ]
 ]
 
 { #category : 'execution' }
-ClapHermesCommand >> createInstaller [
+HermesClapCommand >> createInstaller [
 	"In the basic installation, the bootstraped version of Hermes,
 	there is only one Installer, the HEInstaller.
 	When the extensions are installed the new installer to use is the HEExtendedInstaller."
@@ -91,7 +92,7 @@ ClapHermesCommand >> createInstaller [
 ]
 
 { #category : 'accessing' }
-ClapHermesCommand >> duplicationMode [
+HermesClapCommand >> duplicationMode [
 
 	^ self
 		  positional: #'on-duplication'
@@ -103,7 +104,7 @@ ClapHermesCommand >> duplicationMode [
 ]
 
 { #category : 'execution' }
-ClapHermesCommand >> execute [ 
+HermesClapCommand >> execute [ 
 
 	self validateParameters.
 	self processFiles.
@@ -111,7 +112,7 @@ ClapHermesCommand >> execute [
 ]
 
 { #category : 'execution' }
-ClapHermesCommand >> processFile: aFileName [
+HermesClapCommand >> processFile: aFileName [
 
 	"It loads the package and installs it in the image"
 	| installer reader readPackage |
@@ -129,18 +130,18 @@ ClapHermesCommand >> processFile: aFileName [
 ]
 
 { #category : 'execution' }
-ClapHermesCommand >> processFiles [
+HermesClapCommand >> processFiles [
 
 	self allHermesFiles do: [ :name | self processFile: name ]
 ]
 
 { #category : 'testing' }
-ClapHermesCommand >> shouldFailOnUndeclared [
+HermesClapCommand >> shouldFailOnUndeclared [
 
 	^ (self hasFlag: #'no-fail-on-undeclared') not
 ]
 
 { #category : 'validating' }
-ClapHermesCommand >> validateParameters [
+HermesClapCommand >> validateParameters [
 	self allHermesFiles ifEmpty: [ ^ self context exitFailure: 'Missing Hermes file as argument' ]
 ]

--- a/src/System-BasicCommandLineHandler/BasicCommandLineHandler.class.st
+++ b/src/System-BasicCommandLineHandler/BasicCommandLineHandler.class.st
@@ -214,7 +214,7 @@ BasicCommandLineHandler >> handleArgument: aString [
 BasicCommandLineHandler >> handleCommandWithClap [
 	
 	| arguments |
-	self firstArgument = 'printVersion' ifFalse: [ ^ false ].
+	(#('loadHermes' 'printVersion') includes: self firstArgument) ifFalse: [ ^ false ].
 	
 	arguments := commandLine arguments copyWithFirst: 'clap'.
 	ClapCommandLineHandler activateWith:( commandLine class withArguments: arguments).


### PR DESCRIPTION
Migrates Hermes command-line handling to use Clap for improved argument parsing and consistency.

- Introduces `HermesClapCommand` for handling 'loadHermes' command with Clap.
- Moves `ClapPharoApplication` to a more general package.
- Updates `runKernelTests.sh` to utilize the new Clap-based Hermes command.
- Improves argument validation and error handling for Hermes loading.