### PR TITLE
Fix minimal image tests

### DIFF
--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -61,7 +61,7 @@ export PHARO_CI_TESTING_ENVIRONMENT=1
 #Adding packages removed from the bootstrap
 ./pharo bootstrap.image perform --save BasicHermesTool load: --as-array Clap-Core.hermes Clap-Commands-Pharo.hermes Hermes-Extensions.hermes
 ./pharo bootstrap.image perform --save Pragma buildCache
-./pharo bootstrap.image loadHermes UIManager.hermes Math-Operations-Extensions.hermes System-Time.hermes NumberParser.hermes AST-Core.hermes Random-Core.hermes System-NumberPrinting.hermes --save --no-fail-on-undeclared --on-duplication ignore
+./pharo bootstrap.image loadHermes UIManager.hermes Math-Operations-Extensions.hermes System-Time.hermes NumberParser.hermes AST-Core.hermes ParseTreeRewriter.hermes Random-Core.hermes System-NumberPrinting.hermes --save --no-fail-on-undeclared --on-duplication ignore
 
 #Initializing the package manager
 ./pharo bootstrap.image perform --save PharoBootstrapFixMethodsTool fixExtensionMethods

--- a/src/AST-Core/ManifestASTCore.class.st
+++ b/src/AST-Core/ManifestASTCore.class.st
@@ -13,7 +13,7 @@ Class {
 ManifestASTCore class >> manuallyResolvedDependencies [
 
 	<ignoreForCoverage>
-	^ #( #'OpalCompiler-Core' #'System-Time')
+	^ #( #'System-Time')
 ]
 
 { #category : 'meta data' }

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -224,7 +224,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 
 		spec group: 'SUnitGroup' with: {
 			'Deprecation'.
-			'ParseTreeRewriter'
+			'ParseTreeRewriter'.
 			'SUnit-Core'.
 			'SUnit-Tests'.
 			'Kernel-Tests'.

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -224,6 +224,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 
 		spec group: 'SUnitGroup' with: {
 			'Deprecation'.
+			'ParseTreeRewriter'
 			'SUnit-Core'.
 			'SUnit-Tests'.
 			'Kernel-Tests'.


### PR DESCRIPTION
A recent change I did broke the tests of the minimal image because Trait depends on OCParseTreeRewriter to manage aliases.

It's weird the CI did not notice it before but here is a fix 