### PR TITLE
Update text fields background color when switching themes

### DIFF
--- a/src/Rubric/RubAbstractTextArea.class.st
+++ b/src/Rubric/RubAbstractTextArea.class.st
@@ -2086,7 +2086,9 @@ RubAbstractTextArea >> themeChanged [
 	(self decoratorNamed: #shoutStyler) ifNotNil: [ :styler |
 		styler refreshStyling
 	].
-	self color: self theme backgroundColor.
+
+	self class backgroundColor: self theme backgroundColor.
+	self color: self defaultColor.
 	super themeChanged
 ]
 


### PR DESCRIPTION
This should fix the black droplists.
Not sure how to handle the `BackgroudColor` SharedVariable correctly, but the problem seems to come from it.