### PR TITLE
Add logs on Metacello pre and post loads

### DIFF
--- a/src/Metacello-Core/MetacelloLoadTarget.class.st
+++ b/src/Metacello-Core/MetacelloLoadTarget.class.st
@@ -44,18 +44,22 @@ MetacelloLoadTarget >> visitPackageLoadDirective: aMetacelloPackageLoadDirective
 
 { #category : 'visiting' }
 MetacelloLoadTarget >> visitPostLoadDirective: aMetacelloPostLoadDirective [
-	
+
 	aMetacelloPostLoadDirective spec postLoadDoItBlock ifNotNil: [ :block |
-		block valueWithPossibleArgs: {
-				self.
-				aMetacelloPostLoadDirective spec } ]
+			MetacelloNotification signal: 'Executing: ' , aMetacelloPostLoadDirective label.
+			block valueWithPossibleArgs: {
+					self.
+					aMetacelloPostLoadDirective spec }.
+			MetacelloNotification signal: 'Done executing: ' , aMetacelloPostLoadDirective label ]
 ]
 
 { #category : 'visiting' }
 MetacelloLoadTarget >> visitPreLoadDirective: aMetacelloPreLoadDirective [
-	
+
 	aMetacelloPreLoadDirective spec preLoadDoItBlock ifNotNil: [ :block |
-		block valueWithPossibleArgs: {
-				self.
-				aMetacelloPreLoadDirective spec } ]
+			MetacelloNotification signal: 'Executing: ' , aMetacelloPreLoadDirective label.
+			block valueWithPossibleArgs: {
+					self.
+					aMetacelloPreLoadDirective spec }.
+			MetacelloNotification signal: 'Done executing: ' , aMetacelloPreLoadDirective label ]
 ]


### PR DESCRIPTION
While cleaning the dependencies in the bootstrap it would be really helpful to find in the logs when the pre and post loads are executed. This PR just adds some Metacello logging