### PR TITLE
Backport changes making #tagNames: on MCOrganizationDefinition ensure the tag names are symbols

### DIFF
--- a/src/Monticello-Model/MCOrganizationDefinition.class.st
+++ b/src/Monticello-Model/MCOrganizationDefinition.class.st
@@ -129,7 +129,7 @@ MCOrganizationDefinition >> tagNames: aCollection [
 	"ensure the tags are sorted alphabetically, so the merge don't take it as a conflict"
 
 	| tags |
-	tags := aCollection.
+	tags := aCollection collect: [ :element | element asSymbol ].
 	tags := tags \ { Package rootTagName }.
 	tagNames := tags sorted asArray
 ]


### PR DESCRIPTION
This pull request backports the changes of pull request #18588 to Pharo 13.