### PR TITLE
Deprecate UIManager>>#confirm: and introduce an alternative.

### DIFF
--- a/src/Debugger-Model/DebugContext.class.st
+++ b/src/Debugger-Model/DebugContext.class.st
@@ -130,16 +130,15 @@ DebugContext >> locateClosureHomeWithContent: aText [
 	user to validate the new context. If closureHome is not found or the user does not
 	validate the new context, return nil. aText is the new content of the current context.
 	If the current context is not a BlockContext return it."
-	| closureHome |
 
+	| closureHome |
 	context isBlockContext ifTrue: [
-		closureHome := context activeHome.
-		closureHome ifNil: [
-			self blockNotFoundDialog: context homeMethod with: aText.
-		 	^ nil ].
-		 (self confirm: 'I will have to revert to the method from\which this block originated.  Is that OK?' withCRs)
-			ifFalse: [ ^ nil ].
-		^ closureHome].
+			closureHome := context activeHome.
+			closureHome ifNil: [
+					self blockNotFoundDialog: context homeMethod with: aText.
+					^ nil ].
+			(ConfirmationRequest signal: 'I will have to revert to the method from\which this block originated.  Is that OK?') ifFalse: [ ^ nil ].
+			^ closureHome ].
 
 	^ context
 ]

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -317,16 +317,12 @@ DebugSession >> recompileMethodTo: text inContext: aContext notifying: aNotifyer
 	| newMethod recompilationContext canRewind |
 	canRewind := (self isContextPostMortem: self interruptedContext) not.
 	(recompilationContext := (self createModelForContext: aContext) locateClosureHomeWithContent: text) ifNil: [ ^ false ].
-	canRewind
-		ifFalse: [ (self confirm: 'Can not rewind post mortem context for new method.\ Accept anyway ?' withCRs) or: [ ^ false ] ].
+	canRewind ifFalse: [ (ConfirmationRequest signal: 'Can not rewind post mortem context for new method.\ Accept anyway ?' withCRs) or: [ ^ false ] ].
 
 	newMethod := (self createModelForContext: recompilationContext) recompileCurrentMethodTo: text notifying: aNotifyer.
 	newMethod ifNil: [ ^ false ].
 
-	(self isContextPostMortem: self interruptedContext)
-		ifFalse: [ self rewindContextToMethod: newMethod fromContext: recompilationContext ].
-
-	"Use an alarm instead of triggering the notification directly, as the content of
+	(self isContextPostMortem: self interruptedContext) ifFalse: [ self rewindContextToMethod: newMethod fromContext: recompilationContext ]. "Use an alarm instead of triggering the notification directly, as the content of
 	the editor can still be unaccepted. "
 	self installAlarm: #contextChanged.
 	^ true

