### PR TITLE
Fix SmalltalkCI

### DIFF
--- a/src/Deprecated14/Metacello.extension.st
+++ b/src/Deprecated14/Metacello.extension.st
@@ -3,13 +3,13 @@ Extension { #name : 'Metacello' }
 { #category : '*Deprecated14' }
 Metacello >> configuration: projectName [
 
-	self error: 'Configurations are not supported anymore. Only Baselines are used now.'
+	self deprecated: 'ConfigurationOf loading is not supported since Pharo 12. Only Baselines are used now.'
 ]
 
 { #category : '*Deprecated14' }
 Metacello >> project: projectName [
 
-	self error: 'Projects are not supported anymore. Only Baselines are used now.'
+	self deprecated: 'Projects are not supported anymore. Only Baselines are used now.'
 ]
 
 { #category : '*Deprecated14' }


### PR DESCRIPTION
We cannot load configurations anymore in Pharo but smalltalk CI is still using Metacello>>configuration: to set something nil. As a temporary fix, I'm updating an error to a deprecation. We'll need to update SmalltalkCI to add nil check before using this API.

Fixes #19060 

Thanks Marcus for the report! 