### PR TITLE
more meaning full method comments!

### DIFF
--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -132,6 +132,8 @@ Announcer >> subscriptionsForClass: subscriberClass [
 
 { #category : 'announce' }
 Announcer >> suspendAllWhile: aBlock [
+	"Returns the result of the block execution."
+	
 	| oldSuspended |
 	oldSuspended := self isSuspended.
 	suspended := true.

--- a/src/Kernel-CodeModel/BlockClosure.class.st
+++ b/src/Kernel-CodeModel/BlockClosure.class.st
@@ -221,9 +221,14 @@ BlockClosure >> endPC [
 { #category : 'exceptions' }
 BlockClosure >> ensure: aBlock [
 	"Evaluate a termination block after evaluating the receiver, regardless of
-	 whether the receiver's evaluation completes.  N.B.  This method is *not*
+	 whether the receiver's evaluation completes.  Returns the receiver execution result."
+	
+	"N.B.  This method is *not*
 	 implemented as a primitive.  Primitive 198 always fails.  The VM uses prim
 	 198 in a context's method as the mark for an ensure:/ifCurtailed: activation."
+
+	"([ 2 ] ensure: [ 3 ]) >>> 2"
+
 
 	| handler complete returnValue |
 	<primitive: 198>

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -291,6 +291,7 @@ ClassDescription >> classify: selector under: aProtocol [
 { #category : 'compiling' }
 ClassDescription >> compile: sourceCode classified: protocol [
 	"Compile the source code in the context of the receiver and install the result in the receiver's method dictionary under the given protocol (this can be a protocol or a protocol name).
+	Return the selector of the compiled method. 
 	
 	The argument sourceCode is either a string or an object that converts to a string or a PositionableStream on an object that converts to a string."
 
@@ -299,7 +300,8 @@ ClassDescription >> compile: sourceCode classified: protocol [
 
 { #category : 'compiling' }
 ClassDescription >> compile: sourceCode classified: protcol notifying: requestor [
-
+	"Return the selector of the compiled method"
+	
 	^ self
 		  compile: sourceCode
 		  classified: protcol
@@ -309,7 +311,8 @@ ClassDescription >> compile: sourceCode classified: protcol notifying: requestor
 
 { #category : 'compiling' }
 ClassDescription >> compile: sourceCode classified: protocol withStamp: changeStamp notifying: requestor [
-
+	"Return the selector of the compiled method."
+	
 	^ self
 		  compile: sourceCode
 		  classified: protocol
@@ -319,10 +322,13 @@ ClassDescription >> compile: sourceCode classified: protocol withStamp: changeSt
 ]
 
 { #category : 'compiling' }
-ClassDescription >> compile: sourceCode classified: protocol withStamp: changeStamp notifying: requestor logSource: logSource [
-
+ClassDescription >> compile: sourceCode classified: protocol 
+	withStamp: changeStamp notifying: requestor 
+	logSource: logSource [
+	
+	"Return the selector of the compiled method."
+	
 	| method |
-
 	method := self compiler
 		source: sourceCode;
 		requestor: requestor;
@@ -332,7 +338,6 @@ ClassDescription >> compile: sourceCode classified: protocol withStamp: changeSt
 		changeStamp: changeStamp;
 		logged: logSource;
 		install.
-
 	^ method selector
 ]
 

--- a/src/SUnit-Core/ClassFactoryForTestCase.class.st
+++ b/src/SUnit-Core/ClassFactoryForTestCase.class.st
@@ -247,7 +247,8 @@ ClassFactoryForTestCase >> silentlyCompile: aString in: aBehavior protocol: anot
 
 { #category : 'compiling - silently' }
 ClassFactoryForTestCase >> silentlyCompile: aString in: aBehavior protocol: anotherString storingSource: aBoolean [
-
+	"Retruns the selector of the compiled method." 
+	
 	^ self silentlyDo: [
 		  aBehavior
 			  compile: aString
@@ -269,7 +270,8 @@ ClassFactoryForTestCase >> silentlyCompile: aString in: aBehavior storingSource:
 
 { #category : 'private' }
 ClassFactoryForTestCase >> silentlyDo: aBlock [
-
+	"Returns the result of the block execution."
+	
 	^ self class codeChangeAnnouncer suspendAllWhile: aBlock
 ]
 


### PR DESCRIPTION
- improve method comments to convey that all the chain of compile:* must return a method selector.
- improve ensure: comments + add an executable comment. 

- "Oh Thanks stef for improving such boring comments."
- "This is nothing! This is my pleasure to enhance Pharo. And this is so easy that every Pharoers could do it."