### PR TITLE
Metacello: a set of cleanings

### DIFF
--- a/src/Deprecated14/MetacelloProjectRegistration.extension.st
+++ b/src/Deprecated14/MetacelloProjectRegistration.extension.st
@@ -6,3 +6,10 @@ MetacelloProjectRegistration >> baselineProjectSpec [
 	self deprecated: 'Use #projectSpec instead.' transformWith: '`@rcv baselineProjectSpec' -> '`@rcv projectSpec'.
 	^ self projectSpec
 ]
+
+{ #category : '*Deprecated14' }
+MetacelloProjectRegistration class >> baselineProjectSpecs [
+
+	self deprecated: 'Use #projectSpecs instead.' transformWith: '`@rcv baselineProjectSpecs' -> '`@rcv projectSpecs'.
+	^ self projectSpecs
+]

--- a/src/Deprecated14/MetacelloProjectRegistration.extension.st
+++ b/src/Deprecated14/MetacelloProjectRegistration.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'MetacelloProjectRegistration' }
+
+{ #category : '*Deprecated14' }
+MetacelloProjectRegistration >> baselineProjectSpec [
+
+	self deprecated: 'Use #projectSpec instead.' transformWith: '`@rcv baselineProjectSpec' -> '`@rcv projectSpec'.
+	^ self projectSpec
+]

--- a/src/Deprecated14/MetacelloProjectRegistry.extension.st
+++ b/src/Deprecated14/MetacelloProjectRegistry.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'MetacelloProjectRegistry' }
+
+{ #category : '*Deprecated14' }
+MetacelloProjectRegistry >> baselineProjectSpecs [
+
+	self deprecated: 'Use #projectSpecs instead.' transformWith: '`@rcv baselineProjectSpecs' -> '`@rcv projectSpecs'.
+	^ self projectSpecs
+]

--- a/src/Deprecated14/MetacelloProjectRegistry.extension.st
+++ b/src/Deprecated14/MetacelloProjectRegistry.extension.st
@@ -6,3 +6,10 @@ MetacelloProjectRegistry >> baselineProjectSpecs [
 	self deprecated: 'Use #projectSpecs instead.' transformWith: '`@rcv baselineProjectSpecs' -> '`@rcv projectSpecs'.
 	^ self projectSpecs
 ]
+
+{ #category : '*Deprecated14' }
+MetacelloProjectRegistry >> baselineRegistry [
+
+	self deprecated: 'Use #projectSpecs instead.' transformWith: '`@rcv baselineProjectSpecs' -> '`@rcv projectSpecs'.
+	^ self projectSpecsRegistry
+]

--- a/src/Metacello-Core/MetacelloBaselineOfProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloBaselineOfProjectSpec.class.st
@@ -57,12 +57,9 @@ MetacelloBaselineOfProjectSpec >> constructClassName [
 MetacelloBaselineOfProjectSpec >> copyForRegistration: aMetacelloProjectRegistration onWrite: aBlock [
 
 	| copy |
-	aMetacelloProjectRegistration
-		baselineProjectSpecIfPresent: [ :spec |
-				copy := spec copy.
-				aBlock value: copy.
-				aMetacelloProjectRegistration baselineProjectSpec: copy ]
-		ifAbsent: [ aBlock value: nil ]
+	copy := aMetacelloProjectRegistration projectSpec copy.
+	aBlock value: copy.
+	aMetacelloProjectRegistration projectSpec: copy
 ]
 
 { #category : 'printing' }

--- a/src/Metacello-Core/MetacelloProjectRegistration.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistration.class.st
@@ -25,24 +25,6 @@ MetacelloProjectRegistration class >> baselineClasses [
     ^ BaselineOf allSubclasses
 ]
 
-{ #category : 'accessing' }
-MetacelloProjectRegistration class >> baselineProjectSpecs [
-    "MetacelloProjectRegistration baselineProjectSpecs"
-
-    ^ self registry baselineProjectSpecs
-]
-
-{ #category : 'accessing' }
-MetacelloProjectRegistration class >> classRemoved: aClassRemovalAnnouncement [
-	"aRemovalAnnouncement is platform-specific ... responds to #itemClass to 
-   answer the class that was removed."
-
-	| aClass registration |
-	aClass := aClassRemovalAnnouncement itemClass.
-	registration := self registry registrationForExactClassNamed: aClass name asString ifAbsent: [ ^ self ].
-	registration unregisterProject
-]
-
 { #category : 'mutability' }
 MetacelloProjectRegistration class >> copyRegistryDuring: aBlock commitIfSuccess: aBoolean [
 	"install copy of registry for duration of <aBlock> execution."
@@ -74,6 +56,12 @@ MetacelloProjectRegistration class >> projectSpec: aProjectSpec [
 { #category : 'querying' }
 MetacelloProjectRegistration class >> projectSpecForClassNamed: aClassName ifAbsent: absentBlock [
     ^ self registry projectSpecForClassNamed: aClassName ifAbsent: absentBlock
+]
+
+{ #category : 'accessing' }
+MetacelloProjectRegistration class >> projectSpecs [
+
+	^ self registry baselineProjectSpecs
 ]
 
 { #category : 'registration' }
@@ -115,7 +103,7 @@ MetacelloProjectRegistration class >> useRegistry: aRegistry during: aBlock [
 
 	| oldRegistry |
 	oldRegistry := Registry.
-	Registry := self new.
+	Registry := MetacelloProjectRegistry new.
 	[ aBlock value ] ensure: [ Registry := oldRegistry ]
 ]
 

--- a/src/Metacello-Core/MetacelloProjectRegistration.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistration.class.st
@@ -173,16 +173,8 @@ MetacelloProjectRegistration >> currentlyLoadedClassesInProject [
 
 { #category : 'testing' }
 MetacelloProjectRegistration >> hasLoadConflicts: aProjectRegistration [
-	"5 combinations of loads with no load conflicts:
-        No configs and baselines =
-        configs = and no baselines
-        configs = and baselines =
-        configs = and no baseline loaded (self) with a baseline to load (aProjectRegistration)
-        config loaded (self), no config to load (aProjectRegistration) and no baseline loaded(self) with a baseline to load (aProjectRegistration) "
 
 	aProjectRegistration validate.
-	self isValid
-		ifFalse: [ ^ false ].
 	^ self projectSpec hasConflictWithProjectSpec: aProjectRegistration projectSpec
 ]
 
@@ -201,13 +193,6 @@ MetacelloProjectRegistration >> immutable [
 MetacelloProjectRegistration >> isMutable [
 
 	^ mutable ifNil: [ true ]
-]
-
-{ #category : 'testing' }
-MetacelloProjectRegistration >> isValid [
-	" has a name and one or the other of the projectSpecs is non-nil, but not both ... this is CRITICAL"
-
-	^ projectSpec isNotNil
 ]
 
 { #category : 'accessing' }
@@ -331,8 +316,8 @@ MetacelloProjectRegistration >> unregisterProject [
 
 { #category : 'accessing' }
 MetacelloProjectRegistration >> validate [
-	self isValid
-		ifFalse: [ self error: 'Invalid project registration' ]
+
+	projectSpec ifNil: [ self error: 'Invalid project registration' ]
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloProjectRegistration.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistration.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : 'MetacelloProjectRegistration',
 	#superclass : 'Object',
 	#instVars : [
-		'projectName',
 		'baselineProjectSpec',
 		'loadedInImage',
 		'locked',
@@ -67,10 +66,9 @@ MetacelloProjectRegistration class >> copyRegistryDuring: aBlock commitIfSuccess
 { #category : 'instance creation' }
 MetacelloProjectRegistration class >> fromMCBaselineProjectSpec: aProjectSpec [
 
-    ^ self new
-        projectName: aProjectSpec name;
-        baselineProjectSpec: aProjectSpec;
-        yourself
+	^ self new
+		  baselineProjectSpec: aProjectSpec;
+		  yourself
 ]
 
 { #category : 'querying' }
@@ -224,7 +222,7 @@ MetacelloProjectRegistration >> hasLoadConflicts: aProjectRegistration [
 { #category : 'comparing' }
 MetacelloProjectRegistration >> hash [
 
-	^ (String stringHash: projectName initialHash: 0) bitXor: baselineProjectSpec metacelloRegistrationHash
+	^ String stringHash: baselineProjectSpec metacelloRegistrationHash initialHash: 0
 ]
 
 { #category : 'mutability' }
@@ -242,7 +240,6 @@ MetacelloProjectRegistration >> isMutable [
 MetacelloProjectRegistration >> isValid [
 	" has a name and one or the other of the projectSpecs is non-nil, but not both ... this is CRITICAL"
 
-	projectName ifNil: [ ^ false ].
 	^ baselineProjectSpec isNotNil
 ]
 
@@ -312,13 +309,8 @@ MetacelloProjectRegistration >> printOn: aStream [
 
 { #category : 'accessing' }
 MetacelloProjectRegistration >> projectName [
-	^ projectName
-]
 
-{ #category : 'accessing' }
-MetacelloProjectRegistration >> projectName: anObject [
-    self shouldBeMutable.
-    projectName := anObject
+	^ self baselineProjectSpec name
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloProjectRegistration.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistration.class.st
@@ -2,11 +2,11 @@ Class {
 	#name : 'MetacelloProjectRegistration',
 	#superclass : 'Object',
 	#instVars : [
-		'baselineProjectSpec',
 		'loadedInImage',
 		'locked',
 		'mutable',
-		'versionInfo'
+		'versionInfo',
+		'projectSpec'
 	],
 	#classVars : [
 		'Registry'
@@ -64,10 +64,10 @@ MetacelloProjectRegistration class >> copyRegistryDuring: aBlock commitIfSuccess
 ]
 
 { #category : 'instance creation' }
-MetacelloProjectRegistration class >> fromMCBaselineProjectSpec: aProjectSpec [
+MetacelloProjectRegistration class >> projectSpec: aProjectSpec [
 
 	^ self new
-		  baselineProjectSpec: aProjectSpec;
+		  projectSpec: aProjectSpec;
 		  yourself
 ]
 
@@ -122,34 +122,12 @@ MetacelloProjectRegistration class >> useRegistry: aRegistry during: aBlock [
 MetacelloProjectRegistration >> = aRegistration [
 
 	aRegistration class == self class ifFalse: [ ^ false ].
-	^ baselineProjectSpec registrationsCompareEqual: aRegistration baselineProjectSpec
+	^ projectSpec registrationsCompareEqual: aRegistration projectSpec
 ]
 
 { #category : 'accessing' }
 MetacelloProjectRegistration >> baseName [
 	^ self projectSpec baseName
-]
-
-{ #category : 'accessing' }
-MetacelloProjectRegistration >> baselineProjectSpec [
-  "only one of baselineProjectSpec or configurationProjectSpec should ever be set"
-
-  ^ baselineProjectSpec
-]
-
-{ #category : 'accessing' }
-MetacelloProjectRegistration >> baselineProjectSpec: anObject [
-
-	self shouldBeMutable.
-	baselineProjectSpec := anObject
-]
-
-{ #category : 'accessing' }
-MetacelloProjectRegistration >> baselineProjectSpecIfPresent: presentBlock ifAbsent: absentBlock [
-
-	^ baselineProjectSpec
-		  ifNotNil: [ presentBlock cull: baselineProjectSpec ]
-		  ifNil: [ absentBlock value ]
 ]
 
 { #category : 'testing' }
@@ -171,8 +149,8 @@ MetacelloProjectRegistration >> canUpgradeTo: aProjectRegistration [
 
 	(self hasLoadConflicts: aProjectRegistration) ifFalse: [ ^ true ].
 
-	baselineProjectSpec ifNotNil: [
-		aProjectRegistration baselineProjectSpec ifNotNil: [ ^ baselineProjectSpec canUpgradeTo: aProjectRegistration baselineProjectSpec ] ].
+	projectSpec ifNotNil: [ ^ projectSpec canUpgradeTo: aProjectRegistration projectSpec ].
+	
 	^ false
 ]
 
@@ -194,7 +172,7 @@ MetacelloProjectRegistration >> copyOnWrite: aBlock [
 { #category : 'accessing' }
 MetacelloProjectRegistration >> currentVersionString [
 
-	^ baselineProjectSpec repositoryVersionString
+	^ projectSpec repositoryVersionString
 ]
 
 { #category : 'accessing' }
@@ -222,7 +200,7 @@ MetacelloProjectRegistration >> hasLoadConflicts: aProjectRegistration [
 { #category : 'comparing' }
 MetacelloProjectRegistration >> hash [
 
-	^ String stringHash: baselineProjectSpec metacelloRegistrationHash initialHash: 0
+	^ String stringHash: projectSpec metacelloRegistrationHash initialHash: 0
 ]
 
 { #category : 'mutability' }
@@ -240,7 +218,7 @@ MetacelloProjectRegistration >> isMutable [
 MetacelloProjectRegistration >> isValid [
 	" has a name and one or the other of the projectSpecs is non-nil, but not both ... this is CRITICAL"
 
-	^ baselineProjectSpec isNotNil
+	^ projectSpec isNotNil
 ]
 
 { #category : 'accessing' }
@@ -274,8 +252,8 @@ MetacelloProjectRegistration >> merge: aProjectRegistration [
 	self shouldBeMutable.
 	aProjectRegistration validate.
 
-	baselineProjectSpec := aProjectRegistration baselineProjectSpec.
-	self versionInfo versionString: baselineProjectSpec repositoryVersionString
+	projectSpec := aProjectRegistration projectSpec.
+	self versionInfo versionString: projectSpec repositoryVersionString
 ]
 
 { #category : 'mutability' }
@@ -294,7 +272,7 @@ MetacelloProjectRegistration >> printOn: aStream [
 
 	| descriptions |
 	aStream
-		nextPutAll: self baselineProjectSpec className;
+		nextPutAll: self projectSpec className;
 		space;
 		nextPutAll: '[baseline]'.
 	(descriptions := self repositoryDescriptions) isEmpty ifTrue: [ ^ self ].
@@ -310,13 +288,20 @@ MetacelloProjectRegistration >> printOn: aStream [
 { #category : 'accessing' }
 MetacelloProjectRegistration >> projectName [
 
-	^ self baselineProjectSpec name
+	^ self projectSpec name
 ]
 
 { #category : 'accessing' }
 MetacelloProjectRegistration >> projectSpec [
 
-	^ baselineProjectSpec
+	^ projectSpec
+]
+
+{ #category : 'accessing' }
+MetacelloProjectRegistration >> projectSpec: anObject [
+
+	self shouldBeMutable.
+	projectSpec := anObject
 ]
 
 { #category : 'accessing' }
@@ -340,7 +325,7 @@ MetacelloProjectRegistration >> registerProject [
 { #category : 'accessing' }
 MetacelloProjectRegistration >> repositoryDescriptions [
 
-	^ self baselineProjectSpec repositoryDescriptions
+	^ self projectSpec repositoryDescriptions
 ]
 
 { #category : 'mutability' }

--- a/src/Metacello-Core/MetacelloProjectRegistration.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistration.class.st
@@ -11,9 +11,9 @@ Class {
 	#classVars : [
 		'Registry'
 	],
-	#category : 'Metacello-Core-Scripts',
+	#category : 'Metacello-Core-Registry',
 	#package : 'Metacello-Core',
-	#tag : 'Scripts'
+	#tag : 'Registry'
 }
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloProjectRegistration.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistration.class.st
@@ -94,8 +94,8 @@ MetacelloProjectRegistration class >> registrationForProjectSpec: aProjectSpec i
 
 { #category : 'accessing' }
 MetacelloProjectRegistration class >> registry [
-    Registry ifNil: [ Registry := MetacelloProjectRegistry new ].
-    ^ Registry
+
+	^ Registry ifNil: [ Registry := MetacelloProjectRegistry new ]
 ]
 
 { #category : 'accessing' }
@@ -115,6 +115,7 @@ MetacelloProjectRegistration class >> useRegistry: aRegistry during: aBlock [
 
 	| oldRegistry |
 	oldRegistry := Registry.
+	Registry := self new.
 	[ aBlock value ] ensure: [ Registry := oldRegistry ]
 ]
 

--- a/src/Metacello-Core/MetacelloProjectRegistrationVersionInfo.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistrationVersionInfo.class.st
@@ -5,9 +5,9 @@ Class {
 		'versionString',
 		'projectVersion'
 	],
-	#category : 'Metacello-Core-Scripts',
+	#category : 'Metacello-Core-Registry',
 	#package : 'Metacello-Core',
-	#tag : 'Scripts'
+	#tag : 'Registry'
 }
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloProjectRegistry.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistry.class.st
@@ -10,17 +10,6 @@ Class {
 }
 
 { #category : 'accessing' }
-MetacelloProjectRegistry >> baselineProjectSpecs [
-    "MetacelloProjectRegistration baselineProjectSpecs"
-
-    | projectSpecs |
-    projectSpecs := OrderedCollection new.
-    self baselineRegistry
-        keysAndValuesDo: [ :className :registration | projectSpecs add: (self projectSpecForClassNamed: className ifAbsent: [ self error: 'not expected' ]) ].
-    ^ projectSpecs asArray
-]
-
-{ #category : 'accessing' }
 MetacelloProjectRegistry >> baselineRegistry [
 
 	^ baselineRegistry ifNil: [ baselineRegistry := Dictionary new ]
@@ -43,6 +32,16 @@ MetacelloProjectRegistry >> postCopy [
 MetacelloProjectRegistry >> projectSpecForClassNamed: aClassName ifAbsent: absentBlock [
 
 	^ (self baselineRegistry at: aClassName ifAbsent: [ ^ absentBlock value ]) projectSpec
+]
+
+{ #category : 'accessing' }
+MetacelloProjectRegistry >> projectSpecs [
+
+	| projectSpecs |
+	projectSpecs := OrderedCollection new.
+	self baselineRegistry keysAndValuesDo: [ :className :registration |
+		projectSpecs add: (self projectSpecForClassNamed: className ifAbsent: [ self error: 'not expected' ]) ].
+	^ projectSpecs asArray
 ]
 
 { #category : 'registration' }

--- a/src/Metacello-Core/MetacelloProjectRegistry.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistry.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'projectSpecsRegistry'
 	],
-	#category : 'Metacello-Core-Scripts',
+	#category : 'Metacello-Core-Registry',
 	#package : 'Metacello-Core',
-	#tag : 'Scripts'
+	#tag : 'Registry'
 }
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloProjectRegistry.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistry.class.st
@@ -2,18 +2,12 @@ Class {
 	#name : 'MetacelloProjectRegistry',
 	#superclass : 'Object',
 	#instVars : [
-		'baselineRegistry'
+		'projectSpecsRegistry'
 	],
 	#category : 'Metacello-Core-Scripts',
 	#package : 'Metacello-Core',
 	#tag : 'Scripts'
 }
-
-{ #category : 'accessing' }
-MetacelloProjectRegistry >> baselineRegistry [
-
-	^ baselineRegistry ifNil: [ baselineRegistry := Dictionary new ]
-]
 
 { #category : 'accessing' }
 MetacelloProjectRegistry >> isEmpty [
@@ -25,23 +19,25 @@ MetacelloProjectRegistry >> isEmpty [
 MetacelloProjectRegistry >> postCopy [
 
 	super postCopy.
-	baselineRegistry := self baselineRegistry copy
+	projectSpecsRegistry := self projectSpecsRegistry copy
 ]
 
 { #category : 'querying' }
 MetacelloProjectRegistry >> projectSpecForClassNamed: aClassName ifAbsent: absentBlock [
 
-	^ (self baselineRegistry at: aClassName ifAbsent: [ ^ absentBlock value ]) projectSpec
+	^ (self projectSpecsRegistry at: aClassName ifAbsent: [ ^ absentBlock value ]) projectSpec
 ]
 
 { #category : 'accessing' }
 MetacelloProjectRegistry >> projectSpecs [
 
-	| projectSpecs |
-	projectSpecs := OrderedCollection new.
-	self baselineRegistry keysAndValuesDo: [ :className :registration |
-		projectSpecs add: (self projectSpecForClassNamed: className ifAbsent: [ self error: 'not expected' ]) ].
-	^ projectSpecs asArray
+	^ self projectSpecsRegistry values
+]
+
+{ #category : 'accessing' }
+MetacelloProjectRegistry >> projectSpecsRegistry [
+
+	^ projectSpecsRegistry ifNil: [ projectSpecsRegistry := Dictionary new ]
 ]
 
 { #category : 'registration' }
@@ -50,23 +46,20 @@ MetacelloProjectRegistry >> registerProjectRegistration: aMetacelloProjectRegist
 
 	| spec |
 	spec := aMetacelloProjectRegistration projectSpec.
-	self baselineRegistry at: spec className ifPresent: [ :existing |
+	self projectSpecsRegistry at: spec className ifPresent: [ :existing |
 			(existing projectSpec registrationsCompareEqual: spec) ifFalse: [
 				MetacelloNotification signal: 'REGISTRATION OF INCOMPATABLE PROJECTS: ' , existing printString , ' REPLACED BY ' , aMetacelloProjectRegistration printString ] ].
 	aMetacelloProjectRegistration versionInfo setVersionString: spec repositoryVersionString.
 	spec immutable.
-	self baselineRegistry at: spec className put: aMetacelloProjectRegistration.
+	self projectSpecsRegistry at: spec className put: aMetacelloProjectRegistration.
 	aMetacelloProjectRegistration immutable
 ]
 
 { #category : 'registration' }
 MetacelloProjectRegistry >> registrationFor: aMetacelloProjectRegistration ifPresent: presentBlock ifAbsent: absentBlock [
 
-	| baseName |
-	baseName := aMetacelloProjectRegistration baseName.
-
-	self baselineRegistry at: aMetacelloProjectRegistration projectSpec className ifPresent: [ :existing | ^ presentBlock value: existing ].
-	self baselineRegistry at: 'BaselineOf' , baseName ifPresent: [ :existing | ^ presentBlock value: existing ].
+	self projectSpecsRegistry at: aMetacelloProjectRegistration projectSpec className ifPresent: [ :existing | ^ presentBlock value: existing ].
+	self projectSpecsRegistry at: 'BaselineOf' , aMetacelloProjectRegistration baseName ifPresent: [ :existing | ^ presentBlock value: existing ].
 	^ absentBlock value
 ]
 
@@ -74,27 +67,25 @@ MetacelloProjectRegistry >> registrationFor: aMetacelloProjectRegistration ifPre
 MetacelloProjectRegistry >> registrationForClassNamed: aClassName ifAbsent: absentBlock [
 
 	^ self registrationForExactClassNamed: aClassName ifAbsent: [
-			  | baseName |
-			  baseName := MetacelloScriptEngine baseNameOf: aClassName.
-			  self baselineRegistry at: 'BaselineOf' , baseName ifPresent: [ :registration | ^ registration ].
+			  self projectSpecsRegistry at: (MetacelloScriptExecutor baselineNameFrom: aClassName) ifPresent: [ :registration | ^ registration ].
 			  absentBlock value ]
 ]
 
 { #category : 'querying' }
 MetacelloProjectRegistry >> registrationForExactClassNamed: aClassName ifAbsent: absentBlock [
 
-	self baselineRegistry at: aClassName ifPresent: [ :registration | ^ registration ].
+	self projectSpecsRegistry at: aClassName ifPresent: [ :registration | ^ registration ].
 	^ absentBlock value
 ]
 
 { #category : 'accessing' }
 MetacelloProjectRegistry >> registrations [
 
-	^ self baselineRegistry values
+	^ self projectSpecsRegistry values
 ]
 
 { #category : 'registration' }
 MetacelloProjectRegistry >> unregisterProjectRegistration: aMetacelloProjectRegistration [
 
-	self baselineRegistry removeKey: aMetacelloProjectRegistration projectSpec className ifAbsent: [ self error: 'unexpectedly missing project registration' ]
+	self projectSpecsRegistry removeKey: aMetacelloProjectRegistration projectSpec className ifAbsent: [ self error: 'unexpectedly missing project registration' ]
 ]

--- a/src/Metacello-Core/MetacelloProjectRegistry.class.st
+++ b/src/Metacello-Core/MetacelloProjectRegistry.class.st
@@ -42,21 +42,21 @@ MetacelloProjectRegistry >> postCopy [
 { #category : 'querying' }
 MetacelloProjectRegistry >> projectSpecForClassNamed: aClassName ifAbsent: absentBlock [
 
-	^ (self baselineRegistry at: aClassName ifAbsent: [ ^ absentBlock value ]) baselineProjectSpec
+	^ (self baselineRegistry at: aClassName ifAbsent: [ ^ absentBlock value ]) projectSpec
 ]
 
 { #category : 'registration' }
 MetacelloProjectRegistry >> registerProjectRegistration: aMetacelloProjectRegistration [
 	"unconditionally register <newRegistration> ... use with care"
 
-	aMetacelloProjectRegistration baselineProjectSpec ifNotNil: [ :spec |
-			self baselineRegistry at: spec className ifPresent: [ :existing |
-					(existing baselineProjectSpec registrationsCompareEqual: spec) ifFalse: [
-						MetacelloNotification signal:
-							'REGISTRATION OF INCOMPATABLE PROJECTS: ' , existing printString , ' REPLACED BY ' , aMetacelloProjectRegistration printString ] ].
-			(aMetacelloProjectRegistration respondsTo: #versionInfo) ifTrue: [ aMetacelloProjectRegistration versionInfo setVersionString: spec repositoryVersionString ].
-			spec immutable.
-			self baselineRegistry at: spec className put: aMetacelloProjectRegistration ].
+	| spec |
+	spec := aMetacelloProjectRegistration projectSpec.
+	self baselineRegistry at: spec className ifPresent: [ :existing |
+			(existing projectSpec registrationsCompareEqual: spec) ifFalse: [
+				MetacelloNotification signal: 'REGISTRATION OF INCOMPATABLE PROJECTS: ' , existing printString , ' REPLACED BY ' , aMetacelloProjectRegistration printString ] ].
+	aMetacelloProjectRegistration versionInfo setVersionString: spec repositoryVersionString.
+	spec immutable.
+	self baselineRegistry at: spec className put: aMetacelloProjectRegistration.
 	aMetacelloProjectRegistration immutable
 ]
 
@@ -65,8 +65,8 @@ MetacelloProjectRegistry >> registrationFor: aMetacelloProjectRegistration ifPre
 
 	| baseName |
 	baseName := aMetacelloProjectRegistration baseName.
-	aMetacelloProjectRegistration baselineProjectSpec ifNotNil: [ :spec |
-		self baselineRegistry at: spec className ifPresent: [ :existing | ^ presentBlock value: existing ] ].
+
+	self baselineRegistry at: aMetacelloProjectRegistration projectSpec className ifPresent: [ :existing | ^ presentBlock value: existing ].
 	self baselineRegistry at: 'BaselineOf' , baseName ifPresent: [ :existing | ^ presentBlock value: existing ].
 	^ absentBlock value
 ]
@@ -97,6 +97,5 @@ MetacelloProjectRegistry >> registrations [
 { #category : 'registration' }
 MetacelloProjectRegistry >> unregisterProjectRegistration: aMetacelloProjectRegistration [
 
-	aMetacelloProjectRegistration baselineProjectSpec ifNotNil: [ :spec |
-		self baselineRegistry removeKey: spec className ifAbsent: [ self error: 'unexpectedly missing project registration' ] ]
+	self baselineRegistry removeKey: aMetacelloProjectRegistration projectSpec className ifAbsent: [ self error: 'unexpectedly missing project registration' ]
 ]

--- a/src/Metacello-Core/MetacelloProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectSpec.class.st
@@ -49,7 +49,7 @@ MetacelloProjectSpec >> asBaselineProjectSpec [
 { #category : 'scripting' }
 MetacelloProjectSpec >> asProjectRegistration [
 
-	^ MetacelloProjectRegistration fromMCBaselineProjectSpec: self asBaselineProjectSpec
+	^ MetacelloProjectRegistration projectSpec: self asBaselineProjectSpec
 ]
 
 { #category : 'scripting' }

--- a/src/Metacello-Core/MetacelloScriptEngine.class.st
+++ b/src/Metacello-Core/MetacelloScriptEngine.class.st
@@ -17,12 +17,8 @@ Class {
 
 { #category : 'utilities' }
 MetacelloScriptEngine class >> baseNameOf: className [
-  ^ (className beginsWith: 'BaselineOf')
-    ifTrue: [ className copyFrom: 'BaselineOf' size + 1 to: className size ]
-    ifFalse: [ 
-      (className beginsWith: 'ConfigurationOf')
-        ifTrue: [ className copyFrom: 'ConfigurationOf' size + 1 to: className size ]
-        ifFalse: [ className ] ]
+
+	^ className withoutPrefix: 'BaselineOf'
 ]
 
 { #category : 'actions api' }

--- a/src/Metacello-Core/MetacelloScriptEngine.class.st
+++ b/src/Metacello-Core/MetacelloScriptEngine.class.st
@@ -303,11 +303,6 @@ MetacelloScriptEngine >> options: aDictionary [
 ]
 
 { #category : 'accessing' }
-MetacelloScriptEngine >> projectName [
-    ^ self projectSpec name
-]
-
-{ #category : 'accessing' }
 MetacelloScriptEngine >> projectReferenceSpec [
     ^ projectReferenceSpec projectReference
 ]
@@ -340,11 +335,6 @@ MetacelloScriptEngine >> register [
 		ifAbsent: [ :new | new registerProject ]
 		ifPresent: [ :existing :new | existing copyOnWrite: [ :existingCopy | existingCopy merge: new ] ].
 	self root: spec
-]
-
-{ #category : 'accessing' }
-MetacelloScriptEngine >> repositories [
-    ^ self projectSpec repositories
 ]
 
 { #category : 'private' }

--- a/src/Metacello-Core/MetacelloScriptExecutor.class.st
+++ b/src/Metacello-Core/MetacelloScriptExecutor.class.st
@@ -18,6 +18,15 @@ Class {
 	#tag : 'Scripts'
 }
 
+{ #category : 'baselines' }
+MetacelloScriptExecutor class >> baselineNameFrom: baseName [
+	"Return the fully-qualified configuration class name."
+
+	^ (baseName indexOfSubCollection: 'BaselineOf') > 0
+		  ifTrue: [ baseName ]
+		  ifFalse: [ 'BaselineOf' , baseName ]
+]
+
 { #category : 'execution' }
 MetacelloScriptExecutor >> applyArgsToProjectSpec: aProjectSpec [
     classNameArg ifNotNil: [ aProjectSpec className: classNameArg ].
@@ -33,15 +42,6 @@ MetacelloScriptExecutor >> baselineArg [
 { #category : 'args' }
 MetacelloScriptExecutor >> baselineArg: anObject [
 	baselineArg := anObject
-]
-
-{ #category : 'baselines' }
-MetacelloScriptExecutor >> baselineNameFrom: baseName [
-	"Return the fully-qualified configuration class name."
-
-	^ (baseName indexOfSubCollection: 'BaselineOf') > 0
-		  ifTrue: [ baseName ]
-		  ifFalse: [ 'BaselineOf' , baseName ]
 ]
 
 { #category : 'args' }
@@ -77,7 +77,7 @@ MetacelloScriptExecutor >> executeString: aString do: projectSpecBlock [
 
 	| projectSpec |
 	singleRoot ifNil: [ self singleRoot: true ].
-	projectSpec := MetacelloProjectRegistration projectSpecForClassNamed: (self baselineNameFrom: aString) ifAbsent: [ ].
+	projectSpec := MetacelloProjectRegistration projectSpecForClassNamed: (self class baselineNameFrom: aString) ifAbsent: [ ].
 
 	(self projectSpecSelectBlock value: projectSpec) ifTrue: [ projectSpecBlock value: (self applyArgsToProjectSpec: projectSpec copy) ]
 ]

--- a/src/Metacello-Core/MetacelloScriptExecutor.class.st
+++ b/src/Metacello-Core/MetacelloScriptExecutor.class.st
@@ -79,7 +79,7 @@ MetacelloScriptExecutor >> executeString: aString do: projectSpecBlock [
 	singleRoot ifNil: [ self singleRoot: true ].
 	projectSpec := MetacelloProjectRegistration projectSpecForClassNamed: (self class baselineNameFrom: aString) ifAbsent: [ ].
 
-	(self projectSpecSelectBlock value: projectSpec) ifTrue: [ projectSpecBlock value: (self applyArgsToProjectSpec: projectSpec copy) ]
+	(self shouldBeExecutedFor: projectSpec) ifTrue: [ projectSpecBlock value: (self applyArgsToProjectSpec: projectSpec copy) ]
 ]
 
 { #category : 'actions api' }
@@ -157,11 +157,6 @@ MetacelloScriptExecutor >> postCopy [
 	options := options copy
 ]
 
-{ #category : 'execution callback' }
-MetacelloScriptExecutor >> projectSpecSelectBlock [
-    ^ [ :projectSpec | true ]
-]
-
 { #category : 'actions api' }
 MetacelloScriptExecutor >> record: required [
     actionArg := #'record:' -> {required}
@@ -186,6 +181,12 @@ MetacelloScriptExecutor >> repositoryArg: anObject [
 MetacelloScriptExecutor >> roots [
 
 	^ roots ifNil: [ roots := OrderedCollection new ]
+]
+
+{ #category : 'execution callback' }
+MetacelloScriptExecutor >> shouldBeExecutedFor: aSpec [
+
+	^ true
 ]
 
 { #category : 'options api' }

--- a/src/Metacello-Core/MetacelloScriptImageExecutor.class.st
+++ b/src/Metacello-Core/MetacelloScriptImageExecutor.class.st
@@ -7,13 +7,12 @@ Class {
 }
 
 { #category : 'execution callback' }
-MetacelloScriptImageExecutor >> projectSpecSelectBlock [
-    ^ [ :projectSpec | 
-    projectSpec
-        ifNil: [ false ]
-        ifNotNil: [ 
-            MetacelloProjectRegistration
-                registrationForProjectSpec: projectSpec
-                ifAbsent: [ false ]
-                ifPresent: [ :existingRegistration :newRegistration | existingRegistration loadedInImage ] ] ]
+MetacelloScriptImageExecutor >> shouldBeExecutedFor: projectSpec [
+
+	projectSpec ifNil: [ ^ false ].
+
+	^ MetacelloProjectRegistration
+		  registrationForProjectSpec: projectSpec
+		  ifAbsent: [ false ]
+		  ifPresent: [ :existingRegistration :newRegistration | existingRegistration loadedInImage ]
 ]

--- a/src/Metacello-Core/MetacelloScriptRegistryExecutor.class.st
+++ b/src/Metacello-Core/MetacelloScriptRegistryExecutor.class.st
@@ -7,18 +7,15 @@ Class {
 }
 
 { #category : 'actions api' }
-MetacelloScriptRegistryExecutor >> prime [
-]
-
-{ #category : 'execution callback' }
-MetacelloScriptRegistryExecutor >> projectSpecSelectBlock [
-  ^ [ :projectSpec | projectSpec isNotNil ]
-]
-
-{ #category : 'actions api' }
 MetacelloScriptRegistryExecutor >> remove [
 ]
 
 { #category : 'initialization' }
 MetacelloScriptRegistryExecutor >> reset [
+]
+
+{ #category : 'execution callback' }
+MetacelloScriptRegistryExecutor >> shouldBeExecutedFor: projectSpec [
+
+	^ projectSpec isNotNil
 ]

--- a/src/Metacello-Core/UndefinedObject.extension.st
+++ b/src/Metacello-Core/UndefinedObject.extension.st
@@ -10,8 +10,3 @@ UndefinedObject >> asMetacelloVersionNumber [
 UndefinedObject >> metacelloRegistrationHash [
     ^ self hash
 ]
-
-{ #category : '*Metacello-Core' }
-UndefinedObject >> registrationsCompareEqual: aMetacelloProjectSpec [
-    ^ self = aMetacelloProjectSpec
-]

--- a/src/Metacello-TestsCore/MetacelloLockTest.class.st
+++ b/src/Metacello-TestsCore/MetacelloLockTest.class.st
@@ -41,5 +41,5 @@ MetacelloLockTest >> testRegisterProject [
 		repository: 'http://repo.com';
 		register.
 
-	self assertCollection: (MetacelloProjectRegistration registry baselineProjectSpecs collect: #name) includesAny: #( 'TestToLock2' )
+	self assertCollection: (MetacelloProjectRegistration registry projectSpecs collect: #name) includesAny: #( 'TestToLock2' )
 ]

--- a/src/Refactoring-UI-Tests/StInformDialogMock.class.st
+++ b/src/Refactoring-UI-Tests/StInformDialogMock.class.st
@@ -7,6 +7,13 @@ Class {
 
 { #category : 'accessing' }
 StInformDialogMock >> label: aString [
+	"Spec is migrating its API from #label: to message:. Delete me once all users will be updated."
+
+	^ self message: aString
+]
+
+{ #category : 'accessing' }
+StInformDialogMock >> message: aString [
 
 	^ 'nothing'
 ]

--- a/src/Refactoring-UI/ReRenameVariableDriver.class.st
+++ b/src/Refactoring-UI/ReRenameVariableDriver.class.st
@@ -55,18 +55,18 @@ ReRenameVariableDriver >> refactoringClass [
 
 { #category : 'private' }
 ReRenameVariableDriver >> requestNewNameBasedOn: aName [
-	| newName |
 
+	| newName |
 	newName := self requestDialog
-       title: 'Rename variable';
-       label: 'Please provide a new variable name';
-       text: aName;
-       openModal.
+		           title: 'Rename variable';
+		           message: 'Please provide a new variable name';
+		           text: aName;
+		           openModal.
 
 	(newName isNil or: [ newName = oldName ]) ifTrue: [
-		shouldEscape := true.
-		^ self ].
-		
+			shouldEscape := true.
+			^ self ].
+
 	previouslyProposedName := newName.
 
 	^ newName


### PR DESCRIPTION
This change bring a set of cleanings in Metacello mostly to merge the "baseline spec" and "project spec" vocabulary since I'm trying to get only one kind of spec here