### PR TITLE
Fix 2 bugs in the calculation of topLeft in FTTableMorph>>#resizeContainer

### DIFF
--- a/src/Morphic-Widgets-FastTable-Tests/FTTableMorphTest.class.st
+++ b/src/Morphic-Widgets-FastTable-Tests/FTTableMorphTest.class.st
@@ -49,3 +49,24 @@ FTTableMorphTest >> testCanAlternateRowColors [
 		equals: 1.
 	self deny: oddColor equals: evenColor
 ]
+
+{ #category : 'tests' }
+FTTableMorphTest >> testResizeContainer [
+
+	| expectedRightSide borderWidth widgetWidth widgetHeight |
+	widgetWidth := 800.
+	widgetHeight := 600.
+	self assert: table bounds equals: (0@0 corner: widgetWidth @ widgetHeight).
+	self assert: table borderWidth equals: 0.
+	expectedRightSide := widgetWidth - table verticalScrollBarWidth.
+	self assert: table container bounds equals: (0@0 corner: expectedRightSide @ widgetHeight).
+
+	widgetWidth := 500.
+	widgetHeight := 300.
+	borderWidth := 10.
+	table borderWidth: borderWidth.
+	table extent: widgetWidth @ widgetHeight. "Trigger #resizeContainer."
+	self assert: table bounds equals: (0@0 corner: widgetWidth @ widgetHeight).
+	expectedRightSide := widgetWidth - table verticalScrollBarWidth - borderWidth.
+	self assert: table container bounds equals: (borderWidth @ borderWidth corner: expectedRightSide @ (widgetHeight - borderWidth))
+]

--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -981,8 +981,8 @@ FTTableMorph >> resizeAllSubviews [
 { #category : 'private' }
 FTTableMorph >> resizeContainer [
 	| topLeft bottomRight |
-	topLeft := (self bounds left - self borderWidth) @ self bounds top - self borderWidth.
-	bottomRight := (self bounds right  - self verticalScrollBarWidth    - self borderWidth)
+	topLeft := (self bounds left + self borderWidth) @ (self bounds top + self borderWidth).
+	bottomRight := (self bounds right - self verticalScrollBarWidth - self borderWidth)
 					 @ (self bounds bottom - self horizontalScrollBarHeight - self borderWidth).
 	self container
 		bounds:


### PR DESCRIPTION
PR for issue reported in the Spec repo: https://github.com/pharo-spec/Spec/issues/1801.

Consider this code to open a table:
```smalltalk
application := SpApplication new
	addStyleSheetFromString: '.application [
		.coloredWidget [
			Draw { #backgroundColor: #green},
			Container { #borderColor: #red, #borderWidth: 10 } ]
	]';
	yourself.
presenter := SpPresenter newApplication: application.
list := (presenter instantiate: SpListPresenter)
	addStyle: 'coloredWidget';
	items: (1 to: 10);
	selectIndex: 10;
	yourself.
layout := SpBoxLayout newTopToBottom
	vAlignCenter;
	hAlignCenter;
	add: list height: 200;
	yourself.
presenter layout: layout.
presenter open
```

### Before the fix

<img width="305" height="291" alt="Screenshot 2025-09-27 at 17 28 28" src="https://github.com/user-attachments/assets/02b8891a-71d2-4455-b142-4ed694ef1d06" />

### After the fix

<img width="305" height="291" alt="Screenshot 2025-09-27 at 17 29 21" src="https://github.com/user-attachments/assets/d090dd87-a987-4f18-ae69-c6a77677ea07" />


### All Morphic tests have been run

There are 4 failing tests, but they already failed before the changes in this PR

<img width="993" height="420" alt="Screenshot 2025-09-27 at 17 20 53" src="https://github.com/user-attachments/assets/1d1aae6c-b541-4876-8f77-637cb0e31b3e" />

