### PR TITLE
Fix 19023

### DIFF
--- a/src/AST-Core/OCProgramNode.class.st
+++ b/src/AST-Core/OCProgramNode.class.st
@@ -372,6 +372,18 @@ OCProgramNode >> checkFaulty: aBlock [
 ]
 
 { #category : 'accessing' }
+OCProgramNode >> childAtPath: aPath [
+
+	"Return the AST node following aPath from myself.
+	aPath is a list of indexes, each index is the index of the child in the children collection.
+	
+	See #treePath"
+	
+	aPath ifEmpty: [ ^ self ].
+	^ (self children at: aPath first) childAtPath: aPath allButFirst
+]
+
+{ #category : 'accessing' }
 OCProgramNode >> children [
 	^#()
 ]
@@ -1073,8 +1085,12 @@ OCProgramNode >> parserClass [
 
 { #category : 'copying' }
 OCProgramNode >> postCopy [
+	| newComments |
 	super postCopy.
-	properties := properties copy
+	properties := properties copy.
+	newComments := self comments copy.
+	newComments do: [ :e | e parent: self ].
+	self comments: newComments
 ]
 
 { #category : 'accessing' }
@@ -1338,6 +1354,27 @@ OCProgramNode >> tempVariableReadNodes [
 { #category : 'accessing' }
 OCProgramNode >> temporaryVariables [
 	^parent ifNil: [#()] ifNotNil: [parent temporaryVariables]
+]
+
+{ #category : 'accessing' }
+OCProgramNode >> treePath [
+
+	"Return the index path to get to self from the method node.
+	
+	See #childAtPath:"
+	
+	^ self treePathUpTo: self methodNode
+]
+
+{ #category : 'accessing' }
+OCProgramNode >> treePathUpTo: aParent [
+
+	"Return the index path to get to self from aParent.
+	
+	See #childAtPath:"
+
+	aParent == self ifTrue: [ ^ #(  ) ].
+	^ (self parent treePathUpTo: aParent) , { (self parent children indexOf: self) }
 ]
 
 { #category : 'querying' }

--- a/src/DebugInfo/OnlineSourceDebugInfo.class.st
+++ b/src/DebugInfo/OnlineSourceDebugInfo.class.st
@@ -87,11 +87,12 @@ OnlineSourceDebugInfo >> asOfflineDebugInfo [
 						blockBody := astScope node body.
 						blockStatements := blockBody statements.
 						currentScopeBytecodeToASTCache := astScope outerNotOptimizedScope node bcToASTCache.
-						blockStatements ifEmpty: [ mappedPCs := currentScopeBytecodeToASTCache pcsForNode: blockBody ] ifNotEmpty: [
+						blockStatements ifEmpty: [
+							mappedPCs := currentScopeBytecodeToASTCache pcsForNode: blockBody ] ifNotEmpty: [
 								mappedPCs := ((blockStatements flatCollect: [ :e | e withAllChildren ])
 									              flatCollect: [ :e | currentScopeBytecodeToASTCache pcsForNode: e ]
-									              as: Set) sorted.
-								mappedPCs := mappedPCs first to: mappedPCs last ]. "It may happen that no children has a mapping.
+									              as: Set) sorted ].
+						"It may happen that no children has a mapping.
 						This happens when a node is completely optimized out.
 						For example, a statement reading a variable but doing nothing else.
 						In that case, save an empty range"

--- a/src/DebugInfo/OnlineSourceDebugScope.class.st
+++ b/src/DebugInfo/OnlineSourceDebugScope.class.st
@@ -47,9 +47,15 @@ OnlineSourceDebugScope >> readVariableNamed: aName fromContext: aContext [
 { #category : 'api' }
 OnlineSourceDebugScope >> variableNamed: aName [
 
+	^ self variableNamed: aName ifAbsent: [ self error: 'Variable not found: ' , aName ]
+]
+
+{ #category : 'api' }
+OnlineSourceDebugScope >> variableNamed: aName ifAbsent: aBlock [
+
 	^ self variables
 		detect: [ :e | e name = aName ]
-		ifNone: [ self error: 'Variable not found: ', aName  ]
+		ifNone: aBlock
 ]
 
 { #category : 'accessing' }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -480,20 +480,29 @@ OCASTTranslator >> replaceVariables: temporaries using: replacements [
 OCASTTranslator >> replaceVariablesInBlock: anOptimizedBlockNode using: replacements [
 
 	| copiedBody |
-	replacements ifEmpty: [ "Avoid crazy stuff with the AST"
-		^ anOptimizedBlockNode body ].
-
+	replacements ifEmpty: [ ^ anOptimizedBlockNode body ].
+	
 	"Use a copy -> leave the original AST as the original code"
 	copiedBody := anOptimizedBlockNode body copy.
+	
 	replacements keysAndValuesDo: [ :k :v |
-			copiedBody allChildren
-				select: [ :node | node isVariable and: [ node name = k asString ] ]
-				thenDo: [ :node |
-						node name: v asString.
-						node variable ifNotNil: [ :var |
-								var name: v asString.
-								"Rename the temp/arg for copied variables on inner blocks"
-								var originalVar name: v asString ]  ] ].
+			(copiedBody allChildren copyWithout: copiedBody) do: [ :node |
+					| originalNode |
+					
+					node isCommentNode ifFalse: [
+						"Store the original variable node as a property.
+							We need this in the IR metadata.
+						Since renames can happen recursively in the tree, lookup the name in the copies of copies"
+						originalNode := anOptimizedBlockNode body childAtPath: (node treePathUpTo: copiedBody).
+						[originalNode hasProperty: #originalNode]
+							whileTrue: [ originalNode := originalNode propertyAt: #originalNode ].
+						node propertyAt: #originalNode put: originalNode ].
+
+					(node isVariable and: [ node name = k asString ]) ifTrue: [
+							node name: v asString.
+							node variable ifNotNil: [ :var |
+									var name: v asString. "Rename the temp/arg for copied variables on inner blocks"
+									var originalVar name: v asString ] ] ] ].
 
 	^ copiedBody
 ]
@@ -525,6 +534,7 @@ OCASTTranslator >> subTranslator [
 { #category : 'visitor - double dispatching' }
 OCASTTranslator >> translateFullBlock: aBlockNode [
 
+	| originalBlockNode |
 	methodBuilder mapToNode: aBlockNode.
 
 	"args, then copied, then temps"
@@ -541,9 +551,11 @@ OCASTTranslator >> translateFullBlock: aBlockNode [
 	self visitNode: aBlockNode body.
 	methodBuilder mapToNode: aBlockNode body.
 	methodBuilder addBlockReturnTopIfRequired.
-	aBlockNode ir: self ir.
-	aBlockNode resetBcToASTCache.
-	^ aBlockNode ir compiledBlock: aBlockNode scope
+	
+	originalBlockNode := aBlockNode propertyAt: #originalNode ifAbsent: [aBlockNode].
+	originalBlockNode ir: self ir.
+	originalBlockNode resetBcToASTCache.
+	^ originalBlockNode ir compiledBlock: originalBlockNode scope
 ]
 
 { #category : 'visiting' }

--- a/src/OpalCompiler-Core/OCIRBuilder.class.st
+++ b/src/OpalCompiler-Core/OCIRBuilder.class.st
@@ -269,8 +269,7 @@ OCIRBuilder >> mapToByteIndex: index [
 { #category : 'mapping' }
 OCIRBuilder >> mapToNode: object [
 	"new instructions will be associated with object"
-
-	sourceMapNodes addLast: object
+	sourceMapNodes addLast: (object propertyAt: #originalNode ifAbsent: [ object ])
 ]
 
 { #category : 'initialize' }

--- a/src/OpalCompiler-Tests/MethodMapExamples.class.st
+++ b/src/OpalCompiler-Tests/MethodMapExamples.class.st
@@ -171,6 +171,33 @@ MethodMapExamples >> exampleTempNamedTempVectorNestedBlock [
 ]
 
 { #category : 'examples' }
+MethodMapExamples >> exampleWithDoubleHoisting [
+	
+	17 ifNil: [ | a | a yourself ] ifNotNil: [ :a | a yourself ].
+	
+	"This a should be hoisted also and conflict with the two above"
+	17 ifNotNil: [ :a | a yourself ]
+]
+
+{ #category : 'examples' }
+MethodMapExamples >> exampleWithHoisting [
+	
+	17 ifNil: [ | a | a yourself ] ifNotNil: [ :a | a yourself ]
+]
+
+{ #category : 'examples' }
+MethodMapExamples >> exampleWithNestedHoisting [
+
+	17
+		ifNil: [
+				| a |
+				a yourself ]
+		ifNotNil: [ :a |
+			"This a should be hoisted also and conflict with the two above"
+			17 ifNotNil: [ :a | a yourself ] ]
+]
+
+{ #category : 'examples' }
 MethodMapExamples >> helperMethod12 [
 	| i |
 	i := 5.

--- a/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
+++ b/src/OpalCompiler-Tests/OCBytecodeToASTCacheTest.class.st
@@ -184,3 +184,43 @@ OCBytecodeToASTCacheTest >> testPcsForNode [
 		 pcsForAimedNode includes: value ]) do: [ :pc |
 		self deny: (cache nodeForPC: pc) identicalTo: aimedNode ]
 ]
+
+{ #category : 'tests' }
+OCBytecodeToASTCacheTest >> testPcsForNodeWithDoubleHoisting [
+
+	| ifNotNilBlockNode pcsForAimedNode |
+	compiledMethod := MethodMapExamples >> #exampleWithDoubleHoisting.
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.
+	
+	ifNotNilBlockNode := compiledMethod ast statements second arguments first.
+	pcsForAimedNode := cache pcsForNode: ifNotNilBlockNode statements first.
+
+	self deny: pcsForAimedNode isEmpty
+]
+
+{ #category : 'tests' }
+OCBytecodeToASTCacheTest >> testPcsForNodeWithHoisting [
+
+	| ifNotNilBlockNode pcsForAimedNode |
+	compiledMethod := MethodMapExamples >> #exampleWithHoisting.
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.
+	
+	ifNotNilBlockNode := compiledMethod ast statements first arguments second.
+	pcsForAimedNode := cache pcsForNode: ifNotNilBlockNode statements first.
+
+	self deny: pcsForAimedNode isEmpty
+]
+
+{ #category : 'tests' }
+OCBytecodeToASTCacheTest >> testPcsForNodeWithNestedHoisting [
+
+	| ifNotNilBlockNode pcsForAimedNode innerIfNotNilBlockNode |
+	compiledMethod := MethodMapExamples >> #exampleWithNestedHoisting.
+	cache := OCBytecodeToASTCache generateForNode: compiledMethod ast.
+	
+	ifNotNilBlockNode := compiledMethod ast statements first arguments second.
+	innerIfNotNilBlockNode := ifNotNilBlockNode statements first arguments first.
+	pcsForAimedNode := cache pcsForNode: innerIfNotNilBlockNode statements first.
+
+	self deny: pcsForAimedNode isEmpty
+]


### PR DESCRIPTION
Fix #19023

[compiler]
 - transformed AST nodes get to know their original one
 - original AST is used for source mapping
 - make sure full closure AST nodes get the right IR
 - Add tests for bytecode to ast cache in the presence of hoisted variables
 
[Debug info]
- consider blocks with children that are all unmapped (optimized out)
- Improve debug info variable lookup error API

[AST]
-  fix AST comment copy
- Add AST child lookup by index list