### PR TITLE
Move loading of 'System-Object Events-Tests'

### DIFF
--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -45,6 +45,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'Rubric-Tests';
 			package: 'ScriptingExtensions-Tests';
 			package: 'STON-Tests';
+			package: 'System-Object Events-Tests';
 			package: 'System-Caching-Tests';
 			package: 'System-Utilities-Tests';
 			package: 'System-Hashing-Tests';

--- a/src/BaselineOfKernelTests/BaselineOfKernelTests.class.st
+++ b/src/BaselineOfKernelTests/BaselineOfKernelTests.class.st
@@ -42,7 +42,6 @@ BaselineOfKernelTests >> baseline: spec [
 			package: 	'Random-Tests';
 			package: 	'Ring-Definitions-Core-Tests';
 			package: 	'Ring-Definitions-Tests-Containers'; 
-			package: 	'System-Object Events-Tests';
 			package: 	'System-OSEnvironments-Tests';
 			package: 	'Zinc-Character-Encoding-Tests' ;
 			package: 	'System-Platforms-Tests';


### PR DESCRIPTION
'System-Object Events-Tests' is currently loaded before 'System-Object Events' because it is declared in BaselineOfGeneralTests that is loaded before Morphic and 'System-Object Events' is loaded with Morphic core. 

I propose to move this test package to be loaded after the classes it tests

<img width="783" height="121" alt="image" src="https://github.com/user-attachments/assets/87726d1a-ff4d-47af-9d4b-9812abc9bf82" />
