### PR TITLE
Metacello: clean MetacelloProjectSpec hierarchy

### DIFF
--- a/src/Metacello-Core/MetacelloBaselineOfProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloBaselineOfProjectSpec.class.st
@@ -25,15 +25,10 @@ MetacelloBaselineOfProjectSpec >> asBaselineProjectSpec [
 ]
 
 { #category : 'scripting' }
-MetacelloBaselineOfProjectSpec >> asProjectRegistration [
-    ^ MetacelloProjectRegistration fromMCBaselineProjectSpec: self
-]
-
-{ #category : 'scripting' }
 MetacelloBaselineOfProjectSpec >> canDowngradeTo: aProjectSpec [
-    "cannot upgrade between baselines"
+	"cannot upgrade between baselines"
 
-    ^ false
+	^ false
 ]
 
 { #category : 'scripting' }
@@ -45,9 +40,17 @@ MetacelloBaselineOfProjectSpec >> canUpgradeTo: aProjectSpec [
   ^ false
 ]
 
+{ #category : 'querying' }
+MetacelloBaselineOfProjectSpec >> className [
+
+	className ifNil: [ self name ifNotNil: [ self className: self constructClassName ] ].
+	^ className
+]
+
 { #category : 'private' }
 MetacelloBaselineOfProjectSpec >> constructClassName [
-    ^ 'BaselineOf' , self name
+
+	^ 'BaselineOf' , self name
 ]
 
 { #category : 'mutability' }
@@ -68,72 +71,49 @@ MetacelloBaselineOfProjectSpec >> hasClassName [
 	^ className isNotNil and: [ className ~= self constructClassName ]
 ]
 
-{ #category : 'testing' }
-MetacelloBaselineOfProjectSpec >> hasConflictWithConfigurationSpec: projectSpec [
-  "baseline can be loaded on top of a configuration without a conflict"
-
-  ^ false
-]
-
-{ #category : 'testing' }
-MetacelloBaselineOfProjectSpec >> hasConflictWithProjectSpec: projectSpec [
-	^ projectSpec hasConflictWithBaselineSpec: self
-]
-
-{ #category : 'testing' }
-MetacelloBaselineOfProjectSpec >> isBaselineOfProjectSpec [
-	^ true
-]
-
 { #category : 'importing' }
 MetacelloBaselineOfProjectSpec >> mergeImportLoads: aLoadList [
-    aLoadList
-        ifNotNil: [ :otherLoads | self loads ifNil: [ loads := otherLoads ] ifNotNil: [ loads := loads , otherLoads ] ]
+
+	aLoadList ifNotNil: [ :otherLoads |
+			self loads
+				ifNil: [ loads := otherLoads ]
+				ifNotNil: [ loads := loads , otherLoads ] ]
 ]
 
 { #category : 'merging' }
 MetacelloBaselineOfProjectSpec >> mergeRepositoriesSpec: anotherRepositories [
-  "anotherRepositories wins ... there can ever only be one repository for the 
+	"anotherRepositories wins ... there can ever only be one repository for the 
    baseline to load from"
 
-  "https://github.com/dalehenrich/metacello-work/issues/251"
+	"https://github.com/dalehenrich/metacello-work/issues/251"
 
-  self repositories: anotherRepositories
+	self repositories: anotherRepositories
 ]
 
 { #category : 'merging' }
 MetacelloBaselineOfProjectSpec >> mergeSpec: anotherSpec [
-    ^ super mergeSpec: anotherSpec asBaselineProjectSpec
+
+	^ super mergeSpec: anotherSpec asBaselineProjectSpec
 ]
 
 { #category : 'printing' }
 MetacelloBaselineOfProjectSpec >> projectLabel [
-    ^ 'baseline'
-]
 
-{ #category : 'querying' }
-MetacelloBaselineOfProjectSpec >> repositoryBranchName [
-	"extract a branch name from the repository ... if possible"
-
-	"must parallel implementation of MetacelloMCBaselineProject>>setBaselineRepositoryDescription: we want the same repoSpec"
-
-	| spec |
-	self repositorySpecs do: [ :repoSpec | spec := repoSpec ].
-	^ spec createRepository repositoryBranchName
+	^ 'baseline'
 ]
 
 { #category : 'querying' }
 MetacelloBaselineOfProjectSpec >> repositoryVersionString [
-  "extract a version string from the repository ... if possible"
+	"extract a version string from the repository ... if possible"
 
-  "must parallel implementation of MetacelloMCBaselineProject>>setBaselineRepositoryDescription: we want the same repoSpec"
+	"must parallel implementation of MetacelloMCBaselineProject>>setBaselineRepositoryDescription: we want the same repoSpec"
 
-  | spec repo |
-  self repositorySpecs do: [ :repoSpec | spec := repoSpec ].
-  [ repo := spec createRepository ]
-    on: Error
-    do: [ :ex | ^ '' ].
-  ^ repo repositoryVersionString
+	| spec repo |
+	self repositorySpecs do: [ :repoSpec | spec := repoSpec ].
+	[ repo := spec createRepository ]
+		on: Error
+		do: [ :ex | ^ '' ].
+	^ repo repositoryVersionString
 ]
 
 { #category : 'querying' }
@@ -146,6 +126,5 @@ MetacelloBaselineOfProjectSpec >> version [
 { #category : 'querying' }
 MetacelloBaselineOfProjectSpec >> versionString [
 
-	^ versionString ifNil: [
-		  self version ifNotNil: [ :v | v versionString ] ]
+	^ versionString ifNil: [ self version ifNotNil: [ :v | v versionString ] ]
 ]

--- a/src/Metacello-Core/MetacelloNamelessProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloNamelessProjectSpec.class.st
@@ -13,7 +13,74 @@ MetacelloNamelessProjectSpec class >> initialize [
 	self deprecatedAliases: #( #MetacelloMCNamelessProjectSpec )
 ]
 
+{ #category : 'visiting' }
+MetacelloNamelessProjectSpec >> acceptVisitor: aVisitor [
+
+	self error: 'Nameless project spec should be transformed into a baseline spec before visit can start.'
+]
+
+{ #category : 'scripting' }
+MetacelloNamelessProjectSpec >> asBaselineProjectSpec [
+
+	^ self copyForScriptingInto: (MetacelloBaselineOfProjectSpec for: self project)
+]
+
+{ #category : 'scripting' }
+MetacelloNamelessProjectSpec >> canDowngradeTo: aMetacelloProjectSpec [
+
+	self file = aMetacelloProjectSpec file ifFalse: [ ^ false ].
+	(self className = aMetacelloProjectSpec className and: [ self operator == aMetacelloProjectSpec operator ]) ifFalse: [ ^ false ].
+	self versionOrNil ifNil: [ "https://github.com/dalehenrich/metacello-work/issues/198#issuecomment-21737458" ^ true ].
+	^ (self compareVersions: aMetacelloProjectSpec usingOperator: self operator) not
+]
+
+{ #category : 'scripting' }
+MetacelloNamelessProjectSpec >> canUpgradeTo: aMetacelloProjectSpec [
+
+	self file = aMetacelloProjectSpec file ifFalse: [ ^ false ].
+	(self className = aMetacelloProjectSpec className and: [ self operator == aMetacelloProjectSpec operator ]) ifFalse: [ ^ false ].
+	self versionOrNil ifNil: [ "https://github.com/dalehenrich/metacello-work/issues/198#issuecomment-21737458" ^ true ].
+	^ self compareVersions: aMetacelloProjectSpec usingOperator: self operator
+]
+
 { #category : 'mutability' }
 MetacelloNamelessProjectSpec >> copyForRegistration: aMetacelloProjectRegistration onWrite: aBlock [
-	self error: 'Should be converting to configuration spec for the registration, so we should not get here'
+
+	self error: 'Should be converting to baseline of project spec for the registration, so we should not get here'
+]
+
+{ #category : 'scripting' }
+MetacelloNamelessProjectSpec >> copyForScriptingInto: aProjectSpec [
+
+	^ aProjectSpec
+		  setName: name;
+		  className: className;
+		  versionString: versionString;
+		  operator: operator;
+		  setLoads: loads;
+		  preLoadDoIt: preLoadDoIt;
+		  postLoadDoIt: postLoadDoIt;
+		  repositories: repositories copy;
+		  file: file
+]
+
+{ #category : 'merging' }
+MetacelloNamelessProjectSpec >> mergeRepositoriesSpec: anotherRepositories [
+
+	self repositories: (self getRepositories
+			 ifNotNil: [ self repositories mergeSpec: anotherRepositories ]
+			 ifNil: [ anotherRepositories ])
+]
+
+{ #category : 'printing' }
+MetacelloNamelessProjectSpec >> projectLabel [
+
+	^ 'project'
+]
+
+{ #category : 'querying' }
+MetacelloNamelessProjectSpec >> version [
+	"Empty version string means use latestVersion or #bleedingEdge"
+
+	^ self versionString ifNotNil: [ self project versionString ]
 ]

--- a/src/Metacello-Core/MetacelloProject.class.st
+++ b/src/Metacello-Core/MetacelloProject.class.st
@@ -251,13 +251,7 @@ MetacelloProject >> projectSpec [
 { #category : 'spec classes' }
 MetacelloProject >> repositoriesSpec [
 
-	^self repositoriesSpecClass for: self
-]
-
-{ #category : 'spec classes' }
-MetacelloProject >> repositoriesSpecClass [
-
-	^MetacelloRepositoriesSpec
+	^ MetacelloRepositoriesSpec for: self
 ]
 
 { #category : 'accessing' }
@@ -268,13 +262,7 @@ MetacelloProject >> repositoryDescription [
 { #category : 'spec classes' }
 MetacelloProject >> repositorySpec [
 
-	^self repositorySpecClass for: self
-]
-
-{ #category : 'spec classes' }
-MetacelloProject >> repositorySpecClass [
-
-	^MetacelloRepositorySpec
+	^ MetacelloRepositorySpec for: self
 ]
 
 { #category : 'development support' }

--- a/src/Metacello-Core/MetacelloProjectRegistration.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistration.class.st
@@ -141,14 +141,8 @@ MetacelloProjectRegistration >> baselineProjectSpec [
 
 { #category : 'accessing' }
 MetacelloProjectRegistration >> baselineProjectSpec: anObject [
-	"force the registration to be consistent -- difficult for Metacello to 
-   repair registrations during load -- I've tried. "
-
-	"https://github.com/dalehenrich/metacello-work/issues/212"
 
 	self shouldBeMutable.
-	self assert: anObject isBaselineOfProjectSpec.
-
 	baselineProjectSpec := anObject
 ]
 

--- a/src/Metacello-Core/MetacelloProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectSpec.class.st
@@ -20,10 +20,9 @@ Class {
 }
 
 { #category : 'instance creation' }
-MetacelloProjectSpec class >> new [
-	self name == #MetacelloProjectSpec
-		ifTrue: [ self error: 'This class is abstract' ].
-	^ super new
+MetacelloProjectSpec class >> isAbstract [
+
+	^ self = MetacelloProjectSpec
 ]
 
 { #category : 'adding' }
@@ -44,13 +43,11 @@ MetacelloProjectSpec >> addToMetacelloPackages: aMetacelloPackagesSpec [
 { #category : 'scripting' }
 MetacelloProjectSpec >> asBaselineProjectSpec [
 
-	^ self copyForScriptingInto: (MetacelloBaselineOfProjectSpec for: self project)
+	^ self subclassResponsibility
 ]
 
 { #category : 'scripting' }
 MetacelloProjectSpec >> asProjectRegistration [
-
-	(self className beginsWith: 'BaselineOf') ifFalse: [ self error: 'The class name should be a baseline and begin with `BaselineOf`.' ].
 
 	^ MetacelloProjectRegistration fromMCBaselineProjectSpec: self asBaselineProjectSpec
 ]
@@ -68,25 +65,19 @@ MetacelloProjectSpec >> baseName [
 { #category : 'scripting' }
 MetacelloProjectSpec >> canDowngradeTo: aMetacelloProjectSpec [
 
-	self file = aMetacelloProjectSpec file ifFalse: [ ^ false ].
-	(self className = aMetacelloProjectSpec className and: [ self operator == aMetacelloProjectSpec operator ]) ifFalse: [ ^ false ].
-	self versionOrNil ifNil: [ "https://github.com/dalehenrich/metacello-work/issues/198#issuecomment-21737458" ^ true ].
-	^ (self compareVersions: aMetacelloProjectSpec usingOperator: self operator) not
+	^ self subclassResponsibility
 ]
 
 { #category : 'scripting' }
 MetacelloProjectSpec >> canUpgradeTo: aMetacelloProjectSpec [
 
-	self file = aMetacelloProjectSpec file ifFalse: [ ^ false ].
-	(self className = aMetacelloProjectSpec className and: [ self operator == aMetacelloProjectSpec operator ]) ifFalse: [ ^ false ].
-	self versionOrNil ifNil: [ "https://github.com/dalehenrich/metacello-work/issues/198#issuecomment-21737458" ^ true ].
-	^ self compareVersions: aMetacelloProjectSpec usingOperator: self operator
+	^ self subclassResponsibility
 ]
 
 { #category : 'querying' }
 MetacelloProjectSpec >> className [
-    className ifNil: [ self name ifNotNil: [ self className: self constructClassName ] ].
-    ^ className
+
+	^ className
 ]
 
 { #category : 'accessing' }
@@ -280,28 +271,10 @@ MetacelloProjectSpec >> configShortCutMethodOn: aStream member: aMember indent: 
 			^ self ]
 ]
 
-{ #category : 'private' }
-MetacelloProjectSpec >> constructClassName [
-    ^ nil
-]
-
 { #category : 'mutability' }
 MetacelloProjectSpec >> copyForRegistration: aMetacelloProjectRegistration onWrite: aBlock [
-    self subclassResponsibility
-]
 
-{ #category : 'scripting' }
-MetacelloProjectSpec >> copyForScriptingInto: aProjectSpec [
-    ^aProjectSpec
-        setName: name;
-        className: className;
-        versionString: versionString;
-        operator: operator;
-        setLoads: loads;
-        preLoadDoIt: preLoadDoIt;
-        postLoadDoIt: postLoadDoIt;
-        repositories: repositories copy;
-        file: file
+	self subclassResponsibility
 ]
 
 { #category : 'accessing' }
@@ -382,16 +355,9 @@ MetacelloProjectSpec >> hasConflictWithBaselineSpec: projectSpec [
 ]
 
 { #category : 'testing' }
-MetacelloProjectSpec >> hasConflictWithConfigurationSpec: projectSpec [
-	^ self hasLoadConflicts: projectSpec
-]
-
-{ #category : 'testing' }
 MetacelloProjectSpec >> hasConflictWithProjectSpec: projectSpec [
 
-	(self className beginsWith: 'BaselineOf') ifFalse: [ self error: 'The class name should be a baseline and begin with `BaselineOf`.' ].
-
-	^ projectSpec hasConflictWithBaselineSpec: self asBaselineProjectSpec
+	^ projectSpec hasConflictWithBaselineSpec: self
 ]
 
 { #category : 'testing' }
@@ -434,11 +400,6 @@ MetacelloProjectSpec >> initialize [
 
 	super initialize.
 	projectInitialized := false
-]
-
-{ #category : 'testing' }
-MetacelloProjectSpec >> isBaselineOfProjectSpec [
-	^ false
 ]
 
 { #category : 'testing' }
@@ -515,9 +476,7 @@ MetacelloProjectSpec >> mergeMap [
 { #category : 'merging' }
 MetacelloProjectSpec >> mergeRepositoriesSpec: anotherRepositories [
 
-	self repositories: (self getRepositories
-			 ifNotNil: [ self repositories mergeSpec: anotherRepositories ]
-			 ifNil: [ anotherRepositories ])
+	self subclassResponsibility
 ]
 
 { #category : 'scripting' }
@@ -648,7 +607,8 @@ MetacelloProjectSpec >> projectInitialized [
 
 { #category : 'printing' }
 MetacelloProjectSpec >> projectLabel [
-    ^ 'project'
+
+	^ self subclassResponsibility
 ]
 
 { #category : 'accessing' }
@@ -768,9 +728,8 @@ MetacelloProjectSpec >> unregisterProject [
 
 { #category : 'querying' }
 MetacelloProjectSpec >> version [
-	"Empty version string means use latestVersion or #bleedingEdge"
 
-	^ self versionString ifNotNil: [ self project versionString ]
+	^ self subclassResponsibility
 ]
 
 { #category : 'querying' }


### PR DESCRIPTION
This is the start of a pretty big refactoring (or series of refactorings) I want to do in the model of Metacello to simpify it!

## Context

The hierarchy of MetacelloProjectSpec is here to manage the declaration of dependencies. In the past this hierarchy was like this:

-> MetacelloProjectSpec (abstract)
---|> MetacelloBaselineOfProjectSpec : defines a dependency via another baseline
---|> MetacelloConfigurationOfProjectSpec : defines a dependency via another configuration
---|> MetacelloNamelessProjectSpec : defines a dependency as a nameless "project" that will be cast as a configuration or baseline project spec before the actual actions of Metacello

Now we do not have the MetacelloConfigurationOfProjectSpec anymore and MetacelloNamelessProjectSpec is almost empty because all its behavior is in MetacelloProjectSpec.

## Change

This change is pushing all the behavior specific to MetacelloNamelessProjectSpec into this class instead of having the behavior in the abstract superclass. This will allow to have a clearer understanding of what are the differences between a NamelessProjectSpec and a BaselineOfProjectSpec.

## Future steps

I have two future steps in mind.

The first future step is to kill the concept of multiple repositories. With configurations, we could look for the project in multiple repositories. But baselines are storing more info in the "repository" since it points for example to branches or versions. Because of that, MetacelloBaselineOfProjectSpec is limited to only one repository. And since MetacelloNamelessProjectSpec **must** be cast into a MetacelloBaselineOfProjectSpec, only the last defined repository will win in the end. 

I want to refactore Metacello API to deprecate this system of multiple repositories and allow only one since it will be the last one (or first one in some cases? it is still not clear to me) that will win. This should simplify further the model of Metacello!

Second, once this change is done, most of the difference between MetacelloNamelessProjectSpec and MetacelloBaselineOfProjectSpec will be gone. I would like to remove entirely the concept of "project dependency" to keep only "baseline of project spec" kind of dependencies. I would rename it "MetacelloDependencySpec". This will remove the need of useless casts. This will simplifcy the API. This will simplify the model. And I believe that we can find much more deadcode if we do that because I am currently unsure if some code is dead or not because of those casts >w<