### PR TITLE
19171-Improving-the-Speed-of-STON-reader

### DIFF
--- a/src/Collections-Streams/PositionableStream.class.st
+++ b/src/Collections-Streams/PositionableStream.class.st
@@ -103,6 +103,12 @@ PositionableStream >> boolean: aBoolean [
 	self nextPut: (aBoolean ifTrue: [1] ifFalse: [0])
 ]
 
+{ #category : 'accessing' }
+PositionableStream >> collection [
+
+	^ collection
+]
+
 { #category : 'private' }
 PositionableStream >> collectionSpecies [
 	"Answer the species of collection into which the receiver can stream"

--- a/src/Collections-Streams/PositionableStream.class.st
+++ b/src/Collections-Streams/PositionableStream.class.st
@@ -103,12 +103,6 @@ PositionableStream >> boolean: aBoolean [
 	self nextPut: (aBoolean ifTrue: [1] ifFalse: [0])
 ]
 
-{ #category : 'accessing' }
-PositionableStream >> collection [
-
-	^ collection
-]
-
 { #category : 'private' }
 PositionableStream >> collectionSpecies [
 	"Answer the species of collection into which the receiver can stream"

--- a/src/STON-Core/STONReader.class.st
+++ b/src/STON-Core/STONReader.class.st
@@ -616,7 +616,7 @@ STONReader >> stringStreamContents: block [
 	stringStream ifNil: [
 		stringStream := (String new: 32) writeStream ].
 	
-	stringStream collection isWideString 
+	stringStream originalContents isWideString 
 		ifTrue: [ stringStream := (String new: 32) writeStream ]  
 		ifFalse: [ stringStream reset ].
 	

--- a/src/STON-Core/STONReader.class.st
+++ b/src/STON-Core/STONReader.class.st
@@ -388,8 +388,15 @@ STONReader >> parseMapOrListRepresentation [
 
 { #category : 'parsing' }
 STONReader >> parseNamedInstVarsFor: anObject [
+
+	| class |
+	class := anObject class.
+
 	self parseMapDo: [ :instVarName :value |
-		anObject instVarNamed: instVarName asString put: value ]
+			class
+				slotNamed: instVarName
+				ifFound: [ :slot | slot write: value to: anObject ]
+				ifNone: [ InstanceVariableNotFound signalFor: instVarName asString ] ]
 ]
 
 { #category : 'parsing-internal' }
@@ -608,7 +615,11 @@ STONReader >> storeReference: object [
 STONReader >> stringStreamContents: block [
 	stringStream ifNil: [
 		stringStream := (String new: 32) writeStream ].
-	stringStream reset.
+	
+	stringStream collection isWideString 
+		ifTrue: [ stringStream := (String new: 32) writeStream ]  
+		ifFalse: [ stringStream reset ].
+	
 	block value: stringStream.
 	^ stringStream contents
 ]


### PR DESCRIPTION
Fix #19171

- When resetting the internal WriteStream for the Strings, make it return to ByteString if it parsed before a WideString
- Accessing once the class when setting the values of objects, this is required for large objects