### PR TITLE
Fix #18557: Unexpected behavior when storing and loading code quality rule settings from files

### DIFF
--- a/src/Renraku/ReAbstractRule.class.st
+++ b/src/Renraku/ReAbstractRule.class.st
@@ -110,7 +110,7 @@ ReAbstractRule class >> designFlawGroup [
 { #category : 'accessing' }
 ReAbstractRule class >> enabled [
 
-	^ enabled ifNil: [ enabled := true ]
+	^ enabled ifNil: [ enabled := self enabledByDefault ]
 ]
 
 { #category : 'accessing' }
@@ -118,6 +118,12 @@ ReAbstractRule class >> enabled: aBoolean [
 
 	enabled := aBoolean.
 	ReRuleManager reset
+]
+
+{ #category : 'manifest' }
+ReAbstractRule class >> enabledByDefault [
+
+	^ true
 ]
 
 { #category : 'accessing' }

--- a/src/Renraku/ReRuleManager.class.st
+++ b/src/Renraku/ReRuleManager.class.st
@@ -231,15 +231,15 @@ ReRuleManager class >> setDefaultProfile [
 ]
 
 { #category : 'settings' }
-ReRuleManager class >> subSettingsOn: aBuilder with: rules [ 
+ReRuleManager class >> subSettingsOn: aBuilder with: rules [
 
-	 ^ (rules sorted: [ :a :b | a name < b name ]) do: [ :rule |
-		  (aBuilder setting: rule enabledSettingID)
-			  selector: #enabled;
-			  target: rule;
-			  default: rule enabled;
-			  label: rule ruleName;
-			  description: rule rationale ]
+	^ (rules sorted: [ :a :b | a name < b name ]) do: [ :rule |
+			  (aBuilder setting: rule enabledSettingID)
+				  selector: #enabled;
+				  target: rule;
+				  default: rule enabledByDefault;
+				  label: rule ruleName;
+				  description: rule rationale ]
 ]
 
 { #category : 'event subscriptions' }


### PR DESCRIPTION
Add a proper default value for the enabled state of code quality rules. Use the new default value in the setting declaration.