### PR TITLE
Speedup MethodAnnouncement>>#isProvidedByExtension

### DIFF
--- a/src/System-Announcements/MethodAnnouncement.class.st
+++ b/src/System-Announcements/MethodAnnouncement.class.st
@@ -19,7 +19,8 @@ MethodAnnouncement >> classAffected [
 
 { #category : 'testing' }
 MethodAnnouncement >> isProvidedByExtension [
-	^self methodOrigin package ~= self methodPackage
+
+	^ self method isExtension
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
I tried to save divers announcements and try both implementations before my change:

[ anns do: [  :ann | ann isProvidedByExtension ] ] bench.  "2,292,923 iterations in 5 seconds 2 milliseconds. 458401.240 per second"
[ anns do: [  :ann | ann method isExtension ] ] bench. "12,324,597 iterations in 5 seconds 3 milliseconds. 2463441.335 per second"

This method is used a lot by Calypso to know what to update when code changes