### PR TITLE
Move RunArrayTest

### DIFF
--- a/src/Text-Tests/RunArrayTest.class.st
+++ b/src/Text-Tests/RunArrayTest.class.st
@@ -9,8 +9,8 @@ Class {
 	#instVars : [
 		'collectionWith5Elements'
 	],
-	#category : 'Collections-Support-Tests',
-	#package : 'Collections-Support-Tests'
+	#category : 'Text-Tests',
+	#package : 'Text-Tests'
 }
 
 { #category : 'requirements' }


### PR DESCRIPTION
RunArray is in Text-Core package but the tests are in Collections-Support-Test. This package is loaded before Text-Core.

In order to reduce the number of undeclared I propose to move RunArrayTest in Text-Tests

<img width="793" height="459" alt="image" src="https://github.com/user-attachments/assets/5e6ce8b6-9f75-4723-aab5-4dc344a6a773" />
