### PR TITLE
Fix: handle invalid interval when getting source code from interval

### DIFF
--- a/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractMethodRefactoring.class.st
@@ -279,6 +279,8 @@ RBExtractMethodRefactoring >> getExtractedSource [
 	((extractionInterval first between: 1 and: (self startLimit: source size))
 		and: [extractionInterval last between: 1 and: source size])
 			ifFalse: [self refactoringError: 'Invalid interval'].
+	(extractionInterval first > extractionInterval last)
+		ifTrue: [ self refactoringError: 'Invalid interval' ].
 	^source copyFrom: extractionInterval first to: extractionInterval last
 ]
 

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodRefactoringTest.class.st
@@ -174,6 +174,23 @@ RBExtractMethodRefactoringTest >> testFailureNonExistantSelector [
 ]
 
 { #category : 'tests' }
+RBExtractMethodRefactoringTest >> testInvalidIntervalShouldRaiseError [
+	| refactoring |
+	refactoring := RBExtractMethodRefactoring
+						model: model
+						extract: (5 to: 1)
+						from: #displayName
+						in: RBLintRuleTestData.
+
+	self 
+		should: [ refactoring generateChanges ] 
+		raise: RBRefactoringError
+		whoseDescriptionIncludes: 'Invalid interval'
+		description: 'Interval should be properly created (start >= stop).'.
+
+]
+
+{ #category : 'tests' }
 RBExtractMethodRefactoringTest >> testModelExtractMethodWithTemporariesSelected [
 	| class refactoring |
 	model := RBNamespace new.


### PR DESCRIPTION
Closes: #18152
