### PR TITLE
Reduce dependencies to UIManager

### DIFF
--- a/src/Kernel/InformativeNotification.class.st
+++ b/src/Kernel/InformativeNotification.class.st
@@ -1,0 +1,12 @@
+"
+I am a notification that should display its message text to the user as an information.
+
+This feature should be added by the IDE of Pharo to not have the kernel depending on the UI layer of Pharo. If it is not loaded, it will fallback to the class printing in the stdout.
+"
+Class {
+	#name : 'InformativeNotification',
+	#superclass : 'SystemNotification',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
+}

--- a/src/System-Sources/PharoFilesOpener.class.st
+++ b/src/System-Sources/PharoFilesOpener.class.st
@@ -100,7 +100,8 @@ PharoFilesOpener >> inform: msg withChangesRef: fileRef [
 
 { #category : 'user interaction' }
 PharoFilesOpener >> inform: msg withRef: fileRef [
-	self inform: (msg copyReplaceAll: '&fileRef' with: fileRef)
+
+	InformativeNotification signal: (msg copyReplaceAll: '&fileRef' with: fileRef)
 ]
 
 { #category : 'user interaction' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -781,7 +781,7 @@ SmalltalkImage >> informSpaceLeftAfterGarbageCollection [
 
 	"SmalltalkImage current informSpaceLeftAfterGarbageCollection"
 
-	self inform: self spaceLeftAfterGarbageCollection
+	InformativeNotification signal: self spaceLeftAfterGarbageCollection
 ]
 
 { #category : 'memory space' }
@@ -998,7 +998,7 @@ SmalltalkImage >> lowSpaceWatcher [
 		ifTrue: [self garbageCollect <= self lowSpaceThreshold
 				ifTrue: ["free space must be above threshold before
 					starting low space watcher"
-					^ self inform: 'Not enough memory to launch the lowSpaceWatcher.']].
+					^ InformativeNotification signal:  'Not enough memory to launch the lowSpaceWatcher.']].
 	self specialObjectsArray at: 23 put: nil.
 	"process causing low space will be saved here"
 	LowSpaceSemaphore := Semaphore new.
@@ -1475,11 +1475,8 @@ SmalltalkImage >> saveAsNewVersion [
 
 	| newImageFile strippedName |
 	newImageFile := self imageFile nextVersion.
-	(newImageFile withExtension: self changesSuffix)
-		ifExists: [ :newChangesFile |
-			^ self
-				inform:
-					'There is already .changes file of the desired name,
+	(newImageFile withExtension: self changesSuffix) ifExists: [ :newChangesFile |
+			^ InformativeNotification signal: 'There is already .changes file of the desired name,
 ' , newChangesFile fullName , '
 curiously already present, even though there is
 no corresponding .' , self imageSuffix , ' file.   Please remedy


### PR DESCRIPTION
In order to reduce the dependencies to UIManager, I propose to introduce a new Notification: InformativeNotification.

The goal of this new exception it to:
- Log in the stdout/transcript a message if we do not have NewTools in the image
- Use the #inform: of StPharoApplication if NewTools is present in the image

For this, a PR to NewTools is also needed