### PR TITLE
Cut dependency from Fonts-Abstract and Text-Core

### DIFF
--- a/src/Fonts-Abstract/AbstractFont.class.st
+++ b/src/Fonts-Abstract/AbstractFont.class.st
@@ -209,12 +209,6 @@ AbstractFont >> lineGrid [
 	^self subclassResponsibility
 ]
 
-{ #category : 'accessing' }
-AbstractFont >> pixelSize [
-	"Make sure that we don't return a Fraction"
-	^ TextStyle pointsToPixels: self pointSize
-]
-
 { #category : 'notifications' }
 AbstractFont >> pixelsPerInchChanged [
 	"The definition of TextStyle class>>pixelsPerInch has changed. Do whatever is necessary."
@@ -237,12 +231,6 @@ AbstractFont >> strikeoutThickness [
 { #category : 'metrics' }
 AbstractFont >> strikeoutTop [
 	^ 0
-]
-
-{ #category : 'accessing' }
-AbstractFont >> textStyle [
-	^ TextStyle actualTextStyles detect:
-		[:aStyle | aStyle fontArray includes: self] ifNone: [ TextStyle fontArray: { self } ]
 ]
 
 { #category : 'accessing' }

--- a/src/Text-Core/AbstractFont.extension.st
+++ b/src/Text-Core/AbstractFont.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : 'AbstractFont' }
+
+{ #category : '*Text-Core' }
+AbstractFont >> pixelSize [
+	"Make sure that we don't return a Fraction"
+	^ TextStyle pointsToPixels: self pointSize
+]
+
+{ #category : '*Text-Core' }
+AbstractFont >> textStyle [
+	^ TextStyle actualTextStyles detect:
+		[:aStyle | aStyle fontArray includes: self] ifNone: [ TextStyle fontArray: { self } ]
+]


### PR DESCRIPTION
Currently Fonts-Abstract can work without the Text support but some methods are referencing classes from Text-Core.

This change clean the dependency