### PR TITLE
Remove double initialization happening in the bootstrap

### DIFF
--- a/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st
+++ b/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st
@@ -13,17 +13,4 @@ mcPackages := #(
 (MonticelloBootstrap inDirectory: (CommandLineArguments new optionAt: 'BOOTSTRAP_PACKAGE_CACHE_DIR' ifAbsent: [ MCCacheRepository uniqueInstance directory ]) asFileReference)
   loadPackagesNamed: mcPackages!
 
-InternetConfiguration initialize.
-NetNameResolver initialize.
-Socket initialize.
-Base64MimeConverter initialize.
-
-ZnBase64Encoder initialize.
-ZnByteEncoder initialize.
-ZnUTF8Encoder initialize.
-ZnLogEvent initialize.
 ZnConstants initialize.
-ZnHeaders initialize.
-ZnNetworkingUtils initialize.
-ZnServer initialize.
-ZnSingleThreadedServer initialize.


### PR DESCRIPTION
In the past we needed to call explicitly to some initialize methods in the bootstrap but that does not seems needed anymore in some places. Here I'm removing some initialization in the loading of Monticello