### PR TITLE
Cut dependency of Collection-Strings to Unicode

### DIFF
--- a/src/Collections-Strings/WideString.class.st
+++ b/src/Collections-Strings/WideString.class.st
@@ -85,7 +85,10 @@ WideString >> asLowercase [
 	"Answer a copy of self with all characters in a lower case.
 	This might be a difficult task, ask Unicode."
 
-	^ Unicode toLowercaseString: self
+	^ self class environment
+		  at: #Unicode
+		  ifPresent: [ :class | class toLowercaseString: self ]
+		  ifAbsent: [ self error: 'In order to do this operation you need the Unicode support in Pharo but it is currently not present.' ]
 ]
 
 { #category : 'converting' }
@@ -93,7 +96,10 @@ WideString >> asUppercase [
 	"Answer a copy of self with all characters in an upper case.
 	This might be a difficult task, ask Unicode."
 
-	^ Unicode toUppercaseString: self
+	^ self class environment
+		  at: #Unicode
+		  ifPresent: [ :class | class toUppercaseString: self ]
+		  ifAbsent: [ self error: 'In order to do this operation you need the Unicode support in Pharo but it is currently not present.' ]
 ]
 
 { #category : 'converting' }


### PR DESCRIPTION
Currently Collections-Strings depends explicitly on Unicode. It would lead to error to move the methods as extension of Unicode because the error would not be clear. I propose to make the dependency  weaker by checking if unicode is in the image and raise a right warning if it is not in the image.