### PR TITLE
Metacello: simplify member managements

### DIFF
--- a/src/Metacello-Core/MetacelloAbstractPackageSpec.class.st
+++ b/src/Metacello-Core/MetacelloAbstractPackageSpec.class.st
@@ -14,11 +14,7 @@ Class {
 { #category : 'adding' }
 MetacelloAbstractPackageSpec >> addToMetacelloPackages: aMetacelloPackagesSpec [
 
-	aMetacelloPackagesSpec addMember: 
-		(aMetacelloPackagesSpec addMember 
-			name: self name;
-			spec: self;
-			yourself)
+	aMetacelloPackagesSpec addMemberForSpec: self
 ]
 
 { #category : 'Protocol (printing) - 4 selector(s)' }
@@ -133,11 +129,7 @@ MetacelloAbstractPackageSpec >> label [
 { #category : 'merging' }
 MetacelloAbstractPackageSpec >> mergeIntoMetacelloPackages: aMetacelloPackagesSpec [
 
-	aMetacelloPackagesSpec addMember: 
-		(aMetacelloPackagesSpec mergeMember 
-			name: self name;
-			spec: self;
-			yourself)
+	aMetacelloPackagesSpec mergeMemberForSpec: self
 ]
 
 { #category : 'merging' }
@@ -204,11 +196,7 @@ MetacelloAbstractPackageSpec >> referencedSpec [
 { #category : 'removing' }
 MetacelloAbstractPackageSpec >> removeFromMetacelloPackages: aMetacelloPackagesSpec [
 
-	aMetacelloPackagesSpec addMember: 
-		(aMetacelloPackagesSpec removeMember 
-			name: self name;
-			spec: self;
-			yourself)
+	aMetacelloPackagesSpec removeMemberForSpec: self
 ]
 
 { #category : 'loading' }

--- a/src/Metacello-Core/MetacelloMemberListSpec.class.st
+++ b/src/Metacello-Core/MetacelloMemberListSpec.class.st
@@ -10,6 +10,12 @@ Class {
 	#tag : 'Members'
 }
 
+{ #category : 'visiting' }
+MetacelloMemberListSpec >> acceptVisitor: aVisitor [
+
+	self error: 'Should not be visitable..'
+]
+
 { #category : 'actions' }
 MetacelloMemberListSpec >> add: aSpec [
 
@@ -21,6 +27,12 @@ MetacelloMemberListSpec >> addMember: aMember [
 
 	self list add: aMember.
 	self clearMemberMap
+]
+
+{ #category : 'adding' }
+MetacelloMemberListSpec >> addMemberForSpec: aSpec [
+
+	^ self addMember: (MetacelloAddMemberSpec for: self project spec: aSpec)
 ]
 
 { #category : 'private' }
@@ -141,6 +153,12 @@ MetacelloMemberListSpec >> merge: aSpec [
 	self subclassResponsibility
 ]
 
+{ #category : 'adding' }
+MetacelloMemberListSpec >> mergeMemberForSpec: aSpec [
+
+	^ self addMember: (MetacelloMergeMemberSpec for: self project spec: aSpec)
+]
+
 { #category : 'merging' }
 MetacelloMemberListSpec >> mergeSpec: anotherSpec [
 
@@ -169,6 +187,20 @@ MetacelloMemberListSpec >> postCopy [
 MetacelloMemberListSpec >> remove: aSpec [
 
 	self subclassResponsibility
+]
+
+{ #category : 'adding' }
+MetacelloMemberListSpec >> removeMemberForSpec: aSpec [
+
+	^ self addMember: (MetacelloRemoveMemberSpec for: self project spec: aSpec)
+]
+
+{ #category : 'adding' }
+MetacelloMemberListSpec >> removeMemberNamed: aString [
+
+	^ self addMember: ((MetacelloRemoveMemberSpec for: self project)
+			   name: aString;
+			   yourself)
 ]
 
 { #category : 'enumeration' }

--- a/src/Metacello-Core/MetacelloMemberSpec.class.st
+++ b/src/Metacello-Core/MetacelloMemberSpec.class.st
@@ -2,13 +2,26 @@ Class {
 	#name : 'MetacelloMemberSpec',
 	#superclass : 'MetacelloSpec',
 	#instVars : [
-		'name',
 		'spec'
 	],
 	#category : 'Metacello-Core-Members',
 	#package : 'Metacello-Core',
 	#tag : 'Members'
 }
+
+{ #category : 'instance creation' }
+MetacelloMemberSpec class >> for: aProject spec: aSpec [
+
+	^ (self for: aProject)
+		  spec: aSpec;
+		  yourself
+]
+
+{ #category : 'visiting' }
+MetacelloMemberSpec >> acceptVisitor: aVisitor [
+
+	self error: 'Should not be visitable..'
+]
 
 { #category : 'adding' }
 MetacelloMemberSpec >> addToMetacelloPackages: aMetacelloPackagesSpec [
@@ -73,13 +86,7 @@ MetacelloMemberSpec >> methodUpdateSelector [
 { #category : 'accessing' }
 MetacelloMemberSpec >> name [
 
-	^name
-]
-
-{ #category : 'accessing' }
-MetacelloMemberSpec >> name: aString [
-
-	name := aString
+	^ self spec name
 ]
 
 { #category : 'removing' }

--- a/src/Metacello-Core/MetacelloPackagesSpec.class.st
+++ b/src/Metacello-Core/MetacelloPackagesSpec.class.st
@@ -66,12 +66,9 @@ MetacelloPackagesSpec >> configMethodOn: aStream indent: indent [
 { #category : 'actions' }
 MetacelloPackagesSpec >> copy: specNamed to: spec [
 
-	self addMember: 
-		(self copyMember 
-			name: spec name;
-			sourceName: specNamed;
-			spec: spec;
-			yourself)
+	self addMember: ((MetacelloCopyMemberSpec for: self project spec: spec)
+			 sourceName: specNamed;
+			 yourself)
 ]
 
 { #category : 'actions' }

--- a/src/Metacello-Core/MetacelloProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectSpec.class.st
@@ -29,15 +29,11 @@ MetacelloProjectSpec class >> isAbstract [
 MetacelloProjectSpec >> addToMetacelloPackages: aMetacelloPackagesSpec [
 
 	| spec |
-	spec := (aMetacelloPackagesSpec project projectReferenceSpec)
-			name: self name;
-			projectReference: self copy;
-			yourself.
-	aMetacelloPackagesSpec addMember: 
-		(aMetacelloPackagesSpec addMember 
-			name: spec name;
-			spec: spec;
-			yourself)
+	spec := aMetacelloPackagesSpec project projectReferenceSpec
+		        name: self name;
+		        projectReference: self copy;
+		        yourself.
+	aMetacelloPackagesSpec addMemberForSpec: spec
 ]
 
 { #category : 'scripting' }

--- a/src/Metacello-Core/MetacelloRemoveMemberSpec.class.st
+++ b/src/Metacello-Core/MetacelloRemoveMemberSpec.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : 'MetacelloRemoveMemberSpec',
 	#superclass : 'MetacelloMemberSpec',
+	#instVars : [
+		'name'
+	],
 	#category : 'Metacello-Core-Members',
 	#package : 'Metacello-Core',
 	#tag : 'Members'
@@ -22,4 +25,16 @@ MetacelloRemoveMemberSpec >> applyToList: aListSpec [
 MetacelloRemoveMemberSpec >> methodUpdateSelector [
 
 	^#remove:
+]
+
+{ #category : 'accessing' }
+MetacelloRemoveMemberSpec >> name [
+
+	^ name ifNil: [ super name ]
+]
+
+{ #category : 'accessing' }
+MetacelloRemoveMemberSpec >> name: aString [
+
+	name := aString
 ]

--- a/src/Metacello-Core/MetacelloRepositoriesSpec.class.st
+++ b/src/Metacello-Core/MetacelloRepositoriesSpec.class.st
@@ -110,8 +110,5 @@ MetacelloRepositoriesSpec >> repository: description username: username password
 		        username: username;
 		        password: password;
 		        yourself.
-	self addMember: (self addMember
-			 name: spec name;
-			 spec: spec;
-			 yourself)
+	self addMemberForSpec: spec
 ]

--- a/src/Metacello-Core/MetacelloRepositorySpec.class.st
+++ b/src/Metacello-Core/MetacelloRepositorySpec.class.st
@@ -16,11 +16,7 @@ Class {
 { #category : 'adding' }
 MetacelloRepositorySpec >> addToMetacelloRepositories: aMetacelloRepositoriesSpec [
 
-	aMetacelloRepositoriesSpec addMember: 
-		(aMetacelloRepositoriesSpec addMember 
-			name: self name;
-			spec: self;
-			yourself)
+	aMetacelloRepositoriesSpec addMemberForSpec: self
 ]
 
 { #category : 'mc support' }
@@ -91,11 +87,7 @@ MetacelloRepositorySpec >> hasNoLoadConflicts: aMetacelloRepositorySpec [
 { #category : 'private' }
 MetacelloRepositorySpec >> mergeIntoMetacelloRepositories: aMetacelloRepositoriesSpec [
 
-	aMetacelloRepositoriesSpec addMember: 
-		(aMetacelloRepositoriesSpec mergeMember 
-			name: self name;
-			spec: self;
-			yourself)
+	aMetacelloRepositoriesSpec mergeMemberForSpec: self
 ]
 
 { #category : 'merging' }
@@ -130,11 +122,7 @@ MetacelloRepositorySpec >> password: aString [
 { #category : 'private' }
 MetacelloRepositorySpec >> removeFromMetacelloRepositories: aMetacelloRepositoriesSpec [
 
-	aMetacelloRepositoriesSpec addMember: 
-		(aMetacelloRepositoriesSpec removeMember 
-			name: self name;
-			spec: self;
-			yourself)
+	aMetacelloRepositoriesSpec removeMemberForSpec: self
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloSpec.class.st
+++ b/src/Metacello-Core/MetacelloSpec.class.st
@@ -28,22 +28,10 @@ MetacelloSpec >> acceptVisitor: aVisitor [
 	self subclassResponsibility
 ]
 
-{ #category : 'spec creation' }
-MetacelloSpec >> addMember [
-
-	^MetacelloAddMemberSpec for: self project
-]
-
 { #category : 'printing' }
 MetacelloSpec >> configMethodOn: aStream indent: indent [
 
 	self subclassResponsibility
-]
-
-{ #category : 'spec creation' }
-MetacelloSpec >> copyMember [
-
-	^MetacelloCopyMemberSpec for: self project
 ]
 
 { #category : 'mutability' }
@@ -98,12 +86,6 @@ MetacelloSpec >> mergeImportLoads: aLoadList [
 MetacelloSpec >> mergeMap [
 
 	^Dictionary new.
-]
-
-{ #category : 'spec creation' }
-MetacelloSpec >> mergeMember [
-
-	^MetacelloMergeMemberSpec for: self project
 ]
 
 { #category : 'merging' }
@@ -171,12 +153,6 @@ MetacelloSpec >> printOn: aStream [
 MetacelloSpec >> project [
 
 	^project
-]
-
-{ #category : 'spec creation' }
-MetacelloSpec >> removeMember [
-
-	^MetacelloRemoveMemberSpec for: self project
 ]
 
 { #category : 'mutability' }

--- a/src/Metacello-Core/String.extension.st
+++ b/src/Metacello-Core/String.extension.st
@@ -4,30 +4,20 @@ Extension { #name : 'String' }
 String >> addToMetacelloPackages: aMetacelloPackagesSpec [
 
 	| spec |
-	spec := 
-		(aMetacelloPackagesSpec project packageSpec)
-			file: self;
-			yourself.
-	aMetacelloPackagesSpec addMember: 
-		(aMetacelloPackagesSpec addMember 
-			name: spec name;
-			spec: spec;
-			yourself)
+	spec := aMetacelloPackagesSpec project packageSpec
+		        file: self;
+		        yourself.
+	aMetacelloPackagesSpec addMemberForSpec: spec
 ]
 
 { #category : '*Metacello-Core' }
 String >> addToMetacelloRepositories: aMetacelloRepositoriesSpec [
 
 	| spec |
-	spec := 
-		(aMetacelloRepositoriesSpec project repositorySpec)
-			description: self;
-			yourself.
-	aMetacelloRepositoriesSpec addMember: 
-		(aMetacelloRepositoriesSpec addMember 
-			name: spec name;
-			spec: spec;
-			yourself)
+	spec := aMetacelloRepositoriesSpec project repositorySpec
+		        description: self;
+		        yourself.
+	aMetacelloRepositoriesSpec addMemberForSpec: spec
 ]
 
 { #category : '*Metacello-Core' }
@@ -40,30 +30,20 @@ String >> asMetacelloVersionNumber [
 String >> mergeIntoMetacelloPackages: aMetacelloPackagesSpec [
 
 	| spec |
-	spec := 
-		(aMetacelloPackagesSpec project packageSpec)
-			file: self;
-			yourself.
-	aMetacelloPackagesSpec addMember: 
-		(aMetacelloPackagesSpec mergeMember 
-			name: spec name;
-			spec: spec;
-			yourself)
+	spec := aMetacelloPackagesSpec project packageSpec
+		        file: self;
+		        yourself.
+	aMetacelloPackagesSpec mergeMemberForSpec: spec
 ]
 
 { #category : '*Metacello-Core' }
 String >> mergeIntoMetacelloRepositories: aMetacelloRepositoriesSpec [
 
 	| spec |
-	spec := 
-		(aMetacelloRepositoriesSpec project repositorySpec)
-			description: self;
-			yourself.
-	aMetacelloRepositoriesSpec addMember: 
-		(aMetacelloRepositoriesSpec mergeMember 
-			name: spec name;
-			spec: spec;
-			yourself)
+	spec := aMetacelloRepositoriesSpec project repositorySpec
+		        description: self;
+		        yourself.
+	aMetacelloRepositoriesSpec mergeMemberForSpec: spec
 ]
 
 { #category : '*Metacello-Core-version comparison' }
@@ -113,19 +93,13 @@ String >> packageFileSpecFor: aMetacelloPackagesSpec [
 { #category : '*Metacello-Core' }
 String >> removeFromMetacelloPackages: aMetacelloPackagesSpec [
 
-	aMetacelloPackagesSpec addMember: 
-		(aMetacelloPackagesSpec removeMember 
-			name: self;
-			yourself)
+	aMetacelloPackagesSpec removeMemberNamed: self
 ]
 
 { #category : '*Metacello-Core' }
 String >> removeFromMetacelloRepositories: aMetacelloRepositoriesSpec [
 
-	aMetacelloRepositoriesSpec addMember: 
-		(aMetacelloRepositoriesSpec removeMember 
-			name: self;
-			yourself)
+	aMetacelloRepositoriesSpec removeMemberNamed: self
 ]
 
 { #category : '*Metacello-Core' }


### PR DESCRIPTION
Here is a little cleaning to simplify the members managements.
- Remove API from MetacelloSpec that was calling unimplemented methods for most of its subclasses
- Add some suggar to make it easier to use
- Implement some subclass responsibility methods