### PR TITLE
Cleanup some dead code un System-Sources

### DIFF
--- a/src/CodeImport/ChunkReadStream.extension.st
+++ b/src/CodeImport/ChunkReadStream.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'ChunkReadStream' }
+
+{ #category : '*CodeImport' }
+ChunkReadStream >> isNextChunkMetaData [
+	| isMetaData |
+	isMetaData := decoratedStream peek = $!.
+	isMetaData ifTrue: [ decoratedStream next ].
+	^ isMetaData
+]

--- a/src/CodeImport/CodeImporter.class.st
+++ b/src/CodeImport/CodeImporter.class.st
@@ -142,7 +142,7 @@ CodeImporter >> file: aFileStream [
 { #category : 'evaluating' }
 CodeImporter >> flushChangesFile [
 
-	logSource ifTrue: [ ChangesLog default forceChangesToDisk ]
+	logSource ifTrue: [ SourceFileArray default forceChangesToDisk ]
 ]
 
 { #category : 'initialization' }

--- a/src/Collections-Streams/Stream.class.st
+++ b/src/Collections-Streams/Stream.class.st
@@ -39,12 +39,6 @@ Stream >> atEnd [
 	self subclassResponsibility
 ]
 
-{ #category : 'private' }
-Stream >> basicNext [
-
-	^ self next
-]
-
 { #category : 'modes' }
 Stream >> binary [
 	"do nothing"

--- a/src/Deprecated14/Stream.extension.st
+++ b/src/Deprecated14/Stream.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : 'Stream' }
 
 { #category : '*Deprecated14' }
+Stream >> basicNext [
+
+	self deprecated: 'Use #next' transformWith: '`@rcv basicNext' -> '`@rcv next'.
+	^ self next
+]
+
+{ #category : '*Deprecated14' }
 Stream >> basicNext: anAmount putAll: aCollection startingAt: startIndex [
 
 	self

--- a/src/System-Sources/ChangesLog.class.st
+++ b/src/System-Sources/ChangesLog.class.st
@@ -7,9 +7,6 @@ But you can have your own instance and log whatever you want.
 Class {
 	#name : 'ChangesLog',
 	#superclass : 'Object',
-	#instVars : [
-		'startupStamp'
-	],
 	#classVars : [
 		'DefaultInstance'
 	],
@@ -49,50 +46,22 @@ ChangesLog class >> unsubscribeAnnouncersOfDefaultInstance [
 	self codeSupportAnnouncer unsubscribe: DefaultInstance
 ]
 
-{ #category : 'private' }
-ChangesLog >> assureStartupStampLogged [
-	"If there is a startup stamp not yet actually logged to disk, do it now."
-
-	startupStamp ifNil: [ ^ self ].
-
-	SourceFileArray default
-		changesWriteStreamDo: [ :changesFile |
-				(ChunkWriteStream on: changesFile)
-					cr;
-					cr;
-					nextPut: startupStamp asString;
-					cr.
-				startupStamp := nil ];
-		forceChangesToDisk
-]
-
-{ #category : 'logging' }
-ChangesLog >> forceChangesToDisk [
-
-	SourceFileArray default forceChangesToDisk
-]
-
 { #category : 'logging' }
 ChangesLog >> logChange: aStringOrText [
 	"Write the argument, aString, onto the changes file."
 
-	| aString sources |
-	sources := SourceFileArray default.
-	(sources changesFileStream isNil or: [ sources changesFileStream closed ]) ifTrue: [ ^ self ].
-
-	self assureStartupStampLogged.
-
+	| aString |
 	aString := aStringOrText asString.
 	(aString findFirst: [ :char | char isSeparator not ]) = 0 ifTrue: [ ^ self ]. "null doits confuse replay"
 
-	sources changesWriteStreamDo: [ :changesFile |
-			changesFile
-				cr;
-				cr.
+	SourceFileArray default
+		changesWriteStreamDo: [ :changesFile |
+				changesFile
+					cr;
+					cr.
 
-			(ChunkWriteStream on: changesFile) nextPut: aString ].
-
-	sources forceChangesToDisk
+				(ChunkWriteStream on: changesFile) nextPut: aString ];
+		forceChangesToDisk
 ]
 
 { #category : 'event-listening' }
@@ -119,28 +88,10 @@ ChangesLog >> logMethodRemoved: announcement [
 ]
 
 { #category : 'event-listening' }
-ChangesLog >> logRemovedClassAnnouncement: announcement [
-
-	self logRemovedClassNamed: announcement classRemoved name
-]
-
-{ #category : 'event-listening' }
-ChangesLog >> logRemovedClassNamed: removedClassName [
-
-	self logChange: 'Smalltalk globals removeClassNamed: #' , removedClassName
-]
-
-{ #category : 'accessing' }
-ChangesLog >> recordStartupStamp [
-
-	startupStamp := '----STARTUP----', DateAndTime now printString, ' as ', Smalltalk imagePath
-]
-
-{ #category : 'event-listening' }
 ChangesLog >> registerToAnnouncements [
 
 	self class codeChangeAnnouncer weak
-		when: ClassRemoved send: #logRemovedClassAnnouncement: to: self;
+		when: ClassRemoved send: #logClassRemoved: to: self;
 		when: ClassRenamed send: #logClassRenamed: to: self;
 		when: MethodRemoved send: #logMethodRemoved: to: self.
 	self class codeSupportAnnouncer weak 

--- a/src/System-Sources/ChunkReadStream.class.st
+++ b/src/System-Sources/ChunkReadStream.class.st
@@ -17,54 +17,23 @@ Class {
 }
 
 { #category : 'decorated' }
-ChunkReadStream >> basicNext [
-
-	nextChar = self terminatorMark
-		ifTrue: [ decoratedStream next ].
-	^ nextChar
-]
-
-{ #category : 'decorated' }
-ChunkReadStream >> basicNextChunk [
+ChunkReadStream >> next [
 	"Answer the contents of the receiver, up to the next terminator character. Doubled terminators indicate an embedded terminator character."
 
 	| out ch |
 	out := (String new: 1000) writeStream.
 	self skipSeparators.
-	[ (ch := decoratedStream next) isNil ]
-		whileFalse: [
-			ch == self terminatorMark
-				ifTrue: [
+	[ (ch := decoratedStream next) isNil ] whileFalse: [
+			ch == self terminatorMark ifTrue: [
 					decoratedStream peek == self terminatorMark
-						ifTrue: [ decoratedStream next	"skip doubled terminator" ]
-						ifFalse: [ ^ out contents	"terminator is not doubled; we're done!" ] ].
+						ifTrue: [ decoratedStream next "skip doubled terminator" ]
+						ifFalse: [ ^ out contents "terminator is not doubled; we're done!" ] ].
 			out nextPut: ch ].
 	^ out contents
 ]
 
-{ #category : 'testing' }
-ChunkReadStream >> isNextChunkMetaData [
-	| isMetaData |
-	isMetaData := decoratedStream peek = $!.
-	isMetaData ifTrue: [ decoratedStream next ].
-	^ isMetaData
-]
-
-{ #category : 'decorated' }
-ChunkReadStream >> next [
-
-    ^ self basicNextChunk
-]
-
-{ #category : 'decorated' }
-ChunkReadStream >> position [
-
-	^ decoratedStream position - (nextChar ifNil: [0] ifNotNil: [1])
-]
-
 { #category : 'initialization' }
 ChunkReadStream >> reset [
-	nextChar := nil.
 	decoratedStream reset
 ]
 

--- a/src/System-Sources/ChunkReadStream.class.st
+++ b/src/System-Sources/ChunkReadStream.class.st
@@ -8,9 +8,6 @@ symbols
 Class {
 	#name : 'ChunkReadStream',
 	#superclass : 'DecoratorStream',
-	#instVars : [
-		'nextChar'
-	],
 	#category : 'System-Sources-Streams',
 	#package : 'System-Sources',
 	#tag : 'Streams'

--- a/src/System-Sources/SourceFile.class.st
+++ b/src/System-Sources/SourceFile.class.st
@@ -135,12 +135,6 @@ SourceFile >> next: anInteger putAll: aString startingAt: startIndex [
 	stream next: anInteger putAll: aString startingAt: startIndex
 ]
 
-{ #category : 'file in/out' }
-SourceFile >> nextChunk [
-
-	^ (ChunkReadStream on: stream) next
-]
-
 { #category : 'accessing' }
 SourceFile >> nextPut: aCharacter [
 

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -216,9 +216,8 @@ SourceFileArray >> forceChangesToDisk [
 	"Ensure that the changes file has been fully written to disk by closing and re-opening it. This makes the system more robust in the face of a power failure or hard-reboot."
 
 	| changesFile |
-	changesFile := self changesFileStream.
-	changesFile isReadOnly ifFalse: [
-		changesFile flush ].
+	changesFile := self changesFileStream ifNil: [ ^ self ].
+	changesFile isReadOnly ifFalse: [ changesFile flush ].
 	changesFile close.
 	changesFile tryOpen.
 	changesFile setToEnd
@@ -478,8 +477,6 @@ SourceFileArray >> writeChangesDuring: aBlock onSuccess: successBlock onFail: fa
 	| file sourceCodePosition |
 	file := self changesFileStream.
 	(file isNil or: [ file closed or: [ file isReadOnly ] ]) ifTrue: [ ^ failBlock value ].
-
-	ChangesLog default assureStartupStampLogged.
 
 	file setToEnd.
 	sourceCodePosition := aBlock value: file.

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1357,12 +1357,6 @@ SmalltalkImage >> recompile [
 		displayingProgress: 'Recompiling all classes and traits'
 ]
 
-{ #category : 'snapshot and quit' }
-SmalltalkImage >> recordStartupStamp [
-
-	ChangesLog default recordStartupStamp
-]
-
 { #category : 'special objects' }
 SmalltalkImage >> recreateSpecialObjectsArray [
 	"Smalltalk recreateSpecialObjectsArray"


### PR DESCRIPTION
- #logRemovedClassNamed: and logRemovedClassAnnouncement: are now removed in favor of #logClassRemoved: that matches the rest of the API
- #recordStartupStamp is not called anymore and it has been the case since multiple Pharo versions so let's remove it (I guess Epicea logging this info in enough)
- Remove code that is never call if the previous method is never called
- Deprecate Stream>>#basicNext since it only calls #next all the time and has no senders
- Remoce dead code in ChunckReadStream. It has a #nextChar variable that was never written so we can remove all the code using it
- Move #isNextChunkMetaData to CodeImport since it's the only user
- Also simplify a little logging of changes to avoid to do 2 times the same verifications (that the changes files exists and is open)