### PR TITLE
Fix: #18702 by making OCBlockScope >> inComingCopiedVarNames consistent to Set inconsistent results

### DIFF
--- a/src/OpalCompiler-Core/OCBlockScope.class.st
+++ b/src/OpalCompiler-Core/OCBlockScope.class.st
@@ -16,7 +16,8 @@ OCBlockScope >> hasEscapingVars [
 
 { #category : 'accessing' }
 OCBlockScope >> inComingCopiedVarNames [
-	^ self copiedVarNames intersection: outerScope copiedVarNames
+
+	^ outerScope copiedVarNames select: [ :e | self copiedVarNames includes: e ]
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
fix: #18702