### PR TITLE
OpalCompiler should not depend on Roassal

### DIFF
--- a/src/Collections-Sequenceable-Tests/ArrayTest.class.st
+++ b/src/Collections-Sequenceable-Tests/ArrayTest.class.st
@@ -727,6 +727,30 @@ ArrayTest >> testLiteralEqual [
 ]
 
 { #category : 'tests' }
+ArrayTest >> testMax [
+
+	self assert: example1 max equals: 5
+]
+
+{ #category : 'tests' }
+ArrayTest >> testMax2 [
+
+	self assert: (example1 max: [ :each | each + 1 ]) equals: 6
+]
+
+{ #category : 'tests' }
+ArrayTest >> testMin [
+
+	self assert: example1 min equals: 1
+]
+
+{ #category : 'tests' }
+ArrayTest >> testMin2 [
+
+	self assert: (example1 min: [ :each | each + 1 ]) equals: 2
+]
+
+{ #category : 'tests' }
 ArrayTest >> testNewWithSize [
 	| array |
 	array := Array new: 5.

--- a/src/Collections-Sequenceable-Tests/ArrayTest.class.st
+++ b/src/Collections-Sequenceable-Tests/ArrayTest.class.st
@@ -733,7 +733,7 @@ ArrayTest >> testMax [
 ]
 
 { #category : 'tests' }
-ArrayTest >> testMax2 [
+ArrayTest >> testMaxWithArgument [
 
 	self assert: (example1 max: [ :each | each + 1 ]) equals: 6
 ]
@@ -745,7 +745,7 @@ ArrayTest >> testMin [
 ]
 
 { #category : 'tests' }
-ArrayTest >> testMin2 [
+ArrayTest >> testMinWithArgument [
 
 	self assert: (example1 min: [ :each | each + 1 ]) equals: 2
 ]

--- a/src/Collections-Sequenceable/SequenceableCollection.class.st
+++ b/src/Collections-Sequenceable/SequenceableCollection.class.st
@@ -1534,6 +1534,11 @@ SequenceableCollection >> lastIndexOfAnyOf: aCollection startingAt: lastIndex if
 	^ exceptionBlock value
 ]
 
+{ #category : 'comparing' }
+SequenceableCollection >> max: aSelectorOrOneArgBlock [
+	^ (self collect: aSelectorOrOneArgBlock) max
+]
+
 { #category : 'sorting' }
 SequenceableCollection >> mergeFirst: first middle: middle last: last into: dst by: aBlock [
 	"Private. Merge the sorted ranges [first..middle] and [middle+1..last]
@@ -1607,6 +1612,11 @@ SequenceableCollection >> middle [
 	"#(a b c d) middle >>> #c"
 
 	^ self at: self size // 2 + 1
+]
+
+{ #category : 'comparing' }
+SequenceableCollection >> min: aSelectorOrOneArgBlock [
+	^ (self collect: aSelectorOrOneArgBlock) min
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
The compiler is using SequenceableCollection>>#min:/max: but those methods are from Roassal. 

I propose to move them directly on SequenceableCollection

I ended up in this code in the bootstrap. So we either need to make the compiler not depend on those methods or to move them in the original class. I propose the later but I am also open to the first