### PR TITLE
Load Text-Tests after Text-Core

### DIFF
--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -36,6 +36,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'FileSystem-Memory-Tests';
 			package: 'Fonts-Infrastructure-Tests';
 			package: 'Graphics-Tests';
+			package: 'Text-Tests';
 			package: 'Morphic-Tests';
 			package: 'Morphic-Widgets-FastTable-Tests';
 			package: 'NECompletion-Tests';

--- a/src/BaselineOfKernelTests/BaselineOfKernelTests.class.st
+++ b/src/BaselineOfKernelTests/BaselineOfKernelTests.class.st
@@ -46,6 +46,5 @@ BaselineOfKernelTests >> baseline: spec [
 			package: 	'System-OSEnvironments-Tests';
 			package: 	'Zinc-Character-Encoding-Tests' ;
 			package: 	'System-Platforms-Tests';
-			package: 'System-Finalization-Tests';
-			package: 	'Text-Tests' ]
+			package: 'System-Finalization-Tests' ]
 ]


### PR DESCRIPTION
TextTests is currently loaded with the kernel tests. But at that step we do not have yet Text packages loaded because they are loaded in Baseline of MorphicCore.

I propose to move those tests in GeneralTests

<img width="845" height="860" alt="image" src="https://github.com/user-attachments/assets/e2ad7051-83fd-49b0-a698-64efd671401f" />
