### PR TITLE
Fix bug in XML serialization of test results

### DIFF
--- a/src/SUnit-UI-Tests/ClapTestRunnerTest.class.st
+++ b/src/SUnit-UI-Tests/ClapTestRunnerTest.class.st
@@ -178,10 +178,13 @@ ClapTestRunnerTest >> testTestRunnerIsCommandLineTestRunnerWhenNoXtermFlagPresen
 
 { #category : 'tests' }
 ClapTestRunnerTest >> testTestRunnerIsHDTestReporWhenJunitXmlOutput [
+	"If we do not restore the stage name, then it will be wrong to export the tests results"
 
-	| command |
-	context := ClapTestRunner commandSpecification activationWith: #('test' '--junit-xml-output' 'SUnit.*').
-	command := context command.
-	
-	self assert: command testRunner equals: HDTestReport
+	| command oldStageName |
+	oldStageName := HDTestReport currentStageName.
+	[
+		context := ClapTestRunner commandSpecification activationWith: #( 'test' '--junit-xml-output' 'SUnit.*' ).
+		command := context command.
+
+		self assert: command testRunner equals: HDTestReport ] ensure: [ HDTestReport currentStageName: oldStageName ]
 ]


### PR DESCRIPTION
I fixed a bug that cause the xml files of the test command line to not all be exported.

This should uncover some test failures in Pharo

Fixes #19104