### PR TITLE
Fixes #18482 Cannot push up a class var.

### DIFF
--- a/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
+++ b/src/Refactoring-Core/RBChildrenToSiblingsRefactoring.class.st
@@ -156,7 +156,7 @@ RBChildrenToSiblingsRefactoring >> pullUpClassVariables [
 	newSuperclass := self abstractSuperclass.
 	parent classVariableNames do:
 			[:each |
-			self generateChangesFor: (RBPullUpClassVariableRefactoring
+			self generateChangesFor: (RePullUpSharedVariableRefactoring
 						model: self model
 						variable: each
 						class: newSuperclass)]

--- a/src/Refactoring-Core/ReDefinesInstanceVariableCondition.class.st
+++ b/src/Refactoring-Core/ReDefinesInstanceVariableCondition.class.st
@@ -27,12 +27,6 @@ ReDefinesInstanceVariableCondition >> check [
 	^ violators isEmpty
 ]
 
-{ #category : 'private' }
-ReDefinesInstanceVariableCondition >> errorBlock [
-	^ [ class printString
-				, ' <1?: > define <1?s:> instance variable ' , instanceVariables ]
-]
-
 { #category : 'accessing' }
 ReDefinesInstanceVariableCondition >> instanceVariables: aColOfStrings [
 

--- a/src/Refactoring-Core/ReDirectlyDefinesInstanceVariableCondition.class.st
+++ b/src/Refactoring-Core/ReDirectlyDefinesInstanceVariableCondition.class.st
@@ -43,12 +43,6 @@ ReDirectlyDefinesInstanceVariableCondition >> class: aRBAbstractClass inModel: a
 	
 ]
 
-{ #category : 'private' }
-ReDirectlyDefinesInstanceVariableCondition >> errorBlock [
-	^ [ class printString
-				, ' <1?: > directly define <1?s:> instance variable ' , instanceVariables ]
-]
-
 { #category : 'accessing' }
 ReDirectlyDefinesInstanceVariableCondition >> instanceVariables: aColOfStrings [
 

--- a/src/Refactoring-Core/ReDirectlyDefinesSharedVariableCondition.class.st
+++ b/src/Refactoring-Core/ReDirectlyDefinesSharedVariableCondition.class.st
@@ -40,7 +40,7 @@ ReDirectlyDefinesSharedVariableCondition >> violationMessageOn: aStream [
 	^ violators do: [ :violator |
 		  aStream
 			nextPutAll: 
-				('The variable {1} is not directly defined in the class {2}' 
+				('The shared variable {1} is not directly defined in the class {2}' 
 					format: { violator. className });
 			nextPut: Character cr ]
 ]

--- a/src/Refactoring-Core/ReHierarchyDefinesInstanceVariableCondition.class.st
+++ b/src/Refactoring-Core/ReHierarchyDefinesInstanceVariableCondition.class.st
@@ -27,12 +27,6 @@ ReHierarchyDefinesInstanceVariableCondition >> check [
 	^ violators isEmpty
 ]
 
-{ #category : 'private' }
-ReHierarchyDefinesInstanceVariableCondition >> errorBlock [
-	^ [ class printString
-				, ' <1?: > define <1?s:> instance variable ' , instanceVariables ]
-]
-
 { #category : 'accessing' }
 ReHierarchyDefinesInstanceVariableCondition >> instanceVariables: aColOfStrings [
 

--- a/src/Refactoring-Core/ReHierarchyDefinesSharedVariableCondition.class.st
+++ b/src/Refactoring-Core/ReHierarchyDefinesSharedVariableCondition.class.st
@@ -1,0 +1,33 @@
+Class {
+	#name : 'ReHierarchyDefinesSharedVariableCondition',
+	#superclass : 'ReClassCondition',
+	#instVars : [
+		'sharedVariables'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'checking' }
+ReHierarchyDefinesSharedVariableCondition >> check [
+	
+	violators := sharedVariables reject: [ :var | class hierarchyDefinesClassVariable: var ].
+	^ violators isEmpty
+]
+
+{ #category : 'accessing' }
+ReHierarchyDefinesSharedVariableCondition >> sharedVariables: aCollection [ 
+	sharedVariables := aCollection
+]
+
+{ #category : 'displaying' }
+ReHierarchyDefinesSharedVariableCondition >> violationMessageOn: aStream [
+
+	^ violators do: [ :violator |
+		  aStream
+			nextPutAll: 
+				('The shared variable {1} is not defined in the class {2} or its subclasses' 
+					format: { violator. className });
+			nextPut: Character cr ]
+]

--- a/src/Refactoring-Core/RePullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RePullUpMethodRefactoring.class.st
@@ -222,7 +222,7 @@ RePullUpMethodRefactoring >> pullUpMethods [
 RePullUpMethodRefactoring >> pullUpSharedVariable: aVariable [
 
 	| refactoring |
-	refactoring := RBPullUpClassVariableRefactoring
+	refactoring := RePullUpSharedVariableRefactoring
 		               model: self model
 		               variable: aVariable
 		               class: targetSuperclass.

--- a/src/Refactoring-Core/RePullUpSharedVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RePullUpSharedVariableRefactoring.class.st
@@ -2,7 +2,7 @@
 I am a refactoring for moving a class variable up to the superclass.
 "
 Class {
-	#name : 'RBPullUpClassVariableRefactoring',
+	#name : 'RePullUpSharedVariableRefactoring',
 	#superclass : 'RBVariableRefactoring',
 	#category : 'Refactoring-Core-Refactorings',
 	#package : 'Refactoring-Core',
@@ -10,32 +10,33 @@ Class {
 }
 
 { #category : 'preconditions' }
-RBPullUpClassVariableRefactoring >> applicabilityPreconditions [
+RePullUpSharedVariableRefactoring >> applicabilityPreconditions [
 
 	^ {
 		  (RBCondition isMetaclass: class) not.
-		  (RBCondition withBlock: [
-			   (class hierarchyDefinesClassVariable: variableName) ifFalse: [
-				   self refactoringError: 'No subclass defines ' , variableName ].
-			   true ]) }
+		  (ReHierarchyDefinesSharedVariableCondition new
+			   class: class;
+			   sharedVariables: { variableName };
+			   yourself) }
 ]
 
 { #category : 'preconditions' }
-RBPullUpClassVariableRefactoring >> breakingChangePreconditions [
+RePullUpSharedVariableRefactoring >> breakingChangePreconditions [
 
 	^ { (RBCondition withBlock: [
 		   (class subclasses anySatisfy: [ :each |
 			    (each directlyDefinesClassVariable: variableName) not ])
 			   ifTrue: [
 				   self refactoringWarning:
-					   'Not all subclasses have an class variable named.<n> Do you want pull up this variable anyway?'
+					   'Not all subclasses have a shared variable named.<n> Do you want pull up this variable anyway?'
 					   , variableName , '.' ].
 		   true ]) }
 ]
 
 { #category : 'transforming' }
-RBPullUpClassVariableRefactoring >> privateTransform [
-
+RePullUpSharedVariableRefactoring >> privateTransform [
+	"Remove all the variables in the hierarchy below the classes and define one on the top."
+	
 	class allSubclasses do:
 		[:each |
 		(each directlyDefinesClassVariable: variableName)

--- a/src/Refactoring-Transformations-Tests/RBPullUpClassVariableParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPullUpClassVariableParametrizedTest.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : 'tests' }
 RBPullUpClassVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
-		addCase: { #rbClass -> RBPullUpClassVariableRefactoring .
+		addCase: { #rbClass -> RePullUpSharedVariableRefactoring .
 					  #constructor -> #variable:class: };
 		addCase: { #rbClass -> RBPullUpVariableTransformation .
 					  #constructor -> #classVariable:class: };

--- a/src/Refactoring-UI/RePushUpVariableDriver.class.st
+++ b/src/Refactoring-UI/RePushUpVariableDriver.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : 'ReInteractionDriver',
 	#instVars : [
 		'class',
-		'variable'
+		'variable',
+		'isSharedVariable'
 	],
 	#category : 'Refactoring-UI-Drivers',
 	#package : 'Refactoring-UI',
@@ -26,7 +27,10 @@ RePushUpVariableDriver >> configureRefactoring [
 
 { #category : 'factory method' }
 RePushUpVariableDriver >> refactoringClass [
-	^ RePullUpInstanceVariableRefactoring
+
+	^ isSharedVariable
+		  ifTrue: [ RePullUpSharedVariableRefactoring ]
+		  ifFalse: [ RePullUpInstanceVariableRefactoring ]
 ]
 
 { #category : 'execution' }
@@ -36,12 +40,14 @@ RePushUpVariableDriver >> runRefactoring [
 	self applyChanges
 ]
 
-{ #category : 'initialization' }
-RePushUpVariableDriver >> scopes: aCollection variable: aString to: aClass [ 
+{ #category : 'factory method' }
+RePushUpVariableDriver >> scopes: aCollection variable: varName shared: isSharedVar to: aClass [ 
+
 	"The driver is initialized in interactive mode (i.e. we will ask for the newName to the user while running the refactoring"
 	
 	scopes := aCollection.
 	model :=  self refactoringScopeOn: scopes first.
 	class := aClass.
-	variable := aString
+	variable := varName.
+	isSharedVariable := isSharedVar
 ]

--- a/src/SystemCommands-VariableCommands/RePullUpInstanceVariableRefactoring.extension.st
+++ b/src/SystemCommands-VariableCommands/RePullUpInstanceVariableRefactoring.extension.st
@@ -2,5 +2,5 @@ Extension { #name : 'RePullUpInstanceVariableRefactoring' }
 
 { #category : '*SystemCommands-VariableCommands' }
 RePullUpInstanceVariableRefactoring class >> classVariableAnalog [
-	^RBPullUpClassVariableRefactoring
+	^ RePullUpSharedVariableRefactoring
 ]

--- a/src/SystemCommands-VariableCommands/SycPushUpVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycPushUpVariableCommand.class.st
@@ -42,6 +42,7 @@ SycPushUpVariableCommand >> executeRefactorings [
 	(RePushUpVariableDriver new
 		 scopes: refactoringScopes
 		 variable: variable actualVariable name
+		 shared: variable isClassVariable
 		 to: variable definingClass superclass) runRefactoring
 ]
 


### PR DESCRIPTION
The push up command of Calypso was always using the instance var refactoring instead of checking wether to use instance or shared var refactoring.