### PR TITLE
Deprecate and replace SourceFiles global variable

### DIFF
--- a/src/EmergencyDebugger/EDDebuggingAPI.class.st
+++ b/src/EmergencyDebugger/EDDebuggingAPI.class.st
@@ -63,7 +63,7 @@ EDDebuggingAPI class >> terminateProcesses: processes [
 
 { #category : 'API - Revert' }
 EDDebuggingAPI >> changeRecordsForMethod: aCompiledMethod [
-	^ SourceFiles changeRecordsFor: aCompiledMethod
+	^ SourceFileArray default changeRecordsFor: aCompiledMethod
 ]
 
 { #category : 'accessing' }

--- a/src/Fuel-Core/FLConfiguration.class.st
+++ b/src/Fuel-Core/FLConfiguration.class.st
@@ -47,7 +47,7 @@ FLConfiguration class >> defaultGlobalEnvironment [
 { #category : 'accessing-defaults' }
 FLConfiguration class >> defaultGlobalSymbols [
 
-    ^ #(#Smalltalk #SourceFiles #Transcript #Undeclared #Display #TextConstants #ActiveWorld #ActiveHand #ActiveEvent #Sensor #Processor #SystemOrganization #World)
+    ^ #(#Smalltalk #Transcript #Undeclared #Display #TextConstants #ActiveWorld #ActiveHand #ActiveEvent #Sensor #Processor #SystemOrganization #World)
 ]
 
 { #category : 'accessing-defaults' }

--- a/src/General-Rules/ReGlobalVariablesUsageRule.class.st
+++ b/src/General-Rules/ReGlobalVariablesUsageRule.class.st
@@ -66,7 +66,6 @@ ReGlobalVariablesUsageRule >> isKnownGlobal: aString [
 			Display
 			Processor
 			Smalltalk
-			SourceFiles
 			Transcript
 			Undeclared
 			World

--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -372,9 +372,10 @@ Class >> classVariablesNeedFullDefinition [
 
 { #category : 'accessing - comment' }
 Class >> comment [
-    ^ self commentSourcePointer
+
+	^ self commentSourcePointer
 		  ifNil: [ '' ]
-		  ifNotNil: [ :ptr | SourceFiles sourceCodeAt: ptr ]
+		  ifNotNil: [ :ptr | SourceFileArray default sourceCodeAt: ptr ]
 ]
 
 { #category : 'accessing - comment' }
@@ -395,7 +396,7 @@ Class >> comment: aString stamp: aStamp [
 
 	pointer := self commentSourcePointer ifNil: [ 0 ].
 
-	SourceFiles
+	SourceFileArray default
 		writeComment: aString
 		ofClass: self
 		metadata: ' '
@@ -427,7 +428,7 @@ Class >> commentStamp [
 
 	^ self commentSourcePointer
 		  ifNil: [ '' ]
-		  ifNotNil: [:sourcePointer | SourceFiles commentTimeStampAt: sourcePointer ]
+		  ifNotNil: [:sourcePointer | SourceFileArray default commentTimeStampAt: sourcePointer ]
 ]
 
 { #category : 'accessing - comment' }

--- a/src/Kernel-CodeModel/CompiledCode.class.st
+++ b/src/Kernel-CodeModel/CompiledCode.class.st
@@ -1007,7 +1007,7 @@ CompiledCode >> timeStamp [
 	"Answer the authoring time-stamp for the given method, retrieved from the sources or changes file. Answer the empty string if no time stamp is available."
 	"(CompiledMethod compiledMethodAt: #timeStamp) timeStamp"
 
-	^ SourceFiles timeStampAt: self sourcePointer
+	^ SourceFileArray default timeStampAt: self sourcePointer
 ]
 
 { #category : 'testing' }

--- a/src/Kernel-CodeModel/CompiledMethod.class.st
+++ b/src/Kernel-CodeModel/CompiledMethod.class.st
@@ -210,7 +210,7 @@ CompiledMethod >> flushCache [
 
 { #category : 'source code management' }
 CompiledMethod >> getPreambleFrom: aFileStream at: position [
-	^ SourceFiles getPreambleFrom: aFileStream at: position
+	^ SourceFileArray default getPreambleFrom: aFileStream at: position
 ]
 
 { #category : 'source code management' }
@@ -219,7 +219,7 @@ CompiledMethod >> getSourceFromFile [
 	"Read the source code from file, determining source file index and
 	file position from the last bytes of this method (size defined in #trailerSize)."
 
-	^ [ SourceFiles sourceCodeAt: self sourcePointer ] on: Error do: [ nil ]
+	^ [ SourceFileArray default sourceCodeAt: self sourcePointer ] on: Error do: [ nil ]
 ]
 
 { #category : 'source code management' }

--- a/src/Kernel-CodeModel/CompiledMethod.class.st
+++ b/src/Kernel-CodeModel/CompiledMethod.class.st
@@ -883,7 +883,7 @@ CompiledMethod >> sourceCodeOrNil [
 { #category : 'source code management' }
 CompiledMethod >> sourcePointer [
 	"Answer the integer which can be used to find the source file and position for this method.
-	The actual interpretation of this number is up to the SourceFileArray stored in the global variable SourceFiles."
+	The actual interpretation of this number is up to the SourceFileArray default instance."
 	| trailerBytes trailerSize start |
 	trailerSize := self class trailerSize.
 	trailerBytes := ByteArray new: trailerSize.

--- a/src/Monticello/MCPackageLoader.class.st
+++ b/src/Monticello/MCPackageLoader.class.st
@@ -77,7 +77,7 @@ MCPackageLoader >> analyze [
 { #category : 'private' }
 MCPackageLoader >> basicLoad [
 
-	SourceFiles deferFlushDuring: [ self basicLoadDefinitions ]
+	SourceFileArray default deferFlushDuring: [ self basicLoadDefinitions ]
 ]
 
 { #category : 'private' }

--- a/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
+++ b/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
@@ -73,7 +73,7 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 	'Initializing sources' traceCr.
 	Smalltalk sourceFileVersionString: 'PharoV60'.
 	(Smalltalk class classVariableNamed: 'LastImagePath') value: Smalltalk imagePath. "set the default value"
-	SourceFiles := SourceFileArray new.
+	SourceFileArray initialize.
 
 	'InitializingFFI' traceCr.
 	"FFI"

--- a/src/PharoBootstrap/PBAbstractImageBuilder.class.st
+++ b/src/PharoBootstrap/PBAbstractImageBuilder.class.st
@@ -331,7 +331,6 @@ PBAbstractImageBuilder >> createInitialObjects [
 			"Initialize the globals of the system. Careful: The AST interpreter will not know about these if we do not put them in the bootstrapEnvironment."
 			self bootstrapInterpreter evaluateCode: 'Smalltalk globals at: #Processor put: nil.'.
 			self bootstrapInterpreter evaluateCode: 'Smalltalk globals at: #Transcript put: nil.'.
-			self bootstrapInterpreter evaluateCode: 'Smalltalk globals at: #SourceFiles put: nil.'.
 
 
 			self log: 'class loader now creates class pools'.

--- a/src/PharoBootstrap/PBBootstrap.class.st
+++ b/src/PharoBootstrap/PBBootstrap.class.st
@@ -386,7 +386,7 @@ PBBootstrap >> prepareEnvironmentForExport [
 			ringEnvironment removePackage: p].
 
 	ringEnvironment cleanGlobalVariables.
-	ringEnvironment addGlobalsNamed: #(#Smalltalk #SourceFiles #Transcript #Undeclared #Display #TextConstants  #Sensor #Processor).
+	ringEnvironment addGlobalsNamed: #(#Smalltalk #Transcript #Undeclared #Display #TextConstants  #Sensor #Processor).
 	ringEnvironment clean
 
 ]
@@ -395,7 +395,7 @@ PBBootstrap >> prepareEnvironmentForExport [
 PBBootstrap >> prepareEnvironmentForHermes [
 	ringEnvironment := self originRepository asRing2EnvironmentWith: self allPackagesForHermes.
 	ringEnvironment fixProtoObjectClassSuperclass.
-	ringEnvironment addGlobalsNamed: #(Smalltalk Transcript FileStream MacRomanTextConverter SourceFiles Processor Display Sensor UTF8TextConverter Undeclared TextConstants).
+	ringEnvironment addGlobalsNamed: #(Smalltalk Transcript FileStream MacRomanTextConverter Processor Display Sensor UTF8TextConverter Undeclared TextConstants).
 	ringEnvironment clean
 ]
 

--- a/src/Ring-Definitions-Core/RGCommentDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGCommentDefinition.class.st
@@ -99,7 +99,7 @@ RGCommentDefinition >> contentAtPointer [
 	"A RGCommentDefinition may be created to point the sourceFile in which case it retrieves the class comment"
 
 	^ self sourcePointer
-		  ifNotNil: [ SourceFiles sourceCodeAt: self sourcePointer ]
+		  ifNotNil: [ SourceFileArray default sourceCodeAt: self sourcePointer ]
 		  ifNil: [ '' ]
 ]
 
@@ -271,7 +271,7 @@ RGCommentDefinition >> stampAtPointer [
 
 	^ self sourcePointer
 		  ifNotNil: [
-			  SourceFiles
+			  SourceFileArray default
 				  timeStampAt: self sourcePointer
 				  for: self commentDataPointers ]
 		  ifNil: [ nil ]

--- a/src/Ring-Definitions-Core/RGMethodDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGMethodDefinition.class.st
@@ -264,7 +264,7 @@ RGMethodDefinition >> fullName [
 
 { #category : 'source pointers' }
 RGMethodDefinition >> getPreambleFrom: aFileStream at: position [
-	^ SourceFiles getPreambleFrom: aFileStream at: position
+	^ SourceFileArray default getPreambleFrom: aFileStream at: position
 ]
 
 { #category : 'testing' }
@@ -550,7 +550,7 @@ RGMethodDefinition >> protocolAtPointer [
 	"A RGMethodDefinition that was set as historical will retrieve the protocol using the sourcePointer"
 
 	^ self sourcePointer
-		  ifNotNil: [ SourceFiles protocolAt: self sourcePointer ]
+		  ifNotNil: [ SourceFileArray default protocolAt: self sourcePointer ]
 		  ifNil: [ nil ]
 ]
 
@@ -606,7 +606,7 @@ RGMethodDefinition >> sourceCodeAtPointer [
 	"A RGMethodDefinition that was set as historical will retrieve the sourceCode using the sourcePointer"
 
 	^ self sourcePointer
-		  ifNotNil: [ SourceFiles sourceCodeAt: self sourcePointer ]
+		  ifNotNil: [ SourceFileArray default sourceCodeAt: self sourcePointer ]
 		  ifNil: [ nil ]
 ]
 
@@ -647,7 +647,7 @@ RGMethodDefinition >> stampAtPointer [
 	"A RGMethodDefinition that was set as historical will retrieve the stamp using the sourcePointer"
 
 	^ self sourcePointer
-		  ifNotNil: [ SourceFiles timeStampAt: self sourcePointer ]
+		  ifNotNil: [ SourceFileArray default timeStampAt: self sourcePointer ]
 		  ifNil: [ nil ]
 ]
 

--- a/src/System-Sources-Tests/SourceFileArrayTest.class.st
+++ b/src/System-Sources-Tests/SourceFileArrayTest.class.st
@@ -21,10 +21,10 @@ SourceFileArrayTest >> ensureChangesFileOpenedInProcess [
 
 	| sourcePointer fileIndex filePosition string |
 	sourcePointer :=  thisContext method sourcePointer.
-	fileIndex := SourceFiles fileIndexFromSourcePointer: sourcePointer.
-	filePosition := SourceFiles filePositionFromSourcePointer: sourcePointer.
+	fileIndex := SourceFileArray default fileIndexFromSourcePointer: sourcePointer.
+	filePosition := SourceFileArray default filePositionFromSourcePointer: sourcePointer.
 	
-	string := SourceFiles
+	string := SourceFileArray default
 		readStreamAtFileIndex: fileIndex
 		atPosition: filePosition
 		ifPresent: [ :readStream | (ChunkReadStream on: readStream) next ]
@@ -49,7 +49,7 @@ SourceFileArrayTest >> testAddressRange [
 { #category : 'tests' }
 SourceFileArrayTest >> testChangesFileStream [
 
-	self assert: SourceFiles changesFileStream isNotNil
+	self assert: SourceFileArray default changesFileStream isNotNil
 ]
 
 { #category : 'tests' }
@@ -94,7 +94,7 @@ SourceFileArrayTest >> testForkedRead [
 		readSemaphore wait.
 
 		"Read the string that was written in other process."
-		readString := SourceFiles
+		readString := SourceFileArray default
 			readStreamAtFileIndex: 2 "changes"
 			atPosition: position
 			ifPresent: [ :readStream | (ChunkReadStream on: readStream) next ]
@@ -103,7 +103,7 @@ SourceFileArrayTest >> testForkedRead [
 		] fork.
 
 	"Write the string, that will be read in other process."
-	SourceFiles changesWriteStreamDo: [ :theFile |
+	SourceFileArray default changesWriteStreamDo: [ :theFile |
 		theFile cr.
 		position := theFile position.
 		(ChunkWriteStream on: theFile) nextPut: originalString.
@@ -131,7 +131,7 @@ SourceFileArrayTest >> testForkedWrite [
 		readSemaphore wait.
 
 		"Write the string, that will be read in other process."
-		SourceFiles changesWriteStreamDo: [ :theFile |
+		SourceFileArray default changesWriteStreamDo: [ :theFile |
 			theFile cr.
 			position := theFile position.
 			(ChunkWriteStream on: theFile) nextPut: originalString.
@@ -144,7 +144,7 @@ SourceFileArrayTest >> testForkedWrite [
 	testSemaphore wait.
 
 	"Read the string that was written in other process."
-	readString := SourceFiles
+	readString := SourceFileArray default
 		readStreamAtFileIndex: 2 "changes"
 		atPosition: position
 		ifPresent: [ :readStream | (ChunkReadStream on: readStream) next ]
@@ -201,11 +201,11 @@ SourceFileArrayTest >> testProtocol [
 
 	| okCm notOkCm |
 	okCm := Point >> #dotProduct:.
-	self assert: ((SourceFiles sourcedDataAt: okCm sourcePointer) beginsWith: 'Point methodsFor: ''point functions''').
-	self assert: (SourceFiles protocolAt: okCm sourcePointer) equals: 'point functions'.
+	self assert: ((SourceFileArray default sourcedDataAt: okCm sourcePointer) beginsWith: 'Point methodsFor: ''point functions''').
+	self assert: (SourceFileArray default protocolAt: okCm sourcePointer) equals: 'point functions'.
 
 	notOkCm := Behavior >> #superclass.
-	self assert: (SourceFiles protocolAt: notOkCm sourcePointer) equals: 'accessing - class hierarchy'
+	self assert: (SourceFileArray default protocolAt: notOkCm sourcePointer) equals: 'accessing - class hierarchy'
 ]
 
 { #category : 'tests' }
@@ -228,7 +228,7 @@ SourceFileArrayTest >> testSourcePointerFromFileIndexAndPosition [
 { #category : 'tests' }
 SourceFileArrayTest >> testSourcesFileStream [
 
-	self assert: SourceFiles sourcesFileStream isNotNil
+	self assert: SourceFileArray default sourcesFileStream isNotNil
 ]
 
 { #category : 'tests' }

--- a/src/System-Sources-Tests/SourceFileBufferedReadWriteStreamTest.class.st
+++ b/src/System-Sources-Tests/SourceFileBufferedReadWriteStreamTest.class.st
@@ -84,7 +84,7 @@ SourceFileBufferedReadWriteStreamTest >> testEnsureWrittenPositionFlushesComplet
 	preambleLength := 2 + trait name size + 13 + 3 + 9 + changestampsize
 	                  + 3.
 
-	SourceFiles changesWriteStreamDo: [ :sourceFile |
+	SourceFileArray default changesWriteStreamDo: [ :sourceFile |
 		| stream |
 		[ "We want the internal buffer to be flushed after
 				writing the first two characters of the method selector"
@@ -93,7 +93,7 @@ SourceFileBufferedReadWriteStreamTest >> testEnsureWrittenPositionFlushesComplet
 		stream sizeBuffer: preambleLength + 2.
 
 		"This happens in MCPackageLoader>>basicLoad:"
-		SourceFiles deferFlushDuring: [ "Compiling a method in a trait with users will lead to
+		SourceFileArray default deferFlushDuring: [ "Compiling a method in a trait with users will lead to
 					the source of the compiled method being read again for
 					compilation in the using class which would read an incomplete
 					chunk and lead to an error.""It's difficult to align the buffer properly to the file size, as

--- a/src/System-Sources/ChangesLog.class.st
+++ b/src/System-Sources/ChangesLog.class.st
@@ -55,45 +55,44 @@ ChangesLog >> assureStartupStampLogged [
 
 	startupStamp ifNil: [ ^ self ].
 
-	SourceFiles changesWriteStreamDo: [ :changesFile |
-			(ChunkWriteStream on: changesFile)
-				cr;
-				cr;
-				nextPut: startupStamp asString;
-				cr.
-			startupStamp := nil ].
-
-	SourceFiles forceChangesToDisk
+	SourceFileArray default
+		changesWriteStreamDo: [ :changesFile |
+				(ChunkWriteStream on: changesFile)
+					cr;
+					cr;
+					nextPut: startupStamp asString;
+					cr.
+				startupStamp := nil ];
+		forceChangesToDisk
 ]
 
 { #category : 'logging' }
 ChangesLog >> forceChangesToDisk [
 
-	SourceFiles forceChangesToDisk
+	SourceFileArray default forceChangesToDisk
 ]
 
 { #category : 'logging' }
 ChangesLog >> logChange: aStringOrText [
 	"Write the argument, aString, onto the changes file."
 
-	| aString |
-	(SourceFiles changesFileStream isNil or: [ SourceFiles changesFileStream closed ])
-    ifTrue: [ ^ self ].
+	| aString sources |
+	sources := SourceFileArray default.
+	(sources changesFileStream isNil or: [ sources changesFileStream closed ]) ifTrue: [ ^ self ].
 
 	self assureStartupStampLogged.
 
 	aString := aStringOrText asString.
-	(aString findFirst: [ :char | char isSeparator not ]) = 0
-		ifTrue: [ ^ self ].	"null doits confuse replay"
+	(aString findFirst: [ :char | char isSeparator not ]) = 0 ifTrue: [ ^ self ]. "null doits confuse replay"
 
-	SourceFiles changesWriteStreamDo: [ :changesFile |
-		changesFile
-			cr; cr.
+	sources changesWriteStreamDo: [ :changesFile |
+			changesFile
+				cr;
+				cr.
 
-		(ChunkWriteStream on: changesFile)
-			nextPut: aString ].
+			(ChunkWriteStream on: changesFile) nextPut: aString ].
 
-	SourceFiles forceChangesToDisk
+	sources forceChangesToDisk
 ]
 
 { #category : 'event-listening' }

--- a/src/System-Sources/CompiledMethod.extension.st
+++ b/src/System-Sources/CompiledMethod.extension.st
@@ -4,7 +4,7 @@ Extension { #name : 'CompiledMethod' }
 CompiledMethod >> putSource: source withFooter: footer protocol: protocol timestamp: aTimestamp priorSourcePointer: priorSourcePointer [
 	"Store the source code for the receiver on an external file."
 
-	SourceFiles
+	SourceFileArray default
 		writeSource: source
 		ofMethod: self
 		protocol: protocol

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -40,6 +40,9 @@ SourceFileArray class >> default: anInstance [
 { #category : 'class initialization' }
 SourceFileArray class >> initialize [
 
+	"Guard since initializing twice would create bugs."
+	self default ifNotNil: [ ^ self ].
+	
 	self default: self new.
 	
 	"This next line is to add a deprecated global variable. The deprecation happened in Pharo 14 development. We can remove it completly in the future."

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -40,7 +40,11 @@ SourceFileArray class >> default: anInstance [
 { #category : 'class initialization' }
 SourceFileArray class >> initialize [
 
-	self default: self new
+	self default: self new.
+	
+	"This next line is to add a deprecated global variable. The deprecation happened in Pharo 14 development. We can remove it completly in the future."
+	self class environment at: #SourceFiles put: self default.
+	(self class environment bindingOf: #SourceFiles) isDeprecated: true
 ]
 
 { #category : 'system startup' }

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -17,10 +17,31 @@ Class {
 		'readOnlyQueue',
 		'flushChanges'
 	],
+	#classVars : [
+		'Default'
+	],
 	#category : 'System-Sources-Sources',
 	#package : 'System-Sources',
 	#tag : 'Sources'
 }
+
+{ #category : 'accessing' }
+SourceFileArray class >> default [
+
+	^ Default
+]
+
+{ #category : 'accessing' }
+SourceFileArray class >> default: anInstance [
+
+	Default := anInstance
+]
+
+{ #category : 'class initialization' }
+SourceFileArray class >> initialize [
+
+	self default: self new
+]
 
 { #category : 'system startup' }
 SourceFileArray class >> startUp: resuming [

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -92,7 +92,7 @@ PharoChangesCondenser >> initialize [
 { #category : 'private - 3 installing' }
 PharoChangesCondenser >> installNewChangesFile [
 
-	SourceFiles changesFileStream close.
+	SourceFileArray default changesFileStream close.
 	self backupOldChanges.
 	self originalFile ensureDelete.
 	newChangesFile moveTo: self originalFile.
@@ -131,20 +131,20 @@ PharoChangesCondenser >> reset [
 PharoChangesCondenser >> shouldCondenseMethod: aMethod [
 	"Only write methods with changes in the current file (not .sources)"
 
-	^ (SourceFiles fileIndexFromSourcePointer: aMethod sourcePointer) == 2
+	^ (SourceFileArray default fileIndexFromSourcePointer: aMethod sourcePointer) == 2
 ]
 
 { #category : 'private - 1 writing' }
 PharoChangesCondenser >> shouldWriteClassComment: commentRemoteString [
 
 	^ commentRemoteString notNil
-		and: [ (SourceFiles fileIndexFromSourcePointer: commentRemoteString) ~= 1 ]
+		and: [ (SourceFileArray default fileIndexFromSourcePointer: commentRemoteString) ~= 1 ]
 ]
 
 { #category : 'private - 2 swapping' }
 PharoChangesCondenser >> sourcePointerFor: remoteString [
 
-	^ SourceFiles sourcePointerFromFileIndex: remoteString first andPosition: remoteString second
+	^ SourceFileArray default sourcePointerFromFileIndex: remoteString first andPosition: remoteString second
 ]
 
 { #category : 'private - 2 swapping' }

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -76,7 +76,7 @@ PharoChangesCondenser >> condenseClassesAndTraits [
 
 { #category : 'accessing' }
 PharoChangesCondenser >> fileIndex [
-	"Return the index into the SourceFiles:
+	"Return the index into the SourceFileArray:
 	1: the .sources file
 	2. the .changes file"
 	^ 2

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -75,7 +75,7 @@ SmalltalkImage class >> new [
 { #category : 'system startup' }
 SmalltalkImage class >> shutDown: isImageClosing [
 
-	isImageClosing ifTrue: [ SourceFiles close ]
+	isImageClosing ifTrue: [ SourceFileArray default close ]
 ]
 
 { #category : 'system startup' }
@@ -245,7 +245,7 @@ SmalltalkImage >> backupTo: newNameWithoutSuffix [
 	Results:
 		true  when continuing in the new session
 		false for the current session"
-	(SourceFiles changesFileStream isNil or: [ SourceFiles changesFileStream closed ])
+	(SourceFileArray default changesFileStream isNil or: [ SourceFileArray default changesFileStream closed ])
     ifFalse: [
 		self
 			closeSourceFiles; "so copying the changes file will always work"
@@ -413,7 +413,7 @@ SmalltalkImage >> closeLog: logger [
 SmalltalkImage >> closeSourceFiles [
 	"Shut down the source files if appropriate."
 
-	SourceFiles close
+	SourceFileArray default close
 ]
 
 { #category : 'system attribute' }
@@ -1210,7 +1210,7 @@ SmalltalkImage >> openSourceFiles [
 	self imagePath = LastImagePath ifFalse: [ "Reset the author full name to blank when the image gets moved"
 		LastImagePath := self imagePath ].
 
-	SourceFiles ensureOpen
+	SourceFileArray default ensureOpen
 ]
 
 { #category : 'system attribute' }
@@ -1458,7 +1458,7 @@ SmalltalkImage >> saveAs: newNameWithoutSuffix [
 		false for the current session "
 
 	newNameWithoutSuffix ifNil: [ ^ self ].
-  (SourceFiles changesFileStream isNil or: [ SourceFiles changesFileStream closed ])
+  (SourceFileArray default changesFileStream isNil or: [ SourceFileArray default changesFileStream closed ])
     ifFalse: [
 		self closeSourceFiles.
 		self saveChangesInFileNamed: (self fullNameForChangesNamed: newNameWithoutSuffix)

--- a/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
+++ b/src/Tool-ExternalBrowser/ExternalChangesBrowser.class.st
@@ -29,7 +29,7 @@ Class {
 ExternalChangesBrowser class >> browseRecentLog [
 	<example>
 
-	^ self openOnStream: SourceFiles changesFileStream
+	^ self openOnStream: SourceFileArray default changesFileStream
 ]
 
 { #category : 'layout' }

--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -341,7 +341,7 @@ TaAbstractComposition >> isNotEmpty [
 { #category : 'operations' }
 TaAbstractComposition >> isSourcesPresentInSystem [
 
-	^ ((Smalltalk globals includesKey: #SourceFiles) and: [ (Smalltalk globals at: #SourceFiles) isNotNil])
+	^ self class environment at: #SourceFileArray ifPresent: [ :class | class default isNotNil ] ifAbsent: [ false ]
 ]
 
 { #category : 'testing' }
@@ -397,7 +397,7 @@ TaAbstractComposition >> reverseAlias: aSelector [
 TaAbstractComposition >> saveSourceCode: sourceCode ofMethod: newMethod [
 	"I have to check because during bootstrap there is no SouceFiles"
 
-	(sourceCode isNotNil and: [ (Smalltalk globals includesKey: #SourceFiles) and: [ (Smalltalk globals at: #SourceFiles) isNotNil ] ])
+	(sourceCode isNotNil and: [ self isSourcesPresentInSystem ])
 		ifFalse: [ ^ self ].
 
 	"Preamble was 'Trait method'.


### PR DESCRIPTION
We do not need a global variable for this. 

I propose to just have a #default shared variable and deprecate the global variable. This will make finding the dependencies to sources easier since the dependency analyzer does not manages globals.