### PR TITLE
Start SessionManager with a session

### DIFF
--- a/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
+++ b/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
@@ -83,7 +83,6 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 	'Initializing Session Manager' traceCr.
 	SessionManager initialize.
 	SessionManager initializeKernelRegistrations.
-	SessionManager default installNewSession.
 
 
 	'Initializing basic command line behaviors' traceCr.

--- a/src/System-SessionManager/SessionManager.class.st
+++ b/src/System-SessionManager/SessionManager.class.st
@@ -233,7 +233,8 @@ SessionManager >> initialize [
 	networkCategory := self createCategory: 'Network'.
 	guiCategory := self createCategory: 'Graphical User Interface'.
 	toolsCategory := self createCategory: 'Tools'.
-	userCategory := self createCategory: 'User'
+	userCategory := self createCategory: 'User'.
+	self installNewSession
 ]
 
 { #category : 'session management' }


### PR DESCRIPTION
Initialize SessionManager instances with a default session instead of calling it explicitly.

This seems like a small change but the ErrorHandler needs the SessionManager to be initialized to log errors. So if an error happens before the end of the kernel initialization, the error handler cannot work if the SessionManager has no session. With this, we will be able to have more error report