### PR TITLE
Fix issue #18598: Duplicating a class fails to log methods in Epicea (clean)

### DIFF
--- a/src/Kernel-Tests/ClassAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ClassAnnouncementsTest.class.st
@@ -7,6 +7,21 @@ Class {
 }
 
 { #category : 'tests' }
+ClassAnnouncementsTest >> testDuplicatingAClassAnnouncesAddition [
+
+	class compile: 'billy ^ #meow' classified: '*' , self packageNameForTests , '2'.
+
+	self when: ClassAdded do: [ :ann |
+		self assert: ann classAffected originalName equals: self classNameForTests, '2'.
+		self assert: ann packageAffected name equals: self packageNameForTests.
+		self assertCollection: (ann packagesAffected collect: [ :package | package name ]) hasSameElements: { self packageNameForTests } ].
+
+	class duplicateClassWithNewName: self classNameForTests, '2'.
+
+	self assert: numberOfAnnouncements equals: 1
+]
+
+{ #category : 'tests' }
 ClassAnnouncementsTest >> testRemovingAClassWithExtension [
 	"Regression test about an issue where class removed was not returning the extension packages in its affected packages"
 

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -22,7 +22,7 @@ Behavior >> compile: selector from: oldClass [
 	| method newMethod |
 	method := oldClass compiledMethodAt: selector.
 	newMethod := oldClass compiler
-		             source: (oldClass sourceCodeAt: selector);
+		             source: method sourceCode;
 		             priorMethod: method;
 		             class: self;
 		             permitFaulty: true;

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -16,6 +16,26 @@ Behavior >> compile: code [
 ]
 
 { #category : '*OpalCompiler-Core' }
+Behavior >> compile: selector from: oldClass [
+	"Compile the method associated with selector in the receiver's method dictionary."
+
+	| method newMethod |
+	method := oldClass compiledMethodAt: selector.
+	newMethod := oldClass compiler
+		             source: (oldClass sourceCodeAt: selector);
+		             priorMethod: method;
+		             class: self;
+		             permitFaulty: true;
+		             "No need to log recompilation in the sources,
+					 	 We are going to reuse the original source pointer."
+		             logged: false;
+		             install.
+	newMethod sourcePointer: method sourcePointer.
+	selector == newMethod selector ifFalse: [
+		self error: 'selector changed!' ]
+]
+
+{ #category : '*OpalCompiler-Core' }
 Behavior >> compile: code notifying: requestor [
 	"Compile the argument, code, as source code in the context of the
 	receiver and insEtall the result in the receiver's method dictionary. The
@@ -36,7 +56,7 @@ Behavior >> compileAllFrom: oldClass [
 	"Compile all the methods in the receiver's method dictionary.
 	This validates sourceCode and variable references and forces
 	all methods to use the current bytecode set"
-	oldClass localSelectors do: [:sel | self recompile: sel from: oldClass]
+	oldClass localSelectors do: [:sel | self compile: sel from: oldClass]
 ]
 
 { #category : '*OpalCompiler-Core' }
@@ -73,24 +93,9 @@ Behavior >> recompile: selector [
 
 { #category : '*OpalCompiler-Core' }
 Behavior >> recompile: selector from: oldClass [
-	"Compile the method associated with selector in the receiver's method dictionary."
-
-	| method newMethod |
 
 	"Recompilation should be done silently, to avoid putting noise in the system"
 	self codeChangeAnnouncer suspendAllWhile: [
-		method := oldClass compiledMethodAt: selector.
-		newMethod := oldClass compiler
-			             source: (oldClass >> selector) sourceCode;
-			             priorMethod: method;
-			             class: self;
-			             permitFaulty: true;
-			             "No need to log recompilation in the sources,
-						 	 We are going to reuse the original source pointer."
-			             logged: false;
-			             install ].
-
-	newMethod sourcePointer: method sourcePointer.
-	selector == newMethod selector ifFalse: [
-		self error: 'selector changed!' ]
+		self compile: selector from: oldClass 
+	]
 ]


### PR DESCRIPTION
### Context
This PR solves [Issue#18598](https://github.com/pharo-project/pharo/issues/18598)

My previous attempt: [PR#18618](https://github.com/pharo-project/pharo/pull/18618) got too complicated because I found new bugs during its resolution ([see here](https://github.com/pharo-project/pharo/pull/18618#issuecomment-3352340166)), so I decided to divide it in 2 different PRs.

----------------------------------------------------------------------------------------

### Description of the Solution
As @akgrant43 pointed out in Issue #18598, Epicea was not logging method creation entries when duplicating classes, because the announcer was silenced in `Behavior>>#recompile:from:`.

My solution preserves the silence for method recompilations, but ensures that method compilations always announce their code changes.
As a result, `Behavior>>compileAllFrom:` now announces its changes. This is correct, since it is only used when copying methods from an existing class into a new one—the exact scenario that was failing in the original issue.