### PR TITLE
Fixing double-click error when creating a new class

### DIFF
--- a/src/Morphic-Base/TextEditorDialogWindow.class.st
+++ b/src/Morphic-Base/TextEditorDialogWindow.class.st
@@ -82,6 +82,12 @@ TextEditorDialogWindow >> initialize [
 	self textEditorMorph selectAll
 ]
 
+{ #category : 'accessing' }
+TextEditorDialogWindow >> interactionModel [
+
+	^ self
+]
+
 { #category : 'actions' }
 TextEditorDialogWindow >> newButtons [
 	"Answer new buttons as appropriate."


### PR DESCRIPTION
# Fixing double-click error when creating a new class

I was trying to reproduce another bug, and I found this small one, so here is a fix.

Note: I'm not sure if it is okay that the model instance of the editor in this case is a TextEditorDialogWindow. I assumed that was correct and added the method to bypass it.

Change: Add interactionModel method to TextEditorDialogWindow.

### Before:

https://github.com/user-attachments/assets/5b2768e6-cf1e-46c2-8186-924d34497f65


### Now:

https://github.com/user-attachments/assets/36f2592a-4811-4f49-b937-30095cec11e8
