### PR TITLE
Add a setting to disable Epicea during Metacello loading

### DIFF
--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -91,6 +91,41 @@ EpMonitor class >> restart [
 	self current enable
 ]
 
+{ #category : 'asserting' }
+EpMonitor class >> shouldLogMetacelloLoading [
+	"If I am registered, it means I'll use the announcements to disable the monitor during Metacello loading"
+
+	^ (self codeSupportAnnouncer hasSubscriber: self) not
+]
+
+{ #category : 'asserting' }
+EpMonitor class >> shouldLogMetacelloLoading: aBoolean [
+	"If it is false, we register to Metacello announcement to disable Epicea."
+
+	| oldValue |
+	self codeSupportAnnouncer unsubscribe: self.
+
+	aBoolean ifFalse: [
+			self codeSupportAnnouncer weak
+				when: MetacelloExecutionStartAnnouncement do: [
+						oldValue := self current isEnabled.
+						self current disable ]
+				for: self;
+				when: MetacelloExecutionEndAnnouncement do: [ self current enabled: oldValue ] for: self ]
+]
+
+{ #category : 'asserting' }
+EpMonitor class >> shouldLogMetacelloLoadingSettingOn: aBuilder [
+
+	<systemsettings>
+	(aBuilder setting: #shouldLogMetacelloLoading)
+		label: 'Log Metacello loading';
+		default: false;
+		description: 'If enable, log the code execution happening during the execution of Metacello loading.';
+		parent: #epicea;
+		target: self
+]
+
 { #category : 'system startup' }
 EpMonitor class >> shutDown: isImageQuitting [
 	(isImageQuitting not

--- a/src/Metacello-Core/MetacelloExecutionAnnouncement.class.st
+++ b/src/Metacello-Core/MetacelloExecutionAnnouncement.class.st
@@ -1,0 +1,45 @@
+"
+I am an abstract class for metacello announcements related to the execution of Metacello.
+
+## Instance Variables
+
+| Attribute | Type | Description |
+|---|---|---|
+| executor | aMetacelloExecutor | The instance of the script executor linked to the announcement. |
+"
+Class {
+	#name : 'MetacelloExecutionAnnouncement',
+	#superclass : 'Announcement',
+	#instVars : [
+		'executor'
+	],
+	#category : 'Metacello-Core-Announcements',
+	#package : 'Metacello-Core',
+	#tag : 'Announcements'
+}
+
+{ #category : 'instance creation' }
+MetacelloExecutionAnnouncement class >> executor: anExecutor [
+
+	^ self new
+		  executor: anExecutor;
+		  yourself
+]
+
+{ #category : 'testing' }
+MetacelloExecutionAnnouncement class >> isAbstract [
+
+	^ self = MetacelloExecutionAnnouncement
+]
+
+{ #category : 'accessing' }
+MetacelloExecutionAnnouncement >> executor [
+
+	^ executor
+]
+
+{ #category : 'accessing' }
+MetacelloExecutionAnnouncement >> executor: anObject [
+
+	executor := anObject
+]

--- a/src/Metacello-Core/MetacelloExecutionEndAnnouncement.class.st
+++ b/src/Metacello-Core/MetacelloExecutionEndAnnouncement.class.st
@@ -1,0 +1,10 @@
+"
+I am an announcement raised when we are finishing to execute a Metacello request.
+"
+Class {
+	#name : 'MetacelloExecutionEndAnnouncement',
+	#superclass : 'MetacelloExecutionAnnouncement',
+	#category : 'Metacello-Core-Announcements',
+	#package : 'Metacello-Core',
+	#tag : 'Announcements'
+}

--- a/src/Metacello-Core/MetacelloExecutionStartAnnouncement.class.st
+++ b/src/Metacello-Core/MetacelloExecutionStartAnnouncement.class.st
@@ -1,0 +1,10 @@
+"
+I am an announcement raised when we are starting to execute a Metacello request.
+"
+Class {
+	#name : 'MetacelloExecutionStartAnnouncement',
+	#superclass : 'MetacelloExecutionAnnouncement',
+	#category : 'Metacello-Core-Announcements',
+	#package : 'Metacello-Core',
+	#tag : 'Announcements'
+}

--- a/src/Metacello-Core/MetacelloScriptExecutor.class.st
+++ b/src/Metacello-Core/MetacelloScriptExecutor.class.st
@@ -65,7 +65,10 @@ MetacelloScriptExecutor >> execute [
 				          options: self options copy;
 				          projectReferenceSpec: projectReferenceSpec;
 				          yourself.
-			engine perform: actionArg key withArguments: actionArg value.
+			[
+				self class codeSupportAnnouncer announce: (MetacelloExecutionStartAnnouncement executor: self).
+				engine perform: actionArg key withArguments: actionArg value ] ensure: [
+				self class codeSupportAnnouncer announce: (MetacelloExecutionEndAnnouncement executor: self) ].
 			engine root ifNotNil: [ :root | self roots add: root ] ].
 	^ (self singleRoot and: [ self roots size == 1 ])
 		  ifTrue: [ self roots first ]


### PR DESCRIPTION
Epicea is often polluated by the code changes happening while loading Metacello code and I see a lot of people adding a way to disable Epicea while loading code in their installation scripts because of this.

I'm proposing a new setting to disable epicea while loading code. By default Epicea will be diabled, but you can change that in the settings browser.

In order to do that, I added announcements before and after executing a Metacello script