### PR TITLE
Some Fuel dependencies cleaning

### DIFF
--- a/src/BaselineOfFonts/BaselineOfFonts.class.st
+++ b/src/BaselineOfFonts/BaselineOfFonts.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'BaselineOfFonts'
 }
 
+{ #category : 'accessing' }
+BaselineOfFonts class >> corePackageNames [
+
+	^ self packagesOfGroupNamed: #Core
+]
+
 { #category : 'baselines' }
 BaselineOfFonts >> baseline: spec [
 
@@ -20,7 +26,7 @@ BaselineOfFonts >> baseline: spec [
 				package: 'Graphics-Fonts' with: [ spec requires: #( 'Fonts-Abstract' 'Fonts-Infrastructure' 'Text-Core' ) ].
 
 			spec
-				group: 'Core' with: #( 'Fonts-Abstract' 'Fonts-Infrastructure' 'Graphics-Fonts' );
+				group: 'Core' with: #( 'Fonts-Abstract' 'Fonts-Infrastructure' 'Graphics-Fonts' 'Text-Core' );
 				group: 'Tests' with: #( 'Fonts-Infrastructure-Tests' ) ]
 ]
 

--- a/src/BaselineOfFreeType/BaselineOfFreeType.class.st
+++ b/src/BaselineOfFreeType/BaselineOfFreeType.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'BaselineOfFreeType'
 }
 
+{ #category : 'accessing' }
+BaselineOfFreeType class >> uiPackageNames [
+
+	^ self packagesOfGroupNamed: #ui
+]
+
 { #category : 'baselines' }
 BaselineOfFreeType >> baseline: spec [
 
@@ -19,7 +25,7 @@ BaselineOfFreeType >> baseline: spec [
 
 			spec
 				group: 'core' with: #( 'FreeType' 'EmbeddedFreeType' );
-				group: 'ui' with: #( 'core' 'FreeType-Graphics' );
+				group: 'ui' with: #( 'FreeType' 'EmbeddedFreeType' 'FreeType-Graphics' );
 				group: 'tests' with: #( 'core' 'FreeType-Tests' 'EmbeddedFreeType-Tests' ) ]
 ]
 

--- a/src/BaselineOfFuel/BaselineOfFuel.class.st
+++ b/src/BaselineOfFuel/BaselineOfFuel.class.st
@@ -11,6 +11,12 @@ Class {
 	#package : 'BaselineOfFuel'
 }
 
+{ #category : 'accessing' }
+BaselineOfFuel class >> corePackageNames [
+
+	^ self packagesOfGroupNamed: #Core
+]
+
 { #category : 'baselines' }
 BaselineOfFuel >> baseline: spec [
 

--- a/src/BaselineOfUI/BaselineOfUI.class.st
+++ b/src/BaselineOfUI/BaselineOfUI.class.st
@@ -33,10 +33,6 @@ BaselineOfUI >> baseline: spec [
 	spec for: #common do: [
 		spec postLoadDoIt: #postload:package:.
 
-		spec baseline: 'Fuel' with: [
-			spec
-				repository: repository;
-				loads: #( 'Core' ) ].
 		spec
 				baseline: 'SUnit' with: [
 						spec

--- a/src/BaselineOfUIInfrastructure/BaselineOfUIInfrastructure.class.st
+++ b/src/BaselineOfUIInfrastructure/BaselineOfUIInfrastructure.class.st
@@ -17,7 +17,8 @@ BaselineOfUIInfrastructure >> baseline: spec [
 				baseline: 'Fonts' with: [ spec loads: #Core from: repository ];
 				baseline: 'FreeType' with: [ spec loads: #ui from: repository ];
 				baseline: 'MenuRegistration' with: [ spec repository: repository ];
-				baseline: 'Keymapping' with: [ spec loads: #Core from: repository ].
+				baseline: 'Keymapping' with: [ spec loads: #Core from: repository ];
+				baseline: 'Fuel' with: [ spec loads: #( 'Core' ) from: repository ]. "Fuel is currently depending on graphics objects so I'm loading it here for now instead of BaselineOfBasicTools."
 
 			spec
 				package: 'System-Utilities';

--- a/src/Fuel-Core/FLDecoder.class.st
+++ b/src/Fuel-Core/FLDecoder.class.st
@@ -248,7 +248,8 @@ FLDecoder >> nextEncodedUint8 [
 ]
 
 { #category : 'decoding' }
-FLDecoder >> nextEncodedWordsInto: aWordsObject [ 
+FLDecoder >> nextEncodedWordsInto: aWordsObject [
+
 	stream fuelNextWordsInto: aWordsObject
 ]
 

--- a/src/Fuel-Core/FLMaterializer.class.st
+++ b/src/Fuel-Core/FLMaterializer.class.st
@@ -21,23 +21,6 @@ FLMaterializer class >> defaultShouldMaterializeHeaderOnly [
 	^ false
 ]
 
-{ #category : 'file service' }
-FLMaterializer class >> fileReaderServicesForFile: fullName suffix: suffix [
-	<fileService>
-	suffix = 'fuel'
-		ifFalse: [ ^ #() ].
-	^ { self serviceFuelMaterialize }
-]
-
-{ #category : 'file service' }
-FLMaterializer class >> inspectMaterializationFromFileNamed: aString [
-	| result |
-	result := self new
-		filePath: aString;
-		materializeRoot.
-	^ result inspect
-]
-
 { #category : 'convenience' }
 FLMaterializer class >> materializeFrom: aStream [
 	^ self new
@@ -75,16 +58,6 @@ FLMaterializer class >> materializeHeaderFromFileNamed: aFilePath [
 	^ self new
 		filePath: aFilePath;
 		materializeHeader
-]
-
-{ #category : 'file service' }
-FLMaterializer class >> serviceFuelMaterialize [
-	^ FileServiceEntry 
-		provider: self 
-		label: 'Materialize Fuel file'
-		selector: #inspectMaterializationFromFileNamed:
-		description: 'Materialize objects previously serialized with Fuel'
-		buttonLabel: 'materialize'
 ]
 
 { #category : 'private' }

--- a/src/Fuel-Core/ManifestFuelCore.class.st
+++ b/src/Fuel-Core/ManifestFuelCore.class.st
@@ -36,6 +36,13 @@ Class {
 	#tag : 'Manifest'
 }
 
+{ #category : 'meta-data - dependency analyser' }
+ManifestFuelCore class >> manuallyResolvedDependencies [
+
+	<ignoreForCoverage>
+	^ #(#'FileSystem-Disk')
+]
+
 { #category : 'code-critics' }
 ManifestFuelCore class >> ruleCollectionMessagesToExternalObjectRuleV1FalsePositive [
 	^ #(#(#(#RGMethodDefinition #(#FLDecoder #initializeMigrations #false)) #'2021-06-20T13:59:18.830224+02:00') )

--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -501,5 +501,6 @@ SystemDependenciesTest >> tonelCorePackageNames [
 SystemDependenciesTest >> uiInfrastructureCoreLayerPackages [
 
 	^ self debuggingLayerPackages , BaselineOfUnifiedFFI allPackageNames , BaselineOfThreadedFFI allPackageNames , BaselineOfDisplay allPackageNames
-	  , BaselineOfFonts allPackageNames , BaselineOfFreeType allPackageNames , BaselineOfMenuRegistration allPackageNames , BaselineOfKeymapping corePackageNames
+	  , BaselineOfFonts corePackageNames , BaselineOfFreeType uiPackageNames , BaselineOfMenuRegistration allPackageNames , BaselineOfKeymapping corePackageNames
+	  , BaselineOfFuel corePackageNames
 ]

--- a/src/Tools/FLMaterializer.extension.st
+++ b/src/Tools/FLMaterializer.extension.st
@@ -1,0 +1,28 @@
+Extension { #name : 'FLMaterializer' }
+
+{ #category : '*Tools' }
+FLMaterializer class >> fileReaderServicesForFile: fullName suffix: suffix [
+	<fileService>
+	suffix = 'fuel'
+		ifFalse: [ ^ #() ].
+	^ { self serviceFuelMaterialize }
+]
+
+{ #category : '*Tools' }
+FLMaterializer class >> inspectMaterializationFromFileNamed: aString [
+	| result |
+	result := self new
+		filePath: aString;
+		materializeRoot.
+	^ result inspect
+]
+
+{ #category : '*Tools' }
+FLMaterializer class >> serviceFuelMaterialize [
+	^ FileServiceEntry 
+		provider: self 
+		label: 'Materialize Fuel file'
+		selector: #inspectMaterializationFromFileNamed:
+		description: 'Materialize objects previously serialized with Fuel'
+		buttonLabel: 'materialize'
+]


### PR DESCRIPTION
- Move deprecated methods to Deprecated14
- Move FLMaterializer service to 'Tools' package because the file service depends on the utilities of Tools and Tools is loaded after Fuel
- Clean some system dependencies errors
- Move the loading a Fuel out of BaselineOfUI. I had to move it to BaselineOfUIInfrastructure even if fuel is not related to UI because its implementation depends on graphics objects

Those changes will allow as a next step to extract System-Identification from Morphic