### PR TITLE
Use a deprecated aliase for ASTCache renaming

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -1,7 +1,0 @@
-Class {
-	#name : 'ASTCache',
-	#superclass : 'OCASTCache',
-	#category : 'AST-Core-Parser',
-	#package : 'AST-Core',
-	#tag : 'Parser'
-}

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -221,6 +221,7 @@ BaselineOfBasicTools >> postload: loader package: packageSpec [
 	OCIRPopIntoRemoteTemp deprecatedAliases: { #IRPopIntoRemoteTemp }.
 	OCIRStoreRemoteTemp deprecatedAliases: { #IRStoreRemoteTemp }.
 	OCIRInstruction deprecatedAliases: { #IRInstruction }.
+	OCASTCache deprecatedAliases: { #ASTCache }.
 	
 	"Next line is added in Pharo14 and should be removed in Pharo 15 or 16 or even 17"
 	FileException deprecatedAliases: { #FileSystemError }.


### PR DESCRIPTION
Because else we break the behavior of the ASTCache for projects working on multiple versions of Pharo