### PR TITLE
Move InstructionClient to Debugging-Core

### DIFF
--- a/src/Debugging-Core/InstructionClient.class.st
+++ b/src/Debugging-Core/InstructionClient.class.st
@@ -8,9 +8,8 @@ Class {
 	#instVars : [
 		'mappedInlinePrimitiveHandlers'
 	],
-	#category : 'Kernel-Methods',
-	#package : 'Kernel',
-	#tag : 'Methods'
+	#category : 'Debugging-Core',
+	#package : 'Debugging-Core'
 }
 
 { #category : 'extended instruction decoding' }


### PR DESCRIPTION
This class has 2 users:
- Debugging core to get the symbolic bytecodes
- Flashback for decompiling

I propose to move it out of the Kernel in Debugging-Core since it's not used in the Kernel of Pharo

This was attempted to the past but other dependencies made the move harder. Now that those dependencies are not there anymore, we can move it easily