### PR TITLE
Rework loading of some packages

### DIFF
--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -1,6 +1,5 @@
 | mcPackages |
 mcPackages := #(
- 'ScriptingExtensions'
  'FileSystem-Memory'
  'STON-Core'
  'MonticelloFileTree-Core'

--- a/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
+++ b/bootstrap/scripts/03-metacello-bootstrap/01-loadMetacello.st
@@ -1,6 +1,5 @@
 | mcPackages |
 mcPackages := #(
- 'FileSystem-Memory'
  'STON-Core'
  'MonticelloFileTree-Core'
  'MonticelloFileTree-FileSystem-Utilities'

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -87,7 +87,8 @@ BaselineOfBasicTools >> baseline: spec [
 			spec package: 'Tools-CodeNavigation'.
 			spec package: 'Tool-Diff'.
 			spec package: 'Tool-ImageCleaner'.
-			spec package: 'Tools' ]
+			spec package: 'Tools'.
+			spec package: 'FileSystem-Memory' ]
 ]
 
 { #category : 'actions' }

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -87,8 +87,7 @@ BaselineOfBasicTools >> baseline: spec [
 			spec package: 'Tools-CodeNavigation'.
 			spec package: 'Tool-Diff'.
 			spec package: 'Tool-ImageCleaner'.
-			spec package: 'Tools'.
-			spec package: 'FileSystem-Memory' ]
+			spec package: 'Tools' ]
 ]
 
 { #category : 'actions' }

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -236,17 +236,15 @@ BaselineOfBasicTools >> postload: loader package: packageSpec [
 	Initialized := true
 ]
 
-{ #category : 'baseline' }
+{ #category : 'accessing' }
 BaselineOfBasicTools >> project [
-	
-	| aProject |
-	
-	aProject := super project.
-	aProject loadType: #atomic.
-	^ aProject.
+
+	^ super project
+		  loadType: #atomic;
+		  yourself
 ]
 
-{ #category : 'baseline' }
+{ #category : 'dependencies' }
 BaselineOfBasicTools >> specRefactoring: spec [
 	
 	"Package used to rename #defaultSpec methods to #defaultLayout.

--- a/src/BaselineOfMetacello/BaselineOfMetacello.class.st
+++ b/src/BaselineOfMetacello/BaselineOfMetacello.class.st
@@ -11,7 +11,6 @@ BaselineOfMetacello >> baseline: spec [
 
 	spec for: #common do: [
 		spec 
-			package: 'ScriptingExtensions';
 			package: 'FileSystem-Memory';
 			package: 'Metacello-Base';
 			package: 'Metacello-Bitbucket';
@@ -31,7 +30,7 @@ BaselineOfMetacello >> baseline: spec [
 			package: 'Metacello-Gitlab-Tests'.
 
 		spec 
-			group: 'Core' with: #('ScriptingExtensions' 'System-FileRegistry' 'FileSystem-Memory' 'PragmaCollector' 'System-FileRegistry' 'Metacello-Base' 'Metacello-Core' 'MonticelloFileTree-Core' 'MonticelloFileTree-FileSystem-Utilities' 'STON-Core' 'Metacello-GitBasedRepository' 'Metacello-GitHub' 'Metacello-Gitlab' 'Metacello-Bitbucket' 'Metacello-CommandLine');
+			group: 'Core' with: #( 'System-FileRegistry' 'FileSystem-Memory' 'PragmaCollector' 'System-FileRegistry' 'Metacello-Base' 'Metacello-Core' 'MonticelloFileTree-Core' 'MonticelloFileTree-FileSystem-Utilities' 'STON-Core' 'Metacello-GitBasedRepository' 'Metacello-GitHub' 'Metacello-Gitlab' 'Metacello-Bitbucket' 'Metacello-CommandLine');
 			group: 'Tests' with: #( 'Metacello-TestsCore' 'Metacello-TestsMCCore' 'Metacello-TestsReference' 'Metacello-Gitlab-Tests');
 			group: 'default' with: #('Core') ]
 ]

--- a/src/BaselineOfMetacello/BaselineOfMetacello.class.st
+++ b/src/BaselineOfMetacello/BaselineOfMetacello.class.st
@@ -11,7 +11,6 @@ BaselineOfMetacello >> baseline: spec [
 
 	spec for: #common do: [
 		spec 
-			package: 'FileSystem-Memory';
 			package: 'Metacello-Base';
 			package: 'Metacello-Bitbucket';
 			package: 'Metacello-Core';
@@ -30,7 +29,7 @@ BaselineOfMetacello >> baseline: spec [
 			package: 'Metacello-Gitlab-Tests'.
 
 		spec 
-			group: 'Core' with: #( 'System-FileRegistry' 'FileSystem-Memory' 'PragmaCollector' 'System-FileRegistry' 'Metacello-Base' 'Metacello-Core' 'MonticelloFileTree-Core' 'MonticelloFileTree-FileSystem-Utilities' 'STON-Core' 'Metacello-GitBasedRepository' 'Metacello-GitHub' 'Metacello-Gitlab' 'Metacello-Bitbucket' 'Metacello-CommandLine');
+			group: 'Core' with: #( 'System-FileRegistry' 'PragmaCollector' 'System-FileRegistry' 'Metacello-Base' 'Metacello-Core' 'MonticelloFileTree-Core' 'MonticelloFileTree-FileSystem-Utilities' 'STON-Core' 'Metacello-GitBasedRepository' 'Metacello-GitHub' 'Metacello-Gitlab' 'Metacello-Bitbucket' 'Metacello-CommandLine');
 			group: 'Tests' with: #( 'Metacello-TestsCore' 'Metacello-TestsMCCore' 'Metacello-TestsReference' 'Metacello-Gitlab-Tests');
 			group: 'default' with: #('Core') ]
 ]

--- a/src/BaselineOfMisc/BaselineOfMisc.class.st
+++ b/src/BaselineOfMisc/BaselineOfMisc.class.st
@@ -10,9 +10,10 @@ BaselineOfMisc >> baseline: spec [
 
 	<baseline>
 	spec for: #common do: [
-		spec
-			package: 'PharoDocComment';
-			package: 'System-CommandLine-TextSupport';
-			package: 'Files-Prompt';
-			package: 'System-SourcesCondenser' ]
+			spec
+				package: 'PharoDocComment';
+				package: 'System-CommandLine-TextSupport';
+				package: 'Files-Prompt';
+				package: 'System-SourcesCondenser';
+				package: 'ScriptingExtensions' ]
 ]

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -45,8 +45,6 @@ BaselineOfMorphic >> baseline: spec [
 
 		spec package: 'System-Localization'.
 
-		spec package: 'FileSystem-Zip'.
-
 		spec package: 'Graphics-Shapes'.
 		spec package: 'Growl'.
 

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -25,20 +25,13 @@ BaselineOfMorphicCore >> baseline: spec [
 	repository := self packageRepositoryURLForSpec: spec.
 
 	spec for: #common do: [
-
-		spec package: 'System-Object Events'.
-		spec package: 'System-Caching'.
-		spec package: 'Graphics-Canvas'.
-		spec package: 'FormCanvas-Core'.
-		spec package: 'Tool-Registry'.
-		spec package: 'System-Model'.
-		spec baseline: 'Fonts' with: [
-				spec
-					repository: repository;
-					loads: #Core ].
-		spec baseline: 'FreeType' with: [
-			spec
-				repository: repository;
-				loads: 'ui' ].
-		spec package: 'Morphic-Core' with: [ spec requires: #( 'System-Model' ) ] ]
+			spec package: 'System-Object Events'.
+			spec package: 'System-Caching'.
+			spec package: 'Graphics-Canvas'.
+			spec package: 'FormCanvas-Core'.
+			spec package: 'Tool-Registry'.
+			spec package: 'System-Model'.
+			spec package: 'FileSystem-Memory'.
+			spec package: 'FileSystem-Zip'.
+			spec package: 'Morphic-Core' with: [ spec requires: #( 'System-Model' ) ] ]
 ]

--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -150,12 +150,12 @@ Class >> addSharedPool: aSharedPool [
 
 { #category : 'pool variables' }
 Class >> addSharedPoolNamed: aSharedPoolName [
+
 	<reflection: 'Class structural modification - Shared pool modification'>
-	|poolClass|
-	poolClass := aSharedPoolName asClassIfAbsent: [nil].
-	poolClass isPool
-		ifTrue: [ self addSharedPool: poolClass ]
-		ifFalse: [ self error: 'The specified class is not pool.' ]
+	self environment at: aSharedPoolName ifPresent: [ :poolClass |
+			poolClass isPool
+				ifTrue: [ self addSharedPool: poolClass ]
+				ifFalse: [ self error: 'The specified class is not pool.' ] ]
 ]
 
 { #category : 'accessing - class hierarchy' }


### PR DESCRIPTION
Scripting extensions is loaded with Metacello while it is not used by it. I propose to load it with the "normal" loading by moving it to BaselineOfMisc. I also cut a dependency of Kernel-CodeModel to this package that is not present at the beginning.

FileSystem-Memory is currently loaded with Metacello but is not used by it. FileSystem-Zip is currently loaded by Morphic but it should not be part of Morphic. Ideally, they should be loaded by BaselineOfBasicTools but the current structure makes it hard to have good dependencies tests about that, so I'm temporarily putting them in BaselineOfMorphicCore. I'll clean further in a next PR by introducing a new group in BaselineOfBasicTools to have better dependencies tests. But this is a first step in the cleaning.

I removed some duplicated projects declarations (font and free type)

I also cleaned some protocols