### PR TITLE
Trimming the package name when we are creating a new package

### DIFF
--- a/src/Kernel-CodeModel-Tests/PackageRenameTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageRenameTest.class.st
@@ -85,6 +85,36 @@ PackageRenameTest >> testRenamePackageToOwnTagNameWithClassesInRoot [
 ]
 
 { #category : 'tests' }
+PackageRenameTest >> testRenamePackageTrimSpacesAtBegining [
+
+	| package |
+	package := self ensurePackage: #Test1.
+	package renameTo: '   TestRename'.
+
+	self assert: package name equals: #TestRename
+]
+
+{ #category : 'tests' }
+PackageRenameTest >> testRenamePackageTrimSpacesAtEnd [
+
+	| package |
+	package := self ensurePackage: #Test1.
+	package renameTo: 'TestRename   '.
+
+	self assert: package name equals: #TestRename
+]
+
+{ #category : 'tests' }
+PackageRenameTest >> testRenamePackageTrimSpacesBothSides [
+
+	| package |
+	package := self ensurePackage: #Test1.
+	package renameTo: '   TestRename   '.
+
+	self assert: package name equals: #TestRename
+]
+
+{ #category : 'tests' }
 PackageRenameTest >> testRenamePackageWithExtensions [
 
 	| package class extendedPackage extension |

--- a/src/Kernel-CodeModel-Tests/PackageTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageTest.class.st
@@ -503,7 +503,8 @@ PackageTest >> testPackageCanNotContainSpaces [
 	self ensurePackage: 'toto '.
 	self ensurePackage: ' toto '.
 
-	self assert: (self organizer packageMatchingWithName: 'toto') size equals: 1
+	self assert: (self organizer packages reject: #isUndefined) size equals: 1.
+
 ]
 
 { #category : 'tests - properties' }

--- a/src/Kernel-CodeModel-Tests/PackageTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageTest.class.st
@@ -471,6 +471,30 @@ PackageTest >> testMoveClassToTagName [
 	self assert: class packageTag package equals: yPackage
 ]
 
+{ #category : 'tests' }
+PackageTest >> testPackageCanNotContainSpaceAtBegining [
+
+	self assert: (self ensurePackage: #'   Test1') name equals: #Test1.
+
+	
+]
+
+{ #category : 'tests' }
+PackageTest >> testPackageCanNotContainSpaceAtEnd [
+
+	self assert: (self ensurePackage: #'Test1   ') name equals: #Test1.
+
+	
+]
+
+{ #category : 'tests' }
+PackageTest >> testPackageCanNotContainSpaceEitherAtBeginingOrEnd [
+
+	self assert: (self ensurePackage: #'      Test1   ') name equals: #Test1.
+
+	
+]
+
 { #category : 'tests - properties' }
 PackageTest >> testPropertyAtPut [
 

--- a/src/Kernel-CodeModel-Tests/PackageTest.class.st
+++ b/src/Kernel-CodeModel-Tests/PackageTest.class.st
@@ -495,6 +495,17 @@ PackageTest >> testPackageCanNotContainSpaceEitherAtBeginingOrEnd [
 	
 ]
 
+{ #category : 'tests' }
+PackageTest >> testPackageCanNotContainSpaces [
+
+
+	self ensurePackage: ' toto'.
+	self ensurePackage: 'toto '.
+	self ensurePackage: ' toto '.
+
+	self assert: (self organizer packageMatchingWithName: 'toto') size equals: 1
+]
+
 { #category : 'tests - properties' }
 PackageTest >> testPropertyAtPut [
 

--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -722,7 +722,7 @@ Package >> roots [
 { #category : 'accessing' }
 Package >> sanitizeName: aName [
 
-	^ aName trimLeft trimRight
+	^ aName trimBoth
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -77,10 +77,10 @@ Package class >> initializeProperties [
 ]
 
 { #category : 'instance creation' }
-Package class >> named: aString [
+Package class >> named: aPackageName [
 
 	^ self new
-		  name: aString;
+		  name: aPackageName trimRight trimLeft;
 		  yourself
 ]
 

--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -80,7 +80,7 @@ Package class >> initializeProperties [
 Package class >> named: aPackageName [
 
 	^ self new
-		  name: aPackageName trimRight trimLeft;
+		  name: aPackageName;
 		  yourself
 ]
 
@@ -502,9 +502,10 @@ Package >> name [
 Package >> name: aSymbol [
 	"Set the name of a package. This method is private and should not be used.
 	If you wish to rename a package, use #renameTo: instead"
-
+	
+	
 	aSymbol isEmptyOrNil ifTrue: [ self error: 'Cannot have empty or nil package name.' ].
-	name := aSymbol asSymbol
+	name := (self sanitizeName: aSymbol) asSymbol
 ]
 
 { #category : 'private' }
@@ -683,7 +684,7 @@ Package >> renameTo: aSymbol [
 
 	| oldName newName |
 	oldName := self name.
-	newName := aSymbol asSymbol.
+	newName := (self sanitizeName: aSymbol) asSymbol.
 	self organizer validatePackageDoesNotExist: aSymbol.
 
 	self organizer basicUnregisterPackage: self.
@@ -716,6 +717,12 @@ Package >> roots [
 
 	^ self definedClasses
 		select: [ :each | each superclass isNil or: [ each superclass package ~~ self ] ]
+]
+
+{ #category : 'accessing' }
+Package >> sanitizeName: aName [
+
+	^ aName trimLeft trimRight
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel-CodeModel/PackageOrganizer.class.st
+++ b/src/Kernel-CodeModel/PackageOrganizer.class.st
@@ -188,6 +188,15 @@ PackageOrganizer >> packageMatchingExtensionName: anExtensionName [
 		  ifFalse: [ self packageNamed: tmpPackageName ]
 ]
 
+{ #category : 'as yet unclassified' }
+PackageOrganizer >> packageMatchingWithName: aPackageName [
+
+	^ self packages select: [ :package | package name includesSubstring: aPackageName ]
+
+	 
+	
+]
+
 { #category : 'accessing' }
 PackageOrganizer >> packageNamed: aSymbol [
 	^ self

--- a/src/Kernel-CodeModel/PackageOrganizer.class.st
+++ b/src/Kernel-CodeModel/PackageOrganizer.class.st
@@ -188,15 +188,6 @@ PackageOrganizer >> packageMatchingExtensionName: anExtensionName [
 		  ifFalse: [ self packageNamed: tmpPackageName ]
 ]
 
-{ #category : 'as yet unclassified' }
-PackageOrganizer >> packageMatchingWithName: aPackageName [
-
-	^ self packages select: [ :package | package name includesSubstring: aPackageName ]
-
-	 
-	
-]
-
 { #category : 'accessing' }
 PackageOrganizer >> packageNamed: aSymbol [
 	^ self


### PR DESCRIPTION
In this PR we propose a fix for #18865.

To avoid possible package names problem, directly we just trim the package name leaving it without spaces just before to create the package.

We added test cases covering the main methods for this feature `name` and `renameTo`.