### PR TITLE
Backport addition of #deviceScale: and #deviceScaleX:y: on AthensCairoSurface to Pharo 12

### DIFF
--- a/src/Athens-Cairo/AthensCairoSurface.class.st
+++ b/src/Athens-Cairo/AthensCairoSurface.class.st
@@ -440,6 +440,30 @@ AthensCairoSurface >> createStrokePaintFor: aPaint [
 	^ AthensCairoStrokePaint new fillPaint: aPaint
 ]
 
+{ #category : 'initialization' }
+AthensCairoSurface >> deviceScale: aPoint [
+
+	self deviceScaleX: aPoint x y: aPoint y
+]
+
+{ #category : 'initialization' }
+AthensCairoSurface >> deviceScaleX: xScale y: yScale [
+	"Sets a scale that is multiplied to the device coordinates determined by the CTM when drawing to this surface. 
+	One common use for this is to render to very high resolution display devices at a scale factor, so that code that assumes 1 pixel will be a certain size will still work. 
+	Setting a transformation via `cairo_scale()` isn't sufficient to do this, since functions like `cairo_device_to_user()` will expose the hidden scale.
+
+	Note that the scale affects drawing to the surface as well as using the surface in a source pattern.
+
+	See: https://www.cairographics.org/manual/cairo-cairo-surface-t.html#cairo-surface-set-device-scale"
+
+	self ffiCall: #(
+		void
+		cairo_surface_set_device_scale (
+			self,
+			double xScale,
+			double yScale ) )
+]
+
 { #category : 'drawing' }
 AthensCairoSurface >> drawDuring: aBlock [
 


### PR DESCRIPTION
This pull request backports the addition of #deviceScale: and #deviceScaleX:y: on AthensCairoSurface from pull request #18469 to Pharo 12.