### PR TITLE
Pharo13: Use a deprecated aliase for ASTCache renaming

### DIFF
--- a/src/AST-Core/ASTCache.class.st
+++ b/src/AST-Core/ASTCache.class.st
@@ -1,7 +1,0 @@
-Class {
-	#name : 'ASTCache',
-	#superclass : 'OCASTCache',
-	#category : 'AST-Core-Parser',
-	#package : 'AST-Core',
-	#tag : 'Parser'
-}

--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -296,6 +296,7 @@ OCIRPushRemoteTemp deprecatedAliases: { #IRPushRemoteTemp }.
 OCIRPopIntoRemoteTemp deprecatedAliases: { #IRPopIntoRemoteTemp }.
 OCIRStoreRemoteTemp deprecatedAliases: { #IRStoreRemoteTemp }.
 OCIRInstruction deprecatedAliases: { #IRInstruction }.
+	OCASTCache deprecatedAliases: { #ASTCache }.
 
 
 


### PR DESCRIPTION
Because else we break the behavior of the ASTCache for projects working on multiple versions of Pharo


Backport for P13