### PR TITLE
Fix bug in storing of protocols in change file

### DIFF
--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -553,7 +553,7 @@ OpalCompiler >> install [
 			method
 				putSource: source
 				withFooter: ''
-				protocol: protocol asString
+				protocol: (protocol isString ifTrue: [ protocol ] ifFalse: [ protocol name ]) asString
 				timestamp: changeStamp asString
 				priorSourcePointer: (self priorMethod ifNil: [ 0 ] ifNotNil: [ self priorMethod sourcePointer ]) ].
 

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -547,7 +547,7 @@ OpalCompiler >> install [
 
 	changeStamp ifNil: [ changeStamp := DateAndTime now printString ].
 	logSource := self logged ifNil: [ true ].
-	protocol := protocol ifNil: [ self priorMethod ifNotNil: [ self priorMethod protocol name ] ].
+	protocol := protocol ifNil: [ self priorMethod ifNotNil: [ self priorMethod protocol name ] ifNil: [ Protocol unclassified ] ].
 
 	logSource ifTrue: [
 			method

--- a/src/OpalCompiler-Tests/OpalCompilerTest.class.st
+++ b/src/OpalCompiler-Tests/OpalCompilerTest.class.st
@@ -254,6 +254,28 @@ OpalCompilerTest >> testInstallRequestor [
 ]
 
 { #category : 'tests' }
+OpalCompilerTest >> testSavedProtocolInChangesFileIsRight [
+	"Regression test, the saved protocol was wrong when we provided a Protocol instance during compilation.."
+	
+	| method |
+	"Cleanup"
+	(MockForCompilation includesSelector: #foo) ifTrue: [
+		MockForCompilation removeSelector: #foo ].
+	"Precond"
+	self deny: (MockForCompilation includesSelector: #foo).
+
+	method := MockForCompilation compiler
+		          source: 'foo ^42';
+		          protocol: (Protocol named: 'hitching');
+		          install.
+
+	self assert: (SourceFileArray default protocolAt: method sourcePointer) equals: 'hitching'.
+	"Cleanup"
+	method removeFromSystem.
+	self deny: (MockForCompilation includesSelector: #foo)
+]
+
+{ #category : 'tests' }
 OpalCompilerTest >> testShadowPseudoVariable [
 	"We can shadw PseudoVariables (here thisContext) and it works"
 	| result |

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -402,7 +402,8 @@ ReleaseTest >> testNoShadowedVariablesInMethods [
 		                   (OCClosureCompilerTest >> #testInlineBlockShadowVariableUsedInInnerInnerBlock).
 		                   (OCClosureCompilerTest >> #testInlineBlockShadowVariableInnerBlocks).
 		                   (OCClosureCompilerTest >> #testInlineBlockShadowVariableParameter).
-		                   (ReClassToConvertTemporaryToInstanceVariable >> #doAction2) }.
+		                   (ReClassToConvertTemporaryToInstanceVariable >> #doAction2).
+		                   (MethodMapExamples >> #exampleWithNestedHoisting) }.
 
 	remaining := found asOrderedCollection
 		             removeAll: validExceptions;


### PR DESCRIPTION
When storing a protocol in a change file it is possible that the stored string in wrong because we send a #asString to a Protocol instead of a symbol or string.

I added a regression test and also I fixed a release test

This was provoking weird behavior such as wrong protocol in the version browser and wrong protocols when reverting a method