### PR TITLE
Move Deprecations and co out of the Kernel

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -151,7 +151,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform --save PharoBootst
 
 # Installing compiler through Hermes 
 echo $(date -u) "[Compiler] Installing compiler through Hermes"
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Debugging-Utils.hermes OpalCompiler-Core.hermes DebugInfo.hermes CodeImport.hermes CodeImport-Commands.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Debugging-Utils.hermes OpalCompiler-Core.hermes Deprecation.hermes DebugInfo.hermes CodeImport.hermes CodeImport-Commands.hermes --save --no-fail-on-undeclared
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "SystemEnvironment deprecatedAliases: { #SystemDictionary }." # This line should be removed in Pharo 14 since it is for backward compatibility.
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/01-init.st --no-source --save --quit
 

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -73,7 +73,7 @@ export PHARO_CI_TESTING_ENVIRONMENT=1
 ./pharo bootstrap.image loadHermes Traits.hermes --save
 
 #Loading Tests
-./pharo bootstrap.image loadHermes Debugging-Utils.hermes SUnit-Core.hermes JenkinsTools-Core.hermes JenkinsTools-Core.hermes SUnit-Tests.hermes --save --no-fail-on-undeclared --on-duplication ignore
+./pharo bootstrap.image loadHermes Debugging-Utils.hermes Deprecation.hermes SUnit-Core.hermes JenkinsTools-Core.hermes JenkinsTools-Core.hermes SUnit-Tests.hermes --save --no-fail-on-undeclared --on-duplication ignore
 ./pharo bootstrap.image perform --save Pragma buildCache
 
 #Running tests

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -226,6 +226,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		}.
 
 		spec group: 'SUnitGroup' with: {
+			'Deprecation'.
 			'SUnit-Core'.
 			'SUnit-Tests'.
 			'Kernel-Tests'.

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -85,6 +85,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		spec package: 'Collections-Unordered'.
 		spec package: 'Collections-Weak'.
 		spec package: 'Debugging-Core'.
+		spec package: 'Deprecation'.
 		spec package: 'Files'.
 		spec package: 'FileSystem-Path'.
 		spec package: 'Hermes'.
@@ -205,7 +206,8 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'Debugging-Utils'.
 			'DebugInfo'.
 			'NumberParser'.
-			'OpalCompiler-Core'}.
+			'OpalCompiler-Core'.
+			'Deprecation'}.
 		
 		spec group: 'FileSystemGroup' with: {
 			'Random-Core'.

--- a/src/Deprecation/AutomaticRewriting.class.st
+++ b/src/Deprecation/AutomaticRewriting.class.st
@@ -15,8 +15,8 @@ Class {
 		'showWarning',
 		'active'
 	],
-	#category : 'Kernel-Exceptions',
-	#package : 'Kernel',
+	#category : 'Deprecation-Exceptions',
+	#package : 'Deprecation',
 	#tag : 'Exceptions'
 }
 

--- a/src/Deprecation/BackwardCompatibility.class.st
+++ b/src/Deprecation/BackwardCompatibility.class.st
@@ -33,8 +33,8 @@ Check class side for posible configurations. You can ignore, raise warning, log 
 Class {
 	#name : 'BackwardCompatibility',
 	#superclass : 'AutomaticRewriting',
-	#category : 'Kernel-Exceptions',
-	#package : 'Kernel',
+	#category : 'Deprecation-Exceptions',
+	#package : 'Deprecation',
 	#tag : 'Exceptions'
 }
 

--- a/src/Deprecation/BackwardCompatibleRewritingCallPerformedNotification.class.st
+++ b/src/Deprecation/BackwardCompatibleRewritingCallPerformedNotification.class.st
@@ -4,7 +4,7 @@ I am a notificaton about an operation that was performed as reaction of a Deprec
 Class {
 	#name : 'BackwardCompatibleRewritingCallPerformedNotification',
 	#superclass : 'SystemNotification',
-	#category : 'Kernel-Exceptions',
-	#package : 'Kernel',
+	#category : 'Deprecation-Exceptions',
+	#package : 'Deprecation',
 	#tag : 'Exceptions'
 }

