### PR TITLE
TObservable: test by isObservableSlot

### DIFF
--- a/src/VariablesLibrary/TObservable.trait.st
+++ b/src/VariablesLibrary/TObservable.trait.st
@@ -39,8 +39,9 @@ TObservable >> notifyPropertyChanged: aName [
 { #category : 'events' }
 TObservable >> observablePropertyNamed: aName [
 	| slot |
+
 	slot := self class slotNamed: aName.
-	(slot class == ObservableSlot) ifFalse: [ NonObservableSlotError signal: aName ].
+	slot isObservableSlot ifFalse: [ NonObservableSlotError signal: aName ].
 
 	"Obtain the raw value.
 	We need to access the underlying value holder to subscribe to it"


### PR DESCRIPTION
which now is on the hierarchy and is better than test by class (otherwise I can't extend ObservableSlot without extending/changing/override TObservable and I do not see a reason
as we now have isObservableSlot in the hierarchy, I guess this is fine.