### PR TITLE
Push the  #new: of Array up to ArrayedCollection.

### DIFF
--- a/src/Collections-Sequenceable/Array.class.st
+++ b/src/Collections-Sequenceable/Array.class.st
@@ -61,17 +61,6 @@ Array class >> empty [
 	^ #()
 ]
 
-{ #category : 'instance creation' }
-Array class >> new: sizeRequested [
-	"Answer an instance of this class with the number of indexable
-	variables specified by the argument, sizeRequested.
-
-	This is a shortcut (direct call of primitive, no #initialize, for performance"
-
-	<primitive: 71>  "This method runs primitively if successful"
-	^ self basicNew: sizeRequested  "Exceptional conditions will be handled in basicNew:"
-]
-
 { #category : 'converting' }
 Array >> as: aSimilarClass [
 

--- a/src/Collections-Sequenceable/ArrayedCollection.class.st
+++ b/src/Collections-Sequenceable/ArrayedCollection.class.st
@@ -22,6 +22,17 @@ ArrayedCollection class >> new [
 ]
 
 { #category : 'instance creation' }
+ArrayedCollection class >> new: sizeRequested [
+	"Answer an instance of this class with the number of indexable
+	variables specified by the argument, sizeRequested.
+
+	This is a shortcut (direct call of primitive, no #initialize, for performance"
+
+	<primitive: 71>  "This method runs primitively if successful"
+	^ self basicNew: sizeRequested  "Exceptional conditions will be handled in basicNew:"
+]
+
+{ #category : 'instance creation' }
 ArrayedCollection class >> new: size withAll: value [
 	"Answer an instance of me, with number of elements equal to size, each
 	of which refers to the argument, value."


### PR DESCRIPTION
Array overrides #new:, but ByteArray does not. This means we will  send #intialize for every instantiation.

This PR pushes the  #new: of Array up to ArrayedCollection.

b1 := [ByteArray new: 1] bench. "54,853,537 iterations in 5 seconds. 10970707.400 per second"

b2 := [ByteArray new: 1] bench.  "566,107,068 iterations in 5 seconds 1 millisecond. 113198773.845 per second"