### PR TITLE
Add missing ffiCall: method

### DIFF
--- a/src/ThreadedFFI/TFCallbackForkRunStrategy.class.st
+++ b/src/ThreadedFFI/TFCallbackForkRunStrategy.class.st
@@ -14,4 +14,5 @@ TFCallbackForkRunStrategy >> executeCallback: aCallbackInvocation on: aTFRunner 
 
 	[ aTFRunner handleExceptionDuring: [ aCallbackInvocation execute ] ]
 		forkAt: Processor highIOPriority - 1
+		named: 'FFICallback'
 ]

--- a/src/ThreadedFFI/TFCallbackQueue.class.st
+++ b/src/ThreadedFFI/TFCallbackQueue.class.st
@@ -79,7 +79,8 @@ TFCallbackQueue >> forkCallbackProcess [
 		[ true ] whileTrue: [
 			semaphore wait.
 			[self executeCallback: self nextPendingCallback]
-				on: Exception fork:  [:ex | ex pass ] ] ]
+				on: Exception 
+				fork:  [:ex | ex pass ] ] ]
 		forkAt: Processor highIOPriority
 		named: 'Callback queue'
 ]

--- a/src/UnifiedFFI/Object.extension.st
+++ b/src/UnifiedFFI/Object.extension.st
@@ -86,6 +86,20 @@ Object >> ffiCall: fnSpec module: aModuleName [
 ]
 
 { #category : '*UnifiedFFI' }
+Object >> ffiCall: fnSpec module: aLibrary fixedArgumentCount: fixedArgumentsCount [
+	<ffiCalloutTranslator>
+
+	"This message allows to call variadic functions.
+	It is required to set the number of fixed arguments in the call as different calling conventions handle them differently"
+
+	self
+		ffiCall: fnSpec
+		library: aLibrary
+		options: #()
+		fixedArgumentCount: fixedArgumentsCount
+]
+
+{ #category : '*UnifiedFFI' }
 Object >> ffiCall: fnSpec module: aModuleName options: callOptions [
 	<ffiCalloutTranslator>
 


### PR DESCRIPTION
there was an ffiCall: method of the family mssing (I am adding variadic control to the gtk library and I realised this was missing).
I also added name to the callback execution, for those cases in which we need to detect them in the process browser.