### PR TITLE
Extract MczInstaller from Morphic

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -69,13 +69,8 @@ BaselineOfBasicTools >> baseline: spec [
 			spec package: 'System-Sources-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
 
 			spec package: 'ClassDefinitionPrinters-Tests'.
-			spec package: 'Kernel-CodeModel-Tests'.
-			spec package: 'Monticello-Tests'.
-			spec package: 'MonticelloMocks'.
 			spec package: 'Network-Mail'.
 			spec package: 'Network-Mail-Tests'.
-
-
 
 			spec package: 'OpalCompiler-ToolFeatures'.
 			spec package: 'OpalCompiler-ToolFeatures-Tests'.

--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -19,7 +19,6 @@ BaselineOfGeneralTests >> baseline: spec [
 			package: 'AST-Core-Tests';
 			package: 'Kernel-CodeModel-Tests';
 			package: 'Monticello-Tests';
-			"required by MonticelloMocks"package: 'System-Installers-Tests';
 			package: 'MonticelloMocks';
 			package: 'Fuel-Core-Tests';
 			package: 'FormCanvas-Tests';

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -85,7 +85,6 @@ BaselineOfMorphic >> baseline: spec [
 		spec package: 'Settings-System'.
 
 		spec package: 'System-History'.
-		spec package: 'System-Installers'.
 		spec package: 'PragmaCollector'.
 		spec package: 'System-Settings-Browser'
 			with: [ spec requires: #( 'PragmaCollector' ) ].
@@ -123,7 +122,7 @@ BaselineOfMorphic >> postload: loader package: packageSpec [
 
 	#( #ProgressBarMorph #GlobalIdentifier #HaloMorph
 	   #CharacterScanner #ImageMorph
-	   #Locale #MczInstaller #MD5NonPrimitive #MenuItemMorph
+	   #Locale #MenuItemMorph
 	   #MenuMorph #RxMatcher #RxParser #RxsPredicate #SHA1
 	   #SystemProgressMorph #SystemWindow #TextContainer
 	   #TextDiffBuilder #ThumbnailMorph #TransferMorph #UITheme )

--- a/src/Monticello-Tests/MCMczInstallerTest.class.st
+++ b/src/Monticello-Tests/MCMczInstallerTest.class.st
@@ -5,21 +5,9 @@ Class {
 		'expected',
 		'diff'
 	],
-	#category : 'System-Installers-Tests',
-	#package : 'System-Installers-Tests'
+	#category : 'Monticello-Tests',
+	#package : 'Monticello-Tests'
 }
-
-{ #category : 'testing' }
-MCMczInstallerTest class >> isAbstract [
-	^ (Smalltalk hasClassNamed: #MczInstaller) not
-]
-
-{ #category : 'accessing' }
-MCMczInstallerTest class >> suite [
-	^ (Smalltalk hasClassNamed: #MczInstaller)
-		ifTrue: [ super suite ]
-		ifFalse: [ self classForTestSuite new name: self name asString ]
-]
 
 { #category : 'assertions' }
 MCMczInstallerTest >> assertDict: dict matchesInfo: info [
@@ -35,29 +23,9 @@ MCMczInstallerTest >> assertNoChange [
 	self assertEmpty: diff
 ]
 
-{ #category : 'assertions' }
-MCMczInstallerTest >> assertVersionInfoPresent [
-	| dict info |
-	dict := MczInstaller versionInfo at: self mockPackage name.
-	info := expected info.
-	self assertDict: dict matchesInfo: info
-]
-
-{ #category : 'utilities' }
-MCMczInstallerTest >> deleteFile [
-	self fileName asFileReference ensureDelete
-]
-
 { #category : 'accessing' }
 MCMczInstallerTest >> fileName [
 	^ 'InstallerTest.mcz'
-]
-
-{ #category : 'accessing' }
-MCMczInstallerTest >> fileStream [
-	^ self fileName asFileReference
-		ensureDelete;
-		binaryWriteStream
 ]
 
 { #category : 'running' }
@@ -69,18 +37,18 @@ MCMczInstallerTest >> setUp [
 
 { #category : 'running' }
 MCMczInstallerTest >> tearDown [
+
 	expected snapshot updatePackage: self mockPackage.
-	self deleteFile.
+	self fileName asFileReference ensureDelete.
 	super tearDown
 ]
 
 { #category : 'tests' }
 MCMczInstallerTest >> testInstallFromFile [
-	| stream |
-	stream := self fileStream.
 
-	MCMczWriter fileOut: expected on: stream.
-	stream close.
+	self fileName asFileReference
+		ensureDelete;
+		binaryWriteStreamDo: [ :stream | MCMczWriter fileOut: expected on: stream ].
 
 	MczInstaller installFileNamed: self fileName.
 	self assertNoChange
@@ -90,10 +58,8 @@ MCMczInstallerTest >> testInstallFromFile [
 MCMczInstallerTest >> testInstallFromStream [
 
 	| array |
-	array := ByteArray streamContents: [:stream |.
-		MCMczWriter fileOut: expected on: stream.
-	].
+	array := ByteArray streamContents: [ :stream | MCMczWriter fileOut: expected on: stream ].
 	MczInstaller installStream: array readStream.
 	self assertNoChange.
-	self assertVersionInfoPresent
+	self assertDict: (MczInstaller versionInfo at: self mockPackage name) matchesInfo: expected info
 ]

--- a/src/MonticelloFileServices/MczInstaller.class.st
+++ b/src/MonticelloFileServices/MczInstaller.class.st
@@ -13,8 +13,8 @@ Class {
 	#classVars : [
 		'Versions'
 	],
-	#category : 'System-Installers',
-	#package : 'System-Installers'
+	#category : 'MonticelloFileServices',
+	#package : 'MonticelloFileServices'
 }
 
 { #category : 'versioninfo' }

--- a/src/System-Installers-Tests/package.st
+++ b/src/System-Installers-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'System-Installers-Tests' }

--- a/src/System-Installers/package.st
+++ b/src/System-Installers/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'System-Installers' }


### PR DESCRIPTION
I think that is the past the FileService was tied to Morphic. Now there are declarations independent or Morphic and Morphic uses those declarations to register them in the world. So the MczInstaller can be extracted from morphic.

- Extract MczInstaller from BaselineOfMorphic by merging SystemInstaller into MonticelloFileService because it contains only one file service related to Monticello
- Merge System-Installer-Tests into Monticello-Tests and simplify it 
- Remove some duplicated package definitions (both in BasicTools and GeneralTests)