### PR TITLE
New rule: Presenter should not redefine `new`

### DIFF
--- a/src/General-Rules-Tests/RePresenterShouldNotRedefineNewTest.class.st
+++ b/src/General-Rules-Tests/RePresenterShouldNotRedefineNewTest.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : 'RePresenterShouldNotRedefineNewTest',
+	#superclass : 'ReAbstractRuleTestCase',
+	#instVars : [
+		'classFactory'
+	],
+	#category : 'General-Rules-Tests-Optimization',
+	#package : 'General-Rules-Tests',
+	#tag : 'Optimization'
+}
+
+{ #category : 'running' }
+RePresenterShouldNotRedefineNewTest >> setUp [
+
+	super setUp.
+	classFactory := ClassFactoryForTestCase new
+]
+
+{ #category : 'running' }
+RePresenterShouldNotRedefineNewTest >> tearDown [
+
+	classFactory cleanUp.
+	super tearDown
+]
+
+{ #category : 'tests' }
+RePresenterShouldNotRedefineNewTest >> testRule [
+
+	| class |
+	class := classFactory make: [ :builder | builder superclass: StPresenter ].
+
+	class compile: 'new ^ 67' classified: 'initialization'.
+
+	self assert: (self myCritiquesOnMethod: class >> #new) size equals: 1
+]
+
+{ #category : 'tests' }
+RePresenterShouldNotRedefineNewTest >> testRuleNotViolated [
+
+	| class |
+	class := classFactory make: [ :builder | builder superclass: StPresenter ].
+
+	class compile: 'method ^ 15' classified: 'initialization'.
+
+	self assertEmpty: (self myCritiquesOnMethod: class >> #method)
+]

--- a/src/General-Rules/RePresenterShouldNotRedefineNew.class.st
+++ b/src/General-Rules/RePresenterShouldNotRedefineNew.class.st
@@ -1,0 +1,34 @@
+"
+This rule warn the user if `new` method is redefined in a StPresenter subclass. 
+Presenters should not define `new` again since they inherit from StPresenter `new` method.
+"
+Class {
+	#name : 'RePresenterShouldNotRedefineNew',
+	#superclass : 'ReNodeBasedRule',
+	#category : 'General-Rules-Optimization',
+	#package : 'General-Rules',
+	#tag : 'Optimization'
+}
+
+{ #category : 'accessing' }
+RePresenterShouldNotRedefineNew class >> ruleName [ 
+
+	^ 'A presenter should not redefine "new" method'
+
+]
+
+{ #category : 'accessing' }
+RePresenterShouldNotRedefineNew class >> severity [
+
+	^ #warning
+]
+
+{ #category : 'running' }
+RePresenterShouldNotRedefineNew >> basicCheck: aNode [
+
+	| class |
+	aNode isMethod ifFalse: [ ^ false ].
+	aNode methodNode selector = #new ifFalse: [ ^ false ].
+	class := aNode methodClass instanceSide.
+	^ class inheritsFrom: StPresenter 
+]


### PR DESCRIPTION
This is a good indicator  for the user to not do this, since the application is given in `new` method of StPresenter.
Fixes #18675