### PR TITLE
[P14] 19033-SDL-window-freezes-after-suspended-context-on-Windows

### DIFF
--- a/src/OSWindow-Core/OSWorldRenderer.class.st
+++ b/src/OSWindow-Core/OSWorldRenderer.class.st
@@ -65,13 +65,22 @@ OSWorldRenderer class >> priority [
 { #category : 'start' }
 OSWorldRenderer class >> restart [
 
+	| oldWindows |
 	UIManager default deactivate.
+
+	"We need to keep all open windows, after the restart if they are still valid we register them back. If we don't do this the events for these windows are never delivered."
+	oldWindows := OSSDL2Driver allWindows.
+
 	self shutDown: true.
 	OSSDL2Driver shutDown: true.
 
 	self startUp: true.
 	UIManager default activate.
-	
+
+	oldWindows 
+	 select: [ :e | e sdl2Window isNotNil ]
+	 thenDo: [ :e | OSSDL2Driver current registerWindow: e ].
+
 	InformativeNotification signal: self class name , ' restarted'
 ]
 


### PR DESCRIPTION
Fix #19033

When we restart the World Renderer, we have to keep the old existing SDL windows, we were only handling the World Window only