### PR TITLE
Fix a failing test

### DIFF
--- a/src/Tools-Tests/ProjectManagerTest.class.st
+++ b/src/Tools-Tests/ProjectManagerTest.class.st
@@ -14,7 +14,7 @@ ProjectManagerTest >> testPackagesInAProject [
 	self
 		assertCollection:
 			#( 'BaselineOfSUnit' 'SUnit-Core' 'SUnit-Core-Traits' 'SUnit-Tests' 'SUnit-Visitor' 'SUnit-Visitor-Tests' 'SUnit-MockObjects' 'SUnit-MockObjects-Tests'
-			   'SUnit-UI' 'Coverage' 'JenkinsTools-Core' 'JenkinsTools-ExtraReports' 'SUnit-Support-UITesting-Tests' 'SUnit-Support-UITesting' 'Coverage-Tests')
+			   'SUnit-UI' 'Coverage' 'JenkinsTools-Core' 'JenkinsTools-Tests' 'JenkinsTools-ExtraReports' 'SUnit-Support-UITesting-Tests' 'SUnit-Support-UITesting' 'Coverage-Tests')
 		hasSameElements: (sUnitProject packages collect: [ :package | package name ])
 ]
 


### PR DESCRIPTION
This test is failing because JenkinsTools-Tests has been added to the baseline. 

Maybe we should generate a baseline in order to have a reliable test but this will be enought for now