### PR TITLE
Bump version of NewTools to v0.10.5

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -95,7 +95,7 @@ BaselineOfPharo class >> newTools [
 		newName: 'NewTools' 
 		owner: 'pharo-spec' 
 		project: 'NewTools' 
-		version: 'v0.10.4'
+		version: 'v0.10.5'
 ]
 
 { #category : 'repository urls' }


### PR DESCRIPTION
## What's Changed
* Fix: window fails to open when message list is nil initially by @balsa-sarenac in https://github.com/pharo-spec/NewTools/pull/1193
* Fixed the same profile switch bug - Pharo 13 by @AlexisCnockaert in https://github.com/pharo-spec/NewTools/pull/1196
* Backport 1222: Allow to add their own bookmarks by @jecisc in https://github.com/pharo-spec/NewTools/pull/1223
* Backport of 1218 (fix StOpenFileOrDirectoryPresenter) by @jecisc in https://github.com/pharo-spec/NewTools/pull/1219
* [backport 1226] Bookmarks initialization by @jecisc in https://github.com/pharo-spec/NewTools/pull/1227
* [Backport] Improve folder selection in the File Browser by @jecisc in https://github.com/pharo-spec/NewTools/pull/1232
* In MessageBrowser, decouple messageList presenter from its list of messages to present DNU in windowTitle method by @carolahp in https://github.com/pharo-spec/NewTools/pull/1124
* Backport #1290 : Fix bug when choosing a protocol name by @jecisc in https://github.com/pharo-spec/NewTools/pull/1292


**Full Changelog**: https://github.com/pharo-spec/NewTools/compare/v0.10.4...v0.10.5