### PR TITLE
Rtf template refactor

### DIFF
--- a/src/AST-Core/OCMethodNode.class.st
+++ b/src/AST-Core/OCMethodNode.class.st
@@ -136,6 +136,12 @@ OCMethodNode >> allDefinedVariables [
 ]
 
 { #category : 'iterating' }
+OCMethodNode >> allMessageNodes [
+
+	^ self allChildren select: [ :aNode | aNode isMessage ]
+]
+
+{ #category : 'iterating' }
 OCMethodNode >> allSequenceNodes [
 
 	^ self allChildren select: #isSequence

--- a/src/RottenTestsFinder-Tests/RTFPrimitiveCallsCollectorTest.class.st
+++ b/src/RottenTestsFinder-Tests/RTFPrimitiveCallsCollectorTest.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : 'RTFPrimitiveCallsCollectorTest',
+	#superclass : 'TestCase',
+	#category : 'RottenTestsFinder-Tests',
+	#package : 'RottenTestsFinder-Tests'
+}
+
+{ #category : 'tests' }
+RTFPrimitiveCallsCollectorTest >> testFindsAssert [
+	
+	| collector tree compiledMethod methods |
+	collector := RTFPrimitiveCallsCollector new.
+	compiledMethod := RTFFakeTestClass >> #assertHelper.
+	tree := RTFSelfCallNode astNode: compiledMethod parseTree compiledMethod: compiledMethod.
+	tree acceptVisitor: collector.
+	methods := collector primitiveCalls 
+]

--- a/src/RottenTestsFinder-Tests/RTFSelfCallInterpreterTest.class.st
+++ b/src/RottenTestsFinder-Tests/RTFSelfCallInterpreterTest.class.st
@@ -24,7 +24,7 @@ RTFSelfCallInterpreterTest >> tearDown [
 { #category : 'tests' }
 RTFSelfCallInterpreterTest >> testCallingSuperHelper [
 	| interpreter |
-	interpreter := RTFSelfCallInterpreter new.
+	interpreter := RTFSelfCallStackBuilder new.
 
 	interpreter considerClassesThat: [ :class | class inheritsFrom: TestAsserter ].
 
@@ -37,7 +37,7 @@ RTFSelfCallInterpreterTest >> testCallingSuperHelper [
 { #category : 'tests' }
 RTFSelfCallInterpreterTest >> testSimple [
 	| interpreter |
-	interpreter := RTFSelfCallInterpreter new.
+	interpreter := RTFSelfCallStackBuilder new.
 
 	interpreter considerClassesThat: [ :class | class inheritsFrom: TestAsserter ].
 
@@ -50,7 +50,7 @@ RTFSelfCallInterpreterTest >> testSimple [
 { #category : 'tests' }
 RTFSelfCallInterpreterTest >> testWithHelper [
 	| interpreter |
-	interpreter := RTFSelfCallInterpreter new.
+	interpreter := RTFSelfCallStackBuilder new.
 
 	interpreter considerClassesThat: [ :class | class inheritsFrom: TestAsserter ].
 
@@ -63,7 +63,7 @@ RTFSelfCallInterpreterTest >> testWithHelper [
 { #category : 'tests' }
 RTFSelfCallInterpreterTest >> testWithHelperHelper [
 	| interpreter |
-	interpreter := RTFSelfCallInterpreter new.
+	interpreter := RTFSelfCallStackBuilder new.
 
 	interpreter considerClassesThat: [ :class | class inheritsFrom: TestAsserter ].
 
@@ -76,7 +76,7 @@ RTFSelfCallInterpreterTest >> testWithHelperHelper [
 { #category : 'tests' }
 RTFSelfCallInterpreterTest >> testWithSuperHelper [
 	| interpreter |
-	interpreter := RTFSelfCallInterpreter new.
+	interpreter := RTFSelfCallStackBuilder new.
 
 	interpreter considerClassesThat: [ :class | class inheritsFrom: TestAsserter ].
 

--- a/src/RottenTestsFinder/RTFSelfCallInterpreter.class.st
+++ b/src/RottenTestsFinder/RTFSelfCallInterpreter.class.st
@@ -35,11 +35,6 @@ RTFSelfCallInterpreter >> analyze [
 	callStack pop
 ]
 
-{ #category : 'accessing' }
-RTFSelfCallInterpreter >> considerClassesThat [
-	^ considerClassesThat
-]
-
 { #category : 'initialization' }
 RTFSelfCallInterpreter >> initialize [ 
 
@@ -63,11 +58,6 @@ RTFSelfCallInterpreter >> rootSelfCall [
 { #category : 'accessing' }
 RTFSelfCallInterpreter >> rootSelfCall: anObject [
 	rootSelfCall := anObject
-]
-
-{ #category : 'accessing' }
-RTFSelfCallInterpreter >> selfSentMethods [
-	^ selfSentMethods
 ]
 
 { #category : 'api' }

--- a/src/RottenTestsFinder/RTFSelfCallInterpreter.class.st
+++ b/src/RottenTestsFinder/RTFSelfCallInterpreter.class.st
@@ -14,7 +14,8 @@ Class {
 		'selfSentMethods',
 		'considerClassesThat',
 		'callStack',
-		'rootSelfCall'
+		'rootSelfCall',
+		'selfSentMethod'
 	],
 	#category : 'RottenTestsFinder-SelfInterpreter',
 	#package : 'RottenTestsFinder',
@@ -27,6 +28,14 @@ RTFSelfCallInterpreter class >> example [
 		considerClassesThat: [ :class | class inheritsFrom: Collection ];
 		send: #select: fromClass: OrderedCollection;
 		rootSelfCall
+]
+
+{ #category : 'private' }
+RTFSelfCallInterpreter >> canMethodBeAdded [
+
+	^ (considerClassesThat value: selfSentMethod methodClass) 
+		| selfSentMethod isPrimitive
+		| (selfSentMethods includes: selfSentMethod)
 ]
 
 { #category : 'accessing' }
@@ -73,41 +82,49 @@ RTFSelfCallInterpreter >> send: aSelector fromClass: aClass [
 	rootSelfCall := callStack pop
 ]
 
+{ #category : 'private' }
+RTFSelfCallInterpreter >> setMethodFromNode: aMessageNode [
+
+	| lookupClass |
+	lookupClass := aMessageNode receiver isSuperVariable
+		               ifTrue: [ selfClass superclass ]
+		               ifFalse: [ selfClass ].
+
+	selfSentMethod := lookupClass lookupSelector: aMessageNode selector.
+	selfSentMethod class = RTFMethodTracer ifTrue: [ selfSentMethod := selfSentMethod method ]
+]
+
 { #category : 'visiting' }
 RTFSelfCallInterpreter >> visitMessageNode: aMessageNode [
-	| selfSentMethod callNode |
-	aMessageNode receiver acceptVisitor: self.
-	aMessageNode arguments do: [ :each | each acceptVisitor: self ].
 
-	(aMessageNode receiver isSelfVariable or: [ aMessageNode receiver isSuperVariable ])
-		ifFalse: [ ^ self ].
+	^ self visitMessageNode: aMessageNode ifMissingMethod: [
+			Warning signal: ('#{1} can not be found in {2} nor in any super class.' format: {
+						 aMessageNode selector.
+						 selfClass name }).
+			^ self ]
+]
 
-	selfSentMethod := (aMessageNode receiver isSuperVariable
-		ifTrue: [ selfClass superclass ]
-		ifFalse: [ selfClass ]) lookupSelector: aMessageNode selector.
+{ #category : 'visiting' }
+RTFSelfCallInterpreter >> visitMessageNode: aMessageNode ifMissingMethod: aBlock [
 
-	selfSentMethod class = RTFMethodTracer
-		ifTrue: [ selfSentMethod := selfSentMethod method ].
-
-	selfSentMethod
-		ifNil: [
-			Warning signal: ('#{1} can not be found in {2} nor in any super class.' format: { aMessageNode selector . selfClass name }).
-			^ self ].
-
+	| callNode |
+	self visitNodes: aMessageNode.
+	(aMessageNode receiver isSelfVariable or: [ aMessageNode receiver isSuperVariable ]) ifFalse: [ ^ self ].
+	self setMethodFromNode: aMessageNode.
+	selfSentMethod ifNil: [
+			aBlock value. ^ self ].
 	callNode := RTFSelfCallNode astNode: aMessageNode compiledMethod: selfSentMethod.
 	callStack top addCall: callNode.
-
-	(considerClassesThat value: selfSentMethod methodClass)
-		ifFalse: [ ^ self ].
-	selfSentMethod isPrimitive
-		ifTrue: [ ^ self ].
-	(selfSentMethods includes: selfSentMethod)
-		ifTrue: [ ^ self ].
-
+	self canMethodBeAdded ifFalse: [ ^ self ].
 	selfSentMethods add: selfSentMethod.
-
-
 	callStack push: callNode.
 	selfSentMethod ast acceptVisitor: self.
 	callStack pop
+]
+
+{ #category : 'visiting' }
+RTFSelfCallInterpreter >> visitNodes: aMessageNode [
+
+	aMessageNode receiver acceptVisitor: self.
+	aMessageNode arguments do: [ :each | each acceptVisitor: self ]
 ]

--- a/src/RottenTestsFinder/RTFSelfCallInterpreter.class.st
+++ b/src/RottenTestsFinder/RTFSelfCallInterpreter.class.st
@@ -8,14 +8,10 @@ See:
 "
 Class {
 	#name : 'RTFSelfCallInterpreter',
-	#superclass : 'OCProgramNodeVisitor',
+	#superclass : 'RTFSelfCallVisitorTemplate',
 	#instVars : [
-		'selfClass',
-		'selfSentMethods',
-		'considerClassesThat',
 		'callStack',
-		'rootSelfCall',
-		'selfSentMethod'
+		'rootSelfCall'
 	],
 	#category : 'RottenTestsFinder-SelfInterpreter',
 	#package : 'RottenTestsFinder',
@@ -31,11 +27,12 @@ RTFSelfCallInterpreter class >> example [
 ]
 
 { #category : 'private' }
-RTFSelfCallInterpreter >> canMethodBeAdded [
+RTFSelfCallInterpreter >> analyze [
 
-	^ (considerClassesThat value: selfSentMethod methodClass) 
-		| selfSentMethod isPrimitive
-		| (selfSentMethods includes: selfSentMethod)
+	super analyze.
+	callStack push: callStack top subCalls last.
+	selfSentMethod ast acceptVisitor: self.
+	callStack pop
 ]
 
 { #category : 'accessing' }
@@ -43,16 +40,19 @@ RTFSelfCallInterpreter >> considerClassesThat [
 	^ considerClassesThat
 ]
 
-{ #category : 'accessing' }
-RTFSelfCallInterpreter >> considerClassesThat: anObject [
-	considerClassesThat := anObject
+{ #category : 'initialization' }
+RTFSelfCallInterpreter >> initialize [ 
+
+	super initialize.
+	callStack := Stack new
 ]
 
-{ #category : 'initialization' }
-RTFSelfCallInterpreter >> initialize [
-	super initialize.
-	selfSentMethods := OrderedCollection new.
-	callStack := Stack new
+{ #category : 'private' }
+RTFSelfCallInterpreter >> preAnalysisHook: aMessageNode [
+
+	| callNode |
+	callNode := RTFSelfCallNode astNode: aMessageNode compiledMethod: selfSentMethod.
+	callStack top addCall: callNode.
 ]
 
 { #category : 'accessing' }
@@ -85,46 +85,6 @@ RTFSelfCallInterpreter >> send: aSelector fromClass: aClass [
 { #category : 'private' }
 RTFSelfCallInterpreter >> setMethodFromNode: aMessageNode [
 
-	| lookupClass |
-	lookupClass := aMessageNode receiver isSuperVariable
-		               ifTrue: [ selfClass superclass ]
-		               ifFalse: [ selfClass ].
-
-	selfSentMethod := lookupClass lookupSelector: aMessageNode selector.
+	super setMethodFromNode: aMessageNode.
 	selfSentMethod class = RTFMethodTracer ifTrue: [ selfSentMethod := selfSentMethod method ]
-]
-
-{ #category : 'visiting' }
-RTFSelfCallInterpreter >> visitMessageNode: aMessageNode [
-
-	^ self visitMessageNode: aMessageNode ifMissingMethod: [
-			Warning signal: ('#{1} can not be found in {2} nor in any super class.' format: {
-						 aMessageNode selector.
-						 selfClass name }).
-			^ self ]
-]
-
-{ #category : 'visiting' }
-RTFSelfCallInterpreter >> visitMessageNode: aMessageNode ifMissingMethod: aBlock [
-
-	| callNode |
-	self visitNodes: aMessageNode.
-	(aMessageNode receiver isSelfVariable or: [ aMessageNode receiver isSuperVariable ]) ifFalse: [ ^ self ].
-	self setMethodFromNode: aMessageNode.
-	selfSentMethod ifNil: [
-			aBlock value. ^ self ].
-	callNode := RTFSelfCallNode astNode: aMessageNode compiledMethod: selfSentMethod.
-	callStack top addCall: callNode.
-	self canMethodBeAdded ifFalse: [ ^ self ].
-	selfSentMethods add: selfSentMethod.
-	callStack push: callNode.
-	selfSentMethod ast acceptVisitor: self.
-	callStack pop
-]
-
-{ #category : 'visiting' }
-RTFSelfCallInterpreter >> visitNodes: aMessageNode [
-
-	aMessageNode receiver acceptVisitor: self.
-	aMessageNode arguments do: [ :each | each acceptVisitor: self ]
 ]

--- a/src/RottenTestsFinder/RTFSelfCallStackBuilder.class.st
+++ b/src/RottenTestsFinder/RTFSelfCallStackBuilder.class.st
@@ -3,12 +3,11 @@ I build a selfcall tree from a class and a selector.
 
 The self call tree is as big as possible. That is to say, if calls are made in conditional blocks, they are taken in account independently from the value of the conditional.
 
-See:
-	self example
+See: the method #example.
 "
 Class {
-	#name : 'RTFSelfCallInterpreter',
-	#superclass : 'RTFSelfCallVisitorTemplate',
+	#name : 'RTFSelfCallStackBuilder',
+	#superclass : 'RTFSelfCallVisitorInterpreter',
 	#instVars : [
 		'callStack',
 		'rootSelfCall'
@@ -19,15 +18,15 @@ Class {
 }
 
 { #category : 'example' }
-RTFSelfCallInterpreter class >> example [
-	^ RTFSelfCallInterpreter new
+RTFSelfCallStackBuilder class >> example [
+	^ RTFSelfCallStackBuilder new
 		considerClassesThat: [ :class | class inheritsFrom: Collection ];
 		send: #select: fromClass: OrderedCollection;
 		rootSelfCall
 ]
 
 { #category : 'private' }
-RTFSelfCallInterpreter >> analyze [
+RTFSelfCallStackBuilder >> analyze [
 
 	super analyze.
 	callStack push: callStack top subCalls last.
@@ -36,14 +35,21 @@ RTFSelfCallInterpreter >> analyze [
 ]
 
 { #category : 'initialization' }
-RTFSelfCallInterpreter >> initialize [ 
+RTFSelfCallStackBuilder >> initialize [ 
 
 	super initialize.
 	callStack := Stack new
 ]
 
 { #category : 'private' }
-RTFSelfCallInterpreter >> preAnalysisHook: aMessageNode [
+RTFSelfCallStackBuilder >> lookupMethodFromNode: aMessageNode [
+
+	super lookupMethodFromNode: aMessageNode.
+	selfSentMethod class = RTFMethodTracer ifTrue: [ selfSentMethod := selfSentMethod method ]
+]
+
+{ #category : 'private' }
+RTFSelfCallStackBuilder >> preAnalysisHook: aMessageNode [
 
 	| callNode |
 	callNode := RTFSelfCallNode astNode: aMessageNode compiledMethod: selfSentMethod.
@@ -51,17 +57,17 @@ RTFSelfCallInterpreter >> preAnalysisHook: aMessageNode [
 ]
 
 { #category : 'accessing' }
-RTFSelfCallInterpreter >> rootSelfCall [
+RTFSelfCallStackBuilder >> rootSelfCall [
 	^ rootSelfCall
 ]
 
 { #category : 'accessing' }
-RTFSelfCallInterpreter >> rootSelfCall: anObject [
+RTFSelfCallStackBuilder >> rootSelfCall: anObject [
 	rootSelfCall := anObject
 ]
 
 { #category : 'api' }
-RTFSelfCallInterpreter >> send: aSelector fromClass: aClass [
+RTFSelfCallStackBuilder >> send: aSelector fromClass: aClass [
 
 	| method |
 	selfClass := aClass.
@@ -70,11 +76,4 @@ RTFSelfCallInterpreter >> send: aSelector fromClass: aClass [
 	callStack push: (RTFSelfCallRootNode compiledMethod: method).
 	method ast acceptVisitor: self.
 	rootSelfCall := callStack pop
-]
-
-{ #category : 'private' }
-RTFSelfCallInterpreter >> setMethodFromNode: aMessageNode [
-
-	super setMethodFromNode: aMessageNode.
-	selfSentMethod class = RTFMethodTracer ifTrue: [ selfSentMethod := selfSentMethod method ]
 ]

--- a/src/RottenTestsFinder/RTFSelfCallVisitorInterpreter.class.st
+++ b/src/RottenTestsFinder/RTFSelfCallVisitorInterpreter.class.st
@@ -2,7 +2,7 @@
 I provide a template to ve overridden for visiting messages nodes sent to self
 "
 Class {
-	#name : 'RTFSelfCallVisitorTemplate',
+	#name : 'RTFSelfCallVisitorInterpreter',
 	#superclass : 'OCProgramNodeVisitor',
 	#instVars : [
 		'selfClass',
@@ -16,30 +16,30 @@ Class {
 }
 
 { #category : 'private' }
-RTFSelfCallVisitorTemplate >> analyze [
+RTFSelfCallVisitorInterpreter >> analyze [
 
 	selfSentMethods add: selfSentMethod.
 ]
 
 { #category : 'accessing' }
-RTFSelfCallVisitorTemplate >> considerClassesThat [
+RTFSelfCallVisitorInterpreter >> considerClassesThat [
 	^ considerClassesThat
 ]
 
 { #category : 'accessing' }
-RTFSelfCallVisitorTemplate >> considerClassesThat: anObject [
+RTFSelfCallVisitorInterpreter >> considerClassesThat: anObject [
 	considerClassesThat := anObject
 ]
 
 { #category : 'initialization' }
-RTFSelfCallVisitorTemplate >> initialize [
+RTFSelfCallVisitorInterpreter >> initialize [
 
 	super initialize.
 	selfSentMethods := OrderedCollection new.
 ]
 
 { #category : 'private' }
-RTFSelfCallVisitorTemplate >> isMethodAnalyzable [
+RTFSelfCallVisitorInterpreter >> isMethodAnalyzable [
 
 	(considerClassesThat value: selfSentMethod methodClass)
 		ifFalse: [ ^ false ].
@@ -51,24 +51,7 @@ RTFSelfCallVisitorTemplate >> isMethodAnalyzable [
 ]
 
 { #category : 'private' }
-RTFSelfCallVisitorTemplate >> preAnalysisHook: aMessageNode [
-
-	^ self
-]
-
-{ #category : 'accessing' }
-RTFSelfCallVisitorTemplate >> selfClass: aClass [
-
-	selfClass := aClass 
-]
-
-{ #category : 'accessing' }
-RTFSelfCallVisitorTemplate >> selfSentMethods [
-	^ selfSentMethods
-]
-
-{ #category : 'private' }
-RTFSelfCallVisitorTemplate >> setMethodFromNode: aMessageNode [
+RTFSelfCallVisitorInterpreter >> lookupMethodFromNode: aMessageNode [
 
 	| lookupClass |
 	lookupClass := aMessageNode receiver isSuperVariable
@@ -78,8 +61,25 @@ RTFSelfCallVisitorTemplate >> setMethodFromNode: aMessageNode [
 	selfSentMethod := lookupClass lookupSelector: aMessageNode selector
 ]
 
+{ #category : 'private' }
+RTFSelfCallVisitorInterpreter >> preAnalysisHook: aMessageNode [
+
+	^ self
+]
+
+{ #category : 'accessing' }
+RTFSelfCallVisitorInterpreter >> selfClass: aClass [
+
+	selfClass := aClass 
+]
+
+{ #category : 'accessing' }
+RTFSelfCallVisitorInterpreter >> selfSentMethods [
+	^ selfSentMethods
+]
+
 { #category : 'visiting' }
-RTFSelfCallVisitorTemplate >> visitMessageNode: aMessageNode [
+RTFSelfCallVisitorInterpreter >> visitMessageNode: aMessageNode [
 
 	^ self visitMessageNode: aMessageNode ifMissingMethod: [
 			Warning signal: ('#{1} can not be found in {2} nor in any super class.' format: {
@@ -89,13 +89,13 @@ RTFSelfCallVisitorTemplate >> visitMessageNode: aMessageNode [
 ]
 
 { #category : 'visiting' }
-RTFSelfCallVisitorTemplate >> visitMessageNode: aMessageNode ifMissingMethod: aBlock [
+RTFSelfCallVisitorInterpreter >> visitMessageNode: aMessageNode ifMissingMethod: aBlock [
 
 	self visitNodes: aMessageNode.
 	(aMessageNode receiver isSelfVariable 
 		or: [ aMessageNode receiver isSuperVariable ]) 
 			ifFalse: [ ^ self ].
-	self setMethodFromNode: aMessageNode.
+	self lookupMethodFromNode: aMessageNode.
 	selfSentMethod ifNil: [
 			aBlock value.
 			^ self ].
@@ -105,7 +105,7 @@ RTFSelfCallVisitorTemplate >> visitMessageNode: aMessageNode ifMissingMethod: aB
 ]
 
 { #category : 'visiting' }
-RTFSelfCallVisitorTemplate >> visitNodes: aMessageNode [
+RTFSelfCallVisitorInterpreter >> visitNodes: aMessageNode [
 
 	aMessageNode receiver acceptVisitor: self.
 	aMessageNode arguments do: [ :each | each acceptVisitor: self ]

--- a/src/RottenTestsFinder/RTFSelfCallVisitorTemplate.class.st
+++ b/src/RottenTestsFinder/RTFSelfCallVisitorTemplate.class.st
@@ -1,0 +1,98 @@
+"
+I provide a template to ve overridden for visiting messages nodes sent to self
+"
+Class {
+	#name : 'RTFSelfCallVisitorTemplate',
+	#superclass : 'OCProgramNodeVisitor',
+	#instVars : [
+		'selfClass',
+		'selfSentMethods',
+		'considerClassesThat',
+		'selfSentMethod'
+	],
+	#category : 'RottenTestsFinder-SelfInterpreter',
+	#package : 'RottenTestsFinder',
+	#tag : 'SelfInterpreter'
+}
+
+{ #category : 'private' }
+RTFSelfCallVisitorTemplate >> analyze [
+
+	selfSentMethods add: selfSentMethod.
+]
+
+{ #category : 'accessing' }
+RTFSelfCallVisitorTemplate >> considerClassesThat: anObject [
+	considerClassesThat := anObject
+]
+
+{ #category : 'initialization' }
+RTFSelfCallVisitorTemplate >> initialize [
+
+	super initialize.
+	selfSentMethods := OrderedCollection new.
+]
+
+{ #category : 'private' }
+RTFSelfCallVisitorTemplate >> isMethodAnalyzable [
+
+	^ (considerClassesThat value: selfSentMethod methodClass) 
+		| selfSentMethod isPrimitive
+		| (selfSentMethods includes: selfSentMethod)
+]
+
+{ #category : 'private' }
+RTFSelfCallVisitorTemplate >> preAnalysisHook: aMessageNode [
+
+	^ self
+]
+
+{ #category : 'accessing' }
+RTFSelfCallVisitorTemplate >> selfClass: aClass [
+
+	selfClass := aClass 
+]
+
+{ #category : 'private' }
+RTFSelfCallVisitorTemplate >> setMethodFromNode: aMessageNode [
+
+	| lookupClass |
+	lookupClass := aMessageNode receiver isSuperVariable
+		               ifTrue: [ selfClass superclass ]
+		               ifFalse: [ selfClass ].
+
+	selfSentMethod := lookupClass lookupSelector: aMessageNode selector
+]
+
+{ #category : 'visiting' }
+RTFSelfCallVisitorTemplate >> visitMessageNode: aMessageNode [
+
+	^ self visitMessageNode: aMessageNode ifMissingMethod: [
+			Warning signal: ('#{1} can not be found in {2} nor in any super class.' format: {
+						 aMessageNode selector.
+						 selfClass name }).
+			^ self ]
+]
+
+{ #category : 'visiting' }
+RTFSelfCallVisitorTemplate >> visitMessageNode: aMessageNode ifMissingMethod: aBlock [
+
+	self visitNodes: aMessageNode.
+	(aMessageNode receiver isSelfVariable 
+		or: [ aMessageNode receiver isSuperVariable ]) 
+			ifFalse: [ ^ self ].
+	self setMethodFromNode: aMessageNode.
+	selfSentMethod ifNil: [
+			aBlock value.
+			^ self ].
+	self preAnalysisHook: aMessageNode.
+	self isMethodAnalyzable 
+		ifTrue: [ self analyze ]
+]
+
+{ #category : 'visiting' }
+RTFSelfCallVisitorTemplate >> visitNodes: aMessageNode [
+
+	aMessageNode receiver acceptVisitor: self.
+	aMessageNode arguments do: [ :each | each acceptVisitor: self ]
+]

--- a/src/RottenTestsFinder/RTFSelfCallVisitorTemplate.class.st
+++ b/src/RottenTestsFinder/RTFSelfCallVisitorTemplate.class.st
@@ -22,6 +22,11 @@ RTFSelfCallVisitorTemplate >> analyze [
 ]
 
 { #category : 'accessing' }
+RTFSelfCallVisitorTemplate >> considerClassesThat [
+	^ considerClassesThat
+]
+
+{ #category : 'accessing' }
 RTFSelfCallVisitorTemplate >> considerClassesThat: anObject [
 	considerClassesThat := anObject
 ]
@@ -51,6 +56,11 @@ RTFSelfCallVisitorTemplate >> preAnalysisHook: aMessageNode [
 RTFSelfCallVisitorTemplate >> selfClass: aClass [
 
 	selfClass := aClass 
+]
+
+{ #category : 'accessing' }
+RTFSelfCallVisitorTemplate >> selfSentMethods [
+	^ selfSentMethods
 ]
 
 { #category : 'private' }

--- a/src/RottenTestsFinder/RTFSelfCallVisitorTemplate.class.st
+++ b/src/RottenTestsFinder/RTFSelfCallVisitorTemplate.class.st
@@ -41,9 +41,13 @@ RTFSelfCallVisitorTemplate >> initialize [
 { #category : 'private' }
 RTFSelfCallVisitorTemplate >> isMethodAnalyzable [
 
-	^ (considerClassesThat value: selfSentMethod methodClass) 
-		| selfSentMethod isPrimitive
-		| (selfSentMethods includes: selfSentMethod)
+	(considerClassesThat value: selfSentMethod methodClass)
+		ifFalse: [ ^ false ].
+	selfSentMethod isPrimitive
+		ifTrue: [ ^ false ].
+	(selfSentMethods includes: selfSentMethod)
+		ifTrue: [ ^ false ].
+	^ true
 ]
 
 { #category : 'private' }

--- a/src/RottenTestsFinder/RottenTestsFinder.class.st
+++ b/src/RottenTestsFinder/RottenTestsFinder.class.st
@@ -102,7 +102,7 @@ RottenTestsFinder >> visitTestCase: aTestCase [
 	testsVisitedCount := testsVisitedCount + 1.
 	compiledMethod := aTestCase class lowestCompiledMethodInInheritanceChainNamed: aTestCase selector.
 
-	rootCallNode := (RTFSelfCallInterpreter new
+	rootCallNode := (RTFSelfCallStackBuilder new
 							considerClassesThat: [ :class | class inheritsFrom: TestAsserter ];
 							send: compiledMethod selector fromClass: aTestCase class;
 							rootSelfCall) cleanSubTreesNotLeadingToAssertPrimitive.


### PR DESCRIPTION
- extract a template of the old interpreter
- create a nice subclass for the rotten green test interpreter
- split large methods into more manageable methods.
- All tests of the rotten green tests are passing