### PR TITLE
Make baselines more readable by using MetacelloProjectSpec>>repository:

### DIFF
--- a/src/BaselineOfAthens/BaselineOfAthens.class.st
+++ b/src/BaselineOfAthens/BaselineOfAthens.class.st
@@ -18,10 +18,12 @@ BaselineOfAthens >> baseline: spec [
 		for: #common
 		do: [ 
 			"Inter packages dependencies are now added but it is missing some dependencies on other projects such as Morphic for Athens-Morphic"
+			spec repository: (self packageRepositoryURLForSpec: spec).
+			
 			"Dependencies"
-			self
-				display: spec;
-				unifiedFFI: spec.
+			spec
+				baseline: 'Display';
+				baseline: 'UnifiedFFI' with: [ spec loads: 'minimal' ]. 
 
 			"Packages"
 			spec
@@ -40,21 +42,4 @@ BaselineOfAthens >> baseline: spec [
 				group: 'Cairo-core' with: #('Athens-Core' 'Athens-Cairo');
 				group: 'Examples' with: #('Athens-Examples');
 				group: 'Tests' with: #('Athens-Cairo-Tests') ]
-]
-
-{ #category : 'baseline' }
-BaselineOfAthens >> display: spec [
-
-	spec
-		baseline: 'Display'
-		with: [ spec repository: (self packageRepositoryURLForSpec: spec) ]
-]
-
-{ #category : 'baseline' }
-BaselineOfAthens >> unifiedFFI: spec [
-	spec
-		baseline: 'UnifiedFFI'
-		with: [ spec
-				loads: 'minimal';
-				repository: (self packageRepositoryURLForSpec: spec) ]
 ]

--- a/src/BaselineOfBaseLibraries/BaselineOfBaseLibraries.class.st
+++ b/src/BaselineOfBaseLibraries/BaselineOfBaseLibraries.class.st
@@ -16,17 +16,15 @@ Class {
 BaselineOfBaseLibraries >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
-
 	spec for: #common do: [
-			spec baseline: 'SUnit' with: [ spec loads: 'Core' from: repository ].
-			spec baseline: 'Kernel' with: [ spec loads: 'Tests' from: repository ].
-			spec baseline: 'Compiler' with: [ spec loads: 'Tests' from: repository ].
-			spec baseline: 'FileSystem' with: [ spec loads: 'Tests' from: repository ].
-			spec baseline: 'Slot' with: [ spec loads: 'core' from: repository ].
-			spec baseline: 'Beacon' with: [ spec loads: #( 'CoreTests' ) from: repository ].
-			spec baseline: 'SystemBenchmark' with: [ spec loads: #( 'tests' ) from: repository ].
-			spec baseline: 'Clap' with: [ spec loads: #( 'core' ) from: repository ].
-			spec baseline: 'TaskIt' with: [ spec loads: #( 'coreTests' ) from: repository ] ]
+			spec repository: (self packageRepositoryURLForSpec: spec).
+			spec baseline: 'SUnit' with: [ spec loads: 'Core' ].
+			spec baseline: 'Kernel' with: [ spec loads: 'Tests' ].
+			spec baseline: 'Compiler' with: [ spec loads: 'Tests' ].
+			spec baseline: 'FileSystem' with: [ spec loads: 'Tests' ].
+			spec baseline: 'Slot' with: [ spec loads: 'core' ].
+			spec baseline: 'Beacon' with: [ spec loads: #( 'CoreTests' ) ].
+			spec baseline: 'SystemBenchmark' with: [ spec loads: #( 'tests' ) ].
+			spec baseline: 'Clap' with: [ spec loads: #( 'core' ) ].
+			spec baseline: 'TaskIt' with: [ spec loads: #( 'coreTests' ) ] ]
 ]

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -33,30 +33,25 @@ Class {
 BaselineOfBasicTools >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
+	
 	spec for: #common do: [
+			spec repository: (self packageRepositoryURLForSpec: spec).
 			spec postLoadDoIt: #postload:package:.
 
 			spec
-				baseline: 'Traits' with: [ spec loads: 'core-traits' from: repository ];
-				baseline: 'SUnit' with: [ spec loads: 'Core' from: repository ];
-				baseline: 'Debugging' with: [ spec loads: 'Core' from: repository ];
-				baseline: 'UnifiedFFI' with: [ spec repository: repository ];
-				baseline: 'ThreadedFFI' with: [ spec repository: repository ];
-				baseline: 'UIInfrastructure' with: [ spec repository: repository ];
-				baseline: 'UI' with: [ spec repository: repository ];
-				baseline: 'Reflectivity' with: [ spec repository: repository ];
-				baseline: 'DebugPoints' with: [ spec repository: repository ];
-				baseline: 'Athens' with: [
-						spec
-							loads: 'Cairo-core';
-							repository: repository ].
+				baseline: 'Traits' with: [ spec loads: 'core-traits' ];
+				baseline: 'SUnit' with: [ spec loads: 'Core' ];
+				baseline: 'Debugging' with: [ spec loads: 'Core' ];
+				baseline: 'UnifiedFFI';
+				baseline: 'ThreadedFFI';
+				baseline: 'UIInfrastructure';
+				baseline: 'UI';
+				baseline: 'Reflectivity';
+				baseline: 'DebugPoints';
+				baseline: 'Athens' with: [ spec loads: 'Cairo-core'].
+
 			spec package: 'Tool-ExternalBrowser'.
-			spec baseline: 'EnlumineurFormatter' with: [
-					spec
-						loads: 'Core';
-						repository: repository ].
+			spec baseline: 'EnlumineurFormatter' with: [ spec loads: 'Core'].
 			spec package: 'System-Changes'.
 			spec package: 'Tool-Profilers'.
 			spec package: 'NECompletion'.
@@ -73,10 +68,7 @@ BaselineOfBasicTools >> baseline: spec [
 
 			spec package: 'OpalCompiler-ToolFeatures'.
 			spec package: 'OpalCompiler-ToolFeatures-Tests'.
-			spec baseline: 'Refactoring' with: [
-					spec
-						repository: repository;
-						loads: #( 'Core' ) ].
+			spec baseline: 'Refactoring' with: [ spec loads: #( 'Core' ) ].
 
 			spec package: 'Monticello-BackwardCompatibility'.
 			spec package: 'MonticelloFileServices'.

--- a/src/BaselineOfCalypso/BaselineOfCalypso.class.st
+++ b/src/BaselineOfCalypso/BaselineOfCalypso.class.st
@@ -9,23 +9,15 @@ Class {
 BaselineOfCalypso >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
 
 	spec for: #common do: [
+		spec repository: (self packageRepositoryURLForSpec: spec).
 		spec
-			baseline: 'ClassAnnotation' with: [
-				spec
-					repository: repository;
-					loads: 'Core' ];
-
-			project: 'ClassAnnotationTests'
-			copyFrom: 'ClassAnnotation'
-			with: [ spec loads: 'Tests' ];
-
-			baseline: 'Commander' with: [ spec repository: repository ];
-			baseline: 'SystemCommands' with: [ spec repository: repository ];
-			baseline: 'CalypsoNavigationModel' with: [ spec repository: repository ].
+			baseline: 'ClassAnnotation' with: [ spec loads: 'Core' ];
+			project: 'ClassAnnotationTests' copyFrom: 'ClassAnnotation' with: [ spec loads: 'Tests' ];
+			baseline: 'Commander';
+			baseline: 'SystemCommands';
+			baseline: 'CalypsoNavigationModel'.
 
 		spec
 			package: #'Calypso-SystemQueries' with: [ spec requires: #( 'CalypsoNavigationModel' #ClassAnnotation ) ];
@@ -49,16 +41,11 @@ BaselineOfCalypso >> baseline: spec [
 			with: [
 				spec requires: #( #'Calypso-SystemQueries-Tests-P1WithHierarchy' ) ];
 			package: #'Calypso-SystemQueries-Tests-P3WithSubclassFromP2'
-			with: [
-				spec requires:
-						#( #'Calypso-SystemQueries-Tests-P2WithSubclassFromP1' ) ];
+			with: [ spec requires: #( #'Calypso-SystemQueries-Tests-P2WithSubclassFromP1' ) ];
 			package: #'Calypso-SystemQueries-Tests-P5WithTags'
-			with: [
-				spec requires: #( #'Calypso-SystemQueries-Tests-PExtendedByP5' ) ];
+			with: [ spec requires: #( #'Calypso-SystemQueries-Tests-PExtendedByP5' ) ];
 			package: #'Calypso-SystemQueries-Tests-PExtendedByP1'
-			with: [
-				spec requires:
-						#( #'Calypso-SystemQueries-Tests-PWithSingleClass' ) ];
+			with: [ spec requires: #( #'Calypso-SystemQueries-Tests-PWithSingleClass' ) ];
 			package: #'Calypso-SystemQueries-Tests-PExtendedByP5';
 			package: #'Calypso-SystemQueries-Tests-PWithSingleClass';
 			package: #'Calypso-SystemPlugins-Traits-Queries'
@@ -237,7 +224,5 @@ BaselineOfCalypso >> baseline: spec [
 				   #'Calypso-SystemPlugins-Reflectivity-Queries-Tests'
 				   #'Calypso-SystemPlugins-Critic-Queries-Tests'
 				   #'Calypso-Browser-Tests' );
-			group: 'default'
-			with:
-				#( 'FullEnvironment' 'SystemBrowser' 'Tests' ) ]
+			group: 'default' with: #( 'FullEnvironment' 'SystemBrowser' 'Tests' ) ]
 ]

--- a/src/BaselineOfCalypsoNavigationModel/BaselineOfCalypsoNavigationModel.class.st
+++ b/src/BaselineOfCalypsoNavigationModel/BaselineOfCalypsoNavigationModel.class.st
@@ -7,18 +7,15 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfCalypsoNavigationModel >> baseline: spec [
+
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
+	spec for: #common do: [
+			spec
+				package: #'Calypso-NavigationModel';
+				package: #'Calypso-NavigationModel-Tests' with: [ spec requires: #( #'Calypso-NavigationModel' ) ].
 
-	spec for: #common do: [ 
-		spec
-			package: #'Calypso-NavigationModel';
-			package: #'Calypso-NavigationModel-Tests'
-				with: [ spec requires: #( #'Calypso-NavigationModel' ) ].
-
-	spec 
-		group: 'default' with: #( 'Core' 'Tests' );
-		group: 'Core' with: #('Calypso-NavigationModel');
-		group: 'Tests' with: #('Core' 'Calypso-NavigationModel-Tests') ]
+			spec
+				group: 'default' with: #( 'Core' 'Tests' );
+				group: 'Core' with: #( 'Calypso-NavigationModel' );
+				group: 'Tests' with: #( 'Core' 'Calypso-NavigationModel-Tests' ) ]
 ]

--- a/src/BaselineOfCommander/BaselineOfCommander.class.st
+++ b/src/BaselineOfCommander/BaselineOfCommander.class.st
@@ -9,18 +9,13 @@ Class {
 BaselineOfCommander >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
-
+	
 	spec for: #common do: [
+		spec repository: (self packageRepositoryURLForSpec: spec).
 		spec
-			baseline: #ClassAnnotation with: [
-				spec
-					repository: repository;
-					loads: 'Core' ];
-			project: #ClassAnnotationTests
-			copyFrom: #ClassAnnotation
-			with: [ spec loads: 'Tests' ];
+			baseline: #ClassAnnotation with: [ spec loads: 'Core' ];
+			project: #ClassAnnotationTests copyFrom: #ClassAnnotation with: [ spec loads: 'Tests' ];
+
 			package: #'Commander-Core'
 			with: [ spec requires: #( ClassAnnotation ) ];
 			package: #'Commander-Core-Tests'

--- a/src/BaselineOfDebugPoints/BaselineOfDebugPoints.class.st
+++ b/src/BaselineOfDebugPoints/BaselineOfDebugPoints.class.st
@@ -10,21 +10,17 @@ BaselineOfDebugPoints >> baseline: spec [
 
 	<baseline>
 	spec for: #common do: [
-		spec
-			baseline: 'Reflectivity'
-			with: [ spec repository: (self packageRepositoryURLForSpec: spec) ].
+			spec repository: (self packageRepositoryURLForSpec: spec).
 
-		spec
-			package: 'DebugPoints'
-			with: [ spec requires: #( 'Reflectivity' ) ].
+			spec baseline: 'Reflectivity'.
 
-		spec
-			package: 'DebugPoints-Tests'
-			with: [ spec requires: #( 'DebugPoints' ) ].
-
-		"Groups"
-		spec
-			group: 'Core' with: #( 'DebugPoints' );
-			group: 'Tests' with: #( 'Core' 'DebugPoints-Tests' );
-			group: 'default' with: #( 'Tests' ) ]
+			spec
+				package: 'DebugPoints' with: [ spec requires: #( 'Reflectivity' ) ];
+				package: 'DebugPoints-Tests' with: [ spec requires: #( 'DebugPoints' ) ].
+			
+			"Groups"
+			spec
+				group: 'Core' with: #( 'DebugPoints' );
+				group: 'Tests' with: #( 'Core' 'DebugPoints-Tests' );
+				group: 'default' with: #( 'Tests' ) ]
 ]

--- a/src/BaselineOfEnlumineurFormatter/BaselineOfEnlumineurFormatter.class.st
+++ b/src/BaselineOfEnlumineurFormatter/BaselineOfEnlumineurFormatter.class.st
@@ -13,21 +13,15 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfEnlumineurFormatter >> baseline: spec [
-	<baseline>
 
+	<baseline>
 	spec for: #pharo do: [
-		spec 
-			package: 'EnlumineurFormatter';
-			package: 'EnlumineurFormatter-Tests' with: [ spec requires: #('EnlumineurFormatter') ]";
-			package: 'EnlumineurFormatterUI' with: [ spec requires: #('EnlumineurFormatter') ];
-			package: 'EnlumineurFormatterUI-Tests' with: [ spec requires: #('EnlumineurFormatterUI') ]". 
-		
-		spec
-			group: 'Core' with: #('EnlumineurFormatter');
-			group: 'Tests' with: #('Core' 'EnlumineurFormatter-Tests');
-			"group: 'UI' with: #('Core' 'EnlumineurFormatterUI');
-			group: 'UI-Tests' with: #('Tests' 'EnlumineurFormatterUI-Tests');"
-			group: 'All' with: #('Core' 'Tests' "'UI' 'UI-Tests'")
-		
-		]
+			spec
+				package: 'EnlumineurFormatter';
+				package: 'EnlumineurFormatter-Tests' with: [ spec requires: #( 'EnlumineurFormatter' ) ].
+
+			spec
+				group: 'Core' with: #( 'EnlumineurFormatter' );
+				group: 'Tests' with: #( 'Core' 'EnlumineurFormatter-Tests' );
+				group: 'All' with: #( 'Core' 'Tests' ) ]
 ]

--- a/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
+++ b/src/BaselineOfGeneralTests/BaselineOfGeneralTests.class.st
@@ -10,20 +10,20 @@ BaselineOfGeneralTests >> baseline: spec [
 	"Needs to be re-sorted"
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
+
 	spec for: #common do: [
+		spec repository: (self packageRepositoryURLForSpec: spec).
 		spec
-			baseline: 'Debugging' with: [ spec loads: #Tests from: repository ];
+			baseline: 'Debugging' with: [ spec loads: #Tests ];
 			package: 'NumberParser-Tests';
 			package: 'Fuel-Core-Tests';
 			package: 'FormCanvas-Tests';
 			package: 'Collections-Arithmetic-Tests';
 			package: 'Metacello-CommandLine-Tests';
-			baseline: 'Epicea' with: [ spec loads: #Tests from: repository ];
+			baseline: 'Epicea' with: [ spec loads: #Tests ];
 			package: 'FileSystem-Memory-Tests';
-			baseline: 'Fonts' with: [ spec loads: #Tests from: repository ];
-			baseline: 'FreeType' with: [ spec loads: #tests from: repository ];
+			baseline: 'Fonts' with: [ spec loads: #Tests ];
+			baseline: 'FreeType' with: [ spec loads: #tests ];
 			package: 'Graphics-Tests';
 			package: 'Text-Tests';
 			package: 'Morphic-Testing-Support';

--- a/src/BaselineOfIDE/BaselineOfIDE.class.st
+++ b/src/BaselineOfIDE/BaselineOfIDE.class.st
@@ -27,9 +27,6 @@ Installs:
 Class {
 	#name : 'BaselineOfIDE',
 	#superclass : 'BaselineOf',
-	#instVars : [
-		'repository'
-	],
 	#classVars : [
 		'Initialized'
 	],
@@ -42,26 +39,25 @@ Class {
 BaselineOfIDE >> baseline: spec [
 
 	<baseline>
-	repository := self packageRepositoryURLForSpec: spec.
+	
 	spec for: #common do: [
+		spec repository: (self packageRepositoryURLForSpec: spec).
 		spec postLoadDoIt: #postload:package:.
-		spec baseline: 'BasicTools' with: [ spec repository: repository ].
-		spec
-			package: 'Tool-MorphicProfiler'
-			with: [ spec requires: #( 'BasicTools' ) ].
-		spec baseline: 'Athens' with: [ spec repository: repository ].
-		spec baseline: 'Flashback' with: [ spec repository: repository ].
 
-		self
-			load: 'Shift' group: 'shift-tests' spec: spec;
-			load: 'Traits' group: 'traits-tests' spec: spec;
-			load: 'Slot' group: 'slot-tests' spec: spec;
-			load: 'Clap' group: 'development' spec: spec;
-			load: 'SUnit' group: 'Tests' spec: spec;
-			load: 'EnlumineurFormatter' group: 'Tests' spec: spec;
-			load: 'Reflectivity' group: 'tests' spec: spec;
-			load: 'DebugPoints' group: 'Tests' spec: spec;
-			load: 'Refactoring' group: 'Tests' spec: spec.
+		spec baseline: 'BasicTools'.
+		spec package: 'Tool-MorphicProfiler' with: [ spec requires: #( 'BasicTools' ) ].
+		spec baseline: 'Athens'.
+		spec baseline: 'Flashback'.
+		
+		spec baseline: 'Shift' with: [ spec loads: 'shift-tests' ].
+		spec baseline: 'Traits' with: [ spec loads: 'traits-tests' ].
+		spec baseline: 'Slot' with: [ spec loads: 'slot-tests' ].
+		spec baseline: 'Clap' with: [ spec loads: 'development' ].
+		spec baseline: 'SUnit' with: [ spec loads: 'Tests' ].
+		spec baseline: 'EnlumineurFormatter' with: [ spec loads: 'Tests' ].
+		spec baseline: 'Reflectivity' with: [ spec loads: 'Tests' ].
+		spec baseline: 'DebugPoints' with: [ spec loads: 'Tests' ].
+		spec baseline: 'Refactoring' with: [ spec loads: 'Tests' ].
 
 		spec package: 'Math-Operations-Extensions-Tests'.
 		spec package: 'Network-Tests'.
@@ -71,53 +67,39 @@ BaselineOfIDE >> baseline: spec [
 		spec package: 'OpalCompiler-UI'.
 		spec package: 'OpalCompiler-UI-Tests'.
 
-		self load: 'Monticello' group: 'Tests' spec: spec.
-		self load: 'Metacello' group: 'Tests' spec: spec.
-
-		spec baseline: 'ReflectionMirrors' with: [ spec repository: repository ].
-		spec baseline: 'FuzzyMatcher' with: [ spec repository: repository ].
-		spec baseline: 'QA' with: [ spec repository: repository ].
-		spec baseline: 'GeneralTests' with: [ spec repository: repository ].
+		spec baseline: 'Monticello' with: [ spec loads: 'Tests' ].
+		spec baseline: 'Metacello' with: [ spec loads: 'Tests' ].
+		spec baseline: 'ReflectionMirrors'.
+		spec baseline: 'FuzzyMatcher'.
+		spec baseline: 'QA'.
+		spec baseline: 'GeneralTests'.
 
 		"Later we will load the UI of enlumineur probably here
 		"
-		spec baseline: 'Shout' with: [ spec repository: repository ].
-		spec baseline: 'OSWindow' with: [ spec repository: repository ].
-		spec
-			baseline: 'EmergencyDebugger'
-			with: [ spec repository: repository ].
-
-		self load: 'Epicea' group: 'Browsers' spec: spec.
-
-		spec baseline: 'Misc' with: [ spec repository: repository ].
-
-		self load: 'Fuel' group: 'Tests' spec: spec.
-
-		self load: 'Keymapping' group: 'Tests' spec: spec.
-
-		spec baseline: 'Zodiac' with: [ spec repository: repository ].
-		spec baseline: 'SortFunctions' with: [ spec repository: repository ].
-		spec baseline: 'Equals' with: [ spec repository: repository ].
-
-		self load: 'NewValueHolder' group: 'tests' spec: spec.
+		spec baseline: 'Shout'.
+		spec baseline: 'OSWindow'.
+		spec baseline: 'EmergencyDebugger'.
+		spec baseline: 'Epicea' with: [ spec loads: 'Browsers' ].
+		spec baseline: 'Misc'.
+		spec baseline: 'Fuel' with: [ spec loads: 'Tests' ].
+		spec baseline: 'Keymapping' with: [ spec loads: 'Tests' ].
+		spec baseline: 'Zodiac'.
+		spec baseline: 'SortFunctions'.
+		spec baseline: 'Equals'.
+		spec baseline: 'NewValueHolder' with: [ spec loads: 'tests' ].
+		
 		spec package: 'STON-Extensions'.
-
 		spec package: 'BaselineOfKernel'.
 		spec package: 'BaselineOfCompiler'.
 		spec package: 'BaselineOfFileSystem'.
 		spec package: 'BaselineOfMonticello'.
 		spec package: 'BaselineOfMetacello'.
 		spec package: 'BaselineOfPharoBootstrap'.
-		spec baseline: 'ReferenceFinder' with: [ spec repository: repository ].
-		spec baseline: 'ClassParser' with: [ spec repository: repository ].
-
-
-		self
-			load: 'Calypso'
-			group: #( 'FullEnvironment' 'SystemBrowser' 'Tests' )
-			spec: spec.
-		spec baseline: 'Ring' with: [ spec repository: repository ].
-		spec baseline: 'HeuristicCompletion' with: [ spec repository: repository ].
+		spec baseline: 'ReferenceFinder'.
+		spec baseline: 'ClassParser'.
+		spec baseline: 'Calypso' with: [ spec loads: #( 'FullEnvironment' 'SystemBrowser' 'Tests' ) ].
+		spec baseline: 'Ring'.
+		spec baseline: 'HeuristicCompletion'.
 		spec package: 'Tool-DependencyAnalyser-UI-Tab' with: [
 			"Depends also on the dependency analyser in newtools"
 			spec requires: #('Calypso') ].
@@ -156,15 +138,6 @@ BaselineOfIDE >> drTests: spec [
 	spec
 		baseline: 'DrTests'
 		with: [ spec repository: (self packageRepositoryURLForSpec: spec) ]
-]
-
-{ #category : 'private - loading' }
-BaselineOfIDE >> load: aProject group: aGroupName spec: spec [
-
-	spec baseline: aProject with: [
-		spec
-			repository: (self packageRepositoryURLForSpec: spec);
-			loads: aGroupName ]
 ]
 
 { #category : 'actions' }

--- a/src/BaselineOfMorphic/BaselineOfMorphic.class.st
+++ b/src/BaselineOfMorphic/BaselineOfMorphic.class.st
@@ -32,10 +32,8 @@ Class {
 BaselineOfMorphic >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
-
 	spec for: #common do: [
+		spec repository: (self packageRepositoryURLForSpec: spec).
 		spec preLoadDoIt: #preload:package:.
 		spec postLoadDoIt: #postload:package:.
 			
@@ -71,10 +69,7 @@ BaselineOfMorphic >> baseline: spec [
 		"Several packages depend on Rubric as a basic Morphic component"
 		spec package: 'Rubric'.
 
-		spec baseline: 'NewValueHolder' with: [
-			spec
-				repository: repository;
-				loads: 'core' ].
+		spec baseline: 'NewValueHolder' with: [ spec loads: 'core' ].
 
 		spec package: 'DarkBlueTheme'.
 

--- a/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
+++ b/src/BaselineOfMorphicCore/BaselineOfMorphicCore.class.st
@@ -21,9 +21,6 @@ Class {
 BaselineOfMorphicCore >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
-
 	spec for: #common do: [
 			spec package: 'System-Object Events'.
 			spec package: 'System-Caching'.

--- a/src/BaselineOfQA/BaselineOfQA.class.st
+++ b/src/BaselineOfQA/BaselineOfQA.class.st
@@ -9,40 +9,24 @@ Class {
 BaselineOfQA >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
-
 	spec for: #common do: [
+		spec repository: (self packageRepositoryURLForSpec: spec).
 		
 		spec package: 'Refactoring-UI'.
-		spec
-			package: 'NautilusRefactoring'
-			with: [ spec requires: #( 'Refactoring-UI' ) ].
-
+		spec package: 'NautilusRefactoring' with: [ spec requires: #( 'Refactoring-UI' ) ].
 		spec package: 'Refactoring-Critics'.
-		spec baseline: 'Manifest' with: [ spec repository: repository ].
+		spec baseline: 'Manifest'.
 
+		spec baseline: 'QualityAssistant'.
 		spec
-			baseline: 'QualityAssistant'
-			with: [ spec repository: repository ].
-		spec
-			package: 'General-Rules'
-			with: [ spec requires: #( 'QualityAssistant' ) ];
-			package: 'General-Rules-Tests'
-			with: [ spec requires: #( 'General-Rules' ) ];
-			package: 'Specific-Rules'
-			with: [ spec requires: #( 'QualityAssistant' ) ];
-			package: 'Specific-Rules-Tests'
-			with: [ spec requires: #( 'Specific-Rules' ) ];
-			package: 'SUnit-Rules'
-			with: [ spec requires: #( 'QualityAssistant' ) ];
-			package: 'SUnit-Rules-Tests'
-			with: [ spec requires: #( 'SUnit-Rules' ) ];
+			package: 'General-Rules' with: [ spec requires: #( 'QualityAssistant' ) ];
+			package: 'General-Rules-Tests' with: [ spec requires: #( 'General-Rules' ) ];
+			package: 'Specific-Rules' with: [ spec requires: #( 'QualityAssistant' ) ];
+			package: 'Specific-Rules-Tests' with: [ spec requires: #( 'Specific-Rules' ) ];
+			package: 'SUnit-Rules' with: [ spec requires: #( 'QualityAssistant' ) ];
+			package: 'SUnit-Rules-Tests' with: [ spec requires: #( 'SUnit-Rules' ) ];
 			package: 'ReleaseTests';
 			package: 'NautilusRefactoring-Tests'.
 
-		spec baseline: 'Reflectivity' with: [
-			spec
-				repository: repository;
-				loads: #( 'tools' ) ] ]
+		spec baseline: 'Reflectivity' with: [ spec loads: #( 'tools' ) ] ]
 ]

--- a/src/BaselineOfSystemCommands/BaselineOfSystemCommands.class.st
+++ b/src/BaselineOfSystemCommands/BaselineOfSystemCommands.class.st
@@ -9,10 +9,9 @@ Class {
 BaselineOfSystemCommands >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
 	spec for: #common do: [
-		spec baseline: 'Commander' with: [ spec repository: repository ].
+		spec repository: (self packageRepositoryURLForSpec: spec).
+		spec baseline: 'Commander'.
 		spec
 			package: #'SystemCommands-RefactoringSupport'
 			with: [ spec requires: #( 'Commander' ) ];

--- a/src/BaselineOfTaskIt/BaselineOfTaskIt.class.st
+++ b/src/BaselineOfTaskIt/BaselineOfTaskIt.class.st
@@ -9,86 +9,24 @@ Class {
 BaselineOfTaskIt >> baseline: spec [
 
 	<baseline>
-	spec for: #'pharo6.1.x' do: [ self baselineForPharo6: spec ].
-	spec for: #'pharo7.x' do: [ self baselineForPharo7: spec ].
+	spec for: #common do: [
+			spec
+				package: #TaskIt;
+				package: #'TaskIt-Tests' with: [ spec requires: #( 'TaskIt' ) ];
+				package: #TaskItRetry with: [ spec requires: #( 'TaskIt' ) ];
+				package: #'TaskItRetry-Tests' with: [ spec requires: #( 'TaskItRetry' ) ];
+				package: #TaskItProcesses with: [ spec requires: #( 'TaskIt' ) ];
+				package: #'TaskItProcesses-Tests' with: [ spec requires: #( 'TaskItProcesses' ) ];
+				package: #TaskItBrowser with: [ spec requires: #( 'TaskItProcesses' ) ];
+				package: #TaskItDebugger with: [ spec requires: #( 'TaskItProcesses' ) ];
+				package: #'TaskItDebugger-Tests' with: [ spec requires: #( 'TaskItDebugger' ) ].
 
-	spec for: (self pharoVersionsFrom: 8) do: [
-		spec package: #TaskIt.
-		self baselineForCommon: spec ]
-]
-
-{ #category : 'baselines' }
-BaselineOfTaskIt >> baselineForCommon: spec [
-
-	spec
-		package: #'TaskIt-Tests' with: [ spec requires: #('TaskIt') ];
-		package: #TaskItRetry with: [ spec requires: #('TaskIt') ];
-		package: #'TaskItRetry-Tests' with: [ spec requires: #('TaskItRetry') ];
-		package: #TaskItProcesses with: [ spec requires: #('TaskIt') ];
-		package: #'TaskItProcesses-Tests' with: [ spec requires: #('TaskItProcesses') ];
-		package: #TaskItBrowser with: [ spec requires: #('TaskItProcesses') ];
-		package: #TaskItDebugger with: [ spec requires: #('TaskItProcesses') ];
-		package: #'TaskItDebugger-Tests' with: [ spec requires: #('TaskItDebugger') ].
-
-	spec
-		group: 'core' with: #('TaskIt');
-		group: 'coreTests' with: #('TaskIt' 'TaskIt-Tests');
-		group: 'default' with: #(
-			'core' 
-			'TaskItProcesses' 
-			'TaskItRetry' 
-			'TaskItDebugger' 
-			'TaskIt-Tests' 
-			'TaskItRetry-Tests' 
-			'TaskItProcesses-Tests' 
-			'TaskItDebugger-Tests');
-		group: 'debug' with: #('minimal' 'TaskItDebugger');
-		group: 'tests' with: #(
-			'default' 
-			'TaskIt-Tests' 
-			'TaskItRetry-Tests' 
-			'TaskItProcesses-Tests' 
-			'TaskItDebugger-Tests');
-		group: 'development' with: #('default' 'debug' 'tests')
-]
-
-{ #category : 'baselines' }
-BaselineOfTaskIt >> baselineForPharo6: spec [
-	spec
-		package: #TaskIt;
-		package: #'TaskIt-Tests' with: [ spec requires: #( 'TaskIt' ) ];
-		package: #TaskItRetry with: [ spec requires: #( 'TaskIt' ) ];
-		package: #'TaskItRetry-Tests'
-		with: [ spec requires: #( 'TaskItRetry' ) ];
-		package: #TaskItProcesses with: [ spec requires: #( 'TaskIt' ) ];
-		package: #'TaskItProcesses-Tests'
-		with: [ spec requires: #( 'TaskItProcesses' ) ];
-		package: #TaskItBrowser
-		with: [ spec requires: #( 'TaskItProcesses' ) ];
-		package: #TaskItDebugger
-		with: [ spec requires: #( 'TaskItProcesses' ) ];
-		package: #'TaskItDebugger-Tests'
-		with: [ spec requires: #( 'TaskItDebugger' ) ].
-	spec
-		group: 'minimal' with: #( 'TaskIt' );
-		group: 'default'
-		with: #( 'minimal' 'TaskItProcesses' 'TaskItRetry' 'TaskItDebugger'
-			   'TaskIt-Tests' 'TaskItRetry-Tests' 'TaskItProcesses-Tests'
-			   'TaskItDebugger-Tests' );
-		group: 'debug' with: #( 'minimal' 'TaskItDebugger' );
-		group: 'tests'
-		with:
-			#( 'default' 'TaskIt-Tests' 'TaskItRetry-Tests' 'TaskItProcesses-Tests'
-			   'TaskItDebugger-Tests' );
-		group: 'development' with: #( 'default' 'debug' 'tests' )
-]
-
-{ #category : 'baselines' }
-BaselineOfTaskIt >> baselineForPharo7: spec [
-
-	spec 
-		baseline: 'ParametrizedTests'
-		with: [ spec repository: 'github://tesonep/ParametrizedTests/src' ].
-	spec package: #TaskIt with: [ spec requires: #('ParametrizedTests') ].
-	self baselineForCommon: spec
+			spec
+				group: 'core' with: #( 'TaskIt' );
+				group: 'coreTests' with: #( 'TaskIt' 'TaskIt-Tests' );
+				group: 'default'
+				with: #( 'core' 'TaskItProcesses' 'TaskItRetry' 'TaskItDebugger' 'TaskIt-Tests' 'TaskItRetry-Tests' 'TaskItProcesses-Tests' 'TaskItDebugger-Tests' );
+				group: 'debug' with: #( 'minimal' 'TaskItDebugger' );
+				group: 'tests' with: #( 'default' 'TaskIt-Tests' 'TaskItRetry-Tests' 'TaskItProcesses-Tests' 'TaskItDebugger-Tests' );
+				group: 'development' with: #( 'default' 'debug' 'tests' ) ]
 ]

--- a/src/BaselineOfUI/BaselineOfUI.class.st
+++ b/src/BaselineOfUI/BaselineOfUI.class.st
@@ -28,27 +28,22 @@ Class {
 BaselineOfUI >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
 	spec for: #common do: [
-		spec postLoadDoIt: #postload:package:.
+			spec repository: (self packageRepositoryURLForSpec: spec).
+			spec postLoadDoIt: #postload:package:.
 
-		spec
-				baseline: 'SUnit' with: [
-						spec
-							loads: 'UI';
-							repository: repository ].
-		
-		"Load morphic before Spec"
-		spec baseline: 'MorphicCore' with: [ spec repository: repository ].
-		spec baseline: 'Morphic' with: [ spec repository: repository ].
-		spec baseline: 'Commander2' with: [ spec repository: repository ].
-		"Spec 2 (base), using external configuration"
-		self specBase: spec.
+			spec baseline: 'SUnit' with: [ spec loads: 'UI' ].
+			
+			"Load morphic before Spec"
+			spec baseline: 'MorphicCore'.
+			spec baseline: 'Morphic'.
+			spec baseline: 'Commander2'.
+			
+			"Spec 2 (base), using external configuration"
+			self specBase: spec.
 
-		spec package: 'Morphic-Widgets-Tree'.
-
-		spec package: 'WebBrowser-Core'  ]
+			spec package: 'Morphic-Widgets-Tree'.
+			spec package: 'WebBrowser-Core' ]
 ]
 
 { #category : 'actions' }

--- a/src/BaselineOfUIInfrastructure/BaselineOfUIInfrastructure.class.st
+++ b/src/BaselineOfUIInfrastructure/BaselineOfUIInfrastructure.class.st
@@ -9,16 +9,15 @@ Class {
 BaselineOfUIInfrastructure >> baseline: spec [
 
 	<baseline>
-	| repository |
-	repository := self packageRepositoryURLForSpec: spec.
 	spec for: #common do: [
+		spec repository: (self packageRepositoryURLForSpec: spec).
 			spec
-				baseline: 'Display' with: [ spec repository: repository ];
-				baseline: 'Fonts' with: [ spec loads: #Core from: repository ];
-				baseline: 'FreeType' with: [ spec loads: #ui from: repository ];
-				baseline: 'MenuRegistration' with: [ spec repository: repository ];
-				baseline: 'Keymapping' with: [ spec loads: #Core from: repository ];
-				baseline: 'Fuel' with: [ spec loads: #( 'Core' ) from: repository ]. "Fuel is currently depending on graphics objects so I'm loading it here for now instead of BaselineOfBasicTools."
+				baseline: 'Display';
+				baseline: 'Fonts' with: [ spec loads: #Core ];
+				baseline: 'FreeType' with: [ spec loads: #ui ];
+				baseline: 'MenuRegistration';
+				baseline: 'Keymapping' with: [ spec loads: #Core ];
+				baseline: 'Fuel' with: [ spec loads: #( 'Core' ) ]. "Fuel is currently depending on graphics objects so I'm loading it here for now instead of BaselineOfBasicTools."
 
 			spec
 				package: 'System-Utilities';

--- a/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
@@ -27,9 +27,7 @@ ReRemoveInstanceVariablesDriver >> breakingChoices [
 { #category : 'execution' }
 ReRemoveInstanceVariablesDriver >> browseInstanceVariableReferences [
 
-	StMessageBrowser
-		browse: refactoring violators
-		
+	(Smalltalk tools toolNamed: #messageList) browse: refactoring violators
 ]
 
 { #category : 'configuration' }


### PR DESCRIPTION
While impriving Metacello I discovered some unknown features such as the fact that we can declare a repository in a project spec and it will be used by all dependency not declaring a repository. Using this we can make the baselines of Pharo more readable

Also fixing a release test