### PR TITLE
Deprecate ClassParentRenamed

### DIFF
--- a/src/Deprecated14/ClassParentRenamed.class.st
+++ b/src/Deprecated14/ClassParentRenamed.class.st
@@ -13,9 +13,8 @@ Class {
 		'parentOldName',
 		'parentNewName'
 	],
-	#category : 'System-Announcements-System-Classes',
-	#package : 'System-Announcements',
-	#tag : 'System-Classes'
+	#category : 'Deprecated14',
+	#package : 'Deprecated14'
 }
 
 { #category : 'instance creation' }
@@ -25,6 +24,13 @@ ClassParentRenamed class >> classParentOf: aClass renamedFrom: oldName to: newNa
 		parentNewName: newName;
 		classAffected: aClass;
 		yourself
+]
+
+{ #category : 'testing' }
+ClassParentRenamed class >> isDeprecated [
+	"You should register to ClassRenamed and iterate over the children instead"
+
+	^ true
 ]
 
 { #category : 'accessing' }

--- a/src/PharoDocComment/CompiledMethod.extension.st
+++ b/src/PharoDocComment/CompiledMethod.extension.st
@@ -8,7 +8,8 @@ CompiledMethod >> hasDocComment [
 { #category : '*PharoDocComment' }
 CompiledMethod >> pharoDocCommentNodes [
 	"we try to avoid to have to create the AST if we are sure that we do not need it"
-	^ (self sourceCode includesSubstring: '>>>')
-		  ifTrue: [ self ast pharoDocCommentNodes ]
-		  ifFalse: [ ^ #(  ) ]
+
+	self sourceCode ifNotNil: [ :code | (code includesSubstring: '>>>') ifTrue: [ ^ self ast pharoDocCommentNodes ] ].
+
+	^ #(  )
 ]

--- a/src/Ring-Core-Tests/RGAnnouncementsTest.class.st
+++ b/src/Ring-Core-Tests/RGAnnouncementsTest.class.st
@@ -129,25 +129,6 @@ RGAnnouncementsTest >> testBehaviorDefinitionModifiedForSuperclass [
 ]
 
 { #category : 'tests' }
-RGAnnouncementsTest >> testBehaviorParentRenamed [
-
-	| env announcements class superclass |
-
-	env := RGEnvironment new.
-	class := env ensureClassNamed: #SomeClass.
-	superclass := env ensureClassNamed: #SomeSuperclass.
-
-	class superclass: superclass.
-
-	announcements := self installAnnouncementsFor: class in: env when: ClassParentRenamed. 
-
-	class name: #NewName.
-	self assert: announcements size equals: 0.
-	superclass name: #NewSuperclass1.
-	self assert: announcements size equals: 1
-]
-
-{ #category : 'tests' }
 RGAnnouncementsTest >> testDirectAnnouncement [
 
 	| def announcements |

--- a/src/Ring-Core/RGBehavior.class.st
+++ b/src/Ring-Core/RGBehavior.class.st
@@ -741,8 +741,7 @@ RGBehavior >> name: aString [
 
 	subclassesWithOldDefinitions do: [ :assoc |
 		self announcer behaviorDefinitionChangedFrom: assoc value to: assoc key.
-		self announcer behaviorModificationAppliedTo: assoc key.
-		self announcer behaviorParentRenamed: assoc key from: oldName ]
+		self announcer behaviorModificationAppliedTo: assoc key ]
 ]
 
 { #category : 'testing' }
@@ -1194,8 +1193,7 @@ RGBehavior >> unresolveName [
 
 	subclassesWithOldDefinitions do: [ :assoc |
 		self announcer behaviorDefinitionChangedFrom: assoc value to: assoc key.
-		self announcer behaviorModificationAppliedTo: assoc key.
-		self announcer behaviorParentRenamed: assoc key from: oldName ]
+		self announcer behaviorModificationAppliedTo: assoc key ]
 ]
 
 { #category : 'accessing - backend' }

--- a/src/Ring-Core/RGEnvironmentAnnouncer.class.st
+++ b/src/Ring-Core/RGEnvironmentAnnouncer.class.st
@@ -44,15 +44,6 @@ RGEnvironmentAnnouncer >> behaviorModificationAppliedTo: anRGBehavior [
 ]
 
 { #category : 'triggering' }
-RGEnvironmentAnnouncer >> behaviorParentRenamed: anRGBehavior from: oldName [
-
-	self announce: (ClassParentRenamed
-		classParentOf: anRGBehavior
-		renamedFrom: oldName
-		to: anRGBehavior name)
-]
-
-{ #category : 'triggering' }
 RGEnvironmentAnnouncer >> behaviorRemoved: anRGBehavior [
 
 	self announce: (ClassRemoved class: anRGBehavior)

--- a/src/System-Announcements/SystemAnnouncer.class.st
+++ b/src/System-Announcements/SystemAnnouncer.class.st
@@ -77,11 +77,6 @@ SystemAnnouncer >> classModificationAppliedTo: aClassOrTrait [
 ]
 
 { #category : 'triggering' }
-SystemAnnouncer >> classParentOf: aClass renamedFrom: oldName to: newName [
-	self announce: (ClassParentRenamed classParentOf: aClass renamedFrom: oldName to: newName)
-]
-
-{ #category : 'triggering' }
 SystemAnnouncer >> classRenamed: aClass from: oldClassName to: newClassName [
 
 	self announce: (ClassRenamed class: aClass oldName: oldClassName newName: newClassName)

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -436,8 +436,7 @@ SystemEnvironment >> renameClass: aClass from: oldName [
 	oldref key: aClass name.
 	self add: oldref. "Old association preserves old refs"
 	self flushClassNameCache.
-	self class codeChangeAnnouncer classRenamed: aClass from: oldName to: aClass name.
-	aClass subclassesDo: [ :subclass | self class codeChangeAnnouncer classParentOf: subclass renamedFrom: oldName to: aClass name ]
+	self class codeChangeAnnouncer classRenamed: aClass from: oldName to: aClass name
 ]
 
 { #category : 'renaming' }


### PR DESCRIPTION
We can just register to ClassRenamed and iterate over the subclasses instead of having a duplicated announcement