### PR TITLE
Convert temp to instance var preview improvement

### DIFF
--- a/src/Refactoring-Core/RBCondition.class.st
+++ b/src/Refactoring-Core/RBCondition.class.st
@@ -57,6 +57,23 @@ RBCondition class >> checkInstanceVariableName: aName in: aClass [
 ]
 
 { #category : 'instance creation' }
+RBCondition class >> checkMultipleTemporaryDefinitionsOf: aString in: aClass [
+
+	| condition |
+	condition := self new.
+	condition
+		block: [
+				| methods |
+				methods := self multipleMethodsDefiningTemporary: aString in: aClass ignore: [ :class :selector | false ].
+				methods size > 1 ifTrue: [
+						condition errorMacro:
+							'More than one method defines temporary variable ' , aString , ': ' , (methods collect: [ :m | m selector ]) asString ].
+				methods size > 1 ]
+		errorString: aClass printString , ' <1?:does not >define<1?s:> temporary variable ' , aString.
+	^ condition
+]
+
+{ #category : 'instance creation' }
 RBCondition class >> definesClassVariable: aString in: aClass [
 	^self new
 		block: [aClass definesClassVariable: aString]
@@ -353,6 +370,25 @@ RBCondition class >> methodDefiningTemporary: aString in: aClass ignore: aBlock 
 				parseTree := class parseTreeForSelector: each.
 				parseTree ifNotNil: [ searcher executeTree: parseTree ] ] ] ].
 	^ nil
+]
+
+{ #category : 'utilities' }
+RBCondition class >> multipleMethodsDefiningTemporary: aString in: aClass ignore: aBlock [
+
+	| searcher methods method |
+	searcher := OCParseTreeSearcher new.
+	methods := OrderedCollection new.
+	method := nil.
+
+	searcher matches: aString do: [ :aNode :answer | methods add: method ].
+	aClass withAllSubclasses do: [ :class |
+			class selectors do: [ :each |
+					(aBlock value: class value: each) ifFalse: [
+							| parseTree  |
+							method := class methodFor: each.
+							parseTree := class parseTreeForSelector: each.
+							parseTree ifNotNil: [ searcher executeTree: parseTree ] ] ] ].
+	^ methods
 ]
 
 { #category : 'instance creation' }

--- a/src/Refactoring-Core/RBTemporaryToInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBTemporaryToInstanceVariableRefactoring.class.st
@@ -106,7 +106,7 @@ RBTemporaryToInstanceVariableRefactoring >> applicabilityPreconditions [
 			   in: class) not.
 		  (RBCondition withBlock: [
 				parseTree ifNotNil: [ .
-				   self checkForValidTemporaryVariable ].
+				   self isTemporaryVariableNameValid ].
 			   true ]) }
 ]
 
@@ -115,29 +115,17 @@ RBTemporaryToInstanceVariableRefactoring >> breakingChangePreconditions [
 
 	^ {
 		  (RBCondition withBlock: [
-			   (class allSubclasses anySatisfy: [ :cls |
-				    cls definesInstanceVariable: temporaryVariableName asString ])
-				   ifTrue: [
-					   self refactoringWarning:
-						   ('One or more subclasses of <1p> already defines an<n>instance variable with the same name. Proceed anyway?'
-							    expandMacrosWith: class name) ].
-			   true ]).
+				   (class allSubclasses anySatisfy: [ :cls | cls definesInstanceVariable: temporaryVariableName asString ]) ifTrue: [
+						   self refactoringWarning:
+							   ('One or more subclasses of <1p> already defines an<n>instance variable with the same name. Proceed anyway?'
+								    expandMacrosWith: class name) ].
+				   true ]).
+		  ((RBCondition checkMultipleTemporaryDefinitionsOf: temporaryVariableName in: class) check ifTrue: [
+				   self refactoringWarning:
+					   ('Two or more methods of <1p> already defines the temporary variable. Proceed anyway?' expandMacrosWith: class name) ]).
 		  (ReVariablesNotReadBeforeWrittenCondition new
 			   subtree: parseTree;
 			   variables: temporaryVariableName) }
