### PR TITLE
Extract SystemVersion from System-Support

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -138,9 +138,9 @@ ${VM} "${COMPILER_IMAGE_NAME}.image" # I have to run once the image so the next 
 
 echo $(date -u) "[Compiler] Adding more Kernel packages"
 ${VM} "${COMPILER_IMAGE_NAME}.image" perform --save BasicHermesTool load: --as-array Clap-Core.hermes Clap-Commands-Pharo.hermes Hermes-Extensions.hermes
-${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Math-Operations-Extensions.hermes System-NumberPrinting.hermes System-Time.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes NumberParser.hermes --save --no-fail-on-undeclared
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Math-Operations-Extensions.hermes System-NumberPrinting.hermes System-Time.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes NumberParser.hermes System-Version.hermes --save --no-fail-on-undeclared
 
-# Now that System-Time is loaded, we can initialize the version
+# Now that System-Version is loaded, we can initialize the version
 ${VM} "${COMPILER_IMAGE_NAME}.image" perform  --save SystemVersion setMajor:minor:patch:suffix:build:commitHash: ${PHARO_MAJOR} ${PHARO_MINOR} ${PHARO_PATCH} ${PHARO_SUFFIX} ${BUILD_NUMBER} ${PHARO_COMMIT_HASH}
 
 ${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Collections-Atomic.hermes Collections-Stack.hermes AST-Core.hermes Collections-Arithmetic.hermes  --save --no-fail-on-undeclared

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -117,6 +117,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		spec package: 'CodeExport'.
 		spec package: 'System-Sources'.
 		spec package: 'System-Support'.
+		spec package: 'System-Version'.
 
 		spec package: 'UIManager'.
 		spec package: 'Zinc-Character-Encoding-Core'.
@@ -186,6 +187,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'System-Time'.
 			'Math-Operations-Extensions'.
 			'System-NumberPrinting'.
+			'System-Version'
 		}.
 
 		spec group: 'MultilingualGroup' with: {

--- a/src/System-Support/Context.extension.st
+++ b/src/System-Support/Context.extension.st
@@ -27,10 +27,14 @@ Context >> errorReportOn: stream [
 		nextPutAll: ' - ';
 		nextPutAll: Smalltalk vm version asString;
 		cr.
-	stream
-		nextPutAll: 'Image: ';
-		nextPutAll: SystemVersion current asString;
-		cr.
+	
+	self class environment at: #SystemVersion ifPresent: [ :class |
+		stream
+			nextPutAll: 'Image: ';
+			nextPutAll: class current asString;
+			cr.
+ ].
+
 	stream cr. "Note: The following is an open-coded version of  Context>>stackOfSize: since this method may be called during a  low space condition and we might run out of space for allocating the  full stack."
 	stackDepth := 0.
 	aContext := self.

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -822,89 +822,6 @@ SmalltalkImage >> lastImagePath [
 	^ LastImagePath
 ]
 
-{ #category : 'sources, change log' }
-SmalltalkImage >> licenseString [
-	^ self licenseStringTemplate format: (Array with: Date today year asString)
-]
-
-{ #category : 'sources, change log' }
-SmalltalkImage >> licenseStringTemplate [
-	^ 'LICENSE
-
-Licensed under the MIT License with parts under the Apache License.
-
-Copyright (c) 2008-{1} The Pharo Project, and Contributors
-Copyright (c) 2008-{1} Inria
-Copyright (c) 1996-2008 Viewpoints Research Institute, and Contributors
-Copyright (c) 1996 Apple Computer, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this
-software and associated documentation files (the "Software"), to deal in the Software
-without restriction, including without limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
-to whom the Software is furnished to do so, subject to the following conditions: The
-above copyright notice and this permission notice shall be included in all copies or
-substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-You may obtain a copy of the Apache License at
-http://www.apache.org/licenses/LICENSE-2.0
-
-Pharo uses icons by Mark James (http://www.famfamfam.com) under
-Creative Commons Attribution 2.5 License.
-
-Pharo uses icons by Eclipse under
-Eclipse Public License - v 1.0
-http://www.eclipse.org/legal/epl-v10.html
-
-Pharo uses Source Code Pro Fonts by Adobe under
-SIL Open Font License, v 1.1
-http://scripts.sil.org/OFL
-
-Pharo uses Open Sans by Steve Matteson under
-Apache License, 2.0
-http://www.apache.org/licenses/LICENSE-2.0.html
-
-Pharo uses  Bitstream Vera Fonts
-http://dejavu-fonts.org/wiki/index.php?title=License
-
-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.
-Bitstream Vera is a trademark of Bitstream, Inc.
-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts
-accompanying this license ("Fonts") and associated documentation files (the "Font Software"),
-to reproduce and distribute the Font Software, including without limitation the rights to use, copy,
-merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom
-the Font Software is furnished to do so, subject to the following conditions:
-The above copyright and trademark notices and this permission notice shall be included in all
-copies of one or more of the Font Software typefaces.
-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs
-or characters in the Fonts may be modified and additional glyphs or characters may be added to
-the Fonts, only if the fonts are renamed to names not containing either the words "Bitstream"
-or the word "Vera".
-This License becomes null and void to the extent applicable to Fonts or Font Software that
-has been modified and is distributed under the "Bitstream Vera" names.
-The Font Software may be sold as part of a larger software package but no copy of one or more
-of the Font Software typefaces may be sold by itself.
-THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT
-SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN
-ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE
-FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
-Except as contained in this notice, the names of Gnome, the Gnome Foundation,
-and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale,
-use or other dealings in this Font Software without prior written authorization from
-the Gnome Foundation or Bitstream Inc., respectively.
-For further information, contact: fonts at gnome dot org.'
-]
-
 { #category : 'miscellaneous' }
 SmalltalkImage >> logDuring: aMonadicBlock [
 	" for safe use, if stream is a file, it needs to be closed after use "
@@ -1696,15 +1613,6 @@ SmalltalkImage >> unregisterExternalObject: anObject [
 	"Unregister the given object in the external objects array. Do nothing if it isn't registered."
 
 	ExternalSemaphoreTable unregisterExternalObject: anObject
-]
-
-{ #category : 'sources, change log' }
-SmalltalkImage >> version [
-	"Answer the version of this release."
-
-	^ SystemVersion current
-		  ifNil: [ 'No version set yet' ]
-		  ifNotNil: [ :version | version version ]
 ]
 
 { #category : 'accessing' }

--- a/src/System-Support/VirtualMachine.class.st
+++ b/src/System-Support/VirtualMachine.class.st
@@ -251,30 +251,6 @@ VirtualMachine >> gcBiasToGrowLimit: arg [
 	^self primitiveFailed
 ]
 
-{ #category : 'statistics' }
-VirtualMachine >> gcStatisticsDuring: aBlockClosure [ 
-	
-	| incrementalGCCount fullGCCount incrementalGCTime fullGCTime timeToRun |
-	incrementalGCCount := self incrementalGCCount.
-	fullGCCount := self fullGCCount.
-	incrementalGCTime := self totalIncrementalGCTime.
-	fullGCTime := self totalFullGCTime.
-	
-	timeToRun := aBlockClosure millisecondsToRun.
-
-	incrementalGCCount := self incrementalGCCount - incrementalGCCount.
-	fullGCCount := self fullGCCount - fullGCCount.
-	incrementalGCTime := self totalIncrementalGCTime - incrementalGCTime.
-	fullGCTime := self totalFullGCTime - fullGCTime.
-
-	
-	^ { #incrementalGCCount -> incrementalGCCount.
-	  #fullGCCount -> fullGCCount.
-	  #incrementalGCTime -> incrementalGCTime milliSecond.
-	  #fullGCTime -> fullGCTime milliSecond.
-	  #timeToRun -> timeToRun } asDictionary 
-]
-
 { #category : 'parameters' }
 VirtualMachine >> getParameters [
 	"Answer an Array containing the current values of the VM's internal
@@ -347,28 +323,6 @@ VirtualMachine >> imagePath [
 	^ Smalltalk image imagePath
 ]
 
-{ #category : 'accessing' }
-VirtualMachine >> imageVersionInImageHeader [
-
-	^ self parameterAt: 79
-]
-
-{ #category : 'accessing' }
-VirtualMachine >> imageVersionInImageHeader: aValue [
-
-	(aValue between: 0 and: 65535)
-		ifFalse: [ self error: 'The image version should be an integer positive of 16bits' ].
-	
-	^ self parameterAt: 79 put: aValue
-]
-
-{ #category : 'parameters' }
-VirtualMachine >> imageVersionNumber [
-	"Image version number (6505 means the Squeak V3 format with BlockClosure support (but _without_ BlockContext support)"
-
-	^ self parameterAt: 41
-]
-
 { #category : 'gc' }
 VirtualMachine >> incrementalGCCount [
 	"Answer the total number of incremental GCs since startup (read-only)."
@@ -417,24 +371,6 @@ VirtualMachine >> isAIOInterrupt [
 	 (This means we are going idle until we have something real to process)"
 
 	^ (self getSystemAttribute: 1010) = 'AIO'
-]
-
-{ #category : 'testing' }
-VirtualMachine >> isPharoVM [
-	"Answers if this VM is a valid PharoVM (made with our sources)"
-	| version |
-
-	self flag: #pharoTodo. "We need a certain way of identify PharoVM, but in the mean time this ensures "
-	version := self version.
-	^ (version beginsWith: 'PharoVM')
-		or: [
-			(version includesSubstring: 'NBCoInterpreter')
-				or: [
-					(version includesSubstring: 'Commit: ')
-						and: [
-							| pos |
-							pos := (version findString: 'Commit: ') + 8.
-							(version copyFrom: pos to: pos + 39) allSatisfy: [ :each | (($a to: $f), ($0 to: $9)) includes: each ] ] ] ]
 ]
 
 { #category : 'testing' }
@@ -847,19 +783,6 @@ VirtualMachine >> processPreemptionYields: aBoolean [
 	self parameterAt: 48 put: ((self parameterAt: 48) bitClear: 4) + (aBoolean ifTrue: [0] ifFalse: [2r100])
 ]
 
-{ #category : 'accessing' }
-VirtualMachine >> saveImageVersionInImageHeader [
-
-	| currentVersion |
-	currentVersion := SystemVersion current.
-
-	"If the primitive is not available we return false"
-	[	self imageVersionInImageHeader: (currentVersion major * 10) + currentVersion minor.
-		^ true ]
-		onErrorDo: [ ^ false ]. 
-		
-]
-
 { #category : 'gc' }
 VirtualMachine >> setGCBiasToGrowGCLimit: aNumber [
 	"Primitive. Indicate that the bias to grow logic should do a GC after aNumber Bytes"
@@ -906,132 +829,6 @@ VirtualMachine >> setGCSemaphore: semaIndex [
 	] fork.
 	process inspect.
 "
-]
-
-{ #category : 'statistics' }
-VirtualMachine >> statisticsReport [
-	"Workspace openContents: (Smalltalk vm statisticsReport) label: 'VM Statistics'"
-
-	| oldSpaceSize youngSpaceSize memorySize freeSize fullGCs fullGCTime incrGCs incrGCTime tenureCount upTime upTime2 fullGCs2 fullGCTime2 incrGCs2 incrGCTime2 tenureCount2 str |
-	oldSpaceSize		:= self oldSpace.
-	youngSpaceSize		:= self youngSpaceSize.
-	tenureCount			:= self tenureCount.
-	memorySize			:= self memorySize.
-	freeSize				:= self freeSize.
-	fullGCs				:= self fullGCCount.
-	fullGCTime			:= self totalFullGCTime.
-	incrGCs				:= self incrementalGCCount.
-	incrGCTime			:= self totalIncrementalGCTime.
-
-	upTime := Time millisecondClockValue.
-	str := (String new: 1000) writeStream.
-	str	<< 'uptime			';
-		print: (upTime / 1000 / 60 // 60); nextPut: $h;
-		print: (upTime / 1000 / 60 \\ 60) asInteger; nextPut: $m;
-		print: (upTime / 1000 \\ 60) asInteger; nextPut: $s; cr.
-
-	str	<< 'memory			'.
-	memorySize printWithCommasOn: str.
-	str << ' bytes'; cr.
-	str	<<	'	old			'.
-	oldSpaceSize printWithCommasOn: str.
-	str << ' bytes (';
-		print: ((oldSpaceSize / memorySize * 100) roundTo: 0.1); << '%)'; cr.
-	str	<< '	young		'.
-	(youngSpaceSize) printWithCommasOn: str.
-	str << ' bytes (';
-		print: ((youngSpaceSize / memorySize * 100) roundTo: 0.1); << '%)'; cr.
-	str	<< '	used		'.
-	youngSpaceSize + oldSpaceSize - freeSize printWithCommasOn: str.
-	str << ' bytes (';
-		print: ((youngSpaceSize + oldSpaceSize - freeSize / memorySize * 100) roundTo: 0.1); << '%)'; cr.
-	str	<< '	free		'.
-	freeSize printWithCommasOn: str.
-	str << ' bytes (';
-		print: ((freeSize / memorySize * 100) roundTo: 0.1); << '%)'; cr.
-
-	str	<< 'GCs				'.
-	(fullGCs + incrGCs) printWithCommasOn: str.
-	fullGCs + incrGCs > 0 ifTrue: [
-		str
-			<< ' (';
-			print: ((upTime / (fullGCs + incrGCs)) roundTo: 1);
-			<< 'ms between GCs)'
-	].
-	str cr.
-	str	<< '	full			';
-		print: fullGCs; << ' totalling '.
-	fullGCTime printWithCommasOn: str.
-	str << 'ms (';
-		print: ((fullGCTime / upTime * 100) roundTo: 0.1);
-		<< '% uptime)'.
-	fullGCs = 0 ifFalse:
-		[str	<< ', avg '; print: ((fullGCTime / fullGCs) roundTo: 0.1); << 'ms'].
-	str	cr.
-	str	<< '	incr		';
-		print: incrGCs; << ' totalling '.
-	incrGCTime printWithCommasOn: str.
-	str << 'ms (';
-		print: ((incrGCTime / upTime * 100) roundTo: 0.1);
-		<< '% uptime), avg '; print: ((incrGCTime / incrGCs) roundTo: 0.1); << 'ms'; cr.
-	str	<< '	tenures		'.
-	tenureCount printWithCommasOn: str.
-	tenureCount = 0 ifFalse:
-		[str << ' (avg '; print: (incrGCs / tenureCount) asInteger; << ' GCs/tenure)'].
-	str	cr.
-
-LastStats ifNil: [LastStats := Array new: 6]
-ifNotNil: [
-	upTime2 := upTime - (LastStats at: 1).
-	fullGCs2 := fullGCs - (LastStats at: 2).
-	fullGCTime2 := fullGCTime - (LastStats at: 3).
-	incrGCs2 := incrGCs - (LastStats at: 4).
-	incrGCTime2 := incrGCTime - (LastStats at: 5).
-	tenureCount2 := tenureCount - (LastStats at: 6).
-
-	str	<<  'Since last view	'.
-	(fullGCs2 + incrGCs2) printWithCommasOn: str.
-	fullGCs2 + incrGCs2 > 0 ifTrue: [
-		str
-			<< ' (';
-			print: ((upTime2 / (fullGCs2 + incrGCs2)) roundTo: 1);
-			<< 'ms between GCs)'.
-	].
-	str cr.
-	str	<< '	uptime		'; print: ((upTime2 / 1000.0) roundTo: 0.1); << 's'; cr.
-	str	<< '	full			';
-		print: fullGCs2; << ' totalling '.
-	fullGCTime2 printWithCommasOn: str.
-	str << 'ms (';
-		print: ((fullGCTime2 / upTime2 * 100) roundTo: 0.1);
-		<< '% uptime)'.
-	fullGCs2 = 0 ifFalse:
-		[str	<< ', avg '; print: ((fullGCTime2 / fullGCs2) roundTo: 0.1); << 'ms'].
-	str	cr.
-	str	<< '	incr		';
-		print: incrGCs2; << ' totalling '.
-	incrGCTime2 printWithCommasOn: str.
-	str << 'ms (';
-		print: ((incrGCTime2 / upTime2 * 100) roundTo: 0.1);
-		<< '% uptime), avg '.
-	incrGCs2 > 0 ifTrue: [
-		 str print: ((incrGCTime2 / incrGCs2) roundTo: 0.1); << 'ms'
-	].
-	str cr.
-	str	<< '	tenures		'.
-	tenureCount2 printWithCommasOn: str.
-	tenureCount2 = 0 ifFalse:
-		[str << ' (avg '; print: (incrGCs2 / tenureCount2) asInteger; << ' GCs/tenure)'].
-	str	cr.
-].
-	LastStats at: 1 put: upTime.
-	LastStats at: 2 put: fullGCs.
-	LastStats at: 3 put: fullGCTime.
-	LastStats at: 4 put: incrGCs.
-	LastStats at: 5 put: incrGCTime.
-	LastStats at: 6 put: tenureCount.
-
-	^ str contents
 ]
 
 { #category : 'testing' }

--- a/src/System-Time/VirtualMachine.extension.st
+++ b/src/System-Time/VirtualMachine.extension.st
@@ -1,0 +1,151 @@
+Extension { #name : 'VirtualMachine' }
+
+{ #category : '*System-Time' }
+VirtualMachine >> gcStatisticsDuring: aBlockClosure [ 
+	
+	| incrementalGCCount fullGCCount incrementalGCTime fullGCTime timeToRun |
+	incrementalGCCount := self incrementalGCCount.
+	fullGCCount := self fullGCCount.
+	incrementalGCTime := self totalIncrementalGCTime.
+	fullGCTime := self totalFullGCTime.
+	
+	timeToRun := aBlockClosure millisecondsToRun.
+
+	incrementalGCCount := self incrementalGCCount - incrementalGCCount.
+	fullGCCount := self fullGCCount - fullGCCount.
+	incrementalGCTime := self totalIncrementalGCTime - incrementalGCTime.
+	fullGCTime := self totalFullGCTime - fullGCTime.
+
+	
+	^ { #incrementalGCCount -> incrementalGCCount.
+	  #fullGCCount -> fullGCCount.
+	  #incrementalGCTime -> incrementalGCTime milliSecond.
+	  #fullGCTime -> fullGCTime milliSecond.
+	  #timeToRun -> timeToRun } asDictionary 
+]
+
+{ #category : '*System-Time' }
+VirtualMachine >> statisticsReport [
+	"Workspace openContents: (Smalltalk vm statisticsReport) label: 'VM Statistics'"
+
+	| oldSpaceSize youngSpaceSize memorySize freeSize fullGCs fullGCTime incrGCs incrGCTime tenureCount upTime upTime2 fullGCs2 fullGCTime2 incrGCs2 incrGCTime2 tenureCount2 str |
+	oldSpaceSize		:= self oldSpace.
+	youngSpaceSize		:= self youngSpaceSize.
+	tenureCount			:= self tenureCount.
+	memorySize			:= self memorySize.
+	freeSize				:= self freeSize.
+	fullGCs				:= self fullGCCount.
+	fullGCTime			:= self totalFullGCTime.
+	incrGCs				:= self incrementalGCCount.
+	incrGCTime			:= self totalIncrementalGCTime.
+
+	upTime := Time millisecondClockValue.
+	str := (String new: 1000) writeStream.
+	str	<< 'uptime			';
+		print: (upTime / 1000 / 60 // 60); nextPut: $h;
+		print: (upTime / 1000 / 60 \\ 60) asInteger; nextPut: $m;
+		print: (upTime / 1000 \\ 60) asInteger; nextPut: $s; cr.
+
+	str	<< 'memory			'.
+	memorySize printWithCommasOn: str.
+	str << ' bytes'; cr.
+	str	<<	'	old			'.
+	oldSpaceSize printWithCommasOn: str.
+	str << ' bytes (';
+		print: ((oldSpaceSize / memorySize * 100) roundTo: 0.1); << '%)'; cr.
+	str	<< '	young		'.
+	(youngSpaceSize) printWithCommasOn: str.
+	str << ' bytes (';
+		print: ((youngSpaceSize / memorySize * 100) roundTo: 0.1); << '%)'; cr.
+	str	<< '	used		'.
+	youngSpaceSize + oldSpaceSize - freeSize printWithCommasOn: str.
+	str << ' bytes (';
+		print: ((youngSpaceSize + oldSpaceSize - freeSize / memorySize * 100) roundTo: 0.1); << '%)'; cr.
+	str	<< '	free		'.
+	freeSize printWithCommasOn: str.
+	str << ' bytes (';
+		print: ((freeSize / memorySize * 100) roundTo: 0.1); << '%)'; cr.
+
+	str	<< 'GCs				'.
+	(fullGCs + incrGCs) printWithCommasOn: str.
+	fullGCs + incrGCs > 0 ifTrue: [
+		str
+			<< ' (';
+			print: ((upTime / (fullGCs + incrGCs)) roundTo: 1);
+			<< 'ms between GCs)'
+	].
+	str cr.
+	str	<< '	full			';
+		print: fullGCs; << ' totalling '.
+	fullGCTime printWithCommasOn: str.
+	str << 'ms (';
+		print: ((fullGCTime / upTime * 100) roundTo: 0.1);
+		<< '% uptime)'.
+	fullGCs = 0 ifFalse:
+		[str	<< ', avg '; print: ((fullGCTime / fullGCs) roundTo: 0.1); << 'ms'].
+	str	cr.
+	str	<< '	incr		';
+		print: incrGCs; << ' totalling '.
+	incrGCTime printWithCommasOn: str.
+	str << 'ms (';
+		print: ((incrGCTime / upTime * 100) roundTo: 0.1);
+		<< '% uptime), avg '; print: ((incrGCTime / incrGCs) roundTo: 0.1); << 'ms'; cr.
+	str	<< '	tenures		'.
+	tenureCount printWithCommasOn: str.
+	tenureCount = 0 ifFalse:
+		[str << ' (avg '; print: (incrGCs / tenureCount) asInteger; << ' GCs/tenure)'].
+	str	cr.
+
+LastStats ifNil: [LastStats := Array new: 6]
+ifNotNil: [
+	upTime2 := upTime - (LastStats at: 1).
+	fullGCs2 := fullGCs - (LastStats at: 2).
+	fullGCTime2 := fullGCTime - (LastStats at: 3).
+	incrGCs2 := incrGCs - (LastStats at: 4).
+	incrGCTime2 := incrGCTime - (LastStats at: 5).
+	tenureCount2 := tenureCount - (LastStats at: 6).
+
+	str	<<  'Since last view	'.
+	(fullGCs2 + incrGCs2) printWithCommasOn: str.
+	fullGCs2 + incrGCs2 > 0 ifTrue: [
+		str
+			<< ' (';
+			print: ((upTime2 / (fullGCs2 + incrGCs2)) roundTo: 1);
+			<< 'ms between GCs)'.
+	].
+	str cr.
+	str	<< '	uptime		'; print: ((upTime2 / 1000.0) roundTo: 0.1); << 's'; cr.
+	str	<< '	full			';
+		print: fullGCs2; << ' totalling '.
+	fullGCTime2 printWithCommasOn: str.
+	str << 'ms (';
+		print: ((fullGCTime2 / upTime2 * 100) roundTo: 0.1);
+		<< '% uptime)'.
+	fullGCs2 = 0 ifFalse:
+		[str	<< ', avg '; print: ((fullGCTime2 / fullGCs2) roundTo: 0.1); << 'ms'].
+	str	cr.
+	str	<< '	incr		';
+		print: incrGCs2; << ' totalling '.
+	incrGCTime2 printWithCommasOn: str.
+	str << 'ms (';
+		print: ((incrGCTime2 / upTime2 * 100) roundTo: 0.1);
+		<< '% uptime), avg '.
+	incrGCs2 > 0 ifTrue: [
+		 str print: ((incrGCTime2 / incrGCs2) roundTo: 0.1); << 'ms'
+	].
+	str cr.
+	str	<< '	tenures		'.
+	tenureCount2 printWithCommasOn: str.
+	tenureCount2 = 0 ifFalse:
+		[str << ' (avg '; print: (incrGCs2 / tenureCount2) asInteger; << ' GCs/tenure)'].
+	str	cr.
+].
+	LastStats at: 1 put: upTime.
+	LastStats at: 2 put: fullGCs.
+	LastStats at: 3 put: fullGCTime.
+	LastStats at: 4 put: incrGCs.
+	LastStats at: 5 put: incrGCTime.
+	LastStats at: 6 put: tenureCount.
+
+	^ str contents
+]

--- a/src/System-Version/ClapPharoVersion.class.st
+++ b/src/System-Version/ClapPharoVersion.class.st
@@ -4,8 +4,8 @@ I report release and version information about the image and VM, in various form
 Class {
 	#name : 'ClapPharoVersion',
 	#superclass : 'ClapPharoApplication',
-	#category : 'Clap-Commands-Pharo',
-	#package : 'Clap-Commands-Pharo'
+	#category : 'System-Version',
+	#package : 'System-Version'
 }
 
 { #category : 'command line' }

--- a/src/System-Version/SmalltalkImage.extension.st
+++ b/src/System-Version/SmalltalkImage.extension.st
@@ -1,0 +1,93 @@
+Extension { #name : 'SmalltalkImage' }
+
+{ #category : '*System-Version' }
+SmalltalkImage >> licenseString [
+	^ self licenseStringTemplate format: (Array with: Date today year asString)
+]
+
+{ #category : '*System-Version' }
+SmalltalkImage >> licenseStringTemplate [
+	^ 'LICENSE
+
+Licensed under the MIT License with parts under the Apache License.
+
+Copyright (c) 2008-{1} The Pharo Project, and Contributors
+Copyright (c) 2008-{1} Inria
+Copyright (c) 1996-2008 Viewpoints Research Institute, and Contributors
+Copyright (c) 1996 Apple Computer, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, subject to the following conditions: The
+above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+You may obtain a copy of the Apache License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Pharo uses icons by Mark James (http://www.famfamfam.com) under
+Creative Commons Attribution 2.5 License.
+
+Pharo uses icons by Eclipse under
+Eclipse Public License - v 1.0
+http://www.eclipse.org/legal/epl-v10.html
+
+Pharo uses Source Code Pro Fonts by Adobe under
+SIL Open Font License, v 1.1
+http://scripts.sil.org/OFL
+
+Pharo uses Open Sans by Steve Matteson under
+Apache License, 2.0
+http://www.apache.org/licenses/LICENSE-2.0.html
+
+Pharo uses  Bitstream Vera Fonts
+http://dejavu-fonts.org/wiki/index.php?title=License
+
+Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.
+Bitstream Vera is a trademark of Bitstream, Inc.
+Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts
+accompanying this license ("Fonts") and associated documentation files (the "Font Software"),
+to reproduce and distribute the Font Software, including without limitation the rights to use, copy,
+merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom
+the Font Software is furnished to do so, subject to the following conditions:
+The above copyright and trademark notices and this permission notice shall be included in all
+copies of one or more of the Font Software typefaces.
+The Font Software may be modified, altered, or added to, and in particular the designs of glyphs
+or characters in the Fonts may be modified and additional glyphs or characters may be added to
+the Fonts, only if the fonts are renamed to names not containing either the words "Bitstream"
+or the word "Vera".
+This License becomes null and void to the extent applicable to Fonts or Font Software that
+has been modified and is distributed under the "Bitstream Vera" names.
+The Font Software may be sold as part of a larger software package but no copy of one or more
+of the Font Software typefaces may be sold by itself.
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT
+SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE
+FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
+Except as contained in this notice, the names of Gnome, the Gnome Foundation,
+and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in this Font Software without prior written authorization from
+the Gnome Foundation or Bitstream Inc., respectively.
+For further information, contact: fonts at gnome dot org.'
+]
+
+{ #category : '*System-Version' }
+SmalltalkImage >> version [
+	"Answer the version of this release."
+
+	^ SystemVersion current
+		  ifNil: [ 'No version set yet' ]
+		  ifNotNil: [ :version | version version ]
+]

--- a/src/System-Version/SystemVersion.class.st
+++ b/src/System-Version/SystemVersion.class.st
@@ -26,9 +26,8 @@ Class {
 	#classVars : [
 		'Current'
 	],
-	#category : 'System-Support-Image',
-	#package : 'System-Support',
-	#tag : 'Image'
+	#category : 'System-Version',
+	#package : 'System-Version'
 }
 
 { #category : 'accessing' }

--- a/src/System-Version/VirtualMachine.extension.st
+++ b/src/System-Version/VirtualMachine.extension.st
@@ -1,0 +1,36 @@
+Extension { #name : 'VirtualMachine' }
+
+{ #category : '*System-Version' }
+VirtualMachine >> imageVersionInImageHeader [
+
+	^ self parameterAt: 79
+]
+
+{ #category : '*System-Version' }
+VirtualMachine >> imageVersionInImageHeader: aValue [
+
+	(aValue between: 0 and: 65535)
+		ifFalse: [ self error: 'The image version should be an integer positive of 16bits' ].
+	
+	^ self parameterAt: 79 put: aValue
+]
+
+{ #category : '*System-Version' }
+VirtualMachine >> imageVersionNumber [
+	"Image version number (6505 means the Squeak V3 format with BlockClosure support (but _without_ BlockContext support)"
+
+	^ self parameterAt: 41
+]
+
+{ #category : '*System-Version' }
+VirtualMachine >> saveImageVersionInImageHeader [
+
+	| currentVersion |
+	currentVersion := SystemVersion current.
+
+	"If the primitive is not available we return false"
+	[	self imageVersionInImageHeader: (currentVersion major * 10) + currentVersion minor.
+		^ true ]
+		onErrorDo: [ ^ false ]. 
+		
+]

--- a/src/System-Version/package.st
+++ b/src/System-Version/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'System-Version' }


### PR DESCRIPTION
System-Support needs to be in the core of Pharo. But SystemVersion depends on System-Time which is not part of the core of Pharo. We do not need the version until it is initialized in the bootstrap so I propose to create a package System-Version to load later in the bootstrap. This will reduce the number of unwanted dependencies in the core of the bootstrap.

I also removed some other unwanted dependencies.

Little note if people have an opinion: Currently we have the version of multiple things such the OS, the VM, the Pharo version... I wonder if the OS and System version should not be accessible via the SystemVersion instead of the Smalltalk global? But it would be for another PR