### PR TITLE
Change template for startup actions to not overwrite settings

### DIFF
--- a/src/StartupPreferences/StartupPreferencesLoader.class.st
+++ b/src/StartupPreferences/StartupPreferencesLoader.class.st
@@ -416,15 +416,16 @@ StartupPreferencesLoader >> templateString [
 	^ 'StartupPreferencesLoader default executeAtomicItems: {
 	StartupAction 
 		name: ''Logo'' 
-		code: [ PolymorphSystemSettings showDesktopLogo: false] .
+		code: [ " PolymorphSystemSettings showDesktopLogo: false " ] .
 	StartupAction 
 		name: ''Git Settings'' 
 		code: [ 
+"
 			Iceberg enableMetacelloIntegration: true.
 			IceCredentialsProvider sshCredentials
 					username: ''git'';
 					publicKey: ''/Users/XXX/.ssh/id_rsa.pub'';
-					privateKey: ''/Users/XX/.ssh/id_rsa''.
+					privateKey: ''/Users/XXX/.ssh/id_rsa''.
 			IceCredentialStore current
 					storeCredential: (IcePlaintextCredentials new
 					username: ''GHUSER'';
@@ -439,6 +440,7 @@ StartupPreferencesLoader >> templateString [
 					token: ''YOUR TOKEN'';
 					yourself) 
 				forHostname: ''github.com''.
+"
 			]. 
 }.'
 ]


### PR DESCRIPTION
The strange behaviour was triggered by a startup action that was defined by "World Menu | System | Startup | Define a global preference file".  The startup action overwrites my settings on every startup with gibberish values.

This is entirely my fault, I must have triggered the World Menu item "System | Startup | Define a global preference file" at leas twice on different computers. (I was using the other menu entries often.)  I also must have ignored the inspector that opens up.

It's not a bug, but I think changing the template string to something that does not overwrite settings would be a good idea.  It cost me some time to figure out what was going on 