### PR TITLE
Metacello: Remove support of #supplyingAnswers:

### DIFF
--- a/src/Deprecated14/MetacelloAbstractVersionConstructor.extension.st
+++ b/src/Deprecated14/MetacelloAbstractVersionConstructor.extension.st
@@ -43,3 +43,9 @@ MetacelloAbstractVersionConstructor >> setTimestampWithBlock: aBlock [
 		self root timestamp: spec ].
 	self with: spec during: aBlock
 ]
+
+{ #category : '*Deprecated14' }
+MetacelloAbstractVersionConstructor >> supplyingAnswers: aCollection [
+
+	self deprecated: 'This option is not available anymore since multiple versions of Pharo.'
+]

--- a/src/Metacello-Core/MetacelloAbstractPackageSpec.class.st
+++ b/src/Metacello-Core/MetacelloAbstractPackageSpec.class.st
@@ -4,8 +4,7 @@ Class {
 	#instVars : [
 		'name',
 		'requires',
-		'includes',
-		'answers'
+		'includes'
 	],
 	#category : 'Metacello-Core-Specs',
 	#package : 'Metacello-Core',
@@ -22,62 +21,38 @@ MetacelloAbstractPackageSpec >> addToMetacelloPackages: aMetacelloPackagesSpec [
 			yourself)
 ]
 
