### PR TITLE
Extract Tool-Registry from Morphic

### DIFF
--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -29,7 +29,6 @@ BaselineOfMorphicCore >> baseline: spec [
 			spec package: 'System-Caching'.
 			spec package: 'Graphics-Canvas'.
 			spec package: 'FormCanvas-Core'.
-			spec package: 'Tool-Registry'.
 			spec package: 'System-Model'.
 			spec package: 'FileSystem-Memory'.
 			spec package: 'FileSystem-Zip'.

--- a/src/BaselineOfUIInfrastructure/BaselineOfUIInfrastructure.class.st
+++ b/src/BaselineOfUIInfrastructure/BaselineOfUIInfrastructure.class.st
@@ -22,5 +22,6 @@ BaselineOfUIInfrastructure >> baseline: spec [
 
 			spec
 				package: 'System-Utilities';
-				package: 'System-FileRegistry' ]
+				package: 'System-FileRegistry';
+				package: 'Tool-Registry'. ]
 ]

--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -328,6 +328,7 @@ SystemDependenciesTest >> testExternalMorphicCoreDependencies [
 		self tonelCorePackageNames,
 		BaselineOfDebugging corePackageNames,
 		BaselineOfUIInfrastructure withAllPackageNames,
+		BaselineOfMenuRegistration withAllPackageNames,
 		BaselineOfTraits corePackages,
 		BaselineOfSUnit corePackageNames,
 		BaselineOfDisplay allPackageNames,

--- a/src/Tool-Registry/ManifestToolRegistry.class.st
+++ b/src/Tool-Registry/ManifestToolRegistry.class.st
@@ -1,0 +1,17 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestToolRegistry',
+	#superclass : 'PackageManifest',
+	#category : 'Tool-Registry-Manifest',
+	#package : 'Tool-Registry',
+	#tag : 'Manifest'
+}
+
+{ #category : 'meta-data - dependency analyser' }
+ManifestToolRegistry class >> manuallyResolvedDependencies [
+
+	<ignoreForCoverage>
+	^ #(#'Graphics-Files' #'Kernel-CodeModel' #MenuRegistration)
+]

--- a/src/Tool-Registry/PharoCommonTools.class.st
+++ b/src/Tool-Registry/PharoCommonTools.class.st
@@ -32,8 +32,8 @@ PharoCommonTools class >> initialize [
 
 { #category : 'world menu' }
 PharoCommonTools class >> menuToploOn: aBuilder [
-	<worldMenu>
 
+	<worldMenu>
 	(aBuilder item: #LoadToplo)
 		parent: #Tools;
 		label: 'Load Toplo and Bloc';
@@ -41,11 +41,11 @@ PharoCommonTools class >> menuToploOn: aBuilder [
 		help: 'Load Toplo, a widget framework on top of Bloc.';
 		order: 100;
 		action: [
-			(Smalltalk classNamed: #Metacello) new
-				baseline: 'Toplo';
-				repository: (Smalltalk classNamed: #BaselineOfPharo) toploRepository;
-				onConflictUseIncoming;
-				load ]
+				Metacello new
+					baseline: 'Toplo';
+					repository: (Smalltalk classNamed: #BaselineOfPharo) toploRepository;
+					onConflictUseIncoming;
+					load ]
 ]
 
 { #category : 'system startup' }
@@ -69,17 +69,7 @@ PharoCommonTools class >> worldMenuOn: aBuilder [
 		order: 0;
 		keyText: 'o, b';
 		help: 'System browser to browse and edit code.';
-		iconName: #smallSystemBrowser.
-
-	(aBuilder item: 'Git Repositories Browser')
-		order: 1;
-		iconName: #komitterSmalltalkhubRemote;
-		parent: #Browsing;
-		keyText: 'o, i';
-		help: 'Iceberg is a set of tools that allow one to handle git repositories directly from a Pharo image.';
-		action: [ "Pay attention using newApplication: ... will break IceTipRepositoriesBrowser because it initializes
-			a model."
-			(Smalltalk at: #IceTipRepositoriesBrowser) ensureIsOpen ]
+		iconName: #smallSystemBrowser
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
I propose to moe the loading of Tool-Registry from BaselineOfMorphicCore to BaselineOfUIInfrastructure because it is not linked to Morphic but is used to build UIs. 

I also removed a dependency to Iceberg (It's moved here: https://github.com/pharo-vcs/iceberg/pull/2007)