### PR TITLE
tests an speedup #asByteArray

### DIFF
--- a/src/Collections-Native-Tests/ByteArrayTest.class.st
+++ b/src/Collections-Native-Tests/ByteArrayTest.class.st
@@ -28,6 +28,12 @@ ByteArrayTest >> setUp [
 ]
 
 { #category : 'tests' }
+ByteArrayTest >> testAsByteArrayOfSize [
+	self assert: (#[51 52 53] asByteArrayOfSize: 10 ) equals: #[0 0 0 0 0 0 0 51 52 53].
+	self assert: (#[51 52 53] asByteArrayOfSize: 3 ) equals: #[51 52 53]
+]
+
+{ #category : 'tests' }
 ByteArrayTest >> testAsInteger [ 
 	self assert: #[122] asInteger equals: 122.
 	self assert: #[122 8] asInteger equals: 31240.

--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -58,21 +58,18 @@ ByteArray >> asByteArray [
 
 { #category : 'converting' }
 ByteArray >> asByteArrayOfSize: size [
-	"
-		'34523' asByteArray asByteArrayOfSize: 100.
 
-	(((
-		| repeats bytes |
-		repeats := 1000000.
-		bytes := '123456789123456789123456789123456789123456789123456789' asByteArray.
-		 [repeats timesRepeat: (bytes asByteArrayOfSize: 1024) ] timeToRun.
-	)))"
+	"(#[51 52 53] asByteArrayOfSize: 10 ) >>> #[0 0 0 0 0 0 0 51 52 53]"
 
-	| bytes |
-	size < self size
+	| answer selfSize |
+	selfSize := self size.
+
+	size < selfSize
 		ifTrue: [^ self error: 'bytearray bigger than ', size asString].
-	bytes := self asByteArray.
-	^ (ByteArray new: (size - bytes size)), bytes
+	
+	answer := ByteArray new: size.
+	answer replaceFrom: size - selfSize + 1 to: size with: self startingAt: 1.
+	^answer
 ]
 
 { #category : 'private' }
@@ -85,11 +82,12 @@ ByteArray >> asByteArrayPointer [
 ByteArray >> asInteger [
 	"Convert me to an Integer, network byte order, most significant byte first, big endian"
 
-	| integer |
+	| integer size |
+	size := self size.
 	integer := 0.
-	1 to: self size do: [ :index |
+	1 to: size do: [ :index |
 		"we use inlined to:do: instead of #withIndexDo:"
-		integer := integer + ((self at: index) bitShift: (self size - index) * 8) ].
+		integer := integer + ((self at: index) bitShift: (size - index) * 8) ].
 	^ integer
 ]
 

--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -422,6 +422,14 @@ StringTest >> testAllRangesOfSubstring [
 ]
 
 { #category : 'tests - converting' }
+StringTest >> testAsByteArray [
+	self assert: 'a' asByteArray equals: #[97].
+	self assert: 'A' asByteArray equals: #[65].
+	self assert: 'ABA' asByteArray equals: #[65 66 65].
+	self assert: '' asByteArray equals: #[]
+]
+
+{ #category : 'tests - converting' }
 StringTest >> testAsCamelCase [
 
 	self assert: 'A man, a plan, a canal, panama' asCamelCase equals: 'AMan,APlan,ACanal,Panama'.

--- a/src/Collections-Strings-Tests/SymbolTest.class.st
+++ b/src/Collections-Strings-Tests/SymbolTest.class.st
@@ -319,6 +319,14 @@ SymbolTest >> testAsAccessor [
 	self should: [ self assert: #'' asAccessor ] raise: Error.	
 ]
 
+{ #category : 'tests - converting' }
+SymbolTest >> testAsByteArray [
+	self assert: #a asByteArray equals: #[97].
+	self assert: #A asByteArray equals: #[65].
+	self assert: #ABA asByteArray equals: #[65 66 65].
+	self assert: #'' asByteArray equals: #[]
+]
+
 { #category : 'tests' }
 SymbolTest >> testAsMutator [
 	self assert: #x asMutator equals: #x:.

--- a/src/Collections-Strings-Tests/WideStringTest.class.st
+++ b/src/Collections-Strings-Tests/WideStringTest.class.st
@@ -19,6 +19,14 @@ WideStringTest >> classToBeTested [
 ]
 
 { #category : 'tests - converting' }
+WideStringTest >> testAsByteArray [
+	self assert: 'a' asWideString asByteArray equals: #[0 0 0 97].
+	self assert: 'A' asWideString asByteArray equals: #[0 0 0 65].
+	self assert: 'ABA' asWideString asByteArray equals: #[0 0 0 65 0 0 0 66 0 0 0 65].
+	self assert: '' asWideString asByteArray equals: #[]	
+]
+
+{ #category : 'tests - converting' }
 WideStringTest >> testAsInteger [
 	self assert: '1796exportFixes-tkMX' asWideString asInteger equals: 1796.
 	self assert: 'donald' asWideString asInteger isNil.
@@ -41,7 +49,6 @@ WideStringTest >> testAsInteger [
 
 { #category : 'testing' }
 WideStringTest >> testAtPut [
-	"Non regression test for http://bugs.squeak.org/view.php?id=6998"
 
 	| w1 |
 	w1 := WideString with: (Unicode value: 402) with: $a with: (Unicode value: 400) with: $b.
@@ -50,7 +57,6 @@ WideStringTest >> testAtPut [
 
 { #category : 'tests - beginswith' }
 WideStringTest >> testBeginsWith [
-	"from johnmci at http://bugs.squeak.org/view.php?id=5331"
 
 	| w1 w2 |
 	self assert: ('abc' beginsWith: 'ab').
@@ -68,7 +74,6 @@ WideStringTest >> testBeginsWith [
 
 { #category : 'tests - match' }
 WideStringTest >> testCharactersExactlyMatching [
-	"from johnmci at http://bugs.squeak.org/view.php?id=5331"
 
 	self assert: ('abc' charactersExactlyMatching: 'abc') equals: 3.
 	self assert: ('abd' charactersExactlyMatching: 'abc') equals: 2.
@@ -83,7 +88,6 @@ WideStringTest >> testCharactersExactlyMatching [
 
 { #category : 'tests - compare' }
 WideStringTest >> testCompare [
-	"from johnmci at http://bugs.squeak.org/view.php?id=5331"
 
 	self assert: ('abc' compare: 'abc') equals: 2.
 	self assert: ('abc' compare: 'abd') equals: 1.
@@ -138,7 +142,6 @@ WideStringTest >> testCompare [
 
 { #category : 'tests - endswith' }
 WideStringTest >> testEndsWith [
-	"from johnmci at http://bugs.squeak.org/view.php?id=5331"
 
 	self assert: ('abc' endsWith: 'bc').
 	self assert: ('abc' endsWith: 'bc' asWideString).
@@ -151,7 +154,6 @@ WideStringTest >> testEndsWith [
 
 { #category : 'tests - compare' }
 WideStringTest >> testEqual [
-	"from johnmci at http://bugs.squeak.org/view.php?id=5331"
 
 	self assert: 'abc' equals: 'abc'.
 	self assert: 'abc' equals: 'abc' asWideString.
@@ -167,8 +169,7 @@ WideStringTest >> testEqual [
 
 { #category : 'tests - substrings' }
 WideStringTest >> testFindSubstring [
-	"This is related to http://bugs.squeak.org/view.php?id=6366
-	finding substring in a WideString was broken because matchTable are byte-wise"
+	"finding substring in a WideString was broken because matchTable are byte-wise"
 
 	| ws1 ws2 |
 	self assert: ('abcd' findString: 'bc' startingAt: 1) equals: 2.
@@ -190,7 +191,6 @@ WideStringTest >> testFindSubstring [
 
 { #category : 'testing' }
 WideStringTest >> testIsAsciiString [
-	"Non-regression for https://pharo.manuscript.com/f/cases/15232 "
 
 	self assert: '' asWideString isAsciiString equals: true.
 	self assert: 'abcdefGHIJKL 98765,./@#%$' asWideString isAsciiString equals: true.
@@ -200,7 +200,6 @@ WideStringTest >> testIsAsciiString [
 
 { #category : 'tests - match' }
 WideStringTest >> testMatch [
-	"from johnmci at http://bugs.squeak.org/view.php?id=5331"
 
 	self assert: ('*baz' match: 'mobaz' ).
 	self assert: ('*foo#zort' match: 'afoo3zortthenfoo3zort' ).
@@ -225,7 +224,6 @@ WideStringTest >> testMatch [
 
 { #category : 'tests - relation order' }
 WideStringTest >> testRelationOrder [
-	"from johnmci at http://bugs.squeak.org/view.php?id=5331"
 
 	self assert: ('aa' < 'ab').
 	self assert: ('aa' <= 'ab').
@@ -258,7 +256,6 @@ WideStringTest >> testRelationOrder [
 
 { #category : 'tests - relation order' }
 WideStringTest >> testRelationOrderWithCase [
-	"from johnmci at http://bugs.squeak.org/view.php?id=5331"
 
 	self assert: ('ABC' caseInsensitiveLessOrEqual: 'abc').
 	self assert: ('ABC' caseInsensitiveLessOrEqual: 'abd').
@@ -288,7 +285,6 @@ WideStringTest >> testRelationOrderWithCase [
 
 { #category : 'tests - compare' }
 WideStringTest >> testSameAs [
-	"from johnmci at http://bugs.squeak.org/view.php?id=5331"
 
 	self assert: ('abc' sameAs: 'aBc' asWideString).
 	self assert: ('aBc' asWideString sameAs: 'abc').
@@ -298,7 +294,6 @@ WideStringTest >> testSameAs [
 
 { #category : 'tests - substrings' }
 WideStringTest >> testSubstrings [
-	"this is related to http://bugs.squeak.org/view.php?id=6367"
 
 	| w1 w2 |
 	w1 := WideString

--- a/src/Collections-Strings/ByteString.class.st
+++ b/src/Collections-Strings/ByteString.class.st
@@ -96,16 +96,6 @@ ByteString class >> translate: aString from: start  to: stop  table: table [
 ]
 
 { #category : 'converting' }
-ByteString >> asByteArray [
-
-	| ba sz |
-	sz := self byteSize.
-	ba := ByteArray new: sz.
-	ba replaceFrom: 1 to: sz with: self startingAt: 1.
-	^ba
-]
-
-{ #category : 'converting' }
 ByteString >> asOctetString [
 
 	^ self

--- a/src/Collections-Strings/ByteSymbol.class.st
+++ b/src/Collections-Strings/ByteSymbol.class.st
@@ -31,15 +31,6 @@ ByteSymbol class >> translate: aString from: start  to: stop  table: table [
 ]
 
 { #category : 'converting' }
-ByteSymbol >> asByteArray [
-	| ba sz |
-	sz := self byteSize.
-	ba := ByteArray new: sz.
-	ba replaceFrom: 1 to: sz with: self startingAt: 1.
-	^ba
-]
-
-{ #category : 'converting' }
 ByteSymbol >> asOctetString [
 	^ self
 ]

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -571,7 +571,11 @@ String >> asByteArray [
 	"'A' asByteArray >>> #[65]"
 	"'ABA' asByteArray >>> #[65 66 65]"
 	
-	self subclassResponsibility
+	| ba sz |
+	sz := self byteSize.
+	ba := ByteArray new: sz.
+	ba replaceFrom: 1 to: sz with: self startingAt: 1.
+	^ba
 ]
 
 { #category : 'converting' }

--- a/src/Collections-Strings/WideString.class.st
+++ b/src/Collections-Strings/WideString.class.st
@@ -57,12 +57,13 @@ WideString class >> fromString: aString [
 { #category : 'converting' }
 WideString >> asByteArray [
 	"Convert to a ByteArray with the ascii values of the string."
-	"'a' asByteArray >>> #[97]"
-	"'A' asByteArray >>> #[65]"
-	"'ABA' asByteArray >>> #[65 66 65]"
-	| b |
-	b := ByteArray new: self byteSize.
-	1 to: self size * 4 do: [:i |
+	"'a' asWideString asByteArray >>> #[0 0 0 97]"
+	"'A' asWideString asByteArray >>> #[0 0 0 65]"
+	
+	| b s |
+	s := self byteSize.
+	b := ByteArray new: s.
+	1 to: s do: [:i |
 		b at: i put: (self byteAt: i)].
 	^ b
 ]

--- a/src/Kernel-Tests/IntegerTest.class.st
+++ b/src/Kernel-Tests/IntegerTest.class.st
@@ -22,6 +22,42 @@ IntegerTest >> testANegativeIntegerCannotBeAPowerOfTwo [
 		description: 'A negative integer cannot be a power of two'
 ]
 
+{ #category : 'tests - converting' }
+IntegerTest >> testAsByteArray [
+	self assert: 1 asByteArray equals: #[ 1 ].
+	"sign is lost"
+	self assert: -1 asByteArray equals: #[ 1 ].
+	self assert: 1 asByteArray equals: (1 asByteArrayOfSize: 1 bytesCount).
+	
+	self assert: SmallInteger maxVal asByteArray equals: #[15 255 255 255 255 255 255 255].
+	self assert: SmallInteger maxVal asByteArray equals: (SmallInteger maxVal asByteArrayOfSize: SmallInteger maxVal bytesCount).
+	
+	self assert: SmallInteger minVal asByteArray equals: #[16 0 0 0 0 0 0 0].
+	
+	self assert: 1 asByteArray asInteger equals: 1.
+	
+		self assert: (SmallInteger maxVal + 1) asByteArray equals: #[16 0 0 0 0 0 0 0].
+	self assert: (SmallInteger maxVal + 1) asByteArray equals: ((SmallInteger maxVal + 1) asByteArrayOfSize: (SmallInteger maxVal + 1)  bytesCount).
+	
+	self assert: (SmallInteger maxVal + 1) asByteArray asInteger equals: (SmallInteger maxVal + 1).
+]
+
+{ #category : 'tests - converting' }
+IntegerTest >> testAsByteArrayOfSize [
+	self assert: (1 asByteArrayOfSize: 1) equals: #[ 1 ].
+	"sign is ignored"
+	self assert: (-1 asByteArrayOfSize: 1) equals: #[ 1 ].
+	self assert: 1 asByteArray equals: (1 asByteArrayOfSize: 1 bytesCount).
+	
+	self assert: (SmallInteger maxVal asByteArrayOfSize: 8) equals: #[15 255 255 255 255 255 255 255].
+	self assert: (SmallInteger minVal asByteArrayOfSize: 8) equals: #[16 0 0 0 0 0 0 0].
+	
+	self assert: (1 asByteArrayOfSize: 1) asInteger equals: 1.
+	
+	self assert: ((SmallInteger maxVal + 1) asByteArrayOfSize: 8) equals: #[16 0 0 0 0 0 0 0].
+	self assert: ((SmallInteger minVal - 1) asByteArrayOfSize: 8) equals: #[16 0 0 0 0 0 0 1].
+]
+
 { #category : 'tests - basic' }
 IntegerTest >> testAsLargerPowerOfTwo [
 "Invalid input testing"

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -290,23 +290,43 @@ Integer >> anyMask: mask [
 
 { #category : 'converting - arrays' }
 Integer >> asByteArray [
+	"Answer a ByteArray with my value, most-significant byte first.
+	Warning: Sign is not encoded"
 
-	| stream |
-	stream := ByteArray new writeStream.
-	self bytesCount to: 1 by: -1 do: [:digitIndex |
-		stream nextPut: (self byteAt: digitIndex)].
-	^ stream contents
+	"1 asByteArray >>> #[1]"
+	"-1 asByteArray >>> #[1]"
+
+	| answer digitPos bytesCount |
+	bytesCount := self bytesCount.
+	answer := ByteArray new: bytesCount.
+	
+	digitPos := 1.
+	bytesCount
+		to: 1
+		by: -1
+		do: [ :pos |
+			answer
+				at: pos
+				put: (self byteAt: digitPos).
+			digitPos := digitPos + 1 ].
+	^ answer
 ]
 
 { #category : 'converting - arrays' }
 Integer >> asByteArrayOfSize: aSize [
-	"Answer a ByteArray of aSize with my value, most-significant byte first."
-	| answer digitPos |
-	aSize < self bytesCount ifTrue: [ self error: 'number to large for byte array' ].
+	"Answer a ByteArray of aSize with my value, most-significant byte first.
+	Warning: Sign is not encoded"
+	"(1 asByteArrayOfSize: 1) >>> 1"
+	"(-1 asByteArrayOfSize: 1) >>> 1"
+	
+	| answer digitPos bytesCount |
+	bytesCount := self bytesCount.
+	
+	aSize < bytesCount ifTrue: [ self error: 'number to large for byte array' ].
 	answer := ByteArray new: aSize.
 	digitPos := 1.
 	aSize
-		to: aSize - self bytesCount + 1
+		to: aSize - bytesCount + 1
 		by: -1
 		do:
 			[ :pos |


### PR DESCRIPTION
- add more tests for #asByteArray and asByteArrayOfSize:
- add examples
- cleanup comments

- faster Integer>>#asByteArray: do not use writeStream, but an optimized loop like #asByteArrayOfSize:
- faster Integer>>#asByteArrayOfSize: by calling #bytesCount once
- little bit faster WideString>>#asByteArray: calculate size once
- push #asByteArray up to to String
- little bit faster ByteArray>>#asInteger: by calculating size once (and not in the loop)
- faste ByteArray>>#asByteArrayOfSize: use primitive instead of concatenation