### PR TITLE
Cut dependencies of FreeType to FormCanvas and System-Model

### DIFF
--- a/src/FreeType-Tests/ShortIntegerArrayTest.class.st
+++ b/src/FreeType-Tests/ShortIntegerArrayTest.class.st
@@ -7,8 +7,8 @@ Class {
 	#instVars : [
 		'shortIntegerArray'
 	],
-	#category : 'FormCanvas-Tests',
-	#package : 'FormCanvas-Tests'
+	#category : 'FreeType-Tests',
+	#package : 'FreeType-Tests'
 }
 
 { #category : 'running' }

--- a/src/FreeType/FreeTypeSystemSettings.class.st
+++ b/src/FreeType/FreeTypeSystemSettings.class.st
@@ -3,7 +3,7 @@ Settings for the FreeType system
 "
 Class {
 	#name : 'FreeTypeSystemSettings',
-	#superclass : 'Model',
+	#superclass : 'Object',
 	#classVars : [
 		'LoadFT2Library'
 	],

--- a/src/FreeType/ShortIntegerArray.class.st
+++ b/src/FreeType/ShortIntegerArray.class.st
@@ -8,9 +8,9 @@ Class {
 	#classVars : [
 		'LastSaveOrder'
 	],
-	#category : 'FormCanvas-Core-BalloonEngine',
-	#package : 'FormCanvas-Core',
-	#tag : 'BalloonEngine'
+	#category : 'FreeType-Base',
+	#package : 'FreeType',
+	#tag : 'Base'
 }
 
 { #category : 'class initialization' }


### PR DESCRIPTION
Remove two simple dependencies of FreeTypes:
- FreeType depends on ShortIntegerArray but it is the only user. So I'm moving the class to this package
- FreeType has a class inheriting from Model but never uses methods from its superclass. We can remove this dependency