### PR TITLE
Do not load Debugging-Core with Hermes

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -138,7 +138,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" # I have to run once the image so the next 
 
 echo $(date -u) "[Compiler] Adding more Kernel packages"
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform --save BasicHermesTool load: --as-array Clap-Core.hermes Clap-Commands-Pharo.hermes Hermes-Extensions.hermes
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Math-Operations-Extensions.hermes Debugging-Core.hermes System-NumberPrinting.hermes System-Time.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes NumberParser.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Math-Operations-Extensions.hermes System-NumberPrinting.hermes System-Time.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes NumberParser.hermes --save --no-fail-on-undeclared
 
 # Now that System-Time is loaded, we can initialize the version
 ${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform  --save SystemVersion setMajor:minor:patch:suffix:build:commitHash: ${PHARO_MAJOR} ${PHARO_MINOR} ${PHARO_PATCH} ${PHARO_SUFFIX} ${BUILD_NUMBER} ${PHARO_COMMIT_HASH}

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -84,7 +84,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		spec package: 'Collections-Support'.
 		spec package: 'Collections-Unordered'.
 		spec package: 'Collections-Weak'.
-		spec package: 'Debugging-Core'.
 		spec package: 'Deprecation'.
 		spec package: 'Files'.
 		spec package: 'FileSystem-Path'.
@@ -188,7 +187,6 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'ReflectionMirrors-Primitives'.
 			'System-Time'.
 			'Math-Operations-Extensions'.
-			'Debugging-Core'.
 			'System-NumberPrinting'.
 		}.
 

