### PR TITLE
Find and replace not stuck with old string anymore

### DIFF
--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
@@ -101,7 +101,7 @@ SpRubFindReplaceService >> openDialog [
 	dialog updateFromModel.
 	(text isNotEmpty and: [ text ~= dialog findInput text ]) ifTrue: [
 		dialog findInput text: text ].
-	dialogWindow := dialog openDialog
+	dialogWindow := dialog openDialog 
 ]
 
 { #category : 'services' }

--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
@@ -95,11 +95,12 @@ SpRubFindReplaceService >> initialize [
 { #category : 'events handling' }
 SpRubFindReplaceService >> openDialog [
 
-	dialogWindow ifNotNil: [ dialogWindow close ].
-
+	| text |
+	text := findText asString.
 	dialog := SpRubFindReplaceDialog on: self.
 	dialog updateFromModel.
-
+	(text isNotEmpty and: [ text ~= dialog findInput text ]) ifTrue: [
+		dialog findInput text: text ].
 	dialogWindow := dialog openDialog
 ]
 

--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceService.class.st
@@ -20,10 +20,22 @@ SpRubFindReplaceService >> caseSensitive [
 	^ caseSensitive ifNil: [caseSensitive := RubAbstractTextArea caseSensitiveFinds]
 ]
 
+{ #category : 'accessing' }
+SpRubFindReplaceService >> dialog [
+
+	^ dialog
+]
+
 { #category : 'services' }
 SpRubFindReplaceService >> dialogIsActiveFor: aTextArea [
 
  ^ false
+]
+
+{ #category : 'accessing' }
+SpRubFindReplaceService >> dialogWindow [
+
+	^ dialogWindow
 ]
 
 { #category : 'events handling' }

--- a/src/Rubric-Tests/RubFindReplaceServiceTest.class.st
+++ b/src/Rubric-Tests/RubFindReplaceServiceTest.class.st
@@ -9,11 +9,51 @@ Class {
 { #category : 'tests' }
 RubFindReplaceServiceTest >> defaultFindReplaceServiceClass [
 
-	^ RubFindReplaceService
+	^ SpRubFindReplaceService
 ]
 
 { #category : 'tests' }
 RubFindReplaceServiceTest >> testCaseSensitive [
 
 	self deny: ( self defaultFindReplaceServiceClass newFor: self) caseSensitive
+]
+
+{ #category : 'tests' }
+RubFindReplaceServiceTest >> testOpenDialogWithDifferentText [
+	"Test that dialog text gets updated when findText differs from dialog input"
+
+	| service mock |
+	mock := MockObject new.
+	mock on: #announcer respond: Announcer new.
+	service := self defaultFindReplaceServiceClass newFor: self.
+	service textArea: mock.
+	service findText: 'old cached text'.
+	service openDialog.
+	service dialogWindow close.
+	service findText: 'selected text'.
+	service openDialog.
+
+	self assert: service dialog findInput text equals: 'selected text'.
+	service dialogWindow close
+]
+
+{ #category : 'tests' }
+RubFindReplaceServiceTest >> testOpenDialogWithSameText [
+	"Test that dialog text stays the same when findText matches cached text"
+
+	| service mock text|
+	text:= 'same text'.
+	mock := MockObject new.
+	mock on: #announcer respond: Announcer new.
+	service := self defaultFindReplaceServiceClass newFor: self.
+	service textArea: mock.
+	service findText: text.
+	service openDialog.
+	"We simulate the find action there"
+	service dialog textToFind: text.
+	service dialogWindow close.
+	"Opening new dialog"
+	service openDialog.
+	self assert: service dialog findInput text equals: text.
+	service dialogWindow close
 ]


### PR DESCRIPTION
-In there the problem was that ```Find & Replace``` kept its old strings for find and replace ( which is good ) but even when the user opened the tool with a selected string
To make it clear the priority for find string when opening ```Find & Replace``` is:
	- Selected string
	- Older string if there is one
	- Nothing if previous ones are nil

So this PR apply this priorities :)

Fixes #18545