### PR TITLE
Extract ParseTreeRewriter to its own package

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -151,7 +151,7 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" perform --save PharoBootstrapFixMethodsTool
 
 # Installing compiler through Hermes 
 echo $(date -u) "[Compiler] Installing compiler through Hermes"
-${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes UIManager.hermes Debugging-Utils.hermes OpalCompiler-Core.hermes Deprecation.hermes DebugInfo.hermes CodeImport.hermes CodeImport-Commands.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes UIManager.hermes Debugging-Utils.hermes OpalCompiler-Core.hermes ParseTreeRewriter.hermes Deprecation.hermes DebugInfo.hermes CodeImport.hermes CodeImport-Commands.hermes --save --no-fail-on-undeclared
 ${VM} "${COMPILER_IMAGE_NAME}.image" eval --save "SystemEnvironment deprecatedAliases: { #SystemDictionary }." # This line should be removed in Pharo 14 since it is for backward compatibility.
 ${VM} "${COMPILER_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/01-init.st --no-source --save --quit
 

--- a/src/AST-Core/ManifestASTCore.class.st
+++ b/src/AST-Core/ManifestASTCore.class.st
@@ -13,7 +13,7 @@ Class {
 ManifestASTCore class >> manuallyResolvedDependencies [
 
 	<ignoreForCoverage>
-	^ #( #'OpalCompiler-Core')
+	^ #( #'OpalCompiler-Core' #'System-Time')
 ]
 
 { #category : 'meta data' }

--- a/src/AST-Core/OCMethodNode.class.st
+++ b/src/AST-Core/OCMethodNode.class.st
@@ -577,20 +577,6 @@ OCMethodNode >> removePragmaNamed: aPragmaName [
 	self pragmaNamed: aPragmaName ifPresent: [ :pragma | self removePragma: pragma ]
 ]
 
-{ #category : 'adding-removing' }
-OCMethodNode >> removeSubtree: aTree [
-
-	^ aTree isReturn
-		ifTrue: [ OCParseTreeRewriter
-					 replace: aTree formattedCode
-					 with: '' in: self
-					 onInterval: aTree sourceInterval ]
-		ifFalse: [ OCParseTreeRewriter
-					  replaceStatements: aTree formattedCode
-		 			  with: '' in: self
-					  onInterval: aTree sourceInterval ]
-]
-
 { #category : 'accessing' }
 OCMethodNode >> renameSelector: newSelector andArguments: varNodeCollection [
 	| oldIntervals oldArguments oldSelector |

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -101,6 +101,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		spec package: 'Multilingual-Encodings'.
 		
 		spec package: 'Transcript-NonInteractive'.
+		spec package: 'ParseTreeRewriter'.
 		spec package: 'PharoBootstrap-Initialization'.
 		spec package: 'Random-Core'.
 		spec package: 'ReflectionMirrors-Primitives'.
@@ -203,6 +204,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'DebugInfo'.
 			'NumberParser'.
 			'OpalCompiler-Core'.
+			'ParseTreeRewriter'.
 			'Deprecation'}.
 		
 		spec group: 'FileSystemGroup' with: {

--- a/src/Deprecation/AutomaticRewriting.class.st
+++ b/src/Deprecation/AutomaticRewriting.class.st
@@ -150,7 +150,8 @@ AutomaticRewriting >> raiseWarning [
 
 { #category : 'private' }
 AutomaticRewriting >> rewriterClass [
-	^ self class environment at: #OCParseTreeRewriter ifAbsent: [ nil ]
+
+	^ OCParseTreeRewriter
 ]
 
 { #category : 'accessing' }

--- a/src/Deprecation/ManifestDeprecation.class.st
+++ b/src/Deprecation/ManifestDeprecation.class.st
@@ -1,0 +1,17 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestDeprecation',
+	#superclass : 'PackageManifest',
+	#category : 'Deprecation-Manifest',
+	#package : 'Deprecation',
+	#tag : 'Manifest'
+}
+
+{ #category : 'meta-data - dependency analyser' }
+ManifestDeprecation class >> manuallyResolvedDependencies [
+
+	<ignoreForCoverage>
+	^ #(#'AST-Core')
+]

--- a/src/ParseTreeRewriter/OCMethodNode.extension.st
+++ b/src/ParseTreeRewriter/OCMethodNode.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : 'OCMethodNode' }
+
+{ #category : '*ParseTreeRewriter' }
+OCMethodNode >> removeSubtree: aTree [
+
+	^ aTree isReturn
+		ifTrue: [ OCParseTreeRewriter
+					 replace: aTree formattedCode
+					 with: '' in: self
+					 onInterval: aTree sourceInterval ]
+		ifFalse: [ OCParseTreeRewriter
+					  replaceStatements: aTree formattedCode
+		 			  with: '' in: self
+					  onInterval: aTree sourceInterval ]
+]

--- a/src/ParseTreeRewriter/OCParseTreeRewriter.class.st
+++ b/src/ParseTreeRewriter/OCParseTreeRewriter.class.st
@@ -42,7 +42,7 @@ You can also have a look at the `ParseTreeRewriterTest` class.
 
 
 Instance Variables:
-	tree	<ASTProgramNode>	the parse tree we're transforming
+	tree	<OCProgramNode>	the parse tree we're transforming
 			
 	
 "
@@ -52,8 +52,8 @@ Class {
 	#instVars : [
 		'tree'
 	],
-	#category : 'AST-Core-Matching',
-	#package : 'AST-Core',
+	#category : 'ParseTreeRewriter-Matching',
+	#package : 'ParseTreeRewriter',
 	#tag : 'Matching'
 }
 

--- a/src/ParseTreeRewriter/package.st
+++ b/src/ParseTreeRewriter/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'ParseTreeRewriter' }


### PR DESCRIPTION
I also removed the fact that we hided a dependency to it in Deprecation. This was when it was in Deprecation but now Deprecation is loaded after the compiler so there is no need to hide the dependency.

Fixes #18866 

@Ducasse here you go :)