### PR TITLE
Simplify BaselineOfMorphic post loads (first step)

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -128,16 +128,9 @@ BaselineOfMorphic >> baseline: spec [
 BaselineOfMorphic >> cleanUpAfterMorphicInitialization [
 
 	MCDataStream initialize.
-	GradientFillStyle initPixelRampCache.
 	FreeTypeCache clearCurrent.
-	ImageMorph
-		writeClassVariableNamed: #DefaultForm
-		value: (Form extent: 1 @ 1 depth: 1).
 	World cleanseOtherworldlySteppers.
-	MCFileBasedRepository flushAllCaches.
-	MCMethodDefinition shutDown.
-	ExternalDropHandler resetRegisteredHandlers.
-	ScrollBarMorph initializeImagesCache
+	MCFileBasedRepository flushAllCaches
 ]
 
 { #category : 'fonts' }
@@ -265,8 +258,6 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	self loadBitmapDejaVuSans.
 	self loadBitmapSourcePro.
 
-	(Smalltalk globals at: #TextStyle) initialize.
-
 	Stdio stdout
 		nextPutAll: 'bitmap fonts loaded' asString;
 		lf.
@@ -284,8 +275,6 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	   #ZnConstants #ZnMimeType #ZnNetworkingUtils #ZnServer #ZnSingleThreadedServer )
 		do: [ :each | (Smalltalk globals at: each) initialize ].
 
-	BalloonMorph setBalloonColorTo: Color yellow.
-
 	UIManager default terminateUIProcess.
 	MorphicUIManager new spawnNewProcess.
 
@@ -294,7 +283,6 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 
 	ErrorHandler defaultErrorHandler: UIManager default.
 
-	PharoLightTheme beCurrent.
 	ScalingCanvas initialize.
 	self cleanUpAfterMorphicInitialization.
 

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -87,14 +87,12 @@ BaselineOfMorphicCore >> postload: loader package: packageSpec [
 	MorphicCoreUIManager new spawnNewProcess.
 	
 	world cleanseOtherworldlySteppers.
-	ExternalDropHandler resetRegisteredHandlers.
 
 	(world instVarNamed: #worldState) invalidate.
 
 	hand instVarNamed: #targetOffset put: 0@0.
 
 	WorldMorph initialize.
-	ExternalDropHandler initialize.
 	PasteUpMorph initialize.
 	DefaultExternalDropHandler initialize.
 

--- a/src/Morphic-Base/ImageMorph.class.st
+++ b/src/Morphic-Base/ImageMorph.class.st
@@ -59,15 +59,7 @@ ImageMorph class >> fromString: aString font: aFont [
 { #category : 'class initialization' }
 ImageMorph class >> initialize [
 
-	| h p d |
-	DefaultForm := (Form extent: 80@40 depth: 16).
-	h := DefaultForm height // 2.
-	0 to: h - 1 do: [:i |
-		p := (i * 2)@i.
-		d := i asFloat / h asFloat.
-		DefaultForm fill:
-			(p corner: DefaultForm extent - p)
-			fillColor: (Color r: d g: 0.5 b: 1.0 - d)]
+	DefaultForm := Form extent: 1 @ 1 depth: 1
 ]
 
 { #category : 'instance creation' }

--- a/src/Morphic-Core/ExternalDropHandler.class.st
+++ b/src/Morphic-Core/ExternalDropHandler.class.st
@@ -44,12 +44,6 @@ ExternalDropHandler class >> defaultHandler: externalDropHandler [
 	DefaultHandler := externalDropHandler
 ]
 
-{ #category : 'class initialization' }
-ExternalDropHandler class >> initialize [
-
-	self resetRegisteredHandlers
-]
-
 { #category : 'accessing' }
 ExternalDropHandler class >> lookupExternalDropHandler: aFileReference [
 


### PR DESCRIPTION
- GradientFillStyle initPixelRampCache is already called during its initialization so we can remove this call
- Remove double initialization of ImageMorph and use of reflectivity to initialize it. Now we have the final code directly right in ImageMorph class>>initialize
- MCMethodDefinition shutDown is useless because it calls an empty method
- ExternalDropHandler resetRegisteredHandlers is useless because we never update the registered handlers in Pharo (there is 0 sender to the method allowing to add handlers, so no need to reset it. Also, the reset happens during the cleanup phase so it will be done anyway
- ScrollBarMorph initializeImagesCache is already called from `ScrollBarMorph initialize`
- TextStyle was initialized twice
- `BalloonMorph setBalloonColorTo: Color yellow.` is useless because the theme will change this value and there is already an initialization in the class initialization
- `PharoLightTheme beCurrent.` is useless because there is a defensive strategy and we set another theme later