### PR TITLE
Fix TFFI reset and fix load order

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -42,6 +42,7 @@ BaselineOfBasicTools >> baseline: spec [
 				baseline: 'Traits' with: [ spec loads: 'core-traits' from: repository ];
 				baseline: 'SUnit' with: [ spec loads: 'Core' from: repository ];
 				baseline: 'UnifiedFFI' with: [ spec repository: repository ];
+				baseline: 'ThreadedFFI' with: [ spec repository: repository ];
 				baseline: 'UIInfrastructure' with: [ spec repository: repository ];
 				baseline: 'UI' with: [ spec repository: repository ];
 				baseline: 'Reflectivity' with: [ spec repository: repository ];

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -128,7 +128,6 @@ BaselineOfIDE >> baseline: spec [
 		spec package: #'BeautifulComments'  with: [ spec requires:  #( 'Microdown') ].
 		
 		spec package: 'IconPacks'.
-		spec baseline: 'ThreadedFFI' with: [ spec repository: repository ].
 		spec package: 'Kernel-ExtraUtils' ]
 ]
 

--- a/src/OSWindow-Tests/SDLStructureTest.class.st
+++ b/src/OSWindow-Tests/SDLStructureTest.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'SDLStructureTest',
+	#superclass : 'TestCase',
+	#category : 'OSWindow-Tests-Tests',
+	#package : 'OSWindow-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'tests' }
+SDLStructureTest >> testClassVariablesAreInitialized [
+
+	SDL2Structure withAllSubclassesDo: [ :class | class classVariables do: [ :variable | self assert: variable value isNotNil ] ]
+]

--- a/src/UnifiedFFI/FFIMethodRegistry.class.st
+++ b/src/UnifiedFFI/FFIMethodRegistry.class.st
@@ -17,8 +17,9 @@ Class {
 }
 
 { #category : 'cleanup' }
-FFIMethodRegistry class >> cleanUp: aggressive [
+FFIMethodRegistry class >> cleanUp [
 	"Only delete change sets when being aggressive"
+
 	self uniqueInstance reset.
 	uniqueInstance := nil
 ]
@@ -43,24 +44,33 @@ FFIMethodRegistry class >> resetAll [
 		- working directory change (and then libraries not found)
 		- indirect functions needs to be recalculated.
 	I am not supposed to be performed when image is just saved to avoid possible problem which can happen when we reset all caches and continue to work"
-	self uniqueInstance reset.
+
 	FFICallbackFunctionResolution reset.
 	FFIStructure resetAllStructures.
-	uniqueInstance := nil
+	self cleanUp
 ]
 
 { #category : 'system startup' }
-FFIMethodRegistry class >> shutDown: quitting [
-	quitting ifFalse: [ ^ self ].
+FFIMethodRegistry class >> softResetAll [
+	"I'm reseting each shutdown and startup because like that I can be sure a complete cleanup is done,
+	 because many things can change:
+		- platform change
+		- working directory change (and then libraries not found)
+		- indirect functions needs to be recalculated.
+	I am not supposed to be performed when image is just saved to avoid possible problem which can happen when we reset all caches and continue to work
+	
+	The soft version is not reseting structures if the platform did not change."
 
-	self resetAll
+	FFICallbackFunctionResolution reset.
+	FFIStructure resetAllStructuresIfPlatformChanged.
+	self cleanUp
 ]
 
 { #category : 'system startup' }
 FFIMethodRegistry class >> startUp: isImageStarting [
 	isImageStarting ifFalse: [ ^ self ].
 
-	self resetAll
+	self softResetAll
 ]
 
 { #category : 'instance creation' }

--- a/src/UnifiedFFI/FFIStructure.class.st
+++ b/src/UnifiedFFI/FFIStructure.class.st
@@ -359,14 +359,27 @@ FFIStructure class >> resetAllStructures [
 	Manage nested structures with a recursive approach.
 	Stop recursing using a tracking collection of already reset structures."
 
-	| alreadyReset currentCompilationPlatform |
-	currentCompilationPlatform := { OSPlatform current family . Smalltalk vm wordSize }.
-	LastCompilationPlatform = currentCompilationPlatform
-		ifTrue: [ ^ self ].
-
-	LastCompilationPlatform := currentCompilationPlatform.
+	| alreadyReset |
 	alreadyReset := IdentitySet new.
 	self allSubclassesDo: [ :each | each resetStructureIfNotIn: alreadyReset ]
+]
+
+{ #category : 'class management' }
+FFIStructure class >> resetAllStructuresIfPlatformChanged [
+	"Reset the offsets of all structures.
+	This is required when there is a platform change since type sizes and padding rules change.
+
+	Manage nested structures with a recursive approach.
+	Stop recursing using a tracking collection of already reset structures."
+
+	| currentCompilationPlatform |
+	currentCompilationPlatform := {
+		                              OSPlatform current family.
+		                              Smalltalk vm wordSize }.
+	LastCompilationPlatform = currentCompilationPlatform ifTrue: [ ^ self ].
+
+	LastCompilationPlatform := currentCompilationPlatform.
+	self resetAllStructures
 ]
 
 { #category : 'class management' }


### PR DESCRIPTION
This PR is once again trying to load TFFI after UFFI since FreeType is using TFFI. 
The bug on linux 64bits was coming from the fact that a reset was happening only in the platform changed, but in some cases we want to reset even when the platform does not change. 

The solution introduced is to have a soft reset to call on startup and a hard reset to call manually. 
Also I removed a shutDown: method that is useless since we are doing the same at the startup.


Old PR message:

I don't know FFI much so I am working kind of blindly here. Since the variables that are not initialized are not because of TFFI, let's try to reset the FFI classes after the loading of BaselineOfIDE instead of moving the whole TFFI loading to baseline of IDE.

Let's see if this can work