### PR TITLE
Remove unused paremeter from multiple InstructionStream methods

### DIFF
--- a/src/Kernel-CodeModel/InstructionStream.class.st
+++ b/src/Kernel-CodeModel/InstructionStream.class.st
@@ -50,7 +50,7 @@ InstructionStream >> compiledCode [
 ]
 
 { #category : 'interpreting' }
-InstructionStream >> interpretNext2ByteSistaV1Instruction: bytecode for: client extA: extA extB: extB startPC: startPC [
+InstructionStream >> interpretNext2ByteSistaV1Instruction: bytecode for: client extA: extA extB: extB [
 	"Send to the argument, client, a message that specifies the next instruction.
 	 This method handles the two-byte codes.
 	 For a table of the bytecode set, see EncoderForV1's class comment."
@@ -114,11 +114,11 @@ InstructionStream >> interpretNext2ByteSistaV1Instruction: bytecode for: client 
 	bytecode = 245 ifTrue:
 		[^client storeIntoTemporaryVariable: byte].
 	"246-247	1111011 i	xxxxxxxx	UNASSIGNED"
-	^self interpretUnusedBytecode: client at: startPC
+	^ client unusedBytecode
 ]
 
 { #category : 'interpreting' }
-InstructionStream >> interpretNext3ByteSistaV1Instruction: bytecode for: client extA: extA extB: extB startPC: startPC [
+InstructionStream >> interpretNext3ByteSistaV1Instruction: bytecode for: client extA: extA extB: extB [
 	"Send to the argument, client, a message that specifies the next instruction.
 	 This method handles the three-byte codes.
 	 For a table of the bytecode set, see EncoderForSistaV1's class comment."
@@ -151,7 +151,7 @@ InstructionStream >> interpretNext3ByteSistaV1Instruction: bytecode for: client 
 			numCopied: (byte3 bitAnd: 16r3F)
 			receiverOnStack: (byte3 bitAt: 7) = 1
 			ignoreOuterContext: (byte3 bitAt: 8) = 1 ].
-	^self interpretUnusedBytecode: client at: startPC
+	^ client unusedBytecode
 ]
 
 { #category : 'interpreting' }
@@ -165,12 +165,11 @@ InstructionStream >> interpretNextInstructionFor: client [
 InstructionStream >> interpretNextSistaV1InstructionFor: client [
 	"Send to the argument, client, a message that specifies the next instruction."
 
-	| byte div16 offset method extA extB savedPC |
+	| byte div16 offset method extA extB |
 	method := self compiledCode.
 	"For a table of the bytecode set, see EncoderForSistaV1's class comment."
 	"consume and compute any extensions first."
 	extA := extB := 0.
-	savedPC := pc.
 	[byte := self compiledCode at: pc.
 	 pc := pc + 1.
 	 byte between: 16rE0 and: 16rE1] whileTrue:
@@ -231,7 +230,7 @@ InstructionStream >> interpretNextSistaV1InstructionFor: client [
 				[^client blockReturnTop].
 			 offset = 15 ifTrue:
 				[^client doNop].
-			 ^self interpretUnusedBytecode: client at: savedPC].
+			 ^ client unusedBytecode ].
 		"short sends"
 		div16 = 6 ifTrue:
 			[^client
@@ -263,11 +262,11 @@ InstructionStream >> interpretNextSistaV1InstructionFor: client [
 		 	[^client popIntoTemporaryVariable: offset].
 		 offset = 8 ifTrue: [ ^ client doPop ].
 		 offset = 9 ifTrue: [ ^ client trap ].
-		^self interpretUnusedBytecode: client at: savedPC].
+		^ client unusedBytecode ].
 	"2 byte and 3 byte codes"
 	byte < 248 ifTrue:
-		[^self interpretNext2ByteSistaV1Instruction: byte for: client extA: extA extB: extB startPC: savedPC].
-	^self interpretNext3ByteSistaV1Instruction: byte for: client extA: extA extB: extB startPC: savedPC
+		[^self interpretNext2ByteSistaV1Instruction: byte for: client extA: extA extB: extB ].
+	^self interpretNext3ByteSistaV1Instruction: byte for: client extA: extA extB: extB
 ]
 
 { #category : 'interpreting' }
@@ -280,11 +279,6 @@ InstructionStream >> interpretSistaV1ExtendedPush: extB for: client [
 	extB = 1
 		ifTrue: [^ client pushActiveProcess].
 	self error: 'undefined extended push'
-]
-
-{ #category : 'interpreting' }
-InstructionStream >> interpretUnusedBytecode: client at: startPC [
-	^ client unusedBytecode
 ]
 
 { #category : 'scanning' }

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -549,7 +549,7 @@ ReleaseTest >> testThatThereAreNoSelectorsRemainingThatAreSentButNotImplemented 
 	                    'FFIFloatType>>#callbackReturnOn:for:' 'FFIIndirectFunctionResolution>>#resolveFunction:'
 	                    'OCIRReconstructor>>#fixPushNilsForTemps' 'IceTipHiedraAltComponentHistoryBrowser>>#newCommitRow:commit:'
 	                    'IceTipHiedraAltHistoryBrowser>>#newCommitRow:commit:' 'IceTipHiedraAltHistoryBrowser>>#initializeCommitList'
-	                    'InstructionStream>>#interpretNext3ByteSistaV1Instruction:for:extA:extB:startPC:'
+	                    'InstructionStream>>#interpretNext3ByteSistaV1Instruction:for:extA:extB:'
 	                    'LazyListMorph>>#drawOnAthensCanvas:' 'MCFileTreeAbstractReader>>#packageProperties' 'MicrodownSpecComponentForTest class>>#open'
 	                    'PSMCClassChangeWrapper>>#remoteChosen' 'PolygonMorph>>#intersects:' 'RBBasicLintRuleTestData class>>#canCall:in:from:'
 	                    'RBBasicLintRuleTestData class>>#createMatcherFor:method:' 'RBBasicLintRuleTestData class>>#sentNotImplementedInApplication'


### PR DESCRIPTION
The saved PC parameter of multiple InstructionStream methods is not needed so we can just remove them. Nothing big but still makes the code a little simpler