### PR TITLE
Backport addition of #isValid on SDL2Handle to Pharo 12

### DIFF
--- a/src/OSWindow-SDL2/SDL2Handle.class.st
+++ b/src/OSWindow-SDL2/SDL2Handle.class.st
@@ -22,3 +22,9 @@ SDL2Handle class >> ffiLibraryName [
 SDL2Handle >> ffiLibraryName [
 	^self class ffiLibraryName
 ]
+
+{ #category : 'testing' }
+SDL2Handle >> isValid [
+
+	^ handle isNotNil and: [ handle isNull not ]
+]


### PR DESCRIPTION
Following my comment [in pull request #18304](https://github.com/pharo-project/pharo/pull/18304#issuecomment-3330636643), this pull request backports the addition of #isValid on SDL2Handle from pull request #17901 to Pharo 12.