### PR TITLE
Bootstrap: Do not duplicate list of packages to load by Hermes

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -163,7 +163,7 @@ echo $(date -u) "[Monticello] Bootstrap Monticello Core and Local repositories"
 
 ${VM} "${CORE_IMAGE_NAME}.image" save ${MC_BOOTSTRAP_IMAGE_NAME}
 echo "Loading packages: $(cat hermesMonticelloPackages.txt)"
-${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" loadHermes Ring-Definitions-Core.hermes Ring-OldChunkImporter.hermes Jobs.hermes Random-Core.hermes System-Hashing.hermes Compression.hermes Monticello-Model.hermes Monticello.hermes Ring-Definitions-Monticello.hermes --save --no-fail-on-undeclared
+${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" loadHermes $(cat hermesMonticelloPackages.txt) --save --no-fail-on-undeclared
 ${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/01-bootstrapMonticello.st --save --quit
 zip "${MC_BOOTSTRAP_IMAGE_NAME}.zip" ${MC_BOOTSTRAP_IMAGE_NAME}.*
 

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -100,9 +100,6 @@ fi
 BOOTSTRAP_IMAGE_NAME=bootstrap
 BOOTSTRAP_ARCHIVE_IMAGE_NAME=${PHARO_NAME_PREFIX}-bootstrap-${SUFFIX}
 
-HERMES_ARCHIVE_NAME=${PHARO_NAME_PREFIX}-hermesPackages-${SUFFIX}
-RPACKAGE_ARCHIVE_NAME=${PHARO_NAME_PREFIX}-rpackage-${SUFFIX}
-
 CORE_IMAGE_NAME=${PHARO_NAME_PREFIX}-core-${SUFFIX}
 COMPILER_IMAGE_NAME=${PHARO_NAME_PREFIX}-compiler-${SUFFIX}
 TRAITS_IMAGE_NAME=${PHARO_NAME_PREFIX}-traits-${SUFFIX}
@@ -113,7 +110,6 @@ PHARO_IMAGE_NAME=${PHARO_NAME_PREFIX}-${SUFFIX}
 #Get inside the bootstrap-cache folder. Pharo interprets relatives as relatives to the image and not the 'working directory'
 cd "${BOOTSTRAP_CACHE}"
 
-
 #Prepare
 echo "Prepare Bootstrap files"
 cp "${BOOTSTRAP_IMAGE_NAME}.image" "${COMPILER_IMAGE_NAME}.image"
@@ -122,46 +118,39 @@ cp "${BOOTSTRAP_IMAGE_NAME}.image" "${COMPILER_IMAGE_NAME}.image"
 cp "${BOOTSTRAP_IMAGE_NAME}.image" "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.image"
 zip "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.zip" "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.image"
 
-# Archive binary Hermes packages
-zip "${HERMES_ARCHIVE_NAME}.zip" *.hermes
-
-# Archive Package definitions
-zip "${RPACKAGE_ARCHIVE_NAME}.zip" protocolsKernel.txt
-
 # Installing Package
-echo $(date -u) "[Compiler] Initializing Bootstraped Image"
+echo $(date -u) "[Compiler] Initializing Bootstraped Image and fixing the code"
 ${VM} "${COMPILER_IMAGE_NAME}.image" # I have to run once the image so the next time it starts the CommandLineHandler.
+${VM} "${COMPILER_IMAGE_NAME}.image" perform --save PharoBootstrapFixMethodsTool fixMethodsIn: protocolsKernel.txt # Fixing some things espell does not handel well
+${VM} "${COMPILER_IMAGE_NAME}.image" perform --save PharoBootstrapFixMethodsTool fixExtensionMethods
 
 echo $(date -u) "[Compiler] Adding more Kernel packages"
-${VM} "${COMPILER_IMAGE_NAME}.image" perform --save BasicHermesTool load: --as-array Clap-Core.hermes Clap-Commands-Pharo.hermes Hermes-Extensions.hermes
-${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Math-Operations-Extensions.hermes System-NumberPrinting.hermes System-Time.hermes Multilingual-Encodings.hermes ReflectionMirrors-Primitives.hermes NumberParser.hermes System-Version.hermes --save --no-fail-on-undeclared
+echo "Loading packages: $(cat hermesAdditionalKernelPackages.txt)"
+${VM} "${COMPILER_IMAGE_NAME}.image" perform --save BasicHermesTool load: --as-array $(cat hermesAdditionalKernelPackages.txt)
 
 # Now that System-Version is loaded, we can initialize the version
 ${VM} "${COMPILER_IMAGE_NAME}.image" perform  --save SystemVersion setMajor:minor:patch:suffix:build:commitHash: ${PHARO_MAJOR} ${PHARO_MINOR} ${PHARO_PATCH} ${PHARO_SUFFIX} ${BUILD_NUMBER} ${PHARO_COMMIT_HASH}
 
-${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes Collections-Atomic.hermes Collections-Stack.hermes AST-Core.hermes Collections-Arithmetic.hermes  --save --no-fail-on-undeclared
-
-echo $(date -u) "[Compiler] Initializing the packages in the Kernel"
-${VM} "${COMPILER_IMAGE_NAME}.image" perform --save PharoBootstrapFixMethodsTool fixMethodsIn: protocolsKernel.txt
-${VM} "${COMPILER_IMAGE_NAME}.image" perform --save PharoBootstrapFixMethodsTool fixExtensionMethods
-
 # Installing compiler through Hermes 
 echo $(date -u) "[Compiler] Installing compiler through Hermes"
-${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes UIManager.hermes OpalCompiler-Core.hermes ParseTreeRewriter.hermes Deprecation.hermes DebugInfo.hermes CodeImport.hermes CodeImport-Commands.hermes --save --no-fail-on-undeclared
+echo "Loading packages: $(cat hermesCompilerPackages.txt)"
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes $(cat hermesCompilerPackages.txt) --save --no-fail-on-undeclared
 ${VM} "${COMPILER_IMAGE_NAME}.image" eval --save "SystemEnvironment deprecatedAliases: { #SystemDictionary }." # This line should be removed in Pharo 14 since it is for backward compatibility.
 ${VM} "${COMPILER_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/01-init.st --no-source --save --quit
 
 echo $(date -u) "[Compiler] Initializing Unicode"
 ${VM} "${COMPILER_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/01-initialization/02-initUnicode.st --no-source --save --quit "${BOOTSTRAP_REPOSITORY}/resources/unicode/"
 
-${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes FileSystem-Path.hermes FileSystem-Core.hermes FileSystem-Disk.hermes --save --no-fail-on-undeclared
+echo "Loading packages: $(cat hermesFileSystemPackages.txt)"
+${VM} "${COMPILER_IMAGE_NAME}.image" loadHermes $(cat hermesFileSystemPackages.txt) --save --no-fail-on-undeclared
 zip "${COMPILER_IMAGE_NAME}.zip" "${COMPILER_IMAGE_NAME}.image"
 
 # Installing Traits through Hermes 
 echo $(date -u) "[Compiler] Installing Traits through Hermes"
 
 ${VM} "${COMPILER_IMAGE_NAME}.image" save ${TRAITS_IMAGE_NAME}
-${VM} "${TRAITS_IMAGE_NAME}.image" loadHermes Traits.hermes --save
+echo "Loading packages: $(cat hermesTraitsPackages.txt)"
+${VM} "${TRAITS_IMAGE_NAME}.image" loadHermes $(cat hermesTraitsPackages.txt) --save
 zip "${TRAITS_IMAGE_NAME}.zip" "${TRAITS_IMAGE_NAME}.image"
 
 #Bootstrap Initialization: Class and Package initialization
@@ -173,6 +162,7 @@ zip "${CORE_IMAGE_NAME}.zip" "${CORE_IMAGE_NAME}.image"
 echo $(date -u) "[Monticello] Bootstrap Monticello Core and Local repositories"
 
 ${VM} "${CORE_IMAGE_NAME}.image" save ${MC_BOOTSTRAP_IMAGE_NAME}
+echo "Loading packages: $(cat hermesMonticelloPackages.txt)"
 ${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" loadHermes Ring-Definitions-Core.hermes Ring-OldChunkImporter.hermes Jobs.hermes Random-Core.hermes System-Hashing.hermes Compression.hermes Monticello-Model.hermes Monticello.hermes Ring-Definitions-Monticello.hermes --save --no-fail-on-undeclared
 ${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/01-bootstrapMonticello.st --save --quit
 zip "${MC_BOOTSTRAP_IMAGE_NAME}.zip" ${MC_BOOTSTRAP_IMAGE_NAME}.*

--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -100,6 +100,9 @@ fi
 BOOTSTRAP_IMAGE_NAME=bootstrap
 BOOTSTRAP_ARCHIVE_IMAGE_NAME=${PHARO_NAME_PREFIX}-bootstrap-${SUFFIX}
 
+HERMES_ARCHIVE_NAME=${PHARO_NAME_PREFIX}-hermesPackages-${SUFFIX}
+RPACKAGE_ARCHIVE_NAME=${PHARO_NAME_PREFIX}-rpackage-${SUFFIX}
+
 CORE_IMAGE_NAME=${PHARO_NAME_PREFIX}-core-${SUFFIX}
 COMPILER_IMAGE_NAME=${PHARO_NAME_PREFIX}-compiler-${SUFFIX}
 TRAITS_IMAGE_NAME=${PHARO_NAME_PREFIX}-traits-${SUFFIX}
@@ -117,6 +120,12 @@ cp "${BOOTSTRAP_IMAGE_NAME}.image" "${COMPILER_IMAGE_NAME}.image"
 # Archive bootstrap image
 cp "${BOOTSTRAP_IMAGE_NAME}.image" "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.image"
 zip "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.zip" "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.image"
+
+# Archive binary Hermes packages
+zip "${HERMES_ARCHIVE_NAME}.zip" *.hermes
+
+# Archive Package definitions
+zip "${RPACKAGE_ARCHIVE_NAME}.zip" protocolsKernel.txt
 
 # Installing Package
 echo $(date -u) "[Compiler] Initializing Bootstraped Image and fixing the code"

--- a/src/BaselineOfCompiler/BaselineOfCompiler.class.st
+++ b/src/BaselineOfCompiler/BaselineOfCompiler.class.st
@@ -31,7 +31,6 @@ BaselineOfCompiler >> baseline: spec [
 				package: 'CodeImport';
 				package: 'CodeImport-Commands';
 				package: 'DebugInfo';
-				package: 'NumberParser';
 				package: 'OpalCompiler-Core';
 				package: 'ParseTreeRewriter';
 				package: 'Deprecation';
@@ -49,7 +48,7 @@ BaselineOfCompiler >> baseline: spec [
 				group: 'Core'
 				with:
 					{ 'UIManager'. 'AST-Core'. 'Collections-Arithmetic'. 'Collections-Atomic'. 'Collections-Stack'. 'CodeImport'. 'CodeImport-Commands'. 'DebugInfo'.
-					'NumberParser'. 'OpalCompiler-Core'. 'ParseTreeRewriter'. 'Deprecation' };
+					'OpalCompiler-Core'. 'ParseTreeRewriter'. 'Deprecation' };
 				group: 'Tests'
 				with:
 					{ 'Collections-Atomic-Tests'. 'Collections-Stack-Tests'. 'Kernel-Extended-Tests'. 'Kernel-Tests-WithCompiler'. 'AST-Core-Tests'. 'OpalCompiler-Tests'.

--- a/src/BaselineOfKernel/BaselineOfKernel.class.st
+++ b/src/BaselineOfKernel/BaselineOfKernel.class.st
@@ -87,6 +87,7 @@ BaselineOfKernel >> baseline: spec [
 				package: 'Zinc-Character-Encoding-Tests';
 				package: 'System-Time-Tests'.
 
+			"The order of packages in the groups are important for the bootstrap! It define the load order."
 			spec
 				group: 'Core'
 				with: { 'FFI-Kernel'. 'Announcements-Core'. 'Collections-Abstract'. 'Collections-DoubleLinkedList'. 'Collections-Native'. 'Collections-Sequenceable'.
@@ -95,7 +96,7 @@ BaselineOfKernel >> baseline: spec [
 					'System-CommandLineHandler'. 'System-Finalization'. 'System-Platforms'. 'System-SessionManager'. 'ClassDefinitionPrinters'. 'CodeExport'. 'System-Sources'.
 					'System-Support'. 'Zinc-Character-Encoding-Core' };
 				group: 'AdditionalPackages'
-				with: { 'Hermes-Extensions'. 'Clap-Core'. 'Clap-Commands-Pharo'. 'ReflectionMirrors-Primitives'. 'System-Time'. 'Math-Operations-Extensions'.
+				with: { 'Clap-Core'. 'Clap-Commands-Pharo'. 'Hermes-Extensions'. 'ReflectionMirrors-Primitives'. 'System-Time'. 'Math-Operations-Extensions'.
 					'System-NumberPrinting'. 'System-Version'. 'Multilingual-Encodings' };
 				group: 'Tests'
 				with:

--- a/src/BaselineOfKernel/BaselineOfKernel.class.st
+++ b/src/BaselineOfKernel/BaselineOfKernel.class.st
@@ -62,6 +62,7 @@ BaselineOfKernel >> baseline: spec [
 				package: 'Hermes-Extensions';
 				package: 'Clap-Core';
 				package: 'Clap-Commands-Pharo';
+				package: 'NumberParser';
 				package: 'ReflectionMirrors-Primitives';
 				package: 'System-Time';
 				package: 'Math-Operations-Extensions';
@@ -96,7 +97,7 @@ BaselineOfKernel >> baseline: spec [
 					'System-CommandLineHandler'. 'System-Finalization'. 'System-Platforms'. 'System-SessionManager'. 'ClassDefinitionPrinters'. 'CodeExport'. 'System-Sources'.
 					'System-Support'. 'Zinc-Character-Encoding-Core' };
 				group: 'AdditionalPackages'
-				with: { 'Clap-Core'. 'Clap-Commands-Pharo'. 'Hermes-Extensions'. 'ReflectionMirrors-Primitives'. 'System-Time'. 'Math-Operations-Extensions'.
+				with: { 'Clap-Core'. 'Clap-Commands-Pharo'. 'Hermes-Extensions'. 'NumberParser'. 'ReflectionMirrors-Primitives'. 'System-Time'. 'Math-Operations-Extensions'.
 					'System-NumberPrinting'. 'System-Version'. 'Multilingual-Encodings' };
 				group: 'Tests'
 				with:

--- a/src/PharoBootstrap/PBBootstrap.class.st
+++ b/src/PharoBootstrap/PBBootstrap.class.st
@@ -128,6 +128,26 @@ PBBootstrap >> buildNumber: aBuildNumber [
 	buildNumber := aBuildNumber
 ]
 
+{ #category : 'package-names' }
+PBBootstrap >> createHermesPackageListFiles [
+	"In order to not duplicate the packages to load by hermes in the baselines and in the build.sh file, we export the list of packages to load in files."
+
+	| toExport |
+	toExport := Dictionary
+		            with: 'hermesAdditionalKernelPackages.txt' -> BaselineOfKernel additionalPackagesPackageNames
+		            with: 'hermesCompilerPackages.txt' -> BaselineOfCompiler corePackageNames
+		            with: 'hermesFileSystemPackages.txt' -> BaselineOfFileSystem corePackageNames
+		            with: 'hermesTraitsPackages.txt' -> BaselineOfTraits corePackageNames
+		            with: 'hermesMonticelloPackages.txt' -> BaselineOfMonticello corePackageNames.
+
+	toExport keysAndValuesDo: [ :fileName :packageNames |
+			self bootstrapCacheDirectory / fileName writeStreamDo: [ :stream |
+					packageNames do: [ :package |
+							stream
+								nextPutAll: package;
+								nextPutAll: '.hermes ' ] ] ]
+]
+
 { #category : 'bootstrapping' }
 PBBootstrap >> createImage [
 
@@ -267,6 +287,7 @@ PBBootstrap >> prepareBootstrap [
 		ensureBaselineOfPharoBootstrap;
 		exportKernelProtocols;
 		exportAllPackagesIntoMcz;
+		createHermesPackageListFiles;
 		prepareEnvironmentForHermes;
 		generateHermesFiles;
 		prepareEnvironmentForExport


### PR DESCRIPTION
Currently if Hermes needs to load a package, it needs to be declared twice. Once in a baseline to be exported as a hermes file. And once in the script to load the packages. 

This change simplifies things so that we also load the list of packages by using the baseline. With this, we have less things to do if we need to update the bootstrap. 

Also I fixed some wrong dependencies in the baselines because they were out of sync with what was loaded in the build.sh script. 