### PR TITLE
Improve error while asking the parse tree of a method without source

### DIFF
--- a/src/AST-Core/CompiledMethod.extension.st
+++ b/src/AST-Core/CompiledMethod.extension.st
@@ -30,11 +30,12 @@ CompiledMethod >> firstComment [
 { #category : '*AST-Core' }
 CompiledMethod >> parseTree [
 	"returns an AST for this method, do not cache it. (see #ast for the cached alternative)"
+
 	| ast |
 	ast := self methodClass compiler
-		source: self sourceCode;
-		class: self methodClass;
-		parse.
+		       source: (self sourceCode ifNil: [ self error: 'Cannot build AST of a method with no source code. Concerned method: ' , self displayString ]);
+		       class: self methodClass;
+		       parse.
 	ast compiledMethod: self.
-	^ast
+	^ ast
 ]


### PR DESCRIPTION
I recently got 2 PR failing the release tests because not all methods have sources. I doubt the problem comes from my PRs but it is hard to find where it comes from.  I'm proposing to at least print the name of the method provoking the problem when this happens so that we can find the origin of the bug in an easier way