### PR TITLE
Reduce depenencies to UIManager

### DIFF
--- a/src/System-SessionManager/ErrorHandlerSessionHandler.class.st
+++ b/src/System-SessionManager/ErrorHandlerSessionHandler.class.st
@@ -34,20 +34,3 @@ ErrorHandlerSessionHandler class >> uniqueInstance [
 ErrorHandlerSessionHandler >> handledId [
 	^ self class name
 ]
-
-{ #category : 'handlers' }
-ErrorHandlerSessionHandler >> shutdown: isImageQuitting [
-
-	"Prepare the shutdown and the next startup"
-
-	UIManager default: StartupUIManager new.
-	ErrorHandler defaultErrorHandler: UIManager default.
-]
-
-{ #category : 'handlers' }
-ErrorHandlerSessionHandler >> startup: isImageStarting [
-	"Install the right UIManager"
-
-	UIManager default: UIManager forCurrentSystemConfiguration.
-	ErrorHandler defaultErrorHandler: UIManager default.
-]

--- a/src/System-SessionManager/ManifestSystemSessionManager.class.st
+++ b/src/System-SessionManager/ManifestSystemSessionManager.class.st
@@ -8,8 +8,3 @@ Class {
 	#package : 'System-SessionManager',
 	#tag : 'Manifest'
 }
-
-{ #category : 'meta-data - dependency analyser' }
-ManifestSystemSessionManager class >> manuallyResolvedDependencies [
-	^ #(#'System-Support')
-]

--- a/src/System-Support/ManifestSystemSupport.class.st
+++ b/src/System-Support/ManifestSystemSupport.class.st
@@ -10,13 +10,8 @@ Class {
 }
 
 { #category : 'meta-data - dependency analyser' }
-ManifestSystemSupport class >> ignoredDependencies [
-	^ #(#'System-Settings-Core' #'Graphics-Primitives')
-]
-
-{ #category : 'meta-data - dependency analyser' }
 ManifestSystemSupport class >> manuallyResolvedDependencies [
-	^ #(#'Collections-Support' #'System-Settings-Core' #'System-Platforms')
+	^ #(#'System-Platforms')
 ]
 
 { #category : 'code-critics' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -682,23 +682,6 @@ SmalltalkImage >> garbageCollectMost [
 	^ self primBytesLeft
 ]
 
-{ #category : 'snapshot and quit' }
-SmalltalkImage >> getFileNameFromUser [
-
-	| givenName strippedName imageFile changesFile |
-	givenName := UIManager default
-		request: 'New File Name?'
-		initialAnswer: (self imageFile basename copyUpToLast:  Path extensionDelimiter).
-	strippedName := self stripImageExtensionFrom: givenName.
-	strippedName isEmptyOrNil ifTrue: [^nil].
-	imageFile := self fileForImageNamed: strippedName.
-	changesFile := self fileForChangesNamed: strippedName.
-	((imageFile exists or: [changesFile exists]) and:
-		[(self confirm: ('{1} already exists. Overwrite?' format: {strippedName})) not])
-			ifTrue: [^nil].
-	^strippedName
-]
-
 { #category : 'accessing' }
 SmalltalkImage >> globals [
 	"Answer the global SystemEnvironment"
@@ -1037,7 +1020,12 @@ SmalltalkImage >> lowSpaceWatcher [
 			self bytesLeft > free
 				ifTrue: [^ self installLowSpaceWatcher]].
 
-	UIManager default lowSpaceWatcherDefaultAction: preemptedProcess.
+	 "When there is a signal from the VM, we signal an exception in the preempted process.
+	If we don't have preemptedProcess we are in an error state. We will throw an error"
+	preemptedProcess
+		ifNotNil: [ preemptedProcess signalException: OutOfMemory new ]
+		ifNil: [ self error: 'We have a lowSpaceWatcher signal, but there is no ctx... how we arrive here' ].
+
 	"We need to reinstall the lowSpaceWatcher"
 	Smalltalk installLowSpaceWatcher
 ]
@@ -1461,13 +1449,6 @@ SmalltalkImage >> restartMethods [
 	classes := Class superclassOrder: classes.
 	"Run the cleanup code"
 	classes do: [ :aClass | aClass restartMethods ]
-]
-
-{ #category : 'saving' }
-SmalltalkImage >> saveAs [
-	"Put up the 'saveAs' prompt, obtain a name, and save the image  under that new name."
-
-	self saveAs: self getFileNameFromUser
 ]
 
 { #category : 'saving' }

--- a/src/UIManager/ErrorHandlerSessionHandler.extension.st
+++ b/src/UIManager/ErrorHandlerSessionHandler.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : 'ErrorHandlerSessionHandler' }
+
+{ #category : '*UIManager' }
+ErrorHandlerSessionHandler >> shutdown: isImageQuitting [
+
+	"Prepare the shutdown and the next startup"
+
+	UIManager default: StartupUIManager new.
+	ErrorHandler defaultErrorHandler: UIManager default.
+]
+
+{ #category : '*UIManager' }
+ErrorHandlerSessionHandler >> startup: isImageStarting [
+	"Install the right UIManager"
+
+	UIManager default: UIManager forCurrentSystemConfiguration.
+	ErrorHandler defaultErrorHandler: UIManager default.
+]

--- a/src/UIManager/SmalltalkImage.extension.st
+++ b/src/UIManager/SmalltalkImage.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : 'SmalltalkImage' }
+
+{ #category : '*UIManager' }
+SmalltalkImage >> getFileNameFromUser [
+
+	| givenName strippedName imageFile changesFile |
+	givenName := UIManager default
+		request: 'New File Name?'
+		initialAnswer: (self imageFile basename copyUpToLast:  Path extensionDelimiter).
+	strippedName := self stripImageExtensionFrom: givenName.
+	strippedName isEmptyOrNil ifTrue: [^nil].
+	imageFile := self fileForImageNamed: strippedName.
+	changesFile := self fileForChangesNamed: strippedName.
+	((imageFile exists or: [changesFile exists]) and:
+		[(self confirm: ('{1} already exists. Overwrite?' format: {strippedName})) not])
+			ifTrue: [^nil].
+	^strippedName
+]
+
+{ #category : '*UIManager' }
+SmalltalkImage >> saveAs [
+	"Put up the 'saveAs' prompt, obtain a name, and save the image  under that new name."
+
+	self saveAs: self getFileNameFromUser
+]

--- a/src/UIManager/StartupUIManager.class.st
+++ b/src/UIManager/StartupUIManager.class.st
@@ -4,8 +4,8 @@ I am a non interactive UI manager that is used only during image startup, where 
 Class {
 	#name : 'StartupUIManager',
 	#superclass : 'NonInteractiveUIManager',
-	#category : 'System-SessionManager-Utilities',
-	#package : 'System-SessionManager',
+	#category : 'UIManager-Utilities',
+	#package : 'UIManager',
 	#tag : 'Utilities'
 }
 

--- a/src/UIManager/UIManager.class.st
+++ b/src/UIManager/UIManager.class.st
@@ -463,19 +463,6 @@ UIManager >> logError: anError [
 		inContext: anError signalerContext
 ]
 
-{ #category : 'default actions' }
-UIManager >> lowSpaceWatcherDefaultAction: preemptedProcess [
-
-	"When there is a signal from the VM, we signal an exception in the preempted process.
-	If we don't have preemptedProcess we are in an error state. We will throw an error"
-
-	preemptedProcess
-		ifNotNil: [ preemptedProcess signalException: OutOfMemory new.
-						^ self ].
-
-	self error: 'We have a lowSpaceWatcher signal, but there is no ctx... how we arrive here'
-]
-
 { #category : 'ui requests' }
 UIManager >> multiLineRequest: queryString initialAnswer: defaultAnswer answerHeight: answerHeight [
 	"Create a multi-line instance of me whose question is queryString with


### PR DESCRIPTION
Cut dependencies of System-Support to UIManager
Remove most dependencies of System-SessionManager to UIManager. The last one is harder to remove. If we can remove this one, then we can remove UIManager from the list of packages to load with Espell