### PR TITLE
Fix large array compilation

### DIFF
--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -1034,6 +1034,10 @@ EncoderForSistaV1 >> genPushConsArray: size [
 		[^self outOfRangeError: 'size' index: size range: 0 to: 127].
 	"231		11100111	jkkkkkkk	Push (Array new: kkkkkkk) (j = 0)
 									&	Pop kkkkkkk elements into: (Array new: kkkkkkk) (j = 1)"
+
+"	(stream stackFrameSize > CompiledCode LargeFrame )
+	ifTrue: [ 1halt ] ifFalse: [ 1halt ].
+"
 	stream
 		nextPut: 231;
 		nextPut: size + 128

--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -1030,14 +1030,13 @@ EncoderForSistaV1 >> genPushCharacter: aCharacterOrCode [
 
 { #category : 'bytecode generation' }
 EncoderForSistaV1 >> genPushConsArray: size [
-	(size < 0 or: [size > 127]) ifTrue:
-		[^self outOfRangeError: 'size' index: size range: 0 to: 127].
 	"231		11100111	jkkkkkkk	Push (Array new: kkkkkkk) (j = 0)
 									&	Pop kkkkkkk elements into: (Array new: kkkkkkk) (j = 1)"
+	| limit |
+	limit := OCIRPushArray sizeLimit.
+	(size < 0 or: [size > limit]) ifTrue:
+		[^self outOfRangeError: 'size' index: size range: 0 to: limit].
 
-"	(stream stackFrameSize > CompiledCode LargeFrame )
-	ifTrue: [ 1halt ] ifFalse: [ 1halt ].
-"
 	stream
 		nextPut: 231;
 		nextPut: size + 128

--- a/src/Kernel-CodeModel/CompiledCode.class.st
+++ b/src/Kernel-CodeModel/CompiledCode.class.st
@@ -39,6 +39,12 @@ Class {
 	#tag : 'Methods'
 }
 
+{ #category : 'class initialization' }
+CompiledCode class >> LargeFrame [
+
+	^ LargeFrame
+]
+
 { #category : 'instance creation' }
 CompiledCode class >> basicNew [
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -555,8 +555,9 @@ OCASTTranslator >> visitAnnotationMarkNode: aAnnotationValueNode [
 { #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitArrayNode: anArrayNode [
 
-	| elementNodes |
-	methodBuilder stackSize + anArrayNode statements size > CompiledCode LargeFrame ifTrue: [
+	| elementNodes stackLimit |
+	stackLimit := CompiledCode LargeFrame min: OCIRPushArray sizeLimit.
+	methodBuilder stackSize + anArrayNode statements size > stackLimit ifTrue: [
 		^ self visitLargeArrayNode: anArrayNode ].
 
 	elementNodes := anArrayNode children.

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -556,11 +556,11 @@ OCASTTranslator >> visitAnnotationMarkNode: aAnnotationValueNode [
 OCASTTranslator >> visitArrayNode: anArrayNode [
 
 	| elementNodes |
-
-	anArrayNode statements size > 32 ifTrue: [^ self visitLargeArrayNode: anArrayNode ].
+	methodBuilder stackSize + anArrayNode statements size > CompiledCode LargeFrame ifTrue: [
+		^ self visitLargeArrayNode: anArrayNode ].
 
 	elementNodes := anArrayNode children.
-	elementNodes do: [:node | self visitNode: node].
+	elementNodes do: [ :node | self visitNode: node ].
 	methodBuilder pushConsArray: elementNodes size
 ]
 
@@ -706,7 +706,7 @@ OCASTTranslator >> visitInlinedBlockNode: anOptimizedBlockNode [
 
 { #category : 'visitor - double dispatching' }
 OCASTTranslator >> visitLargeArrayNode: anArrayNode [
-	"Long form: using at:put:"
+	"Long approach using at:put:"
 	methodBuilder pushLiteralVariable: Array binding.
 	methodBuilder pushLiteral: anArrayNode statements size.
 	methodBuilder send: #new:.

--- a/src/OpalCompiler-Core/OCIRBuilder.class.st
+++ b/src/OpalCompiler-Core/OCIRBuilder.class.st
@@ -33,7 +33,8 @@ Class {
 		'jumpAheadStacks',
 		'currentSequence',
 		'sourceMapNodes',
-		'sourceMapByteIndex'
+		'sourceMapByteIndex',
+		'stackSize'
 	],
 	#category : 'OpalCompiler-Core-IR-Manipulation',
 	#package : 'OpalCompiler-Core',
@@ -56,6 +57,8 @@ OCIRBuilder >> add: instr [
 	"Associate instr with current parse node or byte range"
 	instr sourceNode: self sourceNode.
 	instr bytecodeIndex: self sourceByteIndex.
+
+	stackSize := stackSize + instr deltaStack.	
 	^ currentSequence add: instr
 ]
 
@@ -175,6 +178,7 @@ OCIRBuilder >> initialize [
 	jumpBackTargetStacks := IdentityDictionary new.
 	sourceMapNodes := OrderedCollection new.	"stack"
 	currentScope := Stack new.
+	stackSize := 0.
 	self pushScope: ir.
 
 	"Leave an empty sequence up front (guaranteed not to be in loop)"
@@ -423,6 +427,12 @@ OCIRBuilder >> sourceNode [
 	^ sourceMapNodes
 		ifEmpty: [nil]
 		ifNotEmpty: [sourceMapNodes last]
+]
+
+{ #category : 'accessing' }
+OCIRBuilder >> stackSize [
+
+	^ stackSize
 ]
 
 { #category : 'private' }

--- a/src/OpalCompiler-Core/OCIRInstruction.class.st
+++ b/src/OpalCompiler-Core/OCIRInstruction.class.st
@@ -250,6 +250,12 @@ OCIRInstruction >> delete [
 	sequence remove: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRInstruction >> deltaStack [
+
+	^ 0
+]
+
 { #category : 'testing' }
 OCIRInstruction >> isBlockReturnTop [
 

--- a/src/OpalCompiler-Core/OCIRInstruction.class.st
+++ b/src/OpalCompiler-Core/OCIRInstruction.class.st
@@ -250,7 +250,7 @@ OCIRInstruction >> delete [
 	sequence remove: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRInstruction >> deltaStack [
 
 	^ 0

--- a/src/OpalCompiler-Core/OCIRInstruction.class.st
+++ b/src/OpalCompiler-Core/OCIRInstruction.class.st
@@ -253,7 +253,7 @@ OCIRInstruction >> delete [
 { #category : 'stack' }
 OCIRInstruction >> deltaStack [
 
-	"This method indicates how the instruction affects the stack.
+	"This method indicates the number of elements that the current instruction introduces or removes from the execution stack.
 		n > 0 -> push n elements to the stack
 		n = 0 -> the stack does not change
 		n < 0 -> pop n elements from the stack

--- a/src/OpalCompiler-Core/OCIRInstruction.class.st
+++ b/src/OpalCompiler-Core/OCIRInstruction.class.st
@@ -253,6 +253,12 @@ OCIRInstruction >> delete [
 { #category : 'stack' }
 OCIRInstruction >> deltaStack [
 
+	"This method indicates how the instruction affects the stack.
+		n > 0 -> push n elements to the stack
+		n = 0 -> the stack does not change
+		n < 0 -> pop n elements from the stack
+	"
+
 	^ 0
 ]
 

--- a/src/OpalCompiler-Core/OCIRPop.class.st
+++ b/src/OpalCompiler-Core/OCIRPop.class.st
@@ -14,6 +14,12 @@ OCIRPop >> accept: aVisitor [
 	^ aVisitor visitPop: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPop >> deltaStack [
+
+	^ -1
+]
+
 { #category : 'testing' }
 OCIRPop >> isPop [
 	^true

--- a/src/OpalCompiler-Core/OCIRPop.class.st
+++ b/src/OpalCompiler-Core/OCIRPop.class.st
@@ -14,7 +14,7 @@ OCIRPop >> accept: aVisitor [
 	^ aVisitor visitPop: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPop >> deltaStack [
 
 	^ -1

--- a/src/OpalCompiler-Core/OCIRPopIntoInstVar.class.st
+++ b/src/OpalCompiler-Core/OCIRPopIntoInstVar.class.st
@@ -14,7 +14,7 @@ OCIRPopIntoInstVar >> accept: aVisitor [
 	^ aVisitor visitPopIntoInstVar: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPopIntoInstVar >> deltaStack [
 
 	^ -1

--- a/src/OpalCompiler-Core/OCIRPopIntoInstVar.class.st
+++ b/src/OpalCompiler-Core/OCIRPopIntoInstVar.class.st
@@ -13,3 +13,9 @@ Class {
 OCIRPopIntoInstVar >> accept: aVisitor [
 	^ aVisitor visitPopIntoInstVar: self
 ]
+
+{ #category : 'as yet unclassified' }
+OCIRPopIntoInstVar >> deltaStack [
+
+	^ -1
+]

--- a/src/OpalCompiler-Core/OCIRPopIntoLiteralVariable.class.st
+++ b/src/OpalCompiler-Core/OCIRPopIntoLiteralVariable.class.st
@@ -14,7 +14,7 @@ OCIRPopIntoLiteralVariable >> accept: aVisitor [
 	^ aVisitor visitPopIntoLiteralVariable: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPopIntoLiteralVariable >> deltaStack [
 
 	^ -1

--- a/src/OpalCompiler-Core/OCIRPopIntoLiteralVariable.class.st
+++ b/src/OpalCompiler-Core/OCIRPopIntoLiteralVariable.class.st
@@ -13,3 +13,9 @@ Class {
 OCIRPopIntoLiteralVariable >> accept: aVisitor [
 	^ aVisitor visitPopIntoLiteralVariable: self
 ]
+
+{ #category : 'as yet unclassified' }
+OCIRPopIntoLiteralVariable >> deltaStack [
+
+	^ -1
+]

--- a/src/OpalCompiler-Core/OCIRPopIntoRemoteTemp.class.st
+++ b/src/OpalCompiler-Core/OCIRPopIntoRemoteTemp.class.st
@@ -13,3 +13,9 @@ Class {
 OCIRPopIntoRemoteTemp >> accept: aVisitor [
 	^ aVisitor visitPopIntoRemoteTemp: self
 ]
+
+{ #category : 'as yet unclassified' }
+OCIRPopIntoRemoteTemp >> deltaStack [
+
+	^ -1
+]

--- a/src/OpalCompiler-Core/OCIRPopIntoRemoteTemp.class.st
+++ b/src/OpalCompiler-Core/OCIRPopIntoRemoteTemp.class.st
@@ -14,7 +14,7 @@ OCIRPopIntoRemoteTemp >> accept: aVisitor [
 	^ aVisitor visitPopIntoRemoteTemp: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPopIntoRemoteTemp >> deltaStack [
 
 	^ -1

--- a/src/OpalCompiler-Core/OCIRPopIntoTemp.class.st
+++ b/src/OpalCompiler-Core/OCIRPopIntoTemp.class.st
@@ -14,7 +14,7 @@ OCIRPopIntoTemp >> accept: aVisitor [
 	^ aVisitor visitPopIntoTemp: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPopIntoTemp >> deltaStack [
 
 	^ -1

--- a/src/OpalCompiler-Core/OCIRPopIntoTemp.class.st
+++ b/src/OpalCompiler-Core/OCIRPopIntoTemp.class.st
@@ -14,6 +14,12 @@ OCIRPopIntoTemp >> accept: aVisitor [
 	^ aVisitor visitPopIntoTemp: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPopIntoTemp >> deltaStack [
+
+	^ -1
+]
+
 { #category : 'accessing' }
 OCIRPopIntoTemp >> nextBytecodeOffsetAfterJump [
 	"if we are in to:do: answers the next byte code offset"

--- a/src/OpalCompiler-Core/OCIRPushArray.class.st
+++ b/src/OpalCompiler-Core/OCIRPushArray.class.st
@@ -30,6 +30,14 @@ OCIRPushArray >> cons: aBool [
 	cons := aBool
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPushArray >> deltaStack [
+
+	^ cons
+		  ifTrue: [ (size - 1) negated ]
+		  ifFalse: [ 1 ]
+]
+
 { #category : 'initialization' }
 OCIRPushArray >> initialize [
 	size := 0.

--- a/src/OpalCompiler-Core/OCIRPushArray.class.st
+++ b/src/OpalCompiler-Core/OCIRPushArray.class.st
@@ -36,7 +36,7 @@ OCIRPushArray >> cons: aBool [
 	cons := aBool
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushArray >> deltaStack [
 
 	^ cons

--- a/src/OpalCompiler-Core/OCIRPushArray.class.st
+++ b/src/OpalCompiler-Core/OCIRPushArray.class.st
@@ -15,6 +15,12 @@ Class {
 	#tag : 'IR-Nodes'
 }
 
+{ #category : 'accessing' }
+OCIRPushArray class >> sizeLimit [
+
+	^ 127
+]
+
 { #category : 'visiting' }
 OCIRPushArray >> accept: aVisitor [
 	^ aVisitor visitPushArray: self

--- a/src/OpalCompiler-Core/OCIRPushDup.class.st
+++ b/src/OpalCompiler-Core/OCIRPushDup.class.st
@@ -16,6 +16,12 @@ OCIRPushDup >> accept: aVisitor [
 	^ aVisitor visitPushDup: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPushDup >> deltaStack [
+
+	^ 1
+]
+
 { #category : 'testing' }
 OCIRPushDup >> isRemovableByPop [
 

--- a/src/OpalCompiler-Core/OCIRPushDup.class.st
+++ b/src/OpalCompiler-Core/OCIRPushDup.class.st
@@ -16,7 +16,7 @@ OCIRPushDup >> accept: aVisitor [
 	^ aVisitor visitPushDup: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushDup >> deltaStack [
 
 	^ 1

--- a/src/OpalCompiler-Core/OCIRPushFullClosure.class.st
+++ b/src/OpalCompiler-Core/OCIRPushFullClosure.class.st
@@ -41,6 +41,12 @@ OCIRPushFullClosure >> copiedValues: anObject [
 	copiedValues := anObject
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPushFullClosure >> deltaStack [
+
+	^( copiedValues size - 1) negated
+]
+
 { #category : 'debugging' }
 OCIRPushFullClosure >> indexForVarNamed: aName [
 	^ sourceNode ir indexForVarNamed: aName

--- a/src/OpalCompiler-Core/OCIRPushFullClosure.class.st
+++ b/src/OpalCompiler-Core/OCIRPushFullClosure.class.st
@@ -41,7 +41,7 @@ OCIRPushFullClosure >> copiedValues: anObject [
 	copiedValues := anObject
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushFullClosure >> deltaStack [
 
 	^( copiedValues size - 1) negated

--- a/src/OpalCompiler-Core/OCIRPushInstVar.class.st
+++ b/src/OpalCompiler-Core/OCIRPushInstVar.class.st
@@ -19,6 +19,12 @@ OCIRPushInstVar >> canBeQuickReturn [
 	^ true
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPushInstVar >> deltaStack [
+
+	^ 1
+]
+
 { #category : 'testing' }
 OCIRPushInstVar >> isRemovableByPop [
 

--- a/src/OpalCompiler-Core/OCIRPushInstVar.class.st
+++ b/src/OpalCompiler-Core/OCIRPushInstVar.class.st
@@ -19,7 +19,7 @@ OCIRPushInstVar >> canBeQuickReturn [
 	^ true
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushInstVar >> deltaStack [
 
 	^ 1

--- a/src/OpalCompiler-Core/OCIRPushLiteral.class.st
+++ b/src/OpalCompiler-Core/OCIRPushLiteral.class.st
@@ -27,6 +27,12 @@ OCIRPushLiteral >> canBeQuickReturn [
 	^ #( nil true false -1 0 1 2 ) includes: literal
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPushLiteral >> deltaStack [
+
+	^ 1
+]
+
 { #category : 'testing' }
 OCIRPushLiteral >> isPushLiteral [
 

--- a/src/OpalCompiler-Core/OCIRPushLiteral.class.st
+++ b/src/OpalCompiler-Core/OCIRPushLiteral.class.st
@@ -27,7 +27,7 @@ OCIRPushLiteral >> canBeQuickReturn [
 	^ #( nil true false -1 0 1 2 ) includes: literal
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushLiteral >> deltaStack [
 
 	^ 1

--- a/src/OpalCompiler-Core/OCIRPushLiteralVariable.class.st
+++ b/src/OpalCompiler-Core/OCIRPushLiteralVariable.class.st
@@ -14,7 +14,7 @@ OCIRPushLiteralVariable >> accept: aVisitor [
 	^ aVisitor visitPushLiteralVariable: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushLiteralVariable >> deltaStack [
 
 	^ 1

--- a/src/OpalCompiler-Core/OCIRPushLiteralVariable.class.st
+++ b/src/OpalCompiler-Core/OCIRPushLiteralVariable.class.st
@@ -13,3 +13,9 @@ Class {
 OCIRPushLiteralVariable >> accept: aVisitor [
 	^ aVisitor visitPushLiteralVariable: self
 ]
+
+{ #category : 'as yet unclassified' }
+OCIRPushLiteralVariable >> deltaStack [
+
+	^ 1
+]

--- a/src/OpalCompiler-Core/OCIRPushReceiver.class.st
+++ b/src/OpalCompiler-Core/OCIRPushReceiver.class.st
@@ -19,6 +19,12 @@ OCIRPushReceiver >> canBeQuickReturn [
 	^ true
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPushReceiver >> deltaStack [
+
+	^ 1
+]
+
 { #category : 'testing' }
 OCIRPushReceiver >> isRemovableByPop [
 

--- a/src/OpalCompiler-Core/OCIRPushReceiver.class.st
+++ b/src/OpalCompiler-Core/OCIRPushReceiver.class.st
@@ -19,7 +19,7 @@ OCIRPushReceiver >> canBeQuickReturn [
 	^ true
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushReceiver >> deltaStack [
 
 	^ 1

--- a/src/OpalCompiler-Core/OCIRPushRemoteTemp.class.st
+++ b/src/OpalCompiler-Core/OCIRPushRemoteTemp.class.st
@@ -14,7 +14,7 @@ OCIRPushRemoteTemp >> accept: aVisitor [
 	^ aVisitor visitPushRemoteTemp: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushRemoteTemp >> deltaStack [
 
 	^ 1

--- a/src/OpalCompiler-Core/OCIRPushRemoteTemp.class.st
+++ b/src/OpalCompiler-Core/OCIRPushRemoteTemp.class.st
@@ -14,6 +14,12 @@ OCIRPushRemoteTemp >> accept: aVisitor [
 	^ aVisitor visitPushRemoteTemp: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPushRemoteTemp >> deltaStack [
+
+	^ 1
+]
+
 { #category : 'testing' }
 OCIRPushRemoteTemp >> isRemovableByPop [
 

--- a/src/OpalCompiler-Core/OCIRPushTemp.class.st
+++ b/src/OpalCompiler-Core/OCIRPushTemp.class.st
@@ -14,7 +14,7 @@ OCIRPushTemp >> accept: aVisitor [
 	^ aVisitor visitPushTemp: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushTemp >> deltaStack [
 
 	^ 1

--- a/src/OpalCompiler-Core/OCIRPushTemp.class.st
+++ b/src/OpalCompiler-Core/OCIRPushTemp.class.st
@@ -14,6 +14,12 @@ OCIRPushTemp >> accept: aVisitor [
 	^ aVisitor visitPushTemp: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPushTemp >> deltaStack [
+
+	^ 1
+]
+
 { #category : 'testing' }
 OCIRPushTemp >> isRemovableByPop [
 

--- a/src/OpalCompiler-Core/OCIRPushThisContext.class.st
+++ b/src/OpalCompiler-Core/OCIRPushThisContext.class.st
@@ -14,7 +14,7 @@ OCIRPushThisContext >> accept: aVisitor [
 	^ aVisitor visitPushThisContext: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushThisContext >> deltaStack [
 
 	^ 1

--- a/src/OpalCompiler-Core/OCIRPushThisContext.class.st
+++ b/src/OpalCompiler-Core/OCIRPushThisContext.class.st
@@ -14,6 +14,12 @@ OCIRPushThisContext >> accept: aVisitor [
 	^ aVisitor visitPushThisContext: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPushThisContext >> deltaStack [
+
+	^ 1
+]
+
 { #category : 'testing' }
 OCIRPushThisContext >> isRemovableByPop [
 

--- a/src/OpalCompiler-Core/OCIRPushThisProcess.class.st
+++ b/src/OpalCompiler-Core/OCIRPushThisProcess.class.st
@@ -14,6 +14,12 @@ OCIRPushThisProcess >> accept: aVisitor [
 	^ aVisitor visitPushThisProcess: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRPushThisProcess >> deltaStack [
+
+	^ 1
+]
+
 { #category : 'testing' }
 OCIRPushThisProcess >> isRemovableByPop [
 

--- a/src/OpalCompiler-Core/OCIRPushThisProcess.class.st
+++ b/src/OpalCompiler-Core/OCIRPushThisProcess.class.st
@@ -14,7 +14,7 @@ OCIRPushThisProcess >> accept: aVisitor [
 	^ aVisitor visitPushThisProcess: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRPushThisProcess >> deltaStack [
 
 	^ 1

--- a/src/OpalCompiler-Core/OCIRReturn.class.st
+++ b/src/OpalCompiler-Core/OCIRReturn.class.st
@@ -14,6 +14,12 @@ OCIRReturn >> accept: aVisitor [
 	^ aVisitor visitReturn: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRReturn >> deltaStack [
+
+	^ 0
+]
+
 { #category : 'testing' }
 OCIRReturn >> isReturn [
 

--- a/src/OpalCompiler-Core/OCIRReturn.class.st
+++ b/src/OpalCompiler-Core/OCIRReturn.class.st
@@ -14,12 +14,6 @@ OCIRReturn >> accept: aVisitor [
 	^ aVisitor visitReturn: self
 ]
 
-{ #category : 'as yet unclassified' }
-OCIRReturn >> deltaStack [
-
-	^ 0
-]
-
 { #category : 'testing' }
 OCIRReturn >> isReturn [
 

--- a/src/OpalCompiler-Core/OCIRSend.class.st
+++ b/src/OpalCompiler-Core/OCIRSend.class.st
@@ -18,6 +18,12 @@ OCIRSend >> accept: aVisitor [
 	^ aVisitor visitSend: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRSend >> deltaStack [
+
+	^ (selector occurrencesOf: $:) negated
+]
+
 { #category : 'testing' }
 OCIRSend >> isSend [
 	^true

--- a/src/OpalCompiler-Core/OCIRSend.class.st
+++ b/src/OpalCompiler-Core/OCIRSend.class.st
@@ -18,7 +18,7 @@ OCIRSend >> accept: aVisitor [
 	^ aVisitor visitSend: self
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'stack' }
 OCIRSend >> deltaStack [
 
 	^ (selector occurrencesOf: $:) negated

--- a/src/OpalCompiler-Core/OCIRStoreTemp.class.st
+++ b/src/OpalCompiler-Core/OCIRStoreTemp.class.st
@@ -14,12 +14,6 @@ OCIRStoreTemp >> accept: aVisitor [
 	^ aVisitor visitStoreTemp: self
 ]
 
-{ #category : 'as yet unclassified' }
-OCIRStoreTemp >> deltaStack [
-
-	^ 0
-]
-
 { #category : 'testing' }
 OCIRStoreTemp >> isStore [
 	^ true

--- a/src/OpalCompiler-Core/OCIRStoreTemp.class.st
+++ b/src/OpalCompiler-Core/OCIRStoreTemp.class.st
@@ -14,6 +14,12 @@ OCIRStoreTemp >> accept: aVisitor [
 	^ aVisitor visitStoreTemp: self
 ]
 
+{ #category : 'as yet unclassified' }
+OCIRStoreTemp >> deltaStack [
+
+	^ 0
+]
+
 { #category : 'testing' }
 OCIRStoreTemp >> isStore [
 	^ true

--- a/src/OpalCompiler-Tests/OCArrayLiteralTest.class.st
+++ b/src/OpalCompiler-Tests/OCArrayLiteralTest.class.st
@@ -86,6 +86,23 @@ OCArrayLiteralTest >> testByteArrayWithinArray [
 ]
 
 { #category : 'tests' }
+OCArrayLiteralTest >> testLiteralArrayLongHavingAnotherArrayLong [
+
+	| method array elements |
+	elements := ((1 to: 32) inject: ' ' into: [ :r :e | r , ' . ' , e asString ]).
+	array := ' { ' , elements , ' }'.
+	array := array copyReplaceAll: '32' with: array.
+	
+	method := self compile: 'array ^' , array.
+	array := method valueWithReceiver: #().
+	
+	self assert: ( array isKindOf: Array).
+	self assert: array size equals: 32.
+	1 to: 31 do: [ :index | self assert: (array at: index) equals: index ].
+	1 to: 32 do: [ :index | self assert: ((array at: 32) at: index) equals: index ].
+]
+
+{ #category : 'tests' }
 OCArrayLiteralTest >> testReservedIdentifiers [
 
 	| method array |

--- a/src/OpalCompiler-Tests/OCOpalExamples.class.st
+++ b/src/OpalCompiler-Tests/OCOpalExamples.class.st
@@ -67,6 +67,18 @@ OCOpalExamples >> exampleAndValueWithShortcircuitEffect [
 	false and: [ result := 17 ]
 ]
 
+{ #category : 'as yet unclassified' }
+OCOpalExamples >> exampleArraySize32AndSize32 [
+
+	^ { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 } }
+]
+
+{ #category : 'as yet unclassified' }
+OCOpalExamples >> exampleArraySize33AndSize33 [
+
+	^ { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 } }
+]
+
 { #category : 'examples - blocks' }
 OCOpalExamples >> exampleBlockArgument [
 	| block block1 block2 |

--- a/src/OpalCompiler-Tests/OCOpalExamples.class.st
+++ b/src/OpalCompiler-Tests/OCOpalExamples.class.st
@@ -67,18 +67,6 @@ OCOpalExamples >> exampleAndValueWithShortcircuitEffect [
 	false and: [ result := 17 ]
 ]
 
-{ #category : 'as yet unclassified' }
-OCOpalExamples >> exampleArraySize32AndSize32 [
-
-	^ { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 } }
-]
-
-{ #category : 'as yet unclassified' }
-OCOpalExamples >> exampleArraySize33AndSize33 [
-
-	^ { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 } }
-]
-
 { #category : 'examples - blocks' }
 OCOpalExamples >> exampleBlockArgument [
 	| block block1 block2 |
@@ -146,6 +134,18 @@ OCOpalExamples >> exampleClassVariableAssignment [
 { #category : 'examples - pragmas' }
 OCOpalExamples >> exampleDoublePrimitive [
 	<primitive: 1>
+]
+
+{ #category : 'examples - misc' }
+OCOpalExamples >> exampleDynamicLiteralArraySize32AndSize32 [
+
+	^ { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 } }
+]
+
+{ #category : 'examples - misc' }
+OCOpalExamples >> exampleDynamicLiteralArraySize33AndSize33 [
+
+	^ { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . { 255 . 255 . 255 . 255 .255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 . 255 } }
 ]
 
 { #category : 'examples - blocks' }

--- a/src/UIManager/Object.extension.st
+++ b/src/UIManager/Object.extension.st
@@ -14,7 +14,8 @@ Object >> confirm: queryString [
 { #category : '*UIManager' }
 Object >> inform: aString [
 	"Display a message for the user to read and then dismiss."
-	
+
+	self halt.
 	"DO NOT CALL THIS METHOD!"
 	aString isEmptyOrNil
 		ifFalse: [ UIManager default inform: aString ]

--- a/src/UIManager/Object.extension.st
+++ b/src/UIManager/Object.extension.st
@@ -15,7 +15,6 @@ Object >> confirm: queryString [
 Object >> inform: aString [
 	"Display a message for the user to read and then dismiss."
 	
-	self halt.
 	"DO NOT CALL THIS METHOD!"
 	aString isEmptyOrNil
 		ifFalse: [ UIManager default inform: aString ]


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/18688

The previous implementation was deciding how to compile the array based on its size but not checking the frame limit (see the problem in the issue).


One important implementation detail is that we added a method `deltaStack` to the IR instructions. We could put that logic in a visitor instead. I don't know what is better...

_Done w/ @FedeLoch in the Pharo sprint 🤟_