### PR TITLE
Add ZnBufferedReadStream>>reset

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnBufferedReadStream.class.st
@@ -340,6 +340,13 @@ ZnBufferedReadStream >> readStream [
 	^ self
 ]
 
+{ #category : 'initialization' }
+ZnBufferedReadStream >> reset [
+
+	stream reset.
+	self discardBuffer
+]
+
 { #category : 'accessing' }
 ZnBufferedReadStream >> setToEnd [
 


### PR DESCRIPTION
This method reset the wrapped stream and discard the buffer. This is needed by the new sources management in Pharo

Fixes #18997