### PR TITLE
fix compiler plugin call of semantic analysis

### DIFF
--- a/src/OpalCompiler-Core/OCCompilationContext.class.st
+++ b/src/OpalCompiler-Core/OCCompilationContext.class.st
@@ -29,7 +29,8 @@ Class {
 		'bindings',
 		'compiledMethodClass',
 		'semanticScope',
-		'compiledBlockClass'
+		'compiledBlockClass',
+		'semanticAnalysisNeeded'
 	],
 	#classVars : [
 		'DefaultOptions',
@@ -509,6 +510,12 @@ OCCompilationContext >> isScripting: aBoolean [
 		semanticScope := OCReceiverDoItSemanticScope targetingNilReceiver ]
 ]
 
+{ #category : 'testing' }
+OCCompilationContext >> isSemanticAnalysisNeeded [
+
+	^ semanticAnalysisNeeded == true
+]
+
 { #category : 'options' }
 OCCompilationContext >> optionBlockClosureOptionalOuter [
 	^ options includes: #optionBlockClosureOptionalOuter
@@ -679,6 +686,18 @@ OCCompilationContext >> requestorScopeClass [
 OCCompilationContext >> requestorScopeClass: anObject [
 	"clients can set their own subclass of OCRequestorScope if needed"
 	requestorScopeClass := anObject
+]
+
+{ #category : 'accessing' }
+OCCompilationContext >> requireSemanticAnalysis [
+
+	semanticAnalysisNeeded := true
+]
+
+{ #category : 'accessing' }
+OCCompilationContext >> semanticAnalysisDone [
+
+	semanticAnalysisNeeded := false
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -370,11 +370,14 @@ OpalCompiler >> compile [
 	"Policy: compiling is non-faulty by default"
 	self permitFaulty ifNil: [ self permitFaulty: false ].
 
-	ast
-		ifNil: [
-			result := self parse.
-			ast ifNil: [ "some failBlock" ^ result ] ]
-		ifNotNil: [ ast scope ifNil: [ self doSemanticAnalysis ] ].
+	ast ifNil: [
+		result := self parse.
+		ast ifNil: [ "some failBlock" ^ result ] ].
+
+	self callPlugins.
+	(compilationContext isSemanticAnalysisNeeded or: [ ast scope isNil ]) 
+		ifTrue: [ 
+			self doSemanticAnalysis ].
 
 	^ self generateMethod
 ]
@@ -444,6 +447,9 @@ OpalCompiler >> doSemanticAnalysis [
 		compilationContext: self compilationContext;
 		outerScope: self buildOuterScope;
 		analyze: ast.
+		
+	self  compilationContext semanticAnalysisDone.
+	
 	^ ast
 ]
 
@@ -533,9 +539,8 @@ OpalCompiler >> generateIR [
 
 { #category : 'private' }
 OpalCompiler >> generateMethod [
-
 	| method ir |
-	self callPlugins.
+	
 	ast scope registerVariables.
 
 	ast bcToASTCache: nil.


### PR DESCRIPTION
some transformation plugins make a semantic analyse explicit, and tha…t was making  the compiler to fail (as there were two semantic analysis in different stages with different data).
plugins need to be called BEFORE doing the analyse, and we need to be able to mark the need ot a semantic analyse to the compilation context.