### PR TITLE
Fix context fetching of temporary variables

### DIFF
--- a/src/Debugging-Core/Context.extension.st
+++ b/src/Debugging-Core/Context.extension.st
@@ -336,7 +336,7 @@ Context >> temporaryVariableNames [
 
 	"If this context did not yet execute, consider the initial PC"
 	| suspendedPC |
-	suspendedPC := self executedPC max: self method initialPC.
+	suspendedPC := self pc max: self method initialPC.
 	^ self method debugInfo variableNamesAt: suspendedPC
 ]
 

--- a/src/OpalCompiler-Tests/ContextDebuggingInfoTest.class.st
+++ b/src/OpalCompiler-Tests/ContextDebuggingInfoTest.class.st
@@ -88,6 +88,19 @@ ContextDebuggingInfoTest >> testTempNamed [
 ]
 
 { #category : 'tests' }
+ContextDebuggingInfoTest >> testTempNamedAtTheEndOfOptimizedBlock [
+	
+	| s process |
+	s := Semaphore new.
+	process := [ 1 to: 17 do: [ :i | 
+			s signal.
+			Processor activeProcess suspend ] ] fork.
+	s wait.
+	
+	self deny: (process suspendedContext temporaryVariableNames includes: #i)
+]
+
+{ #category : 'tests' }
 ContextDebuggingInfoTest >> testTempNamedPut [
 	| oneTemp |
 	oneTemp := 1.


### PR DESCRIPTION
`Context>>#temporaryVariableNames` and `Context>>#tempNamed:` are not in sync.

Initially discussed/found in https://github.com/pharo-contributions/MethodProxies/issues/36.

The issue is that
- `temporaryVariableNames` uses `executedPC`, getting the temporary variables available *in the previous PC*
- `tempNamed:` uses `pc`, reading variables available *in the current PC*

I decided to align it both to `pc`, as I find the semantics of `executedPC` a bit fuzzy and I don't like them :)