### PR TITLE
Rename System-BasicCommandLineHandler to System-CommandLineHandler

### DIFF
--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -67,7 +67,7 @@ BaselineOfGeneralTests >> baseline: spec [
 			"requires Zinc-Resource-Meta-Tests"package:
 			'System-Identification-Tests';
 			package: 'System-Dependencies-Tests';
-			package: 'System-BasicCommandLineHandler-Tests';
+			package: 'System-CommandLineHandler-Tests';
 			package: 'Transcript-NonInteractive-Tests';
 			package: 'PharoDocComment-Tests' "standalone" ]
 ]

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -108,7 +108,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		spec package: 'ReflectionMirrors-Primitives'.
 		spec package: 'Shift-ClassBuilder'.
 		spec package: 'System-Announcements'.
-		spec package: 'System-BasicCommandLineHandler'.
+		spec package: 'System-CommandLineHandler'.
 		spec package: 'Clap-Core'.
 		spec package: 'Clap-CommandLine'.
 		spec package: 'Clap-Commands-Pharo' .
@@ -166,7 +166,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'PharoBootstrap-Initialization'.
 			'Shift-ClassBuilder'.
 			'System-Announcements'.
-			'System-BasicCommandLineHandler'.
+			'System-CommandLineHandler'.
 			'System-CommandLine'.
 			'System-Finalization'.
 			'System-Platforms'.

--- a/src/System-BasicCommandLineHandler-Tests/package.st
+++ b/src/System-BasicCommandLineHandler-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'System-BasicCommandLineHandler-Tests' }

--- a/src/System-BasicCommandLineHandler/package.st
+++ b/src/System-BasicCommandLineHandler/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'System-BasicCommandLineHandler' }

--- a/src/System-CommandLineHandler-Tests/CommandLineArgumentsTest.class.st
+++ b/src/System-CommandLineHandler-Tests/CommandLineArgumentsTest.class.st
@@ -7,8 +7,8 @@ Class {
 	#instVars : [
 		'commandLine'
 	],
-	#category : 'System-BasicCommandLineHandler-Tests-Base',
-	#package : 'System-BasicCommandLineHandler-Tests',
+	#category : 'System-CommandLineHandler-Tests-Base',
+	#package : 'System-CommandLineHandler-Tests',
 	#tag : 'Base'
 }
 

--- a/src/System-CommandLineHandler-Tests/CommandLineHandlerTest.class.st
+++ b/src/System-CommandLineHandler-Tests/CommandLineHandlerTest.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : 'CommandLineHandlerTest',
 	#superclass : 'TestCase',
-	#category : 'System-BasicCommandLineHandler-Tests-Base',
-	#package : 'System-BasicCommandLineHandler-Tests',
+	#category : 'System-CommandLineHandler-Tests-Base',
+	#package : 'System-CommandLineHandler-Tests',
 	#tag : 'Base'
 }
 

--- a/src/System-CommandLineHandler-Tests/CommandLinePasswordManagerTest.class.st
+++ b/src/System-CommandLineHandler-Tests/CommandLinePasswordManagerTest.class.st
@@ -7,8 +7,8 @@ Class {
 	#instVars : [
 		'passwordManager'
 	],
-	#category : 'System-BasicCommandLineHandler-Tests-Utilities',
-	#package : 'System-BasicCommandLineHandler-Tests',
+	#category : 'System-CommandLineHandler-Tests-Utilities',
+	#package : 'System-CommandLineHandler-Tests',
 	#tag : 'Utilities'
 }
 

--- a/src/System-CommandLineHandler-Tests/ManifestSystemCommandLineHandlerTests.class.st
+++ b/src/System-CommandLineHandler-Tests/ManifestSystemCommandLineHandlerTests.class.st
@@ -2,14 +2,14 @@
 I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
 "
 Class {
-	#name : 'ManifestSystemBasicCommandLineHandlerTests',
+	#name : 'ManifestSystemCommandLineHandlerTests',
 	#superclass : 'PackageManifest',
-	#category : 'System-BasicCommandLineHandler-Tests-Manifest',
-	#package : 'System-BasicCommandLineHandler-Tests',
+	#category : 'System-CommandLineHandler-Tests-Manifest',
+	#package : 'System-CommandLineHandler-Tests',
 	#tag : 'Manifest'
 }
 
 { #category : 'code-critics' }
-ManifestSystemBasicCommandLineHandlerTests class >> ruleRBBadMessageRuleV1FalsePositive [
+ManifestSystemCommandLineHandlerTests class >> ruleRBBadMessageRuleV1FalsePositive [
 	^ #(#(#(#RGClassDefinition #(#STCommandLineHandlerTest)) #'2019-06-30T23:16:50.788113+02:00') )
 ]

--- a/src/System-CommandLineHandler-Tests/PerformMessageCommandLineHandlerTest.class.st
+++ b/src/System-CommandLineHandler-Tests/PerformMessageCommandLineHandlerTest.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : 'PerformMessageCommandLineHandlerTest',
 	#superclass : 'TestCase',
-	#category : 'System-BasicCommandLineHandler-Tests-Base',
-	#package : 'System-BasicCommandLineHandler-Tests',
+	#category : 'System-CommandLineHandler-Tests-Base',
+	#package : 'System-CommandLineHandler-Tests',
 	#tag : 'Base'
 }
 

--- a/src/System-CommandLineHandler-Tests/package.st
+++ b/src/System-CommandLineHandler-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'System-CommandLineHandler-Tests' }

