### PR TITLE
Reduce dependencies of Oups to UIManager

### DIFF
--- a/src/Debugger-Oups-Tests/OupsDummyDebuggerSystem.class.st
+++ b/src/Debugger-Oups-Tests/OupsDummyDebuggerSystem.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : 'OupsDummyDebuggerSystem',
 	#superclass : 'OupsDebuggerSystem',
 	#instVars : [
-		'customUIManager',
 		'debugRequestSentToHandleDebugRequest',
 		'callsToHandleDebugRequest'
 	],
@@ -24,11 +23,6 @@ OupsDummyDebuggerSystem >> callsToHandleDebugRequest: aValue [
 	callsToHandleDebugRequest := aValue
 ]
 
-{ #category : 'default values' }
-OupsDummyDebuggerSystem >> customUIManager: aUIManager [
-	customUIManager := aUIManager
-]
-
 { #category : 'accessing' }
 OupsDummyDebuggerSystem >> debugRequestSentToHandleDebugRequest [
 	^ debugRequestSentToHandleDebugRequest
@@ -37,12 +31,6 @@ OupsDummyDebuggerSystem >> debugRequestSentToHandleDebugRequest [
 { #category : 'default values' }
 OupsDummyDebuggerSystem >> debuggerSelectionStrategy [
 	^ OupsDummySelectionStrategy new
-]
-
-{ #category : 'default values' }
-OupsDummyDebuggerSystem >> defaultUIManager [
-	customUIManager ifNil: [ ^ super defaultUIManager ].
-	^ customUIManager
 ]
 
 { #category : 'open debugger' }
@@ -59,7 +47,7 @@ OupsDummyDebuggerSystem >> suspendDebuggedProcess: aDebugRequest [
 ]
 
 { #category : 'open debugger' }
-OupsDummyDebuggerSystem >> warningRequest: aDebugRequest withUIManager: aCommandLineUIManager [
+OupsDummyDebuggerSystem >> warningRequest: aDebugRequest withErrorManager: anErrorHandler [
 
 	self openDebuggerOnRequest: aDebugRequest
 ]

--- a/src/Debugger-Oups/NonInteractiveUIManager.extension.st
+++ b/src/Debugger-Oups/NonInteractiveUIManager.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'NonInteractiveUIManager' }
+
+{ #category : '*Debugger-Oups' }
+NonInteractiveUIManager >> handleWarningDebugRequest: aDebugRequest fromDebuggerSystem: anOupsDebuggerSystem [
+
+	anOupsDebuggerSystem warningRequest: aDebugRequest withErrorManager: self
+]

--- a/src/Debugger-Oups/OupsDebuggerSystem.class.st
+++ b/src/Debugger-Oups/OupsDebuggerSystem.class.st
@@ -36,11 +36,6 @@ OupsDebuggerSystem >> debuggerSelectionStrategy [
 		  self availableDebuggers
 ]
 
-{ #category : 'default values' }
-OupsDebuggerSystem >> defaultUIManager [
-	^ UIManager default
-]
-
 { #category : 'exceptions' }
 OupsDebuggerSystem >> ensureExceptionIn: aDebugSession [
 
@@ -64,7 +59,7 @@ OupsDebuggerSystem >> handleWarningDebugRequest: aWarningDebugRequest [
 	"A WarningDebugRequest has been submitted. Ask what to do to the default UIManager. Typically, the UIManager will call back my #openDebuggerOnRequest: method to open a debugger"
 
 	[
-	self defaultUIManager handleWarningDebugRequest: aWarningDebugRequest fromDebuggerSystem: self]
+	UIManager default handleWarningDebugRequest: aWarningDebugRequest fromDebuggerSystem: self]
 		on: Error
 		do: [ self signalDebuggerError: aWarningDebugRequest ]
 ]
@@ -111,7 +106,7 @@ OupsDebuggerSystem >> suspendDebuggedProcess: aDebugRequest [
 ]
 
 { #category : 'open debugger' }
-OupsDebuggerSystem >> warningRequest: aDebugRequest withUIManager: aCommandLineUIManager [
+OupsDebuggerSystem >> warningRequest: aDebugRequest withErrorManager: anErrorHandler [
 
-	aCommandLineUIManager handleWarning: aDebugRequest exception
+	anErrorHandler handleWarning: aDebugRequest exception
 ]

--- a/src/Debugger-Oups/UIManager.extension.st
+++ b/src/Debugger-Oups/UIManager.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : 'UIManager' }
 
 { #category : '*Debugger-Oups' }
+UIManager >> handleWarningDebugRequest: aWarningDebugRequest fromDebuggerSystem: anOupsDebuggerSystem [
+	"Handle warning notification. Should be overidden by subclass."
+
+	self subclassResponsibility
+]
+
+{ #category : '*Debugger-Oups' }
 UIManager >> requestDebuggerOpeningFor: anException [
 
 	<debuggerCompleteToSender>

--- a/src/UIManager/NonInteractiveUIManager.class.st
+++ b/src/UIManager/NonInteractiveUIManager.class.st
@@ -220,14 +220,6 @@ NonInteractiveUIManager >> handleWarning: aWarning [
 	aWarning resume
 ]
 
-{ #category : 'handle debug requests' }
-NonInteractiveUIManager >> handleWarningDebugRequest: aDebugRequest fromDebuggerSystem: anOupsDebuggerSystem [
-
-	anOupsDebuggerSystem
-		warningRequest: aDebugRequest
-		withUIManager: self
-]
-
 { #category : 'ui requests' }
 NonInteractiveUIManager >> inform: aString [
 

--- a/src/UIManager/UIManager.class.st
+++ b/src/UIManager/UIManager.class.st
@@ -412,13 +412,6 @@ UIManager >> handleWarning: aWarning [
 	self subclassResponsibility
 ]
 
-{ #category : 'debug requests' }
-UIManager >> handleWarningDebugRequest: aWarningDebugRequest fromDebuggerSystem: anOupsDebuggerSystem [
-	"Handle warning notification. Should be overidden by subclass."
-
-	self subclassResponsibility
-]
-
 { #category : 'ui requests' }
 UIManager >> inform: aString [
 	"Display a message for the user to read and then dismiss."


### PR DESCRIPTION
I am trying to extract the UIManager from the Kernel of Pharo but my PR does not pass and I'm trying to produce smaller changes. 

Here I am proposing to clean a little Oups to rely less on the UIManager.
- Remove #customUIManager that is not used anymore
- Rename methods to use "ErrorHandler" instead of "UIManager" since it will soon be the error handler that will be used
- Remove #defaultUIManager