### PR TITLE
fix announcement for testsuite composite

### DIFF
--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -640,6 +640,12 @@ TestCase >> announcer [
 ]
 
 { #category : 'private' }
+TestCase >> cleanAfterRunOn: aTestSuite [
+
+	aTestSuite cleanTestCase: self
+]
+
+{ #category : 'private' }
 TestCase >> cleanUpInstanceVariables [
 	self class allInstVarNames do: [ :name |
 		(self instanceVariablesToKeep includes: name) ifFalse: [
@@ -784,6 +790,12 @@ TestCase >> prepareToRunAgain [
 	self
 		tearDown;
 		setUp
+]
+
+{ #category : 'private' }
+TestCase >> prepareToRunOn: aTestSuite [
+
+	aTestSuite prepareTestCase: self
 ]
 
 { #category : 'printing' }

--- a/src/SUnit-Core/TestSuite.class.st
+++ b/src/SUnit-Core/TestSuite.class.st
@@ -54,6 +54,26 @@ TestSuite >> announceTest: aTest [
 	^ self testSuiteAnnouncer announce: (TestAnnouncement with: aTest)
 ]
 
+{ #category : 'private' }
+TestSuite >> cleanAfterRunOn: aTestSuite [
+	"as a test suite is in fact a composite (that can have other test suites), 
+	 we visit this suite in the context of its execution"
+
+	aTestSuite cleanTestSuite: self
+]
+
+{ #category : 'private' }
+TestSuite >> cleanTestCase: aTestCase [
+
+	aTestCase class removeSubscription: self testSuiteAnnouncer
+]
+
+{ #category : 'private' }
+TestSuite >> cleanTestSuite: aTestSuite [
+
+	aTestSuite testSuiteAnnouncer: nil
+]
+
 { #category : 'running' }
 TestSuite >> debug [
 	| result |
@@ -95,6 +115,29 @@ TestSuite >> name [
 TestSuite >> name: aString [
 
 	name := aString
+]
+
+{ #category : 'private' }
+TestSuite >> prepareTestCase: aTestCase [
+
+	aTestCase class announcer
+		when: TestCaseAnnouncement 
+		send: #announce: 
+		to: self testSuiteAnnouncer
+]
+
+{ #category : 'private' }
+TestSuite >> prepareTestSuite: aTestSuite [
+	
+	aTestSuite testSuiteAnnouncer: self testSuiteAnnouncer
+]
+
+{ #category : 'private' }
+TestSuite >> prepareToRunOn: aTestSuite [
+	"as a test suite is in fact a composite (that can have other test suites), 
+	 we visit this suite in the context of its execution"
+
+	aTestSuite prepareTestSuite: self
 ]
 
 { #category : 'accessing' }
@@ -146,12 +189,10 @@ TestSuite >> runWith: aBlock [
 	self setUp.
 	[ 
 		self shuffledTests do: [ :each |
-			each class announcer
-				when: TestCaseAnnouncement 
-				send: #announce: 
-				to: self testSuiteAnnouncer.
-			aBlock value: each.
-			each class removeSubscription: self testSuiteAnnouncer.
+			"prepare for testing"
+			each prepareToRunOn: self.
+			[ aBlock value: each ]
+			ensure: [ each cleanAfterRunOn: self ].
 			self announceTest: each ] ]
 	ensure: [ 
 		self tearDown ]
@@ -188,7 +229,14 @@ TestSuite >> tearDown [
 
 { #category : 'announcing' }
 TestSuite >> testSuiteAnnouncer [
+
 	^ announcer ifNil: [ announcer := Announcer new. ]
+]
+
+{ #category : 'tests' }
+TestSuite >> testSuiteAnnouncer: anAnnouncer [
+
+	announcer := anAnnouncer
 ]
 
 { #category : 'accessing' }

--- a/src/SUnit-Tests/TestSuiteTest.class.st
+++ b/src/SUnit-Tests/TestSuiteTest.class.st
@@ -43,6 +43,44 @@ TestSuiteTest >> testAnnouncement [
 ]
 
 { #category : 'tests' }
+TestSuiteTest >> testAnnouncementInCompositeTest [
+	| announcements unitTest suiteTest result |
+	unitTest := ClassFactoryForTestCaseTest.
+	unitTest resetAnnouncer.
+	
+	suiteTest := TestSuite new 
+		addTest: unitTest suite;
+		addTest: unitTest suite;
+		yourself.
+	announcements := Dictionary new.
+
+	suiteTest testSuiteAnnouncer 
+		when: TestCaseAnnouncement 
+		do: [ :ann | (announcements at: ann class ifAbsentPut: [ OrderedCollection new ]) add: ann ] 
+		for: self.
+
+	result := suiteTest run.
+
+	self assertEmpty: result failures.
+	self assertEmpty: result errors.
+
+	self
+		assert: (announcements at: TestCaseStarted ifAbsent: [ #() ]) size
+		equals: (suiteTest tests collect: [ :eachSuite | eachSuite tests size ]) sum.
+	self
+		assert: (announcements at: TestCaseEnded ifAbsent: [ #() ]) size
+		equals: (suiteTest tests collect: [ :eachSuite | eachSuite tests size ]) sum.
+	
+	self assertCollection: announcements keys hasSameElements: {
+			TestCaseStarted.
+			TestCaseEnded.
+			TestSuiteEnded }.
+			
+	"announcer should have been reset after suite execution"
+	self deny: unitTest shouldAnnounce
+]
+
+{ #category : 'tests' }
 TestSuiteTest >> testHistory [
 	| unitTest suiteTest result |
 	

--- a/src/SUnit-Tests/TestSuiteTest.class.st
+++ b/src/SUnit-Tests/TestSuiteTest.class.st
@@ -66,11 +66,11 @@ TestSuiteTest >> testAnnouncementInCompositeTest [
 
 	self
 		assert: (announcements at: TestCaseStarted ifAbsent: [ #() ]) size
-		equals: (suiteTest tests collect: [ :eachSuite | eachSuite tests size ]) sum.
+		equals: (suiteTest tests inject: 0 into: [ :sum :suite | sum + suite tests size ]).
 	self
 		assert: (announcements at: TestCaseEnded ifAbsent: [ #() ]) size
-		equals: (suiteTest tests collect: [ :eachSuite | eachSuite tests size ]) sum.
-	
+		equals: (suiteTest tests inject: 0 into: [ :sum :suite | sum + suite tests size ]). 
+
 	self assertCollection: announcements keys hasSameElements: {
 			TestCaseStarted.
 			TestCaseEnded.


### PR DESCRIPTION
Since testsuites can be composite of other testsuites. Ensure the announcement of tests correctly.

Test validates we can send announcements (and collect them) to a composite of suites.