-{ #category : 'querying' }
-MetacelloAbstractPackageSpec >> answers [
+{ #category : 'Protocol (printing) - 4 selector(s)' }
+MetacelloAbstractPackageSpec >> configMethodBodyOn: aStream hasName: hasName cascading: hasCascading indent: indent [
 
-	^answers ifNil: [ answers := #() ].
-]
-
-{ #category : 'accessing' }
-MetacelloAbstractPackageSpec >> answers: aListOfPairs [
-
-	self setAnswers: aListOfPairs
-]
-
-{ #category : 'printing' }
-MetacelloAbstractPackageSpec >> configMethodBodyOn: aStream hasName: hasName cascading: cascading indent: indent [
-
-	| hasCascading hasRequires hasIncludes hasAnswers |
-	hasCascading := cascading.
-	hasRequires := self requires isEmpty not.
-	hasIncludes := self includes isEmpty not.
-	hasAnswers := self answers isEmpty not.
-	hasRequires
-		ifTrue: [ 
-			hasName | hasIncludes | hasAnswers | hasCascading
-				ifTrue: [ aStream cr; tab: indent ].
+	| hasRequires hasIncludes |
+	hasRequires := self requires isNotEmpty.
+	hasIncludes := self includes isNotEmpty.
+	hasRequires ifTrue: [
+			hasName | hasIncludes | hasCascading ifTrue: [
+					aStream
+						cr;
+						tab: indent ].
 			aStream nextPutAll: 'requires: #('.
-			self requires do: [:str | aStream nextPutAll: str printString, ' ' ].
-			hasIncludes | hasAnswers | hasCascading
+			self requires do: [ :str |
+					aStream
+						print: str;
+						nextPutAll: ' ' ].
+			hasIncludes | hasCascading
 				ifTrue: [ aStream nextPutAll: ');' ]
-				ifFalse: [ aStream nextPut: $) ]].
-	hasIncludes
-		ifTrue: [ 
-			hasName | hasRequires | hasAnswers | hasCascading
-				ifTrue: [ aStream cr; tab: indent ].
+				ifFalse: [ aStream nextPut: $) ] ].
+	hasIncludes ifTrue: [
+			hasName | hasRequires | hasCascading ifTrue: [
+					aStream
+						cr;
+						tab: indent ].
 			aStream nextPutAll: 'includes: #('.
-			self includes do: [:str | aStream nextPutAll: str printString, ' ' ].
-			hasAnswers | hasCascading
-				ifTrue: [ aStream nextPutAll: ');' ]
-				ifFalse: [ aStream nextPut: $) ]].
-	hasAnswers
-		ifTrue: [ 
-			hasName | hasRequires | hasIncludes | hasCascading
-				ifTrue: [ aStream cr; tab: indent ].
-			aStream nextPutAll: 'supplyingAnswers: #( '.
-			self answers do: [:ar | 
-				aStream nextPutAll: '#( '.
-				ar do: [:val | 
-					(val isString or: [ val isNumber or: [ val isSymbol or: [ val isCharacter ]]])
-						ifTrue: [  aStream nextPutAll: val printString, ' ' ].
-					val == true
-						ifTrue: [  aStream nextPutAll: 'true ' ].
-					val == false
-						ifTrue: [  aStream nextPutAll: 'false ' ]].
-				aStream nextPutAll: ') ' ].
+			self includes do: [ :str |
+					aStream
+						print: str;
+						nextPutAll: ' ' ].
 			hasCascading
 				ifTrue: [ aStream nextPutAll: ');' ]
-				ifFalse: [ aStream nextPut: $) ]].
+				ifFalse: [ aStream nextPut: $) ] ]
 ]
 
 { #category : 'printing' }
@@ -172,7 +147,6 @@ MetacelloAbstractPackageSpec >> mergeMap [
 	map := super mergeMap.
 	map at: #requires put: requires.
 	map at: #includes put: includes.
-	map at: #answers put: answers.
 	^map
 ]
 
@@ -185,7 +159,6 @@ MetacelloAbstractPackageSpec >> mergeSpec: anotherSpec [
 	anotherSpec name ifNotNil: [ newSpec name: anotherSpec name ].
 	(map at: #requires) ifNotNil: [ :anotherRequires | newSpec setRequires: self requires , anotherRequires ].
 	(map at: #includes) ifNotNil: [ :anotherIncludes | newSpec setIncludes: self includes , anotherIncludes ].
-	(map at: #answers) ifNotNil: [ :anotherAnswers | newSpec setAnswers: self answers , anotherAnswers ].
 	^ newSpec
 ]
 
@@ -205,7 +178,7 @@ MetacelloAbstractPackageSpec >> name: aString [
 { #category : 'merging' }
 MetacelloAbstractPackageSpec >> nonOverridable [
 
-	^#( includes requires answers )
+	^#( includes requires )
 ]
 
 { #category : 'copying' }
@@ -213,8 +186,7 @@ MetacelloAbstractPackageSpec >> postCopy [
 
 	super postCopy.
 	requires := requires copy.
-	includes := includes copy.
-	answers := answers copy.
+	includes := includes copy
 ]
 
 { #category : 'visiting' }
@@ -293,12 +265,6 @@ MetacelloAbstractPackageSpec >> resolveToPackagesAndProjectsIn: aVersionSpec  vi
 MetacelloAbstractPackageSpec >> resolveToPackagesIn: aVersionSpec visited: visited [
 
 	^self subclassResponsibility
-]
-
-{ #category : 'private' }
-MetacelloAbstractPackageSpec >> setAnswers: aCollection [
-
-	answers := aCollection
 ]
 
 { #category : 'private' }

--- a/src/Metacello-Core/MetacelloAbstractVersionConstructor.class.st
+++ b/src/Metacello-Core/MetacelloAbstractVersionConstructor.class.st
@@ -604,12 +604,6 @@ MetacelloAbstractVersionConstructor >> setProject: aProject [
 	project := aProject
 ]
 
-{ #category : 'api' }
-MetacelloAbstractVersionConstructor >> supplyingAnswers: aCollection [
-
-	self root answers: aCollection
-]
-
 { #category : 'accessing' }
 MetacelloAbstractVersionConstructor >> symbolicVersion [
 

--- a/src/Metacello-Core/MetacelloGroupSpec.class.st
+++ b/src/Metacello-Core/MetacelloGroupSpec.class.st
@@ -12,12 +12,6 @@ MetacelloGroupSpec >> acceptVisitor: aVisitor [
 	^ aVisitor visitGroupSpec: self
 ]
 
-{ #category : 'accessing' }
-MetacelloGroupSpec >> answers: aListOfPairs [
-
-	self shouldNotImplement
-]
-
 { #category : 'printing' }
 MetacelloGroupSpec >> configMethodCascadeOn: aStream member: aMember last: lastCascade indent: indent [
 

--- a/src/Metacello-Core/MetacelloPackageSpec.class.st
+++ b/src/Metacello-Core/MetacelloPackageSpec.class.st
@@ -22,13 +22,13 @@ MetacelloPackageSpec >> acceptVisitor: aVisitor [
 { #category : 'printing' }
 MetacelloPackageSpec >> configMethodBodyOn: aStream hasName: hasName indent: indent [
 
-	| hasFile hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludesOrAnswers |
+	| hasFile hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes |
 	hasFile := file isNotNil.
 	hasRepositories := self repositorySpecs size > 0.
 	hasPreLoadDoIt := self getPreLoadDoIt isNotNil.
 	hasPostLoadDoIt := self getPostLoadDoIt isNotNil.
-	hasRequiresOrIncludesOrAnswers := (self requires isEmpty and: [ self includes isEmpty and: [ self answers isEmpty ] ]) not.
-	hasRequiresOrIncludesOrAnswers ifTrue: [
+	hasRequiresOrIncludes := (self requires isEmpty and: [ self includes isEmpty ]) not.
+	hasRequiresOrIncludes ifTrue: [
 		self
 			configMethodBodyOn: aStream
 			hasName: hasName
@@ -38,13 +38,13 @@ MetacelloPackageSpec >> configMethodBodyOn: aStream hasName: hasName indent: ind
 		configMethodOn: aStream
 		for: file
 		selector: 'file: '
-		cascading: hasName | hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludesOrAnswers
+		cascading: hasName | hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes
 		cascade: hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt
 		indent: indent.
 	hasRepositories ifTrue: [
 		self repositorySpecs size > 1
 			ifTrue: [
-				hasName | hasFile | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludesOrAnswers ifTrue: [
+				hasName | hasFile | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes ifTrue: [
 					aStream
 						cr;
 						tab: indent ].
@@ -57,7 +57,7 @@ MetacelloPackageSpec >> configMethodBodyOn: aStream hasName: hasName indent: ind
 				self repositories configMethodCascadeOn: aStream indent: indent + 1.
 				aStream nextPutAll: ' ]' ]
 			ifFalse: [
-				hasName | hasFile | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludesOrAnswers ifTrue: [
+				hasName | hasFile | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes ifTrue: [
 					aStream
 						cr;
 						tab: indent ].
@@ -67,14 +67,14 @@ MetacelloPackageSpec >> configMethodBodyOn: aStream hasName: hasName indent: ind
 		configMethodOn: aStream
 		for: self getPreLoadDoIt
 		selector: 'preLoadDoIt: '
-		cascading: hasName | hasFile | hasRepositories | hasPostLoadDoIt | hasRequiresOrIncludesOrAnswers
+		cascading: hasName | hasFile | hasRepositories | hasPostLoadDoIt | hasRequiresOrIncludes
 		cascade: hasPostLoadDoIt
 		indent: indent.
 	self
 		configMethodOn: aStream
 		for: self getPostLoadDoIt
 		selector: 'postLoadDoIt: '
-		cascading: hasName | hasFile | hasRepositories | hasPreLoadDoIt | hasRequiresOrIncludesOrAnswers
+		cascading: hasName | hasFile | hasRepositories | hasPreLoadDoIt | hasRequiresOrIncludes
 		cascade: false
 		indent: indent.
 	aStream nextPut: $.
@@ -94,16 +94,16 @@ MetacelloPackageSpec >> configMethodCascadeOn: aStream member: aMember last: las
 { #category : 'printing' }
 MetacelloPackageSpec >> configMethodOn: aStream indent: indent [
 
-	| hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludesOrAnswers hasFile |
+	| hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes hasFile |
 	hasFile := file isNotNil.
 	hasRepositories := self repositorySpecs size > 0.
 	hasPreLoadDoIt := self getPreLoadDoIt isNotNil.
 	hasPostLoadDoIt := self getPostLoadDoIt isNotNil.
-	hasRequiresOrIncludesOrAnswers := (self requires isEmpty and: [ self includes isEmpty and: [ self answers isEmpty ] ]) not.
+	hasRequiresOrIncludes := (self requires isEmpty and: [ self includes isEmpty ]) not.
 	aStream
 		tab: indent;
 		nextPutAll: 'spec '.
-	hasFile | hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludesOrAnswers
+	hasFile | hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes
 		ifTrue: [
 			aStream
 				cr;
@@ -117,13 +117,13 @@ MetacelloPackageSpec >> configMethodOn: aStream indent: indent [
 { #category : 'printing' }
 MetacelloPackageSpec >> configShortCutMethodBodyOn: aStream member: aMember indent: indent [
 
-	| hasFile hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludesOrAnswers |
+	| hasFile hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes |
 	hasFile := file isNotNil.
 	hasRepositories := self repositorySpecs size > 0.
 	hasPreLoadDoIt := self getPreLoadDoIt isNotNil.
 	hasPostLoadDoIt := self getPostLoadDoIt isNotNil.
-	hasRequiresOrIncludesOrAnswers := (self requires isEmpty and: [ self includes isEmpty and: [ self answers isEmpty ] ]) not.
-	hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludesOrAnswers ifTrue: [
+	hasRequiresOrIncludes := (self requires isEmpty and: [ self includes isEmpty ]) not.
+	hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes ifTrue: [
 		aStream
 			nextPutAll: 'package: ' , self name printString , ' ';
 			nextPutAll: aMember methodUpdateSelector asString , ' [';

--- a/src/Metacello-Core/MetacelloProjectReferenceSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectReferenceSpec.class.st
@@ -20,12 +20,6 @@ MetacelloProjectReferenceSpec >> acceptVisitor: aVisitor [
 	^ aVisitor visitProjectReference: self
 ]
 
-{ #category : 'accessing' }
-MetacelloProjectReferenceSpec >> answers: aListOfPairs [
-
-	self shouldNotImplement
-]
-
 { #category : 'printing' }
 MetacelloProjectReferenceSpec >> configMethodCascadeOn: aStream member: aMember last: lastCascade indent: indent [
 

--- a/src/Metacello-Core/MetacelloSpec.class.st
+++ b/src/Metacello-Core/MetacelloSpec.class.st
@@ -34,12 +34,6 @@ MetacelloSpec >> addMember [
 	^MetacelloAddMemberSpec for: self project
 ]
 
-{ #category : 'querying' }
-MetacelloSpec >> answers [
-
-	^#()
-]
-
 { #category : 'printing' }
 MetacelloSpec >> configMethodOn: aStream indent: indent [
 

--- a/src/Metacello-TestsCore/MetacelloGroupSpecTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloGroupSpecTestCase.class.st
@@ -38,6 +38,5 @@ MetacelloGroupSpecTestCase >> testGroupSpec [
 	self assert: group name equals: 'Platform'.
 	self assert: (group includes includes: 'Core').
 	self should: [ group requires: #() ] raise: Error.
-	self should: [ group answers: #() ] raise: Error.
 	group projectDo: [ :ignored | self assert: false ] packageDo: [ :ignored | self assert: false ] groupDo: [ :grp | self assert: group identicalTo: grp ]
 ]

--- a/src/Metacello-TestsCore/MetacelloPackagesSpecTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloPackagesSpecTestCase.class.st
@@ -62,7 +62,6 @@ MetacelloPackagesSpecTestCase >> testAddPackageA [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
 				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
@@ -73,14 +72,12 @@ MetacelloPackagesSpecTestCase >> testAddPackageA [
 				name: 'Package';
 				requires: 'AndAnotherPackage';
 				includes: 'AndIncludedPackage';
-				answers: #(#('postload' 'postload answer'));
 				file: 'Package-dkh.2';
 				yourself).
 	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AndAnotherPackage').
 	self assert: package includes equals: #('AndIncludedPackage').
-	self assert: package answers equals: #(#('postload' 'postload answer')).
 	self assert: package file equals: 'Package-dkh.2'.
 	self assert: package preLoadDoIt value identicalTo: nil.
 	self assert: package postLoadDoIt value identicalTo: nil
@@ -98,7 +95,6 @@ MetacelloPackagesSpecTestCase >> testAddPackageB [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
 				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
@@ -106,14 +102,12 @@ MetacelloPackagesSpecTestCase >> testAddPackageB [
 				name: 'Package';
 				requires: 'AndAnotherPackage';
 				includes: 'AndIncludedPackage';
-				answers: #(#('postload' 'postload answer'));
 				file: 'Package-dkh.2';
 				yourself)}.
 	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AndAnotherPackage').
 	self assert: package includes equals: #('AndIncludedPackage').
-	self assert: package answers equals: #(#('postload' 'postload answer')).
 	self assert: package file equals: 'Package-dkh.2'.
 	self assert: package preLoadDoIt value identicalTo: nil.
 	self assert: package postLoadDoIt value identicalTo: nil
@@ -177,7 +171,6 @@ MetacelloPackagesSpecTestCase >> testAddProjectA [
 	self assert: projectReferenceSpec versionString equals: '1.0'.
 	self should: [ projectReferenceSpec includes: #() ] raise: Error.
 	self should: [ projectReferenceSpec requires: #() ] raise: Error.
-	self should: [ projectReferenceSpec answers: #() ] raise: Error.
 	projectReferenceSpec
 		projectDo: [ :prjct | self assert: projectReferenceSpec identicalTo: prjct ]
 		packageDo: [ :ignored | self assert: false ]
@@ -222,7 +215,6 @@ MetacelloPackagesSpecTestCase >> testAddProjectB [
 	self assert: projectReferenceSpec versionString equals: '1.0'.
 	self should: [ projectReferenceSpec includes: #() ] raise: Error.
 	self should: [ projectReferenceSpec requires: #() ] raise: Error.
-	self should: [ projectReferenceSpec answers: #() ] raise: Error.
 	projectReferenceSpec
 		projectDo: [ :prjct | self assert: projectReferenceSpec identicalTo: prjct ]
 		packageDo: [ :ignored | self assert: false ]
@@ -282,7 +274,6 @@ MetacelloPackagesSpecTestCase >> testCopyToPackage [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
 				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
@@ -297,7 +288,6 @@ MetacelloPackagesSpecTestCase >> testCopyToPackage [
 	self assert: package name equals: 'PackageCopy'.
 	self assert: package requires equals: #('AnotherPackage').
 	self assert: package includes equals: #('IncludedPackage').
-	self assert: package answers equals: #(#('preload' 'preload answer') #('postload' 'postload answer')).
 	self assert: package file equals: 'Package-dkh.1'.
 	self assert: package preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: package postLoadDoIt value identicalTo: #postLoadDoIt
@@ -395,7 +385,6 @@ MetacelloPackagesSpecTestCase >> testMergePackageA [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
 				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
@@ -406,14 +395,12 @@ MetacelloPackagesSpecTestCase >> testMergePackageA [
 				name: 'Package';
 				requires: 'AndAnotherPackage';
 				includes: 'AndIncludedPackage';
-				answers: #(#('xpostload' 'xpostload answer'));
 				file: 'Package-dkh.2';
 				yourself).
 	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AnotherPackage' 'AndAnotherPackage').
 	self assert: package includes equals: #('IncludedPackage' 'AndIncludedPackage').
-	self assert: package answers equals: #(#('preload' 'preload answer') #('postload' 'postload answer') #('xpostload' 'xpostload answer')).
 	self assert: package file equals: 'Package-dkh.2'.
 	self assert: package preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: package postLoadDoIt value identicalTo: #postLoadDoIt
@@ -431,7 +418,6 @@ MetacelloPackagesSpecTestCase >> testMergePackageB [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
 				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
@@ -442,14 +428,12 @@ MetacelloPackagesSpecTestCase >> testMergePackageB [
 				name: 'Package';
 				requires: 'AndAnotherPackage';
 				includes: 'AndIncludedPackage';
-				answers: #(#('xpostload' 'xpostload answer'));
 				file: 'Package-dkh.2';
 				yourself)}.
 	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AnotherPackage' 'AndAnotherPackage').
 	self assert: package includes equals: #('IncludedPackage' 'AndIncludedPackage').
-	self assert: package answers equals: #(#('preload' 'preload answer') #('postload' 'postload answer') #('xpostload' 'xpostload answer')).
 	self assert: package file equals: 'Package-dkh.2'.
 	self assert: package preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: package postLoadDoIt value identicalTo: #postLoadDoIt
@@ -566,7 +550,6 @@ MetacelloPackagesSpecTestCase >> testPackageMergeSpec [
 		name: 'Package';
 		requires: 'AnotherPackage';
 		includes: 'IncludedPackage';
-		answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
 		file: 'Package-dkh.1';
 		preLoadDoIt: #preLoadDoIt;
 		postLoadDoIt: #postLoadDoIt;
@@ -577,7 +560,6 @@ MetacelloPackagesSpecTestCase >> testPackageMergeSpec [
 		name: 'Package';
 		requires: 'AndAnotherPackage';
 		includes: 'AndIncludedPackage';
-		answers: #(#('xpostload' 'xpostload answer'));
 		file: 'Package-dkh.2';
 		repository: 'http://example.com/repository' username: 'DaleHenrichs' password: 'secret';
 		repository: '/opt/gemstone/repo';
@@ -586,7 +568,6 @@ MetacelloPackagesSpecTestCase >> testPackageMergeSpec [
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AnotherPackage' 'AndAnotherPackage').
 	self assert: package includes equals: #('IncludedPackage' 'AndIncludedPackage').
-	self assert: package answers equals: #(#('preload' 'preload answer') #('postload' 'postload answer') #('xpostload' 'xpostload answer')).
 	self assert: package file equals: 'Package-dkh.2'.
 	self assert: package preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: package postLoadDoIt value identicalTo: #postLoadDoIt.
@@ -607,7 +588,6 @@ MetacelloPackagesSpecTestCase >> testPackageSpec [
 		name: 'Package';
 		requires: 'AnotherPackage';
 		includes: 'IncludedPackage';
-		answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
 		file: 'Package-dkh.1';
 		preLoadDoIt: #preLoadDoIt;
 		postLoadDoIt: #postLoadDoIt;
@@ -617,7 +597,6 @@ MetacelloPackagesSpecTestCase >> testPackageSpec [
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AnotherPackage').
 	self assert: package includes equals: #('IncludedPackage').
-	self assert: package answers equals: #(#('preload' 'preload answer') #('postload' 'postload answer')).
 	self assert: package file equals: 'Package-dkh.1'.
 	self assert: package preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: package postLoadDoIt value identicalTo: #postLoadDoIt.
@@ -740,7 +719,6 @@ MetacelloPackagesSpecTestCase >> testRemovePackageA [
                 name: 'Package';
                 requires: 'AnotherPackage';
                 includes: 'IncludedPackage';
-                answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
                 file: 'Package-dkh.1';
                 preLoadDoIt: #'preLoadDoIt';
                 postLoadDoIt: #'postLoadDoIt';
@@ -767,7 +745,6 @@ MetacelloPackagesSpecTestCase >> testRemovePackageB [
                 name: 'Package';
                 requires: 'AnotherPackage';
                 includes: 'IncludedPackage';
-                answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
                 file: 'Package-dkh.1';
                 preLoadDoIt: #'preLoadDoIt';
                 postLoadDoIt: #'postLoadDoIt';
@@ -794,7 +771,6 @@ MetacelloPackagesSpecTestCase >> testRemovePackageC [
                 name: 'Package';
                 requires: 'AnotherPackage';
                 includes: 'IncludedPackage';
-                answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
                 file: 'Package-dkh.1';
                 preLoadDoIt: #'preLoadDoIt';
                 postLoadDoIt: #'postLoadDoIt';
@@ -817,7 +793,6 @@ MetacelloPackagesSpecTestCase >> testRemovePackageD [
                 name: 'Package';
                 requires: 'AnotherPackage';
                 includes: 'IncludedPackage';
-                answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
                 file: 'Package-dkh.1';
                 preLoadDoIt: #'preLoadDoIt';
                 postLoadDoIt: #'postLoadDoIt';

--- a/src/Metacello-TestsCore/MetacelloProjectReferenceSpecTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloProjectReferenceSpecTestCase.class.st
@@ -52,7 +52,6 @@ MetacelloProjectReferenceSpecTestCase >> testProjectReferenceSpec [
 	self assert: projectReference projectReference identicalTo: project.
 	self should: [ projectReference includes: #() ] raise: Error.
 	self should: [ projectReference requires: #() ] raise: Error.
-	self should: [ projectReference answers: #() ] raise: Error.
 	projectReference
 		projectDo: [ :prjct | self assert: projectReference identicalTo: prjct ]
 		packageDo: [ :ignored | self assert: false ]

--- a/src/Metacello-TestsCore/MetacelloProjectSpecTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloProjectSpecTestCase.class.st
@@ -93,7 +93,6 @@ MetacelloProjectSpecTestCase >> testProjectSpec [
 	self assert: project postLoadDoIt value identicalTo: #postLoadDoIt.
 	self should: [ project includes: #() ] raise: Error.
 	self should: [ project requires: #() ] raise: Error.
-	self should: [ project answers: #() ] raise: Error.
 	project projectDo: [ :prjct | self assert: project identicalTo: prjct ] packageDo: [ :ignored | self assert: false ] groupDo: [ :ignored | self assert: false ].
 	self should: [ project preLoadDoIt: '' ] raise: Error.
 	self should: [ project postLoadDoIt: '' ] raise: Error

--- a/src/Metacello-TestsCore/MetacelloVersionSpecTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloVersionSpecTestCase.class.st
@@ -164,7 +164,6 @@ MetacelloVersionSpecTestCase >> testVersionSpec2 [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				answers: #(#('preload' 'preload answer') #('postload' 'postload answer'));
 				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;

--- a/src/Metacello-TestsReference/MetacelloReferenceTestCase.class.st
+++ b/src/Metacello-TestsReference/MetacelloReferenceTestCase.class.st
@@ -83,7 +83,6 @@ spec
 		spec 
 			requires: #(''Example-Core'' ''UI Support'' );
 			includes: #(''Example-UI'' );
-			supplyingAnswers: #( #( ''list of packages'' ''Kernel* Collection*'' ) );
 			file: ''Example-AddOn-anon.7'';
 			repository: ''http://www.example.com/or'' username: ''foo'' password: ''bar'';
 			preLoadDoIt: #''preloadForAddOn'';
@@ -113,7 +112,6 @@ MetacelloReferenceTestCase >> testReferenceConfig [
 	name: ''Example-AddOn'';
 	requires: #(''Example-Core'' ''UI Support'' );
 	includes: #(''Example-UI'' );
-	supplyingAnswers: #( #( ''list of packages'' ''Kernel* Collection*'' ) );
 	file: ''Example-AddOn-anon.5'';
 	repository: ''http://www.example.com/or'' username: ''foo'' password: ''bar'';
 	preLoadDoIt: #''preloadForAddOn'';


### PR DESCRIPTION
I am doing a big cleaning of Metacello but to make it easier to review I'm starting to split it into smaller PRs.

The #supplyingAnswers: option is not used in Metacello internals since Pharo 11. This change is announcing to the user the uselessness of this feature and cleans the code of Metacello