### PR TITLE
Fix bug in maximize window

### DIFF
--- a/src/Polymorph-Widgets/SystemWindow.extension.st
+++ b/src/Polymorph-Widgets/SystemWindow.extension.st
@@ -474,7 +474,6 @@ SystemWindow >> drawDropShadowOn: aCanvas [
 SystemWindow >> expandBoxHit [
 	"The fullscreen expand box has been hit"
 
-	self canBeMaximized ifFalse: [ ^ self ].
 	self isCollapsed ifTrue: [
 			self
 				hide;
@@ -486,6 +485,8 @@ SystemWindow >> expandBoxHit [
 			^ self show ].
 	self unexpandedFrame
 		ifNil: [
+				"Some window should not be able to be maximized so we check it there."
+				self canBeMaximized ifFalse: [ ^ self ].
 				self
 					unexpandedFrame: fullFrame;
 					fullscreen ]


### PR DESCRIPTION
Since the PR https://github.com/pharo-project/pharo/pull/18118 it is not possible to minimize a window.  This change fixes this.

I fixed it by moving the guard right before we try to maximize a window. Not when we try to minimize it. 

Fixes #18472