--- a/src/BaselineOfUI/BaselineOfUI.class.st
+++ b/src/BaselineOfUI/BaselineOfUI.class.st
@@ -40,6 +40,7 @@ BaselineOfUI >> baseline: spec [
 		spec postLoadDoIt: #postload:package:.
 
 		"Loading the debugger model and infrastructure before the UI"
+		spec package: 'Debugging-Core'.
 		spec package: 'Debugger-Model'.
 		spec package: 'Debugger-Oups'.
 

--- a/src/BaselineOfUI/BaselineOfUI.class.st
+++ b/src/BaselineOfUI/BaselineOfUI.class.st
@@ -69,7 +69,7 @@ BaselineOfUI >> baseline: spec [
 				loads: 'ui' ].
 		spec package: 'WebBrowser-Core'.
 		
-		spec group: 'Debugger-Base-UI' with: #( 'Debugger-Model' 'Debugger-Oups') ]
+		spec group: 'Debugger-Base-UI' with: #('Debugging-Core' 'Debugger-Model' 'Debugger-Oups') ]
 ]
 
 { #category : 'actions' }

--- a/src/Debugging-Core/InstructionStream.extension.st
+++ b/src/Debugging-Core/InstructionStream.extension.st
@@ -74,23 +74,6 @@ InstructionStream >> previousPc [
 ]
 
 { #category : '*Debugging-Core' }
-InstructionStream >> scanFor: scanBlock [
-	"Check all bytecode instructions with scanBlock, answer true if scanBlock answers true.
-	This can be used to, e.g., check whether a method contains 'push closure' bytecodes like this:
-	aMethod scanFor: [ :b | b = 143 ]"
-
-	| method encoderClass end byte |
-	method := self method.
-	end := method endPC.
-	encoderClass := method encoderClass.
-	[pc <= end] whileTrue: 
-		[(scanBlock value: (byte := method at: pc)) ifTrue:
-			[^true].
-		 pc := pc + (encoderClass bytecodeSize: byte)].
-	^false
-]
-
-{ #category : '*Debugging-Core' }
 InstructionStream >> secondByte [
 	"Answer the second byte of the current bytecode."
 

--- a/src/Debugging-Core/InstructionStream.extension.st
+++ b/src/Debugging-Core/InstructionStream.extension.st
@@ -60,13 +60,6 @@ InstructionStream >> interpretWithClient: aClient [
 ]
 
 { #category : '*Debugging-Core' }
-InstructionStream >> nextPc: currentByte [
-	"Answer the pc of the next bytecode following the current one, given the current bytecode.
-	 Skips the extension bytecodes."
-	^ pc + (self method encoderClass instructionSizeAt: pc of: self method)
-]
-
-{ #category : '*Debugging-Core' }
 InstructionStream >> peekByte [
 	"Answer the first byte of the current bytecode."
 

--- a/src/Kernel-CodeModel/CompiledBlock.class.st
+++ b/src/Kernel-CodeModel/CompiledBlock.class.st
@@ -176,30 +176,6 @@ CompiledBlock >> pathOfLiteralIndexes [
 	^ self outerCode pathOfLiteralIndexes copyWithAll: self indexesInOuter
 ]
 
-{ #category : 'accessing' }
-CompiledBlock >> pcInOuter [
-	| outer end instructionStream |
-	outer := self outerCode.
-	instructionStream := InstructionStream on: outer.
-	end := outer endPC.
-	[instructionStream pc <= end] whileTrue:
-		[ (self encoderClass isCreateFullBlock: self code: outer at: instructionStream pc)
-			ifTrue: [ ^ instructionStream pc ].
-			instructionStream pc: (instructionStream nextPc: (outer at: instructionStream pc))].
-	"scan for clean block"
-	instructionStream := InstructionStream on: outer.
-	[instructionStream pc <= end] whileTrue: [
-			| literalOffset |
-			literalOffset := self encoderClass literalIndexOfBytecodeAt: instructionStream pc in: outer.
-			literalOffset ifNotNil: [
-				| literal |
-				literal := (self outerCode literalAt: literalOffset + 1).
-				((literal isKindOf: CleanBlockClosure) and: [literal compiledBlock == self  ])ifTrue: [ ^ instructionStream pc ].  ].
-			instructionStream pc: (instructionStream nextPc: (outer at: instructionStream pc))].
-
-	self error: 'block not installed in outer code'
-]
-
 { #category : 'accessing - pragmas & properties' }
 CompiledBlock >> pragmas [
 	<reflection: 'Class structural inspection - Pragma'>

--- a/src/Kernel-CodeModel/InstructionStream.class.st
+++ b/src/Kernel-CodeModel/InstructionStream.class.st
@@ -325,3 +325,20 @@ InstructionStream >> peekInstruction [
 	self pc: currentPc.
 	^ instruction
 ]
+
+{ #category : 'scanning' }
+InstructionStream >> scanFor: scanBlock [
+	"Check all bytecode instructions with scanBlock, answer true if scanBlock answers true.
+	This can be used to, e.g., check whether a method contains 'push closure' bytecodes like this:
+	aMethod scanFor: [ :b | b = 143 ]"
+
+	| method encoderClass end byte |
+	method := self method.
+	end := method endPC.
+	encoderClass := method encoderClass.
+	[pc <= end] whileTrue: 
+		[(scanBlock value: (byte := method at: pc)) ifTrue:
+			[^true].
+		 pc := pc + (encoderClass bytecodeSize: byte)].
+	^false
+]

--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -29,6 +29,30 @@ CompiledBlock >> methodNode [
 ]
 
 { #category : '*OpalCompiler-Core' }
+CompiledBlock >> pcInOuter [
+	| outer end instructionStream |
+	outer := self outerCode.
+	instructionStream := InstructionStream on: outer.
+	end := outer endPC.
+	[instructionStream pc <= end] whileTrue:
+		[ (self encoderClass isCreateFullBlock: self code: outer at: instructionStream pc)
+			ifTrue: [ ^ instructionStream pc ].
+			instructionStream pc: (instructionStream nextPc: (outer at: instructionStream pc))].
+	"scan for clean block"
+	instructionStream := InstructionStream on: outer.
+	[instructionStream pc <= end] whileTrue: [
+			| literalOffset |
+			literalOffset := self encoderClass literalIndexOfBytecodeAt: instructionStream pc in: outer.
+			literalOffset ifNotNil: [
+				| literal |
+				literal := (self outerCode literalAt: literalOffset + 1).
+				((literal isKindOf: CleanBlockClosure) and: [literal compiledBlock == self  ])ifTrue: [ ^ instructionStream pc ].  ].
+			instructionStream pc: (instructionStream nextPc: (outer at: instructionStream pc))].
+
+	self error: 'block not installed in outer code'
+]
+
+{ #category : '*OpalCompiler-Core' }
 CompiledBlock >> sourceNode [
 	^ self sourceNodeInOuter
 ]

--- a/src/OpalCompiler-Core/InstructionStream.extension.st
+++ b/src/OpalCompiler-Core/InstructionStream.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'InstructionStream' }
+
+{ #category : '*OpalCompiler-Core' }
+InstructionStream >> nextPc: currentByte [
+	"Answer the pc of the next bytecode following the current one, given the current bytecode.
+	 Skips the extension bytecodes."
+	^ pc + (self method encoderClass instructionSizeAt: pc of: self method)
+]


### PR DESCRIPTION
We do not need this package before loading Oups. So we can load it with a normal Metacello loading instead of loading it with Hermes.