### PR TITLE
Make method definition caching for Monticello snapshots actually work

### DIFF
--- a/src/Monticello-Model/CompiledMethod.extension.st
+++ b/src/Monticello-Model/CompiledMethod.extension.st
@@ -34,7 +34,7 @@ CompiledMethod >> basicAsMCMethodDefinition [
 CompiledMethod >> sameAsMCDefinition: anMCMethodDefinition [
 
 	^ anMCMethodDefinition selector = self selector and: [
-		  anMCMethodDefinition className = self className and: [
+		  anMCMethodDefinition className = self methodClass name and: [
 			  anMCMethodDefinition classIsMeta = self isClassSide and: [
 				  anMCMethodDefinition protocol = self protocolName and: [ anMCMethodDefinition source = self sourceCode ] ] ] ]
 ]

--- a/src/Monticello-Model/CompiledMethod.extension.st
+++ b/src/Monticello-Model/CompiledMethod.extension.st
@@ -34,7 +34,7 @@ CompiledMethod >> basicAsMCMethodDefinition [
 CompiledMethod >> sameAsMCDefinition: anMCMethodDefinition [
 
 	^ anMCMethodDefinition selector = self selector and: [
-		  anMCMethodDefinition className = self methodClass name and: [
+		  anMCMethodDefinition className = self methodClass instanceSide name and: [
 			  anMCMethodDefinition classIsMeta = self isClassSide and: [
 				  anMCMethodDefinition protocol = self protocolName and: [ anMCMethodDefinition source = self sourceCode ] ] ] ]
 ]


### PR DESCRIPTION
Monticello's package snapshots can take a long time for large packages. Iceberg's "Commit" action relies on such a snapshot to calculate the diff between the image and HEAD, and is therefore also slowed down. The bulk of the time is spent converting methods, in particular resolving the authoring time stamps from sources or changes files (CompiledCode >> timeStamp).

There is a caching mechanism implemented in asMCMethodDefinition, but it never actually returns a cache hit. When finding a hit, it verifies that it still matches the actual method, but the comparison of class names is broken. `self className`, in this context, always returns 'CompiledMethod', instead of the name of the class on which the method is defined.

Fixing this gives a noticable speed up of creating package snapshots.

On the Pharo14 branch, the caching mechanism has been removed altogether. See https://github.com/pharo-project/pharo/pull/18501/commits/26998edd75b0667c2b16ed8e8a13b332bbdc7208#diff-4858dc43f8aeddebf93084fa0530dfe8370e8702bf28d73c2e383e60931ee1ad. Perhaps it was (somewhat correctly) identified as useless. However, now that it works, perhaps it should be reintroduced?