### PR TITLE
Group remote Metacello repositories

### DIFF
--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -8,9 +8,6 @@ mcPackages := #(
  'Metacello-Base'
  'Metacello-Core'
  'Metacello-GitBasedRepository'
- 'Metacello-Gitlab'
- 'Metacello-GitHub'
- 'Metacello-Bitbucket'
  'Metacello-CommandLine'
  ).
 

--- a/src/BaselineOfMetacello/BaselineOfMetacello.class.st
+++ b/src/BaselineOfMetacello/BaselineOfMetacello.class.st
@@ -14,11 +14,8 @@ BaselineOfMetacello >> baseline: spec [
 			package: 'ScriptingExtensions';
 			package: 'FileSystem-Memory';
 			package: 'Metacello-Base';
-			package: 'Metacello-Bitbucket';
 			package: 'Metacello-Core';
 			package: 'Metacello-GitBasedRepository';
-			package: 'Metacello-GitHub';
-			package: 'Metacello-Gitlab';
 			package: 'MonticelloFileTree-Core';
 			package: 'MonticelloFileTree-FileSystem-Utilities';
 			package: 'STON-Core';
@@ -26,12 +23,11 @@ BaselineOfMetacello >> baseline: spec [
 
 		spec
 			package: 'Metacello-TestsCore';
-			package: 'Metacello-TestsMCCore';	"standalone"
-			package: 'Metacello-TestsReference';	"standalone"
-			package: 'Metacello-Gitlab-Tests'.
+			package: 'Metacello-TestsMCCore';
+			package: 'Metacello-TestsReference'.
 
 		spec 
-			group: 'Core' with: #('ScriptingExtensions' 'System-FileRegistry' 'FileSystem-Memory' 'PragmaCollector' 'System-FileRegistry' 'Metacello-Base' 'Metacello-Core' 'MonticelloFileTree-Core' 'MonticelloFileTree-FileSystem-Utilities' 'STON-Core' 'Metacello-GitBasedRepository' 'Metacello-GitHub' 'Metacello-Gitlab' 'Metacello-Bitbucket' 'Metacello-CommandLine');
-			group: 'Tests' with: #( 'Metacello-TestsCore' 'Metacello-TestsMCCore' 'Metacello-TestsReference' 'Metacello-Gitlab-Tests');
+			group: 'Core' with: #('ScriptingExtensions' 'System-FileRegistry' 'FileSystem-Memory' 'PragmaCollector' 'System-FileRegistry' 'Metacello-Base' 'Metacello-Core' 'MonticelloFileTree-Core' 'MonticelloFileTree-FileSystem-Utilities' 'STON-Core' 'Metacello-GitBasedRepository' 'Metacello-CommandLine' );
+			group: 'Tests' with: #( 'Metacello-TestsCore' 'Metacello-TestsMCCore' 'Metacello-TestsReference' );
 			group: 'default' with: #('Core') ]
 ]

--- a/src/Metacello-Bitbucket/package.st
+++ b/src/Metacello-Bitbucket/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'Metacello-Bitbucket' }

--- a/src/Metacello-GitBasedRepository/MCBitbucketRepository.class.st
+++ b/src/Metacello-GitBasedRepository/MCBitbucketRepository.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : 'MCBitbucketRepository',
 	#superclass : 'MCPrivateHostableRepository',
-	#category : 'Metacello-Bitbucket',
-	#package : 'Metacello-Bitbucket'
+	#category : 'Metacello-GitBasedRepository',
+	#package : 'Metacello-GitBasedRepository'
 }
 
 { #category : 'accessing' }

--- a/src/Metacello-GitBasedRepository/MCGitHubRepository.class.st
+++ b/src/Metacello-GitBasedRepository/MCGitHubRepository.class.st
@@ -6,8 +6,8 @@ Class {
 		'DownloadCache',
 		'ETagsCache'
 	],
-	#category : 'Metacello-GitHub',
-	#package : 'Metacello-GitHub'
+	#category : 'Metacello-GitBasedRepository',
+	#package : 'Metacello-GitBasedRepository'
 }
 
 { #category : 'accessing' }

--- a/src/Metacello-GitBasedRepository/MCGitlabRepository.class.st
+++ b/src/Metacello-GitBasedRepository/MCGitlabRepository.class.st
@@ -29,8 +29,8 @@ Internal Representation and Key Implementation Points.
 Class {
 	#name : 'MCGitlabRepository',
 	#superclass : 'MCPrivateHostableRepository',
-	#category : 'Metacello-Gitlab',
-	#package : 'Metacello-Gitlab'
+	#category : 'Metacello-GitBasedRepository',
+	#package : 'Metacello-GitBasedRepository'
 }
 
 { #category : 'accessing' }

--- a/src/Metacello-GitHub/package.st
+++ b/src/Metacello-GitHub/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'Metacello-GitHub' }

--- a/src/Metacello-Gitlab-Tests/package.st
+++ b/src/Metacello-Gitlab-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'Metacello-Gitlab-Tests' }

--- a/src/Metacello-Gitlab/package.st
+++ b/src/Metacello-Gitlab/package.st
@@ -1,1 +1,0 @@
-Package { #name : 'Metacello-Gitlab' }

--- a/src/Metacello-TestsMCCore/MCGitlabRepositoryTest.class.st
+++ b/src/Metacello-TestsMCCore/MCGitlabRepositoryTest.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : 'MCGitlabRepositoryTest',
 	#superclass : 'TestCase',
-	#category : 'Metacello-Gitlab-Tests',
-	#package : 'Metacello-Gitlab-Tests'
+	#category : 'Metacello-TestsMCCore',
+	#package : 'Metacello-TestsMCCore'
 }
 
 { #category : 'tests' }


### PR DESCRIPTION
I tried to do a bigger change that does not pass the building of Pharo. In order to make it simpler to debug, I'm trying to divide the PR into smaller changes and here is one

Metacello has a lot of packages to declare remote repositories and Monticello even has some of its own. A propose as a first step to group all the Metacello ones because we don't have the granularity to not load them together and it just takes useless space in the package list to have so many packages with 1 class each.