### PR TITLE
Speed up computation of Monticello snapshots

### DIFF
--- a/src/Monticello-Model/CompiledMethod.extension.st
+++ b/src/Monticello-Model/CompiledMethod.extension.st
@@ -4,18 +4,11 @@ Extension { #name : 'CompiledMethod' }
 CompiledMethod >> asMCMethodDefinition [
 	"Creates a MCMethodDefinition from the receiver"
 
-	^ MCMethodDefinition
-		  className: self methodClass instanceSide name
-		  classIsMeta: self isClassSide
-		  selector: self selector
-		  category: self protocolName
-		  timeStamp: self stamp
-		  source: self sourceCode
+	^ self basicAsMCMethodDefinition
 ]
 
 { #category : '*Monticello-Model' }
 CompiledMethod >> basicAsMCMethodDefinition [
-
 	"Creates a MCMethodDefinition from the receiver"
 
 	^ MCMethodDefinition
@@ -23,6 +16,6 @@ CompiledMethod >> basicAsMCMethodDefinition [
 		  classIsMeta: self isClassSide
 		  selector: self selector
 		  category: self protocolName
-		  timeStamp: self stamp
+		  sourcePointer: self sourcePointer
 		  source: self sourceCode
 ]

--- a/src/Monticello-Model/CompiledMethod.extension.st
+++ b/src/Monticello-Model/CompiledMethod.extension.st
@@ -4,7 +4,16 @@ Extension { #name : 'CompiledMethod' }
 CompiledMethod >> asMCMethodDefinition [
 	"Creates a MCMethodDefinition from the receiver"
 
-	^ self basicAsMCMethodDefinition
+	| cached |
+	cached := MCMethodDefinition cachedDefinitions at: self ifAbsent: [ nil ].
+	
+	"we compare that the cached version is in sync with the version 
+	the receiver represents because it is an identity structure and the container (here the method definition may have changed internally: different packages, protocol.... )"
+	(cached isNotNil and: [ self sameAsMCDefinition: cached ]) ifFalse: [
+			cached := self basicAsMCMethodDefinition.
+			MCMethodDefinition cachedDefinitions at: self put: cached ].
+
+	^ cached
 ]
 
 { #category : '*Monticello-Model' }

--- a/src/Monticello-Model/CompiledMethod.extension.st
+++ b/src/Monticello-Model/CompiledMethod.extension.st
@@ -24,7 +24,7 @@ CompiledMethod >> basicAsMCMethodDefinition [
 CompiledMethod >> sameAsMCDefinition: anMCMethodDefinition [
 
 	^ anMCMethodDefinition selector = self selector and: [
-		  anMCMethodDefinition className = self methodClass name and: [
+		  anMCMethodDefinition className = self methodClass instanceSide name and: [
 			  anMCMethodDefinition classIsMeta = self isClassSide and: [
 				  anMCMethodDefinition protocol = self protocolName and: [ anMCMethodDefinition source = self sourceCode ] ] ] ]
 ]

--- a/src/Monticello-Model/CompiledMethod.extension.st
+++ b/src/Monticello-Model/CompiledMethod.extension.st
@@ -19,3 +19,12 @@ CompiledMethod >> basicAsMCMethodDefinition [
 		  sourcePointer: self sourcePointer
 		  source: self sourceCode
 ]
+
+{ #category : '*Monticello-Model' }
+CompiledMethod >> sameAsMCDefinition: anMCMethodDefinition [
+
+	^ anMCMethodDefinition selector = self selector and: [
+		  anMCMethodDefinition className = self methodClass name and: [
+			  anMCMethodDefinition classIsMeta = self isClassSide and: [
+				  anMCMethodDefinition protocol = self protocolName and: [ anMCMethodDefinition source = self sourceCode ] ] ] ]
+]

--- a/src/Monticello-Model/MCMethodDefinition.class.st
+++ b/src/Monticello-Model/MCMethodDefinition.class.st
@@ -2,6 +2,10 @@
 A MCMethodDefinition represents a method definition. 
 It captures the following information.
 
+## Implementation details
+
+It might be long to get the timestamp of a method since it requires to access the source file. As an optimization we might save the source pointer instead and retireve the timestamp lazily in case we don't always need this timestamp.
+
 Instance Variables
 	category:		<Object>
 	classIsMeta:		<Object>
@@ -22,7 +26,8 @@ Class {
 		'selector',
 		'className',
 		'timeStamp',
-		'sortKey'
+		'sortKey',
+		'sourcePointer'
 	],
 	#classVars : [
 		'InitializersEnabled'
@@ -32,28 +37,41 @@ Class {
 }
 
 { #category : 'instance creation' }
-MCMethodDefinition class >> className: classString classIsMeta: metaBoolean selector: selectorString category: catString timeStamp: timeString source: sourceString [
+MCMethodDefinition class >> className: classString classIsMeta: metaBoolean selector: selectorString category: protocolName sourcePointer: aNumber source: sourceString [
+
 	^ self new
-		initializeWithClassName: classString
-		classIsMeta: metaBoolean
-		selector: selectorString
-		category: catString
-		timeStamp: timeString
-		source: sourceString
+		  className: classString;
+		  selector: selectorString;
+		  protocol: protocolName;
+		  sourcePointer: aNumber;
+		  classIsMeta: metaBoolean;
+		  source: sourceString;
+		  yourself
 ]
 
 { #category : 'instance creation' }
-MCMethodDefinition class >> className: classString
-selector: selectorString
-category: catString
-timeStamp: timeString
-source: sourceString [
-	^ self	className: classString
-			classIsMeta: false
-			selector: selectorString
-			category: catString
-			timeStamp: timeString
-			source: sourceString
+MCMethodDefinition class >> className: classString classIsMeta: metaBoolean selector: selectorString category: protocolName timeStamp: timeString source: sourceString [
+
+	^ self new
+		  className: classString;
+		  selector: selectorString;
+		  protocol: protocolName;
+		  timeStamp: timeString;
+		  classIsMeta: metaBoolean;
+		  source: sourceString;
+		  yourself
+]
+
+{ #category : 'instance creation' }
+MCMethodDefinition class >> className: classString selector: selectorString category: catString timeStamp: timeString source: sourceString [
+
+	^ self
+		  className: classString
+		  classIsMeta: false
+		  selector: selectorString
+		  category: catString
+		  timeStamp: timeString
+		  source: sourceString
 ]
 
 { #category : 'settings' }
@@ -104,8 +122,20 @@ MCMethodDefinition >> classIsMeta [
 ]
 
 { #category : 'accessing' }
+MCMethodDefinition >> classIsMeta: aBoolean [
+
+	classIsMeta := aBoolean
+]
+
+{ #category : 'accessing' }
 MCMethodDefinition >> className [
 	^className
+]
+
+{ #category : 'serializing' }
+MCMethodDefinition >> className: aString [
+
+	className := aString asSymbol
 ]
 
 { #category : 'printing' }
@@ -142,17 +172,6 @@ MCMethodDefinition >> hash [
 	hash := String stringHash: category initialHash: hash.
 	hash := String stringHash: className initialHash: hash.
 	^ hash
-]
-
-{ #category : 'serializing' }
-MCMethodDefinition >> initializeWithClassName: classString classIsMeta: metaBoolean selector: selectorString category: protocolName timeStamp: timeString source: sourceString [
-
-	className := classString asSymbol.
-	selector := selectorString asSymbol.
-	category := protocolName isEmptyOrNil ifTrue: [ Protocol unclassified ] ifFalse: [ protocolName asSymbol ].
-	timeStamp := timeString.
-	classIsMeta := metaBoolean.
-	source := sourceString withInternalLineEndings
 ]
 
 { #category : 'installing' }
@@ -234,6 +253,14 @@ MCMethodDefinition >> protocol [
 	^ category
 ]
 
+{ #category : 'serializing' }
+MCMethodDefinition >> protocol: anObject [
+
+	category := anObject isEmptyOrNil
+		            ifTrue: [ Protocol unclassified ]
+		            ifFalse: [ anObject asSymbol ]
+]
+
 { #category : 'installing' }
 MCMethodDefinition >> removeSelector: aSelector fromClass: aClass [
 	"Safely remove the given selector from the target class.
@@ -261,6 +288,12 @@ MCMethodDefinition >> selector [
 	^selector
 ]
 
+{ #category : 'serializing' }
+MCMethodDefinition >> selector: aString [
+
+	selector := aString asSymbol
+]
+
 { #category : 'comparing' }
 MCMethodDefinition >> sortKey [
 	^ sortKey
@@ -276,6 +309,17 @@ MCMethodDefinition >> source [
 	^ source
 ]
 
+{ #category : 'serializing' }
+MCMethodDefinition >> source: aString [
+
+	source := aString withInternalLineEndings
+]
+
+{ #category : 'accessing' }
+MCMethodDefinition >> sourcePointer: anObject [
+	sourcePointer := anObject
+]
+
 { #category : 'printing' }
 MCMethodDefinition >> summary [
 
@@ -284,7 +328,15 @@ MCMethodDefinition >> summary [
 
 { #category : 'accessing' }
 MCMethodDefinition >> timeStamp [
-	^ timeStamp
+	"My computation is lazy because it takes time to compute and is not always necessary."
+
+	^ timeStamp ifNil: [ sourcePointer ifNotNil: [ :pointer | timeStamp := SourceFileArray default timeStampAt: pointer ] ]
+]
+
+{ #category : 'serializing' }
+MCMethodDefinition >> timeStamp: aString [
+
+	timeStamp := aString
 ]
 
 { #category : 'installing' }

--- a/src/Monticello-Model/MCMethodDefinition.class.st
+++ b/src/Monticello-Model/MCMethodDefinition.class.st
@@ -30,11 +30,18 @@ Class {
 		'sourcePointer'
 	],
 	#classVars : [
+		'Definitions',
 		'InitializersEnabled'
 	],
 	#category : 'Monticello-Model',
 	#package : 'Monticello-Model'
 }
+
+{ #category : 'accessing' }
+MCMethodDefinition class >> cachedDefinitions [
+
+	^ Definitions ifNil: [ Definitions := WeakIdentityKeyDictionary new ]
+]
 
 { #category : 'instance creation' }
 MCMethodDefinition class >> className: classString classIsMeta: metaBoolean selector: selectorString category: protocolName sourcePointer: aNumber source: sourceString [
@@ -74,6 +81,26 @@ MCMethodDefinition class >> className: classString selector: selectorString cate
 		  source: sourceString
 ]
 
+{ #category : 'cleanup' }
+MCMethodDefinition class >> cleanUp [
+	"Flush caches"
+
+	self shutDown
+]
+
+{ #category : 'cleanup' }
+MCMethodDefinition class >> flushMethodCache [
+	"We do not named this method flushCache because it would override an important class methods."
+
+	Definitions := nil
+]
+
+{ #category : 'class initialization' }
+MCMethodDefinition class >> initialize [
+
+	SessionManager default registerSystemClassNamed: self name
+]
+
 { #category : 'settings' }
 MCMethodDefinition class >> initializersEnabled [
 
@@ -84,6 +111,13 @@ MCMethodDefinition class >> initializersEnabled [
 MCMethodDefinition class >> initializersEnabled: aBoolean [
 
 	InitializersEnabled := aBoolean
+]
+
+{ #category : 'system startup' }
+MCMethodDefinition class >> shutDown [
+	"Free up all cached monticello method definitions"
+
+	self flushMethodCache
 ]
 
 { #category : 'comparing' }

--- a/src/Monticello/MCPackage.class.st
+++ b/src/Monticello/MCPackage.class.st
@@ -88,18 +88,11 @@ MCPackage >> snapshot [
 	^ MCSnapshot fromDefinitions: (self systemPackage
 			   ifNil: [ #(  ) ]
 			   ifNotNil: [ :systemPackage |
-				   OrderedCollection new
-					   add: (MCOrganizationDefinition packageName: systemPackage name tagNames: systemPackage tagNames);
-					   addAll: (systemPackage methods collect: [ :method | 
-							MCMethodDefinition
-							  className: method methodClass instanceSide name
-							  classIsMeta: method isClassSide
-							  selector: method selector
-							  category: method protocolName
-							  timeStamp: method stamp
-							  source: method sourceCode ]);
-					   addAll: (systemPackage definedClasses collect: [ :class | class asClassDefinition ]);
-					   yourself ])
+					   OrderedCollection new
+						   add: (MCOrganizationDefinition packageName: systemPackage name tagNames: systemPackage tagNames);
+						   addAll: (systemPackage methods collect: [ :method | method asMCMethodDefinition ]);
+						   addAll: (systemPackage definedClasses collect: [ :class | class asClassDefinition ]);
+						   yourself ])
 ]
 
 { #category : 'storing' }


### PR DESCRIPTION
Monticello snapshots are used in some features such as the diff computation of Iceberg. For example when we recalculate the dirty packages or when we compare the head of a branch to a commit.

This operation takes some times because it is building MCMethodDefinitions for each methods of the concerned packages.

Checking the analysis of [stimberm](https://github.com/stimberm) in the PR https://github.com/pharo-project/pharo/pull/18962, I am proposing this PR to Pharo 14 including two changes:
- Add back the cache of the MCMethodDefinition but fixing a bug the was preventing #asMCMethodDefinition from hitting the cache
- Make the computation of the timestamp of a method lazy in some case by providing the sourcePointer that is much faster to retrieve

The addition of the cache seems to be here to bypass the caching of MCCacheRepository done in the creation of the MCVersion. Since everything happens locally, I wonder if we should cache versions... To me caches should be done only in remote repositories. But I am not 100% sure so let's try this as first improvement.

I tried on my machine to do some benches by recomputing the dirty packages of the pharo repository.
- Before the changes: 66sec
- With the addition of the cache: 34sec
- With the lazy timestamp: 32sec
- With both: 11sec

This seems like a nice speedup if this change does not break anything else :) 

Big thanks to stimberm! If this works well we can backport to P13 and P12