--- a/src/System-CommandLineHandler/CommandLineArguments.class.st
+++ b/src/System-CommandLineHandler/CommandLineArguments.class.st
@@ -12,8 +12,8 @@ Class {
 	#instVars : [
 		'arguments'
 	],
-	#category : 'System-BasicCommandLineHandler-Base',
-	#package : 'System-BasicCommandLineHandler',
+	#category : 'System-CommandLineHandler-Base',
+	#package : 'System-CommandLineHandler',
 	#tag : 'Base'
 }
 

--- a/src/System-CommandLineHandler/CommandLineHandler.class.st
+++ b/src/System-CommandLineHandler/CommandLineHandler.class.st
@@ -12,8 +12,8 @@ Class {
 		'stdout',
 		'stderr'
 	],
-	#category : 'System-BasicCommandLineHandler-Base',
-	#package : 'System-BasicCommandLineHandler',
+	#category : 'System-CommandLineHandler-Base',
+	#package : 'System-CommandLineHandler',
 	#tag : 'Base'
 }
 

--- a/src/System-CommandLineHandler/CommandLinePasswordManager.class.st
+++ b/src/System-CommandLineHandler/CommandLinePasswordManager.class.st
@@ -30,8 +30,8 @@ Class {
 	#classVars : [
 		'Instance'
 	],
-	#category : 'System-BasicCommandLineHandler-Utilities',
-	#package : 'System-BasicCommandLineHandler',
+	#category : 'System-CommandLineHandler-Utilities',
+	#package : 'System-CommandLineHandler',
 	#tag : 'Utilities'
 }
 

--- a/src/System-CommandLineHandler/ManifestSystemCommandLineHandler.class.st
+++ b/src/System-CommandLineHandler/ManifestSystemCommandLineHandler.class.st
@@ -2,19 +2,19 @@
 Package to provide basic command line handling.
 "
 Class {
-	#name : 'ManifestSystemBasicCommandLineHandler',
+	#name : 'ManifestSystemCommandLineHandler',
 	#superclass : 'PackageManifest',
-	#category : 'System-BasicCommandLineHandler-Manifest',
-	#package : 'System-BasicCommandLineHandler',
+	#category : 'System-CommandLineHandler-Manifest',
+	#package : 'System-CommandLineHandler',
 	#tag : 'Manifest'
 }
 
 { #category : 'meta-data - dependency analyser' }
-ManifestSystemBasicCommandLineHandler class >> ignoredDependencies [
+ManifestSystemCommandLineHandler class >> ignoredDependencies [
 	^ #(#'System-Settings-Core' #StartupPreferences #'System-Hashing')
 ]
 
 { #category : 'meta-data - dependency analyser' }
-ManifestSystemBasicCommandLineHandler class >> manuallyResolvedDependencies [
+ManifestSystemCommandLineHandler class >> manuallyResolvedDependencies [
 	^ #( #'Collections-Abstract' #'FileSystem-Core' #'System-Support' #'Kernel-CodeModel' #'System-Settings-Core' #'Collections-Streams' #'System-Hashing')
 ]

--- a/src/System-CommandLineHandler/PerformMessageCommandLineHandler.class.st
+++ b/src/System-CommandLineHandler/PerformMessageCommandLineHandler.class.st
@@ -27,8 +27,8 @@ Class {
 		'messageArguments',
 		'commandOptions'
 	],
-	#category : 'System-BasicCommandLineHandler-Base',
-	#package : 'System-BasicCommandLineHandler',
+	#category : 'System-CommandLineHandler-Base',
+	#package : 'System-CommandLineHandler',
 	#tag : 'Base'
 }
 

--- a/src/System-CommandLineHandler/PharoOptionsHandler.class.st
+++ b/src/System-CommandLineHandler/PharoOptionsHandler.class.st
@@ -30,8 +30,8 @@ Class {
 	#classVars : [
 		'ShouldIgnorePreferences'
 	],
-	#category : 'System-BasicCommandLineHandler',
-	#package : 'System-BasicCommandLineHandler'
+	#category : 'System-CommandLineHandler',
+	#package : 'System-CommandLineHandler'
 }
 
 { #category : 'accessing' }

--- a/src/System-CommandLineHandler/package.st
+++ b/src/System-CommandLineHandler/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'System-CommandLineHandler' }


### PR DESCRIPTION
Because we don't have other handlers anymore so there is no need for the "basic"