### PR TITLE
Bootstrap: Remove some duplicated load spots

### DIFF
--- a/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st
+++ b/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st
@@ -1,5 +1,5 @@
 | mcPackages |
-mcPackages := BaselineOfMonticello remoteRepositoriesPackageNames.
+mcPackages := #( 'Network-Kernel' 'Network-Protocols' 'Zinc-Resource-Meta-Core' 'Network-MIME' 'Zinc-HTTP' 'MonticelloRemoteRepositories' 'Zodiac-Core' ).
 
 (MonticelloBootstrap inDirectory: (CommandLineArguments new optionAt: 'BOOTSTRAP_PACKAGE_CACHE_DIR' ifAbsent: [ MCCacheRepository uniqueInstance directory ]) asFileReference)
   loadPackagesNamed: mcPackages!

--- a/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st
+++ b/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st
@@ -1,16 +1,5 @@
 | mcPackages |
-mcPackages := #(
- 'Network-Kernel'
- 'Network-Protocols'
-
- 'Zinc-Resource-Meta-Core'
- 'Network-MIME'
- 'Zinc-HTTP'
- 
- 'MonticelloRemoteRepositories'
-
- 'Zodiac-Core'
- ).
+mcPackages := BaselineOfMonticello remoteRepositoriesPackageNames.
 
 (MonticelloBootstrap inDirectory: (CommandLineArguments new optionAt: 'BOOTSTRAP_PACKAGE_CACHE_DIR' ifAbsent: [ MCCacheRepository uniqueInstance directory ]) asFileReference)
   loadPackagesNamed: mcPackages!

--- a/src/PharoBootstrap/PBBootstrap.class.st
+++ b/src/PharoBootstrap/PBBootstrap.class.st
@@ -145,6 +145,7 @@ PBBootstrap >> createImage [
 PBBootstrap >> ensureBaselineOfPharoBootstrap [
 	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfPharoBootstrap')) load.
 	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfTraits')) load.
+	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfMonticello')) load.
 	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfMetacello')) load.	
 ]
 
@@ -321,22 +322,15 @@ PBBootstrap >> mczCache [
 { #category : 'package-names' }
 PBBootstrap >> monticelloNetworkPackageNames [
 
-	^ #('Network-Kernel'
-		 'Network-Protocols'
-		 
-		 'Zinc-Resource-Meta-Core'
-		 'Network-MIME'
-		 'Zinc-HTTP'
-
-		 'MonticelloRemoteRepositories'
-		 
-		 'Zodiac-Core')
+	self ensureBaselineOfPharoBootstrap.
+	^ #BaselineOfMonticello asClass remoteRepositoriesPackageNames
 ]
 
 { #category : 'package-names' }
 PBBootstrap >> monticelloPackageNames [
 
-	^ #('System-Changes' 'Ring-Definitions-Core' 'Ring-OldChunkImporter' 'Jobs' 'Compression' 'Monticello-Model' 'Monticello' 'Ring-Definitions-Monticello' )
+	self ensureBaselineOfPharoBootstrap.
+	^ #BaselineOfMonticello asClass corePackageNames
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Packages to load for the core of monticello needs to be declared in 2 places (1 outside of the loaded Pharo code).

Packages to load for remote repositories of Monticello needs to be declared in 3 places (2 outside of the loaded Pharo code).

With this change, we will only need to declare them in one place for Monticello and in 2 places for remote monticello