### PR TITLE
[Instrumentation] Added few more methods to make the instrumentation safe

### DIFF
--- a/src/Instrumentation/Object.extension.st
+++ b/src/Instrumentation/Object.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'Object' }
+
+{ #category : '*Instrumentation' }
+Object >> insInequality: anObject [
+    "Answer whether the receiver and the argument do not represent the
+	same object."
+
+    <noInstrumentation>
+    ^ (self insIsEqual: anObject) insIsEqual: false
+]

--- a/src/Instrumentation/Process.extension.st
+++ b/src/Instrumentation/Process.extension.st
@@ -3,9 +3,9 @@ Extension { #name : 'Process' }
 { #category : '*Instrumentation' }
 Process >> isActiveInMetaLevel: n [
 
-	<metaLinkOptions: #( #+ optionDisabledLink )>
-	<noInstrumentation>
-	^ level = n or: [ level == nil ]
+    <metaLinkOptions: #( #+ optionDisabledLink )>
+    <noInstrumentation>
+    ^ (level insIsEqual: n) or: [ level insIsEqual: nil ]
 ]
 
 { #category : '*Instrumentation' }
@@ -14,7 +14,7 @@ Process >> isMeta [
 	<metaLinkOptions: #( #+ optionDisabledLink )>
 	<noInstrumentation>
 	level ifNil: [ level := 0 ].
-	^ level ~= 0
+	^ level insInequality: 0
 ]
 
 { #category : '*Instrumentation' }

--- a/src/Instrumentation/SmallInteger.extension.st
+++ b/src/Instrumentation/SmallInteger.extension.st
@@ -1,17 +1,37 @@
 Extension { #name : 'SmallInteger' }
 
 { #category : '*Instrumentation' }
+SmallInteger >> insInequality: anObj [
+
+    <primitive: 8>
+    <noInstrumentation>
+    ^ super insInequality: anObj
+]
+
+{ #category : '*Instrumentation' }
+SmallInteger >> insIsEqual: aNumber [
+	"Primitive. Compare the receiver with the argument and answer true if
+	the receiver is equal to the argument. Otherwise answer false. Fail if the
+	argument is not a SmallInteger. Essential. No Lookup. See Object
+	documentation whatIsAPrimitive. "
+
+	<primitive: 7>
+	<noInstrumentation>
+	^super insIsEqual: aNumber
+]
+
+{ #category : '*Instrumentation' }
 SmallInteger >> insMinus: aNumber [
-	"I am a re-implementation of the method SmallInteger>>#- and I have the same code except
+    "I am a re-implementation of the method SmallInteger>>#- and I have the same code except
 	for the instrumentation pragmas. I re-implemented the method just to be able to use it
 	without poluting the instrumentation. Let's say that one wants to instrument the method
 	SmallInteger>>#-. If we not override the  SmallInteger>>#- method we will enter to an
 	endless loop."
 
-	<metaLinkOptions: #( #+ optionDisabledLink )>
-	<noInstrumentation>
-	<primitive: 2>
-	^ super - aNumber
+    <metaLinkOptions: #( #+ optionDisabledLink )>
+    <noInstrumentation>
+    <primitive: 2>
+    ^ super - aNumber
 ]
 
 { #category : '*Instrumentation' }


### PR DESCRIPTION
The instrumentation methods are methdos that are being called (Metalinks or MethodProxies use them) to check if the execution is in the meta state or not. Therefore, those methods should not call any method from outside. In this Pr I add some methods that were messing 