### PR TITLE
Introduced MetacelloAbstractSpecGenerator

### DIFF
--- a/src/Metacello-Core/MetacelloAbstractSpecGenerator.class.st
+++ b/src/Metacello-Core/MetacelloAbstractSpecGenerator.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : 'MetacelloAbstractSpecGenerator',
+	#superclass : 'Object',
+	#instVars : [
+		'target'
+	],
+	#category : 'Metacello-Core-Scripts',
+	#package : 'Metacello-Core',
+	#tag : 'Scripts'
+}
+
+{ #category : 'accessing' }
+MetacelloAbstractSpecGenerator >> projectSpecCreationBlock [
+	^ self subclassResponsibility
+]
+
+{ #category : 'accessing' }
+MetacelloAbstractSpecGenerator >> projectSpecListBlock [
+	^ self subclassResponsibility
+]
+
+{ #category : 'accessing' }
+MetacelloAbstractSpecGenerator >> projectSpecLookupBlock [
+	^ self subclassResponsibility
+]
+
+{ #category : 'accessing' }
+MetacelloAbstractSpecGenerator >> target [
+	^ target
+]
+
+{ #category : 'accessing' }
+MetacelloAbstractSpecGenerator >> target: anObject [
+	target := anObject
+]

--- a/src/Metacello-Core/MetacelloBaselineSpecGenerator.class.st
+++ b/src/Metacello-Core/MetacelloBaselineSpecGenerator.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'MetacelloBaselineSpecGenerator',
-	#superclass : 'MetacelloProjectSpecGenerator',
+	#superclass : 'MetacelloAbstractSpecGenerator',
 	#category : 'Metacello-Core-Scripts',
 	#package : 'Metacello-Core',
 	#tag : 'Scripts'

--- a/src/Metacello-Core/MetacelloConfigurationSpecGenerator.class.st
+++ b/src/Metacello-Core/MetacelloConfigurationSpecGenerator.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'MetacelloConfigurationSpecGenerator',
-	#superclass : 'MetacelloProjectSpecGenerator',
+	#superclass : 'MetacelloAbstractSpecGenerator',
 	#category : 'Metacello-Core-Scripts',
 	#package : 'Metacello-Core',
 	#tag : 'Scripts'

--- a/src/Metacello-Core/MetacelloProjectSpecGenerator.class.st
+++ b/src/Metacello-Core/MetacelloProjectSpecGenerator.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : 'MetacelloProjectSpecGenerator',
-	#superclass : 'Object',
-	#instVars : [
-		'target'
-	],
+	#superclass : 'MetacelloAbstractSpecGenerator',
 	#category : 'Metacello-Core-Scripts',
 	#package : 'Metacello-Core',
 	#tag : 'Scripts'
@@ -28,14 +25,4 @@ MetacelloProjectSpecGenerator >> projectSpecLookupBlock [
     (MetacelloProjectRegistration
         projectSpecForClassNamed: (MetacelloScriptEngine configurationNameFrom: projectName)
         ifAbsent: [  ])} ]
-]
-
-{ #category : 'accessing' }
-MetacelloProjectSpecGenerator >> target [
-	^ target
-]
-
-{ #category : 'accessing' }
-MetacelloProjectSpecGenerator >> target: anObject [
-	target := anObject
 ]


### PR DESCRIPTION
Before we had the BaselineSpecGenerator and ConfigurationSpecGenerator inheriting from the ProjectSpecGenerator. But this class is neither an abstract class or a generalization of the other two.

The three of them should be on the same level so I propose to introduce an abstract superclass to the 3 of them