### PR TITLE
`ReConvertTemporaryToInstanceVariableDriver` update

### DIFF
--- a/src/Refactoring-Core/RBTemporaryToInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBTemporaryToInstanceVariableRefactoring.class.st
@@ -114,7 +114,6 @@ RBTemporaryToInstanceVariableRefactoring >> applicabilityPreconditions [
 RBTemporaryToInstanceVariableRefactoring >> breakingChangePreconditions [
 
 	^ {
-		  self preconditionNoSubclassDefinesVar.
 		  self preconditionNoMultipleTempOccurences.
 		  self preconditionNoReadBeforeWritten }
 ]
@@ -151,16 +150,6 @@ RBTemporaryToInstanceVariableRefactoring >> preconditionNoReadBeforeWritten [
 ]
 
 { #category : 'preconditions' }
-RBTemporaryToInstanceVariableRefactoring >> preconditionNoSubclassDefinesVar [
-
-	^ RBCondition
-		  withBlock: [ (class allSubclasses anySatisfy: [ :cls | cls definesInstanceVariable: temporaryVariableName asString ]) not ]
-		  errorString:
-			  ('One or more subclasses of <1p> already defines an<n>instance variable with the same name.'
-				   expandMacrosWith: class name)
-]
-
-{ #category : 'preconditions' }
 RBTemporaryToInstanceVariableRefactoring >> preconditions [
 
 	^ self applicabilityPreconditions & self breakingChangePreconditions
@@ -176,7 +165,11 @@ RBTemporaryToInstanceVariableRefactoring >> prepareForExecution [
 RBTemporaryToInstanceVariableRefactoring >> privateTransform [
 
 	self removeTemporaryOfClass: class.
-	class addInstanceVariable: temporaryVariableName
+	class allSubclasses do: [ :cls |
+			(cls definesInstanceVariable: temporaryVariableName)
+				ifTrue: [ cls removeInstanceVariable: temporaryVariableName ]
+				ifFalse: [ self removeTemporaryOfClass: cls ] ].
+	class addInstanceVariable: temporaryVariableName 
 ]
 
 { #category : 'removing' }

--- a/src/Refactoring-UI/ReConvertTemporaryToInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/ReConvertTemporaryToInstanceVariableDriver.class.st
@@ -5,7 +5,6 @@ Class {
 		'class',
 		'variable',
 		'selector',
-		'subclassesNotDefiningVar',
 		'notMultipleTempOccurences',
 		'noReadBeforeWritten'
 	],
@@ -19,7 +18,6 @@ ReConvertTemporaryToInstanceVariableDriver >> breakingChoices [
 
 	| items |
 	items := OrderedCollection new.
-	subclassesNotDefiningVar check ifFalse: [ items add: (ReBrowseClassReferencesChoice new driver: self) ].
 	noReadBeforeWritten check ifFalse: [ items add: (ReBrowseMethodChoice new driver: self) ].
 	notMultipleTempOccurences check ifFalse: [
 			items add: (ReBrowseMethodsChoice new
@@ -46,12 +44,6 @@ ReConvertTemporaryToInstanceVariableDriver >> browseMethods [
 ReConvertTemporaryToInstanceVariableDriver >> browseMethodsDescription [
 
 	^ 'Browse all methods containing a temporary variable with the same name'
-]
-
-{ #category : 'actions' }
-ReConvertTemporaryToInstanceVariableDriver >> browseReferences [
-
-	(application toolNamed: #browser) browseClasses: (class allSubclasses select: [ :cls | cls hasInstVarNamed: variable ])
 ]
 
 { #category : 'instance creation' }
@@ -91,20 +83,11 @@ ReConvertTemporaryToInstanceVariableDriver >> instantiateRefactoring [
 ReConvertTemporaryToInstanceVariableDriver >> labelBasedOnBreakingChanges [
 
 	^ String streamContents: [ :stream |
-			  subclassesNotDefiningVar check ifFalse: [
-					  subclassesNotDefiningVar violationMessageOn: stream.
-					  stream cr ].
 			  notMultipleTempOccurences violationMessageOn: stream.
 			  stream cr.
 			  noReadBeforeWritten violationMessageOn: stream.
 			  stream cr.
 			  stream nextPutAll: 'Select a strategy' ]
-]
-
-{ #category : 'actions' }
-ReConvertTemporaryToInstanceVariableDriver >> pushUpInstanceVariableAndRemoveTemp [
-
-	
 ]
 
 { #category : 'execution' }
@@ -115,7 +98,7 @@ ReConvertTemporaryToInstanceVariableDriver >> runRefactoring [
 			self informConditions: conditions.
 			^ false ].
 	self setBreakingChangesPreconditions.
-	subclassesNotDefiningVar check & notMultipleTempOccurences check & noReadBeforeWritten check
+	notMultipleTempOccurences check & noReadBeforeWritten check
 		ifTrue: [ self applyChanges ]
 		ifFalse: [ self handleBreakingChanges ]
 ]
@@ -132,7 +115,6 @@ ReConvertTemporaryToInstanceVariableDriver >> scopes: aScope class: aClass selec
 { #category : 'initialization' }
 ReConvertTemporaryToInstanceVariableDriver >> setBreakingChangesPreconditions [
 
-	subclassesNotDefiningVar := refactoring preconditionNoSubclassDefinesVar.
 	notMultipleTempOccurences := refactoring preconditionNoMultipleTempOccurences.
-	noReadBeforeWritten := refactoring preconditionNoReadBeforeWritten
+	noReadBeforeWritten := refactoring preconditionNoReadBeforeWritten 
 ]


### PR DESCRIPTION
Fixed the test towards the refactoring and deleted a choice from the driver since we want to do it anyway.
We want to remove the instance variables that has the same name as the temporary present in the hierarchy if we want the refactoring to operate.
Fixes #19148