### PR TITLE
Handle short-form #rgb[a] colors in Color

### DIFF
--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -350,7 +350,7 @@ Color class >> fromHexString: aColorHex [
 				  g: g
 				  b: b
 				  alpha: a ].
-	self error: 'Color hex string must be 3, 4, 6 or characters long.'
+	self error: 'Color hex string must be 3, 4, 6 or 8 characters long.'
 ]
 
 { #category : 'instance creation' }

--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -312,17 +312,45 @@ Color class >> fromHexString: aColorHex [
 
 	"(Color fromHexString: 'FFFFFF')>>> (Color white) "
 
-	| green red blue alpha hexString |
+	"(Color fromHexString: '000')>>> (Color black)"
+
+	| hexString |
 	hexString := aColorHex withoutPrefix: '#'.
-	red := (Integer readFrom: (hexString first: 2) base: 16) / 255.
-	green := (Integer readFrom: (hexString copyFrom: 3 to: 4) base: 16) / 255.
-	blue := (Integer readFrom: (hexString copyFrom: 5 to: 6) base: 16) / 255.
-
-	alpha := hexString size = 8
-		ifFalse: [ 1.0 ]
-		ifTrue: [ (Integer readFrom: (hexString copyFrom: 7 to: 8) base: 16) / 255 ].
-
-	^ self r: red g: green b: blue alpha: alpha
+	hexString size = 3 ifTrue: [
+			| r g b |
+			r := Integer readFrom: hexString first asString base: 16.
+			g := Integer readFrom: hexString second asString base: 16.
+			b := Integer readFrom: hexString third asString base: 16.
+			^ self r: r * 16 + r / 255 g: g * 16 + g / 255 b: b * 16 + b / 255 ].
+	hexString size = 4 ifTrue: [
+			| r g b a |
+			r := Integer readFrom: hexString first asString base: 16.
+			g := Integer readFrom: hexString second asString base: 16.
+			b := Integer readFrom: hexString third asString base: 16.
+			a := Integer readFrom: hexString fourth asString base: 16.
+			^ self
+				  r: r * 16 + r / 255
+				  g: g * 16 + g / 255
+				  b: b * 16 + b / 255
+				  alpha: a * 16 + a / 255 ].
+	hexString size = 6 ifTrue: [
+			| r g b |
+			r := (Integer readFrom: (hexString first: 2) base: 16) / 255.
+			g := (Integer readFrom: (hexString copyFrom: 3 to: 4) base: 16) / 255.
+			b := (Integer readFrom: (hexString copyFrom: 5 to: 6) base: 16) / 255.
+			^ self r: r g: g b: b ].
+	hexString size = 8 ifTrue: [
+			| r g b a |
+			r := (Integer readFrom: (hexString first: 2) base: 16) / 255.
+			g := (Integer readFrom: (hexString copyFrom: 3 to: 4) base: 16) / 255.
+			b := (Integer readFrom: (hexString copyFrom: 5 to: 6) base: 16) / 255.
+			a := (Integer readFrom: (hexString copyFrom: 7 to: 8) base: 16) / 255.
+			^ self
+				  r: r
+				  g: g
+				  b: b
+				  alpha: a ].
+	self error: 'Color hex string must be 3, 4, 6 or characters long.'
 ]
 
 { #category : 'instance creation' }

--- a/src/Colors/Color.class.st
+++ b/src/Colors/Color.class.st
@@ -366,20 +366,22 @@ Color class >> fromString: aString [
 	"Return a color for HTML color spec: #FFCCAA or white/black passed as string."
 
 	"(Color fromString: '#FFCCAA')>>> (Color r: 1.0 g: 0.8 b: 0.667 alpha: 1.0) "
+
 	"(Color fromString: 'orange') >>> Color orange"
 
 	| aColorHex |
-	aString isEmptyOrNil
-		ifTrue: [ ^ self white ].
+	aString isEmptyOrNil ifTrue: [ ^ self white ].
 	aColorHex := aString first = $#
-		ifTrue: [ aString allButFirst ]
-		ifFalse: [ aString ].	"Try to match aColorHex with known named colors, case insensitive."
+		             ifTrue: [ aString allButFirst ]
+		             ifFalse: [ aString ]. "Try to match aColorHex with known named colors, case insensitive."
 	^ self registeredColorNames
-		detect: [ :each | each sameAs: aColorHex ]
-		ifFound: [ :namedColor | self named: namedColor ]
-		ifNone: [ (aColorHex size = 6 and: [ aColorHex allSatisfy: [ :character | '0123456789ABCDEFabcdef' includes: character ] ])
-				ifTrue: [ self fromHexString: aColorHex ]
-				ifFalse: [ self white ] ]
+		  detect: [ :each | each sameAs: aColorHex ]
+		  ifFound: [ :namedColor | self named: namedColor ]
+		  ifNone: [
+				  (({ 3. 4. 6. 8 } includes: aColorHex size) and: [
+					   aColorHex allSatisfy: [ :character | '0123456789ABCDEFabcdef' includes: character ] ])
+					  ifTrue: [ self fromHexString: aColorHex ]
+					  ifFalse: [ self white ] ]
 ]
 
 { #category : 'accessing - defaults' }

--- a/src/Graphics-Tests/ColorTest.class.st
+++ b/src/Graphics-Tests/ColorTest.class.st
@@ -182,7 +182,7 @@ ColorTest >> testFromString [
 		assert: ((Color fromString: nil) asHexString sameAs: 'ffffff');
 		assert: ((Color fromString: 'inexistent color') asHexString sameAs: 'ffffff'); "should return white"
 		assert: ((Color fromString: 'XXXXXX') asHexString sameAs: 'ffffff'); "not alphanumeric"
-		assert: ((Color fromString: '00000000') asHexString sameAs: 'ffffff'). "too many digits"
+		assert: ((Color fromString: '000000000') asHexString sameAs: 'ffffff'). "too many digits"
 
 	self
 		assert: (Color fromString: 'DARKGRAY') = Color darkGray description: 'Color can be specified with a case insensitive color name';

--- a/src/Graphics-Tests/ColorTest.class.st
+++ b/src/Graphics-Tests/ColorTest.class.st
@@ -151,7 +151,6 @@ ColorTest >> testContrastingColorAdjustment [
 ColorTest >> testFromHexString [
 
 	| color |
-
 	color := Color fromHexString: 'FFFFFF'.
 	self assert: color equals: Color white.
 
@@ -165,7 +164,13 @@ ColorTest >> testFromHexString [
 	self assert: color equals: Color magenta.
 
 	color := Color fromHexString: '#FF00FF55'.
-	self assert: (color alpha > 0.3 and: [color alpha < 0.4])
+	self assert: (color alpha > 0.3 and: [ color alpha < 0.4 ]).
+
+	color := Color fromHexString: '#000'.
+	self assert: color equals: Color black.
+
+	color := Color fromHexString: '#f0f5'.
+	self assert: (color alpha > 0.3 and: [ color alpha < 0.4 ])
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
More recent versions of HTML/CSS allow an abbreviated form of hex colors `#rgb[a]`, which is equivalent to the long form `#rrggbb[aa]`. This caused some weirdness for me when trying to use Athens-SVG with some SVG files using this syntax, since A-SVG uses `Color>>fromString:` internally to parse colors. This PR extends the Color parsing logic to accomodate this syntax and adds some tests.

I've not yet submitted the contributor agreement, but I'll mail at as soon as I've been to the office and had the chance to print a copy I can sign and mail.