### PR TITLE
Change icon and text for DebugPoint commands

### DIFF
--- a/src/Calypso-SystemPlugins-DebugPoints-Browser/ClyAddBreakPointCommand.class.st
+++ b/src/Calypso-SystemPlugins-DebugPoints-Browser/ClyAddBreakPointCommand.class.st
@@ -22,12 +22,13 @@ ClyAddBreakPointCommand class >> methodEditorLeftBarClickActivation [
 
 { #category : 'accessing' }
 ClyAddBreakPointCommand >> defaultMenuIconName [
-	^#smallError
+	^#smallDebug 
 ]
 
 { #category : 'accessing' }
 ClyAddBreakPointCommand >> defaultMenuItemName [
-	^' Add Breakpoint to: ',  sourceNode displaySourceCode
+
+	^ String streamContents: [ :stream | stream << 'Break on "' << sourceNode displaySourceCode << '"' ]
 ]
 
 { #category : 'execution' }

--- a/src/Calypso-SystemPlugins-DebugPoints-Browser/ClyAddWatchDebugPointCommand.class.st
+++ b/src/Calypso-SystemPlugins-DebugPoints-Browser/ClyAddWatchDebugPointCommand.class.st
@@ -20,7 +20,8 @@ ClyAddWatchDebugPointCommand >> defaultMenuIconName [
 
 { #category : 'accessing' }
 ClyAddWatchDebugPointCommand >> defaultMenuItemName [
-	^' Add Watch to: ',  sourceNode displaySourceCode
+
+	^ String streamContents: [ :stream | stream << 'Watch "' << sourceNode displaySourceCode << '"' ]
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
Change the DebugPoint's icon to match the one in Debugger.

In addition, we change the text for clarity.