### PR TITLE
Remove double registration of OSEnvironment to SessionManager

### DIFF
--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -305,7 +305,7 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	#( #AbstractFont #BalloonMorph #Clipboard #EmbeddedFreeTypeFontInstaller
 	   #FLCompiledMethodCluster #FreeTypeFontProvider
 	   #GradientFillStyle #IconicButtonMorph #KMLog #LogicalFont
-	   #LucidaGrandeRegular #OSEnvironment #ScrollBarMorph
+	   #LucidaGrandeRegular #ScrollBarMorph
 	   #StrikeFont #SystemSettingsPersistence #TabMorph #TaskbarMorph
 	   #TextAction #TextConstants #TextStyle ) do: [ :each |
 		(Smalltalk globals at: each) initialize ].


### PR DESCRIPTION
OSEnvironement is initializing itself during its loading (It is loaded by UFFI which enables class init) but it is also initialized in BaselineOfMorphic. 

Let's remove the second initalization