### PR TITLE
Update Toplo World Menu entry to load 'Pharo13' branch

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -170,7 +170,7 @@ BaselineOfPharo class >> toplo [
 		newName: 'Toplo' 
 		owner: 'pharo-graphics' 
 		project: 'Toplo' 
-		version: 'v0.5.0'
+		version: 'Pharo13'
 ]
 
 { #category : 'repository urls' }


### PR DESCRIPTION
This branch currently points to v0.7.0 but next version could be updated in the git repo, without a code change in pharo repo.