### PR TITLE
identify text style style table in use 

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -216,6 +216,6 @@ BaselineOfPharo >> postload: loader package: packageSpec [
 		'Removing credential.' traceCr ].
 
 	"Open the WelcomeBrowser as last step"
-	"(self class environment classNamed: #StWelcomeBrowser)
-		ifNotNil: [ :aClass | aClass openForRelease ]"
+	(self class environment classNamed: #StWelcomeBrowser)
+		ifNotNil: [ :aClass | aClass openForRelease ]
 ]

--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -216,6 +216,6 @@ BaselineOfPharo >> postload: loader package: packageSpec [
 		'Removing credential.' traceCr ].
 
 	"Open the WelcomeBrowser as last step"
-	(self class environment classNamed: #StWelcomeBrowser)
-		ifNotNil: [ :aClass | aClass openForRelease ]
+	"(self class environment classNamed: #StWelcomeBrowser)
+		ifNotNil: [ :aClass | aClass openForRelease ]"
 ]

--- a/src/Morphic-Base/UITheme.class.st
+++ b/src/Morphic-Base/UITheme.class.st
@@ -89,7 +89,11 @@ UITheme class >> current: aUITheme [
 	SystemProgressMorph reset. "reset to use new fill styles"
 	ScrollBarMorph initializeImagesCache. "reset to use new arrows"
 
-	self class environment at: #SHPreferences ifPresent: [ :shPreferences | shPreferences setStyleTable: aUITheme shStyleTable ].
+	self class environment 
+		at: #SHPreferences 
+		ifPresent: [ :shPreferences | 
+			aUITheme shStyleTable 
+				ifNotNil: [ :aName | shPreferences styleTableSelector: aName ] ].
 
 	self class environment at: #PolymorphSystemSettings ifPresent: [ :polymorphSystemSettings | polymorphSystemSettings desktopColor: aUITheme desktopColor ].
 
@@ -4103,8 +4107,8 @@ UITheme >> shStyleTable [
 	"Styling depends on shout. If it is not present, means there is no style
 	 table to apply"
 	^ (self class environment classNamed: #SHRBTextStyler)
-		ifNotNil: [ :aClass | aClass styleTableSelector: self shStyleTableName ]
-		ifNil: [ #() ]
+		ifNotNil: [ :aClass | self shStyleTableName ]
+		ifNil: [ nil ]
 ]
 
 { #category : 'accessing' }

--- a/src/Morphic-Base/UITheme.class.st
+++ b/src/Morphic-Base/UITheme.class.st
@@ -4103,7 +4103,7 @@ UITheme >> shStyleTable [
 	"Styling depends on shout. If it is not present, means there is no style
 	 table to apply"
 	^ (self class environment classNamed: #SHRBTextStyler)
-		ifNotNil: [ :aClass | aClass perform: self shStyleTableName ]
+		ifNotNil: [ :aClass | aClass styleTableSelector: self shStyleTableName ]
 		ifNil: [ #() ]
 ]
 

--- a/src/Shout-Tests/SHRBTextStylerTest.class.st
+++ b/src/Shout-Tests/SHRBTextStylerTest.class.st
@@ -26,3 +26,31 @@ SHRBTextStylerTest >> testStyleForBackgroundColor [
 		assert: ((table at: #style3) detect: [ :each | each class = TextBackgroundColor ]) color 
 		equals: (Color fromHexString: '0F0000')
 ]
+
+{ #category : 'tests' }
+SHRBTextStylerTest >> testStyleTableSelector [
+	| oldSelector |
+
+	oldSelector := SHRBTextStyler styleTableSelector.
+	"Is not nil, but I actually don't know which one it is"
+	self assert: oldSelector isNotNil. 
+	
+	[ 	
+		#(
+			(blueStyleTable 'Blue')
+			(darkBlueStyleTable 'DarkBlue')
+			(darkStyleTable 'Dark')
+			(solarizedStyleTable 'Solarized')
+			(tangoStyleTable 'Tango')
+			(vintageStyleTable 'Vintage')
+		) do: [ :eachPair |
+			SHRBTextStyler styleTableSelector: eachPair first.
+			self assert: SHRBTextStyler styleTableSelector equals: eachPair first.
+			"check comment (as an example) has same attributes" 
+			self 
+				assert: ((SHRBTextStyler initialTextAttributes) at: #comment) first color
+				equals: ((SHRBTextStyler newAttributesForStyleTableNamed: eachPair second) at: #comment) first color ] ]
+	ensure: [
+		"restore active style"
+		SHRBTextStyler styleTableSelector: oldSelector ]
+]

--- a/src/Shout/SHPreferences.class.st
+++ b/src/Shout/SHPreferences.class.st
@@ -19,7 +19,8 @@ Class {
 { #category : 'private' }
 SHPreferences class >> applyStyle [
 	| table |
-	table := Groups values flatCollect: [:group | group styleForTable].
+	
+	table := Groups values flatCollect: [:group | group styleForTable ].
 	SHRBTextStyler styleTable: table
 ]
 
@@ -54,14 +55,107 @@ SHPreferences class >> customStyleTable: anArray [
 	self initializeGroups
 ]
 
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultArgsStyle [
+
+	^ SHStyleElement 
+		color: (Color r: 0.0 g: 0.0 b: 0.5004887585532747 alpha: 1.0) 
+		tokens: #(#patternArg #blockPatternArg #blockArg #argument)
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultBaseStyle [
+
+	^ SHStyleElement 
+		color: Color black 
+ 		tokens: #(#default)
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultCommentStyle [
+
+	^ SHStyleElement 
+		color: (Color r: 0.4203323558162268 g: 0.4203323558162268 b: 0.4203323558162268 alpha: 1.0) 
+		tokens: #(#comment)
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultErrorStyle [
+
+	^ SHStyleElement 
+		color: Color red 
+		tokens: #(#invalid #undefinedSelector #undefinedIdentifier)
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultGlobalVarStyle [
+
+	^ SHStyleElement 
+		color: (Color r: 0.0 g: 0.0 b: 0.5004887585532747 alpha: 1.0) 
+		tokens: #(#globalVar #poolConstant)
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultInstanceVarStyle [
+
+	^ SHStyleElement 
+		color: (Color r: 0.0 g: 0.0 b: 0.5004887585532747 alpha: 1.0) 
+		tokens: #(#instVar #classVar)
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultMessageSendsStyle [
+
+	^ SHStyleElement color: Color black tokens: #(selector #incompleteSelector)
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultPrimitiveTypesStyle [
+
+	^ SHStyleElement 
+		color: (Color r: 0.5004887585532747 g: 0.0 b: 0.0 alpha: 1.0) 
+		tokens: #(#character #number #symbol #string)
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultReservedWordsStyle [
+
+	^ SHStyleElement 
+		color: (Color r: 0.0 g: 0.5004887585532747 b: 0.5004887585532747 alpha: 1.0) 
+		tokens: #(#self #super #true #false #nil #thisContext)
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultSelectorPatternsStyle [
+
+	^ SHStyleElement 
+		emphasis: #bold 
+		tokens: #(#patternSelector)
+]
+
 { #category : 'accessing - styles' }
 SHPreferences class >> defaultStyle [
+
 	^ Groups at: #default
 ]
 
 { #category : 'accessing - styles' }
 SHPreferences class >> defaultStyle: aGroupStyle [
 	^ Groups at: #default put: aGroupStyle
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultSyntaxStyle [
+
+	^ SHStyleElement tokens: #(#return #blockArgColon #parenthesis #parenthesis1 #parenthesis2 #parenthesis3 #parenthesis4 #parenthesis5 #parenthesis6 #parenthesis7 #block #block1 #block2 #block3 #block4 #block5 #block6 #block7 #byteArrayStart #byteArrayEnd #byteArrayStart1 #byteArrayEnd1 #brace #brace1 #brace2 #brace3 #brace4 #brace5 #brace6 #brace7 #cascadeSeparator #statementSeparator #methodTempBar #blockTempBar #blockArgsBar)
+]
+
+{ #category : 'accessing - style defaults' }
+SHPreferences class >> defaultVariableStyle [
+
+	^ SHStyleElement 
+		color: (Color r: 0.0 g: 0.0 b: 0.5004887585532747 alpha: 1.0) 
+		tokens: #(#blockTempVar #blockPatternTempVar #tempVar #patternTempVar #incompleteIdentifier)
 ]
 
 { #category : 'accessing' }
@@ -97,7 +191,8 @@ SHPreferences class >> globalVarStyle: aGroupStyle [
 
 { #category : 'class initialization' }
 SHPreferences class >> initialize [
-	self customStyleTable: SHRBTextStyler defaultStyleTable
+
+	self customStyleTable: SHRBTextStyler styleTable
 ]
 
 { #category : 'private - initialization' }
@@ -161,6 +256,7 @@ SHPreferences class >> selectorPatternsStyle: aGroupStyle [
 
 { #category : 'settings' }
 SHPreferences class >> setStyleTable: anArray [
+
 	SHRBTextStyler styleTable: anArray
 ]
 
@@ -173,70 +269,89 @@ SHPreferences class >> setStyleTableNamed: aString [
 { #category : 'settings' }
 SHPreferences class >> settingsOn: aBuilder [
 	<systemsettings>
+	
 	(aBuilder setting: #'Syntax Highlighting')
 		target: self;
-		dialog: [ self styleTableRow ];
+		"dialog: [ self styleTableRow ];"
 		parentName: #codeBrowsing;
 		description: 'Syntax Highlighting As You Type: Enable syntax highlighting in browsers, debuggers and workspaces and set patterns style.';
 		selector: #enabled;
 		default: true;
 		iconName: #smallConfiguration;
 		with: [
+			(aBuilder pickOne: #styleTableSelector)
+				order: 0;
+				label: 'Syntax Highlight Table';
+				domainValues: self styleTableAvailableStylesMethodsWithNames;
+				description: 'Syntax Highlight stylb;e table selection'.
 			(aBuilder setting: #selectorPatternsStyle)
 				label: 'Selector Patterns';
-				default: (SHStyleElement emphasis: #bold tokens: #(#patternSelector));
+				default: self defaultSelectorPatternsStyle;
 				description: 'Selector patterns in method pane'.
 			(aBuilder setting: #errorStyle)
-				default: (SHStyleElement color: Color red tokens: #(#invalid #undefinedSelector #undefinedIdentifier));
+				default: self defaultErrorStyle;
 				label: 'Syntactic error';
 				description: 'Invalid and undefined code' .
 			(aBuilder setting: #argsStyle)
 				label: 'Parameters';
-				default: (SHStyleElement color: (Color r: 0.0 g: 0.0 b: 0.5004887585532747 alpha: 1.0) tokens: #(#patternArg #blockPatternArg #blockArg #argument));
+				default: self defaultArgsStyle;
 				description: 'Parameters in patterns, message sends, and blocks' .
 			(aBuilder setting: #commentStyle)
 				label: 'Comments';
-				default: (SHStyleElement color: (Color r: 0.4203323558162268 g: 0.4203323558162268 b: 0.4203323558162268 alpha: 1.0) tokens: #(#comment));
+				default: self defaultCommentStyle;
 				description: 'Comments in code pane' .
-			(aBuilder setting: #defaultStyle)
+			(aBuilder setting: #defaultBaseStyle)
 				label: 'Default' ;
-				default: (SHStyleElement color: Color black tokens: #(#default));
+				default: self defaultStyle;
 				description: 'Default style' .
 			(aBuilder setting: #globalVarStyle)
 				label: 'Global variables' ;
-				default: (SHStyleElement color: (Color r: 0.0 g: 0.0 b: 0.5004887585532747 alpha: 1.0) tokens: #(#globalVar #poolConstant));
+				default: self defaultGlobalVarStyle;
 				description: 'References to global variables, including classes' .
 			(aBuilder setting: #instanceVarStyle)
 				label: 'Instance/class variables' ;
-				default: (SHStyleElement color: (Color r: 0.0 g: 0.0 b: 0.5004887585532747 alpha: 1.0) tokens: #(#instVar #classVar));
+				default: self defaultInstanceVarStyle;
 				description: 'References to instance and class variables' .
 			(aBuilder setting: #messageSendsStyle)
-				default: (SHStyleElement color: Color black tokens: #(selector #incompleteSelector));
+				default: self defaultMessageSendsStyle;
 				label: 'Message sends' ;
 				description: 'Message sends' .
 			(aBuilder setting: #primitiveTypesStyle)
 				label: 'Primitive types';
-				default: (SHStyleElement color: (Color r: 0.5004887585532747 g: 0.0 b: 0.0 alpha: 1.0) tokens: #(#character #number #symbol #string));
+				default: self defaultPrimitiveTypesStyle;
 				description: 'Literal data' .
 			(aBuilder setting: #reservedWordsStyle)
 				label: 'Reserved words';
-				default: (SHStyleElement color: (Color r: 0.0 g: 0.5004887585532747 b: 0.5004887585532747 alpha: 1.0) tokens: #(#self #super #true #false #nil #thisContext));
+				default: self defaultReservedWordsStyle;
 				description: 'Reserved words of the Smalltalk language' .
 			(aBuilder setting: #syntaxStyle)
 				label: 'Syntax';
-				default: (SHStyleElement tokens: #(#return #blockArgColon #parenthesis #parenthesis1 #parenthesis2 #parenthesis3 #parenthesis4 #parenthesis5 #parenthesis6 #parenthesis7 #block #block1 #block2 #block3 #block4 #block5 #block6 #block7 #byteArrayStart #byteArrayEnd #byteArrayStart1 #byteArrayEnd1 #brace #brace1 #brace2 #brace3 #brace4 #brace5 #brace6 #brace7 #cascadeSeparator #statementSeparator #methodTempBar #blockTempBar #blockArgsBar));
+				default: self defaultSyntaxStyle;
 				description: 'Any other syntactic element' .
 			(aBuilder setting: #variableStyle)
 				label: 'Variable';
-				default: (SHStyleElement color: (Color r: 0.0 g: 0.0 b: 0.5004887585532747 alpha: 1.0) tokens: #(#blockTempVar #blockPatternTempVar #tempVar #patternTempVar #incompleteIdentifier));
-				description: 'Temporary variable'  ]
+				default: self defaultVariableStyle;
+				description: 'Temporary variable']
+]
+
+{ #category : 'settings' }
+SHPreferences class >> styleTableAvailableStyles [
+	
+	^ Pragma allNamed: #styleTable: in: SHRBTextStyler class
+]
+
+{ #category : 'settings' }
+SHPreferences class >> styleTableAvailableStylesMethodsWithNames [
+	
+	^ self styleTableAvailableStyles 
+		collect: [ :eachPragma | (eachPragma argumentAt: 1) -> eachPragma methodSelector ]
 ]
 
 { #category : 'settings' }
 SHPreferences class >> styleTableRow [
 	| allStyles |
 
-	allStyles := Pragma  allNamed: #styleTable: in: SHRBTextStyler class.
+	allStyles := self styleTableAvailableStyles.
 	^Smalltalk ui theme
 		newRowIn: self
 		for: (
@@ -253,6 +368,19 @@ SHPreferences class >> styleTableRow [
 					help: ('Change style table to ', (eachPragma argumentAt: 1)) translated)
 						label: (eachPragma argumentAt: 1);
 						yourself ] ))
+]
+
+{ #category : 'settings' }
+SHPreferences class >> styleTableSelector [
+
+	^ SHRBTextStyler styleTableSelector
+]
+
+{ #category : 'settings' }
+SHPreferences class >> styleTableSelector: aName [
+
+	SHRBTextStyler styleTableSelector: aName
+	
 ]
 
 { #category : 'accessing - styles' }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -81,8 +81,8 @@ SHRBTextStyler class >> blueStyleTable [
 	"
 	<styleTable: 'Blue'>
 
-			"(symbol color [emphasisSymbolOrArray [textStyleName [pixelHeight]]])"
- ^ #(
+	"(symbol color [emphasisSymbolOrArray [textStyleName [pixelHeight]]])"
+ 	^ #(
 			(default 								black)
 			(invalid 									red)
 
@@ -399,6 +399,15 @@ SHRBTextStyler class >> newAttributesForStyleTableNamed: aString [
 ]
 
 { #category : 'initialization' }
+SHRBTextStyler class >> reset [
+	<script>
+
+	styleTable := nil.
+	styleTableSelector := nil.
+	textAttributes := nil
+]
+
+{ #category : 'initialization' }
 SHRBTextStyler class >> resetTextAttributesCaches [
 
 	<script>
@@ -513,8 +522,14 @@ SHRBTextStyler class >> solarizedStyleTable [
 { #category : 'accessing' }
 SHRBTextStyler class >> styleTable [
 
+	'=========================== styleTable' crTrace.
+	styleTable crTrace. 
+	self styleTableSelector crTrace.
+	
 	^ styleTable ifNil: [ 
-		styleTable := self perform: self styleTableSelector ]
+		styleTable := self perform: self styleTableSelector.
+		styleTable crTrace.
+		styleTable ]
 ]
 
 { #category : 'accessing' }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -18,6 +18,7 @@ Class {
 	#classInstVars : [
 		'formatIncompleteIdentifiers',
 		'styleTable',
+		'styleTableSelector',
 		'textAttributes'
 	],
 	#category : 'Shout-Styling',
@@ -162,7 +163,7 @@ SHRBTextStyler class >> darkBlueStyleTable [
 	<styleTable: 'DarkBlue'>
 
 			"(symbol color [emphasisSymbolOrArray [textStyleName [pixelHeight]]])"
- ^ #(
+ 	^ #(
 			(default 								white)
 			(invalid 								'FF8A80') 
 
@@ -334,14 +335,9 @@ SHRBTextStyler class >> darkStyleTable [
 
 { #category : 'styles' }
 SHRBTextStyler class >> defaultStyleTable [
-	"color can be a valid argument to Color class>>colorFrom: , or nil to
-	use the editor text color.
-	Multiple emphases can be specified using an array e.g. #(bold italic).
-	If emphasis is not specified, #normal will be used.
-	if pixel height is not specified , then the editor font size will be used.
-	"
+	"Answer the selector identifying the default style table"
 
- 	^ self blueStyleTable
+ 	^ #blueStyleTable
 ]
 
 { #category : 'styles' }
@@ -516,8 +512,8 @@ SHRBTextStyler class >> solarizedStyleTable [
 
 { #category : 'accessing' }
 SHRBTextStyler class >> styleTable [
-	^ styleTable 
-		ifNil: [styleTable := self defaultStyleTable]
+
+	^ styleTable ifNil: [ styleTable := self perform: self styleTableSelector ]
 ]
 
 { #category : 'accessing' }
@@ -555,6 +551,19 @@ SHRBTextStyler class >> styleTablePragmas [
 		  allNamed: #styleTable:
 		  from: self class
 		  to: SHRBTextStyler class
+]
+
+{ #category : 'accessing' }
+SHRBTextStyler class >> styleTableSelector [
+
+	^ styleTableSelector ifNil: [ styleTableSelector := self defaultStyleTable ]
+]
+
+{ #category : 'accessing' }
+SHRBTextStyler class >> styleTableSelector: aSelector [
+
+	styleTableSelector := aSelector.
+	self styleTable: (self perform: styleTableSelector)
 ]
 
 { #category : 'styles' }

--- a/src/Shout/SHRBTextStyler.class.st
+++ b/src/Shout/SHRBTextStyler.class.st
@@ -334,7 +334,7 @@ SHRBTextStyler class >> darkStyleTable [
 ]
 
 { #category : 'styles' }
-SHRBTextStyler class >> defaultStyleTable [
+SHRBTextStyler class >> defaultStyleTableSelector [
 	"Answer the selector identifying the default style table"
 
  	^ #blueStyleTable
@@ -513,7 +513,8 @@ SHRBTextStyler class >> solarizedStyleTable [
 { #category : 'accessing' }
 SHRBTextStyler class >> styleTable [
 
-	^ styleTable ifNil: [ styleTable := self perform: self styleTableSelector ]
+	^ styleTable ifNil: [ 
+		styleTable := self perform: self styleTableSelector ]
 ]
 
 { #category : 'accessing' }
@@ -556,7 +557,7 @@ SHRBTextStyler class >> styleTablePragmas [
 { #category : 'accessing' }
 SHRBTextStyler class >> styleTableSelector [
 
-	^ styleTableSelector ifNil: [ styleTableSelector := self defaultStyleTable ]
+	^ styleTableSelector ifNil: [ styleTableSelector := self defaultStyleTableSelector ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
text styler was not keeping information about *which* highlight style was being used,
in consequence, when trying to modify it in the settings, we did not know what table is being used and we cannot pick the right element in the style table... in general is not a good thing to not beeing able to reproduce the selected stuff. hence, we are adding the used highlight selector.

Also, some cleanups (extracted styles to "default" methods) 