### PR TITLE
[Refactorings] Solves issue#18507 "Scope issue breaks refactoring"

### DIFF
--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -653,6 +653,13 @@ RBBrowserEnvironment >> referencesTo: aLiteral in: aClass [
 	^(self forClasses: classes) referencesTo: aLiteral
 ]
 
+{ #category : 'testing' }
+RBBrowserEnvironment >> representsScope: aClass [
+	"For compatibility with ClyScope"
+
+	^ false
+]
+
 { #category : 'private' }
 RBBrowserEnvironment >> rootEnvironment [
 	"The root environment representing everything."

--- a/src/Refactoring-UI/ReInsertSubclassDriver.class.st
+++ b/src/Refactoring-UI/ReInsertSubclassDriver.class.st
@@ -110,10 +110,10 @@ ReInsertSubclassDriver >> runRefactoring [
 { #category : 'accessing' }
 ReInsertSubclassDriver >> scopes: refactoringScopes [
 
-	scopes := refactoringScopes.
+	"Exclude custom scopes created in the ScopesEditor"
+	scopes := refactoringScopes select: [ :scp | scp representsScope: ClyScope ].
 	model := self refactoringScopeOn: scopes last.
 	superclass := model classObjectFor: superclass
-
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReInsertSuperclassDriver.class.st
+++ b/src/Refactoring-UI/ReInsertSuperclassDriver.class.st
@@ -106,7 +106,8 @@ ReInsertSuperclassDriver >> runRefactoring [
 { #category : 'accessing' }
 ReInsertSuperclassDriver >> scopes: refactoringScopes [
 
-	scopes := refactoringScopes.
+	"Exclude custom scopes created in the ScopesEditor"
+	scopes := refactoringScopes select: [ :scp | scp representsScope: ClyScope ].
 	model := self refactoringScopeOn: scopes last.
 	superclass := model classObjectFor: superclass
 	

--- a/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand2.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand2.class.st
@@ -65,13 +65,7 @@ SycCmInsertSubclassCommand2 >> packageNames [
 { #category : 'preparation' }
 SycCmInsertSubclassCommand2 >> prepareFullExecution [
 	
-	"Here there is a bug when we repplace firstNavigationScopes by refactoringScopes
-	when using refactoringScopes the model is not able to find the superclass of a class. 
-	Probably because the model is just made for the class and not the class hierarchy.
-	After fighting to understand I decided to stop and introduced firstNavigationScopes which is breaking the scope
-	reduction but.... else insert is not working."
-	
-	refactoringScopes := context firstNavigationScopes.
+	refactoringScopes := context refactoringScopes.
 	targetClass := context lastSelectedClass.
 
 ]

--- a/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand2.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand2.class.st
@@ -56,13 +56,7 @@ SycCmInsertSuperclassCommand2 >> packageNames [
 { #category : 'preparation' }
 SycCmInsertSuperclassCommand2 >> prepareFullExecution [
 
-	"Here there is a bug when we repplace firstNavigationScopes by refactoringScopes
-	when using refactoringScopes the model is not able to find the superclass of a class. 
-	Probably because the model is just made for the class and not the class hierarchy.
-	After fighting to understand I decided to stop and introduced firstNavigationScopes which is breaking the scope
-	reduction but.... else insert is not working."
-	
-	refactoringScopes := context firstNavigationScopes.
+	refactoringScopes := context refactoringScopes.
 	targetClass := context lastSelectedClass.
 
 ]


### PR DESCRIPTION
Solves [Issue#18507](https://github.com/pharo-project/pharo/issues/18507)

User defined scopes (created in ScopesEditor) produced errors in ReInsertSubclass and ReInsertSuperclass drivers. 

Ignoring these scopes solves the issue because these drivers expect an instance of `ClyBothMetaLevelClassScope` (which is last in the default list of scopes).

However, in the near future we should be able to handle user defined scopes in all refactorings and drivers