### PR TITLE
Introduce BaselineOfDebugging and clean some dependencies

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -41,6 +41,7 @@ BaselineOfBasicTools >> baseline: spec [
 			spec
 				baseline: 'Traits' with: [ spec loads: 'core-traits' from: repository ];
 				baseline: 'SUnit' with: [ spec loads: 'Core' from: repository ];
+				baseline: 'Debugging' with: [ spec loads: 'Core' from: repository ];
 				baseline: 'UnifiedFFI' with: [ spec repository: repository ];
 				baseline: 'ThreadedFFI' with: [ spec repository: repository ];
 				baseline: 'UIInfrastructure' with: [ spec repository: repository ];

--- a/src/BaselineOfDebugging/BaselineOfDebugging.class.st
+++ b/src/BaselineOfDebugging/BaselineOfDebugging.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : 'BaselineOfDebugging',
+	#superclass : 'BaselineOf',
+	#category : 'BaselineOfDebugging',
+	#package : 'BaselineOfDebugging'
+}
+
+{ #category : 'accessing' }
+BaselineOfDebugging class >> corePackageNames [
+
+	^ self packagesOfGroupNamed: #Core
+]
+
+{ #category : 'baselines' }
+BaselineOfDebugging >> baseline: spec [
+
+	<baseline>
+	spec for: #common do: [
+			spec
+				package: 'Debugging-Core';
+				package: 'Debugging-Utils' with: [ spec requires: #( 'Debugging-Core' ) ];
+				package: 'Debugger-Model' with: [ spec requires: #( 'Debugging-Core' 'Debugging-Utils' ) ];
+				package: 'Debugger-Oups' with: [ spec requires: #( 'Debugger-Model' ) ];
+				package: 'Debugging-Utils-Tests' with: [ spec requires: #( 'Debugging-Utils' ) ];
+				package: 'Debugger-Model-Tests' with: [ spec requires: #( 'Debugger-Model' ) ];
+				package: 'Debugger-Oups-Tests' with: [ spec requires: #( 'Debugger-Oups' ) ].
+
+			spec
+				group: 'Core' with: #( 'Debugging-Core' 'Debugging-Utils' 'Debugger-Model' 'Debugger-Oups' );
+				group: 'Tests' with: #( 'Debugging-Utils-Tests' 'Debugger-Mode-Tests' 'Debugger-Oups-Tests' ) ]
+]

--- a/src/BaselineOfDebugging/BaselineOfDebugging.class.st
+++ b/src/BaselineOfDebugging/BaselineOfDebugging.class.st
@@ -27,5 +27,5 @@ BaselineOfDebugging >> baseline: spec [
 
 			spec
 				group: 'Core' with: #( 'Debugging-Core' 'Debugging-Utils' 'Debugger-Model' 'Debugger-Oups' );
-				group: 'Tests' with: #( 'Debugging-Utils-Tests' 'Debugger-Mode-Tests' 'Debugger-Oups-Tests' ) ]
+				group: 'Tests' with: #( 'Debugging-Utils-Tests' 'Debugger-Model-Tests' 'Debugger-Oups-Tests' ) ]
 ]

--- a/src/BaselineOfDebugging/package.st
+++ b/src/BaselineOfDebugging/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'BaselineOfDebugging' }

--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -14,7 +14,7 @@ BaselineOfGeneralTests >> baseline: spec [
 	repository := self packageRepositoryURLForSpec: spec.
 	spec for: #common do: [
 		spec
-			package: 'Debugging-Utils-Tests';
+			baseline: 'Debugging' with: [ spec loads: #Tests from: repository ];
 			package: 'NumberParser-Tests';
 			package: 'AST-Core-Tests';
 			package: 'Kernel-CodeModel-Tests';
@@ -26,8 +26,6 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'Collections-DoubleLinkedList-Tests';
 			package: 'Collections-Arithmetic-Tests';
 			package: 'Metacello-CommandLine-Tests';
-			package: 'Debugger-Model-Tests';
-			package: 'Debugger-Oups-Tests';
 			baseline: 'Epicea' with: [
 				spec
 					repository: repository;

--- a/src/BaselineOfUI/BaselineOfUI.class.st
+++ b/src/BaselineOfUI/BaselineOfUI.class.st
@@ -24,12 +24,6 @@ Class {
 	#package : 'BaselineOfUI'
 }
 
-{ #category : 'loading' }
-BaselineOfUI class >> debuggerBaseUIPackageNames [
-
-	^ self packagesOfGroupNamed: #'Debugger-Base-UI'
-]
-
 { #category : 'baseline' }
 BaselineOfUI >> baseline: spec [
 
@@ -38,12 +32,6 @@ BaselineOfUI >> baseline: spec [
 	repository := self packageRepositoryURLForSpec: spec.
 	spec for: #common do: [
 		spec postLoadDoIt: #postload:package:.
-
-		"Loading the debugger model and infrastructure before the UI"
-		spec package: 'Debugging-Utils'.
-		spec package: 'Debugging-Core'.
-		spec package: 'Debugger-Model'.
-		spec package: 'Debugger-Oups'.
 
 		spec baseline: 'Fuel' with: [
 			spec
@@ -64,9 +52,7 @@ BaselineOfUI >> baseline: spec [
 
 		spec package: 'Morphic-Widgets-Tree'.
 
-		spec package: 'WebBrowser-Core'.
-		
-		spec group: 'Debugger-Base-UI' with: #('Debugging-Utils' 'Debugging-Core' 'Debugger-Model' 'Debugger-Oups') ]
+		spec package: 'WebBrowser-Core'  ]
 ]
 
 { #category : 'actions' }

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -71,26 +71,13 @@ DebugSession class >> fastStepThroughMode: aBoolean [
 	^ FastStepThroughMode := aBoolean
 ]
 
-{ #category : 'settings' }
-DebugSession class >> fastStepThroughModeSettingOn: aBuilder [
-
-	<systemsettings>
-	(aBuilder setting: #fastStepThroughMode)
-		label: 'Enable the fast step through mode';
-		target: self;
-		parent: #debugging;
-		default: false;
-		description:
-			'If enabled, the debugger will perform step through operations using halting blocks. This implementation is more efficient than the original one based on interpreter steps'
-]
-
-{ #category : 'settings' }
+{ #category : 'accessing' }
 DebugSession class >> logDebuggerStackToFile [
 	^ LogDebuggerStackToFile 
 		ifNil: [ LogDebuggerStackToFile := false ]
 ]
 
-{ #category : 'settings' }
+{ #category : 'accessing' }
 DebugSession class >> logDebuggerStackToFile: aBoolean [
 	LogDebuggerStackToFile := aBoolean
 ]

--- a/src/Debugger-Model/DebuggerSettings.class.st
+++ b/src/Debugger-Model/DebuggerSettings.class.st
@@ -9,38 +9,11 @@ Class {
 	#tag : 'Core'
 }
 
-{ #category : 'settings' }
+{ #category : 'accessing' }
 DebuggerSettings class >> availableDebuggers [
 
 	^ (self systemDebuggers select: [ :dbgClass |
 		   dbgClass availableAutomatically ]) asOrderedCollection
-]
-
-{ #category : 'settings' }
-DebuggerSettings class >> debuggerRankSettingsOn: aBuilder [
-	<systemsettings>
-	(aBuilder group: #debuggers)
-		label: 'Debuggers';
-		parent: #debugging.
-	self systemDebuggers do: [ :debuggerClass |
-		(aBuilder group: debuggerClass name asSymbol)
-			label: debuggerClass name;
-			parent: #debuggers;
-			with: [
-				(aBuilder pickOne: #rank)
-					label: 'Priority';
-					target: debuggerClass;
-					default: debuggerClass defaultDebuggerRank;
-					domainValues: (1 to: 10);
-					description:
-						'Debugger priority: a debugger with a high priority will be chosen for debugging over a debugger with a low priority.
-Lowest priority: 1. Highest priority: 10'.
-				(aBuilder setting: #availableAutomatically)
-					label: 'Available';
-					target: debuggerClass;
-					default: self defaultAvailability;
-					description:
-						'(De)activates the debugger. A deactivated debugger will not be used by the system.' ] ]
 ]
 
 { #category : 'accessing' }
@@ -61,54 +34,7 @@ DebuggerSettings class >> emergencyDebugger [
 		  ifAbsent: [ DebuggerEmmergencyLogger new ]
 ]
 
-{ #category : 'settings' }
-DebuggerSettings class >> generalDebuggingSettingsOn: aBuilder [
-
-	<systemsettings>
-	(aBuilder group: #debugging)
-		label: 'Debugging';
-		parent: #tools;
-		description: 'All Debugger settings';
-		with: [
-			(aBuilder group: #deprecationHandling)
-				label: 'Deprecation handling';
-				description: 'How deprecation are handled';
-				target: Deprecation;
-				with: [
-					(aBuilder setting: #activateTransformations)
-						label:
-							'Performs automatic transformations on deprecated methods';
-						default: true;
-						description:
-							'If true, then the caller will be rewritten for each deprecated method invocation'.
-					(aBuilder setting: #raiseWarning)
-						label: 'Raise a blocking dialog';
-						default: true;
-						description:
-							'If true, then a dialog is popup for each deprecated method invocation'.
-					(aBuilder setting: #showWarning)
-						label: 'Transcript message';
-						default: true;
-						description:
-							'If true, then a message is send to the Transcript for each deprecated method invocation' ].
-
-			(aBuilder setting: #logDebuggerStackToFile)
-				label: 'Write message to debug log file when fall into debugger';
-				target: DebugSession;
-				default: false;
-				description:
-					'If true, whenever you fall into a debugger a summary of its stack will be written to a file named'.
-
-
-			(aBuilder setting: #logFileName)
-				label: 'Log file name';
-				target: Smalltalk;
-				default: 'PharoDebug.log';
-				description:
-					'A name of the file, which will be used for logging all errors and notifications' ]
-]
-
-{ #category : 'settings' }
+{ #category : 'accessing' }
 DebuggerSettings class >> systemDebuggers [
 
 	^ (TDebugger users flatCollect: [ :class | class withAllSubclasses ])

--- a/src/Debugger-Model/ManifestDebuggerModel.class.st
+++ b/src/Debugger-Model/ManifestDebuggerModel.class.st
@@ -1,0 +1,17 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestDebuggerModel',
+	#superclass : 'PackageManifest',
+	#category : 'Debugger-Model-Manifest',
+	#package : 'Debugger-Model',
+	#tag : 'Manifest'
+}
+
+{ #category : 'meta-data - dependency analyser' }
+ManifestDebuggerModel class >> manuallyResolvedDependencies [
+
+	<ignoreForCoverage>
+	^ #(#'System-Object Events' #'Tool-Base' #'Morphic-Core' #DebugInfo #'OpalCompiler-Core')
+]

--- a/src/Debugger-Oups/ManifestDebuggerOups.class.st
+++ b/src/Debugger-Oups/ManifestDebuggerOups.class.st
@@ -1,0 +1,17 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestDebuggerOups',
+	#superclass : 'PackageManifest',
+	#category : 'Debugger-Oups-Manifest',
+	#package : 'Debugger-Oups',
+	#tag : 'Manifest'
+}
+
+{ #category : 'meta-data - dependency analyser' }
+ManifestDebuggerOups class >> manuallyResolvedDependencies [
+
+	<ignoreForCoverage>
+	^ #(#Traits #'Kernel-CodeModel' #'Transcript-NonInteractive' #'System-Support')
+]

--- a/src/Debugger-Oups/OupsDebuggerSelectionStrategy.class.st
+++ b/src/Debugger-Oups/OupsDebuggerSelectionStrategy.class.st
@@ -20,31 +20,19 @@ Class {
 	#tag : 'Strategies'
 }
 
-{ #category : 'settings' }
+{ #category : 'accessing' }
 OupsDebuggerSelectionStrategy class >> debuggerSelectionStrategy [
 
 	^ debuggerSelectionStrategy ifNil: [
 		  debuggerSelectionStrategy := self defaultDebuggerSelectionStrategy ]
 ]
 
-{ #category : 'settings' }
+{ #category : 'accessing' }
 OupsDebuggerSelectionStrategy class >> debuggerSelectionStrategy: aClass [
 	debuggerSelectionStrategy := aClass
 ]
 
-{ #category : 'settings' }
-OupsDebuggerSelectionStrategy class >> debuggerSelectionStrategySettingsOn: aBuilder [
-	<systemsettings>
-	(aBuilder pickOne: #debuggerSelectionStrategy)
-		label: 'Debugger selection strategy';
-		target: self;
-		default: self defaultDebuggerSelectionStrategy;
-		parent: #debugging;
-		domainValues: (self allSubclasses);
-		description: 'Sets the strategy to open a debugger.'
-]
-
-{ #category : 'settings' }
+{ #category : 'accessing' }
 OupsDebuggerSelectionStrategy class >> defaultDebuggerSelectionStrategy [
 	^OupsDebuggerSelector
 ]

--- a/src/Debugger-Oups/OupsDebuggerSelector.class.st
+++ b/src/Debugger-Oups/OupsDebuggerSelector.class.st
@@ -23,25 +23,14 @@ Class {
 	#tag : 'Strategies'
 }
 
-{ #category : 'settings' }
+{ #category : 'accessing' }
 OupsDebuggerSelector class >> handleDebuggerErrors [
 	^ handleDebuggerErrors ifNil: [ handleDebuggerErrors := false ]
 ]
 
-{ #category : 'settings' }
+{ #category : 'accessing' }
 OupsDebuggerSelector class >> handleDebuggerErrors: aBoolean [
 	handleDebuggerErrors := aBoolean
-]
-
-{ #category : 'settings' }
-OupsDebuggerSelector class >> handleDebuggerErrorsSettingsOn: aBuilder [
-	<systemsettings>
-	(aBuilder setting: #handleDebuggerErrors)
-		label: 'Handle debugger errors';
-		target: self;
-		default: false;
-		parent: #debugging;
-		description: 'Try to debug debugger errors when they occur.'
 ]
 
 { #category : 'accessing' }

--- a/src/Debugging-Core/ManifestDebuggingCore.class.st
+++ b/src/Debugging-Core/ManifestDebuggingCore.class.st
@@ -1,0 +1,17 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestDebuggingCore',
+	#superclass : 'PackageManifest',
+	#category : 'Debugging-Core-Manifest',
+	#package : 'Debugging-Core',
+	#tag : 'Manifest'
+}
+
+{ #category : 'meta-data - dependency analyser' }
+ManifestDebuggingCore class >> manuallyResolvedDependencies [
+
+	<ignoreForCoverage>
+	^ #(#'Collections-Streams' #'Collections-Abstract' #'OpalCompiler-Core' #'System-NumberPrinting' #'AST-Core' #DebugInfo #'Kernel-BytecodeEncoders')
+]

--- a/src/Debugging-Utils/ManifestDebuggingUtils.class.st
+++ b/src/Debugging-Utils/ManifestDebuggingUtils.class.st
@@ -1,0 +1,17 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestDebuggingUtils',
+	#superclass : 'PackageManifest',
+	#category : 'Debugging-Utils-Manifest',
+	#package : 'Debugging-Utils',
+	#tag : 'Manifest'
+}
+
+{ #category : 'meta-data - dependency analyser' }
+ManifestDebuggingUtils class >> manuallyResolvedDependencies [
+
+	<ignoreForCoverage>
+	^ #(#'SUnit-Basic-CLI' #'Kernel-CodeModel' #'SUnit-Core' #'Debugging-Core')
+]

--- a/src/Kernel-CodeModel/Behavior.class.st
+++ b/src/Kernel-CodeModel/Behavior.class.st
@@ -1438,6 +1438,12 @@ Behavior >> methodDictionary: aDictionary [
 	self methodDict: aDictionary
 ]
 
+{ #category : 'accessing' }
+Behavior >> methodNamed: aSelector [
+	<reflection: 'Class structural inspection - Selectors and methods inspection'>
+	^ self methodDict at: aSelector
+]
+
 { #category : 'accessing - method dictionary' }
 Behavior >> methods [
 	<reflection: 'Class structural inspection - Selectors and methods inspection'>

--- a/src/Ring-Definitions-Core/Behavior.extension.st
+++ b/src/Ring-Definitions-Core/Behavior.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'Behavior' }
-
-{ #category : '*Ring-Definitions-Core' }
-Behavior >> methodNamed: aSelector [
-	<reflection: 'Class structural inspection - Selectors and methods inspection'>
-	^ self methodDict at: aSelector
-]

--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -29,6 +29,12 @@ SystemDependenciesTest >> compilerLayerPackages [
 	^ self kernelLayerPackages , BaselineOfPharoBootstrap compilerPackageNames
 ]
 
+{ #category : 'packages' }
+SystemDependenciesTest >> debuggingLayerPackages [
+
+	^ self sunitCoreLayerPackages , BaselineOfDebugging corePackageNames
+]
+
 { #category : 'accessing' }
 SystemDependenciesTest >> dependenciesReport [
 
@@ -70,6 +76,13 @@ SystemDependenciesTest >> knownCompilerDependencies [
 ]
 
 { #category : 'known dependencies' }
+SystemDependenciesTest >> knownDebuggingDependencies [
+	"ideally this list should be empty"
+
+	^ #( #'Morphic-Core' #'System-Object Events' #'Tool-Base' )
+]
+
+{ #category : 'known dependencies' }
 SystemDependenciesTest >> knownKernelDependencies [
 	"ideally this list should be empty"
 
@@ -80,7 +93,7 @@ SystemDependenciesTest >> knownKernelDependencies [
 SystemDependenciesTest >> knownMorphicCoreDependencies [
 	"ideally this list should be empty"
 
-	^ #(#'Keymapping-KeyCombinations' #'Morphic-Base' 'Morphic-Widgets-ColorPicker')
+	^ #(#'Keymapping-KeyCombinations' #'Morphic-Base' 'Morphic-Widgets-ColorPicker' 'Tool-Base')
 ]
 
 { #category : 'known dependencies' }
@@ -97,6 +110,13 @@ SystemDependenciesTest >> knownUIDependencies [
 
 	^ #( 'Athens-Cairo' 'Athens-Core' #'Refactoring-Environment' 'Reflectivity-Tools' #Shout #'Tool-Diff' #'HeuristicCompletion-Model'
 	     'NECompletion-Morphic' #VariablesLibrary #'Tools-CodeNavigation' #'Spec2-CommonWidgets' #'NewTools-Scopes' #'NewTools-FileBrowser' #EnlumineurFormatter )
+]
+
+{ #category : 'known dependencies' }
+SystemDependenciesTest >> knownUIInfrastructureDependencies [
+	"ideally this list should be empty"
+
+	^ #( #'Morphic-Core' #'System-Object Events' #'Tool-Base' )
 ]
 
 { #category : 'packages' }
@@ -169,7 +189,8 @@ SystemDependenciesTest >> testExternalBasicToolsDependencies [
 		self tonelCorePackageNames,
 		BaselineOfKernelTests withAllPackageNames,
 		BaselineOfTraits corePackages,
-		BaselineOfSUnit withAllPackageNames, "ALL"
+		BaselineOfSUnit withAllPackageNames,
+		BaselineOfDebugging corePackageNames,
 		BaselineOfDisplay withAllPackageNames,
 		BaselineOfUnifiedFFI withAllPackageNames,
 		BaselineOfFonts allPackageNames,
@@ -201,6 +222,15 @@ SystemDependenciesTest >> testExternalCompilerDependencies [
 	dependencies := self externalDependendiesOf: self compilerLayerPackages.
 
 	self assertCollection: dependencies hasSameElements: self knownCompilerDependencies
+]
+
+{ #category : 'tests' }
+SystemDependenciesTest >> testExternalDebuggingDependencies [
+
+	| dependencies |
+	dependencies := self externalDependendiesOf: self debuggingLayerPackages.
+
+	self assertCollection: dependencies hasSameElements: self knownDebuggingDependencies
 ]
 
 { #category : 'tests' }
@@ -296,7 +326,7 @@ SystemDependenciesTest >> testExternalMorphicCoreDependencies [
 	dependencies := self externalDependendiesOf: (
 		self metacelloPackageNames,
 		self tonelCorePackageNames,
-		BaselineOfUI debuggerBaseUIPackageNames,
+		BaselineOfDebugging corePackageNames,
 		BaselineOfUIInfrastructure withAllPackageNames,
 		BaselineOfTraits corePackages,
 		BaselineOfSUnit corePackageNames,
@@ -318,7 +348,7 @@ SystemDependenciesTest >> testExternalMorphicDependencies [
 	dependencies := self externalDependendiesOf: (
 		self metacelloPackageNames,
 		self tonelCorePackageNames,
-		BaselineOfUI debuggerBaseUIPackageNames,
+		BaselineOfDebugging corePackageNames,
 		BaselineOfUIInfrastructure withAllPackageNames,
 		BaselineOfTraits corePackages,
 		BaselineOfSUnit corePackageNames,
@@ -355,6 +385,7 @@ SystemDependenciesTest >> testExternalSpec2Dependencies [
 		"Language"
 		self metacelloPackageNames,
 		self tonelCorePackageNames,
+		BaselineOfDebugging corePackageNames,
 		BaselineOfUI allPackageNames,
 		BaselineOfUIInfrastructure withAllPackageNames,
 		BaselineOfTraits corePackages,
@@ -407,6 +438,7 @@ SystemDependenciesTest >> testExternalUIDependencies [
 	dependencies := (self externalDependendiesOf: (
 		self metacelloPackageNames,
 		self tonelCorePackageNames,
+		BaselineOfDebugging corePackageNames,
 		BaselineOfUI allPackageNames,
 		BaselineOfUIInfrastructure withAllPackageNames,
 		BaselineOfTraits corePackages,
@@ -437,7 +469,7 @@ SystemDependenciesTest >> testExternalUIInfrastructureDependencies [
 	| dependencies |
 	dependencies := self externalDependendiesOf: self uiInfrastructureCoreLayerPackages.
 
-	self assertEmpty: dependencies
+	self assertCollection: dependencies hasSameElements: self knownUIInfrastructureDependencies
 ]
 
 { #category : 'tests' }
@@ -468,6 +500,6 @@ SystemDependenciesTest >> tonelCorePackageNames [
 { #category : 'packages' }
 SystemDependenciesTest >> uiInfrastructureCoreLayerPackages [
 
-	^ self sunitCoreLayerPackages , BaselineOfUnifiedFFI allPackageNames , BaselineOfThreadedFFI allPackageNames , BaselineOfDisplay allPackageNames
+	^ self debuggingLayerPackages , BaselineOfUnifiedFFI allPackageNames , BaselineOfThreadedFFI allPackageNames , BaselineOfDisplay allPackageNames
 	  , BaselineOfFonts allPackageNames , BaselineOfFreeType allPackageNames , BaselineOfMenuRegistration allPackageNames , BaselineOfKeymapping corePackageNames
 ]

--- a/src/System-Settings-Core/DebugSession.extension.st
+++ b/src/System-Settings-Core/DebugSession.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : 'DebugSession' }
+
+{ #category : '*System-Settings-Core' }
+DebugSession class >> fastStepThroughModeSettingOn: aBuilder [
+
+	<systemsettings>
+	(aBuilder setting: #fastStepThroughMode)
+		label: 'Enable the fast step through mode';
+		target: self;
+		parent: #debugging;
+		default: false;
+		description:
+			'If enabled, the debugger will perform step through operations using halting blocks. This implementation is more efficient than the original one based on interpreter steps'
+]

--- a/src/System-Settings-Core/DebuggerSettings.extension.st
+++ b/src/System-Settings-Core/DebuggerSettings.extension.st
@@ -1,0 +1,75 @@
+Extension { #name : 'DebuggerSettings' }
+
+{ #category : '*System-Settings-Core' }
+DebuggerSettings class >> debuggerRankSettingsOn: aBuilder [
+	<systemsettings>
+	(aBuilder group: #debuggers)
+		label: 'Debuggers';
+		parent: #debugging.
+	self systemDebuggers do: [ :debuggerClass |
+		(aBuilder group: debuggerClass name asSymbol)
+			label: debuggerClass name;
+			parent: #debuggers;
+			with: [
+				(aBuilder pickOne: #rank)
+					label: 'Priority';
+					target: debuggerClass;
+					default: debuggerClass defaultDebuggerRank;
+					domainValues: (1 to: 10);
+					description:
+						'Debugger priority: a debugger with a high priority will be chosen for debugging over a debugger with a low priority.
+Lowest priority: 1. Highest priority: 10'.
+				(aBuilder setting: #availableAutomatically)
+					label: 'Available';
+					target: debuggerClass;
+					default: self defaultAvailability;
+					description:
+						'(De)activates the debugger. A deactivated debugger will not be used by the system.' ] ]
+]
+
+{ #category : '*System-Settings-Core' }
+DebuggerSettings class >> generalDebuggingSettingsOn: aBuilder [
+
+	<systemsettings>
+	(aBuilder group: #debugging)
+		label: 'Debugging';
+		parent: #tools;
+		description: 'All Debugger settings';
+		with: [
+			(aBuilder group: #deprecationHandling)
+				label: 'Deprecation handling';
+				description: 'How deprecation are handled';
+				target: Deprecation;
+				with: [
+					(aBuilder setting: #activateTransformations)
+						label:
+							'Performs automatic transformations on deprecated methods';
+						default: true;
+						description:
+							'If true, then the caller will be rewritten for each deprecated method invocation'.
+					(aBuilder setting: #raiseWarning)
+						label: 'Raise a blocking dialog';
+						default: true;
+						description:
+							'If true, then a dialog is popup for each deprecated method invocation'.
+					(aBuilder setting: #showWarning)
+						label: 'Transcript message';
+						default: true;
+						description:
+							'If true, then a message is send to the Transcript for each deprecated method invocation' ].
+
+			(aBuilder setting: #logDebuggerStackToFile)
+				label: 'Write message to debug log file when fall into debugger';
+				target: DebugSession;
+				default: false;
+				description:
+					'If true, whenever you fall into a debugger a summary of its stack will be written to a file named'.
+
+
+			(aBuilder setting: #logFileName)
+				label: 'Log file name';
+				target: Smalltalk;
+				default: 'PharoDebug.log';
+				description:
+					'A name of the file, which will be used for logging all errors and notifications' ]
+]

--- a/src/System-Settings-Core/OupsDebuggerSelectionStrategy.extension.st
+++ b/src/System-Settings-Core/OupsDebuggerSelectionStrategy.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : 'OupsDebuggerSelectionStrategy' }
+
+{ #category : '*System-Settings-Core' }
+OupsDebuggerSelectionStrategy class >> debuggerSelectionStrategySettingsOn: aBuilder [
+	<systemsettings>
+	(aBuilder pickOne: #debuggerSelectionStrategy)
+		label: 'Debugger selection strategy';
+		target: self;
+		default: self defaultDebuggerSelectionStrategy;
+		parent: #debugging;
+		domainValues: (self allSubclasses);
+		description: 'Sets the strategy to open a debugger.'
+]

--- a/src/System-Settings-Core/OupsDebuggerSelector.extension.st
+++ b/src/System-Settings-Core/OupsDebuggerSelector.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : 'OupsDebuggerSelector' }
+
+{ #category : '*System-Settings-Core' }
+OupsDebuggerSelector class >> handleDebuggerErrorsSettingsOn: aBuilder [
+	<systemsettings>
+	(aBuilder setting: #handleDebuggerErrors)
+		label: 'Handle debugger errors';
+		target: self;
+		default: false;
+		parent: #debugging;
+		description: 'Try to debug debugger errors when they occur.'
+]


### PR DESCRIPTION
This PR bring those changes:
- Move #methodNamed: from Ring to its defining class because it is used by projects that do not depend on ring except for this method
- Move setting declarations de System-Settings-Core since they are loaded after the debugging utilities
- Introduce BaselineOfDebugging to group packages related to debugging
- Declare dependencies between those packages
- Add system dependency tests about this layer. The tests currently have some violators. Those are dependencies we will need to cut in the future
- Improve categorization of some methods


Next steps:
- Move EmmergencyDebugger to this baseline?
- Cut unwanted dependencies: #'Morphic-Core' #'System-Object Events' #'Tool-Base'

This will also allow me to extract more non morphic packages from BaselineOfMorphic without breaking the dependencies tests
