### PR TITLE
Move loading of NumberParser to hermes phase

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -138,7 +138,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" # I have to run once the image so the next 
 
 echo $(date -u) "[Compiler] Adding more Kernel packages"
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform --save BasicHermesTool load: --as-array Clap-Core.hermes Clap-CommandLine.hermes Clap-Commands-Pharo.hermes Hermes-Extensions.hermes
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Math-Operations-Extensions.hermes Debugging-Core.hermes System-NumberPrinting.hermes System-Time.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Math-Operations-Extensions.hermes Debugging-Core.hermes System-NumberPrinting.hermes System-Time.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes NumberParser.hermes --save --no-fail-on-undeclared
 
 # Now that System-Time is loaded, we can initialize the version
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform  --save SystemVersion setMajor:minor:patch:suffix:build:commitHash: ${PHARO_MAJOR} ${PHARO_MINOR} ${PHARO_PATCH} ${PHARO_SUFFIX} ${BUILD_NUMBER} ${PHARO_COMMIT_HASH}

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -62,7 +62,7 @@ export PHARO_CI_TESTING_ENVIRONMENT=1
 ./pharo bootstrap.image perform --save BasicHermesTool load: --as-array Clap-Core.hermes Clap-CommandLine.hermes Clap-Commands-Pharo.hermes Hermes-Extensions.hermes
 ./pharo bootstrap.image perform --save Pragma buildCache
 ./pharo bootstrap.image perform --save ClapCommandLineHandler initialize
-./pharo bootstrap.image loadHermes System-Time.hermes AST-Core.hermes Random-Core.hermes System-NumberPrinting.hermes --save --no-fail-on-undeclared --on-duplication ignore
+./pharo bootstrap.image loadHermes System-Time.hermes NumberParser.hermes AST-Core.hermes Random-Core.hermes System-NumberPrinting.hermes --save --no-fail-on-undeclared --on-duplication ignore
 ./pharo bootstrap.image perform --save ChronologyConstants initialize
 
 #Initializing the package manager

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -176,7 +176,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'System-Sources'.
 			
 			'System-Support'.
-			'NumberParser'.
 
 			'UIManager'.
 			'Zinc-Character-Encoding-Core' }.
@@ -207,6 +206,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'CodeImport-Commands'.
 			'Debugging-Utils'.
 			'DebugInfo'.
+			'NumberParser'.
 			'OpalCompiler-Core'}.
 		
 		spec group: 'FileSystemGroup' with: {


### PR DESCRIPTION
Number parser is used by AST-Core and FileSystem-Core. So there is no need to load it with Espell