### PR TITLE
Removed duplicate classes in new DrTest

### DIFF
--- a/src/DrTests-Tests/DrTestsUITest.class.st
+++ b/src/DrTests-Tests/DrTestsUITest.class.st
@@ -80,20 +80,20 @@ DrTestsUITest >> testInitialWindowTitleIsInitialPluginWindowTitle [
 
 { #category : 'tests' }
 DrTestsUITest >> testMultipleSelectingPackagesWillUpdateTheClassesList [
-	| currentPluginSelected randomPackage newPackagesSelected classesList packageSelected |
+
+	| currentPluginSelected randomPackage newPackagesSelected classesList packageSelected allTreeItems |
 	currentPluginSelected := drTestsUI pluginsDropList selectedItem.
 	newPackagesSelected := OrderedCollection new.
 	packageSelected := drTestsUI pluginPresenter packagesList items anyOne.
-	randomPackage := (drTestsUI pluginPresenter packagesList items
-		\ {packageSelected}) anyOne.
+	randomPackage := (drTestsUI pluginPresenter packagesList items \ { packageSelected }) anyOne.
 	newPackagesSelected add: packageSelected.
 	newPackagesSelected add: randomPackage.
 	drTestsUI pluginPresenter whenPackagesSelectionChanged: newPackagesSelected.
-	classesList := currentPluginSelected new
-		itemsToBeAnalysedFor: newPackagesSelected.
-	self
-		assertCollection: drTestsUI pluginPresenter itemsList items
-		hasSameElements: classesList flattened
+	classesList := currentPluginSelected new itemsToBeAnalysedFor: newPackagesSelected.
+	allTreeItems := drTestsUI pluginPresenter itemsList items , (drTestsUI pluginPresenter itemsList items flatCollect: [ :root |
+		                 root allSubclasses & (newPackagesSelected flatCollect: [ :package | package classes ]) ]).
+
+	self assertCollection: allTreeItems hasSameElements: classesList flattened
 ]
 
 { #category : 'tests' }

--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -442,5 +442,8 @@ DTDefaultPluginPresenter >> whenPackagesSelectionChanged: packagesSelected [
 		expandAll.
 	itemsList roots: itemsList items.
 	itemsList selectAll.
-	self updatePackagesListLabel 
+	self updatePackagesListLabel.
+
+
+
 ]

--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -433,16 +433,14 @@ DTDefaultPluginPresenter >> whenItemsSelectionChanged: itemsSelected [
 { #category : 'private' }
 DTDefaultPluginPresenter >> whenPackagesSelectionChanged: packagesSelected [
 
+	| allClasses |
+	allClasses := packagesSelected flatCollect: [ :package | package classes ].
 	itemsList
-		roots: ((plugin itemsToBeAnalysedFor: packagesSelected) sorted:
+		roots: (((plugin itemsToBeAnalysedFor: packagesSelected) reject: [ :aClass | allClasses includes: aClass superclass ]) sorted:
 					 #name ascending);
-		children: [ :aClass |
-				aClass subclasses
-				& (packagesSelected flatCollect: [ :package | package classes ])
-					sorted: #name ascending ];
+		children: [ :aClass | aClass subclasses & allClasses sorted: #name ascending ];
 		expandAll.
 	itemsList roots: itemsList items.
-
 	itemsList selectAll.
-	self updatePackagesListLabel
+	self updatePackagesListLabel 
 ]


### PR DESCRIPTION
- Subclasses in the tree were duplicated and considered as normal classes, not subclasses 
- Now the tree view hierarchy is fully respected