### PR TITLE
Better comment and names for refactoring

### DIFF
--- a/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBAbstractInstanceVariableRefactoring.class.st
@@ -48,7 +48,7 @@ RBAbstractInstanceVariableRefactoring >> accessorsRefactoring [
 				class: class
 				classVariable: false
 			]
-		ifNotNil: [ accessorsRefactoring ]
+
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Core/RBProtectInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBProtectInstanceVariableRefactoring.class.st
@@ -1,8 +1,9 @@
 "
-I am a refactoring for protecting instance variable access.
+I am a refactoring for protecting instance variable access.  
 
-If a class defines methods for reading and writing instance variables, they are removed and all calls on this methods.
-Omit method that are redefined in subclasses.
+When doing a transformation on the source code, I will check for accessors of instance variable and inline all calls to the method calling them. 
+I take subclasses and sibling classes into account, preventing breaking changes.
+Also if any subclass redefines an accessor for the variable, I will not apply changes for it. 
 "
 Class {
 	#name : 'RBProtectInstanceVariableRefactoring',
@@ -20,6 +21,8 @@ RBProtectInstanceVariableRefactoring >> applicabilityPreconditions [
 
 { #category : 'private - accessing' }
 RBProtectInstanceVariableRefactoring >> getterSetterMethods [
+	"Getter/setters are methods are accessors that are not redefined in subclasses."
+	
 	| matcher |
 	matcher := self parseTreeSearcher.
 	matcher

--- a/src/Refactoring-Transformations/RBAbstractInstanceVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAbstractInstanceVariableTransformation.class.st
@@ -15,7 +15,7 @@ Preconditions:
 overriden from RBAddAccessorsForClassTransformation and RBRemoveDirectAccessToVariableTransformation
 "
 Class {
-	#name : 'RBProtectVariableTransformation',
+	#name : 'RBAbstractInstanceVariableTransformation',
 	#superclass : 'RBCompositeVariableTransformation',
 	#category : 'Refactoring-Transformations-Model-Unused',
 	#package : 'Refactoring-Transformations',
@@ -23,7 +23,7 @@ Class {
 }
 
 { #category : 'executing' }
-RBProtectVariableTransformation >> buildTransformations [
+RBAbstractInstanceVariableTransformation >> buildTransformations [
 
 	^ OrderedCollection
 		with: (RBAddVariableAccessorTransformation
@@ -35,11 +35,11 @@ RBProtectVariableTransformation >> buildTransformations [
 				model: self model
 				variable: variableName asString
 				class: className
-				classVariable: isClassVariable)
+				classVariable: isClassVariable) 
 ]
 
 { #category : 'storing' }
-RBProtectVariableTransformation >> storeOn: aStream [
+RBAbstractInstanceVariableTransformation >> storeOn: aStream [
 
 	aStream nextPut: $(.
 	self class storeOn: aStream.
@@ -53,7 +53,7 @@ RBProtectVariableTransformation >> storeOn: aStream [
 ]
 
 { #category : 'api' }
-RBProtectVariableTransformation >> variable: aVariableName class: aClassName classVariable: aBoolean [
+RBAbstractInstanceVariableTransformation >> variable: aVariableName class: aClassName classVariable: aBoolean [
 
 	variableName := aVariableName.
 	isClassVariable := aBoolean.


### PR DESCRIPTION
- Rename the transformation to AbstractInstanceVariable since it was doing the opposite of ProtectVariable refactoring
- Better comments for `RBProtectInstanceVariableRefactoring` to know better the scope action
- Fixes #18848