### PR TITLE
Add a test on write stream

### DIFF
--- a/src/Collections-Streams-Tests/WriteStreamTest.class.st
+++ b/src/Collections-Streams-Tests/WriteStreamTest.class.st
@@ -252,3 +252,16 @@ WriteStreamTest >> testWithFromTo [
 		assert: stream contents equals: self string;
 		assert: stream size equals: self stringSize
 ]
+
+{ #category : 'tests' }
+WriteStreamTest >> testWriteStreamWithOrderedCollectionAndSet [
+	"This is a regression test showing a bug that got introduce at some point in Pharo."
+
+	| set stream |
+	set := Set withAll: { 1. 2. 3 }.
+	stream := self newStreamOn: OrderedCollection new.
+
+	stream nextPutAll: set.
+
+	self assertCollection: stream contents equals: (OrderedCollection withAll: { 1. 2. 3 })
+]


### PR DESCRIPTION
This highlights why we needed to revert https://github.com/pharo-project/pharo/pull/18963