### PR TITLE
P14-18785-OmTimeStampSuffixStrategy-could-generate-duplicated-values

### DIFF
--- a/src/Ombu/OmTimeStampSuffixStrategy.class.st
+++ b/src/Ombu/OmTimeStampSuffixStrategy.class.st
@@ -7,6 +7,9 @@ Class {
 	#instVars : [
 		'lastSuffix'
 	],
+	#pools : [
+		'ChronologyConstants'
+	],
 	#category : 'Ombu-Strategies',
 	#package : 'Ombu',
 	#tag : 'Strategies'
@@ -22,8 +25,13 @@ OmTimeStampSuffixStrategy >> nextSuffix [
 	Maybe this will get fixed in the  future? Check https://github.com/pharo-project/pharo/issues/13447 and if it's the case, remove the hack :)
 	OmSessionStoreTest>>#testNextStoreName is here to make sure we have no regression while running it on Windows, so if the hack is still needed you will know it."
 
-	| stamp |
-	stamp := DateAndTime now asNanoSeconds printStringHex.
+	| stamp currentNanos now |
+	now := DateAndTime now asUTC.
+
+	"We need to get the full nanos, since epoch, because only using #nanoSecond is from midnight"
+	currentNanos := now asSeconds * NanosInSecond + now nanoSecond.
+
+	stamp := currentNanos printStringHex.
 	"We continue until we have a new stamp because we changed of millisecond"
 	^ (Smalltalk os isWindows and: [ lastSuffix = stamp ])
 		  ifTrue: [ self nextSuffix ]


### PR DESCRIPTION
Fix #18785 for P14