### PR TITLE
Fix bug disabling Epicea after loading a Metacello project

### DIFF
--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -116,7 +116,7 @@ EpMonitor class >> shouldLogMetacelloLoading: aBoolean [
 						oldValues push: self current isEnabled.
 						self current disable ]
 				for: self;
-				when: MetacelloExecutionEndAnnouncement do: [ self current enabled: oldValues pop ] for: self ]
+				when: MetacelloExecutionEndAnnouncement do: [ "old values can be empty during Epicea loading because we are already in a Metacello loading" oldValues ifNotEmpty: [ self current enabled: oldValues pop ] ] for: self ]
 ]
 
 { #category : 'asserting' }

--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -102,18 +102,21 @@ EpMonitor class >> shouldLogMetacelloLoading [
 
 { #category : 'asserting' }
 EpMonitor class >> shouldLogMetacelloLoading: aBoolean [
-	"If it is false, we register to Metacello announcement to disable Epicea."
+	"If it is false, we register to Metacello announcement to disable Epicea.
+	
+	We save the old value in a stack because one project can load multiple other. If we keep only one value, we will lose the original value."
 
-	| oldValue |
+	| oldValues |
 	self codeSupportAnnouncer unsubscribe: self.
 
+	oldValues := Stack new.
 	aBoolean ifFalse: [
 			self codeSupportAnnouncer weak
 				when: MetacelloExecutionStartAnnouncement do: [
-						oldValue := self current isEnabled.
+						oldValues push: self current isEnabled.
 						self current disable ]
 				for: self;
-				when: MetacelloExecutionEndAnnouncement do: [ self current enabled: oldValue ] for: self ]
+				when: MetacelloExecutionEndAnnouncement do: [ self current enabled: oldValues pop ] for: self ]
 ]
 
 { #category : 'asserting' }


### PR DESCRIPTION
Recently I added a feature to disable Epicea while loading a project but I did not take into account projects depending on other projects. This ended up disabling Epicea totally.  Here is a new version that takes this into account and enable again Epicea after the loading