### PR TITLE
asDateAndTime deprecation with transformation

### DIFF
--- a/src/Deprecated14/String.extension.st
+++ b/src/Deprecated14/String.extension.st
@@ -8,6 +8,13 @@ String >> asDate [
 ]
 
 { #category : '*Deprecated14' }
+String >> asDateAndTime [
+ 	"Convert from UTC format"
+	self backwardCompatible: 'Should use DateAndTime class directly' on: '21 Nov 2025' in: 'pharo14' transformWith: '`@receiver asDateAndTime' -> '`DateAndTime fromString: @receiver'.
+	^ DateAndTime fromString: self
+]
+
+{ #category : '*Deprecated14' }
 String >> isValidSelector [
 	"check I could be a valid selector (name of method).
 	 For checking if there is symbol like me used as a selector, see #isSelectorSymbol on Symbol"

--- a/src/System-Time/String.extension.st
+++ b/src/System-Time/String.extension.st
@@ -1,13 +1,6 @@
 Extension { #name : 'String' }
 
 { #category : '*System-Time' }
-String >> asDateAndTime [
- 	"Convert from UTC format"
-
-	^ DateAndTime fromString: self
-]
-
-{ #category : '*System-Time' }
 String >> asDuration [
  	"Convert from [-]D:HH:MM:SS[.S] format. What is between [] implies optional elements"
 


### PR DESCRIPTION
We added a backwardCompatible deprecation on the method.

Since `DateAndTime fromString:` is not deprecated we can do it, but i may be cleaner to just deprecate it without transformation if `DateAndTime` will follow `Date` and ask for users to provide a pattern.

For #18325