### PR TITLE
Fix kernel system dependency test

### DIFF
--- a/src/Kernel-BytecodeEncoders/BytecodeEncoder.class.st
+++ b/src/Kernel-BytecodeEncoders/BytecodeEncoder.class.st
@@ -13,6 +13,12 @@ Class {
 }
 
 { #category : 'accessing' }
+BytecodeEncoder class >> arraySizeLimitForPushArrayInstruction [
+
+	^ 127
+]
+
+{ #category : 'accessing' }
 BytecodeEncoder class >> instructionSizeAt: pc of: aMehtod [
 
 	self subclassResponsibility

--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -1033,7 +1033,7 @@ EncoderForSistaV1 >> genPushConsArray: size [
 	"231		11100111	jkkkkkkk	Push (Array new: kkkkkkk) (j = 0)
 									&	Pop kkkkkkk elements into: (Array new: kkkkkkk) (j = 1)"
 	| limit |
-	limit := OCIRPushArray sizeLimit.
+	limit := self class arraySizeLimitForPushArrayInstruction.
 	(size < 0 or: [size > limit]) ifTrue:
 		[^self outOfRangeError: 'size' index: size range: 0 to: limit].
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -556,9 +556,8 @@ OCASTTranslator >> visitAnnotationMarkNode: aAnnotationValueNode [
 OCASTTranslator >> visitArrayNode: anArrayNode [
 
 	| elementNodes stackLimit |
-	stackLimit := CompiledCode LargeFrame min: OCIRPushArray sizeLimit.
-	methodBuilder stackSize + anArrayNode statements size > stackLimit ifTrue: [
-		^ self visitLargeArrayNode: anArrayNode ].
+	stackLimit := CompiledCode LargeFrame min: self compilationContext encoderClass arraySizeLimitForPushArrayInstruction.
+	methodBuilder stackSize + anArrayNode statements size > stackLimit ifTrue: [ ^ self visitLargeArrayNode: anArrayNode ].
 
 	elementNodes := anArrayNode children.
 	elementNodes do: [ :node | self visitNode: node ].

--- a/src/OpalCompiler-Core/OCIRPushArray.class.st
+++ b/src/OpalCompiler-Core/OCIRPushArray.class.st
@@ -15,12 +15,6 @@ Class {
 	#tag : 'IR-Nodes'
 }
 
-{ #category : 'accessing' }
-OCIRPushArray class >> sizeLimit [
-
-	^ 127
-]
-
 { #category : 'visiting' }
 OCIRPushArray >> accept: aVisitor [
 	^ aVisitor visitPushArray: self


### PR DESCRIPTION
A dependency got introduced to fix a bug in the generation of large arrays. It makes the Bytecode depend on the compiler to access a constant. I moved the constant to the encoder to break the dependency.

Change made with Nahuel (which fixed the large array problem)