### PR TITLE
Make #tagNames: on MCOrganizationDefinition ensure the tag names are symbols

### DIFF
--- a/src/Monticello-Model/MCOrganizationDefinition.class.st
+++ b/src/Monticello-Model/MCOrganizationDefinition.class.st
@@ -129,7 +129,7 @@ MCOrganizationDefinition >> tagNames: aCollection [
 	"ensure the tags are sorted alphabetically, so the merge don't take it as a conflict"
 
 	| tags |
-	tags := aCollection.
+	tags := aCollection collect: [ :element | element asSymbol ].
 	tags := tags \ { Package rootTagName }.
 	tagNames := tags sorted asArray
 ]


### PR DESCRIPTION
Following my comment [in pull request #15102](https://github.com/pharo-project/pharo/pull/15102#issuecomment-3323689753), this pull request makes #tagNames: on MCOrganizationDefinition ensure the tag names are symbols as is done in #tagName: on MCClassDefinition.