### PR TITLE
Use v1.7.10 of PharoBootstrap

### DIFF
--- a/bootstrap/scripts/2-download.sh
+++ b/bootstrap/scripts/2-download.sh
@@ -51,7 +51,7 @@ if [ ! -e "${BOOTSTRAP_DOWNLOADS}/vmBootstrap/pharo" ]; then
 fi 
 
 if [ ! -e "${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip" ]; then
-	download_to https://github.com/guillep/PharoBootstrap/releases/download/v1.7.8/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip
+	download_to https://github.com/guillep/PharoBootstrap/releases/download/v1.7.10/bootstrapImage.zip ${BOOTSTRAP_DOWNLOADS}/bootstrapImage.zip
 fi 
 
 # checking for PharoV60.sources


### PR DESCRIPTION
This new host image is built from a Pharo 10 official release and an official pharo-vm tag!