### PR TITLE
ReExtractMethodDriver fixes from Balsa's review

### DIFF
--- a/src/Refactoring-Core-Tests/RBSubtreeDoesNotContainReturnConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/RBSubtreeDoesNotContainReturnConditionTest.class.st
@@ -22,6 +22,21 @@ RBSubtreeDoesNotContainReturnConditionTest >> testFailureWhenSubtreeContainsRetu
 ]
 
 { #category : 'tests' }
+RBSubtreeDoesNotContainReturnConditionTest >> testFailureWhenSubtreeContainsReturnInBlockExpectFalse [
+
+	| precondition model class parseTree subtree x |
+	model := self modelOnClasses: { self class }.
+	class := model classObjectFor: self class.
+	parseTree := class parseTreeForSelector: self selector.
+	subtree := parseTree extractSubtreeWith: 'x:=[^1]'.
+	
+	precondition := ReSubtreeDoesNotContainReturnCondition new subtree: subtree.
+	
+	self deny: precondition check.
+	x:=[^1] "maybe this is a bad thing to do in a test, I can change it if needed"
+]
+
+{ #category : 'tests' }
 RBSubtreeDoesNotContainReturnConditionTest >> testSubtreeDoesNotContainReturnExpectTrue [
 
 	| precondition model class parseTree subtree |
@@ -33,4 +48,19 @@ RBSubtreeDoesNotContainReturnConditionTest >> testSubtreeDoesNotContainReturnExp
 	precondition := ReSubtreeDoesNotContainReturnCondition new subtree: subtree.
 	
 	self assert: precondition check
+]
+
+{ #category : 'tests' }
+RBSubtreeDoesNotContainReturnConditionTest >> testSubtreeIsAnAssignmentExpectTrue [
+
+	| precondition model class parseTree subtree x |
+	model := self modelOnClasses: { self class }.
+	class := model classObjectFor: self class.
+	parseTree := class parseTreeForSelector: self selector.
+	subtree := parseTree extractSubtreeWith: 'x := 42'.
+	
+	precondition := ReSubtreeDoesNotContainReturnCondition new subtree: subtree.
+	
+	self assert: precondition check.
+	x := 42 "maybe this is a bad thing to do in a test, I can change it if needed"
 ]

--- a/src/Refactoring-Core/ReHasSameExitPointAsItsMethodCondition.class.st
+++ b/src/Refactoring-Core/ReHasSameExitPointAsItsMethodCondition.class.st
@@ -19,5 +19,5 @@ ReHasSameExitPointAsItsMethodCondition >> check [
 { #category : 'displaying' }
 ReHasSameExitPointAsItsMethodCondition >> violationMessageOn: aStream [ 
 
-	^ aStream nextPutAll: 'Extracting guard clauses and other expressions that directly affect a method’s execution flow may result in unreachable code in the original method.'
+	^ aStream nextPutAll: 'Extracting guard clauses and other expressions that directly affect a method’s execution flow may cause unexpected behavior in the original method.'
 ]

--- a/src/Refactoring-UI/ReExtractAndBrowseMethodOverridesChoice.class.st
+++ b/src/Refactoring-UI/ReExtractAndBrowseMethodOverridesChoice.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : 'ReExtractAndBrowseMethodOverridesChoice',
+	#superclass : 'ReMethodChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
+}
+
+{ #category : 'accessing' }
+ReExtractAndBrowseMethodOverridesChoice >> action [
+
+	driver extractMethod.
+	driver browseOverrides
+]
+
+{ #category : 'accessing' }
+ReExtractAndBrowseMethodOverridesChoice >> description [
+
+	^ description ifNil: [ description := 'Extract method and browse existing methods that will then be overriden' ]
+]

--- a/src/Refactoring-UI/ReExtractMethodChoice.class.st
+++ b/src/Refactoring-UI/ReExtractMethodChoice.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'ReExtractMethodChoice',
+	#superclass : 'ReMethodChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
+}
+
+{ #category : 'accessing' }
+ReExtractMethodChoice >> action [
+
+	driver extractMethod
+]
+
+{ #category : 'accessing' }
+ReExtractMethodChoice >> description [
+
+	^ description ifNil: [ description := 'Extract method' ]
+]

--- a/src/Refactoring-UI/ReExtractMethodDriver.class.st
+++ b/src/Refactoring-UI/ReExtractMethodDriver.class.st
@@ -28,15 +28,13 @@ ReExtractMethodDriver >> breakingChoices [
 	items := OrderedCollection new.
 	
 	(notOverride check and: sameExitPoint check) ifFalse: [
-			items add: (ReRenameMethodChoice new
+			items add: (ReExtractMethodChoice new
 					 driver: self;
-					 description: 'Extract method';
 					 yourself) ].
 
 	notOverride check ifFalse: [ "These choices are exclusive to notOverride"
-			items add: (ReRenameAndBrowseMethodOverridesChoice new
+			items add: (ReExtractAndBrowseMethodOverridesChoice new
 					 driver: self;
-					 description: 'Extract method and browse existing methods that will then be overriden';
 					 yourself).
 			items add: (ReBrowseMethodOverridesChoice new
 					 driver: self;
@@ -49,10 +47,9 @@ ReExtractMethodDriver >> breakingChoices [
 { #category : 'actions' }
 ReExtractMethodDriver >> browseOverrides [
 
-	| conditions overrides |
-	conditions := refactoring failedBreakingChangePreconditions.
-	overrides := conditions flatCollect: [ :cond |
-		             cond violators collect: [ :cls | cls realClass methodNamed: newMessage methodName asSymbol ] ].
+	| overrides |
+	overrides := notOverride violators collect: [ :cls | cls realClass methodNamed: newMessage methodName asSymbol ].
+	
 	overrides do: [ :method | method browse ]
 ]
 
@@ -118,6 +115,12 @@ ReExtractMethodDriver >> extract: aString from: compiledMethod in: aClass [
 	body := aString
 ]
 
+{ #category : 'actions' }
+ReExtractMethodDriver >> extractMethod [
+	
+	^ self applyChanges
+]
+
 { #category : 'execution' }
 ReExtractMethodDriver >> handleBreakingChanges [
 
@@ -147,14 +150,6 @@ ReExtractMethodDriver >> methodNameEditorPresenterClass [
 ReExtractMethodDriver >> methodNameEditorPresenterClass: aClass [
 
 	methodNameEditorPresenterClass := aClass
-]
-
-{ #category : 'actions' }
-ReExtractMethodDriver >> renameMethod [
-	"Eventhough we are not renaming methods, but extracting them, we implement this action to reuse both
-	ReRenameAndBrowseMethodOverridesChoice and ReRenameMethodChoice"
-
-	^ self applyChanges
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/StMethodNameEditorPresenter.class.st
+++ b/src/Refactoring-UI/StMethodNameEditorPresenter.class.st
@@ -228,6 +228,12 @@ StMethodNameEditorPresenter >> canRenameArgs: anObject [
 	argumentsList items do: [ :arg | arg canBeRenamed: anObject ]
 ]
 
+{ #category : 'accessing' }
+StMethodNameEditorPresenter >> cancelled [
+	
+	^ self withWindowDo: #cancelled
+]
+
 { #category : 'action' }
 StMethodNameEditorPresenter >> computePermutation [
 


### PR DESCRIPTION
This PR applies suggestions made by @balsa-sarenac in [PR#18561](https://github.com/pharo-project/pharo/pull/18561) 

This code is mainly a refactoring of `ReExtractMethodDriver`.
It also adds two tests for `ReSubtreeDoesNotContainReturnCondition`