### PR TITLE
Old ring chunk importer should depend on Ring-Definition-Core

### DIFF
--- a/src/BaselineOfMonticello/BaselineOfMonticello.class.st
+++ b/src/BaselineOfMonticello/BaselineOfMonticello.class.st
@@ -43,7 +43,7 @@ BaselineOfMonticello >> baseline: spec [
 			package: 'MonticelloRemoteRepositories';
 			package: 'Zodiac-Core'.
 		spec 
-			group: 'Core' with: #('Ring-OldChunkImporter' 'System-Changes' 'Ring-Definitions-Core' 'Jobs' 'Compression' 'Monticello-Model' 'Monticello' 'Ring-Definitions-Monticello');
+			group: 'Core' with: #('System-Changes' 'Ring-Definitions-Core' 'Ring-OldChunkImporter' 'Jobs' 'Compression' 'Monticello-Model' 'Monticello' 'Ring-Definitions-Monticello');
 			group: 'RemoteRepositories' with: #( 'Network-Kernel' 'Network-MIME' 'Network-Protocols' 'Zinc-Resource-Meta-Core' 'Zinc-HTTP' 'MonticelloRemoteRepositories' 'Zodiac-Core' );
 
 			group: 'default' with: #('Core' 'RemoteRepositories' ). ].

--- a/src/PharoBootstrap/PBBootstrap.class.st
+++ b/src/PharoBootstrap/PBBootstrap.class.st
@@ -336,7 +336,7 @@ PBBootstrap >> monticelloNetworkPackageNames [
 { #category : 'package-names' }
 PBBootstrap >> monticelloPackageNames [
 
-	^ #('Ring-OldChunkImporter'  'System-Changes' 'Ring-Definitions-Core' 'Jobs' 'Compression' 'Monticello-Model' 'Monticello' 'Ring-Definitions-Monticello' )
+	^ #('System-Changes' 'Ring-Definitions-Core' 'Ring-OldChunkImporter' 'Jobs' 'Compression' 'Monticello-Model' 'Monticello' 'Ring-Definitions-Monticello' )
 ]
 
 { #category : 'accessing' }

--- a/src/Ring-OldChunkImporter/ManifestRingOldChunkImporter.class.st
+++ b/src/Ring-OldChunkImporter/ManifestRingOldChunkImporter.class.st
@@ -11,5 +11,5 @@ Class {
 
 { #category : 'meta-data - dependency analyser' }
 ManifestRingOldChunkImporter class >> manuallyResolvedDependencies [
-	^ #(#'OpalCompiler-Core' #'FileSystem-Core' #'Collections-Abstract' #'Collections-Strings' #'System-Support')
+	^ #(#'OpalCompiler-Core' #'FileSystem-Core' #'Collections-Strings' #'Collections-Sequenceable')
 ]


### PR DESCRIPTION
Currently we get undeclared while loading the code.

I wonder if we should not merge it in Monticello since it's one of the only user