### PR TITLE
Fix issue #18507: Scope issue breaks refactoring

### DIFF
--- a/src/Refactoring-Environment/RBBrowserEnvironment.class.st
+++ b/src/Refactoring-Environment/RBBrowserEnvironment.class.st
@@ -253,6 +253,12 @@ RBBrowserEnvironment >> cleanGarbageInCache [
 	self accessGuard critical: [ self queryCache clyCleanGarbage ]
 ]
 
+{ #category : 'accessing - classes' }
+RBBrowserEnvironment >> collectAllClasses [
+	
+	^ self classes
+]
+
 { #category : 'copying' }
 RBBrowserEnvironment >> copyEmpty [
 	^ self class new
@@ -460,6 +466,11 @@ RBBrowserEnvironment >> isClassEnvironment [
 RBBrowserEnvironment >> isCompositeEnvironment [
 
 	^ false
+]
+
+{ #category : 'testing' }
+RBBrowserEnvironment >> isCurrentImage [
+	^ self isSystem
 ]
 
 { #category : 'testing' }

--- a/src/Refactoring-UI-Tests/ReInsertSubclassDriverTest.class.st
+++ b/src/Refactoring-UI-Tests/ReInsertSubclassDriverTest.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'ReInsertSubclassDriverTest',
 	#superclass : 'ReDriverTest',
 	#instVars : [
-		'testingEnvironment'
+		'testingEnvironment',
+		'systemEnvironment'
 	],
 	#category : 'Refactoring-UI-Tests-Driver',
 	#package : 'Refactoring-UI-Tests',
@@ -19,7 +20,8 @@ ReInsertSubclassDriverTest >> newSubclassName [
 ReInsertSubclassDriverTest >> setUp [
 
 	super setUp.
-	testingEnvironment := RBClassEnvironment classes: self superclassToAddSubclass withAllSubclasses 
+	testingEnvironment := RBClassEnvironment classes: self superclassToAddSubclass withAllSubclasses.
+	systemEnvironment := RBBrowserEnvironment default
 ]
 
 { #category : 'tests' }
@@ -60,6 +62,20 @@ ReInsertSubclassDriverTest >> testInsertSubclass [
 ]
 
 { #category : 'tests' }
+ReInsertSubclassDriverTest >> testInsertSubclassChoosesASmallScopeIfAvailable [
+
+	| driver aClass |
+
+	driver := ReInsertSubclassDriver new.
+	aClass := self superclassToAddSubclass.
+	self setUpDriver: driver.
+	driver superclass: aClass.
+	driver scopes: { systemEnvironment . testingEnvironment }.
+	
+	self deny: driver model environment isSystem
+]
+
+{ #category : 'tests' }
 ReInsertSubclassDriverTest >> testInsertSubclassInADifferentPackage [
 
 	| driver rbClass |
@@ -93,4 +109,19 @@ ReInsertSubclassDriverTest >> testInsertSubclassInADifferentPackage [
 	self
 		assert: driver refactoring changes changes first package
 		equals: ReAddSubclassDriver packageName
+]
+
+{ #category : 'tests' }
+ReInsertSubclassDriverTest >> testInsertSubclasssMissingAValidScopeFails [
+
+	| driver aClass invalidEnvironment |
+
+	driver := ReInsertSuperclassDriver new.
+	aClass := self superclassToAddSubclass.
+	self setUpDriver: driver.
+	driver superclass: aClass.
+	invalidEnvironment := RBClassEnvironment classes: { aClass subclasses first }.
+	
+	"The environment does not include aClass, the driver should fail."
+	self should: [ driver scopes: { invalidEnvironment } ] raise: RefactoringDriverError .
 ]

--- a/src/Refactoring-UI-Tests/ReInsertSuperclassDriverTest.class.st
+++ b/src/Refactoring-UI-Tests/ReInsertSuperclassDriverTest.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'ReInsertSuperclassDriverTest',
 	#superclass : 'ReDriverTest',
 	#instVars : [
-		'testingEnvironment'
+		'testingEnvironment',
+		'systemEnvironment'
 	],
 	#category : 'Refactoring-UI-Tests-Driver',
 	#package : 'Refactoring-UI-Tests',
@@ -19,7 +20,8 @@ ReInsertSuperclassDriverTest >> newSubclassName [
 ReInsertSuperclassDriverTest >> setUp [
 
 	super setUp.
-	testingEnvironment := RBClassEnvironment classes: RBRootClassForInsertingSubclasses withAllSubclasses 
+	testingEnvironment := RBClassEnvironment classes: RBRootClassForInsertingSubclasses withAllSubclasses.
+	systemEnvironment := RBBrowserEnvironment default
 ]
 
 { #category : 'tests' }
@@ -52,6 +54,35 @@ ReInsertSuperclassDriverTest >> testInsertSuperclass [
 
 	
 	self assert: rbLeafClass superclass name equals: self newSubclassName.
+]
+
+{ #category : 'tests' }
+ReInsertSuperclassDriverTest >> testInsertSuperclassChoosesASmallScopeIfAvailable [
+
+	| driver aClass |
+
+	driver := ReInsertSuperclassDriver new.
+	aClass := self theClassToAddASuperclass.
+	self setUpDriver: driver.
+	driver superclass: aClass.
+	driver scopes: { systemEnvironment . testingEnvironment }.
+	
+	self deny: driver model environment isSystem
+]
+
+{ #category : 'tests' }
+ReInsertSuperclassDriverTest >> testInsertSuperclassMissingAValidScopeFails [
+
+	| driver aClass invalidEnvironment |
+
+	driver := ReInsertSuperclassDriver new.
+	aClass := self theClassToAddASuperclass.
+	self setUpDriver: driver.
+	driver superclass: aClass.
+	invalidEnvironment := RBClassEnvironment classes: { aClass }.
+	
+	"The environment does not include aClass superclass, the driver should fail."
+	self should: [ driver scopes: { invalidEnvironment } ] raise: RefactoringDriverError .
 ]
 
 { #category : 'tests' }

--- a/src/Refactoring-UI/ReInsertSubclassDriver.class.st
+++ b/src/Refactoring-UI/ReInsertSubclassDriver.class.st
@@ -107,11 +107,25 @@ ReInsertSubclassDriver >> runRefactoring [
 	^ true
 ]
 
+{ #category : 'private' }
+ReInsertSubclassDriver >> scopeForModel [
+
+	| sorted selected |
+	"Place the system scope first"
+	sorted := scopes sorted: [ :each | each isCurrentImage ] descending. 
+	"Select the first scope that includes the classes I need to work"
+	selected := sorted reversed
+		              detect: [ :scope | scope collectAllClasses includes: superclass ]
+		              ifNone: [ RefactoringDriverError signal: 'No scope contains the class for inserting a new subclass' ].
+
+	^ selected
+]
+
 { #category : 'accessing' }
 ReInsertSubclassDriver >> scopes: refactoringScopes [
 
 	scopes := refactoringScopes.
-	model := self refactoringScopeOn: scopes last.
+	model := self refactoringScopeOn: self scopeForModel.
 	superclass := model classObjectFor: superclass
 
 ]

--- a/src/Refactoring-UI/ReInsertSuperclassDriver.class.st
+++ b/src/Refactoring-UI/ReInsertSuperclassDriver.class.st
@@ -103,13 +103,30 @@ ReInsertSuperclassDriver >> runRefactoring [
 	^ true
 ]
 
+{ #category : 'private' }
+ReInsertSuperclassDriver >> scopeForModel [
+
+	| sorted selected |
+	"Place the system scope first"
+	sorted := scopes sorted: [ :each | each isCurrentImage ] descending. "Select the first scope that includes the classes I need to work"
+	selected := sorted reversed
+		              detect: [ :each |
+				              each collectAllClasses includesAll: {
+						              superclass.
+						              superclass superclass } ]
+		              ifNone: [
+				              RefactoringDriverError signal:
+					              'No scope contains both: the class for inserting a new superclass, and also its original superclass.' ].
+
+	^ selected
+]
+
 { #category : 'accessing' }
 ReInsertSuperclassDriver >> scopes: refactoringScopes [
 
 	scopes := refactoringScopes.
-	model := self refactoringScopeOn: scopes last.
+	model := self refactoringScopeOn: self scopeForModel.
 	superclass := model classObjectFor: superclass
-	
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/RefactoringDriverError.class.st
+++ b/src/Refactoring-UI/RefactoringDriverError.class.st
@@ -1,0 +1,10 @@
+"
+I am a fatal error occurring during a driver instantiation or configuration.
+"
+Class {
+	#name : 'RefactoringDriverError',
+	#superclass : 'Error',
+	#category : 'Refactoring-UI-Exceptions',
+	#package : 'Refactoring-UI',
+	#tag : 'Exceptions'
+}

--- a/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand2.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand2.class.st
@@ -64,14 +64,8 @@ SycCmInsertSubclassCommand2 >> packageNames [
 
 { #category : 'preparation' }
 SycCmInsertSubclassCommand2 >> prepareFullExecution [
-	
-	"Here there is a bug when we repplace firstNavigationScopes by refactoringScopes
-	when using refactoringScopes the model is not able to find the superclass of a class. 
-	Probably because the model is just made for the class and not the class hierarchy.
-	After fighting to understand I decided to stop and introduced firstNavigationScopes which is breaking the scope
-	reduction but.... else insert is not working."
-	
-	refactoringScopes := context firstNavigationScopes.
+
+	refactoringScopes := context refactoringScopes.
 	targetClass := context lastSelectedClass.
 
 ]

--- a/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand2.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand2.class.st
@@ -56,13 +56,7 @@ SycCmInsertSuperclassCommand2 >> packageNames [
 { #category : 'preparation' }
 SycCmInsertSuperclassCommand2 >> prepareFullExecution [
 
-	"Here there is a bug when we repplace firstNavigationScopes by refactoringScopes
-	when using refactoringScopes the model is not able to find the superclass of a class. 
-	Probably because the model is just made for the class and not the class hierarchy.
-	After fighting to understand I decided to stop and introduced firstNavigationScopes which is breaking the scope
-	reduction but.... else insert is not working."
-	
-	refactoringScopes := context firstNavigationScopes.
+	refactoringScopes := context refactoringScopes.
 	targetClass := context lastSelectedClass.
 
 ]


### PR DESCRIPTION
Fix for [Issue#18507](https://github.com/pharo-project/pharo/issues/18507)
Previusly `ReInsertSubclassDriver` and `ReInsertSuperclassDriver` selected the last item in `refactoringScopes` to build their model. However, this scope did not always include classes required by the refactoring to run. 

This solution creates the method `#scopeForModel` in both drivers. This method selects the first scope that defines the required classes, while avoiding scopes that define the full environment, thus preserving performance. 

Tests were added to validate the new method.