### PR TITLE
ByteArray>>#asByteArrayOfSize: speedup

### DIFF
--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -60,9 +60,11 @@ ByteArray >> asByteArray [
 ByteArray >> asByteArrayOfSize: size [
 
 	"(#[51 52 53] asByteArrayOfSize: 10 ) >>> #[0 0 0 0 0 0 0 51 52 53]"
+	"(#[51 52 53] asByteArrayOfSize: 3 ) >>> #[51 52 53]"
 
 	| answer selfSize |
 	selfSize := self size.
+	size == selfSize ifTrue: [ ^self].
 
 	size < selfSize
 		ifTrue: [^ self error: 'bytearray bigger than ', size asString].


### PR DESCRIPTION
Avoid creating a new instance when asByteArrayOfSize: is called with a parameter that does not need shortening