### PR TITLE
Simplify the registering of OpalCompiler

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -152,7 +152,6 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform --save PharoBootst
 # Installing compiler through Hermes 
 echo $(date -u) "[Compiler] Installing compiler through Hermes"
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Debugging-Utils.hermes OpalCompiler-Core.hermes DebugInfo.hermes CodeImport.hermes CodeImport-Commands.hermes --save --no-fail-on-undeclared
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "OpalCompiler register."
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "SystemEnvironment deprecatedAliases: { #SystemDictionary }." # This line should be removed in Pharo 14 since it is for backward compatibility.
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/01-init.st --no-source --save --quit
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -99,6 +99,13 @@ OpalCompiler class >> evaluate: textOrString [
 		evaluate
 ]
 
+{ #category : 'class initialization' }
+OpalCompiler class >> initialize [
+	"If no compiler is register when I'm loaded, I'll set myself as the compiler of the image."
+
+	SmalltalkImage current compilerClass ifNil: [ self register ]
+]
+
 { #category : 'public' }
 OpalCompiler class >> isActive [
 	^Smalltalk compilerClass == self

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -53,9 +53,7 @@ SmalltalkImage class >> cleanUp [
 { #category : 'settings' }
 SmalltalkImage class >> compilerClass [
 
-	^CompilerClass ifNil: [
-		"use OpalCompiler as the fallback compiler if installed"
-		self class environment at: #OpalCompiler ifAbsent: [ nil ] ]
+	^ CompilerClass
 ]
 
 { #category : 'settings' }


### PR DESCRIPTION
Up until now we have SmalltalkImage looking if OpalCompiler is in the system and we also register in the bootstrap the compiler.

I propose to simplify things. SmalltalkImage should not know the compiler. And I removed the explicit registration from the bootstrap. Instead, when we load Opal, it will check if a compiler is registered. If not, it will register itself. (This is now possible since Hermes is executing the #initialize methods now)

This is a small cleaning to remove a bad dependency and simplify (a tiny bit) the bootstrap