### PR TITLE
Simplify Bitmap initialization

### DIFF
--- a/src/BaselineOfDisplay/BaselineOfDisplay.class.st
+++ b/src/BaselineOfDisplay/BaselineOfDisplay.class.st
@@ -41,25 +41,12 @@ BaselineOfDisplay >> baseline: spec [
 ]
 
 { #category : 'actions' }
-BaselineOfDisplay >> installBitmap [
-
-	"install new Bitmap class to special objects array"
-
-	| array |
-	
-	array := Smalltalk specialObjectsArray copy.
-	array at: 5 put: Bitmap.
-
-	Smalltalk specialObjectsArray becomeForward: array.
-]
-
-{ #category : 'actions' }
 BaselineOfDisplay >> postload: loader package: packageSpec [
 
 	"Ignore pre and post loads if already executed"
 	Initialized = true ifTrue: [ ^ self ].
 	
-	self installBitmap.
+	Bitmap initialize.
 
 	Cursor webLink. "set the webLink cursor shape"
 					

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -325,10 +325,6 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	LogicalFontManager current addFontProvider:
 		FreeTypeFontProvider current.
 
-	array := Smalltalk specialObjectsArray copy.
-	array at: 5 put: Bitmap.
-	Smalltalk specialObjectsArray becomeForward: array.
-
 	MCMethodDefinition initializersEnabled: initializersEnabled.
 
 	Initialized := true

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -245,7 +245,6 @@ BaselineOfMorphic >> loadBitmapSourcePro [
 { #category : 'actions' }
 BaselineOfMorphic >> postload: loader package: packageSpec [
 
-	| array |
 	"Ignore pre and post loads if already executed"
 	Initialized = true ifTrue: [ ^ self ].
 

--- a/src/Graphics-Primitives/Bitmap.class.st
+++ b/src/Graphics-Primitives/Bitmap.class.st
@@ -42,9 +42,13 @@ Bitmap class >> decompressFromByteArray: byteArray [
 
 { #category : 'class initialization' }
 Bitmap class >> initialize [
-	Smalltalk specialObjectsArray
-		at: 5
-		put: self
+	"Put BitMap in the special object array. But maybe this is useless? We should check if the VM still needs this entry."
+
+	| array |
+	array := Smalltalk specialObjectsArray copy.
+	array at: 5 put: self.
+
+	Smalltalk specialObjectsArray becomeForward: array
 ]
 
 { #category : 'instance creation' }


### PR DESCRIPTION
Bitmap is put in the special object array in 3 places during the loading of Pharo. 

I'm updating this to have only one initialization