### PR TITLE
Speed up Character #cr and #lf retrieval

### DIFF
--- a/src/Kernel/Character.class.st
+++ b/src/Kernel/Character.class.st
@@ -13,7 +13,9 @@ Class {
 	#type : 'immediate',
 	#classVars : [
 		'CharSet',
-		'DigitValues'
+		'Cr',
+		'DigitValues',
+		'Lf'
 	],
 	#category : 'Kernel-BasicObjects',
 	#package : 'Kernel',
@@ -103,7 +105,7 @@ Character class >> constantNames [
 Character class >> cr [
 	"Answer the Character representing a carriage return."
 
-	^self value: 13
+	^ Cr
 ]
 
 { #category : 'accessing - untypeable characters' }
@@ -154,7 +156,11 @@ Character class >> home [
 Character class >> initialize [
 	"Create the DigitsValues table."
 
-	self initializeDigitValues
+	self initializeDigitValues.
+
+	"Cr and LF are heavily used by some projects and we gain to cache them."
+	Cr := self value: 13.
+	Lf := self value: 10
 ]
 
 { #category : 'private - initialization' }
@@ -179,7 +185,7 @@ Character class >> insert [
 Character class >> lf [
 	"Answer the Character representing a linefeed."
 
-	^self value: 10
+	^ Lf
 ]
 
 { #category : 'accessing - untypeable characters' }
@@ -461,11 +467,6 @@ Character >> hexDigitValue [
 	^ ((codePoint := self asInteger) between: 0 and: 127)
 		ifTrue: [ #(nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil 0 1 2 3 4 5 6 7 8 9 nil nil nil nil nil nil nil 10 11 12 13 14 15 nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil 10 11 12 13 14 15 nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil) at: codePoint + 1 ]
 		ifFalse: [ nil ]
-]
-
-{ #category : 'initialization' }
-Character >> initialize [
-		super initialize.
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
#cr and #lf are heavily used in the system and in external library. I propose to cache them. This produces for example a 5% speed up of the Tonel parser and the optimization is not really complicated. 

I also removed an useless method 