### PR TITLE
Small cleanup of Metacello/Monticello

### DIFF
--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -25,10 +25,8 @@ MCMethodDefinition initializersEnabled: true.
 "For now, it happens that the bootstrap does not caches the pragmas. This should be fixed later by reloading the packages after Metacello and Monticello are reloaded but we need them for reseting the system announcer for example."
 CompiledMethod allInstancesDo: [ :m | m cachePragmas ].
 
-MCFileTreeStCypressWriter initialize.
 MCFileTreeFileSystemUtils initialize.
 
-ConfigurationOf initialize.
 MetacelloPlatform initialize.
 
 STONWriter initialize.

--- a/src/Metacello-GitBasedRepository/MCGitBasedNetworkRepository.class.st
+++ b/src/Metacello-GitBasedRepository/MCGitBasedNetworkRepository.class.st
@@ -113,11 +113,9 @@ MCGitBasedNetworkRepository class >> flushProjectEntry: projectPath version: ver
 { #category : 'class initialization' }
 MCGitBasedNetworkRepository class >> initialize [
 
-	(Smalltalk classNamed: #SessionManager)
-		ifNotNil: [ :c | c default perform: #registerNetworkClassNamed: with: self name ]
-		ifNil:[ Smalltalk addToStartUpList: self ].
-  self flushDownloadCache.
-  self resetCacheDirectoryIfInvalid
+	SessionManager default registerNetworkClassNamed: self name.
+	self flushDownloadCache.
+	self resetCacheDirectoryIfInvalid
 ]
 
 { #category : 'accessing' }

--- a/src/MonticelloFileTree-Core/MCFileTreeStCypressWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreeStCypressWriter.class.st
@@ -44,13 +44,6 @@ MCFileTreeStCypressWriter class >> fileNameForSelector: selector [
 
 ]
 
-{ #category : 'class initialization' }
-MCFileTreeStCypressWriter class >> initialize [
-    "Force initialization of specials ..."
-
-    specials := nil
-]
-
 { #category : 'private' }
 MCFileTreeStCypressWriter class >> initializeSpecials [
     | map |
@@ -79,6 +72,13 @@ MCFileTreeStCypressWriter class >> initializeSpecials [
 { #category : 'accessing' }
 MCFileTreeStCypressWriter class >> monticelloMetaDirName [
     ^ 'monticello.meta'
+]
+
+{ #category : 'class initialization' }
+MCFileTreeStCypressWriter class >> resetSpecials [
+    "Force initialization of specials ..."
+
+    specials := nil
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
- Metacello is loaded after the SessionManager so we can have an explicit dependency in MCGitBasedNetworkRepository
- MCFileTreeStCypressWriter initializer is just a reset method. Remove the need to initialize it (since it's at the begining of the loading we need to call the initialize by hand)
- ConfugirationOf does not have an initializer