### PR TITLE
Revert loading order of TFFI

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -42,7 +42,6 @@ BaselineOfBasicTools >> baseline: spec [
 				baseline: 'Traits' with: [ spec loads: 'core-traits' from: repository ];
 				baseline: 'SUnit' with: [ spec loads: 'Core' from: repository ];
 				baseline: 'UnifiedFFI' with: [ spec repository: repository ];
-				baseline: 'ThreadedFFI' with: [ spec repository: repository ];
 				baseline: 'UIInfrastructure' with: [ spec repository: repository ];
 				baseline: 'UI' with: [ spec repository: repository ];
 				baseline: 'Reflectivity' with: [ spec repository: repository ];

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -128,7 +128,7 @@ BaselineOfIDE >> baseline: spec [
 		spec package: #'BeautifulComments'  with: [ spec requires:  #( 'Microdown') ].
 		
 		spec package: 'IconPacks'.
-
+		spec baseline: 'ThreadedFFI' with: [ spec repository: repository ].
 		spec package: 'Kernel-ExtraUtils' ]
 ]
 


### PR DESCRIPTION
The error happening on linux seems to come from not initialized fields in SDL. 

This seems to be done via FFI since I did not find any code setting the class variables but those classes manipulate FFI.
Let's try to revert the part concerning TFFI from https://github.com/pharo-project/pharo/pull/18830 to see if the produced image can open on linux.

Fixes https://github.com/pharo-project/pharo/issues/18877 