### PR TITLE
Removal of old test

### DIFF
--- a/src/Refactoring-Transformations-Tests/RBTemporaryToInstanceVariableRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBTemporaryToInstanceVariableRefactoringTest.class.st
@@ -25,16 +25,6 @@ RBTemporaryToInstanceVariableRefactoringTest >> setUp [
 ]
 
 { #category : 'tests' }
-RBTemporaryToInstanceVariableRefactoringTest >> testFailureHierarchyDefinesVarableNamedAsTemporary [
-
-	| class |
-	class := model classNamed: #Foo.
-	self
-		should: [ (RBTemporaryToInstanceVariableRefactoring class: class selector: #someMethod variable: 'foo') generateChanges ]
-		raise: RBRefactoringWarning
-]
-
-{ #category : 'tests' }
 RBTemporaryToInstanceVariableRefactoringTest >> testFailureOtherMethodDefinesTemporaryVariable [
 
 	| class |


### PR DESCRIPTION
Since behaviour chanfed for this refactoring, we dont raise a warning now, instead we delete the variable in the hierarchy Last failing test of the CI !