--- a/src/Deprecation/Deprecation.class.st
+++ b/src/Deprecation/Deprecation.class.st
@@ -32,8 +32,8 @@ Check the class side for configurations. You can raise, ignore, log and rewrite 
 Class {
 	#name : 'Deprecation',
 	#superclass : 'AutomaticRewriting',
-	#category : 'Kernel-Exceptions',
-	#package : 'Kernel',
+	#category : 'Deprecation-Exceptions',
+	#package : 'Deprecation',
 	#tag : 'Exceptions'
 }
 

--- a/src/Deprecation/DeprecationPerformedNotification.class.st
+++ b/src/Deprecation/DeprecationPerformedNotification.class.st
@@ -4,7 +4,7 @@ I am a notificaton about an operation that was performed as reaction of a Deprec
 Class {
 	#name : 'DeprecationPerformedNotification',
 	#superclass : 'SystemNotification',
-	#category : 'Kernel-Exceptions',
-	#package : 'Kernel',
+	#category : 'Deprecation-Exceptions',
+	#package : 'Deprecation',
 	#tag : 'Exceptions'
 }

--- a/src/Deprecation/Object.extension.st
+++ b/src/Deprecation/Object.extension.st
@@ -1,0 +1,93 @@
+Extension { #name : 'Object' }
+
+{ #category : '*Deprecation' }
+Object >> backwardCompatible: anExplanationString on: date in: version transformWith: aRule [
+	"Automatically transform the backward compatible calls to this method"
+
+	BackwardCompatibility new
+		context: thisContext sender;
+		explanation: anExplanationString;
+		date: date;
+		version: version;
+		rule: aRule;
+		signal
+]
+
+{ #category : '*Deprecation' }
+Object >> deprecated: anExplanationString [
+	"Warn that the sending method has been deprecated."
+
+	Deprecation new
+		context: thisContext sender;
+		explanation: anExplanationString;
+		signal
+]
+
+{ #category : '*Deprecation' }
+Object >> deprecated: anExplanationString on: date in: version [
+	"Warn that the sending method has been deprecated."
+
+	Deprecation new
+		context: thisContext sender;
+		explanation: anExplanationString;
+		date: date;
+		version: version;
+		signal
+]
+
+{ #category : '*Deprecation' }
+Object >> deprecated: anExplanationString 
+	on: date 
+	in: version 
+	transformWith: aRule [
+	"Automatically transform the deprecated calls."
+
+	Deprecation new
+		context: thisContext sender;
+		explanation: anExplanationString;
+		date: date;
+		version: version;
+		rule: aRule;
+		signal
+]
+
+{ #category : '*Deprecation' }
+Object >> deprecated: anExplanationString 
+	on: date 
+	in: version 
+	transformWith: aRule 
+	when: conditionBlock [
+	"Automatically transform the deprecated call if it matches the condition."
+
+	Deprecation new
+		context: thisContext sender;
+		explanation: anExplanationString;
+		date: date;
+		version: version;
+		rule: aRule;
+		condition: conditionBlock;
+		signal
+]
+
+{ #category : '*Deprecation' }
+Object >> deprecated: anExplanationString transformWith: aRule [
+	"Automatically transform the deprecated call."
+
+	Deprecation new
+		context: thisContext sender;
+		explanation: anExplanationString;
+		rule: aRule;
+		signal
+]
+
+{ #category : '*Deprecation' }
+Object >> deprecated: anExplanationString transformWith: aRule when: conditionBlock [
+	"Automatically transform the deprecated call if it matches the condition."
+
+	Deprecation new
+		context: thisContext sender;
+		explanation: anExplanationString;
+		rule: aRule;
+		condition: conditionBlock;
+		signal
+]

--- a/src/Deprecation/package.st
+++ b/src/Deprecation/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'Deprecation' }

--- a/src/Kernel/ManifestKernel.class.st
+++ b/src/Kernel/ManifestKernel.class.st
@@ -16,13 +16,13 @@ ManifestKernel class >> dependencies [
 
 { #category : 'meta-data - dependency analyser' }
 ManifestKernel class >> ignoredDependencies [
-	^ #('Reflectivity' 'Regex-Core' 'FFI-Kernel')
+	^ #('FFI-Kernel')
 ]
 
 { #category : 'meta-data - dependency analyser' }
 ManifestKernel class >> manuallyResolvedDependencies [
 
-	^ #( #Reflectivity #'Shift-ClassBuilder' )
+	^ #( #'Shift-ClassBuilder' )
 ]
 
 { #category : 'meta-data' }

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -390,19 +390,6 @@ Object >> attemptToAssign: value withIndex: index [
 	"CAN'T REACH"
 ]
 
-{ #category : 'deprecation' }
-Object >> backwardCompatible: anExplanationString on: date in: version transformWith: aRule [
-	"Automatically transform the backward compatible calls to this method"
-
-	BackwardCompatibility new
-		context: thisContext sender;
-		explanation: anExplanationString;
-		date: date;
-		version: version;
-		rule: aRule;
-		signal
-]
-
 { #category : 'accessing' }
 Object >> basicAt: index [
 	"Primitive. Assumes receiver is indexable. Answer the value of an
@@ -623,85 +610,6 @@ It doesn't handle cycles, #veryDeepCopy does. In the future we will make it hand
 			[newObject instVarAt: index put: (self instVarAt: index) deepCopy.
 			index := index - 1].
 	^newObject
-]
-
-{ #category : 'deprecation' }
-Object >> deprecated: anExplanationString [
-	"Warn that the sending method has been deprecated."
-
-	Deprecation new
-		context: thisContext sender;
-		explanation: anExplanationString;
-		signal
-]
-
-{ #category : 'deprecation' }
-Object >> deprecated: anExplanationString on: date in: version [
-	"Warn that the sending method has been deprecated."
-
-	Deprecation new
-		context: thisContext sender;
-		explanation: anExplanationString;
-		date: date;
-		version: version;
-		signal
-]
-
-{ #category : 'deprecation' }
-Object >> deprecated: anExplanationString 
-	on: date 
-	in: version 
-	transformWith: aRule [
-	"Automatically transform the deprecated calls."
-
-	Deprecation new
-		context: thisContext sender;
-		explanation: anExplanationString;
-		date: date;
-		version: version;
-		rule: aRule;
-		signal
-]
-
-{ #category : 'deprecation' }
-Object >> deprecated: anExplanationString 
-	on: date 
-	in: version 
-	transformWith: aRule 
-	when: conditionBlock [
-	"Automatically transform the deprecated call if it matches the condition."
-
-	Deprecation new
-		context: thisContext sender;
-		explanation: anExplanationString;
-		date: date;
-		version: version;
-		rule: aRule;
-		condition: conditionBlock;
-		signal
-]
-
-{ #category : 'deprecation' }
-Object >> deprecated: anExplanationString transformWith: aRule [
-	"Automatically transform the deprecated call."
-
-	Deprecation new
-		context: thisContext sender;
-		explanation: anExplanationString;
-		rule: aRule;
-		signal
-]
-
-{ #category : 'deprecation' }
-Object >> deprecated: anExplanationString transformWith: aRule when: conditionBlock [
-	"Automatically transform the deprecated call if it matches the condition."
-
-	Deprecation new
-		context: thisContext sender;
-		explanation: anExplanationString;
-		rule: aRule;
-		condition: conditionBlock;
-		signal
 ]
 
 { #category : 'displaying' }


### PR DESCRIPTION
Deprecation, Automatic rewriting and BackwardCompatibility are classes relying on the compiler to produce transformations but the Kernel should not depend on the compiler. Since they cannot work before we load the compiler, I propose to move all those classes out of the Kernel in their own package and to load them alongside the compiler.