### PR TITLE
Update HDTestReport

### DIFF
--- a/src/Calypso-SystemPlugins-Critic-Browser/ClyShowCritiqueDetailsCommand.class.st
+++ b/src/Calypso-SystemPlugins-Critic-Browser/ClyShowCritiqueDetailsCommand.class.st
@@ -37,7 +37,7 @@ ClyShowCritiqueDetailsCommand >> execute [
 
 	self specUIManager
 		title: critique title;
-		label: self critiqueDescription;
+		message: self critiqueDescription;
 		acceptLabel: 'close';
 		extent: 500 @ 500;
 		openDialog

--- a/src/SUnit-Basic-CLI/HDTestReport.class.st
+++ b/src/SUnit-Basic-CLI/HDTestReport.class.st
@@ -41,20 +41,16 @@ HDTestReport class >> runClasses: aCollectionOfClasses named: packageName [
 	| suite classes time result |
 	suite := TestSuite named: packageName.
 	ShuffleSeed ifNotNil: [ suite shuffleSeed: ShuffleSeed asInteger ].
-	classes := (aCollectionOfClasses select: [ :class |
-		            class isTestCase and: [ class isAbstract not ] ])
-		           asSortedCollection: [ :a :b | a name <= b name ].
+
+	classes := (aCollectionOfClasses select: [ :class | class isTestCase and: [ class isAbstract not ] ]) asSortedCollection: [ :a :b | a name <= b name ].
 	classes ifEmpty: [ ^ nil ].
+
 	classes do: [ :class | suite addTests: class buildSuite tests ].
 	time := DateAndTime now.
-	('Beginning to run tests of ' , packageName , ' with random seed '
-	 , suite shuffleSeed asString , OSPlatform current lineEnding)
-		traceCr.
+	('Beginning to run tests of ' , packageName , ' with random seed ' , suite shuffleSeed asString , OSPlatform current lineEnding) traceCr.
 	result := self runSuite: suite.
-	('Finished to run tests of ' , packageName , ' in '
-	 , (DateAndTime now - time) humanReadablePrintString
-	 , OSPlatform current lineEnding) traceCr.
-	^ result 
+	('Finished to run tests of ' , packageName , ' in ' , (DateAndTime now - time) humanReadablePrintString , OSPlatform current lineEnding) traceCr.
+	^ result
 ]
 
 { #category : 'running' }
@@ -66,7 +62,9 @@ HDTestReport class >> runPackage: aString [
 { #category : 'running' }
 HDTestReport class >> runSuite: aTestSuite [
 
-	^ self new runSuite: aTestSuite
+	^ self new
+		  suite: aTestSuite;
+		  run
 ]
 
 { #category : 'running' }
@@ -96,12 +94,6 @@ HDTestReport >> calculateNodeName [
 		at: 'JENKINS_HOME'
 		ifPresent: [ :value | name ]
 		ifAbsent: [ '' ]
-]
-
-{ #category : 'running' }
-HDTestReport >> done [
-	"just close the file"
-	[ progressStream close ] on: Error do: []
 ]
 
 { #category : 'private' }
@@ -136,11 +128,6 @@ HDTestReport >> initialize [
 	stageName := self class currentStageName.
 	nodeName := self calculateNodeName.
 	
-]
-
-{ #category : 'initialization' }
-HDTestReport >> initializeOn: aTestSuite [
-	suite := aTestSuite
 ]
 
 { #category : 'private' }
@@ -251,17 +238,9 @@ HDTestReport >> reportTestCase: aTestCase runBlock: aBlock [
 { #category : 'running' }
 HDTestReport >> run [
 
-	[
-	self setUp.
-	suiteTime := [ self runAll ] millisecondsToRun ] ensure: [
-		self tearDown ]
-]
-
-{ #category : 'running' }
-HDTestReport >> runAll [
-	CurrentExecutionEnvironment runTestsBy: [ 
-		suite tests do: [ :each | each run: self ]
-	]
+	suiteTime := [
+		             self setUp.
+		             [ CurrentExecutionEnvironment runTestsBy: [ suite tests do: [ :each | each run: self ] ] ] millisecondsToRun ] ensure: [ self tearDown ]
 ]
 
 { #category : 'running' }
@@ -276,14 +255,6 @@ HDTestReport >> runCase: aTestCase [
 			] on: Exception do: [ :exc | 
 					exc recordResultOf: aTestCase inHDTestReport: self ]
 		]
-]
-
-{ #category : 'running' }
-HDTestReport >> runSuite: aTestSuite [
-	^ self
-		initializeOn: aTestSuite;
-		run;
-		done
 ]
 
 { #category : 'running' }
@@ -372,6 +343,12 @@ HDTestReport >> stageName [
 { #category : 'accessing' }
 HDTestReport >> stageName: anObject [
 	stageName := anObject
+]
+
+{ #category : 'initialization' }
+HDTestReport >> suite: aTestSuite [
+
+	suite := aTestSuite
 ]
 
 { #category : 'accessing' }

--- a/src/SUnit-Basic-CLI/HDTestReport.class.st
+++ b/src/SUnit-Basic-CLI/HDTestReport.class.st
@@ -293,7 +293,7 @@ HDTestReport >> setUp [
 	self openProgressStream.
 	logString := String streamContents: [ :aStream |
 			             aStream
-				             nextPutAll: 'Running suite ';
+				             nextPutAll: 'Beginning to run tests of ';
 				             nextPutAll: suite name;
 				             nextPutAll: ' with random seed ';
 				             print: suite shuffleSeed;
@@ -413,7 +413,7 @@ HDTestReport >> tearDown [
 	
 	logString := String streamContents: [ :aStream |
 			             aStream
-				             nextPutAll: 'Finishing running suite ';
+				             nextPutAll: 'Finished to run tests of ';
 				             nextPutAll: suite name;
 				             nextPutAll: ' in '.
 			             suiteTime printHumanReadableOn: aStream ]. "We print in the progress file but also in the stdout for the CI infos."

--- a/src/SUnit-Basic-CLI/HDTestReport.class.st
+++ b/src/SUnit-Basic-CLI/HDTestReport.class.st
@@ -38,7 +38,7 @@ HDTestReport class >> currentStageName: aStageName [
 { #category : 'running' }
 HDTestReport class >> runClasses: aCollectionOfClasses named: packageName [
 
-	| suite classes time result |
+	| suite classes result |
 	suite := TestSuite named: packageName.
 	ShuffleSeed ifNotNil: [ suite shuffleSeed: ShuffleSeed asInteger ].
 
@@ -46,10 +46,7 @@ HDTestReport class >> runClasses: aCollectionOfClasses named: packageName [
 	classes ifEmpty: [ ^ nil ].
 
 	classes do: [ :class | suite addTests: class buildSuite tests ].
-	time := DateAndTime now.
-	('Beginning to run tests of ' , packageName , ' with random seed ' , suite shuffleSeed asString , OSPlatform current lineEnding) traceCr.
 	result := self runSuite: suite.
-	('Finished to run tests of ' , packageName , ' in ' , (DateAndTime now - time) humanReadablePrintString , OSPlatform current lineEnding) traceCr.
 	^ result
 ]
 
@@ -238,9 +235,12 @@ HDTestReport >> reportTestCase: aTestCase runBlock: aBlock [
 { #category : 'running' }
 HDTestReport >> run [
 
-	suiteTime := [
-		             self setUp.
-		             [ CurrentExecutionEnvironment runTestsBy: [ suite tests do: [ :each | each run: self ] ] ] millisecondsToRun ] ensure: [ self tearDown ]
+	[
+		| time |
+		self setUp.
+		time := DateAndTime now.
+		CurrentExecutionEnvironment runTestsBy: [ suite tests do: [ :each | each run: self ] ].
+		suiteTime := DateAndTime now - time ] ensure: [ self tearDown ]
 ]
 
 { #category : 'running' }
@@ -289,10 +289,20 @@ HDTestReport >> serializeError: error of: aTestCase [
 { #category : 'running' }
 HDTestReport >> setUp [
 
-	| aFile |
+	| aFile logString |
 	self openProgressStream.
-	progressStream nextPutAll: 'running suite: ';
-		nextPutAll: suite name ; crlf; flush.
+	logString := String streamContents: [ :aStream |
+			             aStream
+				             nextPutAll: 'Running suite ';
+				             nextPutAll: suite name;
+				             nextPutAll: ' with random seed ';
+				             print: suite shuffleSeed;
+				             nextPutAll: OSPlatform current lineEnding ].
+	 "We print in the progress file but also in the stdout for the CI infos."
+	logString trace.
+	progressStream
+		nextPutAll: logString;
+		flush.
 
 	aFile := File named: self suiteFileNameWithoutExtension , '.xml' .
 	aFile delete.
@@ -385,6 +395,7 @@ HDTestReport >> suiteTotal [
 
 { #category : 'running' }
 HDTestReport >> tearDown [
+	| logString |
 	suite resources 
 		do: [ :each | each reset ].
 		
@@ -396,13 +407,19 @@ HDTestReport >> tearDown [
 	stream 
 		nextPutAll: ' failures="'; print: suiteFailures; 
 		nextPutAll: '" errors="'; print: suiteErrors; 
-		nextPutAll: '" time="'; print: suiteTime / 1000.0; 
+		nextPutAll: '" time="'; print: suiteTime asMilliSeconds / 1000.0; 
 		nextPutAll: '">'.
 	stream close.
 	
-	progressStream 
-		nextPutAll: 'finished running suite: ';
-		nextPutAll: suite name;
+	logString := String streamContents: [ :aStream |
+			             aStream
+				             nextPutAll: 'Finishing running suite ';
+				             nextPutAll: suite name;
+				             nextPutAll: ' in '.
+			             suiteTime printHumanReadableOn: aStream ]. "We print in the progress file but also in the stdout for the CI infos."
+	logString traceCr.
+	progressStream
+		nextPutAll: logString;
 		close
 ]
 

--- a/src/SUnit-UI/CommandLineTestRunner.class.st
+++ b/src/SUnit-UI/CommandLineTestRunner.class.st
@@ -25,10 +25,6 @@ CommandLineTestRunner >> createStdout [
 	^ Stdio stdout
 ]
 
-{ #category : 'running' }
-CommandLineTestRunner >> done [
-]
-
 { #category : 'helper' }
 CommandLineTestRunner >> increaseTestCount [
 	currentTest := currentTest + 1


### PR DESCRIPTION
List of changes:
- Commit an automatic transformation
- Simplify the logging mechanism (before we had one for the STDout et one for the progress.log file. Now we only have one way to log infos)
- Simplify the API. The API was confusing because #runAll was a public API but could not be used by itself, it bypassed the #setUp and #tearDown 
- Remove double closing the progress file

Fixes #18954
 