### PR TITLE
18616-OmTimeStampSuffixStrategy-allows-low-priority-processes-to-run-before-startup-completes

### DIFF
--- a/src/Ombu/OmTimeStampSuffixStrategy.class.st
+++ b/src/Ombu/OmTimeStampSuffixStrategy.class.st
@@ -4,6 +4,9 @@ I attach a timestamp as a suffix to the name (after last _).
 Class {
 	#name : 'OmTimeStampSuffixStrategy',
 	#superclass : 'OmSuffixAfterDotStrategy',
+	#instVars : [
+		'lastNanos'
+	],
 	#category : 'Ombu-Strategies',
 	#package : 'Ombu',
 	#tag : 'Strategies'
@@ -19,6 +22,13 @@ OmTimeStampSuffixStrategy >> nextSuffix [
 	Maybe this will get fixed in the  future? Check https://github.com/pharo-project/pharo/issues/13447 and if it's the case, remove the hack :)
 	OmSessionStoreTest>>#testNextStoreName is here to make sure we have no regression while running it on Windows, so if the hack is still needed you will know it."
 
-	Smalltalk os isWindows ifTrue: [ 1 milliSeconds wait ].
-	^ DateAndTime now asNanoSeconds printStringHex
+	| currentNanos |
+	
+	currentNanos := DateAndTime now asNanoSeconds.
+	
+	lastNanos :=  (lastNanos isNotNil and: [currentNanos <= lastNanos]) 
+		ifTrue: [ lastNanos + 1 ]
+		ifFalse: [ currentNanos ].
+	
+	^ lastNanos printStringHex
 ]


### PR DESCRIPTION
Improving the hack for handling the impresion of DateAndTime in Windows.
Fix #18616 