### PR TITLE
fix: make OnlineSourceDebugInfo>>#readVariableNamed:fromContext: work…

### DIFF
--- a/src/DebugInfo-Tests/DebugInfoTest.class.st
+++ b/src/DebugInfo-Tests/DebugInfoTest.class.st
@@ -826,6 +826,24 @@ DebugInfoTest >> testReadLocalMethodTemporaryVariable [
 ]
 
 { #category : 'tests - read variables' }
+DebugInfoTest >> testReadLocalMethodTemporaryVariableFromDeadContext [
+
+	| debugInfo contextWithArguments |
+	contextWithArguments := thisContext copy
+		pc: nil;
+		yourself.
+	self assert: contextWithArguments isDead.
+	debugInfo := self newDebugInfoFor: contextWithArguments method.
+
+	self
+		shouldnt: [
+			debugInfo
+				 readVariableNamed: #contextWithArguments
+				 fromContext: contextWithArguments ]
+		raise: MessageNotUnderstood
+]
+
+{ #category : 'tests - read variables' }
 DebugInfoTest >> testReadLocalOptimizedBlockArgumentVariable [
 
 	| debugInfo context |

--- a/src/DebugInfo/OnlineSourceDebugInfo.class.st
+++ b/src/DebugInfo/OnlineSourceDebugInfo.class.st
@@ -250,7 +250,11 @@ OnlineSourceDebugInfo >> rangeForPC: aPC [
 { #category : 'api' }
 OnlineSourceDebugInfo >> readVariableNamed: aName fromContext: aContext [
 
-	^ (self debugScopeAt: aContext currentPC) readVariableNamed: aName fromContext: aContext
+    | currentPC |
+    "If the context is dead (pc = nil) then we really cannot know how to interpret the temp slots, as it could have been killed in any state.
+    For backwards compatibility, assume that the dead context has all the temps available at the beginning of the method -- i.e., at its initial PC"
+    currentPC := aContext pc ifNil: [ compiledCode initialPC ].
+	^ (self debugScopeAt: currentPC) readVariableNamed: aName fromContext: aContext
 ]
 
 { #category : 'api' }

--- a/src/DebugInfo/OnlineSourceDebugInfo.class.st
+++ b/src/DebugInfo/OnlineSourceDebugInfo.class.st
@@ -250,7 +250,7 @@ OnlineSourceDebugInfo >> rangeForPC: aPC [
 { #category : 'api' }
 OnlineSourceDebugInfo >> readVariableNamed: aName fromContext: aContext [
 
-	^ (self debugScopeAt: aContext pc) readVariableNamed: aName fromContext: aContext
+	^ (self debugScopeAt: aContext currentPC) readVariableNamed: aName fromContext: aContext
 ]
 
 { #category : 'api' }


### PR DESCRIPTION
… with dead contexts

Use `#currentPC` instead of `pc` to access the PC of the context to prevent errors on dead contexts, where `pc` is `nil`.

fixes #18718