-]
-
-{ #category : 'preconditions' }
-RBTemporaryToInstanceVariableRefactoring >> checkForValidTemporaryVariable [ 
-
-	(parseTree allTemporaryVariables includes: temporaryVariableName)
-		ifFalse:
-			[self refactoringError: temporaryVariableName
-						, ' isn''t a valid temporary variable name'].
-	(parseTree allArgumentVariables includes: temporaryVariableName)
-		ifTrue:
-			[self refactoringError: temporaryVariableName , ' is a block parameter'].
-
 ]
 
 { #category : 'initialization' }
@@ -145,6 +133,15 @@ RBTemporaryToInstanceVariableRefactoring >> class: aClass selector: aSelector va
 	class := self classObjectFor: aClass.
 	selector := aSelector.
 	temporaryVariableName := aVariableName
+]
+
+{ #category : 'preconditions' }
+RBTemporaryToInstanceVariableRefactoring >> isTemporaryVariableNameValid [
+
+	(parseTree allTemporaryVariables includes: temporaryVariableName) ifFalse: [
+		self refactoringError: temporaryVariableName , ' isn''t a valid temporary variable name' ].
+	(parseTree allArgumentVariables includes: temporaryVariableName) ifTrue: [
+		self refactoringError: temporaryVariableName , ' is a block parameter' ]
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Transformations-Tests/RBTemporaryToInstanceVariableRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBTemporaryToInstanceVariableRefactoringTest.class.st
@@ -12,14 +12,14 @@ RBTemporaryToInstanceVariableRefactoringTest >> setUp [
 	super setUp.
 	model := self rbModelForVariableTest.
 	model defineClass: [ :aBuilder |
-		aBuilder
-			superclassName: #Foo;
-			name: #Foo1;
-			slots: { #foo };
-			package: #'Refactory-Test data' ].
-	(model classNamed: #Foo)
-		compile: 'someMethod | foo | foo := 4. ^foo'
-		classified: #( #accessing )
+			aBuilder
+				superclassName: #Foo;
+				name: #Foo1;
+				slots: { #foo };
+				package: #'Refactory-Test data' ].
+	(model classNamed: #Foo) compile: 'someMethod | foo | foo := 4. ^foo' classified: #( #accessing ).
+	(model classNamed: #Bar) compile: 'tempMethod | bar | bar := 10. ^bar' classified: #( #accessing ).
+	(model classNamed: #Bar) compile: 'tempMethod2| bar | bar := -6. ^bar' classified: #( #accessing )
 ]
 
 { #category : 'tests' }
@@ -28,10 +28,16 @@ RBTemporaryToInstanceVariableRefactoringTest >> testFailureHierarchyDefinesVarab
 	| class |
 	class := model classNamed: #Foo.
 	self
-		should: [
-			(RBTemporaryToInstanceVariableRefactoring
-				 class: class
-				 selector: #someMethod
-				 variable: 'foo') generateChanges ]
+		should: [ (RBTemporaryToInstanceVariableRefactoring class: class selector: #someMethod variable: 'foo') generateChanges ]
+		raise: RBRefactoringWarning
+]
+
+{ #category : 'tests' }
+RBTemporaryToInstanceVariableRefactoringTest >> testFailureOtherMethodDefinesTemporaryVariable [
+
+	| class |
+	class := model classNamed: #Bar.
+	self
+		should: [ (RBTemporaryToInstanceVariableRefactoring class: class selector: #tempMethod variable: 'bar') generateChanges ]
 		raise: RBRefactoringWarning
 ]

--- a/src/Refactoring-Transformations/RBTemporaryToInstanceVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBTemporaryToInstanceVariableTransformation.class.st
@@ -161,13 +161,14 @@ RBTemporaryToInstanceVariableTransformation >> removeTemporaryOfClass: aClass [
 
 { #category : 'removing' }
 RBTemporaryToInstanceVariableTransformation >> removeTemporaryOfMethod: aSelector in: aClass [
+
 	| parseTree matcher aMethod |
 	aMethod := aClass methodFor: aSelector.
 	parseTree := aMethod parseTree.
 	parseTree ifNil: [ self refactoringError: 'Could not parse method' ].
-	( matcher := self parseTreeRewriterClass removeTemporaryNamed: temporaryVariableName )
-		executeTree: parseTree.
-	aMethod compileTree: matcher tree
+	(parseTree temporaryNames includes: temporaryVariableName) ifFalse: [ ^ self ].
+	(matcher := self parseTreeRewriterClass removeTemporaryNamed: temporaryVariableName) executeTree: parseTree.
+	aMethod compileTree: matcher tree 
 ]
 
 { #category : 'storing' }

--- a/src/Refactoring-Transformations/RBTemporaryToInstanceVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBTemporaryToInstanceVariableTransformation.class.st
@@ -113,12 +113,19 @@ RBTemporaryToInstanceVariableTransformation >> applicabilityPreconditions [
 			   definesInstanceVariable: temporaryVariableName asString
 			   in: class) not.
 		  (RBCondition withBlock: [
-			   self checkForValidTemporaryVariable.
+			   self isTemporaryVariableNameValid.
 			   true ]) }
 ]
 
+{ #category : 'instance creation' }
+RBTemporaryToInstanceVariableTransformation >> class: aClass selector: aSelector variable: aVariableName [
+	class := self model classObjectFor: aClass.
+	selector := aSelector.
+	temporaryVariableName := aVariableName
+]
+
 { #category : 'preconditions' }
-RBTemporaryToInstanceVariableTransformation >> checkForValidTemporaryVariable [
+RBTemporaryToInstanceVariableTransformation >> isTemporaryVariableNameValid [
 	| parseTree |
 	parseTree := class parseTreeForSelector: selector.
 	parseTree ifNil: [ self refactoringError: 'Could not create parse tree for ' class name , '>>' , selector ].
@@ -135,13 +142,6 @@ RBTemporaryToInstanceVariableTransformation >> checkForValidTemporaryVariable [
 				[self
 					refactoringWarning: ('<1s> is read before it is written.<n>Proceed anyway?'
 							expandMacrosWith: temporaryVariableName)]
-]
-
-{ #category : 'instance creation' }
-RBTemporaryToInstanceVariableTransformation >> class: aClass selector: aSelector variable: aVariableName [
-	class := self model classObjectFor: aClass.
-	selector := aSelector.
-	temporaryVariableName := aVariableName
 ]
 
 { #category : 'executing' }
@@ -166,9 +166,8 @@ RBTemporaryToInstanceVariableTransformation >> removeTemporaryOfMethod: aSelecto
 	aMethod := aClass methodFor: aSelector.
 	parseTree := aMethod parseTree.
 	parseTree ifNil: [ self refactoringError: 'Could not parse method' ].
-	(parseTree temporaryNames includes: temporaryVariableName) ifFalse: [ ^ self ].
 	(matcher := self parseTreeRewriterClass removeTemporaryNamed: temporaryVariableName) executeTree: parseTree.
-	aMethod compileTree: matcher tree 
+	aMethod compileTree: matcher tree
 ]
 
 { #category : 'storing' }


### PR DESCRIPTION
- The refactoring was applying the remove temp on every single method of the class, meaning  all method appeared in the changes
- Solution I found was to filter those methods and keep only the good ones that actually contains the temp variable
- Fixes #16969