### PR TITLE
Fix failing test + driver bug for `RBTemporaryToInstanceVariableRefactoring`

### DIFF
--- a/src/Refactoring-Transformations-Tests/RBTemporaryToInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBTemporaryToInstanceVariableParametrizedTest.class.st
@@ -92,6 +92,5 @@ RBTemporaryToInstanceVariableParametrizedTest >> testWhenHierarchyDefinesVariabl
 		{ class . #someMethod . 'foo' }.
 	self proceedThroughWarning: [ self executeRefactoring: refactoring ].
 	self assert: (class definesInstanceVariable: 'foo').
-	self deny: ((model classNamed: #Foo1) directlyDefinesInstanceVariable: 'foo').
 	self assert: (class parseTreeForSelector: #someMethod) equals: (self parseMethod: 'someMethod foo := 4. ^ foo')
 ]

--- a/src/Refactoring-UI/ReConvertTemporaryToInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/ReConvertTemporaryToInstanceVariableDriver.class.st
@@ -51,7 +51,7 @@ ReConvertTemporaryToInstanceVariableDriver >> browseMethodsDescription [
 { #category : 'actions' }
 ReConvertTemporaryToInstanceVariableDriver >> browseReferences [
 
-	(application toolNamed: #browser) browseClasses: (class allSubclasses select: [ :cls | cls hasInstVarNamed: variable ])
+	(application toolNamed: #messageList) browseClasses: (class allSubclasses select: [ :cls | cls hasInstVarNamed: variable ]) 
 ]
 
 { #category : 'instance creation' }


### PR DESCRIPTION
Since I improved the driver of this refactoring, now if a subclass already defines an instance variable that has the same name as the temporary the user wants to convert, it gives choices to him rather than automatically deleting the instance variable. So the deny: line of code is not up to date with the refactoring. 
Also the `browseReferences` method had an error when called and raised a DNU, fixed it. 
Fixes #19148