### PR TITLE
Metacello: Improve MetacelloPackagesSpec api

### DIFF
--- a/src/Metacello-Core/MetacelloPackagesSpec.class.st
+++ b/src/Metacello-Core/MetacelloPackagesSpec.class.st
@@ -56,47 +56,12 @@ MetacelloPackagesSpec >> clearMemberMap [
 	memberMap := nil.
 ]
 
-{ #category : 'enumeration' }
-MetacelloPackagesSpec >> collect: aBlock [ 
-	| newCollection |
-	newCollection :=OrderedCollection new.
-	self do: [:each | newCollection add: (aBlock value: each)].
-	^ newCollection
-]
-
 { #category : 'actions' }
 MetacelloPackagesSpec >> copy: specNamed to: spec [
 
 	self addMember: ((MetacelloCopyMemberSpec spec: spec)
 			 sourceName: specNamed;
 			 yourself)
-]
-
-{ #category : 'enumeration' }
-MetacelloPackagesSpec >> detect: aBlock [
-	"Evaluate aBlock with each of the receiver's elements as the argument. 
-	Answer the first element for which aBlock evaluates to true."
-
-	^ self detect: aBlock ifNone: [ self error: 'Object is not in the collection.' ]
-]
-
-{ #category : 'enumeration' }
-MetacelloPackagesSpec >> detect: aBlock ifNone: exceptionBlock [
-	"Evaluate aBlock with each of the receiver's elements as the argument.  
-	Answer the first element for which aBlock evaluates to true. If none  
-	evaluate to true, then evaluate the argument, exceptionBlock."
-
-	self
-		do: [ :each | 
-			(aBlock value: each)
-				ifTrue: [ ^ each ] ].
-	^ exceptionBlock value
-]
-
-{ #category : 'enumeration' }
-MetacelloPackagesSpec >> do: aBlock [
-
-	self specs do: aBlock
 ]
 
 { #category : 'testing' }
@@ -116,6 +81,21 @@ MetacelloPackagesSpec >> list: aCollection [
 
 	list := aCollection.
 	self clearMemberMap
+]
+
+{ #category : 'accessing' }
+MetacelloPackagesSpec >> loadableSpecNamed: aString ifAbsent: aBlock [
+
+	^ self loadableSpecs
+		  detect: [ :spec | spec name = aString ]
+		  ifNone: aBlock
+]
+
+{ #category : 'accessing' }
+MetacelloPackagesSpec >> loadableSpecs [
+	"Return the list of specs I contains once all members are applied."
+
+	^ self map values
 ]
 
 { #category : 'accessing' }
@@ -147,7 +127,10 @@ MetacelloPackagesSpec >> mergeSpec: anotherSpec [
 { #category : 'accessing' }
 MetacelloPackagesSpec >> packageNamed: aString ifAbsent: aBlock [
 
-	^self map at: aString ifAbsent: aBlock
+	self deprecated: '' transformWith: '`@rcv packageNamed: `@arg ifAbsent: `@arg2' -> '`@rcv loadableSpecNamed: `@arg ifAbsent: `@arg2'.
+	^ self loadableSpecs
+		  detect: [ :spec | spec name = aString ]
+		  ifNone: aBlock
 ]
 
 { #category : 'accessing' }
@@ -219,7 +202,7 @@ MetacelloPackagesSpec >> printOn: aStream [
 
 	super printOn: aStream.
 	aStream nextPutAll: ' ['.
-	self specs
+	self loadableSpecs
 		ifEmpty: [ aStream nextPutAll: 'Empty' ]
 		ifNotEmpty: [ :specs | specs do: [ :spec | aStream nextPutAll: spec name ] separatedBy: [ aStream nextPutAll: ', ' ] ].
 	aStream nextPutAll: ']'
@@ -229,14 +212,6 @@ MetacelloPackagesSpec >> printOn: aStream [
 MetacelloPackagesSpec >> remove: aSpec [
 
 	self addMember: (MetacelloRemoveMemberSpec spec: aSpec)
-]
-
-{ #category : 'enumeration' }
-MetacelloPackagesSpec >> select: aBlock [ 
-	| newCollection |
-	newCollection := OrderedCollection new.
-	self do: [:each | (aBlock value: each) ifTrue: [newCollection add: each]].
-	^newCollection
 ]
 
 { #category : 'accessing' }
@@ -328,11 +303,4 @@ MetacelloPackagesSpec >> sortPackageSpecs: orderedSpecs packageSpec: packageSpec
 				ifTrue: [ orderedSpecs add: packageSpec beforeIndex: packageIndex ]
 				ifFalse: [ orderedSpecs add: packageSpec afterIndex: targetIndex ] ].
 	^ moved
-]
-
-{ #category : 'accessing' }
-MetacelloPackagesSpec >> specs [
-	"Return the list of specs I contains once all members are applied."
-
-	^ self map values
 ]

--- a/src/Metacello-Core/MetacelloPackagesSpec.class.st
+++ b/src/Metacello-Core/MetacelloPackagesSpec.class.st
@@ -86,9 +86,13 @@ MetacelloPackagesSpec >> list: aCollection [
 { #category : 'accessing' }
 MetacelloPackagesSpec >> loadableSpecNamed: aString ifAbsent: aBlock [
 
-	^ self loadableSpecs
-		  detect: [ :spec | spec name = aString ]
-		  ifNone: aBlock
+	^ self loadableSpecs detect: [ :spec | spec name = aString ] ifNone: aBlock
+]
+
+{ #category : 'accessing' }
+MetacelloPackagesSpec >> loadableSpecNamed: aString ifPresent: aBlock [
+
+	^ self loadableSpecs detect: [ :spec | spec name = aString ] ifFound: aBlock
 ]
 
 { #category : 'accessing' }
@@ -122,15 +126,6 @@ MetacelloPackagesSpec >> mergeSpec: anotherSpec [
 	newSpec list: self list copy.
 	anotherSpec list do: [ :groupMember | newSpec addMember: groupMember ].
 	^ newSpec
-]
-
-{ #category : 'accessing' }
-MetacelloPackagesSpec >> packageNamed: aString ifAbsent: aBlock [
-
-	self deprecated: '' transformWith: '`@rcv packageNamed: `@arg ifAbsent: `@arg2' -> '`@rcv loadableSpecNamed: `@arg ifAbsent: `@arg2'.
-	^ self loadableSpecs
-		  detect: [ :spec | spec name = aString ]
-		  ifNone: aBlock
 ]
 
 { #category : 'accessing' }

--- a/src/Metacello-Core/MetacelloVersionSpec.class.st
+++ b/src/Metacello-Core/MetacelloVersionSpec.class.st
@@ -186,28 +186,28 @@ MetacelloVersionSpec >> packageNamed: aString [
 { #category : 'querying' }
 MetacelloVersionSpec >> packageNamed: aString ifAbsent: absentBlock [
 
-	| importSpec map |
-	map := self packagesSpec map.
-	^ map at: aString ifAbsent: [
-			  (self importArray isNotNil or: [ self import isNotNil ]) ifTrue: [ "expect the 'missing' name to be satisfied within context of imported project"
-					  importArray ifNotNil: [
-							  importArray do: [ :assoc |
-									  ((assoc value includes: aString) and: [ map includesKey: assoc key ]) ifTrue: [
-											  importSpec := (map at: assoc key)
-												                mergeImportLoads: { aString };
-												                yourself ] ].
-							  importSpec ifNotNil: [ ^ importSpec ] ].
-					  (importSpec isNil and: [ self import isNotNil ]) ifTrue: [
-							  ^ (map at: self import ifAbsent: absentBlock)
-								    mergeImportLoads: { aString };
-								    yourself ] ].
-			  (aString = 'default' or: [ aString = 'ALL' ])
-				  ifTrue: [
-						  self project groupSpec
-							  name: aString;
-							  includes: self packageNames;
-							  yourself ]
-				  ifFalse: [ absentBlock value ] ]
+	self packagesSpec loadableSpecNamed: aString ifPresent: [ :spec | ^ spec ].
+
+	self hasImports ifTrue: [ "expect the 'missing' name to be satisfied within context of imported project"
+			importArray ifNotNil: [
+					importArray do: [ :assoc |
+							(assoc value includes: aString) ifTrue: [
+									self packagesSpec loadableSpecNamed: assoc key ifPresent: [ :spec |
+											^ spec
+												  mergeImportLoads: { aString };
+												  yourself ] ] ] ].
+			self import ifNotNil: [
+					^ (self packagesSpec loadableSpecNamed: self import ifAbsent: absentBlock)
+						  mergeImportLoads: { aString };
+						  yourself ] ].
+
+	^ (#( 'default' 'ALL' ) includes: aString)
+		  ifTrue: [
+				  self project groupSpec
+					  name: aString;
+					  includes: self packageNames;
+					  yourself ]
+		  ifFalse: [ absentBlock value ]
 ]
 
 { #category : 'querying' }

--- a/src/Metacello-Core/MetacelloVersionSpec.class.st
+++ b/src/Metacello-Core/MetacelloVersionSpec.class.st
@@ -50,7 +50,7 @@ MetacelloVersionSpec >> defaultPackageNames [
 	"if there is a package named 'default' (a group) then it defines the default package names,
 	 otherwise answer a list of all of the package names in this version"
 
-	self packagesSpec packageNamed: 'default' ifAbsent: [ ^ self packageNames ].
+	self packagesSpec loadableSpecNamed: 'default' ifAbsent: [ ^ self packageNames ].
 	^ #( 'default' )
 ]
 

--- a/src/Metacello-Tests/MetacelloPackagesSpecTest.class.st
+++ b/src/Metacello-Tests/MetacelloPackagesSpecTest.class.st
@@ -20,7 +20,7 @@ MetacelloPackagesSpecTest >> testAddGroupA [
 			 name: 'Platform';
 			 includes: 'Tests';
 			 yourself).
-	group := packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
+	group := packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
 	self deny: (group includes includes: 'Core').
 	self assert: (group includes includes: 'Tests')
 ]
@@ -39,7 +39,7 @@ MetacelloPackagesSpecTest >> testAddGroupB [
 			 name: 'Platform';
 			 includes: 'Tests';
 			 yourself).
-	group := packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
+	group := packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
 	self deny: (group includes includes: 'Core').
 	self assert: (group includes includes: 'Tests')
 ]
@@ -62,7 +62,7 @@ MetacelloPackagesSpecTest >> testAddPackageA [
 			 requires: 'AndAnotherPackage';
 			 includes: 'AndIncludedPackage';
 			 yourself).
-	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
+	package := packages loadableSpecNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #( 'AndAnotherPackage' ).
 	self assert: package includes equals: #( 'AndIncludedPackage' ).
@@ -88,7 +88,7 @@ MetacelloPackagesSpecTest >> testAddPackageB [
 			 requires: 'AndAnotherPackage';
 			 includes: 'AndIncludedPackage';
 			 yourself).
-	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
+	package := packages loadableSpecNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #( 'AndAnotherPackage' ).
 	self assert: package includes equals: #( 'AndIncludedPackage' ).
@@ -111,9 +111,9 @@ MetacelloPackagesSpecTest >> testAddPackageC [
 	packages add: (self packageSpec
 			 name: 'Tests';
 			 yourself).
-	packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
-	packages packageNamed: 'Base' ifAbsent: [ self assert: false ].
-	packages packageNamed: 'Tests' ifAbsent: [ self assert: false ]
+	packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Base' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Tests' ifAbsent: [ self assert: false ]
 ]
 
 { #category : 'tests' }
@@ -125,7 +125,7 @@ MetacelloPackagesSpecTest >> testAddPackageD [
 	packages add: (self packageSpec
 			 name: 'Platform';
 			 yourself).
-	packages packageNamed: 'Platform' ifAbsent: [ self assert: false ]
+	packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ]
 ]
 
 { #category : 'tests' }
@@ -148,7 +148,7 @@ MetacelloPackagesSpecTest >> testAddProjectA [
 				  preLoadDoIt: #preLoadDoIt;
 				  postLoadDoIt: #postLoadDoIt;
 				  yourself)).
-	projectReferenceSpec := packages packageNamed: 'Project' ifAbsent: [ self assert: false ].
+	projectReferenceSpec := packages loadableSpecNamed: 'Project' ifAbsent: [ self assert: false ].
 	self assert: projectReferenceSpec projectName equals: 'Project'.
 	self should: [ projectReferenceSpec includes: #(  ) ] raise: Error.
 	self should: [ projectReferenceSpec requires: #(  ) ] raise: Error.
@@ -182,7 +182,7 @@ MetacelloPackagesSpecTest >> testAddProjectB [
 				  preLoadDoIt: #preLoadDoIt;
 				  postLoadDoIt: #postLoadDoIt;
 				  yourself)).
-	projectReferenceSpec := packages packageNamed: 'Project' ifAbsent: [ self assert: false ].
+	projectReferenceSpec := packages loadableSpecNamed: 'Project' ifAbsent: [ self assert: false ].
 	self assert: projectReferenceSpec projectName equals: 'Project'.
 	self should: [ projectReferenceSpec includes: #(  ) ] raise: Error.
 	self should: [ projectReferenceSpec requires: #(  ) ] raise: Error.
@@ -210,7 +210,7 @@ MetacelloPackagesSpecTest >> testCopyToGroup [
 			 name: 'Platform';
 			 includes: 'Tests';
 			 yourself).
-	group := packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
+	group := packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
 	self assert: (group includes includes: 'Core').
 	self assert: (group includes includes: 'Tests').
 	group := self groupSpec
@@ -218,7 +218,7 @@ MetacelloPackagesSpecTest >> testCopyToGroup [
 		         includes: 'Copy';
 		         yourself.
 	packages copy: 'Platform' to: group.
-	group := packages packageNamed: 'PlatformCopy' ifAbsent: [ self assert: false ].
+	group := packages loadableSpecNamed: 'PlatformCopy' ifAbsent: [ self assert: false ].
 	self assert: (group includes includes: 'Core').
 	self assert: (group includes includes: 'Copy').
 	self assert: (group includes includes: 'Tests')
@@ -240,7 +240,7 @@ MetacelloPackagesSpecTest >> testCopyToPackage [
 	packages copy: 'Package' to: (self packageSpec
 			 name: 'PackageCopy';
 			 yourself).
-	package := packages packageNamed: 'PackageCopy' ifAbsent: [ self assert: false ].
+	package := packages loadableSpecNamed: 'PackageCopy' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'PackageCopy'.
 	self assert: package requires equals: #( 'AnotherPackage' ).
 	self assert: package includes equals: #( 'IncludedPackage' ).
@@ -266,7 +266,7 @@ MetacelloPackagesSpecTest >> testCopyToProject [
 		           yourself.
 	referenceSpec := MetacelloProjectReferenceSpec projectReference: project.
 	packages copy: 'Project' to: referenceSpec.
-	project := (packages packageNamed: 'ProjectCopy' ifAbsent: [ self assert: false ]) referencedSpec.
+	project := (packages loadableSpecNamed: 'ProjectCopy' ifAbsent: [ self assert: false ]) referencedSpec.
 	self assert: project name equals: 'ProjectCopy'.
 	self assert: project className equals: 'BaselineOfProjectA'.
 	self assert: project loads equals: #( 'MyPackage' 'MyTests' ).
@@ -288,7 +288,7 @@ MetacelloPackagesSpecTest >> testMergeGroupA [
 			 name: 'Platform';
 			 includes: 'Tests';
 			 yourself).
-	group := packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
+	group := packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
 	self assert: (group includes includes: 'Core').
 	self assert: (group includes includes: 'Tests')
 ]
@@ -307,7 +307,7 @@ MetacelloPackagesSpecTest >> testMergeGroupB [
 			 name: 'Platform';
 			 includes: 'Tests';
 			 yourself).
-	group := packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
+	group := packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
 	self assert: (group includes includes: 'Core').
 	self assert: (group includes includes: 'Tests')
 ]
@@ -330,7 +330,7 @@ MetacelloPackagesSpecTest >> testMergePackageA [
 			 requires: 'AndAnotherPackage';
 			 includes: 'AndIncludedPackage';
 			 yourself).
-	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
+	package := packages loadableSpecNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #( 'AnotherPackage' 'AndAnotherPackage' ).
 	self assert: package includes equals: #( 'IncludedPackage' 'AndIncludedPackage' ).
@@ -356,7 +356,7 @@ MetacelloPackagesSpecTest >> testMergePackageB [
 			 requires: 'AndAnotherPackage';
 			 includes: 'AndIncludedPackage';
 			 yourself).
-	package := packages packageNamed: 'Package' ifAbsent: [ self assert: false ].
+	package := packages loadableSpecNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
 	self assert: package requires equals: #( 'AnotherPackage' 'AndAnotherPackage' ).
 	self assert: package includes equals: #( 'IncludedPackage' 'AndIncludedPackage' ).
@@ -377,8 +377,8 @@ MetacelloPackagesSpecTest >> testMergePackageD [
 		merge: (self packageSpec
 				 name: 'Tests';
 				 yourself).
-	packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
-	packages packageNamed: 'Tests' ifAbsent: [ self assert: false ]
+	packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Tests' ifAbsent: [ self assert: false ]
 ]
 
 { #category : 'tests' }
@@ -405,7 +405,7 @@ MetacelloPackagesSpecTest >> testMergeProjectA [
 		           yourself.
 	referenceSpec := MetacelloProjectReferenceSpec projectReference: project.
 	packages merge: referenceSpec.
-	projectReferenceSpec := packages packageNamed: 'Project' ifAbsent: [ self assert: false ].
+	projectReferenceSpec := packages loadableSpecNamed: 'Project' ifAbsent: [ self assert: false ].
 	project := projectReferenceSpec referencedSpec.
 	self assert: project name equals: 'Project'.
 	self assert: project className equals: 'BaselineOfProject'.
@@ -439,7 +439,7 @@ MetacelloPackagesSpecTest >> testMergeProjectB [
 		           yourself.
 	referenceSpec := MetacelloProjectReferenceSpec projectReference: project.
 	packages merge: referenceSpec.
-	projectReferenceSpec := packages packageNamed: 'Project' ifAbsent: [ self assert: false ].
+	projectReferenceSpec := packages loadableSpecNamed: 'Project' ifAbsent: [ self assert: false ].
 	project := projectReferenceSpec referencedSpec.
 	self assert: project name equals: 'Project'.
 	self assert: project className equals: 'BaselineOfProject'.
@@ -526,7 +526,7 @@ MetacelloPackagesSpecTest >> testRemoveGroupA [
 			 name: 'Platform';
 			 includes: 'Tests';
 			 yourself).
-	group := packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
+	group := packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
 	self assert: (group includes includes: 'Core').
 	self assert: (group includes includes: 'Tests').
 	packages remove: (self groupSpec
@@ -534,7 +534,7 @@ MetacelloPackagesSpecTest >> testRemoveGroupA [
 			 includes: 'Core';
 			 yourself).
 	removed := false.
-	packages packageNamed: 'Platform' ifAbsent: [ removed := true ].
+	packages loadableSpecNamed: 'Platform' ifAbsent: [ removed := true ].
 	self assert: removed
 ]
 
@@ -556,9 +556,9 @@ MetacelloPackagesSpecTest >> testRemoveGroupB [
 			 name: 'Tests';
 			 includes: 'Tests';
 			 yourself).
-	packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
-	packages packageNamed: 'Base' ifAbsent: [ self assert: false ].
-	packages packageNamed: 'Tests' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Base' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Tests' ifAbsent: [ self assert: false ].
 	packages
 		remove: (self groupSpec
 				 name: 'Base';
@@ -566,12 +566,12 @@ MetacelloPackagesSpecTest >> testRemoveGroupB [
 		remove: (self groupSpec
 				 name: 'Tests';
 				 yourself).
-	packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
 	removed := false.
-	packages packageNamed: 'Base' ifAbsent: [ removed := true ].
+	packages loadableSpecNamed: 'Base' ifAbsent: [ removed := true ].
 	self assert: removed.
 	removed := false.
-	packages packageNamed: 'Tests' ifAbsent: [ removed := true ].
+	packages loadableSpecNamed: 'Tests' ifAbsent: [ removed := true ].
 	self assert: removed
 ]
 
@@ -593,16 +593,16 @@ MetacelloPackagesSpecTest >> testRemoveGroupC [
 			 name: 'Tests';
 			 includes: 'Tests';
 			 yourself).
-	packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
-	packages packageNamed: 'Base' ifAbsent: [ self assert: false ].
-	packages packageNamed: 'Tests' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Base' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Tests' ifAbsent: [ self assert: false ].
 	packages remove: (self groupSpec
 			 name: 'Tests';
 			 yourself).
-	packages packageNamed: 'Platform' ifAbsent: [ self assert: false ].
-	packages packageNamed: 'Base' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
+	packages loadableSpecNamed: 'Base' ifAbsent: [ self assert: false ].
 	removed := false.
-	packages packageNamed: 'Tests' ifAbsent: [ removed := true ].
+	packages loadableSpecNamed: 'Tests' ifAbsent: [ removed := true ].
 	self assert: removed
 ]
 
@@ -623,7 +623,7 @@ MetacelloPackagesSpecTest >> testRemovePackageA [
 			 name: 'Package';
 			 yourself).
 	removed := false.
-	packages packageNamed: 'Package' ifAbsent: [ removed := true ].
+	packages loadableSpecNamed: 'Package' ifAbsent: [ removed := true ].
 	self assert: removed
 ]
 
@@ -644,7 +644,7 @@ MetacelloPackagesSpecTest >> testRemovePackageB [
 			 name: 'Package';
 			 yourself).
 	removed := false.
-	packages packageNamed: 'Package' ifAbsent: [ removed := true ].
+	packages loadableSpecNamed: 'Package' ifAbsent: [ removed := true ].
 	self assert: removed
 ]
 
@@ -665,7 +665,7 @@ MetacelloPackagesSpecTest >> testRemovePackageC [
 			 name: 'Package';
 			 yourself).
 	removed := false.
-	packages packageNamed: 'Package' ifAbsent: [ removed := true ].
+	packages loadableSpecNamed: 'Package' ifAbsent: [ removed := true ].
 	self assert: removed
 ]
 
@@ -686,7 +686,7 @@ MetacelloPackagesSpecTest >> testRemovePackageD [
 			 name: 'Package';
 			 yourself).
 	removed := false.
-	packages packageNamed: 'Package' ifAbsent: [ removed := true ].
+	packages loadableSpecNamed: 'Package' ifAbsent: [ removed := true ].
 	self assert: removed
 ]
 
@@ -703,7 +703,7 @@ MetacelloPackagesSpecTest >> testRemoveProjectA [
 				  preLoadDoIt: #preLoadDoIt;
 				  postLoadDoIt: #postLoadDoIt;
 				  yourself)).
-	projectReferenceSpec := packages packageNamed: 'Project' ifAbsent: [ self assert: false ].
+	projectReferenceSpec := packages loadableSpecNamed: 'Project' ifAbsent: [ self assert: false ].
 	project := projectReferenceSpec referencedSpec.
 	self assert: project name equals: 'Project'.
 	self assert: project className equals: 'BaselineOfProject'.
@@ -712,7 +712,7 @@ MetacelloPackagesSpecTest >> testRemoveProjectA [
 	self assert: project postLoadDoIt value identicalTo: #postLoadDoIt.
 	packages remove: (MetacelloProjectReferenceSpec projectReference: project).
 	removed := false.
-	packages packageNamed: 'Project' ifAbsent: [ removed := true ].
+	packages loadableSpecNamed: 'Project' ifAbsent: [ removed := true ].
 	self assert: removed
 ]
 
@@ -729,7 +729,7 @@ MetacelloPackagesSpecTest >> testRemoveProjectB [
 				  preLoadDoIt: #preLoadDoIt;
 				  postLoadDoIt: #postLoadDoIt;
 				  yourself)).
-	projectReferenceSpec := packages packageNamed: 'Project' ifAbsent: [ self assert: false ].
+	projectReferenceSpec := packages loadableSpecNamed: 'Project' ifAbsent: [ self assert: false ].
 	project := projectReferenceSpec referencedSpec.
 	self assert: project name equals: 'Project'.
 	self assert: project className equals: 'BaselineOfProject'.
@@ -738,6 +738,6 @@ MetacelloPackagesSpecTest >> testRemoveProjectB [
 	self assert: project postLoadDoIt value identicalTo: #postLoadDoIt.
 	packages remove: (MetacelloProjectReferenceSpec projectReference: project).
 	removed := false.
-	packages packageNamed: 'Project' ifAbsent: [ removed := true ].
+	packages loadableSpecNamed: 'Project' ifAbsent: [ removed := true ].
 	self assert: removed
 ]

--- a/src/Metacello-Tests/MetacelloVersionSpecTest.class.st
+++ b/src/Metacello-Tests/MetacelloVersionSpecTest.class.st
@@ -74,9 +74,9 @@ MetacelloVersionSpecTest >> testVersionMergeSpec2 [
 	self assert: repository type equals: 'http'.
 	self assert: repository username equals: 'DaleHenrichs'.
 	self assert: repository password equals: 'secret'.
-	package := version packagesSpec packageNamed: 'Package' ifAbsent: [ self assert: false ].
+	package := version packagesSpec loadableSpecNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
-	projectReferenceSpec := version packagesSpec packageNamed: 'Project' ifAbsent: [ self assert: false ].
+	projectReferenceSpec := version packagesSpec loadableSpecNamed: 'Project' ifAbsent: [ self assert: false ].
 	self assert: projectReferenceSpec projectName equals: 'Project'.
 	projectReferenceSpec repositories repositoryNamed: '/opt/gemstone/repository' ifPresent: [ self assert: false ].
 	repository := projectReferenceSpec repositories repositoryNamed: '/opt/gemstone/repo' ifAbsent: [ self assert: false ].
@@ -85,7 +85,7 @@ MetacelloVersionSpecTest >> testVersionMergeSpec2 [
 	self assert: repository type equals: 'http'.
 	self assert: repository username equals: 'DaleHenrichs'.
 	self assert: repository password equals: 'secret'.
-	group := version packagesSpec packageNamed: 'Platform' ifAbsent: [ self assert: false ].
+	group := version packagesSpec loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
 	self assert: (group includes includes: 'Core').
 	self assert: (group includes includes: 'Tests')
 ]
@@ -136,19 +136,18 @@ MetacelloVersionSpecTest >> testVersionSpec2 [
 					  loads: #( 'MyPackage' 'MyTests' );
 					  preLoadDoIt: #preLoadDoItB;
 					  postLoadDoIt: #postLoadDoItB;
-					  yourself));
-		yourself.
+					  yourself)).
 	repository := version repositories repositoryNamed: '/opt/gemstone/repository' ifAbsent: [ self assert: false ].
 	self assert: repository type equals: 'directory'.
 	repository := version repositories repositoryNamed: 'http://example.com/repository' ifAbsent: [ self assert: false ].
 	self assert: repository type equals: 'http'.
 	self assert: repository username equals: 'dkh'.
 	self assert: repository password equals: 'password'.
-	package := version packagesSpec packageNamed: 'Package' ifAbsent: [ self assert: false ].
+	package := version packagesSpec loadableSpecNamed: 'Package' ifAbsent: [ self assert: false ].
 	self assert: package name equals: 'Package'.
-	group := version packagesSpec packageNamed: 'Platform' ifAbsent: [ self assert: false ].
+	group := version packagesSpec loadableSpecNamed: 'Platform' ifAbsent: [ self assert: false ].
 	self assert: (group includes includes: 'Core').
-	projectReferenceSpec := version packagesSpec packageNamed: 'Project' ifAbsent: [ self assert: false ].
+	projectReferenceSpec := version packagesSpec loadableSpecNamed: 'Project' ifAbsent: [ self assert: false ].
 	self assert: projectReferenceSpec projectName equals: 'Project'
 ]
 


### PR DESCRIPTION
- Remove dead code
- Rename #packageNamed:ifAbsent: to #loadableSpecNamed:ifAbsent: because it can also return groups and project references