### PR TITLE
Updated outdated class comments in the AST-Core package

### DIFF
--- a/src/AST-Core-Tests/OCCodeSnippet.class.st
+++ b/src/AST-Core-Tests/OCCodeSnippet.class.st
@@ -1,7 +1,7 @@
 "
 Small pieces of source code used used to test various AST based tools.
 
-See `RBCodeSnippet allSnippets` for a various collection of instances.
+See `OCCodeSnippet allSnippets` for a various collection of instances.
 
 * source <String> the source code of the snippet
 * isScripting <Boolean> the source is for a script (without pattern or pragmas)
@@ -15,7 +15,7 @@ See `RBCodeSnippet allSnippets` for a various collection of instances.
 * numberOfCritique <Integer> how many critiques are expected
 * skippedTests <Collection> list of test to not execute (that should be fixed)
 
-Tests are executed by the parametrized matrix class `RBCodeSnippetTest`
+Tests are executed by the parametrized matrix class `OCCodeSnippetTest`
 
 Additional tools can add more information and expectation (please improve the list and the tools)
 "

--- a/src/AST-Core-Tests/OCCodeSnippetTest.class.st
+++ b/src/AST-Core-Tests/OCCodeSnippetTest.class.st
@@ -2,7 +2,7 @@
 This class contains tests
 
 Parametrized matrix test class to run various test on code snippets.
