### PR TITLE
Cleaning iteration on BaselineOfMorphic post load (part 2)

### DIFF
--- a/src/BaselineOfMetacello/BaselineOfMetacello.class.st
+++ b/src/BaselineOfMetacello/BaselineOfMetacello.class.st
@@ -32,7 +32,7 @@ BaselineOfMetacello >> baseline: spec [
 			package: 'Metacello-Gitlab-Tests'.
 
 		spec 
-			group: 'Core' with: #('ScriptingExtensions' 'System-FileRegistry' 'FileSystem-Memory' 'Regex-Core' 'StartupPreferences' 'PragmaCollector' 'System-FileRegistry' 'Metacello-Base' 'Metacello-Core' 'MonticelloFileTree-Core' 'MonticelloFileTree-FileSystem-Utilities' 'STON-Core' 'Metacello-GitBasedRepository' 'Metacello-GitHub' 'Metacello-Gitlab' 'Metacello-Bitbucket' 'Metacello-CommandLine');
+			group: 'Core' with: #('ScriptingExtensions' 'System-FileRegistry' 'FileSystem-Memory' 'StartupPreferences' 'PragmaCollector' 'System-FileRegistry' 'Metacello-Base' 'Metacello-Core' 'MonticelloFileTree-Core' 'MonticelloFileTree-FileSystem-Utilities' 'STON-Core' 'Metacello-GitBasedRepository' 'Metacello-GitHub' 'Metacello-Gitlab' 'Metacello-Bitbucket' 'Metacello-CommandLine');
 			group: 'Tests' with: #( 'Metacello-TestsCore' 'Metacello-TestsMCCore' 'Metacello-TestsReference' 'Metacello-Gitlab-Tests');
 			group: 'default' with: #('Core') ]
 ]

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -262,17 +262,14 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 		nextPutAll: 'bitmap fonts loaded' asString;
 		lf.
 
-	#( #ProgressBarMorph #BalloonEngineConstants #BalloonEngine
-	   #CornerRounder #DigitalSignatureAlgorithm
-	   #FT2Types #FT2FFILibrary #FreeTypeCacheConstants
+	#( #ProgressBarMorph #FT2Types #FT2FFILibrary #FreeTypeCacheConstants
 	   #FreeTypeCache #FreeTypeSettings #FreeTypeSubPixelAntiAliasedGlyphRenderer
 	   #FT2Constants #GIFReadWriter #GlobalIdentifier #HaloMorph
 	   #CharacterScanner #ImageMorph #JPEGHuffmanTable #JPEGReadStream
 	   #Locale #MczInstaller #MD5NonPrimitive #MenuItemMorph
-	   #MenuMorph #RxMatcher #RxParser #RxsPredicate #SHA1 #ShortIntegerArray
-	   #SystemProgressMorph #SystemWindow #TestCase #TextContainer
-	   #TextDiffBuilder #ThumbnailMorph #TransferMorph #UITheme #ZnByteEncoder
-	   #ZnConstants #ZnMimeType #ZnNetworkingUtils #ZnServer #ZnSingleThreadedServer )
+	   #MenuMorph #RxMatcher #RxParser #RxsPredicate #SHA1
+	   #SystemProgressMorph #SystemWindow #TextContainer
+	   #TextDiffBuilder #ThumbnailMorph #TransferMorph #UITheme )
 		do: [ :each | (Smalltalk globals at: each) initialize ].
 
 	UIManager default terminateUIProcess.

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -95,6 +95,10 @@ BaselineOfMorphicCore >> postload: loader package: packageSpec [
 	WorldMorph initialize.
 	PasteUpMorph initialize.
 	DefaultExternalDropHandler initialize.
+	BalloonEngineConstants initialize.
+	BalloonEngine initialize.
+	CornerRounder initialize.
+	ShortIntegerArray initialize.
 
 	Initialized := true.
 ]


### PR DESCRIPTION
- Remove 'Regex-Core' from Metacello baseline because this package is not loaded there
- BalloonEngine, BalloonEngineConstants, CornerRounder and ShortIntegerArray are part of MorphicCore and should be initialized in MorphicCore
- DigitalSignatureAlgorithm is initialized by Hermes already
- TestCase is initialized by the baseline of SUnit already
- ZnByteEncoder, ZnConstants, ZnMimeType, ZnNetworkingUtils, ZnServer, ZnSingleThreadedServer are initialized earlier in the bootstrap process