### PR TITLE
Add test to ensure we do not depend on deprecated package

### DIFF
--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -438,6 +438,15 @@ SystemDependenciesTest >> testFilesShouldNotDependOnRandom [
 	self deny: (dependencies includes: 'Random-Core')
 ]
 
+{ #category : 'tests' }
+SystemDependenciesTest >> testNoDependencyToDeprecatedPackages [
+
+	| dependencies |
+	dependencies := self externalDependendiesOf: (self class packageOrganizer packageNames reject: [ :name | name includesSubstring: 'Deprecated' ]).
+
+	self assertEmpty: dependencies
+]
+
 { #category : 'accessing' }
 SystemDependenciesTest >> tonelCorePackageNames [
 


### PR DESCRIPTION
I added a system dependency to ensure that we do not depend on a deprecated package in non deprecated packages

This will not work on deprecated methods with non deprecated polymorphic methods but it's better than nothing