### PR TITLE
18812-Race-conditions-when-globally-changing-SystemAnnouncer

### DIFF
--- a/src/Announcements-Core-Tests/AnnouncerTest.class.st
+++ b/src/Announcements-Core-Tests/AnnouncerTest.class.st
@@ -99,6 +99,44 @@ AnnouncerTest >> testAnnouncingReentrant [
 	self assert: ok
 ]
 
+{ #category : 'tests' }
+AnnouncerTest >> testConcurrentSuspendAllWhile [
+
+	| p1Resume p2Resume p1End p2End p1 isSuspended1 p2 isSuspended2 |
+	
+	p1Resume := Semaphore new.
+	p2Resume := Semaphore new.
+	p1End := Semaphore new.
+	p2End := Semaphore new.
+	
+	p1 := [ 
+		isSuspended1 := announcer isSuspended.
+		announcer suspendAllWhile: [ 
+			p2Resume signal.
+			p1Resume wait.].
+			p1End signal.
+		] fork .
+
+	p2 := [ 
+		isSuspended2 := announcer isSuspended.
+		p2Resume wait.
+		announcer suspendAllWhile: [ 
+			p1Resume signal.
+			p2Resume wait. ].
+		p2End signal.
+		
+		] fork.
+	
+	p1End wait.
+	p2Resume signal.
+	p2End wait.
+
+	self deny: isSuspended1.
+	self assert: isSuspended2.
+	self assert: announcer suspendedCount equals: 0.
+	self deny: announcer isSuspended.	
+]
+
 { #category : 'tests - subscribers' }
 AnnouncerTest >> testHandleSubscriberClass [
 

--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -8,6 +8,8 @@ Users can create subclasses of Announcement, then objects can register to an ann
 The implementation uses a threadsafe subscription registry, in the sense that registering, unregistering, and announcing from an announcer at the same time in different threads should never cause failures.
 
 The method #prevent:during: allows one to prevent the firing of some announcements during the execution of a block wile letting the other announcements go throuht.
+
+It is also possible to suspend the announcements during the execution of a block (either to prevent all announcements, or to announce them as a bulk after the bloc execution). This feature was originaly implemented using a boolean, but we are now using a counter because it is possible to do concurent calls to the announcer. See #testConcurrentSuspendAllWhile for an example.
 "
 Class {
 	#name : 'Announcer',

--- a/src/Announcements-Core/Announcer.class.st
+++ b/src/Announcements-Core/Announcer.class.st
@@ -15,8 +15,8 @@ Class {
 	#instVars : [
 		'registry',
 		'preventedAnnouncements',
-		'suspended',
-		'storedAnnouncements'
+		'storedAnnouncements',
+		'suspendedCount'
 	],
 	#category : 'Announcements-Core-Base',
 	#package : 'Announcements-Core',
@@ -74,13 +74,16 @@ Announcer >> hasSubscriber: anObject [
 
 { #category : 'initialization' }
 Announcer >> initialize [
+
 	super initialize.
-	registry := SubscriptionRegistry new
+	registry := SubscriptionRegistry new.
+	suspendedCount := 0.
 ]
 
 { #category : 'testing' }
 Announcer >> isSuspended [
-	^suspended ifNil: [ suspended := false ]
+
+	^ suspendedCount > 0
 ]
 
 { #category : 'statistics' }
@@ -134,10 +137,9 @@ Announcer >> subscriptionsForClass: subscriberClass [
 Announcer >> suspendAllWhile: aBlock [
 	"Returns the result of the block execution."
 	
-	| oldSuspended |
-	oldSuspended := self isSuspended.
-	suspended := true.
-	^aBlock ensure: [ suspended := oldSuspended ]
+	suspendedCount := suspendedCount + 1.
+	^aBlock ensure: [ 
+		suspendedCount := suspendedCount - 1 ]
 ]
 
 { #category : 'announce' }
@@ -159,6 +161,17 @@ Announcer >> suspendAllWhileStoring: aBlock [
 			storedAnnouncements := nil.
 		]
 	]
+]
+
+{ #category : 'accessing' }
+Announcer >> suspendedCount [
+
+	^ suspendedCount
+]
+
+{ #category : 'accessing' }
+Announcer >> suspendedCount: anInteger [ 
+	suspendedCount := anInteger
 ]
 
 { #category : 'subscription' }


### PR DESCRIPTION
Fix #18812
- Replace the use of a boolean flag with and integer to handle the concurrent calls to Announcer