### PR TITLE
P12 - 18785-OmTimeStampSuffixStrategy-could-generate-duplicated-values

### DIFF
--- a/src/Ombu/OmTimeStampSuffixStrategy.class.st
+++ b/src/Ombu/OmTimeStampSuffixStrategy.class.st
@@ -7,6 +7,9 @@ Class {
 	#instVars : [
 		'lastNanos'
 	],
+	#pools : [
+		'ChronologyConstants'
+	],
 	#category : 'Ombu-Strategies',
 	#package : 'Ombu',
 	#tag : 'Strategies'
@@ -22,9 +25,11 @@ OmTimeStampSuffixStrategy >> nextSuffix [
 	Maybe this will get fixed in the  future? Check https://github.com/pharo-project/pharo/issues/13447 and if it's the case, remove the hack :)
 	OmSessionStoreTest>>#testNextStoreName is here to make sure we have no regression while running it on Windows, so if the hack is still needed you will know it."
 
-	| currentNanos |
+	| currentNanos now |
 	
-	currentNanos := DateAndTime now asNanoSeconds.
+	now := DateAndTime now asUTC.
+	"We need to get the full nanos, since epoch, because only using #nanoSecond is from midnight"
+	currentNanos := now asSeconds * NanosInSecond + now nanoSecond.
 	
 	lastNanos :=  (lastNanos isNotNil and: [currentNanos <= lastNanos]) 
 		ifTrue: [ lastNanos + 1 ]


### PR DESCRIPTION
Fix #18785 for Pharo12