### PR TITLE
Bootstrap: Load Monticello via Hermes

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -128,9 +128,6 @@ zip "${HERMES_ARCHIVE_NAME}.zip" *.hermes
 # Archive Package definitions
 zip "${RPACKAGE_ARCHIVE_NAME}.zip" protocolsKernel.txt
 
-# Find st-cache path
-[[ -z "${BOOTSTRAP_CACHE}" ]] && ST_CACHE='st-cache' || ST_CACHE="${BOOTSTRAP_CACHE}/st-cache"
-
 # Installing Package
 echo $(date -u) "[Compiler] Initializing Bootstraped Image"
 ${VM} "${COMPILER_IMAGE_NAME}.image" # I have to run once the image so the next time it starts the CommandLineHandler.
@@ -176,8 +173,7 @@ zip "${CORE_IMAGE_NAME}.zip" "${CORE_IMAGE_NAME}.image"
 echo $(date -u) "[Monticello] Bootstrap Monticello Core and Local repositories"
 
 ${VM} "${CORE_IMAGE_NAME}.image" save ${MC_BOOTSTRAP_IMAGE_NAME}
-#cp "${CORE_IMAGE_NAME}.image" "${MC_BOOTSTRAP_IMAGE_NAME}.image"
-${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" st ${ST_CACHE}/Monticello.st --save --quit
+${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" loadHermes Ring-Definitions-Core.hermes Ring-OldChunkImporter.hermes Jobs.hermes Random-Core.hermes System-Hashing.hermes Compression.hermes Monticello-Model.hermes Network-UUID.hermes Monticello.hermes Ring-Definitions-Monticello.hermes --save --no-fail-on-undeclared
 ${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/01-bootstrapMonticello.st --save --quit
 zip "${MC_BOOTSTRAP_IMAGE_NAME}.zip" ${MC_BOOTSTRAP_IMAGE_NAME}.*
 

--- a/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
+++ b/src/BaselineOfPharoBootstrap/BaselineOfPharoBootstrap.class.st
@@ -142,6 +142,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 		spec package: 'SUnit-Tests'.
 		spec package: 'Kernel-Tests'.
 		spec package: 'SUnit-Basic-CLI'.		
+		BaselineOfMonticello corePackageNames do: [ :package | spec package: package ].
 
 		spec group: 'KernelGroup' with: {
 			'FFI-Kernel'.
@@ -175,7 +176,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			
 			'System-Support'.
 
-			'Zinc-Character-Encoding-Core' }.
+			'Zinc-Character-Encoding-Core' } .
 
 		"These packages are added using hermes after bootstrap"
 
@@ -210,6 +211,8 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'FileSystem-Path'.
 			'FileSystem-Core'.
 			'FileSystem-Disk'}.
+			
+		spec group: 'MonticelloCore' with: BaselineOfMonticello corePackageNames.
 
 		spec group: 'ToLoadByHermes' with: {
 			'AdditionalPackages'.
@@ -217,6 +220,7 @@ BaselineOfPharoBootstrap >> baseline: spec [
 			'CompilerGroup'.
 			'FileSystemGroup'.
 			'Hermes-Extensions'.
+			'MonticelloCore'.
 			'SUnitGroup'.
 		}.
 

--- a/src/PharoBootstrap/PBBootstrap.class.st
+++ b/src/PharoBootstrap/PBBootstrap.class.st
@@ -143,9 +143,9 @@ PBBootstrap >> createImage [
 
 { #category : 'pre-requisites' }
 PBBootstrap >> ensureBaselineOfPharoBootstrap [
+	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfMonticello')) load.
 	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfPharoBootstrap')) load.
 	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfTraits')) load.
-	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfMonticello')) load.
 	(self originRepository versionWithInfo: (self originRepository versionInfoFromVersionNamed: 'BaselineOfMetacello')) load.	
 ]
 
@@ -170,84 +170,6 @@ PBBootstrap >> exportKernelProtocols [
 	self exportProtocolsFor: self kernelPackageNames to: self bootstrapCacheDirectory / 'protocolsKernel.txt'.
 	
 	
-]
-
-{ #category : 'preparation' }
-PBBootstrap >> exportMonticelloInStFile [
-
-	self
-		exportPackages: self monticelloPackageNames
-		usingInitializeScript: '		
-		ZipConstants initialize.
-		ZipFileConstants initialize.
-		ZipWriteStream initialize.
-		GZipConstants initialize.
-		InflateStream initialize.
-		FastInflateStream initialize.
-		
-		MCCacheRepository initialize.
-		MCWorkingCopy initialize.
-		MCLazyVersionInfo initialize.
-		SharedRandom initialize.
-		DigitalSignatureAlgorithm initialize.
-		MD5NonPrimitive initialize.
-		SHA1 initialize.
-		UUIDGenerator initialize.'
-		intoFile: 'Monticello.st'
-
-]
-
-{ #category : 'exporting' }
-PBBootstrap >> exportPackageNamesFor: packageNames to: aTextFile [
-
-	"export list of packages for the Package initialization. Eech package on standalone line"
-		
-	aTextFile ensureDelete.
-	aTextFile writeStreamDo: [:stream | 
-		packageNames do: [ :each | stream nextPutAll: each; cr ]].
-]
-
-{ #category : 'exporting' }
-PBBootstrap >> exportPackages: packageList intoFile: aFileName [
-
-	self
-		exportPackages: packageList
-		usingInitializeScript: ''
-		intoFile: aFileName
-]
-
-{ #category : 'exporting' }
-PBBootstrap >> exportPackages: packageList usingInitializeScript: aScriptString intoFile: aFileName [
-
-	self
-		exportPackages: packageList
-		withBlacklistedClasses: #()
-		withBlacklistedMethods: #() 
-		usingInitializeScript: aScriptString
-		intoFile: aFileName
-]
-
-{ #category : 'exporting' }
-PBBootstrap >> exportPackages: packageList withBlacklistedClasses: blacklistedClasses withBlacklistedMethods: methods usingInitializeScript: aString intoFile: aFileName [
-
-	| mcst | 	
-	mcst := (self bootstrapCacheDirectory / 'st-cache' / aFileName) asFileReference.
-	mcst ensureDelete.
-	mcst parent ensureCreateDirectory.
-	mcst writeStreamDo: [ :stream | | writer version |
-		writer := MCStWriter on: stream.
-		writer writeInitializers: false.
-		
-		packageList do: [ :packageName |
-			| definitions |
-			version := (self originRepository loadVersionFromFileNamed: packageName).
-			definitions := version snapshot definitions.
-			definitions := definitions reject: [:def | blacklistedClasses includes: def className ].
-			definitions := definitions reject: [:def | def isMethodDefinition and: [methods includes: def selector] ].
-			writer writeDefinitions: definitions ].
-		"Write initialization instructions"
-		stream nextPutAll: aString.
-	].
 ]
 
 { #category : 'preparation' }
@@ -323,7 +245,7 @@ PBBootstrap >> mczCache [
 ]
 
 { #category : 'package-names' }
-PBBootstrap >> monticelloPackageNames [
+PBBootstrap >> monticelloCorePackageNames [
 
 	self ensureBaselineOfPharoBootstrap.
 	^ #BaselineOfMonticello asClass corePackageNames
@@ -343,7 +265,7 @@ PBBootstrap >> originRepository [
 { #category : 'package-names' }
 PBBootstrap >> packagesToExportAsMCZ [
 
-	^ #(BaselineOfMetacello) , (#BaselineOfMetacello asClass allPackageNames)  , self monticelloPackageNames , self hermesPackageNames, self kernelPackageNames
+	^ #(BaselineOfMetacello) , (#BaselineOfMetacello asClass allPackageNames)  , self monticelloCorePackageNames , self hermesPackageNames, self kernelPackageNames
 ]
 
 { #category : 'preparation' }
@@ -352,7 +274,6 @@ PBBootstrap >> prepareBootstrap [
 	self
 		exportKernelProtocols;
 		exportAllPackagesIntoMcz;
-		exportMonticelloInStFile;
 		
 		prepareEnvironmentForHermes;
 		generateHermesFiles;


### PR DESCRIPTION
For now the bootstrap has multiple steps:
- Load the core via Espell
- Load another part via hermes 
- Load Monticello core via st files
- Reload the full code via mcz files
- Load Metacello via mcz files
- Load MonticelloRemote via Metacello (normal loading)
- Load the rest of Pharo (normal loading)

Each step has a different way to be managed and this adds a lot of complexity in the bootstrap. I propose to simplify this to load Monticello core via hermes instead of st files. The process now become:

- Load the core via Espell
- Load another part via hermes 
- Reload the full code via mcz files
- Load Metacello via mcz files
- Load MonticelloRemote via Metacello (normal loading)
- Load the rest of Pharo (normal loading)


This change depends on https://github.com/pharo-project/pharo/pull/19003 to avoid conflicts