### PR TITLE
Improve error message of UIID generation

### DIFF
--- a/src/Random-Core/ByteArray.extension.st
+++ b/src/Random-Core/ByteArray.extension.st
@@ -5,5 +5,7 @@ ByteArray >> generateUUIDInPlace [
 
 	<primitive: 'primitiveMakeUUID' module: 'UUIDPlugin'>
 	self size = 16 ifFalse: [ self error: 'The byte array size has to be 16 bytes.' ].
+	"We should remove the next line around the moment we release Pharo 14"
+	self error: ('Cannot generate UUID. It requires at least version 10.3.9 of the Pharo vm. Current version: ', Smalltalk vm interpreterSourceVersion).
 	self primitiveFailed
 ]


### PR DESCRIPTION
Let the users know that if they cannot generate an UUID it's because they have a VM that is too old