### PR TITLE
Add a temporary hack to allow Iceberg's tests to run

### DIFF
--- a/src/SUnit-Core/TestSuite.class.st
+++ b/src/SUnit-Core/TestSuite.class.st
@@ -144,17 +144,18 @@ TestSuite >> run: aResult [
 TestSuite >> runWith: aBlock [
 
 	self setUp.
-	[ 
+	[
 		self shuffledTests do: [ :each |
-			each class announcer
-				when: TestCaseAnnouncement 
-				send: #announce: 
-				to: self testSuiteAnnouncer.
-			aBlock value: each.
-			each class removeSubscription: self testSuiteAnnouncer.
-			self announceTest: each ] ]
-	ensure: [ 
-		self tearDown ]
+				"THIS IS A TEMPORARY HACK!! This should be removed during the development of Pharo14. See the description of this issue: https://github.com/pharo-vcs/iceberg/issues/1993
+				I am here to allow the tests of some CIs to run"
+				(each isKindOf: TestCase)
+					ifTrue: [
+							each class announcer when: TestCaseAnnouncement send: #announce: to: self testSuiteAnnouncer.
+							aBlock value: each.
+							each class removeSubscription: self testSuiteAnnouncer ]
+					ifFalse: [ aBlock value: each ].
+
+				self announceTest: each ] ] ensure: [ self tearDown ]
 ]
 
 { #category : 'running' }


### PR DESCRIPTION
Recently a refactoring of the announcements in SUnit broke some CI like Iceberg's CI. The origin was found and esteban will fix it.  I propose to add a workaround in the meantime because I was trying to fix problems on Iceberg's CI and this bug make it difficult. 

See https://github.com/pharo-vcs/iceberg/issues/1993 for more infos