### PR TITLE
Deprecate #basicInspect

### DIFF
--- a/src/Deprecated14/Object.extension.st
+++ b/src/Deprecated14/Object.extension.st
@@ -1,6 +1,20 @@
 Extension { #name : 'Object' }
 
 { #category : '*Deprecated14' }
+Object >> basicInspect [
+
+	self deprecated: 'Basic inspector does not exist anymore, you should use the inpector.' transformWith: '`@rcv basicInspect' -> '`@rcv inspect'.
+	^ self inspect
+]
+
+{ #category : '*Deprecated14' }
+Object >> basicInspector [
+
+	self deprecated: 'Basic inspector does not exist anymore, you should use the inpector.' transformWith: '`@rcv basicInspector' -> '`@rcv inspector'.
+	^ self inspector
+]
+
+{ #category : '*Deprecated14' }
 Object >> haltOnAccess [
 
 	self

--- a/src/Rubric/RubSmalltalkCodeMode.class.st
+++ b/src/Rubric/RubSmalltalkCodeMode.class.st
@@ -59,11 +59,6 @@ RubSmalltalkCodeMode class >> menuOn: aBuilder [
 		selector: #browseFullClass;
 		help: nil;
 		iconName: #smallSystemBrowser.
-	(aBuilder item: #'Do & basic inspect it' translated)
-		keyText: 'I';
-		selector: #basicInspectIt;
-		help: nil;
-		iconName: #smallInspectIt.
 	(aBuilder item: #'Debug it' translated)
 		keyText: 'D';
 		selector: #debugIt;

--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -45,12 +45,6 @@ RubSmalltalkEditor class >> buildShortcutsOn: aBuilder [
 		do: [ :target | target editor inspectIt: nil ]
 		description: 'Do & inspect it'.
 
-	(aBuilder shortcut: #basicInspectIt)
-		category: RubSmalltalkEditor name
-		default: $i meta shift
-		do: [ :target | target editor basicInspectIt ]
-		description: 'Do & basic inspect it'.
-
 	(aBuilder shortcut: #implementorsOfIt)
 		category: RubSmalltalkEditor name
 		default: $m meta
@@ -155,11 +149,6 @@ RubSmalltalkEditor >> atCompletionPosition [
 	cursorPosition := self startIndex.
 	cursorPosition < 2 ifTrue: [ ^ false ].
 	^ (self lineIndentationStart: cursorPosition) < cursorPosition
-]
-
-{ #category : 'do-its' }
-RubSmalltalkEditor >> basicInspectIt [
-	self evaluateSelectionAndDo: [:result | result basicInspect]
 ]
 
 { #category : 'source navigation' }

--- a/src/Tools/Object.extension.st
+++ b/src/Tools/Object.extension.st
@@ -1,20 +1,6 @@
 Extension { #name : 'Object' }
 
 { #category : '*Tools' }
-Object >> basicInspect [
-	"Create and schedule an Inspector in which the user can examine the receiver's variables.
-	Return the receiver. For getting the inspector, use #basicInspector"
-	(Smalltalk tools toolNamed: #basicInspector) inspect: self
-]
-
-{ #category : '*Tools' }
-Object >> basicInspector [
-	"Create and schedule a basic Inspector in which the user can examine the receiver's variables.
-	Return the inspector. For getting the object itself, use #basicInspect"
-	^ (Smalltalk tools toolNamed: #basicInspector) inspect: self
-]
-
-{ #category : '*Tools' }
 Object >> browse [
 	
 	^ (Smalltalk tools toolNamed: #browser) openOnClass: self class


### PR DESCRIPTION
In the past we had two inspectors. A 'simple' one called basicInspector and a more developed one called 'inspector'. But since a few years we only have one, so I propose to deprecate the basic inspector.