### PR TITLE
Clean some kernel dependencies (Mostly on System-Time and Files)

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -630,13 +630,6 @@ String >> asComment [
 ]
 
 { #category : 'converting' }
-String >> asDateAndTime [
- 	"Convert from UTC format"
-
-	^ DateAndTime fromString: self
-]
-
-{ #category : 'converting' }
 String >> asDuration [
  	"Convert from [-]D:HH:MM:SS[.S] format. What is between [] implies optional elements"
 

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -630,13 +630,6 @@ String >> asComment [
 ]
 
 { #category : 'converting' }
-String >> asDuration [
- 	"Convert from [-]D:HH:MM:SS[.S] format. What is between [] implies optional elements"
-
- 	^ Duration fromString: self
-]
-
-{ #category : 'converting' }
 String >> asFourCode [
 	"'abcd' asFourCode >>> -513645724"
 	"'1111' asFourCode >>> 825307441"
@@ -741,13 +734,6 @@ String >> asString [
 String >> asSymbol [
 	"Answer the unique Symbol whose characters are the characters of the string."
 	^Symbol intern: self
-]
-
-{ #category : 'converting' }
-String >> asTime [
-	"Many allowed forms, see Time>>readFrom:"
-
-	^ Time fromString: self
 ]
 
 { #category : 'converting' }

--- a/src/Deprecated14/FileSystem.extension.st
+++ b/src/Deprecated14/FileSystem.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'FileSystem' }
+
+{ #category : '*Deprecated14' }
+FileSystem >> extensionDelimiter [
+
+	self deprecated: 'Ask this to File.' transformWith: '`@rcv extensionDelimiter' -> 'File extensionDelimiter'.
+	^ File extensionDelimiter
+]

--- a/src/Deprecated14/Path.extension.st
+++ b/src/Deprecated14/Path.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'Path' }
+
+{ #category : '*Deprecated14' }
+Path class >> extensionDelimiter [
+
+	self deprecated: 'Ask this to File.' transformWith: '`@rcv extensionDelimiter' -> 'File extensionDelimiter'.
+	^ File extensionDelimiter
+]

--- a/src/Deprecated14/Time.extension.st
+++ b/src/Deprecated14/Time.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'Time' }
+
+{ #category : '*Deprecated14' }
+Time class >> primMillisecondClock [
+	"Primitive. Answer the number of milliseconds since the millisecond clock
+	 was last reset or rolled over. Answer zero if the primitive fails.
+	As an alternative you can use #primUTCMillisecondsClock which does not overflow."
+
+	self deprecated: 'Use #millisecondClockValue instead' transformWith: '`@rcv primMillisecondClock' -> '`@rcv millisecondClockValue'.
+	^ self millisecondClockValue
+]

--- a/src/FileSystem-Core-Tests/AsyncFile.extension.st
+++ b/src/FileSystem-Core-Tests/AsyncFile.extension.st
@@ -1,0 +1,33 @@
+Extension { #name : 'AsyncFile' }
+
+{ #category : '*FileSystem-Core-Tests' }
+AsyncFile >> test: byteCount fileName: fileName [
+	"AsyncFile new test: 10000 fileName: 'testData'"
+
+	| buf1 buf2 bytesWritten bytesRead |
+	buf1 := String new: byteCount withAll: $x.
+	buf2 := String new: byteCount.
+	self open: fileName  asFileReference fullName forWrite: true.
+	self primWriteStart: fileHandle
+		fPosition: 0
+		fromBuffer: buf1
+		at: 1
+		count: byteCount.
+	semaphore wait.
+	bytesWritten := self primWriteResult: fileHandle.
+	self close.
+
+	self open: fileName asFileReference fullName forWrite: false.
+	self primReadStart: fileHandle fPosition: 0 count: byteCount.
+	semaphore wait.
+	bytesRead :=
+		self primReadResult: fileHandle
+			intoBuffer: buf2
+			at: 1
+			count: byteCount.
+	self close.
+
+	buf1 = buf2 ifFalse: [self error: 'buffers do not match'].
+	^ 'wrote ', bytesWritten printString, ' bytes; ',
+	   'read ', bytesRead printString, ' bytes'
+]

--- a/src/FileSystem-Core/FileException.extension.st
+++ b/src/FileSystem-Core/FileException.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'FileException' }
+
+{ #category : '*FileSystem-Core' }
+FileException >> fileName [
+	"If the entity is a string we return it. Else we ask it to the file reference."
+
+	^ entity isString
+		  ifTrue: [ entity ]
+		  ifFalse: [ entity asPath pathString ]
+]

--- a/src/FileSystem-Core/FileSystem.class.st
+++ b/src/FileSystem-Core/FileSystem.class.st
@@ -404,11 +404,6 @@ FileSystem >> exists: aResolvable [
 ]
 
 { #category : 'public' }
-FileSystem >> extensionDelimiter [
-	^ $.
-]
-
-{ #category : 'public' }
 FileSystem >> file: aResolvable posixPermissions: anInteger [
 	"Set the mode of aResolvable to anInteger (as defined by chmod())"
 

--- a/src/FileSystem-Disk/VirtualMachine.extension.st
+++ b/src/FileSystem-Disk/VirtualMachine.extension.st
@@ -1,0 +1,26 @@
+Extension { #name : 'VirtualMachine' }
+
+{ #category : '*FileSystem-Disk' }
+VirtualMachine >> interpreterSourceDate [
+	"Return the date of changes given by `self interpreterSourceVersion`"
+	| dateString parts |
+
+	dateString := (self interpreterSourceVersion splitOn: 'Date: ') second.
+
+	dateString first isDigit
+		ifTrue: [
+			"most probably the date is in ISO 8601 Format"
+			^ dateString asDateAndTime ].
+
+	"Otherwise assume the old format: DDD MMM DD HH:MM:SS YYYY +TTTT ..."
+	parts := dateString substrings first: 6.
+	"create a more reasonable string.."
+	dateString := String streamContents: [ :s |
+		s
+			nextPutAll: (parts at: 5 ); space; "year"
+			nextPutAll: (parts at: 2 ); space; "month name"
+			nextPutAll: (parts at: 3 ); space; "day of month"
+			nextPutAll: (parts at: 4 ); space; "time"
+			nextPutAll: (parts last); space    "timezone"].
+	^ dateString asDateAndTime
+]

--- a/src/FileSystem-Path/Path.class.st
+++ b/src/FileSystem-Path/Path.class.st
@@ -114,12 +114,6 @@ Path class >> delimiter [
 	^$/
 ]
 
-{ #category : 'encodings' }
-Path class >> extensionDelimiter [
-	"Return the extension delimiter character."
-	^ $.
-]
-
 { #category : 'instance creation' }
 Path class >> from: aString [
 	"Answer an instance of the receiver with the supplied path using the default delimiter"
@@ -409,7 +403,8 @@ Path >> extension [
 
 { #category : 'accessing' }
 Path >> extensionDelimiter [
-	^ self class extensionDelimiter
+
+	^ File extensionDelimiter
 ]
 
 { #category : 'accessing' }

--- a/src/Files/AsyncFile.class.st
+++ b/src/Files/AsyncFile.class.st
@@ -156,38 +156,6 @@ AsyncFile >> readByteCount: byteCount fromFilePosition: fPosition onCompletionDo
 	] forkAt: Processor userInterruptPriority
 ]
 
-{ #category : 'tests' }
-AsyncFile >> test: byteCount fileName: fileName [
-	"AsyncFile new test: 10000 fileName: 'testData'"
-
-	| buf1 buf2 bytesWritten bytesRead |
-	buf1 := String new: byteCount withAll: $x.
-	buf2 := String new: byteCount.
-	self open: fileName  asFileReference fullName forWrite: true.
-	self primWriteStart: fileHandle
-		fPosition: 0
-		fromBuffer: buf1
-		at: 1
-		count: byteCount.
-	semaphore wait.
-	bytesWritten := self primWriteResult: fileHandle.
-	self close.
-
-	self open: fileName asFileReference fullName forWrite: false.
-	self primReadStart: fileHandle fPosition: 0 count: byteCount.
-	semaphore wait.
-	bytesRead :=
-		self primReadResult: fileHandle
-			intoBuffer: buf2
-			at: 1
-			count: byteCount.
-	self close.
-
-	buf1 = buf2 ifFalse: [self error: 'buffers do not match'].
-	^ 'wrote ', bytesWritten printString, ' bytes; ',
-	   'read ', bytesRead printString, ' bytes'
-]
-
 { #category : 'write and read' }
 AsyncFile >> waitForCompletion [
 

--- a/src/Files/File.class.st
+++ b/src/Files/File.class.st
@@ -526,6 +526,13 @@ File class >> exists: aString [
 	^self primExists: (self encodePathString: aString)
 ]
 
+{ #category : 'primitives - path' }
+File class >> extensionDelimiter [
+	"This method makes more sens on Path but it is needed in the minimal version of Pharo for now so it needs to be in Files."
+
+	^ $.
+]
+
 { #category : 'attributes' }
 File class >> file: pathString posixPermissions: anInteger [
 	"Set the mode of pathString to anInteger (as defined by chmod())"

--- a/src/Files/FileException.class.st
+++ b/src/Files/FileException.class.st
@@ -52,15 +52,6 @@ FileException >> entity: anObject [
 	entity := anObject
 ]
 
-{ #category : 'accessing' }
-FileException >> fileName [
-	"If the entity is a string we return it. Else we ask it to the file reference."
-
-	^ entity isString
-		  ifTrue: [ entity ]
-		  ifFalse: [ entity asPath pathString ]
-]
-
 { #category : 'testing' }
 FileException >> isResumable [
 	"Determine whether an exception is resumable."

--- a/src/Files/ManifestFiles.class.st
+++ b/src/Files/ManifestFiles.class.st
@@ -13,7 +13,7 @@ Class {
 ManifestFiles class >> manuallyResolvedDependencies [
 
 	<ignoreForCoverage>
-	^ #( #'Collections-Abstract' #'System-Platforms' #'System-Support' )
+	^ #(#'Kernel-CodeModel' #'Collections-Abstract' #'System-Support')
 ]
 
 { #category : 'code-critics' }

--- a/src/Files/OSPlatform.extension.st
+++ b/src/Files/OSPlatform.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'OSPlatform' }
+
+{ #category : '*Files' }
+OSPlatform >> createStdioFileFor: moniker [
+	"This is a hack due to Windows vm limitations."
+
+	self error: moniker , ' is unavailable'
+]

--- a/src/Files/Stdio.class.st
+++ b/src/Files/Stdio.class.st
@@ -43,18 +43,6 @@ Stdio class >> cleanStdioHandles [
 	Stderr := Stdin := Stdout := nil
 ]
 
-{ #category : 'private' }
-Stdio class >> createStdioFileFor: moniker [
-
-	^ [
-	  [ self createWriteStreamBlock cull: moniker asString ]
-		  on: CannotDeleteFileException
-		  do: [ "HACK: if the image is opened a second time windows barks about the already opened locked file"
-			  self createWriteStreamBlock cull: moniker asString , '_' , DateAndTime now asFileNameCompatibleString ] ]
-		  on: FileException
-		  do: [ NullStream new ]
-]
-
 { #category : 'accessing' }
 Stdio class >> createWriteStreamBlock [
 
@@ -82,9 +70,7 @@ Stdio class >> standardIOStreamNamed: moniker forWrite: forWrite [
 	handle := File stdioHandles at: streamIndex.
 	(handle isNil or: [ (File fileDescriptorIsAvailable: streamIndex-1) not ]) ifTrue: [
 		"On windows, create a file for stdio, error on other platforms"
-		Smalltalk os isWindows
-			ifTrue: [ ^ self createStdioFileFor: moniker ]
-			ifFalse: [ self error: moniker , ' is unavailable' ] ].
+		^ Smalltalk os createStdioFileFor: moniker ].
 	^ StdioStream handle: handle file: (File named: moniker) forWrite: forWrite
 ]
 

--- a/src/Metacello-Core/MetacelloProject.class.st
+++ b/src/Metacello-Core/MetacelloProject.class.st
@@ -91,8 +91,13 @@ MetacelloProject >> defaultBlessing [
 
 { #category : 'private' }
 MetacelloProject >> defaultPlatformAttributes [
+	"Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general."
 
-	^ Smalltalk image metacelloPlatformAttributes
+	^ {
+		  #squeakCommon.
+		  #pharo.
+		  ('pharo' , SystemVersion current major asString , '.x') asSymbol.
+		  ('pharo' , SystemVersion current major asString , '.0.x') asSymbol }
 ]
 
 { #category : 'versions' }

--- a/src/System-Support/ExternalSemaphoreTable.class.st
+++ b/src/System-Support/ExternalSemaphoreTable.class.st
@@ -77,7 +77,7 @@ ExternalSemaphoreTable class >> freedSlotsIn: externalObjects ratherThanIncrease
 
 				needToGrow
 					ifTrue: ["If we did GC, warn we had to gc so actions could be taken if appropriate."
-						self class environment at: #DateAndTime ifPresent: [ self traceCr: DateAndTime now printString ].
+						self class environment at: #DateAndTime ifPresent: [ :class | self traceCr: class now printString ].
 						self
 							traceCr:  'WARNING:  Had to GC to make room for more external objects.';
 							traceCr: 'If this happens often, it would be a good idea to either:';

--- a/src/System-Support/ExternalSemaphoreTable.class.st
+++ b/src/System-Support/ExternalSemaphoreTable.class.st
@@ -77,7 +77,8 @@ ExternalSemaphoreTable class >> freedSlotsIn: externalObjects ratherThanIncrease
 
 				needToGrow
 					ifTrue: ["If we did GC, warn we had to gc so actions could be taken if appropriate."
-						self traceCr: DateAndTime now printString;
+						self class environment at: #DateAndTime ifPresent: [ self traceCr: DateAndTime now printString ].
+						self
 							traceCr:  'WARNING:  Had to GC to make room for more external objects.';
 							traceCr: 'If this happens often, it would be a good idea to either:';
 							traceCr: '- Raise the maxExternalSemaphores size.';

--- a/src/System-Support/ExternalSemaphoreTable.class.st
+++ b/src/System-Support/ExternalSemaphoreTable.class.st
@@ -77,7 +77,6 @@ ExternalSemaphoreTable class >> freedSlotsIn: externalObjects ratherThanIncrease
 
 				needToGrow
 					ifTrue: ["If we did GC, warn we had to gc so actions could be taken if appropriate."
-						self class environment at: #DateAndTime ifPresent: [ :class | self traceCr: class now printString ].
 						self
 							traceCr:  'WARNING:  Had to GC to make room for more external objects.';
 							traceCr: 'If this happens often, it would be a good idea to either:';

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1648,10 +1648,10 @@ SmalltalkImage >> stripImageExtensionFrom: aString [
 
 	| answer imageExtension delimitedImageExtension |
 	answer := aString.
-	imageExtension := Path extensionDelimiter asString, self imageSuffix.
-	delimitedImageExtension := imageExtension copyWith: Path extensionDelimiter.
+	imageExtension := File extensionDelimiter asString, self imageSuffix.
+	delimitedImageExtension := imageExtension copyWith: File extensionDelimiter.
 	[answer isNil not and: [(answer endsWith: imageExtension) or: [answer endsWith: delimitedImageExtension]]]
-		whileTrue: [answer := answer copyUpToLast: Path extensionDelimiter].
+		whileTrue: [answer := answer copyUpToLast: File extensionDelimiter].
 	^answer
 ]
 

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1055,17 +1055,6 @@ SmalltalkImage >> memoryHogs [
 	^ MemoryHogs ifNil: [MemoryHogs := OrderedCollection new]
 ]
 
-{ #category : 'miscellaneous' }
-SmalltalkImage >> metacelloPlatformAttributes [
-	"Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general."
-
-	^ {
-		  #squeakCommon.
-		  #pharo.
-		  ('pharo' , SystemVersion current major asString , '.x') asSymbol.
-		  ('pharo' , SystemVersion current major asString , '.0.x') asSymbol }
-]
-
 { #category : 'special objects' }
 SmalltalkImage >> newSpecialObjectsArray [
 	"Smalltalk recreateSpecialObjectsArray"

--- a/src/System-Support/VirtualMachine.class.st
+++ b/src/System-Support/VirtualMachine.class.st
@@ -335,14 +335,6 @@ VirtualMachine >> hasSmallFloats [
 ]
 
 { #category : 'accessing' }
-VirtualMachine >> headlessOption [
-	"Return the default name for the headless option for this VM"
-	^ self optionDash, (Smalltalk os isUnix
-		ifTrue: [ 'vm-display-null' ]
-		ifFalse: [ 'headless' ])
-]
-
-{ #category : 'accessing' }
 VirtualMachine >> imageFile [
 	"Image file "
 	^ Smalltalk image imageFile
@@ -388,31 +380,6 @@ VirtualMachine >> incrementalGCCount [
 VirtualMachine >> interpreterClass [
 	"Return the interpreter class that is currently executing the system (Cog VM only)"
 	^ self getSystemAttribute: 1007
-]
-
-{ #category : 'accessing' }
-VirtualMachine >> interpreterSourceDate [
-	"Return the date of changes given by `self interpreterSourceVersion`"
-	| dateString parts |
-
-	dateString := (self interpreterSourceVersion splitOn: 'Date: ') second.
-
-	dateString first isDigit
-		ifTrue: [
-			"most probably the date is in ISO 8601 Format"
-			^ dateString asDateAndTime ].
-
-	"Otherwise assume the old format: DDD MMM DD HH:MM:SS YYYY +TTTT ..."
-	parts := dateString substrings first: 6.
-	"create a more reasonable string.."
-	dateString := String streamContents: [ :s |
-		s
-			nextPutAll: (parts at: 5 ); space; "year"
-			nextPutAll: (parts at: 2 ); space; "month name"
-			nextPutAll: (parts at: 3 ); space; "day of month"
-			nextPutAll: (parts at: 4 ); space; "time"
-			nextPutAll: (parts last); space    "timezone"].
-	^ dateString asDateAndTime
 ]
 
 { #category : 'accessing' }
@@ -677,14 +644,6 @@ VirtualMachine >> optionAt: i [
 	"Answer the i-th option of the command line, or nil if not so many options."
 
 	^self getSystemAttribute: i negated
-]
-
-{ #category : 'accessing' }
-VirtualMachine >> optionDash [
-	"VMs release in Mai 2013 use -- instead of - for VM command line options"
-	^ (Smalltalk vm interpreterSourceDate > (Date readFrom: '17-5-2013' pattern: 'd-m-y'))
-		ifTrue: [ '--' ]
-		ifFalse: [ '-' ]
 ]
 
 { #category : 'accessing' }

--- a/src/System-Time/String.extension.st
+++ b/src/System-Time/String.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'String' }
+
+{ #category : '*System-Time' }
+String >> asDateAndTime [
+ 	"Convert from UTC format"
+
+	^ DateAndTime fromString: self
+]

--- a/src/System-Time/String.extension.st
+++ b/src/System-Time/String.extension.st
@@ -6,3 +6,17 @@ String >> asDateAndTime [
 
 	^ DateAndTime fromString: self
 ]
+
+{ #category : '*System-Time' }
+String >> asDuration [
+ 	"Convert from [-]D:HH:MM:SS[.S] format. What is between [] implies optional elements"
+
+ 	^ Duration fromString: self
+]
+
+{ #category : '*System-Time' }
+String >> asTime [
+	"Many allowed forms, see Time>>readFrom:"
+
+	^ Time fromString: self
+]

--- a/src/System-Time/Time.class.st
+++ b/src/System-Time/Time.class.st
@@ -203,16 +203,6 @@ Time class >> nowUTC [
 ]
 
 { #category : 'primitives' }
-Time class >> primMillisecondClock [
-	"Primitive. Answer the number of milliseconds since the millisecond clock
-	 was last reset or rolled over. Answer zero if the primitive fails.
-	As an alternative you can use #primUTCMillisecondsClock which does not overflow."
-
-	<primitive: 135>
-	^ 0
-]
-
-{ #category : 'primitives' }
 Time class >> primUTCMicrosecondsClock [
 	"Answer the number of micro-seconds ellapsed since epoch.
 	That is since 00:00 on the morning of January 1, 1901 UTC.

--- a/src/System-Time/WinPlatform.extension.st
+++ b/src/System-Time/WinPlatform.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : 'WinPlatform' }
+
+{ #category : '*System-Time' }
+WinPlatform >> createStdioFileFor: moniker [
+	"I am added by System-Time because I need the date to create the file and it is not available in the minimal image."
+
+	^ [
+		  [ Stdio createWriteStreamBlock cull: moniker asString ]
+			  on: CannotDeleteFileException
+			  do: [ "HACK: if the image is opened a second time windows barks about the already opened locked file"
+				  Stdio createWriteStreamBlock cull: moniker asString , '_' , DateAndTime now asFileNameCompatibleString ] ]
+		  on: FileException
+		  do: [ NullStream new ]
+]

--- a/src/Tool-Base/DailyNonInteractiveTranscript.class.st
+++ b/src/Tool-Base/DailyNonInteractiveTranscript.class.st
@@ -10,9 +10,8 @@ Class {
 	#instVars : [
 		'date'
 	],
-	#category : 'Transcript-NonInteractive-Base',
-	#package : 'Transcript-NonInteractive',
-	#tag : 'Base'
+	#category : 'Tool-Base',
+	#package : 'Tool-Base'
 }
 
 { #category : 'constants' }

--- a/src/UIManager/SmalltalkImage.extension.st
+++ b/src/UIManager/SmalltalkImage.extension.st
@@ -6,7 +6,7 @@ SmalltalkImage >> getFileNameFromUser [
 	| givenName strippedName imageFile changesFile |
 	givenName := UIManager default
 		request: 'New File Name?'
-		initialAnswer: (self imageFile basename copyUpToLast:  Path extensionDelimiter).
+		initialAnswer: (self imageFile basename copyUpToLast:  File extensionDelimiter).
 	strippedName := self stripImageExtensionFrom: givenName.
 	strippedName isEmptyOrNil ifTrue: [^nil].
 	imageFile := self fileForImageNamed: strippedName.


### PR DESCRIPTION
- Move String>>#asDateAndTime/asDuration/asDate to System-Time
- Deprecate #primMillisecondClock that is a duplication withouth senders of millisecondClockValue
- Move FileException>>#fileName to FileSystem-Core 
- Move AsyncFile>>test:fileName: to FileSystem-Core-Tests since it depends on FileSystem-Core and is used for testing
- Instead of having an 'if' depending on the platform to create a hacking STDIO stream for windows that depends on DateAndTime, I now added the code on OSPlatform and the method depending on DateAndTime is added by System-Time to cut one of the last dependency to System-Time from the kernel
- Remove some dead code related to the virtual machine state that is not used anymore since the headless mecanism got updated
- Move #interpreterSourceDate to FileSystem-Disk since it's the only user and this depends on FileSystem-Core
- Remove Metacello code from SmalltalkImage
- Remove a dependency between System-Support and FileSystem-Path
- Move DailyNonInteractiveTranscript to Tool-Base since it depends on Date


Maybe DailyNonInteractiveTrascript should be removed since it's not used? For now I just moved it since I'm not sure 