### PR TITLE
Initialize objectsIndexes with aNumber size

### DIFF
--- a/src/Fuel-Core/FLEncoder.class.st
+++ b/src/Fuel-Core/FLEncoder.class.st
@@ -219,7 +219,7 @@ FLEncoder >> objectCount [
 { #category : 'accessing' }
 FLEncoder >> objectCount: aNumber [
 	objectCount := aNumber.
-	objectsIndexes := IdentityDictionary new.
+	objectsIndexes := IdentityDictionary new: aNumber.
 	substitutionIndexes := IdentityDictionary new.
 	indexStream := FLIndexStream on: stream digits: aNumber bytesCount
 ]


### PR DESCRIPTION
This avoids wasting time in gradual "grows".

Benchmark:

```smalltalk
bigData := (1 to: 200000) collect:[ :e | CollectionElement with: (e * e) ].

3 timesRepeat: [ Smalltalk garbageCollect ].
fuelFile := (FileLocator imageDirectory / 'a.fuel') asFileReference. fuelFile ensureDelete.
fuelWriteTime := [
	fuelFile binaryWriteStreamDo: [ :ws | bigData serializeOn: ws ] ] millisecondsToRun.
fuelReadTime := [
	result := fuelFile binaryReadStreamDo: [ :rs | FLMaterializer materializeFrom: rs ] ] millisecondsToRun.
fuelSize := fuelFile size. 
self assert: result = bigData.

{ 'fuel'. fuelWriteTime. fuelReadTime. fuelSize humanReadableSISizeString }
```