### PR TITLE
Backport to P13 one of the two Monticello snaposhot computation speedup

### DIFF
--- a/src/Monticello-Model/CompiledMethod.extension.st
+++ b/src/Monticello-Model/CompiledMethod.extension.st
@@ -34,7 +34,7 @@ CompiledMethod >> basicAsMCMethodDefinition [
 CompiledMethod >> sameAsMCDefinition: anMCMethodDefinition [
 
 	^ anMCMethodDefinition selector = self selector and: [
-		  anMCMethodDefinition className = self className and: [
+		  anMCMethodDefinition className = self methodClass name and: [
 			  anMCMethodDefinition classIsMeta = self isClassSide and: [
 				  anMCMethodDefinition protocol = self protocolName and: [ anMCMethodDefinition source = self sourceCode ] ] ] ]
 ]

--- a/src/Monticello-Model/CompiledMethod.extension.st
+++ b/src/Monticello-Model/CompiledMethod.extension.st
@@ -34,7 +34,7 @@ CompiledMethod >> basicAsMCMethodDefinition [
 CompiledMethod >> sameAsMCDefinition: anMCMethodDefinition [
 
 	^ anMCMethodDefinition selector = self selector and: [
-		  anMCMethodDefinition className = self methodClass name and: [
+		  anMCMethodDefinition className = self methodClass instanceSide name and: [
 			  anMCMethodDefinition classIsMeta = self isClassSide and: [
 				  anMCMethodDefinition protocol = self protocolName and: [ anMCMethodDefinition source = self sourceCode ] ] ] ]
 ]


### PR DESCRIPTION
2 speedup of Monticello snapshot creation got integrated in P14. One cannot be integrated because it depends on other P14 changes. But another can so I'm proposing to integrate it in P13. This divide by two the computation of the snapshots