### PR TITLE
Make #printOn: on Character not print surrogates as a literal

### DIFF
--- a/src/Kernel-Tests/CharacterTest.class.st
+++ b/src/Kernel-Tests/CharacterTest.class.st
@@ -115,7 +115,9 @@ CharacterTest >> testPrintString [
 	self assert: Character space printString equals: 'Character space'.
 
 	self assert: (Character value: 0) printString equals: 'Character null'.
-	self assert: (Character value: 17) printString equals: 'Character value: 17'
+	self assert: (Character value: 17) printString equals: 'Character value: 17'.
+	self assert: (Character value: 16rD800) printString equals: 'Character value: 55296'.
+	self assert: (Character value: 16rDFFF) printString equals: 'Character value: 57343'.
 ]
 
 { #category : 'tests' }
@@ -142,7 +144,9 @@ CharacterTest >> testStoreString [
 	self assert: Character space storeString equals: 'Character space'.
 	self assert: (Character value: 0) storeString equals: 'Character null'.
 
-	self assert: (Character value: 17) storeString equals: '(Character value: 17)'
+	self assert: (Character value: 17) storeString equals: '(Character value: 17)'.
+	self assert: (Character value: 16rD800) storeString equals: '(Character value: 55296)'.
+	self assert: (Character value: 16rDFFF) storeString equals: '(Character value: 57343)'.
 ]
 
 { #category : 'tests' }

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -830,7 +830,7 @@ Character >> nextObject [
 { #category : 'printing' }
 Character >> printOn: aStream [
 	| name |
-	(self asInteger > 32 and: [ self asInteger ~= 127])
+	(self asInteger > 32 and: [ self asInteger ~= 127 and: [ (self asInteger between: 16rD800 and: 16rDFFF) not ] ])
 		ifTrue: [ aStream nextPut: $$; nextPut: self ]
 		ifFalse: [
 			name := self class constantNameFor: self.

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -830,7 +830,7 @@ Character >> nextObject [
 { #category : 'printing' }
 Character >> printOn: aStream [
 	| name |
-	(self asInteger > 32 and: [ self asInteger ~= 127 and: [ (self asInteger between: 16rD800 and: 16rDFFF) not ] ])
+	(self asInteger > 32 and: [ self asInteger ~= 127 and: [ (self asInteger between: 16rD800 and: 16rDFFF) not "¹" ] ])
 		ifTrue: [ aStream nextPut: $$; nextPut: self ]
 		ifFalse: [
 			name := self class constantNameFor: self.
@@ -838,6 +838,11 @@ Character >> printOn: aStream [
 			name isNotNil
 				ifTrue: [ aStream space; nextPutAll: name ]
 				ifFalse: [ aStream nextPutAll: ' value: '; print: self asInteger ] ]
+
+	"¹ Covers the surrogate code points which should not be printed as a literal as they “cannot be assigned
+	to [an] abstract character” and “cannot be conformantly interchanged using Unicode encoding forms” per
+	section ‘2.4.1 Types of Code Points’ in ‘The Unicode Standard, Version 17.0 – Core Specification’
+	available at: https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-2/#G14527"
 ]
 
 { #category : 'printing' }


### PR DESCRIPTION
Following my comment [in issue #17542](https://github.com/pharo-project/pharo/issues/17542#issuecomment-2585395462), this pull request makes #printOn: on Character print instances with surrogate code points as an instance creation expression instead of as a literal. Printing them as a literal does not make much sense as per [section ‘2.4.1 Types of Code Points’ in ‘The Unicode Standard, Version 17.0 – Core Specification’](https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-2/#G14527) surrogate code points “cannot be assigned to [an] abstract character” and “cannot be conformantly interchanged using Unicode encoding forms”.