### PR TITLE
Pharo 12 backport: fix cache flush SystemDictionary>>#add:

### DIFF
--- a/src/System-Support-Tests/SystemDictionaryTest.class.st
+++ b/src/System-Support-Tests/SystemDictionaryTest.class.st
@@ -56,6 +56,20 @@ SystemDictionaryTest >> supportsNilKey [
 	^ false
 ]
 
+{ #category : 'tests' }
+SystemDictionaryTest >> testAddFlushesCaches [
+	"we add to the environemnt with #add: and the cache is reset"
+	| enviroment |
+	enviroment := SystemDictionary new.
+	
+	enviroment add: (GlobalVariable key: #Object value: Object).
+	enviroment allBehaviors.
+	enviroment add: (GlobalVariable key: #Class value: Class).
+	"check that the cache was reset and we can find Class"
+	self assert: (enviroment instVarNamed: 'cachedBehaviors') isNil. 
+	self assert:( enviroment allBehaviors includes: Class).
+]
+
 { #category : 'tests - DictionaryIndexAccessing' }
 SystemDictionaryTest >> testAtPutNil [
 

--- a/src/System-Support/SystemDictionary.class.st
+++ b/src/System-Support/SystemDictionary.class.st
@@ -124,7 +124,7 @@ SystemDictionary >> at: aKey put: anObject [
  	index := self findElementOrNil: aKey.
  	assoc := array at: index.
  	assoc
- 		ifNil: [self atNewIndex: index put: (GlobalVariable key: aKey value: anObject). self flushClassNameCache]
+ 		ifNil: [self atNewIndex: index put: (GlobalVariable key: aKey value: anObject)]
  		ifNotNil: [assoc value: anObject].
 		
 	registeredMethods do: [ :aMethod | aMethod isInstalled ifTrue: [aMethod recompile] ].		
@@ -136,6 +136,7 @@ SystemDictionary >> at: aKey put: anObject [
 SystemDictionary >> atNewIndex: index put: aGlobalVariable [
 
 	aGlobalVariable isAssociation ifTrue: [ self error: 'Only global variables should be added to the SystemDictionary and not associations.' ].
+	self flushClassNameCache.
 	^ super atNewIndex: index put: aGlobalVariable
 ]
 


### PR DESCRIPTION
This is a backport of #1807: move cache flush to #atNewIndex:put: so it will be done for all code paths, including #add: