### PR TITLE
Cut multiple dependencies of Command line handler

### DIFF
--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -2,7 +2,6 @@
 mcPackages := #(
  'ScriptingExtensions'
  'FileSystem-Memory'
- 'StartupPreferences'
  'STON-Core'
  'MonticelloFileTree-Core'
  'MonticelloFileTree-FileSystem-Utilities'

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -137,77 +137,77 @@ echo $(date -u) "[Compiler] Initializing Bootstraped Image"
 ${VM} "${COMPILER_IMAGE_NAME}.image" # I have to run once the image so the next time it starts the CommandLineHandler.
 
 echo $(date -u) "[Compiler] Adding more Kernel packages"
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform --save BasicHermesTool load: --as-array Clap-Core.hermes Clap-Commands-Pharo.hermes Hermes-Extensions.hermes
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Math-Operations-Extensions.hermes System-NumberPrinting.hermes System-Time.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes NumberParser.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" perform --save BasicHermesTool load: --as-array Clap-Core.hermes Clap-Commands-Pharo.hermes Hermes-Extensions.hermes
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Math-Operations-Extensions.hermes System-NumberPrinting.hermes System-Time.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes NumberParser.hermes --save --no-fail-on-undeclared
 
 # Now that System-Time is loaded, we can initialize the version
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform  --save SystemVersion setMajor:minor:patch:suffix:build:commitHash: ${PHARO_MAJOR} ${PHARO_MINOR} ${PHARO_PATCH} ${PHARO_SUFFIX} ${BUILD_NUMBER} ${PHARO_COMMIT_HASH}
+${VM} "${COMPILER_IMAGE_NAME}.image" perform  --save SystemVersion setMajor:minor:patch:suffix:build:commitHash: ${PHARO_MAJOR} ${PHARO_MINOR} ${PHARO_PATCH} ${PHARO_SUFFIX} ${BUILD_NUMBER} ${PHARO_COMMIT_HASH}
 
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Collections-Atomic.hermes Collections-Stack.hermes AST-Core.hermes Collections-Arithmetic.hermes  --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Collections-Atomic.hermes Collections-Stack.hermes AST-Core.hermes Collections-Arithmetic.hermes  --save --no-fail-on-undeclared
 
 echo $(date -u) "[Compiler] Initializing the packages in the Kernel"
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform --save PharoBootstrapFixMethodsTool fixMethodsIn: protocolsKernel.txt
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" perform --save PharoBootstrapFixMethodsTool fixExtensionMethods
+${VM} "${COMPILER_IMAGE_NAME}.image" perform --save PharoBootstrapFixMethodsTool fixMethodsIn: protocolsKernel.txt
+${VM} "${COMPILER_IMAGE_NAME}.image" perform --save PharoBootstrapFixMethodsTool fixExtensionMethods
 
 # Installing compiler through Hermes 
 echo $(date -u) "[Compiler] Installing compiler through Hermes"
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes UIManager.hermes Debugging-Utils.hermes OpalCompiler-Core.hermes Deprecation.hermes DebugInfo.hermes CodeImport.hermes CodeImport-Commands.hermes --save --no-fail-on-undeclared
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "SystemEnvironment deprecatedAliases: { #SystemDictionary }." # This line should be removed in Pharo 14 since it is for backward compatibility.
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/01-init.st --no-source --save --quit
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes UIManager.hermes Debugging-Utils.hermes OpalCompiler-Core.hermes Deprecation.hermes DebugInfo.hermes CodeImport.hermes CodeImport-Commands.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" eval --save "SystemEnvironment deprecatedAliases: { #SystemDictionary }." # This line should be removed in Pharo 14 since it is for backward compatibility.
+${VM} "${COMPILER_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/01-init.st --no-source --save --quit
 
 echo $(date -u) "[Compiler] Initializing Unicode"
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/02-initUnicode.st --no-source --save --quit "${BOOTSTRAP_REPOSITORY}/resources/unicode/"
+${VM} "${COMPILER_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/02-initUnicode.st --no-source --save --quit "${BOOTSTRAP_REPOSITORY}/resources/unicode/"
 
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Random-Core.hermes System-Hashing.hermes FileSystem-Path.hermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Random-Core.hermes System-Hashing.hermes FileSystem-Path.hermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
 zip "${COMPILER_IMAGE_NAME}.zip" "${COMPILER_IMAGE_NAME}.image"
 
 # Installing Traits through Hermes 
 echo $(date -u) "[Compiler] Installing Traits through Hermes"
 
-${VM} "${COMPILER_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save ${TRAITS_IMAGE_NAME}
-${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" loadHermes Traits.hermes --save
+${VM} "${COMPILER_IMAGE_NAME}.image" save ${TRAITS_IMAGE_NAME}
+${VM} "${TRAITS_IMAGE_NAME}.image" loadHermes Traits.hermes --save
 zip "${TRAITS_IMAGE_NAME}.zip" "${TRAITS_IMAGE_NAME}.image"
 
 #Bootstrap Initialization: Class and Package initialization
 echo $(date -u) "[Core] Class and Package initialization"
-${VM} "${TRAITS_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save ${CORE_IMAGE_NAME}
+${VM} "${TRAITS_IMAGE_NAME}.image" save ${CORE_IMAGE_NAME}
 zip "${CORE_IMAGE_NAME}.zip" "${CORE_IMAGE_NAME}.image"
 
 #Bootstrap Monticello Part 1: Core and Local repositories
 echo $(date -u) "[Monticello] Bootstrap Monticello Core and Local repositories"
 
-${VM} "${CORE_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save ${MC_BOOTSTRAP_IMAGE_NAME}
+${VM} "${CORE_IMAGE_NAME}.image" save ${MC_BOOTSTRAP_IMAGE_NAME}
 #cp "${CORE_IMAGE_NAME}.image" "${MC_BOOTSTRAP_IMAGE_NAME}.image"
-${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${ST_CACHE}/Monticello.st --save --quit
-${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/01-bootstrapMonticello.st --save --quit
+${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" st ${ST_CACHE}/Monticello.st --save --quit
+${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/01-bootstrapMonticello.st --save --quit
 zip "${MC_BOOTSTRAP_IMAGE_NAME}.zip" ${MC_BOOTSTRAP_IMAGE_NAME}.*
 
 #Bootstrap Monticello Part 2: Networking Packages and Remote Repositories
 echo $(date -u) "[Monticello] Loading Networking Packages and Remote Repositories"
-${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save $MC_IMAGE_NAME
-${VM} "${MC_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st --save --quit
+${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" save $MC_IMAGE_NAME
+${VM} "${MC_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/02-bootstrapMonticelloRemote.st --save --quit
 zip "${MC_IMAGE_NAME}.zip" ${MC_IMAGE_NAME}.*
 
 #Bootstrap Metacello
 echo "[Metacello] Bootstrapping Metacello"
-${VM} "${MC_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save ${METACELLO_IMAGE_NAME}
-${VM} "${METACELLO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st --save --quit
-${VM} "${METACELLO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" metacello install --save --signalErrorOnWarning 'github://pharo-vcs/tonel:Pharo12' Tonel --groups core
+${VM} "${MC_IMAGE_NAME}.image" save ${METACELLO_IMAGE_NAME}
+${VM} "${METACELLO_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st --save --quit
+${VM} "${METACELLO_IMAGE_NAME}.image" metacello install --save --signalErrorOnWarning 'github://pharo-vcs/tonel:Pharo12' Tonel --groups core
 zip "${METACELLO_IMAGE_NAME}.zip" ${METACELLO_IMAGE_NAME}.*
 
 echo $(date -u) "[Pharo] Reloading rest of packages"
-${VM} "${METACELLO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" save "${PHARO_IMAGE_NAME}"
+${VM} "${METACELLO_IMAGE_NAME}.image" save "${PHARO_IMAGE_NAME}"
 
 #Terrible HACK!!!! 
 #I am increasing the size of the eden space.
 #This allows to load the big baselines.
 #However, this is only needed because the VM has a bug when extending the space itself. It is corrupting the objects, this produces random crashes
-${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Smalltalk vm parameterAt: 45 put: (Smalltalk vm parameterAt: 44) * 4"
+${VM} "${PHARO_IMAGE_NAME}.image" eval --save "Smalltalk vm parameterAt: 45 put: (Smalltalk vm parameterAt: 44) * 4"
 
 env 2>&1 > env.log
 
-${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "MCCacheRepository uniqueInstance disable"
-${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" metacello install --save --signalErrorOnWarning "tonel://${BOOTSTRAP_REPOSITORY}/src" Pharo
+${VM} "${PHARO_IMAGE_NAME}.image" eval --save "MCCacheRepository uniqueInstance disable"
+${VM} "${PHARO_IMAGE_NAME}.image" metacello install --save --signalErrorOnWarning "tonel://${BOOTSTRAP_REPOSITORY}/src" Pharo
 
 #Storing the image version into the image header
 ${VM} "${PHARO_IMAGE_NAME}.image" "${IMAGE_FLAGS}" eval --save "Smalltalk vm saveImageVersionInImageHeader"

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -74,8 +74,6 @@ BaselineOfBasicTools >> baseline: spec [
 			spec package: 'Network-Mail'.
 			spec package: 'Network-Mail-Tests'.
 
-			spec package: 'StartupPreferences'.
-
 
 
 			spec package: 'OpalCompiler-ToolFeatures'.

--- a/src/BaselineOfMetacello/BaselineOfMetacello.class.st
+++ b/src/BaselineOfMetacello/BaselineOfMetacello.class.st
@@ -13,7 +13,6 @@ BaselineOfMetacello >> baseline: spec [
 		spec 
 			package: 'ScriptingExtensions';
 			package: 'FileSystem-Memory';
-			package: 'StartupPreferences';
 			package: 'Metacello-Base';
 			package: 'Metacello-Bitbucket';
 			package: 'Metacello-Core';
@@ -32,7 +31,7 @@ BaselineOfMetacello >> baseline: spec [
 			package: 'Metacello-Gitlab-Tests'.
 
 		spec 
-			group: 'Core' with: #('ScriptingExtensions' 'System-FileRegistry' 'FileSystem-Memory' 'StartupPreferences' 'PragmaCollector' 'System-FileRegistry' 'Metacello-Base' 'Metacello-Core' 'MonticelloFileTree-Core' 'MonticelloFileTree-FileSystem-Utilities' 'STON-Core' 'Metacello-GitBasedRepository' 'Metacello-GitHub' 'Metacello-Gitlab' 'Metacello-Bitbucket' 'Metacello-CommandLine');
+			group: 'Core' with: #('ScriptingExtensions' 'System-FileRegistry' 'FileSystem-Memory' 'PragmaCollector' 'System-FileRegistry' 'Metacello-Base' 'Metacello-Core' 'MonticelloFileTree-Core' 'MonticelloFileTree-FileSystem-Utilities' 'STON-Core' 'Metacello-GitBasedRepository' 'Metacello-GitHub' 'Metacello-Gitlab' 'Metacello-Bitbucket' 'Metacello-CommandLine');
 			group: 'Tests' with: #( 'Metacello-TestsCore' 'Metacello-TestsMCCore' 'Metacello-TestsReference' 'Metacello-Gitlab-Tests');
 			group: 'default' with: #('Core') ]
 ]

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -41,6 +41,7 @@ BaselineOfMorphic >> baseline: spec [
 			
 		spec package: 'System-Identification'.
 		spec package: 'System-Settings-Core' with: [ spec requires: #( 'System-Identification' ) ].
+		spec package: 'StartupPreferences'. "This should move out of Morphic but currently there is a cyclic dependency with System-Settings-Core..."
 
 		spec package: 'System-Localization'.
 

--- a/src/BaselineOfUI/BaselineOfUI.class.st
+++ b/src/BaselineOfUI/BaselineOfUI.class.st
@@ -61,7 +61,6 @@ BaselineOfUI >> baseline: spec [
 		"Spec 2 (base), using external configuration"
 		self specBase: spec.
 
-		spec package: 'StartupPreferences'.
 		spec package: 'Morphic-Widgets-Tree'.
 
 		spec baseline: 'Keymapping' with: [

--- a/src/StartupPreferences/PharoOptionsHandler.class.st
+++ b/src/StartupPreferences/PharoOptionsHandler.class.st
@@ -31,10 +31,10 @@ Class {
 	#package : 'StartupPreferences'
 }
 
-{ #category : 'accessing' }
-PharoOptionsHandler class >> priority [
+{ #category : 'class initialization' }
+PharoOptionsHandler class >> initialize [
 
-	^ 100
+	CurrentOptionsHandler := self
 ]
 
 { #category : 'accessing' }

--- a/src/StartupPreferences/PharoOptionsHandler.class.st
+++ b/src/StartupPreferences/PharoOptionsHandler.class.st
@@ -23,29 +23,18 @@ It first checks if another handler is available. If so it will activate the foun
 "
 Class {
 	#name : 'PharoOptionsHandler',
-	#superclass : 'Object',
-	#instVars : [
-		'arguments'
-	],
+	#superclass : 'BasicPharoOptionsHandler',
 	#classVars : [
 		'ShouldIgnorePreferences'
 	],
-	#category : 'System-CommandLineHandler',
-	#package : 'System-CommandLineHandler'
+	#category : 'StartupPreferences',
+	#package : 'StartupPreferences'
 }
 
 { #category : 'accessing' }
-PharoOptionsHandler class >> forArguments: arguments [
+PharoOptionsHandler class >> priority [
 
-	^ self new
-		arguments: arguments;
-		yourself
-]
-
-{ #category : 'accessing' }
-PharoOptionsHandler class >> handle: arguments [
-
-	^ (self forArguments: arguments) handlePharoArguments
+	^ 100
 ]
 
 { #category : 'accessing' }
@@ -58,17 +47,6 @@ PharoOptionsHandler class >> shouldIgnorePreferences [
 { #category : 'accessing' }
 PharoOptionsHandler class >> shouldIgnorePreferences: anObject [
 	ShouldIgnorePreferences := anObject
-]
-
-{ #category : 'accessing' }
-PharoOptionsHandler >> arguments [
-	^ arguments
-]
-
-{ #category : 'accessing' }
-PharoOptionsHandler >> arguments: aCollection [ 
-	
-	arguments := aCollection 
 ]
 
 { #category : 'private - preferences' }
@@ -98,17 +76,14 @@ PharoOptionsHandler >> filteredArguments [
 
 { #category : 'execution' }
 PharoOptionsHandler >> handlePharoArguments [
-	
 	"If the command line is configured to force the omission of preferences, we should skip them in any case. To ensure the command line works perfectly, we should still ensure that there is no unneeded parameters as 'preferences-file' of 'no-default-preferences'."
 
-	self shouldIgnorePreferences
-		ifFalse: [
+	self shouldIgnorePreferences ifFalse: [
 			self isChangingPreferences
 				ifTrue: [ self changePreferences ]
-				ifFalse: [ self runPreferences ]
-		].
-	
-	^ self filteredArguments
+				ifFalse: [ self runPreferences ] ].
+
+	^ super handlePharoArguments
 ]
 
 { #category : 'private - preferences' }
@@ -156,10 +131,8 @@ PharoOptionsHandler >> preferencesFileArgument [
 { #category : 'private - preferences' }
 PharoOptionsHandler >> runPreferences [
 
-	Smalltalk at: #SystemSettingsPersistence ifPresent: [:persistence |
-		persistence resumeSystemSettings].
-	Smalltalk at: #StartupPreferencesLoader ifPresent: [:loader |
-		loader default loadFromDefaultLocations ]
+	SystemSettingsPersistence resumeSystemSettings.
+	StartupPreferencesLoader default loadFromDefaultLocations
 ]
 
 { #category : 'accessing' }

--- a/src/System-CommandLineHandler/BasicPharoOptionsHandler.class.st
+++ b/src/System-CommandLineHandler/BasicPharoOptionsHandler.class.st
@@ -1,0 +1,82 @@
+"
+I'm responsible to manage the default image options.
+
+Usage: [<subcommand>] [--help] [--copyright] [--version] [--list] [ --no-quit ]
+	--help       print this help message
+	--copyright  print the copyrights
+	--version    print the version for the image and the vm
+	--list       list a description of all active command line handlers
+	--no-quit    keep the image running without activating any other command line handler
+	--deploymentPassword   if a password needs to be used by the user to launch the command
+	--readWriteAccessMode, --readOnlyAccessMode, --writeOnlyAccessMode, --disabledAccessMode
+	             specify disk access mode, read-write mode as default
+	<subcommand> a valid subcommand in --list
+	
+Documentation:
+A PharoCommandLineHandler handles default command line arguments and options.
+The PharoCommandLineHandler is activated before all other handlers. 
+It first checks if another handler is available. If so it will activate the found handler.
+"
+Class {
+	#name : 'BasicPharoOptionsHandler',
+	#superclass : 'Object',
+	#instVars : [
+		'arguments'
+	],
+	#category : 'System-CommandLineHandler',
+	#package : 'System-CommandLineHandler'
+}
+
+{ #category : 'accessing' }
+BasicPharoOptionsHandler class >> currentOptionHandler [
+
+	^ ((self withAllSubclasses reject: [ :class | class isAbstract ]) sorted: [ :a :b | a priority > b priority ]) anyOne
+]
+
+{ #category : 'accessing' }
+BasicPharoOptionsHandler class >> forArguments: arguments [
+
+	^ self new
+		arguments: arguments;
+		yourself
+]
+
+{ #category : 'accessing' }
+BasicPharoOptionsHandler class >> handle: arguments [
+
+	^ (self forArguments: arguments) handlePharoArguments
+]
+
+{ #category : 'accessing' }
+BasicPharoOptionsHandler class >> priority [
+
+	^ 10
+]
+
+{ #category : 'accessing' }
+BasicPharoOptionsHandler >> arguments [
+	^ arguments
+]
+
+{ #category : 'accessing' }
+BasicPharoOptionsHandler >> arguments: aCollection [ 
+	
+	arguments := aCollection 
+]
+
+{ #category : 'accessing' }
+BasicPharoOptionsHandler >> filteredArguments [
+	
+	arguments ifEmpty: [ ^ arguments ].
+		
+	arguments first = '--interactive'
+		ifTrue: [ ^ arguments copyWithoutFirst ].
+		
+	^ arguments
+]
+
+{ #category : 'execution' }
+BasicPharoOptionsHandler >> handlePharoArguments [
+
+	^ self filteredArguments
+]

--- a/src/System-CommandLineHandler/BasicPharoOptionsHandler.class.st
+++ b/src/System-CommandLineHandler/BasicPharoOptionsHandler.class.st
@@ -23,6 +23,9 @@ Class {
 	#instVars : [
 		'arguments'
 	],
+	#classVars : [
+		'CurrentOptionsHandler'
+	],
 	#category : 'System-CommandLineHandler',
 	#package : 'System-CommandLineHandler'
 }
@@ -30,7 +33,7 @@ Class {
 { #category : 'accessing' }
 BasicPharoOptionsHandler class >> currentOptionHandler [
 
-	^ ((self withAllSubclasses reject: [ :class | class isAbstract ]) sorted: [ :a :b | a priority > b priority ]) anyOne
+	^ CurrentOptionsHandler ifNil: [ CurrentOptionsHandler := self ]
 ]
 
 { #category : 'accessing' }
@@ -45,12 +48,6 @@ BasicPharoOptionsHandler class >> forArguments: arguments [
 BasicPharoOptionsHandler class >> handle: arguments [
 
 	^ (self forArguments: arguments) handlePharoArguments
-]
-
-{ #category : 'accessing' }
-BasicPharoOptionsHandler class >> priority [
-
-	^ 10
 ]
 
 { #category : 'accessing' }

--- a/src/System-CommandLineHandler/CommandLineHandler.class.st
+++ b/src/System-CommandLineHandler/CommandLineHandler.class.st
@@ -97,13 +97,10 @@ CommandLineHandler >> exitSuccess [
 { #category : 'activation' }
 CommandLineHandler >> handleExit: exit [
 
-	Smalltalk isInteractive ifFalse: [ ^ exit pass ].
-	
-	"We are in interactive mode"
-	exit isSuccess
-		ifFalse: [ ^ Error signal: exit messageText ].
-		
-	self inform: 'Command line successfully finished'.
+	Smalltalk isInteractive ifFalse: [ ^ exit pass ]. "We are in interactive mode"
+	exit isSuccess ifFalse: [ ^ Error signal: exit messageText ].
+
+	InformativeNotification signal: 'Command line successfully finished'
 ]
 
 { #category : 'testing' }
@@ -130,7 +127,7 @@ CommandLineHandler >> isInteractiveAndNoArguments [
 CommandLineHandler >> parseGeneralOptions [
 
 	| filteredArguments |
-	filteredArguments := PharoOptionsHandler handle: self commandLine arguments.
+	filteredArguments := BasicPharoOptionsHandler currentOptionHandler handle: self commandLine arguments.
 	self commandLine arguments: filteredArguments
 ]
 

--- a/src/System-CommandLineHandler/ManifestSystemCommandLineHandler.class.st
+++ b/src/System-CommandLineHandler/ManifestSystemCommandLineHandler.class.st
@@ -11,10 +11,10 @@ Class {
 
 { #category : 'meta-data - dependency analyser' }
 ManifestSystemCommandLineHandler class >> ignoredDependencies [
-	^ #(#StartupPreferences #'System-Hashing')
+	^ #( #'System-Hashing')
 ]
 
 { #category : 'meta-data - dependency analyser' }
 ManifestSystemCommandLineHandler class >> manuallyResolvedDependencies [
-	^ #( #'Collections-Abstract' #'FileSystem-Core' #'System-Support' #'Kernel-CodeModel' #'Collections-Streams' #'System-Hashing')
+	^ #( #'Collections-Abstract' #'System-Support' #'Kernel-CodeModel' #'Collections-Streams' #'System-Hashing')
 ]


### PR DESCRIPTION
This changes is cutting multiple dependencie of PharoCommandLineHandler to some projects:
- FileSystem-Core
- UIManager
- StartupPreferences

In order to do this, I splited PharoOptionHandler into two. BasicPharoOptionHandler that has the minimal options handling and PharoOtpionHandler loaded later that is managing the preferences.

I also cleaned some baselines.

In a future step I also plan to cut also the dependency to System-Hashing but that will be in a future step because I will also add back the password manager with this step.