### PR TITLE
Fix error report generation during the bootstrap

### DIFF
--- a/src/System-Support/Context.extension.st
+++ b/src/System-Support/Context.extension.st
@@ -7,9 +7,18 @@ Context >> errorReportOn: stream [
 	Suppress any errors while getting printStrings.  Limit the length."
 
 	| stackDepth aContext |
-	stream print: Date today; space; print: Time now; cr.
+	"The packae System-Time is not loaded during the first steps of the bootstrap. Thus we print the date only if we have the necessary classes loaded in the system. Else we at least print the useful info."
+	self class environment at: #Date ifPresent: [ :date |
+			self class environment at: #Time ifPresent: [ :time |
+					stream
+						print: date today;
+						space;
+						print: time now;
+						cr ] ].
+
 	stream cr.
-	stream nextPutAll: 'VM: ';
+	stream
+		nextPutAll: 'VM: ';
 		nextPutAll: Smalltalk os name asString;
 		nextPutAll: ' - ';
 		nextPutAll: Smalltalk os subtype asString;
@@ -18,8 +27,9 @@ Context >> errorReportOn: stream [
 		nextPutAll: ' - ';
 		nextPutAll: Smalltalk vm version asString;
 		cr.
-	stream nextPutAll: 'Image: ';
-		nextPutAll:  SystemVersion current version asString;
+	stream
+		nextPutAll: 'Image: ';
+		nextPutAll: SystemVersion current version asString;
 		nextPutAll: ' [';
 		nextPutAll: Smalltalk lastUpdateString asString;
 		nextPutAll: ']';
@@ -28,23 +38,29 @@ Context >> errorReportOn: stream [
 	"Note: The following is an open-coded version of  Context>>stackOfSize: since this method may be called during a  low space condition and we might run out of space for allocating the  full stack."
 	stackDepth := 0.
 	aContext := self.
-	[ aContext isNotNil and: [ (stackDepth := stackDepth + 1) < 40 ]]
-		whileTrue: [
-			"variable values"
+	[ aContext isNotNil and: [ (stackDepth := stackDepth + 1) < 40 ] ] whileTrue: [ "variable values"
 			aContext printDetails: stream.
 			stream cr.
 			aContext := aContext sender ].
-	stream cr; nextPutAll: '--- The full stack ---'; cr.
+	stream
+		cr;
+		nextPutAll: '--- The full stack ---';
+		cr.
 	aContext := self.
 	stackDepth := 0.
-	[ aContext == nil ] whileFalse:	[
-		stackDepth := stackDepth + 1.
-		stackDepth = 40 ifTrue: [ stream nextPutAll: ' - - - - - - - - - - - - - - -
-			- - - - - - - - - - - - - - - - - -'; cr ].
-		"just class>>selector"
-		stream print: aContext; cr.
-		stackDepth > 200 ifTrue: [
-			stream nextPutAll: '-- and more not shown --'.
-			^  self ].
-		aContext := aContext sender ]
+	[ aContext == nil ] whileFalse: [
+			stackDepth := stackDepth + 1.
+			stackDepth = 40 ifTrue: [
+					stream
+						nextPutAll: ' - - - - - - - - - - - - - - -
+			- - - - - - - - - - - - - - - - - -';
+						cr ].
+			"just class>>selector"
+			stream
+				print: aContext;
+				cr.
+			stackDepth > 200 ifTrue: [
+					stream nextPutAll: '-- and more not shown --'.
+					^ self ].
+			aContext := aContext sender ]
 ]


### PR DESCRIPTION
Currently if we end up in an error before loading the System-Time package, we have the error report that is crashing because it is trying to print the date and time. This change makes it optional to print the time before the classes Date and Time and loaded in the image.  This allows is to at least have an minimal error report during the bootstrap.