### PR TITLE
Faster implementation for StepThrough in P14

### DIFF
--- a/src/Debugger-Model-Tests/FastStepThroughTest.class.st
+++ b/src/Debugger-Model-Tests/FastStepThroughTest.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : 'FastStepThroughTest',
+	#superclass : 'StepThroughTest',
+	#category : 'Debugger-Model-Tests-Core',
+	#package : 'Debugger-Model-Tests',
+	#tag : 'Core'
+}
+
+{ #category : 'utilities' }
+FastStepThroughTest >> settingUpSessionAndProcessAndContextForBlock: block [
+
+	super settingUpSessionAndProcessAndContextForBlock: block.
+	currentFastStepThrough := DebugSession fastStepThroughMode.
+	DebugSession fastStepThroughMode: true.
+	session := DebugSession named: 'test session' on: process startedAt: context
+]

--- a/src/Debugger-Model-Tests/StepThroughTest.class.st
+++ b/src/Debugger-Model-Tests/StepThroughTest.class.st
@@ -20,8 +20,8 @@ StepThroughTest >> evalBlock: aBlockClosure afterLoop: remainingCount [
 ]
 
 { #category : 'helper' }
-StepThroughTest >> evalBlockThenReturnOne: aBlock [
-	aBlock value.
+StepThroughTest >> evalBlockThenReturnOne: block [
+	block value.
 	^1
 ]
 

--- a/src/Debugger-Model-Tests/StepThroughTest.class.st
+++ b/src/Debugger-Model-Tests/StepThroughTest.class.st
@@ -1,15 +1,36 @@
 Class {
 	#name : 'StepThroughTest',
 	#superclass : 'DebuggerTest',
+	#instVars : [
+		'currentFastStepThrough',
+		'aBlock',
+		'failed'
+	],
 	#category : 'Debugger-Model-Tests-Core',
 	#package : 'Debugger-Model-Tests',
 	#tag : 'Core'
 }
 
 { #category : 'helper' }
+StepThroughTest >> evalBlock: aBlockClosure afterLoop: remainingCount [
+
+	remainingCount = 1 ifTrue: [ ^ aBlockClosure value ].
+
+	^ self evalBlock: aBlockClosure afterLoop: remainingCount - 1
+]
+
+{ #category : 'helper' }
 StepThroughTest >> evalBlockThenReturnOne: aBlock [
 	aBlock value.
 	^1
+]
+
+{ #category : 'utilities' }
+StepThroughTest >> settingUpSessionAndProcessAndContextForBlock: block [
+
+	currentFastStepThrough := DebugSession fastStepThroughMode.
+	DebugSession fastStepThroughMode: false.
+	super settingUpSessionAndProcessAndContextForBlock: block
 ]
 
 { #category : 'helper' }
@@ -38,6 +59,140 @@ StepThroughTest >> stepB3 [
 	^ 43
 ]
 
+{ #category : 'helper' }
+StepThroughTest >> stepC1 [
+
+	self evalBlock: [ self stepC2 ] afterLoop: 10000
+]
+
+{ #category : 'helper' }
+StepThroughTest >> stepC2 [
+
+	^ 5
+]
+
+{ #category : 'helper' }
+StepThroughTest >> stepD1 [
+
+	aBlock := [ 2 + 3 ].
+
+	self stepD2
+]
+
+{ #category : 'helper' }
+StepThroughTest >> stepD2 [
+
+	aBlock value
+]
+
+{ #category : 'helper' }
+StepThroughTest >> stepE1 [
+
+	| tmpBlock |
+	tmpBlock := [ 2 - 3 ].
+
+	self evalBlockThenReturnOne: tmpBlock
+]
+
+{ #category : 'helper' }
+StepThroughTest >> stepF1 [
+
+	| tmpBlock |
+	tmpBlock := [ 2 - 3 ].
+
+	tmpBlock value
+]
+
+{ #category : 'helper' }
+StepThroughTest >> stepG1 [
+
+	| sem |
+	sem := Semaphore new.
+
+	self stepG2: [ 1 + 3 ] sem: sem
+]
+
+{ #category : 'helper' }
+StepThroughTest >> stepG2: aTmp sem: sem [
+
+	[
+		sem wait.
+		[
+			aTmp value.
+			failed := false ]
+			on: Exception
+			do: [ :e | failed := true ] ] forkAt: Processor activePriority + 1.
+
+	sem signal.
+
+	[ failed isNil ] whileTrue: [ Processor yield ]
+]
+
+{ #category : 'helper' }
+StepThroughTest >> stepH1 [
+
+	| tmpBlock |
+	tmpBlock := [ :a | a + 3 ].
+
+	tmpBlock value: 1
+]
+
+{ #category : 'helper' }
+StepThroughTest >> stepI1 [
+
+	^ self stepI2: [ :i | i + 1 ]
+]
+
+{ #category : 'helper' }
+StepThroughTest >> stepI2: someBlock [
+
+	^ someBlock value: 24
+]
+
+{ #category : 'running' }
+StepThroughTest >> tearDown [
+
+	currentFastStepThrough ifNotNil: [ DebugSession fastStepThroughMode: currentFastStepThrough ].
+	super tearDown
+]
+
+{ #category : 'tests' }
+StepThroughTest >> testStepIntoBlockArgumentInMessageSend [
+
+	| node expectedMethod |
+	self settingUpSessionAndProcessAndContextForBlock: [ self stepI1 ].
+	session stepInto.
+	session stepInto. 
+
+	"Reached node 'self stepI2: [ :i | i + 1 ]' of method stepI1" 
+	"Checking that the execution is indeed at this node"
+	self assert: session interruptedContext method equals: (self class lookupSelector: #stepI1).
+	node := (self class lookupSelector: #stepI1) sourceNodeForPC: session interruptedContext pc.
+	self assert: node isMessage.
+	self assert: node selector equals: #stepI2:.
+	session stepThrough. 
+	
+	"Reached message node in the blocks body '+ 1'"
+	expectedMethod := (self class lookupSelector: #stepI1) literalAt: 1.
+	node := expectedMethod compiledBlock sourceNodeForPC: session interruptedContext pc.
+	self assert: node isMessage.
+	self assert: node selector equals: #+.
+	session stepThrough. 
+	
+	"Reached sequence node in the blocks body 'i + 1'"
+	expectedMethod := (self class lookupSelector: #stepI1) literalAt: 1.
+	self assert: session interruptedContext method equals: expectedMethod compiledBlock.
+	node := expectedMethod compiledBlock sourceNodeForPC: session interruptedContext pc.
+	self assert: node isSequence.
+	session stepThrough. 
+	
+	"Reached ^ self stepI2: [:i | i + 1 ] in stepI1"
+	self assert: session interruptedContext method equals: (self class lookupSelector: #stepI1).
+	node := (self class lookupSelector: #stepI1) sourceNodeForPC: session interruptedContext pc.
+	self assert: node isReturn.
+	self assert: session interruptedContext sender isNotNil
+]
+
 { #category : 'tests' }
 StepThroughTest >> testStepThrough [
 	"In a context c, define a block b, send a message to another method to get b evaluated.
@@ -48,22 +203,25 @@ StepThroughTest >> testStepThrough [
 	session stepInto.
 	"Reached node 'self evalBlockThenReturnOne: [self stepA2]' of method stepA1"
 	"Checking that the execution is indeed at this node"
-	self assert: (session interruptedContext method) equals: (self class>>#stepA1).
-	node := self class>>#stepA1 sourceNodeForPC: session interruptedContext pc.
+	self assert: (session interruptedContext method) equals: (self class lookupSelector: #stepA1).
+	node := (self class lookupSelector: #stepA1) sourceNodeForPC: session interruptedContext pc.
 	self assert: node isMessage.
 	self assert: node receiver isSelfVariable.
 	self assert: node selector equals: #evalBlockThenReturnOne:.
 	session stepThrough.
 
 	"With fullblocks the method of the suspended context is a compiledBlock, not the method having it"
-	expectedMethod := (self class >> #stepA1) literalAt: 1 .
+	expectedMethod := (self class lookupSelector: #stepA1) literalAt: 1 .
 
 	"Checking that after the step through, the execution is at the 'self stepA2' node of the stepA1 method"
 	self assert: (session interruptedContext method) equals: expectedMethod.
 	node := expectedMethod sourceNodeForPC: session interruptedContext pc.
 	self assert: node isMessage.
 	self assert: node receiver isSelfVariable.
-	self assert: node selector equals: #stepA2
+	self assert: node selector equals: #stepA2.
+		self deny: (session isContextPostMortem: session interruptedContext).
+	self assert: session interruptedContext sender isNotNil
+	
 ]
 
 { #category : 'tests' }
@@ -72,40 +230,217 @@ StepThroughTest >> testStepThroughDoesTheSameThingAsStepOverWhenNoBlockIsInvolve
 	| node |
 
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepB1 ].
-	[session interruptedContext method == (self class>>#stepB1)]
+	[session interruptedContext method == (self class lookupSelector: #stepB1)]
 		whileFalse: [ session stepInto ].
 
 	"Reached node 'self stepB2' of method stepB1"
-	self assert: session interruptedContext method equals: self class>>#stepB1.
+	self assert: session interruptedContext method equals: (self class lookupSelector: #stepB1).
 	session stepOver.
-	self assert: (session interruptedContext method) equals: (self class>>#stepB1).
+	self assert: (session interruptedContext method) equals: (self class lookupSelector: #stepB1).
 	"Checking that after the step over, we reached the node 'self stepB3' of method stepB1"
-	node := self class>>#stepB1 sourceNodeForPC: session interruptedContext pc.
+	node := (self class lookupSelector: #stepB1) sourceNodeForPC: session interruptedContext pc.
 	self assert: node isMessage.
 	self assert: node receiver isSelfVariable.
 	self assert: node selector equals: #stepB3.
 
 	"Set up the debugged execution again"
 	self settingUpSessionAndProcessAndContextForBlock: [ self stepB1 ].
-	[session interruptedContext method == (self class>>#stepB1)]
+	[session interruptedContext method == (self class lookupSelector: #stepB1)]
 		whileFalse: [ session stepInto ].
 
 	"Reached node 'self stepB2' of method stepB1"
-	self assert: session interruptedContext method equals: self class>>#stepB1.
+	self assert: session interruptedContext method equals: (self class lookupSelector: #stepB1).
 	session stepThrough.
 	"Checking that after the step through, we reached the node 'self stepB3' of method stepB1 (the same node that was reached with the step over"
-	node := self class>>#stepB1 sourceNodeForPC: session interruptedContext pc.
+	node := (self class lookupSelector: #stepB1) sourceNodeForPC: session interruptedContext pc.
 	self assert: node isMessage.
 	self assert: node receiver isSelfVariable.
-	self assert: node selector equals: #stepB3
+	self assert: node selector equals: #stepB3.
+	self deny: (session isContextPostMortem: session interruptedContext).
+	self assert: session interruptedContext sender isNotNil
+]
+
+{ #category : 'tests' }
+StepThroughTest >> testStepThroughInABlockInAInstanceVariable [
+	"In a context c, define a block b, send a message to another method to get b evaluated.
+	Testing that a step through on this message send moves the execution to the point where the block b is about to be evaluated."
+	| node expectedMethod |
+
+	self settingUpSessionAndProcessAndContextForBlock: [ self stepD1 ].
+	session stepInto.
+	session stepInto.
+	session stepInto.
+
+	"Reached node 'self evalBlock: [ self stepC2 ] afterLoop: 10' of method stepC1"
+	"Checking that the execution is indeed at this node"
+	self assert: (session interruptedContext method) equals: (self class lookupSelector: #stepD1).
+	node := (self class lookupSelector:#stepD1) sourceNodeForPC: session interruptedContext pc.
+	session stepThrough.
+
+	"With fullblocks the method of the suspended context is a compiledBlock, not the method having it"
+	expectedMethod := (self class lookupSelector: #stepD1) literalAt: 1 .
+
+	"Checking that after the step through, the execution is at the 'self stepA2' node of the stepA1 method"
+	self assert: (session interruptedContext method) equals: expectedMethod compiledBlock.
+	node := expectedMethod compiledBlock sourceNodeForPC: session interruptedContext pc.
+	self assert: node isMessage.
+	self assert: node receiver value equals: 2.
+	self assert: node selector equals: #+.
+	self deny: (session isContextPostMortem: session interruptedContext).
+	self assert: session interruptedContext sender isNotNil
+]
+
+{ #category : 'tests' }
+StepThroughTest >> testStepThroughInABlockInATemporary [
+
+	| node expectedMethod |
+
+	self settingUpSessionAndProcessAndContextForBlock: [ self stepE1 ].
+	session stepInto.
+	session stepInto.
+	session stepInto.
+
+	self assert: (session interruptedContext method) equals: (self class lookupSelector: #stepE1).
+	node := (self class lookupSelector:#stepE1) sourceNodeForPC: session interruptedContext pc.
+	session stepThrough.
+
+	"With fullblocks the method of the suspended context is a compiledBlock, not the method having it"
+	expectedMethod := (self class lookupSelector: #stepE1) literalAt: 1 .
+
+	"Checking that after the step through, the execution is at the 'self stepA2' node of the stepA1 method"
+	self assert: (session interruptedContext method) equals: expectedMethod compiledBlock.
+	node := expectedMethod compiledBlock sourceNodeForPC: session interruptedContext pc.
+	self assert: node isMessage.
+	self assert: node receiver value equals: 2.
+	self assert: node selector equals: #-.
+	self deny: (session isContextPostMortem: session interruptedContext).
+	self assert: session interruptedContext sender isNotNil
+]
+
+{ #category : 'tests' }
+StepThroughTest >> testStepThroughInABlockInATemporaryDirectly [
+
+	| node expectedMethod |
+
+	self settingUpSessionAndProcessAndContextForBlock: [ self stepF1 ].
+	session stepInto.
+	session stepInto.
+	session stepInto.
+
+	self assert: (session interruptedContext method) equals: (self class lookupSelector: #stepF1).
+	node := (self class lookupSelector:#stepF1) sourceNodeForPC: session interruptedContext pc.
+	session stepThrough.
+
+	"With fullblocks the method of the suspended context is a compiledBlock, not the method having it"
+	expectedMethod := (self class lookupSelector: #stepF1) literalAt: 1 .
+
+	"Checking that after the step through, the execution is at the 'self stepA2' node of the stepA1 method"
+	self assert: (session interruptedContext method) equals: expectedMethod compiledBlock.
+	node := expectedMethod compiledBlock sourceNodeForPC: session interruptedContext pc.
+	self assert: node isMessage.
+	self assert: node receiver value equals: 2.
+	self assert: node selector equals: #-.
+	self deny: (session isContextPostMortem: session interruptedContext).
+	self assert: session interruptedContext sender isNotNil
+]
+
+{ #category : 'tests' }
+StepThroughTest >> testStepThroughInOtherProcess [
+
+	self settingUpSessionAndProcessAndContextForBlock: [ self stepG1 ].
+	session stepInto.
+	session stepThrough.
+	session stepThrough.
+	session stepThrough.
+	session stepThrough.
+
+	self deny: failed.
+	self deny: (session isContextPostMortem: session interruptedContext).
+	self assert: session interruptedContext sender isNotNil
+]
+
+{ #category : 'tests' }
+StepThroughTest >> testStepThroughJumpsToHomeWhenBlockEvaluationEnds [
+	"In a context c, define a block b, send a message to another method to get b evaluated.
+	Testing that a step through on this message send moves the execution to the point where the block b is about to be evaluated."
+	| node expectedMethod |
+	
+	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1 ].
+	session stepInto.
+	session stepInto.
+	session stepThrough.
+	session stepThrough.
+	session stepThrough.
+
+	expectedMethod := self class lookupSelector: #stepA1 .
+
+	"Checking that after the step through, the execution is at the 'stepA1' return node"
+	self assert: (session interruptedContext method) equals: expectedMethod.
+	node := expectedMethod sourceNodeForPC: session interruptedContext pc.
+	self assert: node isMethod.
+	self assert: node selector equals: #stepA1.
+	self deny: (session isContextPostMortem: session interruptedContext).
+	self assert: session interruptedContext sender isNotNil
+]
+
+{ #category : 'tests' }
+StepThroughTest >> testStepThroughLonger [
+	"In a context c, define a block b, send a message to another method to get b evaluated.
+	Testing that a step through on this message send moves the execution to the point where the block b is about to be evaluated."
+	| node expectedMethod |
+
+	self settingUpSessionAndProcessAndContextForBlock: [ self stepC1 ].
+	session stepInto.
+	session stepInto.
+	
+	"Reached node 'self evalBlock: [ self stepC2 ] afterLoop: 10' of method stepC1"
+	"Checking that the execution is indeed at this node"
+	self assert: (session interruptedContext method) equals: (self class lookupSelector:#stepC1).
+	node := (self class lookupSelector:#stepC1) sourceNodeForPC: session interruptedContext pc.
+	session stepThrough.
+
+	"With fullblocks the method of the suspended context is a compiledBlock, not the method having it"
+	expectedMethod := (self class lookupSelector: #stepC1) literalAt: 1 .
+
+	"Checking that after the step through, the execution is at the 'self stepA2' node of the stepA1 method"
+	self assert: (session interruptedContext method) equals: expectedMethod.
+	node := expectedMethod sourceNodeForPC: session interruptedContext pc.
+	self assert: node isMessage.
+	self assert: node receiver isSelfVariable.
+	self assert: node selector equals: #stepC2.
+	self deny: (session isContextPostMortem: session interruptedContext).
+	self assert: session interruptedContext sender isNotNil
 ]
 
 { #category : 'tests' }
 StepThroughTest >> testStepThroughUntilTermination [
 	"Stepping over a message node brings the execution to the next node in the same method."
-	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1 ].
 
+	self settingUpSessionAndProcessAndContextForBlock: [ self stepA1 ].
 	[ session interruptedProcess isTerminated ] whileFalse: [ session stepThrough ].
 
-	self assert: session interruptedProcess isTerminated
+	self assert: session interruptedProcess isTerminated.
+	self deny: (session isContextPostMortem: session interruptedContext).
+	self assert: session interruptedContext sender isNil
+]
+
+{ #category : 'tests' }
+StepThroughTest >> testStepThroughValueWithArguments [ 
+
+	| node |
+	self settingUpSessionAndProcessAndContextForBlock: [ self stepH1 ].
+	session stepInto.
+	session stepOver. 
+	session stepOver.
+
+	"Reached node 'tmpBlock value: 1' of method stepH1"
+	"Checking that the execution is indeed at this node"
+	self assert: (session interruptedContext method) equals: (self class lookupSelector: #stepH1).
+	node := (self class lookupSelector: #stepH1) sourceNodeForPC: session interruptedContext pc.
+	self assert: node isMessage.
+	self assert: node selector equals: #value:.
+	session stepThrough.
+
+	self assert: session interruptedContext numTemps equals: 1.
+	self assert: session interruptedContext sender isNotNil
 ]

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -26,9 +26,11 @@ Class {
 		'name',
 		'interruptedContext',
 		'interruptedProcess',
-		'exception'
+		'exception',
+		'stepThroughController'
 	],
 	#classVars : [
+		'FastStepThroughMode',
 		'LogDebuggerStackToFile'
 	],
 	#classInstVars : [
@@ -55,6 +57,31 @@ DebugSession class >> contextModelClass: anObject [
 DebugSession class >> defaultContextModelClass [
 
 	^ DebugContext
+]
+
+{ #category : 'accessing' }
+DebugSession class >> fastStepThroughMode [
+
+	^ FastStepThroughMode ifNil: [ FastStepThroughMode := false ]
+]
+
+{ #category : 'accessing' }
+DebugSession class >> fastStepThroughMode: aBoolean [
+
+	^ FastStepThroughMode := aBoolean
+]
+
+{ #category : 'settings' }
+DebugSession class >> fastStepThroughModeSettingOn: aBuilder [
+
+	<systemsettings>
+	(aBuilder setting: #fastStepThroughMode)
+		label: 'Enable the fast step through mode';
+		target: self;
+		parent: #debugging;
+		default: false;
+		description:
+			'If enabled, the debugger will perform step through operations using halting blocks. This implementation is more efficient than the original one based on interpreter steps'
 ]
 
 { #category : 'settings' }
@@ -116,6 +143,76 @@ DebugSession >> exception [
 { #category : 'accessing' }
 DebugSession >> exception: anObject [
 	exception := anObject
+]
+
+{ #category : 'debugging actions' }
+DebugSession >> fastStepThrough: aContext [
+	"Send messages until you return to selectedContext.
+	 Used to step into a block in the method."
+
+	| newContext blockContext callingContext home currentContext haltingBlockSeen |
+
+	"Prevent stopping the execution inside very short methods, such as accessors."
+	aContext stepIntoQuickMethod: false.
+
+	"If the context is dead, return."
+	(self isContextPostMortem: aContext) ifTrue: [ ^ self ].
+	
+	"Wrap every block in the given context with a HaltingBlock, replacing the originals."
+	self stepThroughController prepareContextForStepThrough: aContext.
+
+	"Set the stepping state to True to make the process interrupt its execution 
+	when the haltIfStepping method in a halting block is reached."
+	interruptedProcess
+		psValueAt: DebuggerSteppingState soleInstance index
+		put: true.
+
+	newContext := interruptedProcess completeStep: aContext.
+	"Set the stepping state back to False for the process."
+	interruptedProcess
+		psValueAt: DebuggerSteppingState soleInstance index
+		put: false.
+
+	blockContext := self stepThroughController findNextContext:
+		                newContext.
+	blockContext == newContext ifTrue: [
+		(blockContext isNotNil and: [
+			 newContext home ~= aContext home and: [
+				 newContext hasSender: aContext home ] ]) ifTrue: [
+			home := aContext home.
+			currentContext := newContext.
+			[ currentContext = home sender ] whileFalse: [
+				currentContext := currentContext sender ].
+			interruptedProcess suspendedContext: currentContext.
+			self updateContextTo: currentContext.
+			self triggerEvent: #stepThrough.
+			^ self ].
+
+		interruptedProcess suspendedContext: newContext.
+		interruptedProcess isTerminated
+			ifTrue: [ aContext terminateTo: nil ]
+			ifFalse: [
+				self updateContextTo:
+					(self stepToFirstInterestingBytecodeIn: interruptedProcess) ].
+		self triggerEvent: #stepThrough.
+		^ self ].
+
+	callingContext := interruptedProcess suspendedContext.
+	haltingBlockSeen := false.
+	[
+	callingContext isNotNil and: [
+		(haltingBlockSeen not and: [
+			 callingContext receiver class ~= HaltingBlock ]) or: [
+			haltingBlockSeen and: [
+				callingContext receiver class = HaltingBlock ] ] ] ] whileTrue: [
+		callingContext := callingContext sender.
+		haltingBlockSeen ifFalse: [
+			haltingBlockSeen := callingContext receiver class = HaltingBlock ] ].
+
+	blockContext sender: (callingContext ifNotNil: [callingContext sender]).
+	self updateContextTo: blockContext.
+	interruptedProcess suspendedContext: blockContext.
+	self triggerEvent: #stepThrough
 ]
 
 { #category : 'evaluating' }
@@ -516,6 +613,12 @@ DebugSession >> stepThrough: aContext [
 	self updateContextTo: (self stepToFirstInterestingBytecodeIn: interruptedProcess).
 
 	self triggerEvent: #stepThrough
+]
+
+{ #category : 'accessing' }
+DebugSession >> stepThroughController [
+	^ stepThroughController ifNil: [
+		  stepThroughController := FastStepThroughController new ]
 ]
 
 { #category : 'private' }

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -147,71 +147,32 @@ DebugSession >> exception: anObject [
 
 { #category : 'debugging actions' }
 DebugSession >> fastStepThrough: aContext [
-	"Send messages until you return to selectedContext.
+	"Send messages until you return to aContext.
 	 Used to step into a block in the method."
-
-	| newContext blockContext callingContext home currentContext haltingBlockSeen |
-
-	"Prevent stopping the execution inside very short methods, such as accessors."
+	|  ctrl originContext targetContext |
+	ctrl := self stepThroughController.	
+		
 	aContext stepIntoQuickMethod: false.
-
-	"If the context is dead, return."
 	(self isContextPostMortem: aContext) ifTrue: [ ^ self ].
+	"Wrap blocks in aContext with HaltingBlocks"
+	ctrl prepareContextForStepThrough: aContext.
 	
-	"Wrap every block in the given context with a HaltingBlock, replacing the originals."
-	self stepThroughController prepareContextForStepThrough: aContext.
-
-	"Set the stepping state to True to make the process interrupt its execution 
-	when the haltIfStepping method in a halting block is reached."
-	interruptedProcess
-		psValueAt: DebuggerSteppingState soleInstance index
-		put: true.
-
-	newContext := interruptedProcess completeStep: aContext.
-	"Set the stepping state back to False for the process."
-	interruptedProcess
-		psValueAt: DebuggerSteppingState soleInstance index
-		put: false.
-
-	blockContext := self stepThroughController findNextContext:
-		                newContext.
-	blockContext == newContext ifTrue: [
-		(blockContext isNotNil and: [
-			 newContext home ~= aContext home and: [
-				 newContext hasSender: aContext home ] ]) ifTrue: [
-			home := aContext home.
-			currentContext := newContext.
-			[ currentContext = home sender ] whileFalse: [
-				currentContext := currentContext sender ].
-			interruptedProcess suspendedContext: currentContext.
-			self updateContextTo: currentContext.
-			self triggerEvent: #stepThrough.
-			^ self ].
-
-		interruptedProcess suspendedContext: newContext.
-		interruptedProcess isTerminated
-			ifTrue: [ aContext terminateTo: nil ]
-			ifFalse: [
-				self updateContextTo:
-					(self stepToFirstInterestingBytecodeIn: interruptedProcess) ].
-		self triggerEvent: #stepThrough.
-		^ self ].
-
-	callingContext := interruptedProcess suspendedContext.
-	haltingBlockSeen := false.
-	[
-	callingContext isNotNil and: [
-		(haltingBlockSeen not and: [
-			 callingContext receiver class ~= HaltingBlock ]) or: [
-			haltingBlockSeen and: [
-				callingContext receiver class = HaltingBlock ] ] ] ] whileTrue: [
-		callingContext := callingContext sender.
-		haltingBlockSeen ifFalse: [
-			haltingBlockSeen := callingContext receiver class = HaltingBlock ] ].
-
-	blockContext sender: (callingContext ifNotNil: [callingContext sender]).
-	self updateContextTo: blockContext.
-	interruptedProcess suspendedContext: blockContext.
+	originContext := ctrl completeStep: aContext inProcess: interruptedProcess.
+	targetContext := ctrl findNextContext: originContext 
+								 having: aContext home 
+					  			 fixing: interruptedProcess suspendedContext .
+	
+	targetContext == originContext 
+		ifTrue: [ "Step through is equivalent to Step over"
+			interruptedProcess suspendedContext: originContext.
+			interruptedProcess isTerminated
+					ifTrue: [ aContext terminateTo: nil ]
+					ifFalse: [ self updateContextTo: 
+									(self stepToFirstInterestingBytecodeIn: interruptedProcess) ] ]
+		ifFalse: [ "Step through either enters of exits the block"
+			interruptedProcess suspendedContext: targetContext.
+			self updateContextTo: targetContext ].
+			
 	self triggerEvent: #stepThrough
 ]
 
@@ -606,6 +567,9 @@ DebugSession >> stepThrough [
 DebugSession >> stepThrough: aContext [
 	"Send messages until you return to selectedContext.
 	 Used to step into a block in the method."
+	
+	self class fastStepThroughMode ifTrue: [ ^ self fastStepThrough: aContext ].
+	
 	aContext stepIntoQuickMethod: false.
 	(self isContextPostMortem: aContext) ifTrue: [^ self].
 

--- a/src/Debugger-Model/DebuggerSteppingState.class.st
+++ b/src/Debugger-Model/DebuggerSteppingState.class.st
@@ -1,0 +1,16 @@
+"
+I am a process variable that defines if the process must stop during the fast step through
+"
+Class {
+	#name : 'DebuggerSteppingState',
+	#superclass : 'ProcessLocalVariable',
+	#category : 'Debugger-Model-Core',
+	#package : 'Debugger-Model',
+	#tag : 'Core'
+}
+
+{ #category : 'accessing' }
+DebuggerSteppingState >> default [
+
+	^ false
+]

--- a/src/Debugger-Model/FastStepThroughController.class.st
+++ b/src/Debugger-Model/FastStepThroughController.class.st
@@ -1,0 +1,108 @@
+"
+I know hot to manipulate contexts and blocks for the fast step through functionality.
+"
+Class {
+	#name : 'FastStepThroughController',
+	#superclass : 'Object',
+	#instVars : [
+		'originalBlocks',
+		'newBlocks'
+	],
+	#category : 'Debugger-Model-Core',
+	#package : 'Debugger-Model',
+	#tag : 'Core'
+}
+
+{ #category : 'menu - operations' }
+FastStepThroughController >> findNextContext: aContext [
+
+	| callingContext haltingBlock newContext args stackp |
+	originalBlocks ifEmpty: [ ^ aContext ].
+
+	(aContext receiver isKindOf: Halt) ifFalse: [ ^ aContext ].
+
+	callingContext := aContext.
+	[ callingContext method = (HaltingBlock >> #haltIfStepping) ]
+		whileFalse: [ callingContext := callingContext sender ].
+
+	haltingBlock := callingContext receiver.
+	args := stackp := nil.
+	[ callingContext receiver class = HaltingBlock ] whileTrue: [
+		(callingContext method selector == #valueWithArguments: and: [
+			 (stackp := callingContext stackPtr) > 0 ]) ifTrue: [
+			args := callingContext at: stackp ].
+		callingContext := callingContext sender ].
+
+	newContext := haltingBlock originalBlock asContextWithSender:
+		              callingContext.
+
+	(args isNotNil and: [ haltingBlock originalBlock numArgs > 0 ])
+		ifTrue: [
+			args isArray
+				ifTrue: [
+					1 to: haltingBlock originalBlock numArgs do: [ :i |
+					newContext tempAt: i put: (args at: i) ] ]
+				ifFalse: [ newContext tempAt: 1 put: args ] ].
+
+	newContext stepToSendOrReturn.
+	^ newContext
+]
+
+{ #category : 'initialization' }
+FastStepThroughController >> initialize [
+
+	super initialize.
+	originalBlocks := OrderedCollection new.
+	newBlocks := OrderedCollection new
+]
+
+{ #category : 'preparation' }
+FastStepThroughController >> prepareContextForStepThrough: aContext [
+
+	| maybeABlock |
+	1 to: aContext size do: [ :idx | self updateFullBlocksOf: aContext withIndex: idx ].
+
+	aContext receiver class allSlots do: [ :aSlot |
+			maybeABlock := aSlot read: aContext receiver.
+			maybeABlock isBlock 
+				ifTrue: [ self updateFullBlockOfReceiver: aContext receiver block: maybeABlock slot: aSlot ] ]
+]
+
+{ #category : 'cleanup' }
+FastStepThroughController >> revertBlocks [
+
+	newBlocks asArray elementsForwardIdentityTo: originalBlocks asArray
+]
+
+{ #category : 'preparation' }
+FastStepThroughController >> transformBlock: originalBlock [
+
+	| blockIndex newBlock |
+	(blockIndex := originalBlocks indexOf: originalBlock) > 0 
+		ifTrue: [ ^ newBlocks at: blockIndex ].
+
+	newBlock := HaltingBlock new
+		            originalBlock: originalBlock;
+		            yourself.
+
+	originalBlocks add: originalBlock.
+	newBlocks add: newBlock.
+
+	^ newBlock
+]
+
+{ #category : 'preparation' }
+FastStepThroughController >> updateFullBlockOfReceiver: aReceiver block: originalBlock slot: aSlot [
+
+	aSlot write: (self transformBlock: originalBlock) to: aReceiver
+]
+
+{ #category : 'preparation' }
+FastStepThroughController >> updateFullBlocksOf: aContext withIndex: anIndex [
+
+	| originalBlock |
+	originalBlock := aContext at: anIndex.
+	originalBlock isBlock ifFalse: [ ^ self ].
+
+	aContext at: anIndex put: (self transformBlock: originalBlock)
+]

--- a/src/Debugger-Model/FastStepThroughController.class.st
+++ b/src/Debugger-Model/FastStepThroughController.class.st
@@ -13,39 +13,122 @@ Class {
 	#tag : 'Core'
 }
 
-{ #category : 'menu - operations' }
-FastStepThroughController >> findNextContext: aContext [
+{ #category : 'context operations' }
+FastStepThroughController >> buildBlockContext: haltingBlock args: args sender: sender [
+	" Create newContext from the originalBlock, and set its argument values if they exist. "
 
-	| callingContext haltingBlock newContext args stackp |
-	originalBlocks ifEmpty: [ ^ aContext ].
-
-	(aContext receiver isKindOf: Halt) ifFalse: [ ^ aContext ].
-
-	callingContext := aContext.
-	[ callingContext method = (HaltingBlock >> #haltIfStepping) ]
-		whileFalse: [ callingContext := callingContext sender ].
-
-	haltingBlock := callingContext receiver.
-	args := stackp := nil.
-	[ callingContext receiver class = HaltingBlock ] whileTrue: [
-		(callingContext method selector == #valueWithArguments: and: [
-			 (stackp := callingContext stackPtr) > 0 ]) ifTrue: [
-			args := callingContext at: stackp ].
-		callingContext := callingContext sender ].
-
-	newContext := haltingBlock originalBlock asContextWithSender:
-		              callingContext.
-
-	(args isNotNil and: [ haltingBlock originalBlock numArgs > 0 ])
-		ifTrue: [
+	| newContext |
+	newContext := haltingBlock originalBlock asContextWithSender: sender.
+	(args isNotNil and: [ haltingBlock originalBlock numArgs > 0 ]) ifTrue: [
 			args isArray
-				ifTrue: [
-					1 to: haltingBlock originalBlock numArgs do: [ :i |
-					newContext tempAt: i put: (args at: i) ] ]
+				ifTrue: [ 1 to: haltingBlock originalBlock numArgs 
+								do: [ :i | newContext tempAt: i put: (args at: i) ] ]
 				ifFalse: [ newContext tempAt: 1 put: args ] ].
+	^ newContext
+]
 
+{ #category : 'context operations' }
+FastStepThroughController >> completeStep: aContext inProcess: aProcess [
+
+	" Enable process interruptions triggered by HaltingBlocks. "
+	| newContext |
+	aProcess psValueAt: DebuggerSteppingState soleInstance index put: true. 
+
+	" Run until aContext is on top, a return is reached, or an Error is signaled. "
+	newContext := aProcess completeStep: aContext. 
+
+	" Disable process interruptions triggered by HaltingBlocks. "
+	aProcess psValueAt: DebuggerSteppingState soleInstance index put: false.
+
+	^ newContext
+]
+
+{ #category : 'context operations' }
+FastStepThroughController >> findContextForMethodHalfIfStepping: aContext [
+	" Find the context for the method #haltIfStepping in aContext sender chain. "
+	
+	| ctx |
+	ctx := aContext.
+	[ ctx method = (HaltingBlock >> #haltIfStepping) ] 
+		whileFalse: [ 
+			ctx := ctx sender 
+		].
+	^ ctx
+]
+
+{ #category : 'context operations' }
+FastStepThroughController >> findFirstContext: aContext withReceiverOfClass: aClass [
+
+	| current receiverSeen |
+	current := aContext.
+	receiverSeen := false.
+
+	[ current isNotNil and: [ receiverSeen = (current receiver class = aClass) ] ] whileTrue: [
+			current := current sender.
+			receiverSeen ifFalse: [ receiverSeen := current receiver class = aClass ] ].
+
+	^ current
+]
+
+{ #category : 'context operations' }
+FastStepThroughController >> findNextContext: aContext [
+	" Build and return a newContext whose closure is the original block. "
+	
+	| current haltingBlock newContext args pair |
+	
+	" missing originalBlocks <=> missing haltingBlocks, and missing Halt means there's nothing to do. "
+	( originalBlocks isEmpty or: [ (aContext receiver isKindOf: Halt) not ] ) 
+	ifTrue: [ ^ aContext ].
+	
+	" get the halting block, the argument values, and the context sender to build newContext. "
+	current :=  self findContextForMethodHalfIfStepping: aContext.
+	haltingBlock := current receiver.
+	
+	pair := self getStackedArguments: current.
+	current := pair first.
+	args := pair second.
+
+	newContext := self buildBlockContext: haltingBlock args: args sender: current.
+	" step into the block "
 	newContext stepToSendOrReturn.
 	^ newContext
+]
+
+{ #category : 'context operations' }
+FastStepThroughController >> findNextContext: originContext having: homeContext fixing: buggyContext [
+
+	| blockContext fixedContext |
+	"Find the next context, restoring blocks, removing HaltingBlocks"
+	blockContext := self findNextContext: originContext.
+	
+	"a. Here step through exits the block is being evaluated."
+	(self stepOutOfBlock: blockContext from: originContext to: homeContext) 
+		ifNotNil: [:targetContext | ^ targetContext ].
+
+	"b. Here step through behaves like step over."
+	blockContext == originContext ifTrue: [ ^ originContext ].
+
+	"c. Here step through steps into a block."
+	fixedContext := self findFirstContext: buggyContext
+								  withReceiverOfClass: HaltingBlock.
+	blockContext sender: (fixedContext ifNotNil: [fixedContext sender ]).
+
+	^ blockContext
+]
+
+{ #category : 'context operations' }
+FastStepThroughController >> getStackedArguments: aContext [
+	" Extract the arguments stacked during the evaluation 
+	  of haltingBlock in aContext and its senders. "
+	
+	| args stackp ctx |
+	ctx := aContext.
+	args := stackp := nil.
+	[ ctx receiver class = HaltingBlock ] whileTrue: [
+			(ctx method selector == #valueWithArguments: and: [ (stackp := ctx stackPtr) > 0 ]) 
+				ifTrue: [ args := ctx at: stackp ].
+			ctx := ctx sender ].
+	^ { ctx. args }
 ]
 
 { #category : 'initialization' }
@@ -58,7 +141,9 @@ FastStepThroughController >> initialize [
 
 { #category : 'preparation' }
 FastStepThroughController >> prepareContextForStepThrough: aContext [
-
+	" Wrap every block from aContext with a HaltingBlock. 
+	 Replace references to the originals by the wrappers in aContext. "
+	
 	| maybeABlock |
 	1 to: aContext size do: [ :idx | self updateFullBlocksOf: aContext withIndex: idx ].
 
@@ -72,6 +157,24 @@ FastStepThroughController >> prepareContextForStepThrough: aContext [
 FastStepThroughController >> revertBlocks [
 
 	newBlocks asArray elementsForwardIdentityTo: originalBlocks asArray
+]
+
+{ #category : 'context operations' }
+FastStepThroughController >> stepOutOfBlock: blockContext from: originContext to: targetContext [
+	" Return the context obtained after stepping out of the blockContext, 
+	but only if this step through corresponds to the moment when the block 
+	is exited. Otherwise return nil"
+
+	| target current block origin |
+	block := blockContext.
+	origin := originContext.
+	target := targetContext.
+
+	(block == origin and: [ block isNotNil and: [ origin home ~= target and: [ origin hasSender: target ] ] ]) ifTrue: [
+			current := origin.
+			[ current = target ] whileFalse: [ current := current sender ].
+			^ current ]. "Return nil if the current step through does not exit the block"
+	^ nil
 ]
 
 { #category : 'preparation' }

--- a/src/Debugger-Model/HaltingBlock.class.st
+++ b/src/Debugger-Model/HaltingBlock.class.st
@@ -1,0 +1,109 @@
+"
+I am a wrapper for blocks to enable halt for the fast step through feature
+"
+Class {
+	#name : 'HaltingBlock',
+	#superclass : 'FullBlockClosure',
+	#type : 'variable',
+	#instVars : [
+		'originalBlock'
+	],
+	#category : 'Debugger-Model-Core',
+	#package : 'Debugger-Model',
+	#tag : 'Core'
+}
+
+{ #category : 'exceptions' }
+HaltingBlock >> haltIfStepping [
+
+	<debuggerCompleteToSender>
+	DebuggerSteppingState value ifTrue: [ Break break ]
+]
+
+{ #category : 'accessing' }
+HaltingBlock >> home [
+
+	^ originalBlock home
+]
+
+{ #category : 'accessing' }
+HaltingBlock >> originalBlock [
+
+	^ originalBlock
+]
+
+{ #category : 'accessing' }
+HaltingBlock >> originalBlock: aBlock [
+
+	outerContext := aBlock outerContext.
+	numArgs := aBlock numArgs.
+	receiver := aBlock receiver.
+	compiledBlock := aBlock compiledBlock.
+	originalBlock := aBlock
+]
+
+{ #category : 'accessing' }
+HaltingBlock >> sender [
+	self flag: 'Delete me without breaking the fast step through'.
+	^ originalBlock sender
+]
+
+{ #category : 'evaluating' }
+HaltingBlock >> value [
+
+	^ self valueWithArguments: #(  )
+]
+
+{ #category : 'evaluating' }
+HaltingBlock >> value: firstArg [
+
+	^ self valueWithArguments: { firstArg }
+]
+
+{ #category : 'evaluating' }
+HaltingBlock >> value: firstArg value: secondArg [
+
+	^ self valueWithArguments: {
+			  firstArg.
+			  secondArg }
+]
+
+{ #category : 'evaluating' }
+HaltingBlock >> value: firstArg value: secondArg value: thirdArg [
+
+	^ self valueWithArguments: {
+			  firstArg.
+			  secondArg.
+			  thirdArg }
+]
+
+{ #category : 'evaluating' }
+HaltingBlock >> value: firstArg value: secondArg value: thirdArg value: fourthArg [
+
+	^ self valueWithArguments: {
+			  firstArg.
+			  secondArg.
+			  thirdArg.
+			  fourthArg }
+]
+
+{ #category : 'evaluating' }
+HaltingBlock >> valueNoContextSwitch [
+
+	self haltIfStepping.
+	^ originalBlock valueNoContextSwitch
+]
+
+{ #category : 'evaluating' }
+HaltingBlock >> valueNoContextSwitch: anArg [
+
+	self haltIfStepping.
+	^ originalBlock valueNoContextSwitch: anArg
+]
+
+{ #category : 'evaluating' }
+HaltingBlock >> valueWithArguments: anArray [
+
+	self haltIfStepping.
+	^ originalBlock valueWithArguments: anArray
+]

--- a/src/Kernel-CodeModel/Context.class.st
+++ b/src/Kernel-CodeModel/Context.class.st
@@ -1882,6 +1882,12 @@ Context >> sender [
 	^sender
 ]
 
+{ #category : 'debugger access' }
+Context >> sender: aContext [
+
+	sender := aContext
+]
+
 { #category : 'private' }
 Context >> setNamedPrimitiveInformationFrom: fromMethod toMethod: toMethod [
 	"For named primitives, the first literal contains a special object that has information of the primitive. In this method we cope such information from one to another one."


### PR DESCRIPTION
This PR ports the solution proposed in [PR#18578](https://github.com/pharo-project/pharo/pull/18578) for P11 into P14.
FastStepThrough behaves the same as stepThrough, but it is faster for long-running executions (e.g. recursive functions).

To test the solution I followed the steps in the original https://github.com/pharo-project/pharo/issues/16351 posted by @VincentBlondeau . The traditional step through took **125 seconds** to step and the fast step through took only **7 secs** (tested in P14, and P11 with almost identical times)
