### PR TITLE
Metacello: Remove unused concept of file

### DIFF
--- a/src/Metacello-Core/MetacelloAbstractPackageSpec.class.st
+++ b/src/Metacello-Core/MetacelloAbstractPackageSpec.class.st
@@ -73,20 +73,6 @@ MetacelloAbstractPackageSpec >> configMethodOn: aStream for: aValue selector: se
 	cascade ifTrue: [ aStream nextPut: $; ]
 ]
 
-{ #category : 'querying' }
-MetacelloAbstractPackageSpec >> file [ 
-	"MetacelloPackageSpec compatibility"
-	
-	^nil
-]
-
-{ #category : 'accessing' }
-MetacelloAbstractPackageSpec >> getFile [
-	"MetacelloPackageSpec compatibility"
-
-	^ nil
-]
-
 { #category : 'testing' }
 MetacelloAbstractPackageSpec >> hasRepository [
     ^ false
@@ -162,9 +148,8 @@ MetacelloAbstractPackageSpec >> name [
 
 { #category : 'accessing' }
 MetacelloAbstractPackageSpec >> name: aString [
-    ((aString at: 1) isSeparator or: [ (aString at: aString size) isSeparator ])
-        ifTrue: [ self error: 'Names are not allowed to have leading or trailing blanks: ' , aString printString ].
-    name := aString
+
+	name := aString trim
 ]
 
 { #category : 'merging' }

--- a/src/Metacello-Core/MetacelloBaselineConstructor.class.st
+++ b/src/Metacello-Core/MetacelloBaselineConstructor.class.st
@@ -145,37 +145,12 @@ MetacelloBaselineConstructor >> extractBaselinePragmaFor: aClass [
 		ifNotEmpty: [ :pragmas | pragmas first ]
 ]
 
-{ #category : 'api' }
+{ #category : 'api - old' }
 MetacelloBaselineConstructor >> file: aString [
-	"Define file field of a package spec (MetacelloPackageSpec) or project spec (MetacelloMCProjectSpec).
+	"Kept for compiatibility with other Smalltalk and old Pharo versions."
 
-	For a package spec, the file: field is optional in a baseline. In a baseline, the file field may be used to specify a package branch for the package:
-	
-		spec package: 'MyPackage' with: [
-			spec file: 'MyPackage.gemstone'. ]'.
-
-	The file: field is required in a version. In a version, the file field defines the explicit version of the package to be loaded:
-	
-		spec package: 'MyPackage' with: [
-			spec file: 'MyPackage.gemstone-dkh.1'. ]'.
-
-	The following may be used as a short cut for specifying the file field in a version:
-
-		spec package: 'MyPackage' with: 'MyPackage.gemstone-dkh.1'.
-
-	For a project spec, the file field specifies the name of the Monticello package that contains the configuration. If you are using the convention of 
-	naming the class and package usingthe  'ConfigurationOf' prefix, then there is no need to specify the file field:
-	
-		spec project: 'MyProject' with: [
-			spec file: 'ConfigurationMyProject'.
-
-	It should only be used when the package name for the configuration is different from the name of the project:
-
-		spec project: 'MyProject' with: [
-			spec file: 'MyProject-Metacello'.
-	 "
-
-	self root file: aString
+	MetacelloNotification signal:
+		'The option #file: will not do anything anymore in Pharo 14+. This option can be removed in it is in an attribute for Pharo 14+ or ignored if this is for a different platform. Reason: This option was here for configurations but not baselines. Since we cannot load configurations anymore in Pharo, it is been removed.'
 ]
 
 { #category : 'api' }
@@ -321,7 +296,6 @@ MetacelloBaselineConstructor >> package: packageName with: aBlock [
 		spec package: 'MyPackage' with: '1.0'.
 		
 		spec package: 'MyPackage' with: [
-			spec file:'MyPackage-dkh.1'.
 			spec repository: '/opt/gemstone/repository'.
 	 "
 
@@ -330,13 +304,10 @@ MetacelloBaselineConstructor >> package: packageName with: aBlock [
 		        name: packageName;
 		        yourself.
 
+	self root packages merge: spec.
 	aBlock isString
-		ifTrue: [
-			spec file: aBlock.
-			self root packages merge: spec ]
-		ifFalse: [
-			self root packages merge: spec.
-			self with: spec during: aBlock ]
+		ifTrue: [ MetacelloNotification signal: 'Now #package:with: only takes a block as second parameter and not a string.' ]
+		ifFalse: [ self with: spec during: aBlock ]
 ]
 
 { #category : 'api' }

--- a/src/Metacello-Core/MetacelloPackageLoadDirective.class.st
+++ b/src/Metacello-Core/MetacelloPackageLoadDirective.class.st
@@ -22,12 +22,6 @@ MetacelloPackageLoadDirective >> acceptVisitor: aVisitor [
 	^ aVisitor visitPackageLoadDirective: self
 ]
 
-{ #category : 'accessing' }
-MetacelloPackageLoadDirective >> file [
-
-	^ self repositorySpecs asString
-]
-
 { #category : 'comparing' }
 MetacelloPackageLoadDirective >> hash [
 

--- a/src/Metacello-Core/MetacelloPackageSpec.class.st
+++ b/src/Metacello-Core/MetacelloPackageSpec.class.st
@@ -2,9 +2,7 @@ Class {
 	#name : 'MetacelloPackageSpec',
 	#superclass : 'MetacelloAbstractPackageSpec',
 	#instVars : [
-		'file',
 		'repositories',
-		'goferPackage',
 		'preLoadDoIt',
 		'postLoadDoIt'
 	],
@@ -22,9 +20,8 @@ MetacelloPackageSpec >> acceptVisitor: aVisitor [
 { #category : 'printing' }
 MetacelloPackageSpec >> configMethodBodyOn: aStream hasName: hasName indent: indent [
 
-	| hasFile hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes |
-	hasFile := file isNotNil.
-	hasRepositories := self repositorySpecs size > 0.
+	| hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes |
+	hasRepositories := self repositorySpecs isNotEmpty.
 	hasPreLoadDoIt := self preLoadDoIt isNotNil.
 	hasPostLoadDoIt := self postLoadDoIt isNotNil.
 	hasRequiresOrIncludes := (self requires isEmpty and: [ self includes isEmpty ]) not.
@@ -32,19 +29,12 @@ MetacelloPackageSpec >> configMethodBodyOn: aStream hasName: hasName indent: ind
 		self
 			configMethodBodyOn: aStream
 			hasName: hasName
-			cascading: hasFile | hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt
+			cascading: hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt
 			indent: indent ].
-	self
-		configMethodOn: aStream
-		for: file
-		selector: 'file: '
-		cascading: hasName | hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes
-		cascade: hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt
-		indent: indent.
 	hasRepositories ifTrue: [
 		self repositorySpecs size > 1
 			ifTrue: [
-				hasName | hasFile | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes ifTrue: [
+				hasName | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes ifTrue: [
 					aStream
 						cr;
 						tab: indent ].
@@ -57,7 +47,7 @@ MetacelloPackageSpec >> configMethodBodyOn: aStream hasName: hasName indent: ind
 				self repositories configMethodCascadeOn: aStream indent: indent + 1.
 				aStream nextPutAll: ' ]' ]
 			ifFalse: [
-				hasName | hasFile | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes ifTrue: [
+				hasName | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes ifTrue: [
 					aStream
 						cr;
 						tab: indent ].
@@ -67,14 +57,14 @@ MetacelloPackageSpec >> configMethodBodyOn: aStream hasName: hasName indent: ind
 		configMethodOn: aStream
 		for: self preLoadDoIt
 		selector: 'preLoadDoIt: '
-		cascading: hasName | hasFile | hasRepositories | hasPostLoadDoIt | hasRequiresOrIncludes
+		cascading: hasName | hasRepositories | hasPostLoadDoIt | hasRequiresOrIncludes
 		cascade: hasPostLoadDoIt
 		indent: indent.
 	self
 		configMethodOn: aStream
 		for: self postLoadDoIt
 		selector: 'postLoadDoIt: '
-		cascading: hasName | hasFile | hasRepositories | hasPreLoadDoIt | hasRequiresOrIncludes
+		cascading: hasName | hasRepositories | hasPreLoadDoIt | hasRequiresOrIncludes
 		cascade: false
 		indent: indent.
 	aStream nextPut: $.
@@ -94,16 +84,15 @@ MetacelloPackageSpec >> configMethodCascadeOn: aStream member: aMember last: las
 { #category : 'printing' }
 MetacelloPackageSpec >> configMethodOn: aStream indent: indent [
 
-	| hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes hasFile |
-	hasFile := file isNotNil.
-	hasRepositories := self repositorySpecs size > 0.
+	| hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes |
+	hasRepositories := self repositorySpecs isNotEmpty.
 	hasPreLoadDoIt := self preLoadDoIt isNotNil.
 	hasPostLoadDoIt := self postLoadDoIt isNotNil.
 	hasRequiresOrIncludes := (self requires isEmpty and: [ self includes isEmpty ]) not.
 	aStream
 		tab: indent;
 		nextPutAll: 'spec '.
-	hasFile | hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes
+	hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes
 		ifTrue: [
 			aStream
 				cr;
@@ -117,8 +106,7 @@ MetacelloPackageSpec >> configMethodOn: aStream indent: indent [
 { #category : 'printing' }
 MetacelloPackageSpec >> configShortCutMethodBodyOn: aStream member: aMember indent: indent [
 
-	| hasFile hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes |
-	hasFile := file isNotNil.
+	| hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes |
 	hasRepositories := self repositorySpecs size > 0.
 	hasPreLoadDoIt := self preLoadDoIt isNotNil.
 	hasPostLoadDoIt := self postLoadDoIt isNotNil.
@@ -134,8 +122,7 @@ MetacelloPackageSpec >> configShortCutMethodBodyOn: aStream member: aMember inde
 		self configMethodBodyOn: aStream hasName: false indent: indent + 2.
 		aStream nextPutAll: ' ]'.
 		^ self ].
-	aStream nextPutAll: 'package: ' , self name printString.
-	hasFile ifTrue: [ aStream nextPutAll: ' with: ' , file printString ]
+	aStream nextPutAll: 'package: ' , self name printString
 ]
 
 { #category : 'loading' }
@@ -150,39 +137,6 @@ MetacelloPackageSpec >> ensureLoadedForDevelopmentUsing: aTarget ithEngine: anEn
 	"noop"
 
 	
-]
-
-{ #category : 'private' }
-MetacelloPackageSpec >> extractNameFromFile [
-
-	^ file
-]
-
-{ #category : 'querying' }
-MetacelloPackageSpec >> file [
-
-	file ifNil: [ ^ self name ].
-	^ file
-]
-
-{ #category : 'accessing' }
-MetacelloPackageSpec >> file: aString [
-
-	file := aString
-]
-
-{ #category : 'accessing' }
-MetacelloPackageSpec >> getFile [
-	"raw access to iv"
-	
-	^file
-]
-
-{ #category : 'accessing' }
-MetacelloPackageSpec >> getName [
-    "raw access to iv"
-
-    ^ name
 ]
 
 { #category : 'accessing' }
@@ -214,7 +168,6 @@ MetacelloPackageSpec >> mergeMap [
 
 	| map |
 	map := super mergeMap.
-	map at: #file put: file.
 	map at: #repositories put: self repositories.
 	map at: #preLoadDoIt put: preLoadDoIt.
 	map at: #postLoadDoIt put: postLoadDoIt.
@@ -236,12 +189,6 @@ MetacelloPackageSpec >> mergeSpec: anotherSpec [
 	^newSpec
 ]
 
-{ #category : 'querying' }
-MetacelloPackageSpec >> name [
-
-	^ name ifNil: [ name := self extractNameFromFile ]
-]
-
 { #category : 'merging' }
 MetacelloPackageSpec >> nonOverridable [
 
@@ -258,7 +205,6 @@ MetacelloPackageSpec >> packageSpecsInLoadOrder [
 MetacelloPackageSpec >> postCopy [
 
 	super postCopy.
-	goferPackage := nil.
 	repositories := repositories copy.
 ]
 

--- a/src/Metacello-Core/MetacelloProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectSpec.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : 'MetacelloProjectSpec',
 	#superclass : 'MetacelloSpec',
 	#instVars : [
-		'file',
 		'preLoadDoIt',
 		'loads',
 		'projectPackage',
@@ -93,7 +92,7 @@ MetacelloProjectSpec >> compareEqual: aMetacelloProjectSpec [
 				  self loads = aMetacelloProjectSpec loads and: [
 					  self preLoadDoIt value == aMetacelloProjectSpec preLoadDoIt value and: [
 						  self postLoadDoIt value == aMetacelloProjectSpec postLoadDoIt value and: [
-							  (self repositories compareEqual: aMetacelloProjectSpec repositories) and: [ self file = aMetacelloProjectSpec file ] ] ] ] ] ] ]
+							  self repositories compareEqual: aMetacelloProjectSpec repositories ] ] ] ] ] ]
 ]
 
 { #category : 'scripting' }
@@ -118,7 +117,7 @@ MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent fromShortCut:
 	| hasOperator hasProjectPackage hasLoads hasClassName hasPreLoadDoIt hasPostLoadDoIt |
 	hasClassName := self hasClassName.
 	hasOperator := operator isNotNil.
-	hasProjectPackage := self hasRepository or: [ hasClassName & self getFile isNotNil ].
+	hasProjectPackage := self hasRepository or: [ hasClassName ].
 	hasLoads := self loads isNotNil.
 	hasPreLoadDoIt := self preLoadDoIt isNotNil.
 	hasPostLoadDoIt := self postLoadDoIt isNotNil.
@@ -184,7 +183,7 @@ MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent fromShortCut:
 	hasProjectPackage ifTrue: [
 		| hasName hasRepo |
 		hasRepo := self hasRepository.
-		hasName := self file ~= self className.
+		hasName := self name ~= self className.
 		hasName ifTrue: [
 			hasClassName | hasOperator | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt
 				ifTrue: [
@@ -192,7 +191,7 @@ MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent fromShortCut:
 						cr;
 						tab: indent + 1 ]
 				ifFalse: [ aStream space ].
-			aStream nextPutAll: 'file: ' , self file printString.
+			aStream nextPutAll: 'file: ' , self name printString.
 			hasRepo ifTrue: [ aStream nextPut: $; ] ].
 		hasRepo ifTrue: [
 			| repos |
@@ -235,7 +234,7 @@ MetacelloProjectSpec >> configShortCutMethodOn: aStream member: aMember indent: 
 	| hasOperator hasProjectPackage hasLoads hasClassName hasPreLoadDoIt hasPostLoadDoIt |
 	hasClassName := self hasClassName.
 	hasOperator := operator isNotNil.
-	hasProjectPackage := self hasRepository or: [ hasClassName & (self getFile isNotNil or: [ className ~= self name ]) ].
+	hasProjectPackage := self hasRepository or: [ hasClassName & (className ~= self name) ].
 	hasLoads := self loads isNotNil.
 	hasPreLoadDoIt := self preLoadDoIt isNotNil.
 	hasPostLoadDoIt := self postLoadDoIt isNotNil.
@@ -290,31 +289,11 @@ MetacelloProjectSpec >> ensureProjectLoadedWithEngine: anEngine [
 	project := anEngine loader loadProject: self
 ]
 
-{ #category : 'querying' }
-MetacelloProjectSpec >> file [
-
-	^ file ifNil: [ ^ self className ]
-]
-
-{ #category : 'accessing' }
-MetacelloProjectSpec >> file: aString [
-    self shouldBeMutable.
-    file := aString.
-    self projectPackage: nil
-]
-
 { #category : 'accessing' }
 MetacelloProjectSpec >> getClassName [
     "raw access to iv"
 
     ^ className
-]
-
-{ #category : 'accessing' }
-MetacelloProjectSpec >> getFile [
-    "raw access to iv"
-
-    ^ file
 ]
 
 { #category : 'accessing' }
@@ -339,25 +318,32 @@ MetacelloProjectSpec >> hasLoadConflicts: aMetacelloProjectSpec [
 MetacelloProjectSpec >> hasNoLoadConflicts: aMetacelloProjectSpec [
 	"'projectPackage repositories'"
 
-	^ (self className = aMetacelloProjectSpec className and: [
-		   (self compareVersionsEqual: aMetacelloProjectSpec) and: [
-			   self operator == aMetacelloProjectSpec operator and: [
-				   (self repositories isEmpty or: [ aMetacelloProjectSpec repositories isEmpty ]) or: [
-					   self repositories hasNoLoadConflicts: aMetacelloProjectSpec repositories ] ] ] ]) and: [ self file = aMetacelloProjectSpec file ]
+	^ self className = aMetacelloProjectSpec className and: [
+			  (self compareVersionsEqual: aMetacelloProjectSpec) and: [
+					  self operator == aMetacelloProjectSpec operator and: [
+						  (self repositories isEmpty or: [ aMetacelloProjectSpec repositories isEmpty ]) or: [
+							  self repositories hasNoLoadConflicts: aMetacelloProjectSpec repositories ] ] ] ]
 ]
 
 { #category : 'testing' }
 MetacelloProjectSpec >> hasNonVersionStringField [
 
-	| hasVersionString hasOperator hasProjectPackage hasLoads hasClassName hasPreLoadDoIt hasPostLoadDoIt |
-	hasClassName := self hasClassName.
-	hasVersionString := self versionString isNotNil.
-	hasOperator := operator isNotNil.
-	hasProjectPackage := (self file isNotNil and: [ hasClassName and: [ self className ~= self name ] ]) or: [ self hasRepository ].
-	hasLoads := self loads isNotNil.
-	hasPreLoadDoIt := self preLoadDoIt isNotNil.
-	hasPostLoadDoIt := self postLoadDoIt isNotNil.
-	^ hasClassName | hasOperator | hasProjectPackage | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt
+	| hasProjectPackage |
+	self hasClassName ifTrue: [ ^ true ].
+
+	self versionString ifNotNil: [ ^ true ].
+
+	operator ifNotNil: [ ^ true ].
+
+	hasProjectPackage := self className ~= self name or: [ self hasRepository ].
+	hasProjectPackage ifTrue: [ ^ true ].
+
+	self loads ifNotNil: [ ^ true ].
+
+	self preLoadDoIt ifNotNil: [ ^ true ].
+	self postLoadDoIt ifNotNil: [ ^ true ].
+
+	^ false
 ]
 
 { #category : 'testing' }
@@ -493,8 +479,7 @@ MetacelloProjectSpec >> metacelloRegistrationHash [
 	hash := String stringHash: self preLoadDoIt asString initialHash: hash.
 	hash := String stringHash: self postLoadDoIt asString initialHash: hash.
 	hash := hash bitXor: loads hash.
-	hash := hash bitXor: self repositories metacelloRegistrationHash.
-	^ String stringHash: self file initialHash: hash
+	^ hash bitXor: self repositories metacelloRegistrationHash
 ]
 
 { #category : 'querying' }
@@ -590,7 +575,6 @@ MetacelloProjectSpec >> projectPackage [
             self className ifNil: [ ^ nil ].
             projectPackage := self project packageSpec.
             projectPackage name: self className.
-            self getFile ifNotNil: [ projectPackage file: self file ].
             projectPackage repositories: self getRepositories ].
     ^ projectPackage
 ]

--- a/src/Metacello-Core/String.extension.st
+++ b/src/Metacello-Core/String.extension.st
@@ -5,7 +5,7 @@ String >> addToMetacelloPackages: aMetacelloPackagesSpec [
 
 	| spec |
 	spec := aMetacelloPackagesSpec project packageSpec
-		        file: self;
+		        name: self;
 		        yourself.
 	aMetacelloPackagesSpec addMemberForSpec: spec
 ]
@@ -31,7 +31,7 @@ String >> mergeIntoMetacelloPackages: aMetacelloPackagesSpec [
 
 	| spec |
 	spec := aMetacelloPackagesSpec project packageSpec
-		        file: self;
+		        name: self;
 		        yourself.
 	aMetacelloPackagesSpec mergeMemberForSpec: spec
 ]

--- a/src/Metacello-TestsCore/MetacelloPackagesSpecTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloPackagesSpecTestCase.class.st
@@ -62,7 +62,6 @@ MetacelloPackagesSpecTestCase >> testAddPackageA [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
 				yourself).
@@ -72,13 +71,11 @@ MetacelloPackagesSpecTestCase >> testAddPackageA [
 				name: 'Package';
 				requires: 'AndAnotherPackage';
 				includes: 'AndIncludedPackage';
-				file: 'Package-dkh.2';
 				yourself).
 	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AndAnotherPackage').
 	self assert: package includes equals: #('AndIncludedPackage').
-	self assert: package file equals: 'Package-dkh.2'.
 	self assert: package preLoadDoIt value identicalTo: nil.
 	self assert: package postLoadDoIt value identicalTo: nil
 ]
@@ -95,20 +92,17 @@ MetacelloPackagesSpecTestCase >> testAddPackageB [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
 				yourself) . (self packageSpec
 				name: 'Package';
 				requires: 'AndAnotherPackage';
 				includes: 'AndIncludedPackage';
-				file: 'Package-dkh.2';
 				yourself)}.
 	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AndAnotherPackage').
 	self assert: package includes equals: #('AndIncludedPackage').
-	self assert: package file equals: 'Package-dkh.2'.
 	self assert: package preLoadDoIt value identicalTo: nil.
 	self assert: package postLoadDoIt value identicalTo: nil
 ]
@@ -266,7 +260,6 @@ MetacelloPackagesSpecTestCase >> testCopyToPackage [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
 				yourself).
@@ -280,7 +273,6 @@ MetacelloPackagesSpecTestCase >> testCopyToPackage [
 	self assert: package name equals: 'PackageCopy'.
 	self assert: package requires equals: #('AnotherPackage').
 	self assert: package includes equals: #('IncludedPackage').
-	self assert: package file equals: 'Package-dkh.1'.
 	self assert: package preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: package postLoadDoIt value identicalTo: #postLoadDoIt
 ]
@@ -375,7 +367,6 @@ MetacelloPackagesSpecTestCase >> testMergePackageA [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
 				yourself).
@@ -385,13 +376,11 @@ MetacelloPackagesSpecTestCase >> testMergePackageA [
 				name: 'Package';
 				requires: 'AndAnotherPackage';
 				includes: 'AndIncludedPackage';
-				file: 'Package-dkh.2';
 				yourself).
 	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AnotherPackage' 'AndAnotherPackage').
 	self assert: package includes equals: #('IncludedPackage' 'AndIncludedPackage').
-	self assert: package file equals: 'Package-dkh.2'.
 	self assert: package preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: package postLoadDoIt value identicalTo: #postLoadDoIt
 ]
@@ -408,7 +397,6 @@ MetacelloPackagesSpecTestCase >> testMergePackageB [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
 				yourself).
@@ -418,13 +406,11 @@ MetacelloPackagesSpecTestCase >> testMergePackageB [
 				name: 'Package';
 				requires: 'AndAnotherPackage';
 				includes: 'AndIncludedPackage';
-				file: 'Package-dkh.2';
 				yourself)}.
 	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AnotherPackage' 'AndAnotherPackage').
 	self assert: package includes equals: #('IncludedPackage' 'AndIncludedPackage').
-	self assert: package file equals: 'Package-dkh.2'.
 	self assert: package preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: package postLoadDoIt value identicalTo: #postLoadDoIt
 ]
@@ -534,7 +520,6 @@ MetacelloPackagesSpecTestCase >> testPackageMergeSpec [
 		name: 'Package';
 		requires: 'AnotherPackage';
 		includes: 'IncludedPackage';
-		file: 'Package-dkh.1';
 		preLoadDoIt: #preLoadDoIt;
 		postLoadDoIt: #postLoadDoIt;
 		repository: 'http://example.com/repository' username: 'dkh' password: 'password';
@@ -544,7 +529,6 @@ MetacelloPackagesSpecTestCase >> testPackageMergeSpec [
 		name: 'Package';
 		requires: 'AndAnotherPackage';
 		includes: 'AndIncludedPackage';
-		file: 'Package-dkh.2';
 		repository: 'http://example.com/repository' username: 'DaleHenrichs' password: 'secret';
 		repository: '/opt/gemstone/repo';
 		yourself.
@@ -552,7 +536,6 @@ MetacelloPackagesSpecTestCase >> testPackageMergeSpec [
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AnotherPackage' 'AndAnotherPackage').
 	self assert: package includes equals: #('IncludedPackage' 'AndIncludedPackage').
-	self assert: package file equals: 'Package-dkh.2'.
 	self assert: package preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: package postLoadDoIt value identicalTo: #postLoadDoIt.
 	repository := package repositories map at: '/opt/gemstone/repository' ifAbsent: [ self assert: false ].
@@ -572,7 +555,6 @@ MetacelloPackagesSpecTestCase >> testPackageSpec [
 		name: 'Package';
 		requires: 'AnotherPackage';
 		includes: 'IncludedPackage';
-		file: 'Package-dkh.1';
 		preLoadDoIt: #preLoadDoIt;
 		postLoadDoIt: #postLoadDoIt;
 		repository: 'http://example.com/repository' username: 'dkh' password: 'password';
@@ -581,7 +563,6 @@ MetacelloPackagesSpecTestCase >> testPackageSpec [
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #('AnotherPackage').
 	self assert: package includes equals: #('IncludedPackage').
-	self assert: package file equals: 'Package-dkh.1'.
 	self assert: package preLoadDoIt value identicalTo: #preLoadDoIt.
 	self assert: package postLoadDoIt value identicalTo: #postLoadDoIt.
 	repository := package repositories map at: '/opt/gemstone/repository' ifAbsent: [ self assert: false ].
@@ -703,7 +684,6 @@ MetacelloPackagesSpecTestCase >> testRemovePackageA [
                 name: 'Package';
                 requires: 'AnotherPackage';
                 includes: 'IncludedPackage';
-                file: 'Package-dkh.1';
                 preLoadDoIt: #'preLoadDoIt';
                 postLoadDoIt: #'postLoadDoIt';
                 yourself).
@@ -729,7 +709,6 @@ MetacelloPackagesSpecTestCase >> testRemovePackageB [
                 name: 'Package';
                 requires: 'AnotherPackage';
                 includes: 'IncludedPackage';
-                file: 'Package-dkh.1';
                 preLoadDoIt: #'preLoadDoIt';
                 postLoadDoIt: #'postLoadDoIt';
                 yourself).
@@ -755,7 +734,6 @@ MetacelloPackagesSpecTestCase >> testRemovePackageC [
                 name: 'Package';
                 requires: 'AnotherPackage';
                 includes: 'IncludedPackage';
-                file: 'Package-dkh.1';
                 preLoadDoIt: #'preLoadDoIt';
                 postLoadDoIt: #'postLoadDoIt';
                 yourself).
@@ -777,7 +755,6 @@ MetacelloPackagesSpecTestCase >> testRemovePackageD [
                 name: 'Package';
                 requires: 'AnotherPackage';
                 includes: 'IncludedPackage';
-                file: 'Package-dkh.1';
                 preLoadDoIt: #'preLoadDoIt';
                 postLoadDoIt: #'postLoadDoIt';
                 yourself).

--- a/src/Metacello-TestsCore/MetacelloProjectSpecTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloProjectSpecTestCase.class.st
@@ -56,7 +56,6 @@ MetacelloProjectSpecTestCase >> testProjectMergeSpec2 [
 	self assert: project name equals: 'Project'.
 	self assert: project className equals: 'ConfigurationOfProjectB'.
 	self assert: project projectPackage name equals: project className.
-	self assert: project projectPackage file equals: project className.
 	project repositories map at: '/opt/gemstone/repository' ifPresent: [ self assert: false ].
 	repository := project repositories map at: '/opt/gemstone/repo' ifAbsent: [ self assert: false ].
 	self assert: repository type equals: 'directory'.
@@ -107,7 +106,6 @@ MetacelloProjectSpecTestCase >> testProjectSpec2 [
 	self assert: project name equals: 'Project'.
 	self assert: project className equals: 'ConfigurationOfProject'.
 	self assert: project projectPackage name equals: project className.
-	self assert: project projectPackage file equals: project className.
 	repository := project repositories map at: '/opt/gemstone/repository' ifAbsent: [ self assert: false ].
 	self assert: repository type equals: 'directory'.
 	repository := project repositories map at: 'http://example.com/repository' ifAbsent: [ self assert: false ].

--- a/src/Metacello-TestsCore/MetacelloReferenceBaseline.class.st
+++ b/src/Metacello-TestsCore/MetacelloReferenceBaseline.class.st
@@ -53,9 +53,7 @@ MetacelloReferenceBaseline >> baseline: spec [
 					"OPTIONAL: Version comparison operator #= #~= #> #< #>= #<= #~> "
 					operator: #~>; 	
 					"OPTIONAL: List of packages to be loaded from project"															
-					loads: #('UI-Core' );	
-					"Optional: Name of package containing the config, by convention same as className"						
-					file: 'ConfigurationOfUI';	
+					loads: #('UI-Core' );
 					"Repository where package resides"					
 					repository: 'http://www.example.com/r' ];	
 			"Create a new project reference to replace existing project reference"
@@ -95,9 +93,7 @@ MetacelloReferenceBaseline >> baseline: spec [
 					"'Example-Core' must be loaded before 'Example-AddOn'" 
 					requires: #('Example-Core' );
 					"When 'Example-AddOn' is loaded, load 'Example-UI'"				
-					includes: #('Example-UI' );
-					"Explicitly oad version 'Example-AddOn-anon.3' of the package"					
-					file: 'Example-AddOn-anon.3';					
+					includes: #('Example-UI' );			
 					repositories: [
 						spec 
 							"Load 'Example-AddOn' from  the 'http://www.example.com/yar'"
@@ -114,12 +110,9 @@ MetacelloReferenceBaseline >> baseline: spec [
 				spec 
 					requires: #('Example-Core' 'UI Support' );
 					includes: #('Example-UI' );
-					file: 'Example-AddOn-anon.7';
 					repository: 'http://www.example.com/or' username: 'foo' password: 'bar' ;
 					preLoadDoIt: #preloadForAddOn;
 					postLoadDoIt: #postloadForAddOn ];
-			"Change the package version loaded"
-			package: 'Example-AddOn' with:'Example-AddOn-anon.5';	
 			"Create 'Example-Core' package in project"					
 			package: 'Example-Core';								
 			package: 'Example-Tests' with: [

--- a/src/Metacello-TestsCore/MetacelloReferenceTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloReferenceTestCase.class.st
@@ -65,7 +65,6 @@ spec
 		spec 
 			requires: #(''Example-Core'' );
 			includes: #(''Example-UI'' );
-			file: ''Example-AddOn-anon.3'';
 			repositories: [
 				spec
 					repository: ''http://www.example.com/yar'';
@@ -76,11 +75,9 @@ spec
 		spec 
 			requires: #(''Example-Core'' ''UI Support'' );
 			includes: #(''Example-UI'' );
-			file: ''Example-AddOn-anon.7'';
 			repository: ''http://www.example.com/or'' username: ''foo'' password: ''bar'';
 			preLoadDoIt: #''preloadForAddOn'';
 			postLoadDoIt: #''postloadForAddOn''. ];
-	package: ''Example-AddOn'' with: ''Example-AddOn-anon.5'';
 	package: ''Example-Core'';
 	package: ''Example-Tests'' with: [
 		spec requires: #(''Example-Core'' ). ];
@@ -106,7 +103,6 @@ MetacelloReferenceTestCase >> testReferenceConfig [
 	name: ''Example-AddOn'';
 	requires: #(''Example-Core'' ''UI Support'' );
 	includes: #(''Example-UI'' );
-	file: ''Example-AddOn-anon.5'';
 	repository: ''http://www.example.com/or'' username: ''foo'' password: ''bar'';
 	preLoadDoIt: #''preloadForAddOn'';
 	postLoadDoIt: #''postloadForAddOn''.'.

--- a/src/Metacello-TestsCore/MetacelloVersionSpecTestCase.class.st
+++ b/src/Metacello-TestsCore/MetacelloVersionSpecTestCase.class.st
@@ -132,7 +132,6 @@ MetacelloVersionSpecTestCase >> testVersionSpec2 [
 				name: 'Package';
 				requires: 'AnotherPackage';
 				includes: 'IncludedPackage';
-				file: 'Package-dkh.1';
 				preLoadDoIt: #preLoadDoIt;
 				postLoadDoIt: #postLoadDoIt;
 				yourself);

--- a/src/Metacello-TestsMCCore/MetacelloRepositoryCommonTestCase.class.st
+++ b/src/Metacello-TestsMCCore/MetacelloRepositoryCommonTestCase.class.st
@@ -13,7 +13,6 @@ MetacelloRepositoryCommonTestCase >> baseline: spec [
 			spec package: 'Example-Core' with: [
 					spec
 						includes: 'Example-AddOn';
-						file: 'Example-Core-anon.1';
 						repository: (OSPlatform current isWindows
 								 ifTrue: [ 'c:\opt\mcexamples' ]
 								 ifFalse: [ '/opt/mcexamples' ]) ].
@@ -21,25 +20,21 @@ MetacelloRepositoryCommonTestCase >> baseline: spec [
 			spec package: 'Example-Core2' with: [
 					spec
 						includes: 'Example-AddOn2';
-						file: 'Example-Core2-anon.1';
 						repository: 'ftp://ftp.example.com/examples' ].
 
 			spec package: 'Example-Core3' with: [
 					spec
 						includes: 'Example-AddOn3';
-						file: 'Example-Core3-anon.1';
 						repository: 'http://example.com/examples' ].
 					
 			spec package: 'Example-Core4' with: [
 					spec
 						includes: 'Example-AddOn4';
-						file: 'Example-Core4-anon.1';
 						repository: 'dictionary://Metacello_Platform_Test_GlobalDictionary' ].
 
 			spec package: 'Example-Core5' with: [
 					spec
 						includes: 'Example-AddOn5';
-						file: 'Example-Core5-anon.1';
 						repository: 'filetree://' , MCFileTreeFileUtils default fullName , '/temp/repo' ] ]
 ]
 


### PR DESCRIPTION
Remove the concept of 'file'. This was used to specify a specific mcz in a configuration (like "Package.Dh.45"). Since this is not used anymore, I removed the code related to this feature

Subpart of another PR that does not pass. I want to find which commit caused the problem