### PR TITLE
OSSDL2AthensRenderer now specifies deviceScale in cairo surface

### DIFF
--- a/src/Athens-Cairo/AthensCairoSurface.class.st
+++ b/src/Athens-Cairo/AthensCairoSurface.class.st
@@ -446,6 +446,30 @@ AthensCairoSurface >> createStrokePaintFor: aPaint [
 	^ AthensCairoStrokePaint new fillPaint: aPaint
 ]
 
+{ #category : 'initialization' }
+AthensCairoSurface >> deviceScale: aPoint [
+
+	self deviceScaleX: aPoint x y: aPoint y
+]
+
+{ #category : 'initialization' }
+AthensCairoSurface >> deviceScaleX: xScale y: yScale [
+	"Sets a scale that is multiplied to the device coordinates determined by the CTM when drawing to this surface. 
+	One common use for this is to render to very high resolution display devices at a scale factor, so that code that assumes 1 pixel will be a certain size will still work. 
+	Setting a transformation via `cairo_scale()` isn't sufficient to do this, since functions like `cairo_device_to_user()` will expose the hidden scale.
+
+	Note that the scale affects drawing to the surface as well as using the surface in a source pattern.
+
+	See: https://www.cairographics.org/manual/cairo-cairo-surface-t.html#cairo-surface-set-device-scale"
+
+	self ffiCall: #(
+		void
+		cairo_surface_set_device_scale (
+			self,
+			double xScale,
+			double yScale ) )
+]
+
 { #category : 'drawing' }
 AthensCairoSurface >> drawDuring: aBlock [
 

--- a/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
+++ b/src/OSWindow-SDL2/OSSDL2AthensRenderer.class.st
@@ -119,6 +119,9 @@ OSSDL2AthensRenderer >> resetResources [
 	self checkSession.
 	extent := renderer outputExtent.
 	athensSurface := AthensCairoSurface extent: extent.
+	"See: https://github.com/pharo-project/pharo/issues/18468"
+	athensSurface deviceScale: extent / backendWindow extent.
+
 	texture ifNotNil: [
 		texture destroy.
 		texture := nil.


### PR DESCRIPTION
Fixes #18468. See issue.

Screenshots now:

<img width="612" height="640" alt="Screenshot 2025-08-17 at 16 50 28" src="https://github.com/user-attachments/assets/0a9cff05-78c3-4daf-8ede-7f3a4e2d0452" />

<img width="612" height="640" alt="Screenshot 2025-08-17 at 16 50 54" src="https://github.com/user-attachments/assets/667305cb-f957-484a-a3e4-3f9e1524859c" />
