### PR TITLE
Metacello: Deprecate configuration API

### DIFF
--- a/src/Deprecated14/MetacelloAbstractVersionConstructor.extension.st
+++ b/src/Deprecated14/MetacelloAbstractVersionConstructor.extension.st
@@ -1,51 +1,49 @@
 Extension { #name : 'MetacelloAbstractVersionConstructor' }
 
 { #category : '*Deprecated14' }
-MetacelloAbstractVersionConstructor >> setAuthorWithBlock: aBlock [
+MetacelloAbstractVersionConstructor >> author: aBlockOrString [
 
-	| spec |
-	self deprecated: 'Author should be provided as a string and not a block since it brind not value.'.
-	(spec := self root getAuthor) ifNil: [
-		spec := self project valueHolderSpec.
-		self root author: spec ].
-	self with: spec during: aBlock
+	self deprecated: 'The author metadata is not supported anymore. It was used with SmalltalkHub but not this information is already managed by git or other CVS.
+	If you wish to keep this as a trace, you can leave the infos in a method comment.'
 ]
 
 { #category : '*Deprecated14' }
-MetacelloAbstractVersionConstructor >> setBlessingWithBlock: aBlock [
+MetacelloAbstractVersionConstructor >> blessing: aBlockOrString [
 
-	| spec |
-	self deprecated: 'Blessing should be provided as a string and not a block since it brind not value.'.
-	(spec := self root getBlessing) ifNil: [
-		spec := self project valueHolderSpec.
-		self root blessing: spec ].
-	self with: spec during: aBlock
+	self deprecated: 'The blessing metadata is not supported anymore.'
 ]
 
 { #category : '*Deprecated14' }
-MetacelloAbstractVersionConstructor >> setDescriptionWithBlock: aBlock [
+MetacelloAbstractVersionConstructor >> configuration: aString with: aBlock [
 
-	| spec |
-	self deprecated: 'Description should be provided as a string and not a block since it brind not value.'.
-	(spec := self root getDescription) ifNil: [
-		spec := self project valueHolderSpec.
-		self root description: spec ].
-	self with: spec during: aBlock
+	self error: 'Configurations are not supported anymore, only baseline can be used as dependencies.'
 ]
 
 { #category : '*Deprecated14' }
-MetacelloAbstractVersionConstructor >> setTimestampWithBlock: aBlock [
+MetacelloAbstractVersionConstructor >> description: aBlockOrString [
 
-	| spec |
-	self deprecated: 'Timestamp should be provided as a string and not a block since it brind not value.'.
-	(spec := self root getTimestamp) ifNil: [
-		spec := self project valueHolderSpec.
-		self root timestamp: spec ].
-	self with: spec during: aBlock
+	self deprecated:
+		'The description metadata is not supported anymore. It was used with SmalltalkHub but not this information is already managed by git or other CVS.
+	If you wish to keep this as a trace, you can leave the infos in a method comment.'
 ]
 
 { #category : '*Deprecated14' }
 MetacelloAbstractVersionConstructor >> supplyingAnswers: aCollection [
 
 	self deprecated: 'This option is not available anymore since multiple versions of Pharo.'
+]
+
+{ #category : '*Deprecated14' }
+MetacelloAbstractVersionConstructor >> timestamp: aBlockOrStringOrDateAndTime [
+
+	self deprecated:
+		'The timestamp metadata is not supported anymore. It was used with SmalltalkHub but not this information is already managed by git or other CVS.
+	If you wish to keep this as a trace, you can leave the infos in a method comment.'
+]
+
+{ #category : '*Deprecated14' }
+MetacelloAbstractVersionConstructor >> versionString: anObject [
+
+	self error:
+		'Configurations are not supported anymore, only baseline can be used as dependencies and project managed with baseline have their version managed by the repositories.'
 ]

--- a/src/Metacello-Base/ConfigurationOf.class.st
+++ b/src/Metacello-Base/ConfigurationOf.class.st
@@ -82,32 +82,12 @@ ConfigurationOf class >> unloadMetacello [
 	(self packageOrganizer packages select: [ :package | package name beginsWith: 'Metacello' ]) do: [ :package | package removeFromSystem ]
 ]
 
-{ #category : 'defaults' }
-ConfigurationOf >> bleedingEdge [ 
-	"override if different behavior desired.
-	 Use:
-		self versionDoesNotExistError: #bleedingEdge
-	 if #bleedingEdge version is disallowed."
-
-	<defaultSymbolicVersion: #bleedingEdge>
-	
-	^self defaultBleedingEdgeVersion
-]
-
 { #category : 'accessing' }
 ConfigurationOf >> customProjectAttributes [
     "Edit to return a collection of any custom attributes e.g. for conditional loading: Array with: #'Condition1' with: #'Condition2.
 	For more information see: http://code.google.com/p/metacello/wiki/CustomProjectAttrributes "
 
     ^ #()
-]
-
-{ #category : 'defaults' }
-ConfigurationOf >> defaultBleedingEdgeVersion [
-
-	^ ((self project map values select: [ :version | version blessing == #baseline ]) detectMax: [ :version | version ])
-		  ifNotNil: [ :bleedingEdgeVersion | bleedingEdgeVersion versionString ]
-		  ifNil: [ #notDefined ]
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloAbstractVersionConstructor.class.st
+++ b/src/Metacello-Core/MetacelloAbstractVersionConstructor.class.st
@@ -50,23 +50,6 @@ MetacelloAbstractVersionConstructor >> attributeOrder [
 ]
 
 { #category : 'api' }
-MetacelloAbstractVersionConstructor >> author: aBlockOrString [
-	"Define author field of version spec (MetacelloMCVersionSpec).
-	 If <aBlockOrString> is a String, the version spec author is set to the String.
-	If <aBlockOrString> is a Block, the specifications in <aBlockOrString> are applied to the author spec (MetacelloValueHolderSpec). Not Recommended! This second version is now deprecated.
-	
-		spec author: 'dkh'.
-		
-		spec author: [
-			spec value: 'dkh'. ].
-	 "
-
-	aBlockOrString isString
-		ifTrue: [ self root author: aBlockOrString ]
-		ifFalse: [ self setAuthorWithBlock: aBlockOrString ]
-]
-
-{ #category : 'api' }
 MetacelloAbstractVersionConstructor >> baseline: aString [
 
 	| spec projectSpec |
@@ -86,28 +69,6 @@ MetacelloAbstractVersionConstructor >> baseline: aString [
 MetacelloAbstractVersionConstructor >> baseline: aString with: aBlock [
 
 	self with: (self baseline: aString) during: aBlock
-]
-
-{ #category : 'api' }
-MetacelloAbstractVersionConstructor >> blessing: aBlockOrString [
-	"Define blessing field of version spec (MetacelloMCVersionSpec).
-	 If <aBlockOrString> is a String, the version spec blessing is set to the String. It is recommended to use a Symbol.
-	If <aBlockOrString> is a Block, the specifications in <aBlockOrString> are applied to the blessing spec (MetacelloValueHolderSpec). Not Recommended! This second version is now deprecated.
-	
-		spec blessing: #release.
-		
-		spec blessing: [
-			spec value: #release. ].
-	
-	The blessing should typically be set to one of three values:
-		#baseline - indicating that the version spec is specifying a baseline version
-		#development - indicating that the version spec is not stabilized and will change over time
-		#release - indicating that the version spec has stabilized and will NOT change over time
-	 "
-
-	aBlockOrString isString
-		ifTrue: [ self root blessing: aBlockOrString ]
-		ifFalse: [ self setBlessingWithBlock: aBlockOrString ]
 ]
 
 { #category : 'initialization' }
@@ -140,42 +101,10 @@ MetacelloAbstractVersionConstructor >> configuration: aConfig [
 	configuration := aConfig
 ]
 
-{ #category : 'api' }
-MetacelloAbstractVersionConstructor >> configuration: aString with: aBlock [
-
-	| spec projectSpec |
-	projectSpec := self project configurationOfProjectSpec
-		               name: aString;
-		               yourself.
-	spec := self project projectReferenceSpec
-		        name: aString;
-		        projectReference: projectSpec;
-		        yourself.
-	self root packages merge: spec.
-	self with: projectSpec during: aBlock
-]
-
 { #category : 'accessing' }
 MetacelloAbstractVersionConstructor >> configurationClass [
 
 	^self configuration class
-]
-
-{ #category : 'api' }
-MetacelloAbstractVersionConstructor >> description: aBlockOrString [
-	"Define description field of version spec (MetacelloMCVersionSpec).
-	 If <aBlockOrString> is a String, the version spec blessing is set to the String. It is recommended to use a Symbol.
-	If <aBlockOrString> is a Block, the specifications in <aBlockOrString> are applied to the blessing spec (MetacelloValueHolderSpec). Not Recommended! This second version is now deprecated.
-	
-		spec description: 'Descriptive comment'.
-		
-		spec description: [
-			spec value: 'Descriptive comment'.
-	 "
-
-	aBlockOrString isString
-		ifTrue: [ self root description: aBlockOrString ]
-		ifFalse: [ self setDescriptionWithBlock: aBlockOrString ]
 ]
 
 { #category : 'private' }
@@ -470,7 +399,7 @@ MetacelloAbstractVersionConstructor >> project [
 { #category : 'api' }
 MetacelloAbstractVersionConstructor >> project: aString [
 
-	self project: aString with: ''
+	self project: aString with: [ ]
 ]
 
 { #category : 'api' }
@@ -516,9 +445,7 @@ MetacelloAbstractVersionConstructor >> project: aString with: aBlockOrString [
 			 projectReference: projectSpec;
 			 yourself).
 
-	aBlockOrString isString
-		ifTrue: [ projectSpec versionString: aBlockOrString ]
-		ifFalse: [ self with: projectSpec during: aBlockOrString ]
+	self with: projectSpec during: aBlockOrString
 ]
 
 { #category : 'accessing' }
@@ -616,29 +543,6 @@ MetacelloAbstractVersionConstructor >> symbolicVersion: aSymbol [
 	symbolicVersion := aSymbol
 ]
 
-{ #category : 'api' }
-MetacelloAbstractVersionConstructor >> timestamp: aBlockOrStringOrDateAndTime [
-	"Define timestamp field of version spec (MetacelloMCVersionSpec).
-	 If <aBlockOrStringOrDateAndTime> is a String, the version spec timetamp is set to the String.
-	 If <aBlockOrStringOrDateAndTime> is a DateAndTime, the version spec timetamp is set to the printString of the DateAndTime.
-	If <aBlockOrStringOrDateAndTime> is a Block, the specifications in <aBlockOrStringOrDateAndTime> are applied to the timestamp spec (MetacelloValueHolderSpec). Not Recommended! This third version is now deprecated.
-	
-		spec timestamp: '10/7/2009 14:40'.
-		
-		spec timestamp: DateAndTime now'.
-		
-		spec timestamp: [
-			spec value: '10/7/2009 14:40'. ].
-    "
-
-	aBlockOrStringOrDateAndTime isString
-		ifTrue: [ self root timestamp: aBlockOrStringOrDateAndTime ]
-		ifFalse: [
-			aBlockOrStringOrDateAndTime isBlock
-				ifTrue: [ self setTimestampWithBlock: aBlockOrStringOrDateAndTime ]
-				ifFalse: [ self timestamp: aBlockOrStringOrDateAndTime printString ] ]
-]
-
 { #category : 'validation' }
 MetacelloAbstractVersionConstructor >> validateDoItSelector: anObject [
 
@@ -654,12 +558,6 @@ MetacelloAbstractVersionConstructor >> value: anObject [
 
 { #category : 'api' }
 MetacelloAbstractVersionConstructor >> version: anObject [
-
-	self root versionString: anObject
-]
-
-{ #category : 'api' }
-MetacelloAbstractVersionConstructor >> versionString: anObject [
 
 	self root versionString: anObject
 ]

--- a/src/Metacello-Core/MetacelloBaselineOfProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloBaselineOfProjectSpec.class.st
@@ -38,11 +38,6 @@ MetacelloBaselineOfProjectSpec >> canUpgradeTo: aProjectSpec [
   ^ false
 ]
 
-{ #category : 'printing' }
-MetacelloBaselineOfProjectSpec >> configHasVersionString [
-  ^ false
-]
-
 { #category : 'private' }
 MetacelloBaselineOfProjectSpec >> constructClassName [
     ^ 'BaselineOf' , self name

--- a/src/Metacello-Core/MetacelloProject.class.st
+++ b/src/Metacello-Core/MetacelloProject.class.st
@@ -83,12 +83,6 @@ MetacelloProject >> configurationOfProjectSpec [
     ^ MetacelloConfigurationOfProjectSpec for: self
 ]
 
-{ #category : 'accessing' }
-MetacelloProject >> defaultBlessing [
-
-	^#release
-]
-
 { #category : 'private' }
 MetacelloProject >> defaultPlatformAttributes [
 	"Returns the tags for the conditional platform loading in Metacello. Pay attention the order is important: from most  to least general."
@@ -117,12 +111,6 @@ MetacelloProject >> errorMap: anObject [
     errorMap := anObject
 ]
 
-{ #category : 'private' }
-MetacelloProject >> excludeFromLatestVersion [
-
-	^#(structural development broken baseline)
-]
-
 { #category : 'spec classes' }
 MetacelloProject >> groupSpec [
 
@@ -142,17 +130,6 @@ MetacelloProject >> lastVersion [
 	coll := (self map values asArray sort: [:a :b | a <= b ]) asOrderedCollection.
 	coll isEmpty ifTrue: [ ^nil ].
 	^coll last
-]
-
-{ #category : 'versions' }
-MetacelloProject >> latestVersion [
-
-	| excluded |
-"	self deprecated: 'Please use #stableVersion instead.'.
-"	self flag: 'deprecate after version 1.0'.
-	excluded := self excludeFromLatestVersion.
-	^(self map values select: [:version |  
-		(excluded includes: version blessing) not ]) detectMax: [:version | version ]
 ]
 
 { #category : 'loading' }
@@ -322,12 +299,6 @@ MetacelloProject >> repositorySpecClass [
 { #category : 'development support' }
 MetacelloProject >> setBaselineRepositoryDescription: aListOrRepositoryDescriptions [
     "noop "
-]
-
-{ #category : 'private' }
-MetacelloProject >> sortedAndFilteredVersions [
-
-		^(self map values asArray sort: [:a :b | a >= b ]) select: [:vrsn | (#(structural broken baseline) includes: vrsn blessing) not ].
 ]
 
 { #category : 'versions' }

--- a/src/Metacello-Core/MetacelloProjectRegistration.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistration.class.st
@@ -256,17 +256,6 @@ MetacelloProjectRegistration >> copyOnWrite: aBlock [
 ]
 
 { #category : 'accessing' }
-MetacelloProjectRegistration >> currentBranchName [
-
-	^ self configurationProjectSpec
-		  ifNotNil: [
-			  configurationProjectSpec versionOrNil
-				  ifNil: [ '' ]
-				  ifNotNil: [ :vrsn | vrsn blessing asString ] ]
-		  ifNil: [ baselineProjectSpec repositoryBranchName ]
-]
-
-{ #category : 'accessing' }
 MetacelloProjectRegistration >> currentVersionString [
 
 	^ self configurationProjectSpec

--- a/src/Metacello-Core/MetacelloProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectSpec.class.st
@@ -142,12 +142,6 @@ MetacelloProjectSpec >> compareVersionsEqual: aMetacelloProjectSpec [
 ]
 
 { #category : 'printing' }
-MetacelloProjectSpec >> configHasVersionString [
-
-	^ self versionString isNotNil
-]
-
-{ #category : 'printing' }
 MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent [
   ^ self configMethodBodyOn: aStream indent: indent fromShortCut: false
 ]
@@ -155,36 +149,22 @@ MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent [
 { #category : 'printing' }
 MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent fromShortCut: fromShortCut [
 
-	| hasVersionString hasOperator hasProjectPackage hasLoads hasClassName hasPreLoadDoIt hasPostLoadDoIt |
+	| hasOperator hasProjectPackage hasLoads hasClassName hasPreLoadDoIt hasPostLoadDoIt |
 	hasClassName := self hasClassName.
-	hasVersionString := self configHasVersionString.
 	hasOperator := operator isNotNil.
 	hasProjectPackage := self hasRepository or: [ hasClassName & self getFile isNotNil ].
 	hasLoads := self loads isNotNil.
 	hasPreLoadDoIt := self getPreLoadDoIt isNotNil.
 	hasPostLoadDoIt := self getPostLoadDoIt isNotNil.
 	hasClassName ifTrue: [
-		hasVersionString | hasOperator | hasProjectPackage | hasLoads
+		hasOperator | hasProjectPackage | hasLoads
 			ifTrue: [
 				aStream
 					cr;
 					tab: indent + 1 ]
 			ifFalse: [ aStream space ].
 		aStream nextPutAll: 'className: ' , self className printString.
-		hasVersionString | hasPreLoadDoIt | hasPostLoadDoIt | hasOperator | hasLoads | hasProjectPackage ifTrue: [ aStream nextPut: $; ] ].
-	hasVersionString ifTrue: [
-		| vs |
-		hasClassName | hasOperator | hasProjectPackage | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt
-			ifTrue: [
-				aStream
-					cr;
-					tab: indent + 1 ]
-			ifFalse: [ aStream space ].
-		vs := self versionString.
-		aStream nextPutAll: 'versionString: '.
-		vs isSymbol ifTrue: [ aStream nextPut: $# ].
-		aStream nextPutAll: vs asString printString.
-		hasPreLoadDoIt | hasPostLoadDoIt | hasOperator | hasProjectPackage | hasLoads ifTrue: [ aStream nextPut: $; ] ].
+		hasPreLoadDoIt | hasPostLoadDoIt | hasOperator | hasLoads | hasProjectPackage ifTrue: [ aStream nextPut: $; ] ].
 	hasPreLoadDoIt ifTrue: [
 		hasClassName | hasOperator | hasProjectPackage | hasLoads | hasPreLoadDoIt
 			ifTrue: [
@@ -216,7 +196,7 @@ MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent fromShortCut:
 			ifFalse: [ aStream nextPutAll: self postLoadDoIt value asString ].
 		hasOperator | hasProjectPackage | hasLoads ifTrue: [ aStream nextPut: $; ] ].
 	hasOperator ifTrue: [
-		hasClassName | hasVersionString | hasProjectPackage | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt
+		hasClassName | hasProjectPackage | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt
 			ifTrue: [
 				aStream
 					cr;
@@ -225,7 +205,7 @@ MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent fromShortCut:
 		aStream nextPutAll: 'operator: #' , self operator asString printString.
 		hasProjectPackage | hasLoads ifTrue: [ aStream nextPut: $; ] ].
 	hasLoads ifTrue: [
-		hasClassName | hasVersionString | hasOperator | hasProjectPackage | hasPreLoadDoIt | hasPostLoadDoIt
+		hasClassName | hasOperator | hasProjectPackage | hasPreLoadDoIt | hasPostLoadDoIt
 			ifTrue: [
 				aStream
 					cr;
@@ -240,7 +220,7 @@ MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent fromShortCut:
 		hasRepo := self hasRepository.
 		hasName := self file ~= self className.
 		hasName ifTrue: [
-			hasClassName | hasVersionString | hasOperator | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt
+			hasClassName | hasOperator | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt
 				ifTrue: [
 					aStream
 						cr;
@@ -255,7 +235,7 @@ MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent fromShortCut:
 				ifTrue: [
 					fromShortCut
 						ifTrue: [
-							hasClassName | hasVersionString | hasOperator | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt | hasName
+							hasClassName | hasOperator | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt | hasName
 								ifTrue: [
 									aStream
 										cr;
@@ -286,36 +266,29 @@ MetacelloProjectSpec >> configMethodOn: aStream indent: indent [
 { #category : 'printing' }
 MetacelloProjectSpec >> configShortCutMethodOn: aStream member: aMember indent: indent [
 
-	| hasVersionString hasOperator hasProjectPackage hasLoads hasClassName hasPreLoadDoIt hasPostLoadDoIt |
+	| hasOperator hasProjectPackage hasLoads hasClassName hasPreLoadDoIt hasPostLoadDoIt |
 	hasClassName := self hasClassName.
-	hasVersionString := self configHasVersionString.
 	hasOperator := operator isNotNil.
 	hasProjectPackage := self hasRepository or: [ hasClassName & (self getFile isNotNil or: [ className ~= self name ]) ].
 	hasLoads := self loads isNotNil.
 	hasPreLoadDoIt := self getPreLoadDoIt isNotNil.
 	hasPostLoadDoIt := self getPostLoadDoIt isNotNil.
 	hasClassName | hasOperator | hasProjectPackage | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt ifTrue: [
-		(aMember methodUpdateSelector == #copy: or: [ aMember methodUpdateSelector == #with: ])
-			ifTrue: [
-				aStream
-					nextPutAll: 'with: [';
-					cr ]
-			ifFalse: [
-				aStream
-					nextPutAll: 'overrides: [';
-					cr ].
-		aStream
-			tab: indent;
-			nextPutAll: 'spec'.
-		self configMethodBodyOn: aStream indent: indent fromShortCut: true.
-		aStream nextPutAll: ' ]'.
-		^ self ].
-	hasVersionString ifTrue: [
-		| vs |
-		vs := self versionString.
-		aStream nextPutAll: 'with: '.
-		vs isSymbol ifTrue: [ aStream nextPut: $# ].
-		aStream nextPutAll: vs asString printString ]
+			(aMember methodUpdateSelector == #copy: or: [ aMember methodUpdateSelector == #with: ])
+				ifTrue: [
+						aStream
+							nextPutAll: 'with: [';
+							cr ]
+				ifFalse: [
+						aStream
+							nextPutAll: 'overrides: [';
+							cr ].
+			aStream
+				tab: indent;
+				nextPutAll: 'spec'.
+			self configMethodBodyOn: aStream indent: indent fromShortCut: true.
+			aStream nextPutAll: ' ]'.
+			^ self ]
 ]
 
 { #category : 'private' }
@@ -808,15 +781,7 @@ MetacelloProjectSpec >> unregisterProject [
 MetacelloProjectSpec >> version [
 	"Empty version string means use latestVersion or #bleedingEdge"
 
-	^ self versionString
-		  ifNotNil: [ self project versionString ]
-		  ifNil: [
-			  | vrsn |
-			  "Eventually it will become an error to not specify a project reference version as default: #stable is the preferred default""self deprecated: 'Must specify a project reference version.'."
-			  self flag: 'deprecate after version 1.0'.
-			  (vrsn := self project latestVersion) isNil
-				  ifTrue: [ self project version: #bleedingEdge ]
-				  ifFalse: [ vrsn ] ]
+	^ self versionString ifNotNil: [ self project versionString ]
 ]
 
 { #category : 'querying' }

--- a/src/Metacello-Core/MetacelloValueHolderSpec.class.st
+++ b/src/Metacello-Core/MetacelloValueHolderSpec.class.st
@@ -9,12 +9,6 @@ Class {
 	#tag : 'Specs'
 }
 
-{ #category : 'private' }
-MetacelloValueHolderSpec >> asMetacelloValueHolderFor: aMetacelloVersionSpec [
-
-	^ self
-]
-
 { #category : 'printing' }
 MetacelloValueHolderSpec >> configMethodOn: aStream indent: indent [
 

--- a/src/Metacello-Core/MetacelloVersion.class.st
+++ b/src/Metacello-Core/MetacelloVersion.class.st
@@ -38,20 +38,9 @@ MetacelloVersion >> = aMetacelloVersion [
 	^self versionNumber = aMetacelloVersion versionNumber
 ]
 
-{ #category : 'querying' }
-MetacelloVersion >> author [
-
-	^self spec author value
-]
-
 { #category : 'accessing' }
 MetacelloVersion >> basicSpec [
     ^ self spec
-]
-
-{ #category : 'querying' }
-MetacelloVersion >> blessing [
-    ^ self basicSpec blessing value
 ]
 
 { #category : 'querying' }
@@ -59,11 +48,6 @@ MetacelloVersion >> defaultPackageNamesToLoad: defaultList [
 	"Answer the list of packages and projects to be loaded: packages already loaded plust defaultList"
 	
 	^ self packageAndProjectNamesToLoad: defaultList loader: nil
-]
-
-{ #category : 'querying' }
-MetacelloVersion >> description [
-    ^ self basicSpec description value
 ]
 
 { #category : 'private' }
@@ -309,11 +293,6 @@ MetacelloVersion >> spec [
 MetacelloVersion >> spec: aMetacellVersionSpec [
 
 	spec := aMetacellVersionSpec
-]
-
-{ #category : 'querying' }
-MetacelloVersion >> timestamp [
-    ^ self basicSpec timestamp value
 ]
 
 { #category : 'actions' }

--- a/src/Metacello-Core/MetacelloVersionSpec.class.st
+++ b/src/Metacello-Core/MetacelloVersionSpec.class.st
@@ -6,14 +6,10 @@ Class {
 		'packages',
 		'versionString',
 		'packageList',
-		'author',
-		'timestamp',
 		'importArray',
 		'postLoadDoIt',
-		'blessing',
 		'importName',
-		'preLoadDoIt',
-		'description'
+		'preLoadDoIt'
 	],
 	#category : 'Metacello-Core-Specs',
 	#package : 'Metacello-Core',
@@ -26,87 +22,29 @@ MetacelloVersionSpec >> acceptVisitor: aVisitor [
 	^ aVisitor visitVersionSpec: self
 ]
 
-{ #category : 'accessing' }
-MetacelloVersionSpec >> author [
-
-	^ author ifNil: [
-		  self project valueHolderSpec
-			  value: '';
-			  yourself ]
-]
-
-{ #category : 'accessing' }
-MetacelloVersionSpec >> author: anObject [
-
-	author := anObject asMetacelloValueHolderFor: self
-]
-
-{ #category : 'accessing' }
-MetacelloVersionSpec >> blessing [
-
-	^ blessing ifNil: [
-		  self project valueHolderSpec
-			  value: self project defaultBlessing;
-			  yourself ]
-]
-
-{ #category : 'accessing' }
-MetacelloVersionSpec >> blessing: anObject [
-
-	blessing := anObject asMetacelloValueHolderFor: self
-]
-
 { #category : 'printing' }
 MetacelloVersionSpec >> configMethodBasicOn: aStream last: last indent: indent [
 
 	| values lastIndex lastBlock |
 	last
 		ifTrue: [ "need to calculate last statement with a value"
-			values := {
-				          self getBlessing.
-				          self getDescription.
-				          self getPreLoadDoIt.
-				          self getPostLoadDoIt.
-				          self getAuthor.
-				          self getTimestamp }.
-			1 to: values size do: [ :index | (values at: index) ifNotNil: [ lastIndex := index ] ].
-			lastBlock := [ :arg | arg = lastIndex ] ]
+				values := {
+					          self getPreLoadDoIt.
+					          self getPostLoadDoIt }.
+				1 to: values size do: [ :index | (values at: index) ifNotNil: [ lastIndex := index ] ].
+				lastBlock := [ :arg | arg = lastIndex ] ]
 		ifFalse: [ lastBlock := [ :arg | false ] ].
-	self
-		configMethodValueOn: aStream
-		for: self getBlessing
-		selector: 'blessing:'
-		last: (lastBlock value: 1)
-		indent: indent.
-	self
-		configMethodValueOn: aStream
-		for: self getDescription
-		selector: 'description:'
-		last: (lastBlock value: 2)
-		indent: indent.
 	self
 		configMethodValueOn: aStream
 		for: self getPreLoadDoIt
 		selector: 'preLoadDoIt:'
-		last: (lastBlock value: 3)
+		last: (lastBlock value: 1)
 		indent: indent.
 	self
 		configMethodValueOn: aStream
 		for: self getPostLoadDoIt
 		selector: 'postLoadDoIt:'
-		last: (lastBlock value: 4)
-		indent: indent.
-	self
-		configMethodValueOn: aStream
-		for: self getAuthor
-		selector: 'author:'
-		last: (lastBlock value: 5)
-		indent: indent.
-	self
-		configMethodValueOn: aStream
-		for: self getTimestamp
-		selector: 'timestamp:'
-		last: (lastBlock value: 6)
+		last: (lastBlock value: 2)
 		indent: indent
 ]
 
@@ -256,36 +194,6 @@ MetacelloVersionSpec >> defaultPackageNames [
 ]
 
 { #category : 'accessing' }
-MetacelloVersionSpec >> description [
-
-	^ description ifNil: [
-		  self project valueHolderSpec
-			  value: '';
-			  yourself ]
-]
-
-{ #category : 'accessing' }
-MetacelloVersionSpec >> description: anObject [
-
-	description := anObject asMetacelloValueHolderFor: self
-]
-
-{ #category : 'accessing' }
-MetacelloVersionSpec >> getAuthor [
-	^author
-]
-
-{ #category : 'accessing' }
-MetacelloVersionSpec >> getBlessing [
-	^blessing
-]
-
-{ #category : 'accessing' }
-MetacelloVersionSpec >> getDescription [
-	^description
-]
-
-{ #category : 'accessing' }
 MetacelloVersionSpec >> getPostLoadDoIt [
 	^postLoadDoIt
 ]
@@ -293,11 +201,6 @@ MetacelloVersionSpec >> getPostLoadDoIt [
 { #category : 'accessing' }
 MetacelloVersionSpec >> getPreLoadDoIt [
 	^preLoadDoIt
-]
-
-{ #category : 'accessing' }
-MetacelloVersionSpec >> getTimestamp [
-	^timestamp
 ]
 
 { #category : 'accessing' }
@@ -337,18 +240,13 @@ MetacelloVersionSpec >> loader: aMetacelloLoadTarget [
 
 { #category : 'merging' }
 MetacelloVersionSpec >> mergeMap [
-    | map |
-    map := super mergeMap.
-    map at: #'versionString' put: versionString.
-    map at: #'blessing' put: blessing.
-    map at: #'description' put: description.
-    map at: #'author' put: author.
-    map at: #'timestamp' put: timestamp.
-    map at: #'preLoadDoIt' put: preLoadDoIt.
-    map at: #'postLoadDoIt' put: postLoadDoIt.
-    map at: #'packageList' put: self packages.
-    map at: #'repositories' put: self repositories.
-    ^ map
+
+	^ super mergeMap
+		  at: #preLoadDoIt put: preLoadDoIt;
+		  at: #postLoadDoIt put: postLoadDoIt;
+		  at: #packageList put: self packages;
+		  at: #repositories put: self repositories;
+		  yourself
 ]
 
 { #category : 'merging' }
@@ -489,14 +387,11 @@ MetacelloVersionSpec >> packagesSpec [
 
 { #category : 'copying' }
 MetacelloVersionSpec >> postCopy [
-    super postCopy.
-  blessing := blessing copy.
-    description := description copy.
-    author := author copy.
-    timestamp := timestamp copy.
-    packageList := packageList copy.
-    repositories := repositories copy.
-    packages := packages copy	"leave reference to packages for upgrade purposes"
+
+	super postCopy.
+	packageList := packageList copy.
+	repositories := repositories copy.
+	packages := packages copy "leave reference to packages for upgrade purposes"
 ]
 
 { #category : 'querying' }
@@ -629,21 +524,6 @@ MetacelloVersionSpec >> specsNamed: packageAndProjectNames projectDo: projectBlo
 	map := self packages map.
 	packageAndProjectNames do: [ :name |
 		(map at: name ifAbsent: [  ]) ifNotNil: [ :pkgSpec | pkgSpec projectDo: projectBlock packageDo: packageBlock groupDo: groupBlock ] ]
-]
-
-{ #category : 'accessing' }
-MetacelloVersionSpec >> timestamp [
-
-	^ timestamp ifNil: [
-		  self project valueHolderSpec
-			  value: '';
-			  yourself ]
-]
-
-{ #category : 'accessing' }
-MetacelloVersionSpec >> timestamp: anObject [
-
-	timestamp := anObject asMetacelloValueHolderFor: self
 ]
 
 { #category : 'private' }

--- a/src/Metacello-Core/String.extension.st
+++ b/src/Metacello-Core/String.extension.st
@@ -31,14 +31,6 @@ String >> addToMetacelloRepositories: aMetacelloRepositoriesSpec [
 ]
 
 { #category : '*Metacello-Core' }
-String >> asMetacelloValueHolderFor: aMetacelloVersionSpec [
-
-	^ aMetacelloVersionSpec project valueHolderSpec
-		  value: self;
-		  yourself
-]
-
-{ #category : '*Metacello-Core' }
 String >> asMetacelloVersionNumber [
 
 	^MetacelloVersionNumber fromString: self

--- a/src/Metacello-TestsCore/MetacelloReferenceBaseline.class.st
+++ b/src/Metacello-TestsCore/MetacelloReferenceBaseline.class.st
@@ -17,13 +17,7 @@ MetacelloReferenceBaseline >> baseline: spec [
 	<baseline>
 	
 	spec for: #common do: [
-		"recommended methods for specifying author, blessing, description, timestamp, preLoadDoIt, postLoadDoit"
-		"#development, #baseline, #release, #beta, etc."
-		spec blessing: #baseline.									
-		spec description: 'Descriptive comment'.
-		spec author: 'dkh'.
-		spec timestamp: (DateAndTime fromString: '2009-07-10T14:40').
-		spec timestamp: '12009-07-10T14:40'.
+		"recommended methods for specifying preLoadDoIt, postLoadDoit"
 		spec
 			"Before loading packages or projects in this version, send #preloadForVersion to an instance of this config"
 			preLoadDoIt: #preloadForVersion;
@@ -52,8 +46,6 @@ MetacelloReferenceBaseline >> baseline: spec [
 					"OPTIONAL: Name of config class (i.e., ConfigurationOfXXX), if not specified, className is assumed to be the 
 					 name of the project prependended with 'ConfigurationOf'"
 					className: 'ConfigurationOfUI';
-					"Version of project to be loaded. if theversionString is not specified, then the latest version of the project is used."
-					versionString: '1.0';
 					"Before loading this project, send #preloadForProject to an instance of this config"
 					preLoadDoIt: #preloadForProject;
 					"After loading this project, send #postloadForProject to an instance of this config"
@@ -71,7 +63,6 @@ MetacelloReferenceBaseline >> baseline: spec [
 				"One or more of the following attributes may be defined"
 				spec
 					className: 'ConfigurationOfUINew';
-					versionString: '1.0';
 					operator: #>=;
 					loads: #('UI-Core' 'UI-Tests' );
 					repository: 'http://www.example.com/r' username: 'foo' password: 'bar' ];
@@ -83,12 +74,11 @@ MetacelloReferenceBaseline >> baseline: spec [
 					"One or more of the following attributes may be changed"
 					spec
 						className: 'ConfigurationOfUI';
-						versionString: '1.0';
 						operator: #~>;
 						loads: #('UI-Core' 'UI-Tests' );
 						repository: 'http://www.example.com/r'];
 			"Change the versionString for 'UI Support' to '1.0.1'"
-			project: 'UI Support' with: '1.0.1';	
+			project: 'UI Support';	
 			"Remove the project reference 'UI Tests'"				
 			removeProject: 'UI Tests';
 			"Multiple repositories for configuration - config may be found in either repository. 
@@ -126,7 +116,6 @@ MetacelloReferenceBaseline >> baseline: spec [
 					requires: #('Example-Core' 'UI Support' );
 					includes: #('Example-UI' );
 					file: 'Example-AddOn-anon.7';
-					supplyingAnswers: #( #('list of packages' 'Kernel* Collection*'));
 					repository: 'http://www.example.com/or' username: 'foo' password: 'bar' ;
 					preLoadDoIt: #preloadForAddOn;
 					postLoadDoIt: #postloadForAddOn ];

--- a/src/Metacello-TestsCore/MetacelloReferenceBaseline.class.st
+++ b/src/Metacello-TestsCore/MetacelloReferenceBaseline.class.st
@@ -77,7 +77,6 @@ MetacelloReferenceBaseline >> baseline: spec [
 						operator: #~>;
 						loads: #('UI-Core' 'UI-Tests' );
 						repository: 'http://www.example.com/r'];
-			"Change the versionString for 'UI Support' to '1.0.1'"
 			project: 'UI Support';	
 			"Remove the project reference 'UI Tests'"				
 			removeProject: 'UI Tests';

--- a/src/Metacello-TestsCore/MetacelloReferenceTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloReferenceTestCase.class.st
@@ -21,12 +21,8 @@ MetacelloReferenceTestCase >> conditionResult: resultString [
 
 { #category : 'testing' }
 MetacelloReferenceTestCase >> expectedPrintString [
-    ^ 'spec blessing: #''baseline''.
-spec description: ''Descriptive comment''.
-spec preLoadDoIt: #''preloadForVersion''.
+    ^ 'spec preLoadDoIt: #''preloadForVersion''.
 spec postLoadDoIt: #''postloadForVersion''.
-spec author: ''dkh''.
-spec timestamp: ''12009-07-10T14:40''.
 spec repositories: [
 	spec
 		repository: ''/opt/mc/repository'';
@@ -40,7 +36,6 @@ spec
 	project: ''UI Support'' with: [
 		spec
 			className: ''ConfigurationOfUI'';
-			versionString: ''1.0'';
 			preLoadDoIt: #''preloadForProject'';
 			postLoadDoIt: #''postloadForProject'';
 			operator: #''~>'';
@@ -49,18 +44,16 @@ spec
 	project: ''UI Support'' overrides: [
 		spec
 			className: ''ConfigurationOfUINew'';
-			versionString: ''1.0'';
 			operator: #''>='';
 			loads: #(''UI-Core'' ''UI-Tests'' );
 			repository: ''http://www.example.com/r'' username: ''foo'' password: ''bar'' ];
 	project: ''UI Tests'' copyFrom: ''UI Support'' with: [
 		spec
 			className: ''ConfigurationOfUI'';
-			versionString: ''1.0'';
 			operator: #''~>'';
 			loads: #(''UI-Core'' ''UI-Tests'' );
 			repository: ''http://www.example.com/r'' ];
-	project: ''UI Support'' with: ''1.0.1'';
+	project: ''UI Support'' ;
 	removeProject: ''UI Tests'';
 	project: ''UI Multi'' with: [
 		spec
@@ -133,7 +126,6 @@ MetacelloReferenceTestCase >> testReferenceConfig [
 	projectReference: [
 		spec
 			className: ''ConfigurationOfUINew'';
-			versionString: ''1.0.1'';
 			operator: #''>='';
 			loads: #(''UI-Core'' ''UI-Tests'' );
 			repository: ''http://www.example.com/r'' username: ''foo'' password: ''bar'' ].'

--- a/src/Metacello-TestsCore/MetacelloVersionSpecTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloVersionSpecTestCase.class.st
@@ -8,31 +8,17 @@ Class {
 
 { #category : 'tests' }
 MetacelloVersionSpecTestCase >> testVersionMergeSpec [
+
 	| versionA versionB version |
 	versionA := self versionSpec
-		blessing: #baseline;
-		versionString: '1.0';
-		description: 'A description';
-		author: 'dkh';
-		timestamp: '1/24/2012 09:59';
-		preLoadDoIt: #preLoadDoIt;
-		postLoadDoIt: #postLoadDoIt;
-		yourself.
+		            preLoadDoIt: #preLoadDoIt;
+		            postLoadDoIt: #postLoadDoIt;
+		            yourself.
 	versionB := self versionSpec
-		blessing: #release;
-		versionString: '1.1';
-		description: 'A FULL description';
-		author: 'DaleHenrichs';
-		timestamp: '1/24/2012 10:22';
-		preLoadDoIt: #preLoadDoItB;
-		postLoadDoIt: #postLoadDoItB;
-		yourself.
+		            preLoadDoIt: #preLoadDoItB;
+		            postLoadDoIt: #postLoadDoItB;
+		            yourself.
 	version := versionA mergeSpec: versionB.
-	self assert: version blessing value equals: #release.
-	self assert: version versionString value equals: '1.1'.
-	self assert: version description value equals: 'A FULL description'.
-	self assert: version author value equals: 'DaleHenrichs'.
-	self assert: version timestamp value equals: '1/24/2012 10:22'.
 	self assert: version preLoadDoIt value identicalTo: #preLoadDoItB.
 	self assert: version postLoadDoIt value identicalTo: #postLoadDoItB
 ]
@@ -41,8 +27,6 @@ MetacelloVersionSpecTestCase >> testVersionMergeSpec [
 MetacelloVersionSpecTestCase >> testVersionMergeSpec2 [
 	| versionA versionB version repository package group projectReferenceSpec |
 	versionA := self versionSpec
-		blessing: #baseline;
-		versionString: '1.0';
 		repository: 'http://example.com/repository' username: 'dkh' password: 'password';
 		repository: '/opt/gemstone/repository';
 		yourself.
@@ -70,8 +54,6 @@ MetacelloVersionSpecTestCase >> testVersionMergeSpec2 [
 						yourself));
 		yourself.
 	versionB := self versionSpec
-		blessing: #release;
-		versionString: '1.1';
 		repository: 'http://example.com/repository' username: 'DaleHenrichs' password: 'secret';
 		repository: '/opt/gemstone/repo';
 		yourself.
@@ -99,8 +81,6 @@ MetacelloVersionSpecTestCase >> testVersionMergeSpec2 [
 						yourself));
 		yourself.
 	version := versionA mergeSpec: versionB.
-	self assert: version blessing value equals: #release.
-	self assert: version versionString value equals: '1.1'.
 	repository := version repositories map at: '/opt/gemstone/repository' ifAbsent: [ self assert: false ].
 	self assert: repository type equals: 'directory'.
 	repository := version repositories map at: '/opt/gemstone/repo' ifAbsent: [ self assert: false ].
@@ -128,21 +108,12 @@ MetacelloVersionSpecTestCase >> testVersionMergeSpec2 [
 
 { #category : 'tests' }
 MetacelloVersionSpecTestCase >> testVersionSpec [
+
 	| version |
 	version := self versionSpec
-		blessing: #baseline;
-		versionString: '1.0';
-		description: 'A description';
-		author: 'dkh';
-		timestamp: '1/24/2012 09:59';
-		preLoadDoIt: #preLoadDoIt;
-		postLoadDoIt: #postLoadDoIt;
-		yourself.
-	self assert: version blessing value equals: #baseline.
-	self assert: version versionString value equals: '1.0'.
-	self assert: version description value equals: 'A description'.
-	self assert: version author value equals: 'dkh'.
-	self assert: version timestamp value equals: '1/24/2012 09:59'.
+		           preLoadDoIt: #preLoadDoIt;
+		           postLoadDoIt: #postLoadDoIt;
+		           yourself.
 	self assert: version preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: version postLoadDoIt value identicalTo: #postLoadDoIt.
 	self should: [ version preLoadDoIt: '' ] raise: Error.
@@ -153,8 +124,6 @@ MetacelloVersionSpecTestCase >> testVersionSpec [
 MetacelloVersionSpecTestCase >> testVersionSpec2 [
 	| version projectReferenceSpec group package repository |
 	version := self versionSpec
-		blessing: #baseline;
-		versionString: '1.0';
 		repository: 'http://example.com/repository' username: 'dkh' password: 'password';
 		repository: '/opt/gemstone/repository';
 		yourself.
@@ -185,14 +154,11 @@ MetacelloVersionSpecTestCase >> testVersionSpec2 [
 			(self projectSpec
 				name: 'Project';
 				className: 'ConfigurationOfProjectA';
-				versionString: #stable;
 				loads: #('MyPackage' 'MyTests');
 				preLoadDoIt: #preLoadDoItB;
 				postLoadDoIt: #postLoadDoItB;
 				yourself);
 		yourself.
-	self assert: version blessing value equals: #baseline.
-	self assert: version versionString value equals: '1.0'.
 	repository := version repositories map at: '/opt/gemstone/repository' ifAbsent: [ self assert: false ].
 	self assert: repository type equals: 'directory'.
 	repository := version repositories map at: 'http://example.com/repository' ifAbsent: [ self assert: false ].
@@ -205,29 +171,18 @@ MetacelloVersionSpecTestCase >> testVersionSpec2 [
 	self assert: (group includes includes: 'Core').
 	projectReferenceSpec := version packages packageNamed: 'Project' ifAbsent: [ self assert: false ].
 	self assert: projectReferenceSpec projectName equals: 'Project'.
-	self assert: projectReferenceSpec versionString equals: #stable.
 	version projectDo: [ :prjct | prjct == projectReferenceSpec ] packageDo: [ :pkg | pkg == package ] groupDo: [ :grp | grp == group ]
 ]
 
 { #category : 'tests' }
 MetacelloVersionSpecTestCase >> testVersionSpecCreateVersion [
+
 	| spec version |
 	spec := self versionSpec
-		blessing: #baseline;
-		versionString: '1.0';
-		description: 'A description';
-		author: 'dkh';
-		timestamp: '1/24/2012 09:59';
-		preLoadDoIt: #preLoadDoIt;
-		postLoadDoIt: #postLoadDoIt;
-		yourself.
+		        preLoadDoIt: #preLoadDoIt;
+		        postLoadDoIt: #postLoadDoIt;
+		        yourself.
 	version := spec createVersion.
 	self assert: version class identicalTo: spec versionClass.
-	self assert: version spec identicalTo: spec.
-	self assert: version versionNumber asString equals: '1.0'.
-	self assert: version blessing equals: #baseline.
-	self assert: version versionString equals: '1.0'.
-	self assert: version description equals: 'A description'.
-	self assert: version author equals: 'dkh'.
-	self assert: version timestamp equals: '1/24/2012 09:59'
+	self assert: version spec identicalTo: spec
 ]


### PR DESCRIPTION
This change is deprecating some of the API that was specific to ConfigurationOf since we have the matadatas of project in git for BaselineOf such as:
- author
- blessing
- timestamp
- description
- configuration:with:
- versionString 

I removed all the code related to timestamp, author, blessing and description. I still need to remove a lot of code related to the version string but this code is deeply rooted in Metacello so I'll need to do that in multiple steps to ensure I do not break anything.  I also thing we can remove the #operator API but it is too deeply rooted in Metacello to be sure for now. I'll do that later also