### PR TITLE
Move methods from Kernel to System-Model

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -663,8 +663,3 @@ Symbol >> valueWithArguments: aCollection [
 
 	^ aCollection first perform: self withArguments: aCollection allButFirst
 ]
-
-{ #category : 'copying' }
-Symbol >> veryDeepCopyWith: deepCopier [
-	"Return self.  I am immutable in the Morphic world.  Do not record me."
-]

--- a/src/Collections-Unordered/HashedCollection.class.st
+++ b/src/Collections-Unordered/HashedCollection.class.st
@@ -271,12 +271,3 @@ HashedCollection >> union: aCollection [
 
 	^ self copy addAll: aCollection; yourself
 ]
-
-{ #category : 'copying' }
-HashedCollection >> veryDeepCopyWith: deepCopier [
-	| copyOfSelf|
-	copyOfSelf := super veryDeepCopyWith: deepCopier.
-	"force Sets and Dictionaries to rehash"
-	copyOfSelf rehash.
-		^ copyOfSelf
-]

--- a/src/Kernel-CodeModel/CompiledMethod.class.st
+++ b/src/Kernel-CodeModel/CompiledMethod.class.st
@@ -963,11 +963,6 @@ CompiledMethod >> valueWithReceiver: aReceiver arguments: anArray [
 	^self receiver: aReceiver withArguments: anArray executeMethod: self
 ]
 
-{ #category : 'copying' }
-CompiledMethod >> veryDeepCopyWith: deepCopier [
-	"Return self.  I am always shared.  Do not record me.  Only use this for blocks.  Normally methodDictionaries should not be copied this way."
-]
-
 { #category : 'runtime system' }
 CompiledMethod >> voidCogVMState [
 	"Tell the VM to remove all references to any machine code form of the method.

--- a/src/Kernel/Boolean.class.st
+++ b/src/Kernel/Boolean.class.st
@@ -209,11 +209,6 @@ Boolean >> storeOn: aStream [
 	self printOn: aStream
 ]
 
-{ #category : 'copying' }
-Boolean >> veryDeepCopyWith: deepCopier [
-	"Return self.  I can't be copied.  Do not record me."
-]
-
 { #category : 'controlling' }
 Boolean >> xor: alternativeBlock [
 	"Nonevaluating conjunction. If the receiver is true, answer the opposite of the

--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -913,9 +913,3 @@ Character >> tokenish [
 Character >> uppercase [
 	^ self asUppercase
 ]
-
-{ #category : 'copying' }
-Character >> veryDeepCopyWith: deepCopier [
-	"Answer the receiver, because Characters are unique."
-	^self
-]

--- a/src/Kernel/Float.class.st
+++ b/src/Kernel/Float.class.st
@@ -856,10 +856,3 @@ Float >> significandAsInteger [
 Float >> timesTwoPower: anInteger [
 	^ self subclassResponsibility
 ]
-
-{ #category : 'copying' }
-Float >> veryDeepCopyWith: deepCopier [
-	"Return self.  Do not record me."
-
-	^ self shallowCopy
-]

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -1863,68 +1863,6 @@ Object >> valueWithArguments: aSequenceOfArguments [
 	^self
 ]
 
-{ #category : 'copying' }
-Object >> veryDeepCopyWith: deepCopier [
-	"Copy me and the entire tree of objects I point to.  An object in the tree twice is copied once, and both references point to him.  deepCopier holds a dictionary of objects we have seen.  Some classes refuse to be copied.  Some classes are picky about which fields get deep copied."
-
-	| class selfNumberOfInstanceVariables fieldOfSelf copyOfSelf currentClass hasVeryDeepInnerMethod currentNumberOfInstanceVariables |
-
-	deepCopier references at: self ifPresent: [ :newer | 	"already copied" ^ newer].
-	class := self class.
-	class isMeta ifTrue: [ "a metaclass" ^ self ].
-	copyOfSelf := self shallowCopy.
-	deepCopier references at: self put: copyOfSelf.	"remember"
-
-	(class isVariable and: [class isPointers]) ifTrue: [
-		self basicSize to: 1 by: -1 do: [ :i |
-			fieldOfSelf := self basicAt: i.
-			copyOfSelf
-				basicAt: i
-				put: (deepCopier references
-					at: fieldOfSelf
-					ifAbsent: [ fieldOfSelf veryDeepCopyWith: deepCopier ])]].
-
-	"Ask each superclass if it wants to share (weak copy) any inst vars"
-	copyOfSelf veryDeepInner: deepCopier.
-
-	"other superclasses want all instance variables deep copied"
-	currentClass := class.
-	selfNumberOfInstanceVariables := class instSize.
-
-	[ selfNumberOfInstanceVariables == 0 ] whileFalse: [
-		hasVeryDeepInnerMethod := currentClass includesSelector: #veryDeepInner:.
-		currentNumberOfInstanceVariables := currentClass instSize - currentClass superclass instSize.
-		hasVeryDeepInnerMethod
-			ifTrue: ["skip inst vars"
-				selfNumberOfInstanceVariables := selfNumberOfInstanceVariables - currentNumberOfInstanceVariables]
-			ifFalse: [
-				currentNumberOfInstanceVariables timesRepeat: [
-					fieldOfSelf := self instVarAt: selfNumberOfInstanceVariables.
-					copyOfSelf
-						instVarAt: selfNumberOfInstanceVariables
-						put: (deepCopier references
-							at: fieldOfSelf
-							ifAbsent: [ fieldOfSelf veryDeepCopyWith: deepCopier ]).
-					selfNumberOfInstanceVariables := selfNumberOfInstanceVariables - 1 ]].
-		currentClass := currentClass superclass ].
-
-	^ copyOfSelf
-]
-
-{ #category : 'copying' }
-Object >> veryDeepFixupWith: deepCopier [
-	"I have no fields and no superclass.  Catch the super call."
-
-	"avoid to use me we will deprecate it in the future"
-]
-
-{ #category : 'copying' }
-Object >> veryDeepInner: deepCopier [
-	"No special treatment for inst vars of my superclasses.  Override when some need to be weakly copied.  Object>>veryDeepCopyWith: will veryDeepCopy any inst var whose class does not actually define veryDeepInner:"
-
-	"avoid to use me we will deprecate it in the future"
-]
-
 { #category : 'model - updating' }
 Object >> windowIsClosing [
 	"This message is used to inform a models that its window is closing. Most models do nothing, but some, such as the Debugger, must do some cleanup. Note that this mechanism must be used with care by models that support multiple views, since one view may be closed while others left open."

--- a/src/Kernel/Point.class.st
+++ b/src/Kernel/Point.class.st
@@ -759,12 +759,6 @@ Point >> truncated [
 	^ x truncated @ y truncated
 ]
 
-{ #category : 'copying' }
-Point >> veryDeepCopyWith: deepCopier [
-	"Return self.  I am immutable in the Morphic world.  Do not record me."
-	^ self
-]
-
 { #category : 'accessing' }
 Point >> x [
 	"Answer the x coordinate."

--- a/src/Kernel/SmallFloat64.class.st
+++ b/src/Kernel/SmallFloat64.class.st
@@ -328,12 +328,6 @@ SmallFloat64 >> truncated [
 		ifFalse: [^ self asTrueFraction.  "Extract all bits of the mantissa and shift if necess"]
 ]
 
-{ #category : 'copying' }
-SmallFloat64 >> veryDeepCopyWith: deepCopier [
-	"Answer the receiver, because SmallFloat64s are unique."
-	^self
-]
-
 { #category : 'comparing' }
 SmallFloat64 >> ~= aNumber [
 	"Primitive. Compare the receiver with the argument and return true

--- a/src/Kernel/SmallInteger.class.st
+++ b/src/Kernel/SmallInteger.class.st
@@ -585,11 +585,6 @@ SmallInteger >> quo: aNumber [
 SmallInteger >> shallowCopy [
 ]
 
-{ #category : 'copying' }
-SmallInteger >> veryDeepCopyWith: deepCopier [
-	"Return self.  I can't be copied.  Do not record me."
-]
-
 { #category : 'comparing' }
 SmallInteger >> ~= aNumber [
 	"Primitive. Compare the receiver with the argument and answer true if

--- a/src/Kernel/UndefinedObject.class.st
+++ b/src/Kernel/UndefinedObject.class.st
@@ -240,8 +240,3 @@ UndefinedObject >> subclassesDo: aBlock [
 	^ Class subclassesDo: [:cl |
 			cl isMeta ifTrue: [aBlock value: cl soleInstance]]
 ]
-
-{ #category : 'copying' }
-UndefinedObject >> veryDeepCopyWith: deepCopier [
-	"Return self.  I can't be copied.  Do not record me."
-]

--- a/src/System-Model/Boolean.extension.st
+++ b/src/System-Model/Boolean.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'Boolean' }
+
+{ #category : '*System-Model' }
+Boolean >> veryDeepCopyWith: deepCopier [
+	"Return self.  I can't be copied.  Do not record me."
+]

--- a/src/System-Model/Character.extension.st
+++ b/src/System-Model/Character.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'Character' }
+
+{ #category : '*System-Model' }
+Character >> veryDeepCopyWith: deepCopier [
+	"Answer the receiver, because Characters are unique."
+	^self
+]

--- a/src/System-Model/CompiledMethod.extension.st
+++ b/src/System-Model/CompiledMethod.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'CompiledMethod' }
+
+{ #category : '*System-Model' }
+CompiledMethod >> veryDeepCopyWith: deepCopier [
+	"Return self.  I am always shared.  Do not record me.  Only use this for blocks.  Normally methodDictionaries should not be copied this way."
+]

--- a/src/System-Model/Float.extension.st
+++ b/src/System-Model/Float.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'Float' }
+
+{ #category : '*System-Model' }
+Float >> veryDeepCopyWith: deepCopier [
+	"Return self.  Do not record me."
+
+	^ self shallowCopy
+]

--- a/src/System-Model/HashedCollection.extension.st
+++ b/src/System-Model/HashedCollection.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'HashedCollection' }
+
+{ #category : '*System-Model' }
+HashedCollection >> veryDeepCopyWith: deepCopier [
+	| copyOfSelf|
+	copyOfSelf := super veryDeepCopyWith: deepCopier.
+	"force Sets and Dictionaries to rehash"
+	copyOfSelf rehash.
+		^ copyOfSelf
+]

--- a/src/System-Model/Object.extension.st
+++ b/src/System-Model/Object.extension.st
@@ -110,3 +110,65 @@ Object >> veryDeepCopy [
 	copier fixDependents.
 	^ new
 ]
+
+{ #category : '*System-Model' }
+Object >> veryDeepCopyWith: deepCopier [
+	"Copy me and the entire tree of objects I point to.  An object in the tree twice is copied once, and both references point to him.  deepCopier holds a dictionary of objects we have seen.  Some classes refuse to be copied.  Some classes are picky about which fields get deep copied."
+
+	| class selfNumberOfInstanceVariables fieldOfSelf copyOfSelf currentClass hasVeryDeepInnerMethod currentNumberOfInstanceVariables |
+
+	deepCopier references at: self ifPresent: [ :newer | 	"already copied" ^ newer].
+	class := self class.
+	class isMeta ifTrue: [ "a metaclass" ^ self ].
+	copyOfSelf := self shallowCopy.
+	deepCopier references at: self put: copyOfSelf.	"remember"
+
+	(class isVariable and: [class isPointers]) ifTrue: [
+		self basicSize to: 1 by: -1 do: [ :i |
+			fieldOfSelf := self basicAt: i.
+			copyOfSelf
+				basicAt: i
+				put: (deepCopier references
+					at: fieldOfSelf
+					ifAbsent: [ fieldOfSelf veryDeepCopyWith: deepCopier ])]].
+
+	"Ask each superclass if it wants to share (weak copy) any inst vars"
+	copyOfSelf veryDeepInner: deepCopier.
+
+	"other superclasses want all instance variables deep copied"
+	currentClass := class.
+	selfNumberOfInstanceVariables := class instSize.
+
+	[ selfNumberOfInstanceVariables == 0 ] whileFalse: [
+		hasVeryDeepInnerMethod := currentClass includesSelector: #veryDeepInner:.
+		currentNumberOfInstanceVariables := currentClass instSize - currentClass superclass instSize.
+		hasVeryDeepInnerMethod
+			ifTrue: ["skip inst vars"
+				selfNumberOfInstanceVariables := selfNumberOfInstanceVariables - currentNumberOfInstanceVariables]
+			ifFalse: [
+				currentNumberOfInstanceVariables timesRepeat: [
+					fieldOfSelf := self instVarAt: selfNumberOfInstanceVariables.
+					copyOfSelf
+						instVarAt: selfNumberOfInstanceVariables
+						put: (deepCopier references
+							at: fieldOfSelf
+							ifAbsent: [ fieldOfSelf veryDeepCopyWith: deepCopier ]).
+					selfNumberOfInstanceVariables := selfNumberOfInstanceVariables - 1 ]].
+		currentClass := currentClass superclass ].
+
+	^ copyOfSelf
+]
+
+{ #category : '*System-Model' }
+Object >> veryDeepFixupWith: deepCopier [
+	"I have no fields and no superclass.  Catch the super call."
+
+	"avoid to use me we will deprecate it in the future"
+]
+
+{ #category : '*System-Model' }
+Object >> veryDeepInner: deepCopier [
+	"No special treatment for inst vars of my superclasses.  Override when some need to be weakly copied.  Object>>veryDeepCopyWith: will veryDeepCopy any inst var whose class does not actually define veryDeepInner:"
+
+	"avoid to use me we will deprecate it in the future"
+]

--- a/src/System-Model/Point.extension.st
+++ b/src/System-Model/Point.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'Point' }
+
+{ #category : '*System-Model' }
+Point >> veryDeepCopyWith: deepCopier [
+	"Return self.  I am immutable in the Morphic world.  Do not record me."
+	^ self
+]

--- a/src/System-Model/SmallFloat64.extension.st
+++ b/src/System-Model/SmallFloat64.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'SmallFloat64' }
+
+{ #category : '*System-Model' }
+SmallFloat64 >> veryDeepCopyWith: deepCopier [
+	"Answer the receiver, because SmallFloat64s are unique."
+	^self
+]

--- a/src/System-Model/SmallInteger.extension.st
+++ b/src/System-Model/SmallInteger.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'SmallInteger' }
+
+{ #category : '*System-Model' }
+SmallInteger >> veryDeepCopyWith: deepCopier [
+	"Return self.  I can't be copied.  Do not record me."
+]

--- a/src/System-Model/SmalltalkImage.extension.st
+++ b/src/System-Model/SmalltalkImage.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'SmalltalkImage' }
+
+{ #category : '*System-Model' }
+SmalltalkImage >> veryDeepCopyWith: deepCopier [
+	"Return self.  I can't be copied.  Do not record me."
+]

--- a/src/System-Model/Symbol.extension.st
+++ b/src/System-Model/Symbol.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'Symbol' }
+
+{ #category : '*System-Model' }
+Symbol >> veryDeepCopyWith: deepCopier [
+	"Return self.  I am immutable in the Morphic world.  Do not record me."
+]

--- a/src/System-Model/SystemEnvironment.extension.st
+++ b/src/System-Model/SystemEnvironment.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'SystemEnvironment' }
+
+{ #category : '*System-Model' }
+SystemEnvironment >> veryDeepCopyWith: deepCopier [
+	"Return self. I can't be copied. Do not record me."
+]

--- a/src/System-Model/UndefinedObject.extension.st
+++ b/src/System-Model/UndefinedObject.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'UndefinedObject' }
+
+{ #category : '*System-Model' }
+UndefinedObject >> veryDeepCopyWith: deepCopier [
+	"Return self.  I can't be copied.  Do not record me."
+]

--- a/src/System-Support/ManifestSystemSupport.class.st
+++ b/src/System-Support/ManifestSystemSupport.class.st
@@ -28,8 +28,3 @@ ManifestSystemSupport class >> ruleClassNameInSelectorRuleV1FalsePositive [
 ManifestSystemSupport class >> ruleInconsistentMethodClassificationRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#SystemEnvironment #at:put: #false)) #'2021-11-02T18:04:16.398839+01:00') #(#(#RGMethodDefinition #(#SystemEnvironment #removeKey:ifAbsent: #false)) #'2021-11-02T18:06:16.506535+01:00') )
 ]
-
-{ #category : 'code-critics' }
-ManifestSystemSupport class >> ruleUtilityMethodsRuleV1FalsePositive [
-	^ #(#(#(#RGMethodDefinition #(#SystemEnvironment #veryDeepCopyWith: #false)) #'2021-11-02T18:14:26.131262+01:00') )
-]

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1721,11 +1721,6 @@ SmalltalkImage >> version [
 		  ifNotNil: [ :version | version version ]
 ]
 
-{ #category : 'copying' }
-SmalltalkImage >> veryDeepCopyWith: deepCopier [
-	"Return self.  I can't be copied.  Do not record me."
-]
-
 { #category : 'accessing' }
 SmalltalkImage >> vm [
 	"Answer the object to query about virtual machine."

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -478,8 +478,3 @@ SystemEnvironment >> undeclaredRegistry [
 
 	^ Undeclared
 ]
-
-{ #category : 'copying' }
-SystemEnvironment >> veryDeepCopyWith: deepCopier [
-	"Return self. I can't be copied. Do not record me."
-]


### PR DESCRIPTION
Multip[le methods of the kernel are here as an inner implementation of system model. I propose to move then in System-Model because this code is useless without this package