### PR TITLE
Add stackoverflow handling

### DIFF
--- a/src/Kernel-CodeModel/Context.class.st
+++ b/src/Kernel-CodeModel/Context.class.st
@@ -1904,6 +1904,12 @@ Context >> stackOfSize: limit [
 	^ stack
 ]
 
+{ #category : 'accessing' }
+Context >> stackOverflow [
+
+	self error: 'Stack overflow'
+]
+
 { #category : 'private' }
 Context >> stackPtr [
 	"For use only by the SystemTracer and the Debugger, Inspectors etc"

--- a/src/Kernel-Extended-Tests/ProcessTest.class.st
+++ b/src/Kernel-Extended-Tests/ProcessTest.class.st
@@ -9,6 +9,12 @@ Class {
 	#tag : 'Processes'
 }
 
+{ #category : 'tests' }
+ProcessTest >> recursive [
+
+	"To test stack overflow"
+]
+
 { #category : 'running' }
 ProcessTest >> setUp [
 	super setUp.
@@ -754,14 +760,20 @@ ProcessTest >> testSchedulingSamePriorityFirstComeFirstServed [
 { #category : 'tests' }
 ProcessTest >> testStackOverflow [
 
-	| p interceptedError |
-	p := [ Smalltalk createStackOverflow ] newProcess.
+	| p interceptedError versionNumber |
+	versionNumber := Smalltalk vm interpreterSourceVersion substrings.
+	versionNumber first < 'v12' ifTrue: [ ^ self skip ].
+	
+	p := [ self recursive ] newProcess.
 	p shouldOverflow: true.
 	p
 		on: Error
 		do: [ :err | interceptedError := err ].
 	p resume.
-	[ p isTerminated ] whileFalse: [ Processor yield ].
+	
+	"This should overflow FAR before 1 second, independent of the architecture"
+	1 second wait.
+	p suspend.
 
 	self assert: interceptedError messageText equals: 'Stack overflow'.
 

--- a/src/Kernel-Extended-Tests/ProcessTest.class.st
+++ b/src/Kernel-Extended-Tests/ProcessTest.class.st
@@ -751,6 +751,22 @@ ProcessTest >> testSchedulingSamePriorityFirstComeFirstServed [
 	self assert: whichRan=2 description: 'Second scheduled process should run after'
 ]
 
+{ #category : 'tests' }
+ProcessTest >> testStackOverflow [
+
+	| p interceptedError |
+	p := [ Smalltalk createStackOverflow ] newProcess.
+	p shouldOverflow: true.
+	p
+		on: Error
+		do: [ :err | interceptedError := err ].
+	p resume.
+	[ p isTerminated ] whileFalse: [ Processor yield ].
+
+	self assert: interceptedError messageText equals: 'Stack overflow'.
+
+]
+
 { #category : 'tests - termination' }
 ProcessTest >> testTerminateActive [
 

--- a/src/Kernel-Extended-Tests/ProcessTest.class.st
+++ b/src/Kernel-Extended-Tests/ProcessTest.class.st
@@ -13,6 +13,7 @@ Class {
 ProcessTest >> recursive [
 
 	"To test stack overflow"
+	self recursive
 ]
 
 { #category : 'running' }

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -30,6 +30,7 @@ Class {
 		'effectiveProcess',
 		'terminating',
 		'level',
+		'shouldOverflow',
 		'errorHandler'
 	],
 	#classVars : [
@@ -487,6 +488,18 @@ Process >> run [
 	[	proc suspend.
 		self resume.
 	] forkAt: Processor highestPriority
+]
+
+{ #category : 'accessing' }
+Process >> shouldOverflow [
+
+	^ shouldOverflow
+]
+
+{ #category : 'accessing' }
+Process >> shouldOverflow: aBoolean [
+
+	shouldOverflow := aBoolean
 ]
 
 { #category : 'signaling' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -947,7 +947,7 @@ SmalltalkImage >> newSpecialObjectsArray [
 							#* 1 #/ 1 #\\ 1 #@ 1 #bitShift: 1 #// 1 #bitAnd: 1 #bitOr: 1
 							#at: 1 #at:put: 2 #size 0 #next 0 #nextPut: 1 #atEnd 0 #== 1 #class 0
 							#'~~' 1 #value 0 #value: 1 #do: 1 #new 0 #new: 1 #x 0 #y 0 ).
-	newArray at: 25 put: nil "was an array of 255 Characters in ascii order".
+	newArray at: 25 put: #stackOverflow.
 	newArray at: 26 put: #mustBeBoolean.
 	newArray at: 27 put: ByteArray.
 	newArray at: 28 put: nil. "was Process."


### PR DESCRIPTION
Related PR: https://github.com/pharo-project/pharo-vm/pull/710

Exploratory PR made with @guillep to add an exception in case of stackoverflow. The VM should be run using the option ` --stackPageSize=1M`, to avoid an excesive amount of stack overflows, and to prevent it from stackoverflowing while handling another stackoverflow, which would cause issues