### PR TITLE
Allow using symbols in #reduce: and #inject:into:

### DIFF
--- a/src/Collections-Strings-Tests/SymbolTest.class.st
+++ b/src/Collections-Strings-Tests/SymbolTest.class.st
@@ -286,6 +286,36 @@ SymbolTest >> subCollectionNotIn [
 ]
 
 { #category : 'tests' }
+SymbolTest >> testArgumentCountInfixSymbol [
+
+	| symbol |
+
+	symbol := #+.
+
+	self assert: symbol argumentCount equals: 2
+]
+
+{ #category : 'tests' }
+SymbolTest >> testArgumentCountManyArgs [
+
+	| symbol |
+
+	symbol := #test:bla123:.
+
+	self assert: symbol argumentCount equals: 3
+]
+
+{ #category : 'tests' }
+SymbolTest >> testArgumentCountOneArg [
+
+	| symbol |
+
+	symbol := #test.
+
+	self assert: symbol argumentCount equals: 1
+]
+
+{ #category : 'tests' }
 SymbolTest >> testAsAccessor [
 	self assert: #x: asAccessor equals: #x.
 	self assert: #x asAccessor equals: #x.
@@ -573,6 +603,37 @@ SymbolTest >> testUncapitalized [
 	lc := #mElViN.
 	self assert: uc uncapitalized equals: lc.
 	self assert: lc uncapitalized equals: lc
+]
+
+{ #category : 'tests' }
+SymbolTest >> testValueValue [
+
+	| symbol |
+	
+	symbol := #+.
+	
+	self assert: (symbol value: 1 value: 4) equals: 5
+]
+
+{ #category : 'tests' }
+SymbolTest >> testValueWithArguments [
+
+	| symbol |
+	
+	symbol := #+.
+	
+	self assert: (symbol valueWithArguments: {1. 4}) equals: 5
+]
+
+{ #category : 'tests' }
+SymbolTest >> testValueWithOneArg [
+
+	| symbol rcvr |
+	
+	symbol := #abs.
+	rcvr := -1.
+	
+	self assert: (symbol value: rcvr) equals: 1
 ]
 
 { #category : 'requirements' }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -323,6 +323,12 @@ Symbol >> = aSymbol [
 	^ super = aSymbol
 ]
 
+{ #category : 'accessing' }
+Symbol >> argumentCount [
+
+	^ self numArgs + 1
+]
+
 { #category : 'converting' }
 Symbol >> asAccessor [
 	"Return a accessor (getter) message from a setter message.
@@ -643,6 +649,18 @@ Symbol >> uncapitalized [
 { #category : 'evaluating' }
 Symbol >> value: anObject [
 	^anObject perform: self
+]
+
+{ #category : 'evaluating' }
+Symbol >> value: anObject value: arg [
+
+	^ anObject perform: self with: arg
+]
+
+{ #category : 'evaluating' }
+Symbol >> valueWithArguments: aCollection [
+
+	^ aCollection first perform: self withArguments: aCollection allButFirst
 ]
 
 { #category : 'copying' }

--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -325,7 +325,8 @@ Symbol >> = aSymbol [
 
 { #category : 'accessing' }
 Symbol >> argumentCount [
-
+    "This method refers to block arguments [:acc :x | ...] has two arguments so argumentCount of a selector that could be used in place of a block
+	should return the same amount of argument than the block."
 	^ self numArgs + 1
 ]
 

--- a/src/Collections-Tests/ReduceTest.class.st
+++ b/src/Collections-Tests/ReduceTest.class.st
@@ -183,3 +183,15 @@ ReduceTest >> testReduceRightSpecial [
 	self assert: ((1 to: 100) reduceRight: [ :a :b | a - b ]) equals: -50.
 	self assert: ('abc' reduceRight: [ :a :b | Array with: a with: b ]) equals: #($a #($b $c))
 ]
+
+{ #category : 'tests' }
+ReduceTest >> testReduceWithInfixSymbol [
+
+	self assert: ((1 to: 4) reduceLeft: #+) equals: 10
+]
+
+{ #category : 'tests' }
+ReduceTest >> testReduceWithSymbol [
+
+	self assert: ((1 to: 4) reduceLeft: #max:) equals: 4
+]


### PR DESCRIPTION
The objective of this PR is to be able to do things like:

```smalltalk
{ 1. 2. 3. 4 } reduce: #+.
{ 1. 2. 3. 4 } reduce: #max:.
```

Similar to how we can do:
```smalltalk
{ 1. 2. 3. 4 } select: #isPowerOfTwo 
```

With that in mind, I implemented `argumentCount`, `value:value:` and `valueWithArguments:` in Symbol
