### PR TITLE
Clean some Monticello-Model dependencies

### DIFF
--- a/src/Monticello-Model/MCClassDefinition.class.st
+++ b/src/Monticello-Model/MCClassDefinition.class.st
@@ -39,14 +39,6 @@ MCClassDefinition >> = aDefinition [
 		and: [ type = aDefinition type and: [ self sortedVariables = aDefinition sortedVariables and: [ comment = aDefinition comment ] ] ] ] ] ] ]]
 ]
 
-{ #category : 'visiting' }
-MCClassDefinition >> accept: aVisitor [
-	aVisitor visitClassDefinition: self.
-	(self hasClassInstanceVariables or: [self hasClassTraitComposition])
-		ifTrue: [aVisitor visitMetaclassDefinition: self].
-
-]
-
 { #category : 'accessing' }
 MCClassDefinition >> actualClass [
 
@@ -125,7 +117,8 @@ MCClassDefinition >> classTraitComposition: classTraitCompositionString [
 
 { #category : 'accessing' }
 MCClassDefinition >> classTraitCompositionCompiled [
-		^(Smalltalk compiler evaluate: self classTraitCompositionString) asTraitComposition 
+
+	^ (self class compiler evaluate: self classTraitCompositionString) asTraitComposition
 ]
 
 { #category : 'accessing' }
@@ -210,7 +203,7 @@ MCClassDefinition >> createClassInEnvironment: anEnvironent [
 
 { #category : 'installing' }
 MCClassDefinition >> createVariableFromString: aString [
-	^[ Smalltalk compiler evaluate: aString ] 
+	^[ self class compiler evaluate: aString ] 
 		on: Error 
 		do: [ 
 			"if an error happens, we parse the slot definition to an ast.
@@ -516,8 +509,8 @@ MCClassDefinition >> sortedVariables [
 { #category : 'installing' }
 MCClassDefinition >> sortedVariablesOfType: aSymbol [
 	"version for complex vars, { definition . definition }"
-	^(((self selectVariables: aSymbol) asSortedCollection collect: [:each | Smalltalk compiler evaluate: each])) asArray.
-		
+
+	^ ((self selectVariables: aSymbol) asSortedCollection collect: [ :each | self class compiler evaluate: each ]) asArray
 ]
 
 { #category : 'printing' }
@@ -594,7 +587,8 @@ MCClassDefinition >> traitComposition: traitCompositionString [
 
 { #category : 'accessing' }
 MCClassDefinition >> traitCompositionCompiled [
-	^(Smalltalk compiler evaluate: self traitCompositionString) asTraitComposition 
+
+	^ (self class compiler evaluate: self traitCompositionString) asTraitComposition
 ]
 
 { #category : 'accessing' }

--- a/src/Monticello-Model/MCMethodDefinition.class.st
+++ b/src/Monticello-Model/MCMethodDefinition.class.st
@@ -75,11 +75,6 @@ MCMethodDefinition >> = aDefinition [
 		and: [ aDefinition source withInternalLineEndings = self source withInternalLineEndings ] ]
 ]
 
-{ #category : 'visiting' }
-MCMethodDefinition >> accept: aVisitor [
-	^ aVisitor visitMethodDefinition: self
-]
-
 { #category : 'accessing' }
 MCMethodDefinition >> actualClass [
 

--- a/src/Monticello-Model/MCOrganizationDefinition.class.st
+++ b/src/Monticello-Model/MCOrganizationDefinition.class.st
@@ -35,11 +35,6 @@ MCOrganizationDefinition >> = aDefinition [
 ]
 
 { #category : 'accessing' }
-MCOrganizationDefinition >> accept: aVisitor [
-	^ aVisitor visitOrganizationDefinition: self
-]
-
-{ #category : 'accessing' }
 MCOrganizationDefinition >> categories [
 
 	^ self packageName

--- a/src/Monticello-Model/MCScriptDefinition.class.st
+++ b/src/Monticello-Model/MCScriptDefinition.class.st
@@ -44,11 +44,6 @@ MCScriptDefinition >> = aDefinition [
 		and: [script = aDefinition script]
 ]
 
-{ #category : 'visiting' }
-MCScriptDefinition >> accept: aVisitor [
-	aVisitor visitScriptDefinition: self
-]
-
 { #category : 'accessing' }
 MCScriptDefinition >> description [
 	^ Array with: packageName with: self scriptSelector
@@ -123,7 +118,7 @@ MCScriptDefinition >> summary [
 MCScriptDefinition >> systemPackage [
 	"Return the corresponding system package. Return nil if no package in the system has this name."
 
-	^ self class environment organization packageNamed: self packageName ifAbsent: [ nil ]
+	^ self class packageOrganizer packageNamed: self packageName ifAbsent: [ nil ]
 ]
 
 { #category : 'installing' }

--- a/src/Monticello-Model/MCTraitDefinition.class.st
+++ b/src/Monticello-Model/MCTraitDefinition.class.st
@@ -22,12 +22,6 @@ MCTraitDefinition >> = aDefinition [
 												  self classInstVarNames = aDefinition classInstVarNames and: [ comment = aDefinition comment ] ] ] ] ] ] ]
 ]
 
-{ #category : 'visiting' }
-MCTraitDefinition >> accept: aVisitor [
-	^ aVisitor visitTraitDefinition: self
-
-]
-
 { #category : 'printing' }
 MCTraitDefinition >> classSlotDefinitionString [
 
@@ -46,18 +40,18 @@ MCTraitDefinition >> classSlotDefinitionString [
 MCTraitDefinition >> createClassInEnvironment: anEnvironent [
 
 	^ [
-	  self class classInstaller make: [ :aBuilder |
-		  aBuilder
-			  name: name;
-			  traitComposition: (Smalltalk compiler evaluate: self traitCompositionString);
-			  classTraitComposition: (Smalltalk compiler evaluate: self classTraitCompositionString);
-			  slots: self instanceVariables;
-			  classSlots: self classInstanceVariables;
-			  package: self packageName;
-			  tag: self tagName;
-			  comment: comment stamp: commentStamp;
-			  beTrait.
-			anEnvironent ifNotNil: [ aBuilder environment: anEnvironent ] ] ]
+		  self class classInstaller make: [ :aBuilder |
+				  aBuilder
+					  name: name;
+					  traitComposition: (self class compiler evaluate: self traitCompositionString);
+					  classTraitComposition: (self class compiler evaluate: self classTraitCompositionString);
+					  slots: self instanceVariables;
+					  classSlots: self classInstanceVariables;
+					  package: self packageName;
+					  tag: self tagName;
+					  comment: comment stamp: commentStamp;
+					  beTrait.
+				  anEnvironent ifNotNil: [ aBuilder environment: anEnvironent ] ] ]
 		  on: Warning , DuplicatedVariableError
 		  do: [ :ex | ex resume ]
 ]

--- a/src/Monticello-Model/ManifestMonticelloModel.class.st
+++ b/src/Monticello-Model/ManifestMonticelloModel.class.st
@@ -13,5 +13,5 @@ Class {
 ManifestMonticelloModel class >> manuallyResolvedDependencies [
 
 	<ignoreForCoverage>
-	^ #(#'OpalCompiler-Core' #'Collections-Abstract' #'Collections-Streams' #'System-Support' #'Shift-ClassBuilder' #'FFI-Kernel' #'System-Changes')
+	^ #(#'OpalCompiler-Core' #'Collections-Abstract' #'Collections-Streams' #'System-Support' #'Shift-ClassBuilder' #'FFI-Kernel')
 ]

--- a/src/Monticello/MCClassDefinition.extension.st
+++ b/src/Monticello/MCClassDefinition.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : 'MCClassDefinition' }
 
 { #category : '*Monticello' }
+MCClassDefinition >> accept: aVisitor [
+	aVisitor visitClassDefinition: self.
+	(self hasClassInstanceVariables or: [self hasClassTraitComposition])
+		ifTrue: [aVisitor visitMetaclassDefinition: self].
+
+]
+
+{ #category : '*Monticello' }
 MCClassDefinition >> storeDataOn: aDataStream [
 	| instVarSize |
 	instVarSize := (self hasTraitComposition or: [ self hasClassTraitComposition ])

--- a/src/Monticello/MCMethodDefinition.extension.st
+++ b/src/Monticello/MCMethodDefinition.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'MCMethodDefinition' }
+
+{ #category : '*Monticello' }
+MCMethodDefinition >> accept: aVisitor [
+	^ aVisitor visitMethodDefinition: self
+]

--- a/src/Monticello/MCOrganizationDefinition.extension.st
+++ b/src/Monticello/MCOrganizationDefinition.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'MCOrganizationDefinition' }
+
+{ #category : '*Monticello' }
+MCOrganizationDefinition >> accept: aVisitor [
+	^ aVisitor visitOrganizationDefinition: self
+]

--- a/src/Monticello/MCScriptDefinition.extension.st
+++ b/src/Monticello/MCScriptDefinition.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'MCScriptDefinition' }
+
+{ #category : '*Monticello' }
+MCScriptDefinition >> accept: aVisitor [
+	aVisitor visitScriptDefinition: self
+]

--- a/src/Monticello/MCTraitDefinition.extension.st
+++ b/src/Monticello/MCTraitDefinition.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'MCTraitDefinition' }
+
+{ #category : '*Monticello' }
+MCTraitDefinition >> accept: aVisitor [
+	^ aVisitor visitTraitDefinition: self
+
+]


### PR DESCRIPTION
- Move some methods to Monticello package because the model should not depend on the rest
- Remove references to Smalltalk
- Clean an obsolete way to access the package manager