### PR TITLE
Fix randomly failing testClassMethodDefinition

### DIFF
--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -166,7 +166,7 @@ MCStWriterTest >> stampRegex [
 	"to match stamps like:
 	 	stamp: '2025-08-13T13:33:59.50038+00:00'"
 	
-	^ 'stamp\: ''\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}.\d{5,6}[+-]\d{2}\:\d{2}'''
+	^ 'stamp\: ''\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}.\d{4,6}[+-]\d{2}\:\d{2}'''
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
testClassMethodDefinition is using #stampRegex but this regex does not match all possible stamps 