### PR TITLE
Fix #18558 - When loading settings, reset settings to their default value when appropriate

### DIFF
--- a/src/System-Settings-Core/SystemSettingsPersistence.class.st
+++ b/src/System-Settings-Core/SystemSettingsPersistence.class.st
@@ -323,13 +323,18 @@ SystemSettingsPersistence >> updateSettingNodes [
 
 { #category : 'loading' }
 SystemSettingsPersistence >> updateSettingNodes: aCollectionOfSettingNodes [
+
 	| storedSettings |
 	storedSettings := self allStoredSettings.
 	aCollectionOfSettingNodes do: [ :eachSettingNode |
-		storedSettings
-			detect: [ :eachStoredSetting | eachStoredSetting isForSettingNode: eachSettingNode ]
-			ifFound: [ :storedSetting | storedSetting updateSettingNode: eachSettingNode ]
-			ifNone: [ "ignore it" ] ]
+			storedSettings
+				detect: [ :eachStoredSetting | eachStoredSetting isForSettingNode: eachSettingNode ]
+				ifFound: [ :storedSetting | storedSetting updateSettingNode: eachSettingNode ]
+				ifNone: [ "Reset setting value to default if possible"
+						| declaration |
+						declaration := eachSettingNode settingDeclaration.
+						(declaration hasDefault and: [ declaration hasDefaultValue not ]) ifTrue: [
+								declaration setToDefault ] ] ]
 ]
 
 { #category : 'streams' }


### PR DESCRIPTION
Fixes #18558 

Settings that are not mentioned in the settings file get reset to their default value, if they have a default value and their current value diverges from it.