### PR TITLE
Speed up MCClassDefinition creation and clean MCMethodDefinition

### DIFF
--- a/src/Monticello-Model/Class.extension.st
+++ b/src/Monticello-Model/Class.extension.st
@@ -20,7 +20,6 @@ Class >> asClassDefinition [
 		              poolDictionaryNames: self sharedPoolNames;
 		              type: self mcType;
 		              comment: self comment;
-		              commentStamp: self commentStamp;
 		              yourself.
 
 	"We do not export the tag if this is the root."

--- a/src/Monticello-Model/CompiledMethod.extension.st
+++ b/src/Monticello-Model/CompiledMethod.extension.st
@@ -4,22 +4,6 @@ Extension { #name : 'CompiledMethod' }
 CompiledMethod >> asMCMethodDefinition [
 	"Creates a MCMethodDefinition from the receiver"
 
-	| cached |
-	cached := MCMethodDefinition cachedDefinitions at: self ifAbsent: [ nil ].
-	
-	"we compare that the cached version is in sync with the version 
-	the receiver represents because it is an identity structure and the container (here the method definition may have changed internally: different packages, protocol.... )"
-	(cached isNotNil and: [ self sameAsMCDefinition: cached ]) ifFalse: [
-			cached := self basicAsMCMethodDefinition.
-			MCMethodDefinition cachedDefinitions at: self put: cached ].
-
-	^ cached
-]
-
-{ #category : '*Monticello-Model' }
-CompiledMethod >> basicAsMCMethodDefinition [
-	"Creates a MCMethodDefinition from the receiver"
-
 	^ MCMethodDefinition
 		  className: self methodClass instanceSide name
 		  classIsMeta: self isClassSide
@@ -27,13 +11,4 @@ CompiledMethod >> basicAsMCMethodDefinition [
 		  category: self protocolName
 		  sourcePointer: self sourcePointer
 		  source: self sourceCode
-]
-
-{ #category : '*Monticello-Model' }
-CompiledMethod >> sameAsMCDefinition: anMCMethodDefinition [
-
-	^ anMCMethodDefinition selector = self selector and: [
-		  anMCMethodDefinition className = self methodClass instanceSide name and: [
-			  anMCMethodDefinition classIsMeta = self isClassSide and: [
-				  anMCMethodDefinition protocol = self protocolName and: [ anMCMethodDefinition source = self sourceCode ] ] ] ]
 ]

--- a/src/Monticello-Model/MCClassDefinition.class.st
+++ b/src/Monticello-Model/MCClassDefinition.class.st
@@ -162,7 +162,12 @@ MCClassDefinition >> comment: aString [
 
 { #category : 'accessing' }
 MCClassDefinition >> commentStamp [
-	^ commentStamp
+	"Lazy initialization of this parameter to speed up the creation of the class definition in some cases by avoiding the reading of the source file. In case the actual class is not in the image, use the default value we had in the past."
+
+	^ commentStamp ifNil: [
+			  commentStamp := [ self actualClass commentStamp ]
+				                  on: Error
+				                  do: [ '' ] ]
 ]
 
 { #category : 'accessing' }
@@ -214,18 +219,6 @@ MCClassDefinition >> createVariableFromString: aString [
 			UndefinedSlot named: slotName ast: ast  ]
 ]
 
-{ #category : 'accessing' }
-MCClassDefinition >> defaultCommentStamp [
-	^ String new
-
-	"The version below avoids stomping on stamps already in the image
-
-	^ (Smalltalk globals at: name ifPresent: [:c | c organization commentStamp])
-		ifNil: ['']
-	"
-
-]
-
 { #category : 'printing' }
 MCClassDefinition >> definitionString [
 	^ String streamContents: [:stream | self printDefinitionOn: stream]
@@ -273,7 +266,6 @@ MCClassDefinition >> initialize [
 	classTraitComposition := '{}'.
 	type := #normal.
 	comment := ''.
-	commentStamp := self defaultCommentStamp.
 	variables := OrderedCollection new
 ]
 

--- a/src/Monticello-Model/MCMethodDefinition.class.st
+++ b/src/Monticello-Model/MCMethodDefinition.class.st
@@ -30,18 +30,11 @@ Class {
 		'sourcePointer'
 	],
 	#classVars : [
-		'Definitions',
 		'InitializersEnabled'
 	],
 	#category : 'Monticello-Model',
 	#package : 'Monticello-Model'
 }
-
-{ #category : 'accessing' }
-MCMethodDefinition class >> cachedDefinitions [
-
-	^ Definitions ifNil: [ Definitions := WeakIdentityKeyDictionary new ]
-]
 
 { #category : 'instance creation' }
 MCMethodDefinition class >> className: classString classIsMeta: metaBoolean selector: selectorString category: protocolName sourcePointer: aNumber source: sourceString [
@@ -81,26 +74,6 @@ MCMethodDefinition class >> className: classString selector: selectorString cate
 		  source: sourceString
 ]
 
-{ #category : 'cleanup' }
-MCMethodDefinition class >> cleanUp [
-	"Flush caches"
-
-	self shutDown
-]
-
-{ #category : 'cleanup' }
-MCMethodDefinition class >> flushMethodCache [
-	"We do not named this method flushCache because it would override an important class methods."
-
-	Definitions := nil
-]
-
-{ #category : 'class initialization' }
-MCMethodDefinition class >> initialize [
-
-	SessionManager default registerSystemClassNamed: self name
-]
-
 { #category : 'settings' }
 MCMethodDefinition class >> initializersEnabled [
 
@@ -111,13 +84,6 @@ MCMethodDefinition class >> initializersEnabled [
 MCMethodDefinition class >> initializersEnabled: aBoolean [
 
 	InitializersEnabled := aBoolean
-]
-
-{ #category : 'system startup' }
-MCMethodDefinition class >> shutDown [
-	"Free up all cached monticello method definitions"
-
-	self flushMethodCache
 ]
 
 { #category : 'comparing' }

--- a/src/Monticello-Model/MCTraitDefinition.class.st
+++ b/src/Monticello-Model/MCTraitDefinition.class.st
@@ -49,7 +49,7 @@ MCTraitDefinition >> createClassInEnvironment: anEnvironent [
 					  classSlots: self classInstanceVariables;
 					  package: self packageName;
 					  tag: self tagName;
-					  comment: comment stamp: commentStamp;
+					  comment: comment stamp: self commentStamp;
 					  beTrait.
 				  anEnvironent ifNotNil: [ aBuilder environment: anEnvironent ] ] ]
 		  on: Warning , DuplicatedVariableError

--- a/src/Monticello-Model/RGMethodDefinition.extension.st
+++ b/src/Monticello-Model/RGMethodDefinition.extension.st
@@ -32,19 +32,3 @@ RGMethodDefinition >> asMCMethodDefinitionFromActiveDefinition [
 		  timeStamp: compiledMethod timeStamp
 		  source: compiledMethod sourceCode
 ]
-
-{ #category : '*Monticello-Model' }
-RGMethodDefinition >> basicAsMCMethodDefinition [
-   "Creates a MCMethodDefinition from the receiver"
-   
-	^ self isActive 
-		ifTrue: [ self asMCMethodDefinitionFromActiveDefinition ]
-		ifFalse: [
-		   ^ MCMethodDefinition
-				className: self instanceSideParentName
-		 	   	classIsMeta: self isMeta
-				selector: self selector
-				category: self protocol
-				timeStamp: self stamp
-				source: self sourceCode ]
-]

--- a/src/Monticello-Model/Trait.extension.st
+++ b/src/Monticello-Model/Trait.extension.st
@@ -14,8 +14,7 @@ Trait >> asClassDefinition [
 		              traitComposition: self traitCompositionString;
 		              packageName: self package name;
 		              classTraitComposition: self class traitCompositionString;
-		              comment: self comment;
-		              commentStamp: self commentStamp.
+		              comment: self comment.
 
 	"We do not export the tag if this is the root."
 	self packageTag ifNotNil: [ :tag | tag isRoot ifFalse: [ definition tagName: tag name ] ].

--- a/src/PharoBootstrap/PBBootstrap.class.st
+++ b/src/PharoBootstrap/PBBootstrap.class.st
@@ -188,7 +188,6 @@ PBBootstrap >> exportMonticelloInStFile [
 		MCCacheRepository initialize.
 		MCWorkingCopy initialize.
 		MCLazyVersionInfo initialize.
-		MCMethodDefinition initialize.
 		SharedRandom initialize.
 		DigitalSignatureAlgorithm initialize.
 		MD5NonPrimitive initialize.


### PR DESCRIPTION
This change brings two improvements to Monticello.

The first is the simplification of MCMethodDefinition. I added back a cache that was present in the past with a fix. But I also simplified a piece of Monticello code reccently making this cache useless because now it takes the same time to check the cache and to create the method definition. So it's better to use the method with the simpler code.

I also speed up the creation of MCClassDefinition and MCTraitDefinition by making the retrieval of the comment stamp lazy because Iceberg does not need this comment stamp and it is the bigger user of Monticello model currently.