--- a/src/Debugger-Model/SmalltalkImage.extension.st
+++ b/src/Debugger-Model/SmalltalkImage.extension.st
@@ -4,11 +4,10 @@ Extension { #name : 'SmalltalkImage' }
 SmalltalkImage >> okayToProceedEvenIfSpaceIsLow [
 	"Return true if either there is enough memory to do so safely or if the user gives permission after being given fair warning."
 
-	self garbageCollectMost > self lowSpaceThreshold ifTrue: [^ true].  "quick"
-	self garbageCollect > self lowSpaceThreshold ifTrue: [^ true].  "work harder"
+	self garbageCollectMost > self lowSpaceThreshold ifTrue: [ ^ true ]. "quick"
+	self garbageCollect > self lowSpaceThreshold ifTrue: [ ^ true ]. "work harder"
 
-	^ self confirm:
-'WARNING: There is not enough space to start the low space watcher.
+	^ ConfirmationRequest signal: 'WARNING: There is not enough space to start the low space watcher.
 If you proceed, you will not be warned again, and the system may
 run out of memory and crash. If you do proceed, you can start the
 low space notifier when more space becomes available simply by

--- a/src/Deprecated14/Object.extension.st
+++ b/src/Deprecated14/Object.extension.st
@@ -153,7 +153,7 @@ Object >> inform: aString [
 	The most simple way to replace the usage of #inform: is to use `InformativeNotification signal: aString`. 
 	But if you have access to a spec application or presenter you can use the #inform: implemented on those instead.'
 		transformWith: '`@rcv inform: `@arg' -> 'InformativeNotification signal: `@arg'.
-	aString isEmptyOrNil ifFalse: [ UIManager default inform: aString ]
+	InformativeNotification signal: aString
 ]
 
 { #category : '*Deprecated14' }

--- a/src/Deprecated14/Object.extension.st
+++ b/src/Deprecated14/Object.extension.st
@@ -15,6 +15,16 @@ Object >> basicInspector [
 ]
 
 { #category : '*Deprecated14' }
+Object >> confirm: queryString [
+	"Put up a yes/no menu with caption queryString. Answer true if the
+	response is yes, false if no. This is a modal question--the user must
+	respond yes or no."
+
+	self deprecated: 'Use the ConfirmationRequest instead.' transformWith: '`@rcv confirm: `@arg' -> 'ConfirmationRequest signal: `@arg'.
+	^ ConfirmationRequest signal: queryString
+]
+
+{ #category : '*Deprecated14' }
 Object >> haltOnAccess [
 
 	self
@@ -132,6 +142,18 @@ Object >> haltOnceOnCallTo: aSelector [
 		transformWith: '`@receiver haltOnceOnCallTo: `@arg' -> '`@receiver breakOnceOnCallTo: `@arg'.
 
 	^ self breakOnceOnCallTo: aSelector
+]
+
+{ #category : '*Deprecated14' }
+Object >> inform: aString [
+	"Display a message for the user to read and then dismiss."
+
+	self
+		deprecated: 'This method will be removed of Object because the API should not hold UI interactions.
+	The most simple way to replace the usage of #inform: is to use `InformativeNotification signal: aString`. 
+	But if you have access to a spec application or presenter you can use the #inform: implemented on those instead.'
+		transformWith: '`@rcv inform: `@arg' -> 'InformativeNotification signal: `@arg'.
+	aString isEmptyOrNil ifFalse: [ UIManager default inform: aString ]
 ]
 
 { #category : '*Deprecated14' }

--- a/src/Graphics-Fonts/FontSet.class.st
+++ b/src/Graphics-Fonts/FontSet.class.st
@@ -50,9 +50,8 @@ FontSet class >> fontNamed: fontName fromMimeLiteral: aString [
 FontSet class >> installAsDefault [
 	"FontSetNewYork installAsDefault"
 
-	(self confirm: 'Do you want to install' translated, '
-''' , self fontName , ''' as default font?' translated)
-		ifFalse: [^ self].
+	(ConfirmationRequest signal: 'Do you want to install
+''' , self fontName , ''' as default font?') ifFalse: [ ^ self ].
 	self installAsTextStyle.
 	TextSharedInformation at: #DefaultTextStyle put: (TextStyle named: self fontName)
 ]
@@ -60,12 +59,11 @@ FontSet class >> installAsDefault [
 { #category : 'installing' }
 FontSet class >> installAsTextStyle [
 	"FontSetNewYork installAsTextStyle"
+
 	| selectors |
-	(TextSharedInformation includesKey: self fontName) ifTrue:
-		[ (self confirm: self fontName , ' is already defined in TextSharedInformation.
+	(TextSharedInformation includesKey: self fontName) ifTrue: [
+			(ConfirmationRequest signal: self fontName , ' is already defined in TextSharedInformation.
 Do you want to replace that definition?') ifFalse: [ ^ self ] ].
 	selectors := (self class selectors select: [ :s | s beginsWith: 'size' ]) asSortedCollection.
-	TextSharedInformation
-		at: self fontName
-		put: (TextStyle fontArray: (selectors collect: [ :each | self perform: each ]))
+	TextSharedInformation at: self fontName put: (TextStyle fontArray: (selectors collect: [ :each | self perform: each ]))
 ]

--- a/src/Graphics-Fonts/StrikeFont.class.st
+++ b/src/Graphics-Fonts/StrikeFont.class.st
@@ -479,7 +479,7 @@ StrikeFont >> characterFormAt: character put: characterForm [
 	ascii := character asciiValue.
 	ascii < minAscii ifTrue: [ ^ self error: 'Cant store characters below min ascii' ].
 	ascii > maxAscii ifTrue:
-		[ (self confirm: 'This font does not accomodate ascii values higher than ' , maxAscii printString , '.
+		[ (ConfirmationRequest signal:  'This font does not accomodate ascii values higher than ' , maxAscii printString , '.
 Do you wish to extend it permanently to handle values up to ' , ascii printString)
 			ifTrue: [ self extendMaxAsciiTo: ascii ]
 			ifFalse: [ ^ self error: 'No change made' ] ].

--- a/src/IconPacks/SpIconPacksFetchPresenter.class.st
+++ b/src/IconPacks/SpIconPacksFetchPresenter.class.st
@@ -412,15 +412,12 @@ SpIconPacksFetchPresenter >> selectedIconPacks [
 
 { #category : 'initialization' }
 SpIconPacksFetchPresenter >> setCurrentIconPack [
-	
-	| selectedIconsPack |
 
-	(self confirm: 'Are you sure to replace the current icon pack?')
-		ifFalse: [ ^ self ].
+	| selectedIconsPack |
+	(ConfirmationRequest signal: 'Are you sure to replace the current icon pack?') ifFalse: [ ^ self ].
 	selectedIconsPack := availableIconPacksPresenter selectedItem.
 	selectedIconsPack beCurrent.
-	self inform:
-		'Current Icons Pack updated to: ' , selectedIconsPack name
+	self inform: 'Current Icons Pack updated to: ' , selectedIconsPack name
 ]
 
 { #category : 'callbacks' }

--- a/src/Kernel/ConfirmationRequest.class.st
+++ b/src/Kernel/ConfirmationRequest.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'ConfirmationRequest',
+	#superclass : 'Warning',
+	#category : 'Kernel-Exceptions',
+	#package : 'Kernel',
+	#tag : 'Exceptions'
+}

--- a/src/Monticello/MCVersionLoader.class.st
+++ b/src/Monticello/MCVersionLoader.class.st
@@ -83,16 +83,16 @@ MCVersionLoader >> checkForModificationsIfCancel: cancelBlock ifMerge: mergeBloc
 
 { #category : 'checking' }
 MCVersionLoader >> confirmMissingDependency: aDependency [
+
 	| name |
 	name := aDependency versionInfo name.
-	(self confirm: 'Can''t find dependency ', name, '. ignore?')
-		ifFalse: [self error: 'Can''t find dependency ', name]
+	(ConfirmationRequest signal: 'Can''t find dependency ' , name , '. ignore?') ifFalse: [ self error: 'Can''t find dependency ' , name ]
 ]
 
 { #category : 'checking' }
 MCVersionLoader >> depAgeIsOk: aDependency [
-	^ aDependency isOlder not 
-		or: [self confirm: 'load older dependency ', aDependency versionInfo name , '?']
+
+	^ aDependency isOlder not or: [ ConfirmationRequest signal: 'load older dependency ' , aDependency versionInfo name , '?' ]
 ]
 
 { #category : 'private' }

--- a/src/MonticelloFileServices/MczInstaller.class.st
+++ b/src/MonticelloFileServices/MczInstaller.class.st
@@ -101,16 +101,20 @@ MczInstaller >> associate: tokens [
 
 { #category : 'utilities' }
 MczInstaller >> checkDependencies [
+
 	| dependencies unmet |
-	dependencies := (zip membersMatching: 'dependencies/*')
-			collect: [:member | self extractInfoFrom: (self parseMember: member)].
-	unmet := dependencies reject: [:dep |
-		self versions: Versions anySatisfy: (dep at: #id)].
+	dependencies := (zip membersMatching: 'dependencies/*') collect: [ :member | self extractInfoFrom: (self parseMember: member) ].
+	unmet := dependencies reject: [ :dep | self versions: Versions anySatisfy: (dep at: #id) ].
 	^ unmet isEmpty or: [
-		self confirm: (String streamContents: [:s|
-			s nextPutAll: 'The following dependencies seem to be missing:'; cr.
-			unmet do: [:each | s nextPutAll: (each at: #name); cr].
-			s nextPutAll: 'Do you still want to install this package?'])]
+			  ConfirmationRequest signal: (String streamContents: [ :s |
+						   s
+							   nextPutAll: 'The following dependencies seem to be missing:';
+							   cr.
+						   unmet do: [ :each |
+								   s
+									   nextPutAll: (each at: #name);
+									   cr ].
+						   s nextPutAll: 'Do you still want to install this package?' ]) ]
 ]
 
 { #category : 'private' }

--- a/src/Morphic-Base/HaloMorph.class.st
+++ b/src/Morphic-Base/HaloMorph.class.st
@@ -1056,19 +1056,16 @@ HaloMorph >> maybeCollapse: evt with: collapseHandle [
 HaloMorph >> maybeDismiss: evt with: dismissHandle [
 	"Ask hand to dismiss my target if mouse comes up in it."
 
-	| confirmed |
 	evt hand obtainHalo: self.
 	(dismissHandle containsPoint: evt cursorPoint)
 		ifTrue: [
-			target resistsRemoval ifTrue: [
-				confirmed := self confirm: 'Really throw this away?' translated.
-				confirmed ifFalse: [ ^ self ] ].
-			evt hand removeHalo.
-			self delete.
-			target dismissViaHalo ]
+				target resistsRemoval ifTrue: [ (ConfirmationRequest signal: 'Really throw this away?') ifFalse: [ ^ self ] ].
+				evt hand removeHalo.
+				self delete.
+				target dismissViaHalo ]
 		ifFalse: [
-			self delete.
-			target addHalo: evt ]
+				self delete.
+				target addHalo: evt ]
 ]
 
 { #category : 'private' }

--- a/src/Morphic-Base/MorphicUIManager.class.st
+++ b/src/Morphic-Base/MorphicUIManager.class.st
@@ -182,6 +182,7 @@ MorphicUIManager >> confirm: aStringOrText [
 	Answer true if the response is yes, false if no.
 	This is a modal question--the user must respond yes or no."
 
+	self deprecated: 'Use ConfirmationRequest signal: instead.'.
 	^ self confirm: aStringOrText label: 'Question' translated
 ]
 

--- a/src/Morphic-Base/WorldState.extension.st
+++ b/src/Morphic-Base/WorldState.extension.st
@@ -33,9 +33,9 @@ WorldState class >> browseWorldMenuOn: aBuilder [
 
 { #category : '*Morphic-Base' }
 WorldState class >> cleanUpImage [
-
 	"Give the user a chance to bail"
-	(self confirm: 'Cleanup will destroy change sets and more.
+
+	(ConfirmationRequest signal: 'Cleanup will destroy change sets and more.
 Are you sure you want to proceed?') ifFalse: [ ^ self ].
 	^ Smalltalk cleanUp: true
 ]

--- a/src/Morphic-Core/PasteUpMorph.class.st
+++ b/src/Morphic-Core/PasteUpMorph.class.st
@@ -215,10 +215,9 @@ PasteUpMorph >> cleanseOtherworldlySteppers [
 
 { #category : 'Morphic-Base-Windows' }
 PasteUpMorph >> closeAllUnchangedWindows [
-	(self confirm: 'Do you really want to close all unchanged windows ?') ifFalse: [
-		^ self ].
-	(self  windowsSatisfying: [:w | w model canDiscardEdits])
-		do: [:w | w delete]
+
+	(ConfirmationRequest signal: 'Do you really want to close all unchanged windows ?') ifFalse: [ ^ self ].
+	(self windowsSatisfying: [ :w | w model canDiscardEdits ]) do: [ :w | w delete ]
 ]
 
 { #category : 'Morphic-Base-Windows' }
@@ -230,12 +229,11 @@ PasteUpMorph >> closeAllWindowsDiscardingChanges [
 PasteUpMorph >> closeUnchangedWindows [
 	"Present a menu of window titles for all windows with changes,
 	and activate the one that gets chosen."
-	(self confirm:
-'Do you really want to close all windows
-except those with unaccepted edits?' translated)
-		ifFalse: [^ self].
 
-	self  closeAllUnchangedWindows
+	(ConfirmationRequest signal: 'Do you really want to close all windows
+except those with unaccepted edits?') ifFalse: [ ^ self ].
+
+	self closeAllUnchangedWindows
 ]
 
 { #category : 'Morphic-Base-Windows' }

--- a/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
+++ b/src/Morphic-Widgets-Taskbar/SystemWindow.extension.st
@@ -248,61 +248,54 @@ SystemWindow >> taskbarButtonMenu: aMenu [
 { #category : '*Morphic-Widgets-Taskbar' }
 SystemWindow >> taskbarCloseAllLikeThis [
 
-	(self confirm: 'Do you really want to close all windows like this?') ifFalse: [
-		^ self ].
-	(self class allSubInstances select: [ :w | w labelString = self labelString]) do: [ :w | w delete ]
+	(ConfirmationRequest signal: 'Do you really want to close all windows like this?') ifFalse: [ ^ self ].
+	(self class allSubInstances select: [ :w | w labelString = self labelString ]) do: [ :w | w delete ]
 ]
 
 { #category : '*Morphic-Widgets-Taskbar' }
 SystemWindow >> taskbarCloseAllToLeft [
 
-	(self confirm: 'Do you really want to close all windows to left ?')
-		ifFalse: [ ^ self ].
+	(ConfirmationRequest signal: 'Do you really want to close all windows to left ?') ifFalse: [ ^ self ].
 	self worldTaskbar ifNotNil: [ :worldTaskbar |
-		worldTaskbar orderedTasks copy do: [ :task |
-			task morph == self ifTrue: [ ^ self ].
-			task morph delete ] ]
+			worldTaskbar orderedTasks copy do: [ :task |
+					task morph == self ifTrue: [ ^ self ].
+					task morph delete ] ]
 ]
 
 { #category : '*Morphic-Widgets-Taskbar' }
 SystemWindow >> taskbarCloseAllToRight [
 
 	| wasFound |
-	(self confirm: 'Do you really want to close all windows to right ?')
-		ifFalse: [ ^ self ].
+	(ConfirmationRequest signal: 'Do you really want to close all windows to right ?') ifFalse: [ ^ self ].
 	wasFound := false.
 	self worldTaskbar ifNotNil: [ :worldTaskbar |
-		worldTaskbar orderedTasks copy do: [ :task |
-			wasFound
-				ifTrue: [ task morph delete ]
-				ifFalse: [ wasFound := task morph == self ] ] ]
+			worldTaskbar orderedTasks copy do: [ :task |
+					wasFound
+						ifTrue: [ task morph delete ]
+						ifFalse: [ wasFound := task morph == self ] ] ]
 ]
 
 { #category : '*Morphic-Widgets-Taskbar' }
 SystemWindow >> taskbarCloseAllWindows [
 
-	(self confirm: 'Do you really want to close all windows ?') ifFalse: [
-		^ self ].
+	(ConfirmationRequest signal: 'Do you really want to close all windows ?') ifFalse: [ ^ self ].
 
-	self worldTaskbar ifNotNil: [ :worldTaskbar |
-		worldTaskbar tasks do: [ :task | task morph delete ] ]
+	self worldTaskbar ifNotNil: [ :worldTaskbar | worldTaskbar tasks do: [ :task | task morph delete ] ]
 ]
 
 { #category : '*Morphic-Widgets-Taskbar' }
 SystemWindow >> taskbarCloseHiddenWindows [
 
 	| windows invisible parts other |
-	(self confirm: 'Do you really want to close all windows hidden behind other windows?') ifFalse: [
-		^ self ].
-	windows := (self world submorphs select: [:each | each isSystemWindow ]) reversed.
-invisible := windows withIndexSelect: [ :win :index |
-	bounds := win fullBoundsInWorld.
-	parts := OrderedCollection new.
-	other := (windows copyFrom: index+1 to: windows size) collect: [:each | each fullBoundsInWorld] .
-	bounds allAreasOutsideList: other do: [ :each | parts add: each  ].
-	parts isEmpty
-].
-invisible do: [ :each | each close ].
+	(ConfirmationRequest signal: 'Do you really want to close all windows hidden behind other windows?') ifFalse: [ ^ self ].
+	windows := (self world submorphs select: [ :each | each isSystemWindow ]) reversed.
+	invisible := windows withIndexSelect: [ :win :index |
+			             bounds := win fullBoundsInWorld.
+			             parts := OrderedCollection new.
+			             other := (windows copyFrom: index + 1 to: windows size) collect: [ :each | each fullBoundsInWorld ].
+			             bounds allAreasOutsideList: other do: [ :each | parts add: each ].
+			             parts isEmpty ].
+	invisible do: [ :each | each close ]
 ]
 
 { #category : '*Morphic-Widgets-Taskbar' }

--- a/src/Morphic-Widgets-Tree/MorphTreeModel.class.st
+++ b/src/Morphic-Widgets-Tree/MorphTreeModel.class.st
@@ -317,9 +317,8 @@ MorphTreeModel >> openDialogWindowIn: aWindow title: aTitle selectedtems: aColle
 MorphTreeModel >> promptForCancel [
 	"Ask if it is OK to cancel changes"
 
-	^(self confirm:
-'Changes have not been saved.
-Is it OK to cancel changes?' translated)
+	^ ConfirmationRequest signal: 'Changes have not been saved.
+Is it OK to cancel changes?'
 ]
 
 { #category : 'announcing' }

--- a/src/Refactoring-Transformations/RBPullUpMethodTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPullUpMethodTransformation.class.st
@@ -117,16 +117,16 @@ RBPullUpMethodTransformation >> checkInstVars [
 
 { #category : 'preconditions' }
 RBPullUpMethodTransformation >> checkInstVarsFor: aSelector [
-	class instanceVariableNames do:
-			[:each |
-			((class whichSelectorsReferToInstanceVariable: each) includes: aSelector) ifTrue:
-					[ (self confirm: ('<1p> refers to #<2s> which is defined in <3p>. Do you want pull up variable #<2s> also?' expandMacrosWith: aSelector
-								with: each
-								with: class))
+
+	class instanceVariableNames do: [ :each |
+			((class whichSelectorsReferToInstanceVariable: each) includes: aSelector) ifTrue: [
+					(ConfirmationRequest signal:
+						 ('<1p> refers to #<2s> which is defined in <3p>. Do you want pull up variable #<2s> also?' expandMacrosWith: aSelector with: each with: class))
 						ifTrue: [ self previousTransformations add: (self pullUpVariable: each) ]
-						ifFalse: [ self refactoringWarning: 'You are about to pull your method without the instance variable it uses.
+						ifFalse: [
+								self refactoringWarning: 'You are about to pull your method without the instance variable it uses.
 						It will bring the system is an inconsistent state. But this may be what you want.
-						So do you want to pull up anyway?' ] ]]
+						So do you want to pull up anyway?' ] ] ]
 ]
 
 { #category : 'preconditions' }

--- a/src/Rubric/RubScrolledTextMorph.class.st
+++ b/src/Rubric/RubScrolledTextMorph.class.st
@@ -37,17 +37,13 @@ RubScrolledTextMorph >> accept [
 
 { #category : 'model protocol' }
 RubScrolledTextMorph >> acceptContents [
-	(self autoAccept not and: [ self canDiscardEdits and: [ self alwaysAccept not ] ])
-		ifTrue: [ ^ self flash ].
-	self hasEditingConflicts
-		ifTrue: [ (self
-				confirm:
-					'Caution! This method may have been
+
+	(self autoAccept not and: [ self canDiscardEdits and: [ self alwaysAccept not ] ]) ifTrue: [ ^ self flash ].
+	self hasEditingConflicts ifTrue: [
+			(ConfirmationRequest signal: 'Caution! This method may have been
 changed elsewhere since you started
-editing it here.  Accept anyway?' translated)
-				ifFalse: [ ^ self flash ] ].
-	self acceptTextInModel == true
-		ifFalse: [ ^ self ].
+editing it here.  Accept anyway?') ifFalse: [ ^ self flash ] ].
+	self acceptTextInModel == true ifFalse: [ ^ self ].
 	self hasUnacceptedEdits: false.
 	self rulers do: [ :r | r textAccepted ].
 	self announcer announce: (RubTextAccepted morph: self)

--- a/src/System-Settings-Browser/SettingBrowser.class.st
+++ b/src/System-Settings-Browser/SettingBrowser.class.st
@@ -548,10 +548,12 @@ SettingBrowser >> menuEmptyList: aTreeNode [
 
 { #category : 'menu' }
 SettingBrowser >> menuSetToDefault: aTreeNode [
+
 	| v |
-	(v := aTreeNode settingDeclaration) hasDefault
-		ifTrue: [(self confirm: 'Set to default value ?' translated)
-				ifTrue: [v setToDefault. self updateList]]
+	(v := aTreeNode settingDeclaration) hasDefault ifTrue: [
+			(ConfirmationRequest signal: 'Set to default value ?') ifTrue: [
+					v setToDefault.
+					self updateList ] ]
 ]
 
 { #category : 'user interface' }
@@ -647,9 +649,10 @@ SettingBrowser >> selection: aSelectionHolder [
 
 { #category : 'menu' }
 SettingBrowser >> setAllToDefault [
-	(self confirm: 'Set all to default value?' translated) ifTrue: [
-		self treeHolder nodeList do: [:node | node item hasDefault ifTrue: [node item setToDefault]].
-		self updateList]
+
+	(ConfirmationRequest signal: 'Set all to default value?') ifTrue: [
+			self treeHolder nodeList do: [ :node | node item hasDefault ifTrue: [ node item setToDefault ] ].
+			self updateList ]
 ]
 
 { #category : 'accessing' }

--- a/src/System-Support/SystemNavigation.class.st
+++ b/src/System-Support/SystemNavigation.class.st
@@ -430,12 +430,8 @@ SystemNavigation >> removeClass: aClass [
 	classToRemove := aClass instanceSide.
 	className := classToRemove name.
 	message := self removeClassMessageFor: className.
-	(result := self confirm: message)
-		ifTrue: [
-			classToRemove subclasses notEmpty
-				ifTrue: [
-					(self confirm: 'class has subclasses: ' , message)
-						ifFalse: [ ^ false ] ].
+	(result := ConfirmationRequest signal: message) ifTrue: [
+			classToRemove subclasses ifNotEmpty: [ (ConfirmationRequest signal: 'Class has subclasses: ' , message) ifFalse: [ ^ false ] ].
 			classToRemove removeFromSystem ].
 	^ result
 ]

--- a/src/Tool-MorphicProfiler/WorldState.extension.st
+++ b/src/Tool-MorphicProfiler/WorldState.extension.st
@@ -3,14 +3,11 @@ Extension { #name : 'WorldState' }
 { #category : '*Tool-MorphicProfiler' }
 WorldState class >> startMessageTally [
 
-	(self confirm: 'MessageTally will start now,
+	(ConfirmationRequest signal: 'MessageTally will start now,
 and stop when the cursor goes
-to the top of the screen' translated)
-		ifFalse: [ ^ self ].
+to the top of the screen') ifFalse: [ ^ self ].
 
-	TimeProfiler spyAllOn: [
-		MorphicRenderLoop new doOneCycleWhile: [
-			self currentWorld activeHand position y > 0 ] ]
+	TimeProfiler spyAllOn: [ MorphicRenderLoop new doOneCycleWhile: [ self currentWorld activeHand position y > 0 ] ]
 ]
 
 { #category : '*Tool-MorphicProfiler' }
@@ -23,11 +20,8 @@ WorldState >> startMessageTally [
 WorldState class >> startThenBrowseMessageTally [
 	"Tally only the UI process"
 
-	(self confirm: 'MessageTally the UI process until the
-mouse pointer goes to the top of the screen')
-		ifFalse: [ ^ self ].
+	(ConfirmationRequest signal: 'MessageTally the UI process until the
+mouse pointer goes to the top of the screen') ifFalse: [ ^ self ].
 
-	TimeProfiler onBlock: [
-		MorphicRenderLoop new doOneCycleWhile: [
-			self currentWorld activeHand position y > 10 ] ]
+	TimeProfiler onBlock: [ MorphicRenderLoop new doOneCycleWhile: [ self currentWorld activeHand position y > 10 ] ]
 ]

--- a/src/UIManager/DummyUIManager.class.st
+++ b/src/UIManager/DummyUIManager.class.st
@@ -33,6 +33,7 @@ DummyUIManager >> chooseFrom: labelList values: valueList lines: linesArray titl
 { #category : 'ui requests' }
 DummyUIManager >> confirm: queryString [
 
+	self deprecated: 'Use ConfirmationRequest signal: instead.'.
 	self error: 'No user response possible'
 ]
 

--- a/src/UIManager/NonInteractiveUIManager.class.st
+++ b/src/UIManager/NonInteractiveUIManager.class.st
@@ -106,7 +106,8 @@ NonInteractiveUIManager >> chooseOrRequestFrom: labelList values: valueList line
 { #category : 'ui requests' }
 NonInteractiveUIManager >> confirm: queryString [
 
-	^  self nonInteractiveWarning: 'Confirming: ', queryString
+	self deprecated: 'Use ConfirmationRequest signal: instead.'.
+	^ self nonInteractiveWarning: 'Confirming: ' , queryString
 ]
 
 { #category : 'ui requests' }

--- a/src/UIManager/Object.extension.st
+++ b/src/UIManager/Object.extension.st
@@ -1,29 +1,6 @@
 Extension { #name : 'Object' }
 
 { #category : '*UIManager' }
-Object >> confirm: queryString [
-	"Put up a yes/no menu with caption queryString. Answer true if the
-	response is yes, false if no. This is a modal question--the user must
-	respond yes or no."
-
-	self halt.
-	"DO NOT CALL THIS METHOD!"
-	^ UIManager default confirm: queryString
-]
-
-{ #category : '*UIManager' }
-Object >> inform: aString [
-	"Display a message for the user to read and then dismiss."
-
-	self halt.
-
-	self deprecated: 'This method will be removed of Object because the API should not hold UI interactions.
-	The most simple way to replace the usage of #inform: is to use `InformativeNotification signal: aString`. 
-	But if you have access to a spec application or presenter you can use the #inform: implemented on those instead.'. "DO NOT CALL THIS METHOD!"
-	aString isEmptyOrNil ifFalse: [ UIManager default inform: aString ]
-]
-
-{ #category : '*UIManager' }
 Object >> uiManager [
 
 	self halt.


### PR DESCRIPTION
This change introduce ConfirmationRequest to replace the #confirm: of UIManager. This will need also a change in NewTools. 
I also deprecated with a transformation the #inform: instead of raising an halt. 

I replaced most users in Pharo (I did not do it yet for Calypso)