### PR TITLE
Small Monticello speedup

### DIFF
--- a/src/Monticello-Model/MCMethodDefinition.class.st
+++ b/src/Monticello-Model/MCMethodDefinition.class.st
@@ -296,12 +296,17 @@ MCMethodDefinition >> selector: aString [
 
 { #category : 'comparing' }
 MCMethodDefinition >> sortKey [
-	^ sortKey
-		ifNil: [ sortKey := self className , '.'
-				,
-					(self classIsMeta
-						ifTrue: [ 'meta' ]
-						ifFalse: [ 'nonmeta' ]) , '.' , self selector ]
+
+	^ sortKey ifNil: [
+			  sortKey := Symbol streamContents: [ :aStream |
+					             aStream
+						             nextPutAll: self className;
+						             nextPut: $.;
+						             nextPutAll: (self classIsMeta
+								              ifTrue: [ 'meta' ]
+								              ifFalse: [ 'nonmeta' ]);
+						             nextPut: $.;
+						             nextPutAll: self selector ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Monticello/MCStWriter.class.st
+++ b/src/Monticello/MCStWriter.class.st
@@ -123,9 +123,7 @@ MCStWriter >> writeDefinitions: aCollection [
 	
 	initializers := Set new.
 
-	(MCDependencySorter sortItems: aCollection)
-		do: [:ea | ea accept: self]
-		displayingProgress: 'Writing definitions...'.
+	(MCDependencySorter sortItems: aCollection) do: [:ea | ea accept: self].
 		
 	presentInitializers := initializers select: [:each | Smalltalk hasClassNamed: each key ].
 	notPresentInitializers := initializers reject: [:each | Smalltalk hasClassNamed: each key ].

--- a/src/MonticelloFileTree-Core/MCFileTreePackageStructureStWriter.class.st
+++ b/src/MonticelloFileTree-Core/MCFileTreePackageStructureStWriter.class.st
@@ -15,9 +15,8 @@ MCFileTreePackageStructureStWriter >> absentInitializers [
 
 { #category : 'visiting' }
 MCFileTreePackageStructureStWriter >> acceptVisitor: aVisitor forDefinitions: aCollection [
-	(MCDependencySorter sortItems: aCollection)
-		do: [ :ea | ea accept: aVisitor ]
-		displayingProgress: 'Writing definitions...'
+
+	(MCDependencySorter sortItems: aCollection) do: [ :ea | ea accept: aVisitor ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
This changes remove useless progress bars (the actions are so fast that progress bars do not even appear anymore) and speed up the computation of MCMethodDefinition>>sortKey (it's now 8 times faster. It was slow because at each concatenation we were creating a symbol and symbol are slow to create. Now we concatenate strings and only at the end we cast it to a symbol)