### PR TITLE
Remove MCCacheRepository when creating a MCVersion

### DIFF
--- a/src/Monticello/MCVersion.class.st
+++ b/src/Monticello/MCVersion.class.st
@@ -37,11 +37,6 @@ MCVersion class >> package: aPackage info: aVersionInfo snapshot: aSnapshot depe
 ]
 
 { #category : 'actions' }
-MCVersion >> addToCache [
-	MCCacheRepository uniqueInstance storeVersion: self
-]
-
-{ #category : 'actions' }
 MCVersion >> adopt [
 	self workingCopy adopt: self
 ]
@@ -90,11 +85,11 @@ MCVersion >> info [
 
 { #category : 'initialization' }
 MCVersion >> initializeWithPackage: aPackage info: aVersionInfo snapshot: aSnapshot dependencies: aCollection [
+
 	package := aPackage.
 	info := aVersionInfo.
 	snapshot := aSnapshot.
-	dependencies := aCollection.
-	self addToCache.
+	dependencies := aCollection
 ]
 
 { #category : 'actions' }


### PR DESCRIPTION
MCCacheRepository is saving a MCZ of every MC snapshot we create or when we use the #fetch feature of Metacello. 

This feature seems to cause more slow down than it brings speed up. 

After a discussion with Guille I propose to remove the cache when we create a MCVersion. Now the caching will happen only when we use the #fetch feature of Metacello