### PR TITLE
Fix bug in #includesSubstring:caseSensitive:

### DIFF
--- a/src/Collections-Strings-Tests/StringTest.class.st
+++ b/src/Collections-Strings-Tests/StringTest.class.st
@@ -1354,11 +1354,12 @@ StringTest >> testIncludesSubstringAt [
 { #category : 'tests' }
 StringTest >> testIncludesSubstringCaseSensitive [
 
-	self deny: ('test this string' includesSubstring: 'Ring' caseSensitive: true ).
+	self deny: ('test this string' includesSubstring: 'Ring' caseSensitive: true).
 	self assert: ('test this string' includesSubstring: 'Ring' caseSensitive: false).
-	self deny: ('123éàôüöß' includesSubstring: '' caseSensitive: false).
 	self assert: ('123éàôüöß' includesSubstring: 'öß' caseSensitive: true).
-	self assert: ('123éàôüöß' includesSubstring: 'ÀÔ' caseSensitive: false)
+	self assert: ('123éàôüöß' includesSubstring: 'ÀÔ' caseSensitive: false).
+	self assert: ('test this string' includesSubstring: '' caseSensitive: true). "Consistent with #includesSubstring:"
+	self assert: ('test this string' includesSubstring: '' caseSensitive: false)
 ]
 
 { #category : 'tests' }

--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -1785,7 +1785,9 @@ String >> includesSubstring: aString caseSensitive: caseSensitive [
 	"('abcdefgh' includesSubstring: 'DE' caseSensitive: false) >>> true"
 	"('abcDefgh' includesSubstring: 'De' caseSensitive: true) >>> true"
 	"('abcDefgh' includesSubstring: 'DE' caseSensitive: true) >>> false"
-
+	
+	aString ifEmpty: [ ^ true ]. "Keep the same behavior than #includesSubstring:. If the string is empty, we consider we contain it."
+	
 	^ (self findString: aString startingAt: 1 caseSensitive: caseSensitive) > 0
 ]
 

--- a/src/Metacello-Tests/MetacelloLockTest.class.st
+++ b/src/Metacello-Tests/MetacelloLockTest.class.st
@@ -21,7 +21,7 @@ MetacelloLockTest >> project [
 { #category : 'tests' }
 MetacelloLockTest >> testLoadLockedWillNotIncludeLockedPackages [
 	"Using record as a way to determine which packages will be loaded"
-
+	| packages |
 	Metacello new
 		baseline: 'TestToLock2';
 		repository: 'http://repo.com';
@@ -30,7 +30,9 @@ MetacelloLockTest >> testLoadLockedWillNotIncludeLockedPackages [
 		baseline: 'TestToLock2';
 		repository: 'http://repo.com';
 		lock.
-	self assertCollection: ((self project version recordWithEngine: MetacelloScriptEngine new) packages collect: #name) hasSameElements: #( 'Package1' )
+		
+	packages := (self project version recordWithEngine: MetacelloScriptEngine new)  loadDirectives collect: [ :directive | directive spec ].
+	self assertCollection: (packages collect: #name) hasSameElements: #( 'Package1' )
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
The method #includesSubstring:caseSensitive: is not consistent with #includesSubstring: in case the parameter is empty.  This change is making sure that both behave the same. 

This is also the same behavior than in Java and Python. If the string to includes is empty, we consider that the string contains it. 

This will allow me to speed up the spotter once this is fixed