### PR TITLE
Fix issue #18598: Duplicating a class fails to log methods in Epicea

### DIFF
--- a/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
+++ b/src/Epicea-Tests/EpCodeChangeIntegrationTest.class.st
@@ -203,6 +203,21 @@ EpCodeChangeIntegrationTest >> testMethodAddition [
 ]
 
 { #category : 'tests' }
+EpCodeChangeIntegrationTest >> testMethodAdditionFromExistingClass [
+
+	| anotherClass |
+	aClass := classFactory newClass.
+	aClass compile: 'fortyTwo ^42'.
+
+	self assert: (self countLogEventsWith: EpMethodAddition) equals: 1.
+	
+	anotherClass := classFactory newClass.
+	anotherClass compileAllFrom: aClass.
+	
+	self assert: (self countLogEventsWith: EpMethodAddition) equals: 2
+]
+
+{ #category : 'tests' }
 EpCodeChangeIntegrationTest >> testMethodModificationOfProtocol [
 
 	| events event |

--- a/src/Kernel-Tests/ClassAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ClassAnnouncementsTest.class.st
@@ -7,6 +7,21 @@ Class {
 }
 
 { #category : 'tests' }
+ClassAnnouncementsTest >> testDuplicatingAClassAnnouncesAddition [
+
+	class compile: 'billy ^ #meow' classified: '*' , self packageNameForTests , '2'.
+
+	self when: ClassAdded do: [ :ann |
+		self assert: ann classAffected originalName equals: self classNameForTests, '2'.
+		self assert: ann packageAffected name equals: self packageNameForTests.
+		self assertCollection: (ann packagesAffected collect: [ :package | package name ]) hasSameElements: { self packageNameForTests } ].
+
+	class duplicateClassWithNewName: self classNameForTests, '2'.
+
+	self assert: numberOfAnnouncements equals: 1
+]
+
+{ #category : 'tests' }
 ClassAnnouncementsTest >> testRemovingAClassWithExtension [
 	"Regression test about an issue where class removed was not returning the extension packages in its affected packages"
 

--- a/src/Kernel-Tests/MethodAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/MethodAnnouncementsTest.class.st
@@ -27,6 +27,25 @@ MethodAnnouncementsTest >> testCompileMethodAnnounceAddition [
 ]
 
 { #category : 'tests' }
+MethodAnnouncementsTest >> testCompileMethodByDuplicatingAClassAnnounceAddition [
+	
+	class compiler
+		protocol: #titan;
+		install: 'king ^ 1'.
+	
+	self when: MethodAdded do: [ :ann |
+		self assert: ann method selector equals: #king.
+		self assert: ann method protocol name equals: #titan.
+		self assert: ann methodClass name equals: self classNameForTests, '2'.
+		self assert: ann methodPackage name equals: self packageNameForTests.
+		self assert: ann packagesAffected equals: { self packageNameForTests asPackage } ].
+
+	class duplicateClassWithNewName: self classNameForTests, '2'.
+
+	self assert: numberOfAnnouncements equals: 1
+]
+
+{ #category : 'tests' }
 MethodAnnouncementsTest >> testRemoveMethodAnnounceRemoval [
 
 	class compiler

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -16,6 +16,26 @@ Behavior >> compile: code [
 ]
 
 { #category : '*OpalCompiler-Core' }
+Behavior >> compile: selector from: oldClass [ 
+	"Compile the method associated with selector in the receiver's method dictionary."
+	
+	| method newMethod |
+	method := oldClass compiledMethodAt: selector.
+	newMethod := oldClass compiler
+		             source: (oldClass sourceCodeAt: selector);
+		             priorMethod: method;
+		             class: self;
+		             permitFaulty: true;
+		             "No need to log recompilation in the sources,
+					 	 We are going to reuse the original source pointer."
+		             logged: false;
+		             install.
+	newMethod sourcePointer: method sourcePointer.
+	selector == newMethod selector ifFalse: [
+		self error: 'selector changed!' ]
+]
+
+{ #category : '*OpalCompiler-Core' }
 Behavior >> compile: code notifying: requestor [
 	"Compile the argument, code, as source code in the context of the
 	receiver and insEtall the result in the receiver's method dictionary. The
@@ -46,7 +66,7 @@ Behavior >> compileAllFrom: oldClass [
 	"Compile all the methods in the receiver's method dictionary.
 	This validates sourceCode and variable references and forces
 	all methods to use the current bytecode set"
-	oldClass localSelectors do: [:sel | self recompile: sel from: oldClass]
+	oldClass localSelectors do: [:sel | self compile: sel from: oldClass]
 ]
 
 { #category : '*OpalCompiler-Core' }
@@ -83,24 +103,8 @@ Behavior >> recompile: selector [
 
 { #category : '*OpalCompiler-Core' }
 Behavior >> recompile: selector from: oldClass [
-	"Compile the method associated with selector in the receiver's method dictionary."
-
-	| method newMethod |
 
 	"Recompilation should be done silently, to avoid putting noise in the system"
 	self codeChangeAnnouncer suspendAllWhile: [
-		method := oldClass compiledMethodAt: selector.
-		newMethod := oldClass compiler
-			             source: (oldClass sourceCodeAt: selector);
-			             priorMethod: method;
-			             class: self;
-			             permitFaulty: true;
-			             "No need to log recompilation in the sources,
-						 	 We are going to reuse the original source pointer."
-			             logged: false;
-			             install ].
-
-	newMethod sourcePointer: method sourcePointer.
-	selector == newMethod selector ifFalse: [
-		self error: 'selector changed!' ]
+		self compile: selector from: oldClass ].
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -121,7 +121,7 @@ ShiftClassBuilder >> build [
 	self oldClass ifNotNil: [
 		originalTag := newClass packageTag.
 		originalPkg := newClass package.
-		self copyPackage.
+		"self copyPackage."
 		self copyProtocols.
 		self newClass commentSourcePointer: self oldClass commentSourcePointer ].
 
@@ -131,9 +131,9 @@ ShiftClassBuilder >> build [
 
 	self oldClass ifNotNil: [ 
 		self builderEnhancer compileMethodsFor: self.
-		self environment codeChangeAnnouncer suspendAllWhile: [ 
+		"self environment codeChangeAnnouncer suspendAllWhile: [ 
 			newClass package: originalPkg tag: originalTag.
-			 ] ].
+			 ]" ].
 	self builderEnhancer afterMethodsCompiled: self.
 	^ newClass
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -56,7 +56,8 @@ Class {
 		'superclassResolver',
 		'inRemake',
 		'package',
-		'tag'
+		'tag',
+		'movedToPackage'
 	],
 	#classVars : [
 		'BuilderEnhancer'
@@ -226,16 +227,32 @@ ShiftClassBuilder >> compileMethods [
 		removeNonexistentSelectorsFromProtocols
 ]
 
-{ #category : 'copying' }
+{ #category : 'building' }
 ShiftClassBuilder >> copyPackage [
 
-	| newPackage newTag |
-	self environment codeChangeAnnouncer suspendAllWhile: [
-		newPackage := oldClass package.
-		newTag := oldClass packageTag.
-		oldClass packageTag removeClass: oldClass.
-		newClass package: newPackage tag: newTag
+	| oldPackage oldTag |
+
+	self isRebuild ifTrue: [
+		oldPackage := oldClass package name.
+		oldTag := oldClass packageTag name.
+
+		{ oldClass instanceSide . oldClass classSide } 
+			do: [:cls | cls package removeClass: cls ] .
+		
+		self package ifNil: [ 
+			self environment codeChangeAnnouncer suspendAllWhile: [
+				newClass package: oldPackage tag: oldTag.
+				movedToPackage := true
+			]
+		]
+	].
+	self movedToPackage ifFalse: [ 
+		self environment codeChangeAnnouncer suspendAllWhile: [
+			newClass package: self package tag: self tag.
+			movedToPackage := true
+		].
 	]
+
 ]
 
 { #category : 'building' }
@@ -496,6 +513,11 @@ ShiftClassBuilder >> metaclassClass [
 	"The metaclass class is determined by the builder enhancer. In case you want to play with your own metaclass class, you can implement a subclass of the buildre enhancer and use this one overriding the method #metaclassClassFor:."
 
 	^ self builderEnhancer metaclassClassFor: self
+]
+
+{ #category : 'accessing' }
+ShiftClassBuilder >> movedToPackage [
+	^ movedToPackage ifNil: [ movedToPackage := false ]
 ]
 
 { #category : 'accessing' }

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -101,6 +101,7 @@ ShiftClassBuilder >> allSlots [
 { #category : 'building' }
 ShiftClassBuilder >> build [
 
+	| originalTag originalPkg |
 	self tryToFillOldClass.
 	self detectBuilderEnhancer.
 	self builderEnhancer validateRedefinition: self oldClass.
@@ -118,6 +119,8 @@ ShiftClassBuilder >> build [
 	self createClass.
 
 	self oldClass ifNotNil: [
+		originalTag := newClass packageTag.
+		originalPkg := newClass package.
 		self copyPackage.
 		self copyProtocols.
 		self newClass commentSourcePointer: self oldClass commentSourcePointer ].
@@ -127,7 +130,10 @@ ShiftClassBuilder >> build [
 	self installSlotsAndVariables.
 
 	self oldClass ifNotNil: [ 
-		self builderEnhancer compileMethodsFor: self ].
+		self builderEnhancer compileMethodsFor: self.
+		self environment codeChangeAnnouncer suspendAllWhile: [ 
+			newClass package: originalPkg tag: originalTag.
+			 ] ].
 	self builderEnhancer afterMethodsCompiled: self.
 	^ newClass
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -101,7 +101,6 @@ ShiftClassBuilder >> allSlots [
 { #category : 'building' }
 ShiftClassBuilder >> build [
 
-	| originalTag originalPkg |
 	self tryToFillOldClass.
 	self detectBuilderEnhancer.
 	self builderEnhancer validateRedefinition: self oldClass.
@@ -119,9 +118,7 @@ ShiftClassBuilder >> build [
 	self createClass.
 
 	self oldClass ifNotNil: [
-		originalTag := newClass packageTag.
-		originalPkg := newClass package.
-		"self copyPackage."
+		self copyPackage.
 		self copyProtocols.
 		self newClass commentSourcePointer: self oldClass commentSourcePointer ].
 
@@ -131,9 +128,9 @@ ShiftClassBuilder >> build [
 
 	self oldClass ifNotNil: [ 
 		self builderEnhancer compileMethodsFor: self.
-		"self environment codeChangeAnnouncer suspendAllWhile: [ 
-			newClass package: originalPkg tag: originalTag.
-			 ]" ].
+		self environment codeChangeAnnouncer  announce: (ClassAdded class: newClass).
+		
+		 ].
 	self builderEnhancer afterMethodsCompiled: self.
 	^ newClass
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -229,8 +229,12 @@ ShiftClassBuilder >> compileMethods [
 { #category : 'copying' }
 ShiftClassBuilder >> copyPackage [
 
+	| newPackage newTag |
 	self environment codeChangeAnnouncer suspendAllWhile: [
-		newClass package: package tag: self tag 
+		newPackage := oldClass package.
+		newTag := oldClass packageTag.
+		oldClass packageTag removeClass: oldClass.
+		newClass package: newPackage tag: newTag
 	]
 ]
 

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -118,6 +118,7 @@ ShiftClassBuilder >> build [
 	self createClass.
 
 	self oldClass ifNotNil: [
+		self copyPackage.
 		self copyProtocols.
 		self newClass commentSourcePointer: self oldClass commentSourcePointer ].
 
@@ -125,8 +126,8 @@ ShiftClassBuilder >> build [
 
 	self installSlotsAndVariables.
 
-	self oldClass ifNotNil: [ self builderEnhancer compileMethodsFor: self ].
-
+	self oldClass ifNotNil: [ 
+		self builderEnhancer compileMethodsFor: self ].
 	self builderEnhancer afterMethodsCompiled: self.
 	^ newClass
 ]
@@ -220,6 +221,14 @@ ShiftClassBuilder >> compileMethods [
 	newClass
 		compileAllFrom: self oldClass;
 		removeNonexistentSelectorsFromProtocols
+]
+
+{ #category : 'copying' }
+ShiftClassBuilder >> copyPackage [
+
+	self environment codeChangeAnnouncer suspendAllWhile: [
+		newClass package: package tag: self tag 
+	]
 ]
 
 { #category : 'building' }

--- a/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
@@ -192,7 +192,7 @@ ShiftClassInstaller >> make [
 		newClass := self oldClass.
 	].
 
-	self updatePackage: newClass.
+	self oldClass ifNil: [ self updatePackage: newClass ].
 	self comment: newClass.
 
 	self notifyChanges.

--- a/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
@@ -170,8 +170,8 @@ ShiftClassInstaller >> installingEnvironment: anEnvironment [
 
 { #category : 'building' }
 ShiftClassInstaller >> make [
-	| newClass |
 
+	| newClass |
 	[
 		newClass := builder build.
 
@@ -185,14 +185,14 @@ ShiftClassInstaller >> make [
 
 		builder builderEnhancer afterMigratingClass: builder installer: self.
 
-		builder builderEnhancer propagateChangesToRelatedClasses: newClass builder: builder.
+		builder builderEnhancer propagateChangesToRelatedClasses: newClass builder: builder 
 		
-	] on: ShNoChangesInClass do:[
+	] on: ShNoChangesInClass do: [ 
 		"If there are no changes in the building, I am not building or replacing nothing"
-		newClass := self oldClass.
+		newClass := self oldClass 
 	].
 
-	self oldClass ifNil: [ self updatePackage: newClass ].
+	builder movedToPackage ifFalse: [ self updatePackage: newClass ].
 	self comment: newClass.
 
 	self notifyChanges.


### PR DESCRIPTION
As @akgrant43 pointed out in Issue #18598, Epicea was not logging method creation entries when duplicating classes, because the announcer was silenced in `Behavior>>#recompile:from:`.

My solution preserves the silence for method recompilations, but ensures that method compilations always announce their code changes.
As a result, `Behavior>>compileAllFrom:` now announces its changes. This is correct, since it is only used when copying methods from an existing class into a new one—the exact scenario that was failing in the original issue.

I also added a test to verify that Epicea entries are correctly created when copying methods from an existing class.