### PR TITLE
19166-Improve-the-Speed-of-Symbol-class--intern

### DIFF
--- a/src/Collections-Strings/Symbol.class.st
+++ b/src/Collections-Strings/Symbol.class.st
@@ -108,8 +108,7 @@ Symbol class >> intern: aStringOrSymbol [
 
 	SymbolTableSemaphore enabled ifFalse: [
 		^ self rawIntern: aStringOrSymbol ].
-	SymbolTableSemaphore singleInstance critical: [
-		^ self rawIntern: aStringOrSymbol ]
+	^ SymbolTableSemaphore singleInstance critical: [ self rawIntern: aStringOrSymbol ]
 ]
 
 { #category : 'instance creation' }


### PR DESCRIPTION
Fixes #19166
Moving the return outside the block to improve the performance when we have a lot of new symbols.