### PR TITLE
Simplify printing of Metacello specs

### DIFF
--- a/src/Metacello-Core/MetacelloAbstractPackageSpec.class.st
+++ b/src/Metacello-Core/MetacelloAbstractPackageSpec.class.st
@@ -5,76 +5,15 @@ Class {
 		'requires',
 		'includes'
 	],
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'testing' }
 MetacelloAbstractPackageSpec class >> isAbstract [
 
 	^ self = MetacelloAbstractPackageSpec
-]
-
-{ #category : 'printing' }
-MetacelloAbstractPackageSpec >> configMethodBodyOn: aStream hasName: hasName cascading: hasCascading indent: indent [
-
-	| hasRequires hasIncludes |
-	hasRequires := self requires isNotEmpty.
-	hasIncludes := self includes isNotEmpty.
-	hasRequires ifTrue: [
-			hasName | hasIncludes | hasCascading ifTrue: [
-					aStream
-						cr;
-						tab: indent ].
-			aStream nextPutAll: 'requires: #('.
-			self requires do: [ :str |
-					aStream
-						print: str;
-						nextPutAll: ' ' ].
-			hasIncludes | hasCascading
-				ifTrue: [ aStream nextPutAll: ');' ]
-				ifFalse: [ aStream nextPut: $) ] ].
-	hasIncludes ifTrue: [
-			hasName | hasRequires | hasCascading ifTrue: [
-					aStream
-						cr;
-						tab: indent ].
-			aStream nextPutAll: 'includes: #('.
-			self includes do: [ :str |
-					aStream
-						print: str;
-						nextPutAll: ' ' ].
-			hasCascading
-				ifTrue: [ aStream nextPutAll: ');' ]
-				ifFalse: [ aStream nextPut: $) ] ]
-]
-
-{ #category : 'printing' }
-MetacelloAbstractPackageSpec >> configMethodCascadeOn: aStream member: aMember last: lastCascade indent: indent [
-
-	self subclassResponsibility
-]
-
-{ #category : 'printing' }
-MetacelloAbstractPackageSpec >> configMethodOn: aStream for: aValue selector: selector cascading: cascading cascade: cascade indent: indent [
-
-	| valuePrintString |
-	aValue ifNil: [ ^ self ].
-	cascading ifTrue: [
-		aStream
-			cr;
-			tab: indent ].
-	valuePrintString := aValue value isSymbol
-		                    ifTrue: [ '#' , aValue value asString printString ]
-		                    ifFalse: [ aValue value printString ].
-	aStream nextPutAll: selector , valuePrintString.
-	cascade ifTrue: [ aStream nextPut: $; ]
-]
-
-{ #category : 'testing' }
-MetacelloAbstractPackageSpec >> hasRepository [
-    ^ false
 ]
 
 { #category : 'private' }
@@ -158,6 +97,16 @@ MetacelloAbstractPackageSpec >> postCopy [
 	super postCopy.
 	requires := requires copy.
 	includes := includes copy
+]
+
+{ #category : 'printing' }
+MetacelloAbstractPackageSpec >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		nextPutAll: ' [';
+		nextPutAll: self name;
+		nextPutAll: ']'
 ]
 
 { #category : 'visiting' }

--- a/src/Metacello-Core/MetacelloAddMemberSpec.class.st
+++ b/src/Metacello-Core/MetacelloAddMemberSpec.class.st
@@ -1,19 +1,13 @@
 Class {
 	#name : 'MetacelloAddMemberSpec',
 	#superclass : 'MetacelloMemberSpec',
-	#category : 'Metacello-Core-Members',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Members'
+	#tag : 'Model'
 }
 
 { #category : 'actions' }
 MetacelloAddMemberSpec >> applyToMap: map [
 
 	map at: self name put: self spec
-]
-
-{ #category : 'accessing' }
-MetacelloAddMemberSpec >> methodUpdateSelector [
-
-	^#overrides:
 ]

--- a/src/Metacello-Core/MetacelloCopyMemberSpec.class.st
+++ b/src/Metacello-Core/MetacelloCopyMemberSpec.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'sourceName'
 	],
-	#category : 'Metacello-Core-Members',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Members'
+	#tag : 'Model'
 }
 
 { #category : 'actions' }
@@ -18,12 +18,6 @@ MetacelloCopyMemberSpec >> applyToMap: map [
 				aSpec aboutToCopy.
 				map at: self name put: (aSpec copy mergeSpec: self spec copy) ]
 		ifAbsent: [ self error: 'Source spec named ' , self sourceName printString , ' not found' ]
-]
-
-{ #category : 'accessing' }
-MetacelloCopyMemberSpec >> methodUpdateSelector [
-
-	^#copy:
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloGroupSpec.class.st
+++ b/src/Metacello-Core/MetacelloGroupSpec.class.st
@@ -5,9 +5,9 @@ Class {
 		'project',
 		'name'
 	],
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'instance creation' }
@@ -22,35 +22,6 @@ MetacelloGroupSpec class >> project: aMetacelloProject [
 MetacelloGroupSpec >> acceptVisitor: aVisitor [ 
 	
 	^ aVisitor visitGroupSpec: self
-]
-
-{ #category : 'printing' }
-MetacelloGroupSpec >> configMethodCascadeOn: aStream member: aMember last: lastCascade indent: indent [
-
-	aMember methodUpdateSelector == #remove:
-		ifTrue: [ aStream nextPutAll: 'removeGroup: ', self name printString. ]
-		ifFalse: [
-			aStream 
-				nextPutAll: 'group: ', self name printString;
-				space; 
-				nextPutAll: aMember methodUpdateSelector asString, ' #('.
-			self includes do: [:str | aStream nextPutAll: str printString, ' ' ].
-			aStream nextPut: $) ].
-	lastCascade
-		ifTrue: [ aStream nextPut: $. ]
-		ifFalse: [ aStream nextPut: $;; cr ].
-]
-
-{ #category : 'printing' }
-MetacelloGroupSpec >> configMethodOn: aStream indent: indent [
-
-	aStream 
-		tab: indent;
-		nextPutAll: 'spec '; cr;
-		tab: indent + 1;
-		nextPutAll: 'name: ', self name printString, ';'.
-	self configMethodBodyOn: aStream hasName: true cascading: false indent: indent + 1.
-	aStream nextPut: $.
 ]
 
 { #category : 'private' }

--- a/src/Metacello-Core/MetacelloMemberListSpec.class.st
+++ b/src/Metacello-Core/MetacelloMemberListSpec.class.st
@@ -5,9 +5,9 @@ Class {
 		'list',
 		'memberMap'
 	],
-	#category : 'Metacello-Core-Members',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Members'
+	#tag : 'Model'
 }
 
 { #category : 'testing' }
@@ -79,7 +79,7 @@ MetacelloMemberListSpec >> detect: aBlock ifNone: exceptionBlock [
 { #category : 'enumeration' }
 MetacelloMemberListSpec >> do: aBlock [
 
-	self map values do: aBlock
+	self specs do: aBlock
 ]
 
 { #category : 'testing' }
@@ -147,6 +147,17 @@ MetacelloMemberListSpec >> postCopy [
 	self clearMemberMap
 ]
 
+{ #category : 'printing' }
+MetacelloMemberListSpec >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream nextPutAll: ' ['.
+	self specs
+		ifEmpty: [ aStream nextPutAll: 'Empty' ]
+		ifNotEmpty: [ :specs | specs do: [ :spec | aStream nextPutAll: spec name ] separatedBy: [ aStream nextPutAll: ', ' ] ].
+	aStream nextPutAll: ']'
+]
+
 { #category : 'actions' }
 MetacelloMemberListSpec >> remove: aSpec [
 
@@ -177,4 +188,11 @@ MetacelloMemberListSpec >> select: aBlock [
 MetacelloMemberListSpec >> specListDo: aBlock [
 
 	self list do: [:member |  aBlock value: member spec ]
+]
+
+{ #category : 'accessing' }
+MetacelloMemberListSpec >> specs [
+	"Return the list of specs I contains once all members are applied."
+
+	^ self map values
 ]

--- a/src/Metacello-Core/MetacelloMemberSpec.class.st
+++ b/src/Metacello-Core/MetacelloMemberSpec.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'spec'
 	],
-	#category : 'Metacello-Core-Members',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Members'
+	#tag : 'Model'
 }
 
 { #category : 'testing' }
@@ -35,36 +35,20 @@ MetacelloMemberSpec >> applyToMap: map [
 	self subclassResponsibility
 ]
 
-{ #category : 'printing' }
-MetacelloMemberSpec >> configMethodCascadeOn: aStream last: lastCascade indent: indent [
-
-	self spec 
-		configMethodCascadeOn: aStream 
-		member: self 
-		last: lastCascade 
-		indent: indent
-]
-
-{ #category : 'printing' }
-MetacelloMemberSpec >> configMethodOn: aStream indent: indent [
-
-	aStream
-		nextPutAll: self class name asString;
-		nextPutAll: ' member: ('.
-	self spec configMethodOn: aStream indent: indent.
-	aStream nextPutAll: ')'
-]
-
-{ #category : 'accessing' }
-MetacelloMemberSpec >> methodUpdateSelector [
-
-	^self subclassResponsibility
-]
-
 { #category : 'accessing' }
 MetacelloMemberSpec >> name [
 
 	^ self spec name
+]
+
+{ #category : 'printing' }
+MetacelloMemberSpec >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		nextPutAll: ' [';
+		nextPutAll: self name;
+		nextPutAll: ']'
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloMergeMemberSpec.class.st
+++ b/src/Metacello-Core/MetacelloMergeMemberSpec.class.st
@@ -1,9 +1,9 @@
 Class {
 	#name : 'MetacelloMergeMemberSpec',
 	#superclass : 'MetacelloMemberSpec',
-	#category : 'Metacello-Core-Members',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Members'
+	#tag : 'Model'
 }
 
 { #category : 'actions' }
@@ -13,10 +13,4 @@ MetacelloMergeMemberSpec >> applyToMap: map [
 		at: self name
 		ifPresent: [ :aSpec | map at: self name put: (aSpec mergeSpec: self spec) ]
 		ifAbsent: [ map at: self name put: self spec copy ]
-]
-
-{ #category : 'accessing' }
-MetacelloMergeMemberSpec >> methodUpdateSelector [
-
-	^#with:
 ]

--- a/src/Metacello-Core/MetacelloPackageSpec.class.st
+++ b/src/Metacello-Core/MetacelloPackageSpec.class.st
@@ -8,9 +8,9 @@ Class {
 		'preLoadDoIt',
 		'postLoadDoIt'
 	],
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'instance creation' }
@@ -25,114 +25,6 @@ MetacelloPackageSpec class >> project: aMetacelloProject [
 MetacelloPackageSpec >> acceptVisitor: aVisitor [
 
 	^ aVisitor visitPackageSpec: self
-]
-
-{ #category : 'printing' }
-MetacelloPackageSpec >> configMethodBodyOn: aStream hasName: hasName indent: indent [
-
-	| hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes |
-	hasRepositories := self repositorySpecs isNotEmpty.
-	hasPreLoadDoIt := self preLoadDoIt isNotNil.
-	hasPostLoadDoIt := self postLoadDoIt isNotNil.
-	hasRequiresOrIncludes := (self requires isEmpty and: [ self includes isEmpty ]) not.
-	hasRequiresOrIncludes ifTrue: [
-		self
-			configMethodBodyOn: aStream
-			hasName: hasName
-			cascading: hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt
-			indent: indent ].
-	hasRepositories ifTrue: [
-		self repositorySpecs size > 1
-			ifTrue: [
-				hasName | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes ifTrue: [
-					aStream
-						cr;
-						tab: indent ].
-				aStream
-					nextPutAll: 'repositories: [';
-					cr;
-					tab: indent + 1;
-					nextPutAll: 'spec';
-					cr.
-				self repositories configMethodCascadeOn: aStream indent: indent + 1.
-				aStream nextPutAll: ' ]' ]
-			ifFalse: [
-				hasName | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes ifTrue: [
-					aStream
-						cr;
-						tab: indent ].
-				self repositories configMethodCascadeOn: aStream indent: indent ].
-		hasPreLoadDoIt | hasPostLoadDoIt ifTrue: [ aStream nextPut: $; ] ].
-	self
-		configMethodOn: aStream
-		for: self preLoadDoIt
-		selector: 'preLoadDoIt: '
-		cascading: hasName | hasRepositories | hasPostLoadDoIt | hasRequiresOrIncludes
-		cascade: hasPostLoadDoIt
-		indent: indent.
-	self
-		configMethodOn: aStream
-		for: self postLoadDoIt
-		selector: 'postLoadDoIt: '
-		cascading: hasName | hasRepositories | hasPreLoadDoIt | hasRequiresOrIncludes
-		cascade: false
-		indent: indent.
-	aStream nextPut: $.
-]
-
-{ #category : 'printing' }
-MetacelloPackageSpec >> configMethodCascadeOn: aStream member: aMember last: lastCascade indent: indent [
-
-	aMember methodUpdateSelector  == #remove:
-		ifTrue: [ aStream  nextPutAll: 'removePackage: ', self name printString ]
-		ifFalse: [ self configShortCutMethodBodyOn: aStream member: aMember indent: indent ].
-	lastCascade
-		ifTrue: [ aStream nextPut: $. ]
-		ifFalse: [ aStream nextPut: $;; cr ]
-]
-
-{ #category : 'printing' }
-MetacelloPackageSpec >> configMethodOn: aStream indent: indent [
-
-	| hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes |
-	hasRepositories := self repositorySpecs isNotEmpty.
-	hasPreLoadDoIt := self preLoadDoIt isNotNil.
-	hasPostLoadDoIt := self postLoadDoIt isNotNil.
-	hasRequiresOrIncludes := (self requires isEmpty and: [ self includes isEmpty ]) not.
-	aStream
-		tab: indent;
-		nextPutAll: 'spec '.
-	hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes
-		ifTrue: [
-			aStream
-				cr;
-				tab: indent + 1;
-				nextPutAll: 'name: ' , self name printString;
-				nextPut: $;.
-			self configMethodBodyOn: aStream hasName: true indent: indent + 1 ]
-		ifFalse: [ aStream nextPutAll: 'name: ' , self name printString ]
-]
-
-{ #category : 'printing' }
-MetacelloPackageSpec >> configShortCutMethodBodyOn: aStream member: aMember indent: indent [
-
-	| hasRepositories hasPreLoadDoIt hasPostLoadDoIt hasRequiresOrIncludes |
-	hasRepositories := self repositorySpecs size > 0.
-	hasPreLoadDoIt := self preLoadDoIt isNotNil.
-	hasPostLoadDoIt := self postLoadDoIt isNotNil.
-	hasRequiresOrIncludes := (self requires isEmpty and: [ self includes isEmpty ]) not.
-	hasRepositories | hasPreLoadDoIt | hasPostLoadDoIt | hasRequiresOrIncludes ifTrue: [
-		aStream
-			nextPutAll: 'package: ' , self name printString , ' ';
-			nextPutAll: aMember methodUpdateSelector asString , ' [';
-			cr.
-		aStream
-			tab: indent + 1;
-			nextPutAll: 'spec '.
-		self configMethodBodyOn: aStream hasName: false indent: indent + 2.
-		aStream nextPutAll: ' ]'.
-		^ self ].
-	aStream nextPutAll: 'package: ' , self name printString
 ]
 
 { #category : 'loading' }
@@ -154,11 +46,6 @@ MetacelloPackageSpec >> getRepositories [
     "raw access to iv"
 
     ^ repositories
-]
-
-{ #category : 'testing' }
-MetacelloPackageSpec >> hasRepository [
-    ^ self repositorySpecs notEmpty
 ]
 
 { #category : 'private' }

--- a/src/Metacello-Core/MetacelloPackagesSpec.class.st
+++ b/src/Metacello-Core/MetacelloPackagesSpec.class.st
@@ -1,9 +1,9 @@
 Class {
 	#name : 'MetacelloPackagesSpec',
 	#superclass : 'MetacelloMemberListSpec',
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'actions' }
@@ -32,35 +32,6 @@ MetacelloPackagesSpec >> applyIncludesTo: orderedSpecs for: pkgSpec firstTime: f
 			 firstTime: firstTime
 			 for: aVersionSpec) ifTrue: [ movedSpecs add: spec name ] ].
 	^ movedSpecs
-]
-
-{ #category : 'printing' }
-MetacelloPackagesSpec >> configMethodOn: aStream indent: indent [
-
-	| packageSpecs |
-	packageSpecs := self map values.
-	packageSpecs size = 0 ifTrue: [ ^aStream nextPutAll: 'spec add: []' ].
-	packageSpecs size = 1
-		ifTrue: [
-			aStream 
-				tab: indent; 
-				nextPutAll: 'spec add: ['; cr.
-			packageSpecs first configMethodOn: aStream indent: indent + 1.
-			aStream nextPut: $]; cr ]
-		ifFalse: [
-			aStream 
-				tab: indent; 
-				nextPutAll: 'spec'.
-			1 to: packageSpecs size do: [:index | | packageSpec |
-				packageSpec := packageSpecs at: index.
-				aStream 
-					tab: indent + 1;
-					nextPutAll: 'add: ['; cr.
-				packageSpec configMethodOn: aStream indent: indent + 2.
-				aStream nextPut: $].
-				index < packageSpecs size
-					ifTrue: [ aStream nextPut: $; ].
-				aStream cr ]]
 ]
 
 { #category : 'actions' }

--- a/src/Metacello-Core/MetacelloProject.class.st
+++ b/src/Metacello-Core/MetacelloProject.class.st
@@ -136,16 +136,11 @@ MetacelloProject >> pragmaKeywords [
 { #category : 'printing' }
 MetacelloProject >> printOn: aStream [
 
-	self configuration class printOn: aStream.
+	super printOn: aStream.
 	aStream nextPut: $(.
-	version
-		ifNil: [ aStream nextPutAll: 'No version yet' ]
-		ifNotNil: [
-				aStream nextPutAll: 'baseline'.
-				version spec projectLabel ifNotEmpty: [ :label | aStream nextPutAll: ' [' , label , ']' ].
-				aStream
-					nextPut: $,;
-					space ].
+	aStream nextPutAll: (version
+			 ifNil: [ 'No version yet' ]
+			 ifNotNil: [ self label ]).
 	aStream nextPut: $)
 ]
 

--- a/src/Metacello-Core/MetacelloProjectReferenceSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectReferenceSpec.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'projectReference'
 	],
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'accessing' }
@@ -26,43 +26,6 @@ MetacelloProjectReferenceSpec >> aboutToCopy [
 MetacelloProjectReferenceSpec >> acceptVisitor: aVisitor [
 	
 	^ aVisitor visitProjectReference: self
-]
-
-{ #category : 'printing' }
-MetacelloProjectReferenceSpec >> configMethodCascadeOn: aStream member: aMember last: lastCascade indent: indent [
-
-	aMember methodUpdateSelector == #remove:
-		ifTrue: [ aStream nextPutAll: 'removeProject: ' , self name printString ]
-		ifFalse: [
-			self projectReference ifNil: [ ^ self ].
-			aStream nextPutAll: self projectLabel , ': ' , self projectName printString , ' '.
-			(aMember methodUpdateSelector == #copy: and: [ self projectReference hasNonVersionStringField ]) ifTrue: [
-				aStream nextPutAll: 'copyFrom: ' , aMember sourceName printString , ' ' ].
-			self projectReference configShortCutMethodOn: aStream member: aMember indent: indent + 1 ].
-	lastCascade
-		ifTrue: [ aStream nextPut: $. ]
-		ifFalse: [
-			aStream
-				nextPut: $;;
-				cr ]
-]
-
-{ #category : 'printing' }
-MetacelloProjectReferenceSpec >> configMethodOn: aStream indent: indent [
-
-	aStream 
-		tab: indent; nextPutAll: 'spec '; cr;
-		tab: indent + 1; nextPutAll: 'name: ', self name printString; nextPut: $;; cr;
-		tab: indent + 1; nextPutAll: 'projectReference: '; nextPut: $[; cr.
-	aStream 
-		tab: indent + 2; nextPutAll: 'spec'.
-	self projectReference ifNotNil: [ self projectReference configMethodBodyOn: aStream indent: indent + 2].
-	aStream nextPutAll: ' ].'
-]
-
-{ #category : 'testing' }
-MetacelloProjectReferenceSpec >> hasRepository [
-    ^ self projectReference hasRepository
 ]
 
 { #category : 'accessing' }
@@ -173,7 +136,7 @@ MetacelloProjectReferenceSpec >> repository: aStringOrMetacelloRepositorySpec [
 { #category : 'loading' }
 MetacelloProjectReferenceSpec >> repositorySpecs [
 
-	^self repositories map values
+	^ self repositories specs
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloProjectSpec.class.st
+++ b/src/Metacello-Core/MetacelloProjectSpec.class.st
@@ -12,9 +12,9 @@ Class {
 		'className',
 		'mutable'
 	],
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'class initialization' }
@@ -98,136 +98,6 @@ MetacelloProjectSpec >> compareEqual: aMetacelloProjectSpec [
 								  self postLoadDoIt == aMetacelloProjectSpec postLoadDoIt and: [ self repositories compareEqual: aMetacelloProjectSpec repositories ] ] ] ] ]
 ]
 
-{ #category : 'printing' }
-MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent [
-  ^ self configMethodBodyOn: aStream indent: indent fromShortCut: false
-]
-
-{ #category : 'printing' }
-MetacelloProjectSpec >> configMethodBodyOn: aStream indent: indent fromShortCut: fromShortCut [
-
-	| hasProjectPackage hasLoads hasClassName hasPreLoadDoIt hasPostLoadDoIt |
-	hasClassName := self hasClassName.
-	hasProjectPackage := self hasRepository or: [ hasClassName ].
-	hasLoads := self loads isNotNil.
-	hasPreLoadDoIt := self preLoadDoIt isNotNil.
-	hasPostLoadDoIt := self postLoadDoIt isNotNil.
-	hasClassName ifTrue: [
-			hasProjectPackage | hasLoads
-				ifTrue: [
-						aStream
-							cr;
-							tab: indent + 1 ]
-				ifFalse: [ aStream space ].
-			aStream nextPutAll: 'className: ' , self className printString.
-			hasPreLoadDoIt | hasPostLoadDoIt | hasLoads | hasProjectPackage ifTrue: [ aStream nextPut: $; ] ].
-	hasPreLoadDoIt ifTrue: [
-			hasClassName | hasProjectPackage | hasLoads | hasPreLoadDoIt
-				ifTrue: [
-						aStream
-							cr;
-							tab: indent + 1 ]
-				ifFalse: [ aStream space ].
-			aStream nextPutAll: 'preLoadDoIt: '.
-			self preLoadDoIt value isSymbol
-				ifTrue: [
-						aStream
-							nextPut: $#;
-							nextPutAll: self preLoadDoIt value asString printString ]
-				ifFalse: [ aStream nextPutAll: self preLoadDoIt value asString ].
-			hasPostLoadDoIt | hasProjectPackage | hasLoads ifTrue: [ aStream nextPut: $; ] ].
-	hasPostLoadDoIt ifTrue: [
-			hasClassName | hasProjectPackage | hasLoads | hasPostLoadDoIt
-				ifTrue: [
-						aStream
-							cr;
-							tab: indent + 1 ]
-				ifFalse: [ aStream space ].
-			aStream nextPutAll: 'postLoadDoIt: '.
-			self postLoadDoIt value isSymbol
-				ifTrue: [
-						aStream
-							nextPut: $#;
-							nextPutAll: self postLoadDoIt value asString printString ]
-				ifFalse: [ aStream nextPutAll: self postLoadDoIt value asString ].
-			hasProjectPackage | hasLoads ifTrue: [ aStream nextPut: $; ] ].
-
-	hasLoads ifTrue: [
-			hasClassName | hasProjectPackage | hasPreLoadDoIt | hasPostLoadDoIt
-				ifTrue: [
-						aStream
-							cr;
-							tab: indent + 1 ]
-				ifFalse: [ aStream space ].
-			aStream nextPutAll: 'loads: #('.
-			self loads do: [ :str | aStream nextPutAll: str printString , ' ' ].
-			aStream nextPut: $).
-			hasProjectPackage ifTrue: [ aStream nextPut: $; ] ].
-	hasProjectPackage ifTrue: [
-			| hasRepo |
-			hasRepo := self hasRepository.
-			hasRepo ifTrue: [
-					| repos |
-					repos := self repositories map values.
-					repos size = 1
-						ifTrue: [
-								fromShortCut
-									ifTrue: [
-											hasClassName | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt
-												ifTrue: [
-														aStream
-															cr;
-															tab: indent + 1 ]
-												ifFalse: [ aStream space ] ]
-									ifFalse: [
-											aStream
-												cr;
-												tab: indent + 1 ].
-								repos first configMethodCascadeOn: aStream lastCascade: true ]
-						ifFalse: [
-								aStream cr.
-								self repositories configMethodCascadeOn: aStream indent: indent ] ] ]
-]
-
-{ #category : 'printing' }
-MetacelloProjectSpec >> configMethodOn: aStream indent: indent [
-
-	aStream 
-		tab: indent;
-		nextPutAll: 'spec '; cr;
-		tab: indent + 1;
-		nextPutAll: 'name: ', self name printString, ';'.
-	self configMethodBodyOn: aStream indent: indent.
-	aStream nextPut: $.
-]
-
-{ #category : 'printing' }
-MetacelloProjectSpec >> configShortCutMethodOn: aStream member: aMember indent: indent [
-
-	| hasProjectPackage hasLoads hasClassName hasPreLoadDoIt hasPostLoadDoIt |
-	hasClassName := self hasClassName.
-	hasProjectPackage := self hasRepository or: [ hasClassName & (className ~= self name) ].
-	hasLoads := self loads isNotNil.
-	hasPreLoadDoIt := self preLoadDoIt isNotNil.
-	hasPostLoadDoIt := self postLoadDoIt isNotNil.
-	hasClassName | hasProjectPackage | hasLoads | hasPreLoadDoIt | hasPostLoadDoIt ifTrue: [
-			(aMember methodUpdateSelector == #copy: or: [ aMember methodUpdateSelector == #with: ])
-				ifTrue: [
-						aStream
-							nextPutAll: 'with: [';
-							cr ]
-				ifFalse: [
-						aStream
-							nextPutAll: 'overrides: [';
-							cr ].
-			aStream
-				tab: indent;
-				nextPutAll: 'spec'.
-			self configMethodBodyOn: aStream indent: indent fromShortCut: true.
-			aStream nextPutAll: ' ]'.
-			^ self ]
-]
-
 { #category : 'private' }
 MetacelloProjectSpec >> constructClassName [
 
@@ -266,12 +136,6 @@ MetacelloProjectSpec >> getRepositories [
     ^ repositories
 ]
 
-{ #category : 'printing' }
-MetacelloProjectSpec >> hasClassName [
-
-	^ className isNotNil and: [ className ~= self constructClassName ]
-]
-
 { #category : 'testing' }
 MetacelloProjectSpec >> hasLoadConflicts: aMetacelloProjectSpec [
   ^ (self hasNoLoadConflicts: aMetacelloProjectSpec) not
@@ -285,28 +149,6 @@ MetacelloProjectSpec >> hasNoLoadConflicts: aMetacelloProjectSpec [
 			  (self hasVersion and: [ aMetacelloProjectSpec hasVersion ]) and: [
 				  (self repositories isEmpty or: [ aMetacelloProjectSpec repositories isEmpty ]) or: [
 					  self repositories hasNoLoadConflicts: aMetacelloProjectSpec repositories ] ] ]
-]
-
-{ #category : 'testing' }
-MetacelloProjectSpec >> hasNonVersionStringField [
-
-	| hasProjectPackage |
-	self hasClassName ifTrue: [ ^ true ].
-
-	hasProjectPackage := self className ~= self name or: [ self hasRepository ].
-	hasProjectPackage ifTrue: [ ^ true ].
-
-	self loads ifNotNil: [ ^ true ].
-
-	self preLoadDoIt ifNotNil: [ ^ true ].
-	self postLoadDoIt ifNotNil: [ ^ true ].
-
-	^ false
-]
-
-{ #category : 'testing' }
-MetacelloProjectSpec >> hasRepository [
-    ^ self repositorySpecs notEmpty
 ]
 
 { #category : 'testing' }
@@ -501,6 +343,16 @@ MetacelloProjectSpec >> preLoadDoIt: aSymbol [
 	preLoadDoIt := aSymbol
 ]
 
+{ #category : 'printing' }
+MetacelloProjectSpec >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		nextPutAll: ' [';
+		nextPutAll: self baseName;
+		nextPutAll: ']'
+]
+
 { #category : 'accessing' }
 MetacelloProjectSpec >> project [
 
@@ -582,8 +434,9 @@ MetacelloProjectSpec >> repositoryDescriptions [
 
 { #category : 'querying' }
 MetacelloProjectSpec >> repositorySpecs [
-    repositories ifNil: [ ^ #() ].
-    ^ self repositories map values
+
+	repositories ifNil: [ ^ #(  ) ].
+	^ self repositories specs
 ]
 
 { #category : 'querying' }

--- a/src/Metacello-Core/MetacelloRemoveMemberSpec.class.st
+++ b/src/Metacello-Core/MetacelloRemoveMemberSpec.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'name'
 	],
-	#category : 'Metacello-Core-Members',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Members'
+	#tag : 'Model'
 }
 
 { #category : 'instance creation' }
@@ -21,12 +21,6 @@ MetacelloRemoveMemberSpec class >> named: aString [
 MetacelloRemoveMemberSpec >> applyToMap: map [
 
 	map removeKey: self name ifAbsent: [ ]
-]
-
-{ #category : 'accessing' }
-MetacelloRemoveMemberSpec >> methodUpdateSelector [
-
-	^#remove:
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloRepositoriesSpec.class.st
+++ b/src/Metacello-Core/MetacelloRepositoriesSpec.class.st
@@ -1,9 +1,9 @@
 Class {
 	#name : 'MetacelloRepositoriesSpec',
 	#superclass : 'MetacelloMemberListSpec',
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'actions' }
@@ -21,8 +21,8 @@ MetacelloRepositoriesSpec >> add: aStringOrSpec [
 MetacelloRepositoriesSpec >> canUpgradeTo: aMetacelloRepositoriesSpec [
 
 	| repositorySpecs anotherRepositorySpecs |
-	repositorySpecs := self map values sort: [ :a :b | a description <= b description ].
-	anotherRepositorySpecs := aMetacelloRepositoriesSpec map values sort: [ :a :b | a description <= b description ].
+	repositorySpecs := self specs sort: [ :a :b | a description <= b description ].
+	anotherRepositorySpecs := aMetacelloRepositoriesSpec specs sort: [ :a :b | a description <= b description ].
 	repositorySpecs size = anotherRepositorySpecs size ifFalse: [ ^ false ].
 	1 to: repositorySpecs size do: [ :index |
 			| repoSpec anotherRepoSpec |
@@ -34,49 +34,25 @@ MetacelloRepositoriesSpec >> canUpgradeTo: aMetacelloRepositoriesSpec [
 
 { #category : 'scripting' }
 MetacelloRepositoriesSpec >> compareEqual: aMetacelloProjectSpec [
-    | repositorySpecs anotherRepositorySpecs |
-    repositorySpecs := (self map values sort: [ :a :b | a description <= b description ])
-        collect: [ :each | each description ].
-    anotherRepositorySpecs := (aMetacelloProjectSpec map values sort: [ :a :b | a description <= b description ])
-        collect: [ :each | each description ].
-    ^ repositorySpecs = anotherRepositorySpecs
-]
 
-{ #category : 'printing' }
-MetacelloRepositoriesSpec >> configMethodCascadeOn: aStream indent: indent [
-
-	| repositorySpecs |
-	repositorySpecs := self map values sort: [ :a :b | a description <= b description ].
-	repositorySpecs size = 1
-		ifTrue: [ repositorySpecs first configMethodCascadeOn: aStream lastCascade: true ]
-		ifFalse: [
-			1 to: repositorySpecs size do: [ :index |
-				aStream tab: indent + 1.
-				(repositorySpecs at: index) configMethodCascadeOn: aStream lastCascade: index >= repositorySpecs size ] ]
-]
-
-{ #category : 'printing' }
-MetacelloRepositoriesSpec >> configMethodOn: aStream indent: indent [
-
-	aStream 
-		tab: indent; 
-		nextPutAll: 'spec';
-		cr.
-	self configMethodCascadeOn: aStream indent: indent
+	| repositorySpecs anotherRepositorySpecs |
+	repositorySpecs := (self specs sort: [ :a :b | a description <= b description ]) collect: [ :each | each description ].
+	anotherRepositorySpecs := (aMetacelloProjectSpec specs sort: [ :a :b | a description <= b description ]) collect: [ :each | each description ].
+	^ repositorySpecs = anotherRepositorySpecs
 ]
 
 { #category : 'scripting' }
 MetacelloRepositoriesSpec >> hasNoLoadConflicts: aMetacelloRepositoriesSpec [
 
 	| repositorySpecs anotherRepositorySpecs |
-	repositorySpecs := self map values sort: [ :a :b | a description <= b description ].
-	anotherRepositorySpecs := aMetacelloRepositoriesSpec map values sort: [ :a :b | a description <= b description ].
+	repositorySpecs := self specs sort: [ :a :b | a description <= b description ].
+	anotherRepositorySpecs := aMetacelloRepositoriesSpec specs sort: [ :a :b | a description <= b description ].
 	repositorySpecs size ~= anotherRepositorySpecs size ifTrue: [ ^ false ].
 	1 to: repositorySpecs size do: [ :index |
-		| repoSpec anotherRepoSpec |
-		repoSpec := repositorySpecs at: index.
-		anotherRepoSpec := anotherRepositorySpecs at: index.
-		(repoSpec hasNoLoadConflicts: anotherRepoSpec) ifFalse: [ ^ false ] ].
+			| repoSpec anotherRepoSpec |
+			repoSpec := repositorySpecs at: index.
+			anotherRepoSpec := anotherRepositorySpecs at: index.
+			(repoSpec hasNoLoadConflicts: anotherRepoSpec) ifFalse: [ ^ false ] ].
 	^ true
 ]
 

--- a/src/Metacello-Core/MetacelloRepositorySpec.class.st
+++ b/src/Metacello-Core/MetacelloRepositorySpec.class.st
@@ -8,9 +8,9 @@ Class {
 		'type',
 		'resolvedReference'
 	],
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'instance creation' }
@@ -34,24 +34,6 @@ MetacelloRepositorySpec >> canUpgradeTo: aMetacelloRepositorySpec [
   (#('github' 'gitorious' 'bitbucket') includes: self type)
     ifTrue: [ ^ self createRepository canUpgradeTo: aMetacelloRepositorySpec createRepository ].
   ^ false
-]
-
-{ #category : 'printing' }
-MetacelloRepositorySpec >> configMethodCascadeOn: aStream lastCascade: lastCascade [
-
-	aStream nextPutAll: 'repository: ', self description printString.
-	(self username isEmpty not or: [ self password isEmpty not ])
-		ifTrue: [ aStream nextPutAll: ' username: ', self username printString, ' password: ', self password printString ].
-	lastCascade ifFalse: [ aStream nextPut: $;; cr ].
-]
-
-{ #category : 'printing' }
-MetacelloRepositorySpec >> configMethodOn: aStream indent: indent [
-
-	aStream 
-		tab: indent; 
-		nextPutAll: 'spec '.
-	self configMethodCascadeOn: aStream lastCascade: true
 ]
 
 { #category : 'mc support' }
@@ -112,8 +94,9 @@ MetacelloRepositorySpec >> mergeMap [
 
 { #category : 'querying' }
 MetacelloRepositorySpec >> name [
+	"To be polymorphic with MetacelloAbstractPackageSpec"
 
-	^self description
+	^ self description
 ]
 
 { #category : 'querying' }
@@ -126,6 +109,15 @@ MetacelloRepositorySpec >> password [
 MetacelloRepositorySpec >> password: aString [
 
 	password := aString
+]
+
+{ #category : 'printing' }
+MetacelloRepositorySpec >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream nextPutAll: ' ['.
+	self description ifEmpty: [ aStream nextPutAll: 'No description' ] ifNotEmpty: [ :string | aStream nextPutAll: string ].
+	aStream nextPutAll: ']'
 ]
 
 { #category : 'private' }

--- a/src/Metacello-Core/MetacelloSpec.class.st
+++ b/src/Metacello-Core/MetacelloSpec.class.st
@@ -1,9 +1,9 @@
 Class {
 	#name : 'MetacelloSpec',
 	#superclass : 'Object',
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'merging' }
@@ -12,12 +12,6 @@ MetacelloSpec >> aboutToCopy [
 
 { #category : 'visiting' }
 MetacelloSpec >> acceptVisitor: aVisitor [
-
-	self subclassResponsibility
-]
-
-{ #category : 'printing' }
-MetacelloSpec >> configMethodOn: aStream indent: indent [
 
 	self subclassResponsibility
 ]
@@ -54,12 +48,6 @@ MetacelloSpec >> mergeSpec: aSpec [
 MetacelloSpec >> nonOverridable [
 
 	^#()
-]
-
-{ #category : 'printing' }
-MetacelloSpec >> printOn: aStream [
-
-	self configMethodOn: aStream indent: 0
 ]
 
 { #category : 'validation' }

--- a/src/Metacello-Core/MetacelloVersionSpec.class.st
+++ b/src/Metacello-Core/MetacelloVersionSpec.class.st
@@ -10,9 +10,9 @@ Class {
 		'preLoadDoIt',
 		'packagesSpec'
 	],
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'class initialization' }
@@ -34,135 +34,6 @@ MetacelloVersionSpec class >> project: aMetacelloProject [
 MetacelloVersionSpec >> acceptVisitor: aVisitor [
 	
 	^ aVisitor visitVersionSpec: self
-]
-
-{ #category : 'printing' }
-MetacelloVersionSpec >> configMethodOn: aStream for: spec selector: selector last: last indent: indent [
-
-	spec ifNil: [ ^ self ].
-	aStream
-		tab: indent;
-		nextPutAll: 'spec ' , selector , ' [';
-		cr.
-	spec configMethodOn: aStream indent: indent + 1.
-	aStream nextPutAll: ' ].'.
-	last ifFalse: [ aStream cr ]
-]
-
-{ #category : 'printing' }
-MetacelloVersionSpec >> configMethodOn: aStream indent: indent [
-
-	| spec hasRepositories hasPackageSpecs hasImport hasPreLoadDoIt hasPostLoadDoIt |
-	hasRepositories := (spec := self repositories) isNotNil and: [ spec list isEmpty not ].
-	hasImport := self import isNotNil.
-	hasPreLoadDoIt := self preLoadDoIt isNotNil.
-	hasPostLoadDoIt := self postLoadDoIt isNotNil.
-	hasPackageSpecs := false.
-	self packagesSpec list do: [ :member |
-			member spec
-				projectDo: [ :proj | member spec name ifNotNil: [ hasPackageSpecs := true ] ]
-				packageDo: [ :package | member spec name ifNotNil: [ hasPackageSpecs := true ] ]
-				groupDo: [ :group | member spec name ifNotNil: [ hasPackageSpecs := true ] ] ].
-	hasPreLoadDoIt ifTrue: [
-			self
-				configMethodValueOn: aStream
-				for: self preLoadDoIt
-				selector: 'preLoadDoIt:'
-				last: (hasRepositories | hasPackageSpecs | hasImport | hasPostLoadDoIt) not
-				indent: indent ].
-	hasPostLoadDoIt ifTrue: [
-			self
-				configMethodValueOn: aStream
-				for: self postLoadDoIt
-				selector: 'postLoadDoIt:'
-				last: (hasRepositories | hasPackageSpecs | hasImport) not
-				indent: indent ].
-	hasImport ifTrue: [
-			self
-				configMethodValueOn: aStream
-				for: self import
-				selector: 'import:'
-				last: (hasRepositories | hasPackageSpecs) not
-				indent: indent ].
-	hasRepositories ifTrue: [
-			spec map values size = 1
-				ifTrue: [
-						aStream
-							tab: indent;
-							nextPutAll: 'spec repository: ';
-							nextPutAll: spec map values first description printString;
-							nextPutAll: '.'.
-						hasPackageSpecs ifTrue: [ aStream cr ] ]
-				ifFalse: [
-						self
-							configMethodOn: aStream
-							for: spec
-							selector: 'repositories:'
-							last: hasPackageSpecs not
-							indent: indent ] ].
-	self configPackagesSpecMethodOn: aStream indent: indent
-]
-
-{ #category : 'printing' }
-MetacelloVersionSpec >> configMethodValueOn: aStream for: spec selector: selector last: last indent: indent [
-
-	| valuePrintString |
-	valuePrintString := spec value isSymbol
-		                    ifTrue: [ '#' , spec value asString printString ]
-		                    ifFalse: [ spec value printString ].
-	aStream
-		tab: indent;
-		nextPutAll: 'spec ' , selector , ' ' , valuePrintString , '.'.
-	last ifFalse: [ aStream cr ]
-]
-
-{ #category : 'printing' }
-MetacelloVersionSpec >> configPackagesSpecMethodOn: aStream indent: indent [
-
-	| projectSpecs packageSpecs groupSpecs |
-	projectSpecs := OrderedCollection new.
-	packageSpecs := OrderedCollection new.
-	groupSpecs := OrderedCollection new.
-	self packagesSpec list do: [ :member |
-			member spec
-				projectDo: [ :proj | member spec name ifNotNil: [ projectSpecs add: member ] ]
-				packageDo: [ :package | member spec name ifNotNil: [ packageSpecs add: member ] ]
-				groupDo: [ :group | member spec name ifNotNil: [ groupSpecs add: member ] ] ].
-	projectSpecs isEmpty ifFalse: [
-			aStream
-				tab: indent;
-				nextPutAll: 'spec '.
-			projectSpecs size > 1 ifTrue: [
-					aStream
-						cr;
-						tab: indent + 1 ].
-			1 to: projectSpecs size do: [ :index |
-					(projectSpecs at: index) configMethodCascadeOn: aStream last: index == projectSpecs size indent: indent + 1.
-					index ~= projectSpecs size ifTrue: [ aStream tab: indent + 1 ] ] ].
-	packageSpecs isEmpty ifFalse: [
-			projectSpecs isEmpty ifFalse: [ aStream cr ].
-			aStream
-				tab: indent;
-				nextPutAll: 'spec '.
-			packageSpecs size > 1 ifTrue: [
-					aStream
-						cr;
-						tab: indent + 1 ].
-			1 to: packageSpecs size do: [ :index |
-					(packageSpecs at: index) configMethodCascadeOn: aStream last: index == packageSpecs size indent: indent + 1.
-					index ~= packageSpecs size ifTrue: [ aStream tab: indent + 1 ] ] ].
-	groupSpecs isEmpty ifFalse: [
-			projectSpecs isEmpty not | packageSpecs isEmpty not ifTrue: [ aStream cr ].
-			aStream
-				tab: indent;
-				nextPutAll: 'spec '.
-			groupSpecs size > 1 ifTrue: [
-					aStream
-						cr;
-						tab: indent + 1 ].
-			1 to: groupSpecs size do: [ :index |
-					(groupSpecs at: index) configMethodCascadeOn: aStream last: index == groupSpecs size indent: indent + 1.
-					index ~= groupSpecs size ifTrue: [ aStream tab: indent + 1 ] ] ]
 ]
 
 { #category : 'enumerating' }
@@ -435,6 +306,16 @@ MetacelloVersionSpec >> preLoadDoIt: aSymbol [
 	preLoadDoIt := aSymbol
 ]
 
+{ #category : 'printing' }
+MetacelloVersionSpec >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		nextPutAll: ' [';
+		nextPutAll: self project label;
+		nextPutAll: ']'
+]
+
 { #category : 'accessing' }
 MetacelloVersionSpec >> project [
 
@@ -513,7 +394,7 @@ MetacelloVersionSpec >> repository: aString username: username password: passwor
 { #category : 'loading' }
 MetacelloVersionSpec >> repositorySpecs [
 
-	^self repositories map values
+	^ self repositories specs
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloVisitedPackages.class.st
+++ b/src/Metacello-Core/MetacelloVisitedPackages.class.st
@@ -6,9 +6,9 @@ Class {
 		'packages',
 		'projects'
 	],
-	#category : 'Metacello-Core-Specs',
+	#category : 'Metacello-Core-Model',
 	#package : 'Metacello-Core',
-	#tag : 'Specs'
+	#tag : 'Model'
 }
 
 { #category : 'initialization' }


### PR DESCRIPTION
Metacello specs are complexe to print currently. I prefer to simplify them and add inspector tabs instead (you can find my PR here: https://github.com/pharo-spec/NewTools/pull/1312).

I also updated the tags of some classes