### PR TITLE
Enable class initialization for BaselineOfKeymapping

### DIFF
--- a/src/BaselineOfKeymapping/BaselineOfKeymapping.class.st
+++ b/src/BaselineOfKeymapping/BaselineOfKeymapping.class.st
@@ -1,30 +1,56 @@
 Class {
 	#name : 'BaselineOfKeymapping',
 	#superclass : 'BaselineOf',
+	#instVars : [
+		'initializersEnabled'
+	],
+	#classVars : [
+		'Initialized'
+	],
 	#category : 'BaselineOfKeymapping',
 	#package : 'BaselineOfKeymapping'
 }
 
 { #category : 'baselines' }
 BaselineOfKeymapping >> baseline: spec [
+
 	<baseline>
-	
-	spec for: #common do: [ 
-		spec 
-			package: 'Keymapping-Core';
-			package: 'Keymapping-KeyCombinations';
-			package: 'Keymapping-Pragmas';
-			package: 'Keymapping-Settings';
-			package: 'Keymapping-Tests'.
-		
-		spec 
-			group: 'default' with: #('core' 'ui' 'tests'); 
-			group: 'core' with: #('Keymapping-Core' 'Keymapping-KeyCombinations' );
-			group: 'morphic' with: #('core' 'Keymapping-Pragmas' 'Keymapping-Settings');
-			group: 'ui' with: #('core' 'morphic');
-			group: 'tests' with: #(
-				'core' 
-				'Keymapping-Tests') ]
+	spec for: #common do: [
+			spec preLoadDoIt: #preload:package:.
+			spec postLoadDoIt: #postload:package:.
+			
+			spec
+				package: 'Keymapping-Core';
+				package: 'Keymapping-KeyCombinations';
+				package: 'Keymapping-Pragmas';
+				package: 'Keymapping-Settings';
+				package: 'Keymapping-Tests'.
+
+			spec
+				group: 'default' with: #( 'core' 'ui' 'tests' );
+				group: 'core' with: #( 'Keymapping-Core' 'Keymapping-KeyCombinations' );
+				group: 'morphic' with: #( 'core' 'Keymapping-Pragmas' 'Keymapping-Settings' );
+				group: 'ui' with: #( 'core' 'morphic' );
+				group: 'tests' with: #( 'core' 'Keymapping-Tests' ) ]
+]
+
+{ #category : 'actions' }
+BaselineOfKeymapping >> postload: loader package: packageSpec [
+	"Ignore pre and post loads if already executed"
+
+	Initialized = true ifTrue: [ ^ self ].
+
+	MCMethodDefinition initializersEnabled: initializersEnabled
+]
+
+{ #category : 'actions' }
+BaselineOfKeymapping >> preload: loader package: packageSpec [
+	"Ignore pre and post loads if already executed"
+
+	Initialized = true ifTrue: [ ^ self ].
+
+	initializersEnabled := MCMethodDefinition initializersEnabled.
+	MCMethodDefinition initializersEnabled: true
 ]
 
 { #category : 'accessing' }

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -304,7 +304,7 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 
 	#( #AbstractFont #BalloonMorph #Clipboard #EmbeddedFreeTypeFontInstaller
 	   #FLCompiledMethodCluster #FreeTypeFontProvider
-	   #GradientFillStyle #IconicButtonMorph #KMLog #LogicalFont
+	   #GradientFillStyle #IconicButtonMorph #LogicalFont
 	   #LucidaGrandeRegular #OSEnvironment #ScrollBarMorph
 	   #StrikeFont #SystemSettingsPersistence #TabMorph #TaskbarMorph
 	   #TextAction #TextConstants #TextStyle ) do: [ :each |

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -262,7 +262,7 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 		nextPutAll: 'bitmap fonts loaded' asString;
 		lf.
 
-	#( #ProgressBarMorph #BalloonEngineConstants #BalloonEngine
+	#( #ProgressBarMorph
 	   #CornerRounder #DigitalSignatureAlgorithm
 	   #FT2Types #FT2FFILibrary #FreeTypeCacheConstants
 	   #FreeTypeCache #FreeTypeSettings #FreeTypeSubPixelAntiAliasedGlyphRenderer

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -95,6 +95,8 @@ BaselineOfMorphicCore >> postload: loader package: packageSpec [
 	WorldMorph initialize.
 	PasteUpMorph initialize.
 	DefaultExternalDropHandler initialize.
+	BalloonEngineConstants initialize.
+	BalloonEngine initialize.
 
 	Initialized := true.
 ]

--- a/src/Keymapping-Core/KMLog.class.st
+++ b/src/Keymapping-Core/KMLog.class.st
@@ -14,7 +14,7 @@ Class {
 
 { #category : 'class initialization' }
 KMLog class >> initialize [
-	debug := false
+	self removeDebug
 ]
 
 { #category : 'logging' }

--- a/src/Keymapping-Core/KMRepository.class.st
+++ b/src/Keymapping-Core/KMRepository.class.st
@@ -41,7 +41,7 @@ KMRepository class >> reset [
 	KMCategory allSubclasses
 		select: [ :c | c isGlobalCategory ]
 		thenDo: [ :c | c new installAsGlobalCategory ].
-	KMPragmaKeymapBuilder uniqueInstance reset
+	KMPragmaKeymapBuilder initialize
 ]
 
 { #category : 'associating' }


### PR DESCRIPTION
This is a step toward enabling the class initialization for all baselines of Pharo and simplifying the postload scripts.

All the extra code in BaselineOfKeymapping will be removed once all baseline enable the class init