-The only parameter is the instance variable `snippet` that is the current code snippet <RBCodeSnippet>.
+The only parameter is the instance variable `snippet` that is the current code snippet <OCCodeSnippet>.
 "
 Class {
 	#name : 'OCCodeSnippetTest',

--- a/src/AST-Core-Tests/OCParserTest.class.st
+++ b/src/AST-Core-Tests/OCParserTest.class.st
@@ -1,5 +1,5 @@
 "
-SUnit tests for RBParser
+SUnit tests for OCParser
 "
 Class {
 	#name : 'OCParserTest',

--- a/src/AST-Core-Tests/OCPatternParserTest.class.st
+++ b/src/AST-Core-Tests/OCPatternParserTest.class.st
@@ -1,6 +1,6 @@
-"
-SUnit tests for RBPatternParser.
-RBPatternParser needs some extra tests not covered by RBPatternTest for its extended syntax
+" 
+SUnit tests for OCPatternParser.
+OCPatternParser needs some extra tests not covered by RBPatternTest for its extended syntax
 (pattern variables and pattern blocks)
 "
 Class {

--- a/src/AST-Core-Tests/OCScannerTest.class.st
+++ b/src/AST-Core-Tests/OCScannerTest.class.st
@@ -1,5 +1,5 @@
-"
-SUnit tests for RBScanner
+" 
+SUnit tests for OCScanner
 "
 Class {
 	#name : 'OCScannerTest',

--- a/src/AST-Core/OCEnglobingErrorNode.class.st
+++ b/src/AST-Core/OCEnglobingErrorNode.class.st
@@ -3,9 +3,9 @@ I am a node representing a source code segment that parsed but never used in a n
 This node also propose a reparation research.
 
 Parsing faulty code without raising a syntax error is done by 
-RBParser parseFaultyExpression:
+OCParser parseFaultyExpression:
 or
-RBParser parseFaultyMethod: 
+OCParser parseFaultyMethod: 
 
 Accessing to the parsed nodes contained inside the node is the method 'content'.
 

--- a/src/AST-Core/OCGenericNodeVisitor.class.st
+++ b/src/AST-Core/OCGenericNodeVisitor.class.st
@@ -1,5 +1,5 @@
 "
-Visit any RBProgrmNode in the syntax tree and evaluate a generic block
+Visit any OCProgramNode in the syntax tree and evaluate a generic block
 "
 Class {
 	#name : 'OCGenericNodeVisitor',

--- a/src/AST-Core/OCKeywordToken.class.st
+++ b/src/AST-Core/OCKeywordToken.class.st
@@ -1,5 +1,5 @@
 "
-RBKeywordToken is the first-class representation of a keyword token (e.g. add:)
+OCKeywordToken is the first-class representation of a keyword token (e.g. add:)
 "
 Class {
 	#name : 'OCKeywordToken',

--- a/src/AST-Core/OCLiteralToken.class.st
+++ b/src/AST-Core/OCLiteralToken.class.st
@@ -1,5 +1,5 @@
-"
-RBLiteralToken is the first-class representation of a literal token (entire literals, even literal arrays, are a single token in the Pharo grammar).
+" 
+OCLiteralToken is the first-class representation of a literal token (entire literals, even literal arrays, are a single token in the Pharo grammar).
 
 Instance Variables:
 - stopPosition <Integer> The position within the source code where the token terminates.

--- a/src/AST-Core/OCParseErrorNode.class.st
+++ b/src/AST-Core/OCParseErrorNode.class.st
@@ -2,9 +2,9 @@
 I am a node representing a source code segment that could not be parsed. I am mainly used for source-code coloring where we should parse as far as possible and mark the rest as a failure.
 
 Parsing faulty code without raising a syntax error is done by 
-RBParser parseFaultyExpression:
+OCParser parseFaultyExpression:
 or
-RBParser parseFaultyMethod: 
+OCParser parseFaultyMethod: 
 
 The return value is either valid nodes representing the AST, or nodes representing the valid portion and an ASTParseErrorNode for the remaining invalid code.
 

--- a/src/AST-Core/OCParseTreeSearcher.class.st
+++ b/src/AST-Core/OCParseTreeSearcher.class.st
@@ -4,7 +4,7 @@ ParseTreeSearcher walks over a normal source code parse tree using the visitor p
 Instance Variables:
 	answer	<Object>	the ""answer"" that is propagated between matches
 	argumentSearches	<Collection of: (Association key: ASTProgramNode value: BlockClosure)>	argument searches (search for the ASTProgramNode and perform the BlockClosure when its found)
-	context	<RBSmallDictionary>	a dictionary that contains what each meta-node matches against. This could be a normal Dictionary that is created for each search but is created once and reused (efficiency).
+	context	<SmallDictionary>	a dictionary that contains what each meta-node matches against. This could be a normal Dictionary that is created for each search but is created once and reused (efficiency).
 	messages	<Collection>	the sent messages in our searches
 	searches	<Collection of: (Association key: ASTProgramNode value: BlockClosure)>	non-argument searches (search for the ASTProgramNode and perform the BlockClosure when its found)
 	

--- a/src/AST-Core/OCParser.class.st
+++ b/src/AST-Core/OCParser.class.st
@@ -1,12 +1,12 @@
-"
-RBParser takes a source code string and generates an AST for it. This is a hand-written, recursive descent parser and has been optimized for speed. The simplest way to call this is either 'RBParser parseExpression: aString' if you want the AST for an expression, or 'RBParser parseMethod: aString' if you want to parse an entire method.
+" 
+OCParser takes a source code string and generates an AST for it. This is a hand-written, recursive descent parser and has been optimized for speed. The simplest way to call this is either 'OCParser parseExpression: aString' if you want the AST for an expression, or 'OCParser parseMethod: aString' if you want to parse an entire method.
 
 Instance Variables:
 	currentToken	<ASTToken>	The current token being processed.
 	emptyStatements	<Boolean>	True if empty statements are allowed. In IBM, they are, in VW they aren't.
 	errorBlock	<BlockClosure>	The block to evaluate on a syntax error.
 	nextToken	<ASTToken>	The next token that will be processed. This allows one-token lookahead.
-	scanner	<RBScanner>	The scanner that generates a stream of tokens to parse.
+	scanner	<OCScanner>	The scanner that generates a stream of tokens to parse.
 	source	<String>	The source code to parse
 	tags	<Collection of: Interval>	The source intervals of the tags appearing at the top of a method (e.g. Primitive calls)
 

--- a/src/AST-Core/OCPatternBlockToken.class.st
+++ b/src/AST-Core/OCPatternBlockToken.class.st
@@ -1,5 +1,5 @@
 "
-RBPatternBlockToken is the first-class representation of the pattern block token.
+OCPatternBlockToken is the first-class representation of the pattern block token.
 
 
 "

--- a/src/AST-Core/OCPatternParser.class.st
+++ b/src/AST-Core/OCPatternParser.class.st
@@ -1,5 +1,5 @@
 "
-RBPatternParser is a subclass of RBParser that allows the extended syntax that creates matching trees. These trees can be used by the ParseTreeMatcher to search and transform source code.
+OCPatternParser is a subclass of OCParser that allows the extended syntax that creates matching trees. These trees can be used by the ParseTreeMatcher to search and transform source code.
 
 "
 Class {

--- a/src/AST-Core/OCPatternScanner.class.st
+++ b/src/AST-Core/OCPatternScanner.class.st
@@ -1,5 +1,5 @@
 "
-RBPatternScanner is a subclass of RBScanner that allows the extended syntax of pattern matching trees.
+OCPatternScanner is a subclass of OCScanner that allows the extended syntax of pattern matching trees.
 
 "
 Class {

--- a/src/AST-Core/OCProgramNode.class.st
+++ b/src/AST-Core/OCProgramNode.class.st
@@ -14,7 +14,7 @@ The #start and #stop methods are used to find the source that corresponds to thi
 
 The #acceptVisitor: method is used by ASTProgramNodeVisitors (the visitor pattern). This will also require updating all the ASTProgramNodeVisitors so that they know of the new node.
 
-The #isFaulty method is used to distinguish between valid nodes and nodes created from an invalid source Smalltalk code. For example, code parsed with RBParsers #parseFaultyExpression: or #parseFaultyMethod:.
+The #isFaulty method is used to distinguish between valid nodes and nodes created from an invalid source Smalltalk code. For example, code parsed with OCParser #parseFaultyExpression: or #parseFaultyMethod:.
 
 Subclasses might also want to redefine match:inContext: and copyInContext: to do parse tree searching and replacing.
 

--- a/src/AST-Core/OCScanner.class.st
+++ b/src/AST-Core/OCScanner.class.st
@@ -1,7 +1,7 @@
 "
-RBScanner is a stream that returns a sequence of tokens from the string. The tokens know where they came from in the source code and which comments were attached to them.
+OCScanner is a stream that returns a sequence of tokens from the string. The tokens know where they came from in the source code and which comments were attached to them.
 
-NOTE: The RBScanner should never be used directly. (If you do so, do it on your own risk!)
+NOTE: The OCScanner should never be used directly. (If you do so, do it on your own risk!)
 The Scanner is private the to Parser, and even the Parser should be used only via the API of the Compiler!
 
 Instance Variables:

--- a/src/AST-Core/OCToken.class.st
+++ b/src/AST-Core/OCToken.class.st
@@ -1,5 +1,5 @@
 "
-ASTToken is the abstract superclass of all of the RB tokens. These tokens (unlike the standard parser's) remember where they came from in the original source code.
+ASTToken is the abstract superclass of all of the OC tokens. These tokens (unlike the standard parser's) remember where they came from in the original source code.
 
 Subclasses must implement the following messages:
 	accessing


### PR DESCRIPTION
The class comments in AST-Core classes had still the old RB names