### PR TITLE
[Refactoring] Fix generating accessors variable slots bug

### DIFF
--- a/src/Calypso-SystemQueries/ClyClassSideScope.class.st
+++ b/src/Calypso-SystemQueries/ClyClassSideScope.class.st
@@ -14,9 +14,20 @@ ClyClassSideScope class >> defaultName [
 	^'class side'
 ]
 
+{ #category : 'testing' }
+ClyClassSideScope class >> isInstanceSide [
+
+	^ false
+]
+
 { #category : 'class selection' }
 ClyClassSideScope class >> metaLevelOf: aClass [
 	^aClass classSide
+]
+
+{ #category : 'testing' }
+ClyClassSideScope >> isInstanceSide [
+	^ self class isInstanceSide
 ]
 
 { #category : 'queries' }

--- a/src/Calypso-SystemQueries/ClyInstanceSideScope.class.st
+++ b/src/Calypso-SystemQueries/ClyInstanceSideScope.class.st
@@ -14,7 +14,18 @@ ClyInstanceSideScope class >> defaultName [
 	^'inst. side'
 ]
 
+{ #category : 'testing' }
+ClyInstanceSideScope class >> isInstanceSide [
+
+	^ true
+]
+
 { #category : 'class selection' }
 ClyInstanceSideScope class >> metaLevelOf: aClass [
 	^aClass instanceSide
+]
+
+{ #category : 'testing' }
+ClyInstanceSideScope >> isInstanceSide [
+	^ self class isInstanceSide
 ]

--- a/src/Calypso-SystemTools-Core/ClyClassDefinitionContext.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassDefinitionContext.class.st
@@ -5,3 +5,9 @@ Class {
 	#package : 'Calypso-SystemTools-Core',
 	#tag : 'Editors-Classes'
 }
+
+{ #category : 'testing' }
+ClyClassDefinitionContext >> isInstanceSide [
+
+	^ selectedSourceNode parent class = CDClassDefinitionNode
+]

--- a/src/Refactoring-UI/ReGenerateAccessorsDriver.class.st
+++ b/src/Refactoring-UI/ReGenerateAccessorsDriver.class.st
@@ -20,15 +20,22 @@ ReGenerateAccessorsDriver class >> refactoringClass [
 
 { #category : 'configuration' }
 ReGenerateAccessorsDriver >> configureRefactoring [
-		
+
 	refactoring := ReUpFrontPreconditionCheckingCompositeRefactoring new
-							model: model; 
-							refactorings: (selectedVariables collect: [:each | 
-									self refactoringClass 
-										model: model 
-										instanceVariable: each 
-										class: self targetClass name ]);
-								yourself.
+		               model: model;
+		               refactorings: (selectedVariables collect: [ :eachSlot | self refactoringForSlot: eachSlot ]);
+		               yourself
+]
+
+{ #category : 'initialization' }
+ReGenerateAccessorsDriver >> refactoringForSlot: aSlot [
+
+	| isClassVariable |
+	isClassVariable := self targetClass realClass class slotNames includes: aSlot.
+
+	^ isClassVariable
+		  ifTrue: [ self refactoringClass model: model classVariable: aSlot class: self targetClass name ]
+		  ifFalse: [ self refactoringClass model: model instanceVariable: aSlot class: self targetClass name ] 
 ]
 
 { #category : 'configuration' }

--- a/src/Refactoring-UI/ReGenerateAccessorsDriver.class.st
+++ b/src/Refactoring-UI/ReGenerateAccessorsDriver.class.st
@@ -7,6 +7,9 @@ It uses the `RBGenerateEqualHashTransformation`.
 Class {
 	#name : 'ReGenerateAccessorsDriver',
 	#superclass : 'ReGenerateMethodDriver',
+	#instVars : [
+		'scopeInstanceSide'
+	],
 	#category : 'Refactoring-UI-Drivers',
 	#package : 'Refactoring-UI',
 	#tag : 'Drivers'
@@ -30,12 +33,9 @@ ReGenerateAccessorsDriver >> configureRefactoring [
 { #category : 'initialization' }
 ReGenerateAccessorsDriver >> refactoringForSlot: aSlot [
 
-	| isClassVariable |
-	isClassVariable := self targetClass realClass class slotNames includes: aSlot.
-
-	^ isClassVariable
-		  ifTrue: [ self refactoringClass model: model classVariable: aSlot class: self targetClass name ]
-		  ifFalse: [ self refactoringClass model: model instanceVariable: aSlot class: self targetClass name ] 
+	^ scopeInstanceSide
+		  ifFalse: [ self refactoringClass model: model classVariable: aSlot class: self targetClass name ]
+		  ifTrue: [ self refactoringClass model: model instanceVariable: aSlot class: self targetClass name ]
 ]
 
 { #category : 'configuration' }
@@ -43,6 +43,12 @@ ReGenerateAccessorsDriver >> runRefactoring [
 
 	self configureRefactoring.
 	self applyChanges
+]
+
+{ #category : 'accessing' }
+ReGenerateAccessorsDriver >> scopeInstanceSide: aBoolean [
+
+	scopeInstanceSide := aBoolean
 ]
 
 { #category : 'configuration' }

--- a/src/SystemCommands-VariableCommands/SycGenerateVariableAccessorCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycGenerateVariableAccessorCommand.class.st
@@ -22,13 +22,14 @@ SycGenerateVariableAccessorCommand >> defaultMenuItemName [
 
 { #category : 'execution' }
 SycGenerateVariableAccessorCommand >> execute [
-	
-	(ReGenerateAccessorsDriver new 
-		targetClass: variables first definingClass;
-		scopes: toolContext refactoringScopes;
-		selectedVariables: (variables collect: [:each | each name ]) ) runRefactoring
-	
 
+	(ReGenerateAccessorsDriver new
+		 targetClass: variables first definingClass;
+		 scopes: toolContext refactoringScopes;
+		 scopeInstanceSide: ((toolContext respondsTo: #metaLevelScope)
+				  ifTrue: [ toolContext metaLevelScope isInstanceSide ]
+				  ifFalse: [ toolContext isInstanceSide ]);
+		 selectedVariables: (variables collect: [ :each | each name ])) runRefactoring
 ]
 
 { #category : 'factory method' }


### PR DESCRIPTION
When generating getter and setter for an instance variable on class side, they were generated on instance side. Therefore, I made the distinction between those two instance variable types when configuring the refactoring
Fixes #18771