### PR TITLE
Zinc needs to be loaded before MonticelloRemoteRepositories

### DIFF
--- a/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st
+++ b/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st
@@ -4,6 +4,7 @@ mcPackages := #(
  'Network-MIME'
  'Network-Protocols'
 
+ 'Zinc-Resource-Meta-Core'
  'Zinc-HTTP'
  
  'MonticelloRemoteRepositories'

--- a/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st
+++ b/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st
@@ -4,9 +4,10 @@ mcPackages := #(
  'Network-MIME'
  'Network-Protocols'
 
+ 'Zinc-HTTP'
+ 
  'MonticelloRemoteRepositories'
 
- 'Zinc-HTTP'
  'Zodiac-Core'
  ).
 

--- a/src/BaselineOfMonticello/BaselineOfMonticello.class.st
+++ b/src/BaselineOfMonticello/BaselineOfMonticello.class.st
@@ -28,7 +28,6 @@ BaselineOfMonticello >> baseline: spec [
 		spec 
 			package: 'Ring-Definitions-Core';
 			package: 'Ring-OldChunkImporter' with: [ spec requires: #('Ring-Definitions-Core') ];
-			package: 'Zinc-Resource-Meta-Core';
 			package: 'System-Changes';
 			package: 'Jobs';
 			package: 'Compression';
@@ -39,12 +38,13 @@ BaselineOfMonticello >> baseline: spec [
 			package: 'Network-Kernel';
 			package: 'Network-MIME';
 			package: 'Network-Protocols';
-			package: 'MonticelloRemoteRepositories';
+			package: 'Zinc-Resource-Meta-Core';
 			package: 'Zinc-HTTP';
+			package: 'MonticelloRemoteRepositories';
 			package: 'Zodiac-Core'.
 		spec 
-			group: 'Core' with: #('Ring-OldChunkImporter' 'Zinc-Resource-Meta-Core' 'System-Changes' 'Ring-Definitions-Core' 'Jobs' 'Compression' 'Monticello-Model' 'Monticello' 'Ring-Definitions-Monticello');
-			group: 'RemoteRepositories' with: #( 'Network-Kernel' 'Network-MIME' 'Network-Protocols' 'MonticelloRemoteRepositories' 'Zinc-HTTP' 'Zodiac-Core' );
+			group: 'Core' with: #('Ring-OldChunkImporter' 'System-Changes' 'Ring-Definitions-Core' 'Jobs' 'Compression' 'Monticello-Model' 'Monticello' 'Ring-Definitions-Monticello');
+			group: 'RemoteRepositories' with: #( 'Network-Kernel' 'Network-MIME' 'Network-Protocols' 'Zinc-Resource-Meta-Core' 'Zinc-HTTP' 'MonticelloRemoteRepositories' 'Zodiac-Core' );
 
 			group: 'default' with: #('Core' 'RemoteRepositories' ). ].
 ]

--- a/src/PharoBootstrap/PBBootstrap.class.st
+++ b/src/PharoBootstrap/PBBootstrap.class.st
@@ -324,17 +324,19 @@ PBBootstrap >> monticelloNetworkPackageNames [
 	^ #('Network-Kernel'
 		 'Network-MIME'
 		 'Network-Protocols'
+		 
+		 'Zinc-Resource-Meta-Core'
+		 'Zinc-HTTP'
 
 		 'MonticelloRemoteRepositories'
-
-		 'Zinc-HTTP'
+		 
 		 'Zodiac-Core')
 ]
 
 { #category : 'package-names' }
 PBBootstrap >> monticelloPackageNames [
 
-	^ #('Ring-OldChunkImporter' 'Zinc-Resource-Meta-Core' 'System-Changes' 'Ring-Definitions-Core' 'Jobs' 'Compression' 'Monticello-Model' 'Monticello' 'Ring-Definitions-Monticello' )
+	^ #('Ring-OldChunkImporter'  'System-Changes' 'Ring-Definitions-Core' 'Jobs' 'Compression' 'Monticello-Model' 'Monticello' 'Ring-Definitions-Monticello' )
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Also I see that we load Zodiac at this step but it seems that we do not need Zodiac yet. We should probably load it in BaselineOfBasicTool or something like this? 

I'll investigate that later

<img width="1019" height="362" alt="image" src="https://github.com/user-attachments/assets/f6cd9a5b-2041-4b56-aab5-21900e7df697" />

