### PR TITLE
Load UIManager later in the Pharo loading and simplify bootstrap scripts

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -99,11 +99,7 @@ fi
 
 BOOTSTRAP_IMAGE_NAME=bootstrap
 BOOTSTRAP_ARCHIVE_IMAGE_NAME=${PHARO_NAME_PREFIX}-bootstrap-${SUFFIX}
-
 HERMES_ARCHIVE_NAME=${PHARO_NAME_PREFIX}-hermesPackages-${SUFFIX}
-RPACKAGE_ARCHIVE_NAME=${PHARO_NAME_PREFIX}-rpackage-${SUFFIX}
-
-CORE_IMAGE_NAME=${PHARO_NAME_PREFIX}-core-${SUFFIX}
 COMPILER_IMAGE_NAME=${PHARO_NAME_PREFIX}-compiler-${SUFFIX}
 TRAITS_IMAGE_NAME=${PHARO_NAME_PREFIX}-traits-${SUFFIX}
 MC_BOOTSTRAP_IMAGE_NAME=${PHARO_NAME_PREFIX}-monticello_bootstrap-${SUFFIX}
@@ -113,25 +109,21 @@ PHARO_IMAGE_NAME=${PHARO_NAME_PREFIX}-${SUFFIX}
 #Get inside the bootstrap-cache folder. Pharo interprets relatives as relatives to the image and not the 'working directory'
 cd "${BOOTSTRAP_CACHE}"
 
-#Prepare
-echo "Prepare Bootstrap files"
-cp "${BOOTSTRAP_IMAGE_NAME}.image" "${COMPILER_IMAGE_NAME}.image"
+# Initializing bootstrap image
+echo $(date -u) "[Compiler] Initializing Bootstraped Image and fixing the code"
+${VM} "${BOOTSTRAP_IMAGE_NAME}.image" # I have to run once the image so the next time it starts the CommandLineHandler.
+${VM} "${BOOTSTRAP_IMAGE_NAME}.image" perform --save PharoBootstrapInitialization fixMethodsIn: protocolsKernel.txt # Fixing some things espell does not handel well
+${VM} "${BOOTSTRAP_IMAGE_NAME}.image" perform --save PharoBootstrapInitialization fixExtensionMethods
 
-# Archive bootstrap image
+# Archive bootstrap image and prepare compiler image
+echo "Prepare Bootstrap files"
 cp "${BOOTSTRAP_IMAGE_NAME}.image" "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.image"
 zip "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.zip" "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.image"
+cp "${BOOTSTRAP_IMAGE_NAME}.image" "${COMPILER_IMAGE_NAME}.image"
 
 # Archive binary Hermes packages
 zip "${HERMES_ARCHIVE_NAME}.zip" *.hermes
 
-# Archive Package definitions
-zip "${RPACKAGE_ARCHIVE_NAME}.zip" protocolsKernel.txt
-
-# Installing Package
-echo $(date -u) "[Compiler] Initializing Bootstraped Image and fixing the code"
-${VM} "${COMPILER_IMAGE_NAME}.image" # I have to run once the image so the next time it starts the CommandLineHandler.
-${VM} "${COMPILER_IMAGE_NAME}.image" perform --save PharoBootstrapInitialization fixMethodsIn: protocolsKernel.txt # Fixing some things espell does not handel well
-${VM} "${COMPILER_IMAGE_NAME}.image" perform --save PharoBootstrapInitialization fixExtensionMethods
 
 echo $(date -u) "[Compiler] Adding more Kernel packages"
 echo "Loading packages: $(cat hermesAdditionalKernelPackages.txt)"
@@ -162,15 +154,10 @@ echo "Loading packages: $(cat hermesTraitsPackages.txt)"
 ${VM} "${TRAITS_IMAGE_NAME}.image" loadHermes $(cat hermesTraitsPackages.txt) --save
 zip "${TRAITS_IMAGE_NAME}.zip" "${TRAITS_IMAGE_NAME}.image"
 
