### PR TITLE
Repackage ScalingCanvas examples

### DIFF
--- a/src/Graphics-Canvas/ScalingCanvas.class.st
+++ b/src/Graphics-Canvas/ScalingCanvas.class.st
@@ -19,22 +19,6 @@ Class {
 }
 
 { #category : 'examples' }
-ScalingCanvas class >> example [
-
-	| morph |
-
-	(morph := MenuMorph new)
-		addTitle: 'Lorem ipsum'.
-	(morph add: 'Dolor sit amet' target: nil selector: #yourself) keyText: 'x';
-		icon: (self iconNamed: #smallConfiguration).
-	(morph add: 'Consectetur adipiscing elit' target: nil selector: #yourself) keyText: 'y'.
-	morph addLine.
-	(morph add: 'Sed do eiusmod' target: nil selector: #yourself) keyText: 'z'.
-	
-	^ self privateExampleWithMorph: morph
-]
-
-{ #category : 'examples' }
 ScalingCanvas class >> exampleDrawPolygon [
 
 	^ self privateExampleWithExtent: 37@44 fillColor: Color white scale: 7 drawBlock: [ :canvas |
@@ -158,49 +142,6 @@ ScalingCanvas class >> exampleFrameAndFillRectangle2 [
 ]
 
 { #category : 'examples' }
-ScalingCanvas class >> exampleImageMorph1 [
-
-	^ self privateExampleWithMorph: (Morph new
-		color: Color veryVeryLightGray;
-		addMorph: ((ImageMorph withForm: (self iconNamed: #search))
-			position: 4@4;
-			yourself);
-		addMorph: ((ImageMorph withForm: (self iconNamed: #search) copy)
-			position: 24@4;
-			yourself);
-		extent: 44@24;
-		yourself)
-]
-
-{ #category : 'examples' }
-ScalingCanvas class >> exampleImageMorph2 [
-
-	| forms imageMorph |
-	
-	forms := (1 to: 2) collect: [ :scale |
-		(FormCanvas extent: 100 asPoint * scale depth: 1)
-			fillOval: ((0 asPoint extent: 100 asPoint * scale) insetBy: 5 * scale) fillStyle: Color green;
-			form ].
-	(imageMorph := ImageMorph withFormSet: (FormSet forms: forms))
-		color: Color blue.
-	^ self privateExampleWithMorph: imageMorph
-]
-
-{ #category : 'examples' }
-ScalingCanvas class >> exampleImageMorph3 [
-
-	| forms imageMorph |
-	
-	forms := (1 to: 2) collect: [ :scale |
-		(FormCanvas extent: 10 asPoint * scale)
-			fillOval: ((0 asPoint extent: 10 asPoint * scale) insetBy: 1 * scale) fillStyle: Color black;
-			form ].
-	(imageMorph := ImageMorph withFormSet: (FormSet forms: forms))
-		resize: 200@100.
-	^ self privateExampleWithMorph: imageMorph
-]
-
-{ #category : 'examples' }
 ScalingCanvas class >> exampleLine1 [
 
 	^ self privateExampleWithExtent: 101@101 fillColor: Color white scale: 4 drawBlock: [ :canvas |
@@ -249,25 +190,6 @@ ScalingCanvas class >> exampleLine2 [
 							width: width color: Color blue translucent ] ] ]
 ]
 
-{ #category : 'examples' }
-ScalingCanvas class >> exampleRubScrolledTextMorph [
-
-	| source |
-
-	source := String streamContents: [ :stream |
-		stream nextPutAll: 'OrderedCollection new'; cr.
-		(1 to: 100) groupsOf: 5 atATimeDo: [ :numbers |
-			stream tab; nextPutAll: ('addAll: {1};' format: { numbers printString }); cr ].
-		stream tab; nextPutAll: 'yourself'; cr ].
-	^ self privateExampleWithMorph:
-		(RubScrolledTextMorph new
-			model: (RubScrolledTextModel new text: source; yourself);
-			beForSmalltalkCode;
-			withCodeSizeFeedback;
-			extent: 320@200;
-			yourself)
-]
-
 { #category : 'instance creation' }
 ScalingCanvas class >> formCanvas: formCanvas scale: scale [
 
@@ -312,16 +234,6 @@ ScalingCanvas class >> privateExampleWithExtent: extent fillColor: fillColor sca
 	drawBlock value: (self formCanvas: form2 getCanvas scale: scale).
 	
 	^ doBlock value: form1 value: form2
-]
-
-{ #category : 'private' }
-ScalingCanvas class >> privateExampleWithMorph: morph [
-
-	^ self privateExampleWithExtent: morph fullBounds bottomRight
-		fillColor: Smalltalk ui theme backgroundColor
-		scale: 2
-		drawBlock: [ :canvas | canvas fullDrawMorph: morph ]
-		do: [ :form1 :form2 | { morph. form1. form2 } inspect ]
 ]
 
 { #category : 'private' }

--- a/src/Morphic-Core/ScalingCanvas.extension.st
+++ b/src/Morphic-Core/ScalingCanvas.extension.st
@@ -29,6 +29,65 @@ ScalingCanvas >> drawImageOn: aCanvas at: aPoint [
 ]
 
 { #category : '*Morphic-Core' }
+ScalingCanvas class >> example [
+
+	| morph |
+
+	(morph := MenuMorph new)
+		addTitle: 'Lorem ipsum'.
+	(morph add: 'Dolor sit amet' target: nil selector: #yourself) keyText: 'x';
+		icon: (self iconNamed: #smallConfiguration).
+	(morph add: 'Consectetur adipiscing elit' target: nil selector: #yourself) keyText: 'y'.
+	morph addLine.
+	(morph add: 'Sed do eiusmod' target: nil selector: #yourself) keyText: 'z'.
+	
+	^ self privateExampleWithMorph: morph
+]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas class >> exampleImageMorph1 [
+
+	^ self privateExampleWithMorph: (Morph new
+		color: Color veryVeryLightGray;
+		addMorph: ((ImageMorph withForm: (self iconNamed: #search))
+			position: 4@4;
+			yourself);
+		addMorph: ((ImageMorph withForm: (self iconNamed: #search) copy)
+			position: 24@4;
+			yourself);
+		extent: 44@24;
+		yourself)
+]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas class >> exampleImageMorph2 [
+
+	| forms imageMorph |
+	
+	forms := (1 to: 2) collect: [ :scale |
+		(FormCanvas extent: 100 asPoint * scale depth: 1)
+			fillOval: ((0 asPoint extent: 100 asPoint * scale) insetBy: 5 * scale) fillStyle: Color green;
+			form ].
+	(imageMorph := ImageMorph withFormSet: (FormSet forms: forms))
+		color: Color blue.
+	^ self privateExampleWithMorph: imageMorph
+]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas class >> exampleImageMorph3 [
+
+	| forms imageMorph |
+	
+	forms := (1 to: 2) collect: [ :scale |
+		(FormCanvas extent: 10 asPoint * scale)
+			fillOval: ((0 asPoint extent: 10 asPoint * scale) insetBy: 1 * scale) fillStyle: Color black;
+			form ].
+	(imageMorph := ImageMorph withFormSet: (FormSet forms: forms))
+		resize: 200@100.
+	^ self privateExampleWithMorph: imageMorph
+]
+
+{ #category : '*Morphic-Core' }
 ScalingCanvas >> numberOfTransparentPixelsForRoundedCorners [
 
 	^ formCanvas numberOfTransparentPixelsForRoundedCorners * scale * scale
@@ -44,6 +103,16 @@ ScalingCanvas >> paintImageFromScalingCanvas: aScalingCanvas at: aPoint [
 ScalingCanvas >> paintImageOn: aCanvas at: aPoint [
 
 	aCanvas paintImageFromScalingCanvas: self at: aPoint
+]
+
+{ #category : '*Morphic-Core' }
+ScalingCanvas class >> privateExampleWithMorph: morph [
+
+	^ self privateExampleWithExtent: morph fullBounds bottomRight
+		fillColor: Smalltalk ui theme backgroundColor
+		scale: 2
+		drawBlock: [ :canvas | canvas fullDrawMorph: morph ]
+		do: [ :form1 :form2 | { morph. form1. form2 } inspect ]
 ]
 
 { #category : '*Morphic-Core' }

--- a/src/Rubric/ScalingCanvas.extension.st
+++ b/src/Rubric/ScalingCanvas.extension.st
@@ -1,5 +1,24 @@
 Extension { #name : 'ScalingCanvas' }
 
+{ #category : '*Rubric' }
+ScalingCanvas class >> exampleRubScrolledTextMorph [
+
+	| source |
+
+	source := String streamContents: [ :stream |
+		stream nextPutAll: 'OrderedCollection new'; cr.
+		(1 to: 100) groupsOf: 5 atATimeDo: [ :numbers |
+			stream tab; nextPutAll: ('addAll: {1};' format: { numbers printString }); cr ].
+		stream tab; nextPutAll: 'yourself'; cr ].
+	^ self privateExampleWithMorph:
+		(RubScrolledTextMorph new
+			model: (RubScrolledTextModel new text: source; yourself);
+			beForSmalltalkCode;
+			withCodeSizeFeedback;
+			extent: 320@200;
+			yourself)
+]
+
 { #category : '*Rubric-Editing-Core' }
 ScalingCanvas >> rubParagraph: paragraph bounds: bounds color: c [
 

--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -67,7 +67,7 @@ SystemDependenciesTest >> knownKernelDependencies [
 SystemDependenciesTest >> knownMorphicCoreDependencies [
 	"ideally this list should be empty"
 
-	^ #(#'Fonts-Infrastructure' #'FreeType' #'Keymapping-KeyCombinations' #'Morphic-Base' #'Refactoring-Critics' #'Refactoring-Environment' #'Rubric' 
+	^ #(#'Fonts-Infrastructure' #'FreeType' #'Keymapping-KeyCombinations' #'Morphic-Base' #'Refactoring-Critics' #'Refactoring-Environment'
 	  'Morphic-Widgets-ColorPicker')
 ]
 


### PR DESCRIPTION
Some examples show how to display things with Morph and are now in a Morphic-Core and an example show how to use it with Rubric and is now packages in Rubric.

Both Morphic and Rubric should not be dependencies a Graphics-Canvas

<img width="1092" height="765" alt="image" src="https://github.com/user-attachments/assets/95a954e7-93af-48dc-9c81-590438ffc7fe" />
