### PR TITLE
Make parser fail when a statement follows a return.

### DIFF
--- a/src/AST-Core-Tests/OCParserTest.class.st
+++ b/src/AST-Core-Tests/OCParserTest.class.st
@@ -1846,6 +1846,17 @@ OCParserTest >> testReplacingNodes [
 ]
 
 { #category : 'tests' }
+OCParserTest >> testReturnShouldBeTheLastStatement [
+	
+	self 
+		should: [ self parserClass parseMethod:
+			'tmp ^ 42. 33 + 33' ] 
+		raise: Error.
+
+			
+]
+
+{ #category : 'tests' }
 OCParserTest >> testScopesEnclosingMatchingLiterals [
 	| tree |
 

--- a/src/AST-Core/OCParser.class.st
+++ b/src/AST-Core/OCParser.class.st
@@ -1052,7 +1052,8 @@ OCParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 	"If the previous node in the statement list is a return node, mark this node as unreachable"
 
 	(statementList notEmpty and: [ statementList last isReturn ]) ifTrue: [
-		self error: 'After the return statement, there is an unreachable statement in this method source: ', source ].
+		(node class = OCCommentNode)
+			ifFalse: [ self error: 'After the return statement, there is an unreachable statement in this method source: ', source ]].
 
 	"Commit the statement to the statements list"
 	statementList add: node

--- a/src/AST-Core/OCParser.class.st
+++ b/src/AST-Core/OCParser.class.st
@@ -1052,7 +1052,7 @@ OCParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 	"If the previous node in the statement list is a return node, mark this node as unreachable"
 
 	(statementList notEmpty and: [ statementList last isReturn ]) ifTrue: [
-		self error: 'after the return statement is an Unreachable statement' ].
+		self error: 'After the return statement, there is an unreachable statement in this method source: ', source ].
 
 	"Commit the statement to the statements list"
 	statementList add: node

--- a/src/AST-Core/OCParser.class.st
+++ b/src/AST-Core/OCParser.class.st
@@ -1052,7 +1052,7 @@ OCParser >> parseStatementInto: statementList periodList: periods withAcceptedSt
 	"If the previous node in the statement list is a return node, mark this node as unreachable"
 
 	(statementList notEmpty and: [ statementList last isReturn ]) ifTrue: [
-		node addWarning: 'Unreachable statement' ].
+		self error: 'after the return statement is an Unreachable statement' ].
 
 	"Commit the statement to the statements list"
 	statementList add: node


### PR DESCRIPTION
Making that parser will fail when a statement follows a return.