-#Bootstrap Initialization: Class and Package initialization
-echo $(date -u) "[Core] Class and Package initialization"
-${VM} "${TRAITS_IMAGE_NAME}.image" save ${CORE_IMAGE_NAME}
-zip "${CORE_IMAGE_NAME}.zip" "${CORE_IMAGE_NAME}.image"
-
 #Bootstrap Monticello Part 1: Core and Local repositories
 echo $(date -u) "[Monticello] Bootstrap Monticello Core and Local repositories"
 
-${VM} "${CORE_IMAGE_NAME}.image" save ${MC_BOOTSTRAP_IMAGE_NAME}
+${VM} "${TRAITS_IMAGE_NAME}.image" save ${MC_BOOTSTRAP_IMAGE_NAME}
 echo "Loading packages: $(cat hermesMonticelloPackages.txt)"
 ${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" loadHermes $(cat hermesMonticelloPackages.txt) --save --no-fail-on-undeclared
 ${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/02-monticello-bootstrap/01-bootstrapMonticello.st --save --quit

--- a/bootstrap/scripts/runKernelTests.sh
+++ b/bootstrap/scripts/runKernelTests.sh
@@ -45,27 +45,16 @@ ${BOOTSTRAP_REPOSITORY:-.}/bootstrap/scripts/getPharoVM.sh ${TEST_VM_VERSION} ${
 IMAGE_ARCHIVE=$(find ${CACHE} -name ${TEST_NAME_PREFIX}-bootstrap-${1}bit-*.zip)
 unzip $IMAGE_ARCHIVE
 IMAGE_FILE=$(find . -name ${TEST_NAME_PREFIX}-bootstrap-${1}bit-*.image)
-
 HERMES_ARCHIVE=$(find ${CACHE} -name ${TEST_NAME_PREFIX}-hermesPackages-${1}bit-*.zip)
 unzip $HERMES_ARCHIVE
-
-RPACKAGE_ARCHIVE=$(find ${CACHE} -name ${TEST_NAME_PREFIX}-rpackage-${1}bit-*.zip)
-unzip $RPACKAGE_ARCHIVE
 
 mv $IMAGE_FILE bootstrap.image
 
 export PHARO_CI_TESTING_ENVIRONMENT=1
-	
-#Initializing the Image
-./pharo bootstrap.image
+
 #Adding packages removed from the bootstrap
 ./pharo bootstrap.image perform --save BasicHermesTool load: --as-array Clap-Core.hermes Clap-Commands-Pharo.hermes Hermes-Extensions.hermes
-./pharo bootstrap.image perform --save Pragma buildCache
-./pharo bootstrap.image loadHermes UIManager.hermes Math-Operations-Extensions.hermes System-Time.hermes NumberParser.hermes AST-Core.hermes ParseTreeRewriter.hermes Random-Core.hermes System-NumberPrinting.hermes --save --no-fail-on-undeclared --on-duplication ignore
-
-#Initializing the package manager
-./pharo bootstrap.image perform --save PharoBootstrapInitialization fixExtensionMethods
-./pharo bootstrap.image perform --save PharoBootstrapInitialization fixMethodsIn: protocolsKernel.txt
+./pharo bootstrap.image loadHermes Math-Operations-Extensions.hermes System-Time.hermes NumberParser.hermes AST-Core.hermes ParseTreeRewriter.hermes Random-Core.hermes System-NumberPrinting.hermes --save --no-fail-on-undeclared --on-duplication ignore
 
 #Load traits
 ./pharo bootstrap.image loadHermes Traits.hermes --save

--- a/src/BaselineOfCompiler/BaselineOfCompiler.class.st
+++ b/src/BaselineOfCompiler/BaselineOfCompiler.class.st
@@ -23,7 +23,6 @@ BaselineOfCompiler >> baseline: spec [
 	<baseline>
 	spec for: #common do: [
 			spec
-				package: 'UIManager';
 				package: 'AST-Core';
 				package: 'Collections-Arithmetic';
 				package: 'Collections-Atomic';
@@ -47,7 +46,7 @@ BaselineOfCompiler >> baseline: spec [
 			spec
 				group: 'Core'
 				with:
-					{ 'UIManager'. 'AST-Core'. 'Collections-Arithmetic'. 'Collections-Atomic'. 'Collections-Stack'. 'CodeImport'. 'CodeImport-Commands'. 'DebugInfo'.
+					{ 'AST-Core'. 'Collections-Arithmetic'. 'Collections-Atomic'. 'Collections-Stack'. 'CodeImport'. 'CodeImport-Commands'. 'DebugInfo'.
 					'OpalCompiler-Core'. 'ParseTreeRewriter'. 'Deprecation' };
 				group: 'Tests'
 				with:

--- a/src/BaselineOfDebugging/BaselineOfDebugging.class.st
+++ b/src/BaselineOfDebugging/BaselineOfDebugging.class.st
@@ -17,6 +17,7 @@ BaselineOfDebugging >> baseline: spec [
 	<baseline>
 	spec for: #common do: [
 			spec
+				package: 'UIManager';
 				package: 'Debugging-Core';
 				package: 'Debugging-Utils' with: [ spec requires: #( 'Debugging-Core' ) ];
 				package: 'Debugger-Model' with: [ spec requires: #( 'Debugging-Core' 'Debugging-Utils' ) ];
@@ -26,6 +27,6 @@ BaselineOfDebugging >> baseline: spec [
 				package: 'Debugger-Oups-Tests' with: [ spec requires: #( 'Debugger-Oups' ) ].
 
 			spec
-				group: 'Core' with: #( 'Debugging-Core' 'Debugging-Utils' 'Debugger-Model' 'Debugger-Oups' );
+				group: 'Core' with: #( 'UIManager' 'Debugging-Core' 'Debugging-Utils' 'Debugger-Model' 'Debugger-Oups' );
 				group: 'Tests' with: #( 'Debugging-Utils-Tests' 'Debugger-Model-Tests' 'Debugger-Oups-Tests' ) ]
 ]

--- a/src/Debugger-Model/SmalltalkImage.extension.st
+++ b/src/Debugger-Model/SmalltalkImage.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : 'SmalltalkImage' }
+
+{ #category : '*Debugger-Model' }
+SmalltalkImage >> okayToProceedEvenIfSpaceIsLow [
+	"Return true if either there is enough memory to do so safely or if the user gives permission after being given fair warning."
+
+	self garbageCollectMost > self lowSpaceThreshold ifTrue: [^ true].  "quick"
+	self garbageCollect > self lowSpaceThreshold ifTrue: [^ true].  "work harder"
+
+	^ self confirm:
+'WARNING: There is not enough space to start the low space watcher.
+If you proceed, you will not be warned again, and the system may
+run out of memory and crash. If you do proceed, you can start the
+low space notifier when more space becomes available simply by
+opening and then closing a debugger (e.g., by hitting Cmd-period.)
+Do you want to proceed?'
+]

--- a/src/Morphic-Base/WorldState.extension.st
+++ b/src/Morphic-Base/WorldState.extension.st
@@ -32,6 +32,15 @@ WorldState class >> browseWorldMenuOn: aBuilder [
 ]
 
 { #category : '*Morphic-Base' }
+WorldState class >> cleanUpImage [
+
+	"Give the user a chance to bail"
+	(self confirm: 'Cleanup will destroy change sets and more.
+Are you sure you want to proceed?') ifFalse: [ ^ self ].
+	^ Smalltalk cleanUp: true
+]
+
+{ #category : '*Morphic-Base' }
 WorldState class >> debugWorldMenuOn: aBuilder [
 
 	<worldMenu>
@@ -119,44 +128,45 @@ WorldState >> startThenBrowseMessageTally [
 
 { #category : '*Morphic-Base' }
 WorldState class >> systemOn: aBuilder [
+
 	<worldMenu>
 	(aBuilder item: #System)
 		order: 60;
 		with: [
-			(aBuilder group: #SystemTools)
-				order: 1;
-				withSeparatorAfter.
-			(aBuilder group: #Startup)
-				order: 2;
-				withSeparatorAfter.
-			(aBuilder group: #Image)
-				order: 3;
-				with: [
-					(aBuilder item: #'Space left')
-						help: 'Do a garbage collection, and report results about the to the user.';
-						order: 1;
-						action: [ Smalltalk informSpaceLeftAfterGarbageCollection ].
-					(aBuilder item: #'Do Image Cleanup')
-						help: 'Clean out any caches and other state that should be flushed when trying to get an image into a pristine state.';
-						order: 2;
-						action: [ Smalltalk cleanUp: true ].
-					aBuilder 	withSeparatorAfter].
-			(aBuilder group: #World)
-				order: 4;
-				with: [
-					(aBuilder item: #'Start drawing again')
-						help: 'Resume the drawing after a draw error of the world.';
-						order: 1;
-						action: [ self currentWorld resumeAfterDrawError ].
-					(aBuilder item: #'Start stepping again')
-						help: 'Resume stepping of Morph after an error has occured.';
-						order: 2;
-						action: [ self currentWorld resumeAfterStepError ].
-					(aBuilder item: #'Restore display')
-						help: 'Restore Morphic display.';
-						order: 3;
-						action: [ self currentWorld restoreMorphicDisplay ].
-					aBuilder withSeparatorAfter ] ]
+				(aBuilder group: #SystemTools)
+					order: 1;
+					withSeparatorAfter.
+				(aBuilder group: #Startup)
+					order: 2;
+					withSeparatorAfter.
+				(aBuilder group: #Image)
+					order: 3;
+					with: [
+							(aBuilder item: #'Space left')
+								help: 'Do a garbage collection, and report results about the to the user.';
+								order: 1;
+								action: [ Smalltalk informSpaceLeftAfterGarbageCollection ].
+							(aBuilder item: #'Do Image Cleanup')
+								help: 'Clean out any caches and other state that should be flushed when trying to get an image into a pristine state.';
+								order: 2;
+								action: [ self cleanUpImage ].
+							aBuilder withSeparatorAfter ].
+				(aBuilder group: #World)
+					order: 4;
+					with: [
+							(aBuilder item: #'Start drawing again')
+								help: 'Resume the drawing after a draw error of the world.';
+								order: 1;
+								action: [ self currentWorld resumeAfterDrawError ].
+							(aBuilder item: #'Start stepping again')
+								help: 'Resume stepping of Morph after an error has occured.';
+								order: 2;
+								action: [ self currentWorld resumeAfterStepError ].
+							(aBuilder item: #'Restore display')
+								help: 'Restore Morphic display.';
+								order: 3;
+								action: [ self currentWorld restoreMorphicDisplay ].
+							aBuilder withSeparatorAfter ] ]
 ]
 
 { #category : '*Morphic-Base' }

--- a/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
+++ b/src/System-Dependencies-Tests/SystemDependenciesTest.class.st
@@ -118,6 +118,13 @@ SystemDependenciesTest >> knownDebuggingDependencies [
 ]
 
 { #category : 'known dependencies' }
+SystemDependenciesTest >> knownDisplayDependencies [
+	"ideally this list should be empty"
+
+	^ #( #'Morphic-Core' #'System-Object Events' #'Tool-Base' )
+]
+
+{ #category : 'known dependencies' }
 SystemDependenciesTest >> knownKernelAdditionalPackagesDependencies [
 	"ideally this list should be empty"
 
@@ -244,12 +251,12 @@ SystemDependenciesTest >> testExternalDisplayDependencies [
 	| dependencies |
 
 	dependencies := self externalDependendiesOf: (
-		self _09sunitCoreLayerPackages,
+		self _10debuggingLayerPackages, 
 		BaselineOfUnifiedFFI allPackageNames,
 		BaselineOfThreadedFFI allPackageNames,
 		BaselineOfDisplay allPackageNames).
 
-	self assertEmpty: dependencies
+	self assert: dependencies equals: self knownDisplayDependencies
 ]
 
 { #category : 'tests' }

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1051,22 +1051,6 @@ SmalltalkImage >> newSpecialObjectsArray [
 	^newArray
 ]
 
-{ #category : 'memory space' }
-SmalltalkImage >> okayToProceedEvenIfSpaceIsLow [
-	"Return true if either there is enough memory to do so safely or if the user gives permission after being given fair warning."
-
-	self garbageCollectMost > self lowSpaceThreshold ifTrue: [^ true].  "quick"
-	self garbageCollect > self lowSpaceThreshold ifTrue: [^ true].  "work harder"
-
-	^ self confirm:
-'WARNING: There is not enough space to start the low space watcher.
-If you proceed, you will not be warned again, and the system may
-run out of memory and crash. If you do proceed, you can start the
-low space notifier when more space becomes available simply by
-opening and then closing a debugger (e.g., by hitting Cmd-period.)
-Do you want to proceed?'
-]
-
 { #category : 'miscellaneous' }
 SmalltalkImage >> openLog [
 	"This is a _private_ method,

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -340,24 +340,7 @@ SmalltalkImage >> cleanUp: aggressive except: exclusions [
 
 	"Smalltalk cleanUp: true except: {Point}"
 
-	^self cleanUp: aggressive except: exclusions confirming: aggressive
-]
-
-{ #category : 'cleanup' }
-SmalltalkImage >> cleanUp: aggressive except: exclusions confirming: aBool [
-	"Clean up. When aggressive is true, this will destroy resources, etc.
-	Leave out any classes specifically listed in exclusions."
-
-	"Smalltalk cleanUp: true except: {Point}
-		- will ask for confirmation"
-	"SmalltalkImage current cleanUp: true except: {} confirming: false
-		- will not ask for confirmation"
-
 	| classes |
-	aBool ifTrue:[
-		"Give the user a chance to bail"
-		(self confirm: 'Cleanup will destroy change sets and more.
-Are you sure you want to proceed?') ifFalse: [^self]].
 
 	"Find all classes implementing #cleanUp or cleanUp:"
 	classes := Smalltalk allClasses select: [:aClass|

--- a/src/Tool-ImageCleaner/ImageCleaner.class.st
+++ b/src/Tool-ImageCleaner/ImageCleaner.class.st
@@ -95,7 +95,7 @@ ImageCleaner >> cleanUpForRelease [
 		cleanOutUndeclared;
 		fixObsoleteReferences;
 		removeEmptyMessageCategories;
-		cleanUp: true except: #(  ) confirming: false.
+		cleanUp: true except: #(  ).
 
 	FreeTypeFontProvider current prepareForRelease.
 

--- a/src/Tool-ImageCleaner/ImageCleanerCliCommand.class.st
+++ b/src/Tool-ImageCleaner/ImageCleanerCliCommand.class.st
@@ -57,5 +57,5 @@ ImageCleanerCliCommand >> runCleanup [
 
 	self isProductionCleanup ifTrue: [ ^ ImageCleaner cleanUpForProduction ].
 
-	Smalltalk cleanUp: true except: #( ) confirming: false
+	Smalltalk cleanUp: true except: #( )
 ]


### PR DESCRIPTION
This change brings a few things:
- Cut some dependencies (the cleanup was only asking for confirmation in the WorldState so I moved the confirmation asking to Morphic and I moved a method used only by the debugger in the debugger)
- Move UIManager loading to its first dependency: the debugger model
- A dependency test was wrong and was missing some current bad dependency. I added those failures explicitly so that we can work on them later
- Run the first steps of the bootstrap before zipping the espell produced image to avoid doing the same step again in runKernelTests.sh
- Remove the production of the "core" image zip because it is exactly the same as the traits image
- Remove the zipping of some resources because they are not used anymore now that runKernelTests.sh is simpler

My next step is to introduce an alternative was of managing the #confirm:. I have an idea but I need some time to see if it's good