### PR TITLE
Make sure that the calypso template has not an empty string for package

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyClassCreationToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassCreationToolMorph.class.st
@@ -59,8 +59,12 @@ ClyClassCreationToolMorph >> belongsToCurrentBrowserContext [
 
 { #category : 'template' }
 ClyClassCreationToolMorph >> classTemplate [
-
-	^ ClassDefinitionPrinter fluid compactClassDefinitionTemplateInPackage:self packageName tag: self tag
+	"Return the default class template and make sure that the package is not an empty string in the template."
+	
+	| packageName  |
+	packageName := self packageName.
+	packageName ifEmpty: [ packageName := '_Unpackaged' ].
+	^ ClassDefinitionPrinter fluid compactClassDefinitionTemplateInPackage: packageName tag: self tag
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
Make sure that the calypso template has not an empty string for package

May be this could be an option for the fluid printer. 
I will have to do a pass to produce a full(meta and instance on the same side) soon and I will add this too. 