### PR TITLE
Extract Fonts and FreeType from BaselineOfMorphicCore

### DIFF
--- a/src/BaselineOfFonts/BaselineOfFonts.class.st
+++ b/src/BaselineOfFonts/BaselineOfFonts.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : 'BaselineOfFonts',
 	#superclass : 'BaselineOf',
-	#instVars : [
-		'initializersEnabled'
-	],
 	#category : 'BaselineOfFonts',
 	#package : 'BaselineOfFonts'
 }
@@ -13,7 +10,6 @@ BaselineOfFonts >> baseline: spec [
 
 	<baseline>
 	spec for: #common do: [
-			spec preLoadDoIt: #preload:package:.
 			spec postLoadDoIt: #postload:package:.
 
 			spec
@@ -134,15 +130,5 @@ BaselineOfFonts >> loadBitmapSourcePro [
 BaselineOfFonts >> postload: loader package: packageSpec [
 
 	self loadBitmapDejaVuSans.
-	self loadBitmapSourcePro.
-
-	MCMethodDefinition initializersEnabled: initializersEnabled
-]
-
-{ #category : 'actions' }
-BaselineOfFonts >> preload: loader package: packageSpec [
-	"For now we ensure the class initialization but in the future it should be true by default"
-
-	initializersEnabled := MCMethodDefinition initializersEnabled.
-	MCMethodDefinition initializersEnabled: true
+	self loadBitmapSourcePro
 ]

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -126,19 +126,11 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 
 	SystemNotification signal: 'Starting postload action'.
 
-	TextConstants initialize.
-
-	Stdio stdout
-		nextPutAll: 'starting...';
-		lf.
-
 	Stdio stdout
 		nextPutAll: Smalltalk ui asString;
 		lf.
 
-	#( #ProgressBarMorph #FT2Types #FT2FFILibrary #FreeTypeCacheConstants
-	   #FreeTypeCache #FreeTypeSettings #FreeTypeSubPixelAntiAliasedGlyphRenderer
-	   #FT2Constants #GlobalIdentifier #HaloMorph
+	#( #ProgressBarMorph #GlobalIdentifier #HaloMorph
 	   #CharacterScanner #ImageMorph
 	   #Locale #MczInstaller #MD5NonPrimitive #MenuItemMorph
 	   #MenuMorph #RxMatcher #RxParser #RxsPredicate #SHA1
@@ -169,15 +161,9 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 	PolymorphSystemSettings showDesktopLogo: true.
 	PolymorphSystemSettings desktopColor: Color white.
 
-	#( #BalloonMorph #EmbeddedFreeTypeFontInstaller
-	   #FreeTypeFontProvider
-	   #IconicButtonMorph #KMLog
-	   #LucidaGrandeRegular #ScrollBarMorph
+	#( #BalloonMorph #IconicButtonMorph #KMLog #ScrollBarMorph
 	   #SystemSettingsPersistence #TabMorph #TaskbarMorph ) do: [ :each |
 		(Smalltalk globals at: each) initialize ].
-
-	LogicalFontManager current addFontProvider:
-		FreeTypeFontProvider current.
 
 	MCMethodDefinition initializersEnabled: initializersEnabled.
 

--- a/src/BaselineOfUI/BaselineOfUI.class.st
+++ b/src/BaselineOfUI/BaselineOfUI.class.st
@@ -44,6 +44,14 @@ BaselineOfUI >> baseline: spec [
 		spec package: 'Debugger-Oups'.
 
 		spec baseline: 'Display' with: [ spec repository: repository ].
+		spec baseline: 'Fonts' with: [
+				spec
+					repository: repository;
+					loads: #Core ].
+		spec baseline: 'FreeType' with: [
+			spec
+				repository: repository;
+				loads: 'ui' ].
 		spec baseline: 'Fuel' with: [
 			spec
 				repository: repository;

--- a/src/Fonts-Abstract/AbstractFont.class.st
+++ b/src/Fonts-Abstract/AbstractFont.class.st
@@ -39,13 +39,6 @@ AbstractFont class >> isAbstract [
 	^self == AbstractFont
 ]
 
-{ #category : 'updating' }
-AbstractFont class >> update: anAspect [
-
-	anAspect == #textDPIChanged ifTrue: [
-		AbstractFont allSubInstancesDo: [ :font | font pixelsPerInchChanged ]]
-]
-
 { #category : 'measuring' }
 AbstractFont >> approxWidthOfText: aText [
 	"Return the width of aText -- quickly, and a little bit dirty. Used by lists morphs containing Text objects to get a quick, fairly accurate measure of the width of a list item."

--- a/src/FreeType/FreeTypeFontProvider.class.st
+++ b/src/FreeType/FreeTypeFontProvider.class.st
@@ -59,7 +59,9 @@ FreeTypeFontProvider class >> initialize [
 	FreeTypeSettings initialize.
 
 	current := nil.
-	self current "this creates an instance of me, and updates from the system"
+	self current. "this creates an instance of me, and updates from the system"
+	LogicalFontManager current addFontProvider:
+		self current.
 ]
 
 { #category : 'accessing' }

--- a/src/Graphics-Fonts/TextStyle.extension.st
+++ b/src/Graphics-Fonts/TextStyle.extension.st
@@ -2,7 +2,8 @@ Extension { #name : 'TextStyle' }
 
 { #category : '*Graphics-Fonts' }
 TextStyle class >> pixelsPerInch: aNumber [
-  "Set the nominal number of pixels per inch to aNumber."
-  TextSharedInformation at: #pixelsPerInch put: aNumber asFloat.
-  self changed: #textDPIChanged
+	"Set the nominal number of pixels per inch to aNumber."
+
+	TextSharedInformation at: #pixelsPerInch put: aNumber asFloat.
+	AbstractFont allSubInstancesDo: [ :font | font pixelsPerInchChanged ]
 ]

--- a/src/Text-Core/ManifestTextCore.class.st
+++ b/src/Text-Core/ManifestTextCore.class.st
@@ -11,5 +11,6 @@ Class {
 
 { #category : 'meta-data - dependency analyser' }
 ManifestTextCore class >> manuallyResolvedDependencies [
-	^ #(#'Fonts-Abstract' #'AST-Core')
+
+	^ #( #'AST-Core' )
 ]

--- a/src/Text-Core/TextStyle.class.st
+++ b/src/Text-Core/TextStyle.class.st
@@ -35,9 +35,6 @@ Class {
 	#pools : [
 		'TextConstants'
 	],
-	#classInstVars : [
-		'notifier'
-	],
 	#category : 'Text-Core-Base',
 	#package : 'Text-Core',
 	#tag : 'Base'
@@ -51,18 +48,6 @@ TextStyle class >> actualTextStyles [
 	aDict := TextSharedInformation select: [ :thang | thang isKindOf: self ].
 	self defaultFamilyNames do: [ :sym | aDict removeKey: sym ].
 	^ aDict
-]
-
-{ #category : 'accessing' }
-TextStyle class >> addDependent: anObject [
-
-	self notifier addDependent: anObject
-]
-
-{ #category : 'accessing' }
-TextStyle class >> changed: anAspect [
-
-	self notifier changed: anAspect
 ]
 
 { #category : 'utilities' }
@@ -164,8 +149,7 @@ TextStyle class >> fontSizesFor: aName [
 { #category : 'class initialization' }
 TextStyle class >> initialize [
 
-	self initializeStyleDecoder.
-	self addDependent: AbstractFont "This code was originaly in AbstractFont class>>initialize but this was creating a cyclic dependency"
+	self initializeStyleDecoder
 ]
 
 { #category : 'private - initialization' }
@@ -209,12 +193,6 @@ TextStyle class >> new [
 	^ super new leading: 2
 ]
 
-{ #category : 'accessing' }
-TextStyle class >> notifier [
-
-	^ notifier ifNil: [ notifier := Model new ]
-]
-
 { #category : 'utilities' }
 TextStyle class >> pixelsPerInch [
 	"Answer the nominal resolution of the screen."
@@ -238,12 +216,6 @@ TextStyle class >> pointSizesFor: aName [
 { #category : 'utilities' }
 TextStyle class >> pointsToPixels: points [
 	^points * self pixelsPerInch / 72.0
-]
-
-{ #category : 'accessing' }
-TextStyle class >> removeDependent: anObject [
-
-	self notifier removeDependent: anObject
 ]
 
 { #category : 'constants' }


### PR DESCRIPTION
This change cut the last dependencies to Morphic (Or to System-Model exactly) in Font and FreeType so now I propose to extract it to BaselineOfUI.
This removes the initialization code of FreeType from BaselineOfMorphic