### PR TITLE
Simplify PharoFilesOpener

### DIFF
--- a/src/System-Sources/PharoFilesOpener.class.st
+++ b/src/System-Sources/PharoFilesOpener.class.st
@@ -4,9 +4,6 @@ My role is to open the .sources and .changes files. My only public methods are i
 Class {
 	#name : 'PharoFilesOpener',
 	#superclass : 'Object',
-	#instVars : [
-		'shouldInformAboutReadOnlyChanges'
-	],
 	#classVars : [
 		'Default',
 		'SourceFileVersionString'
@@ -93,27 +90,17 @@ PharoFilesOpener >> changesFileOrNil [
 { #category : 'public' }
 PharoFilesOpener >> changesFileOrNilReadOnly: readOnly [
 
-	^ self changesFileOrNilReadOnly: readOnly silent: false
-]
-
-{ #category : 'public' }
-PharoFilesOpener >> changesFileOrNilReadOnly: readOnly silent: silent [
 	| changesFile |
-	changesFile := self openChanges: self changesName readOnly: readOnly.
-	(changesFile isNil and: [ silent not ])
-		ifTrue: [ self informProblemInChanges: self cannotLocateMsg ].
+	changesFile := (self locateSources: self changesName forImage: self lastImagePath)
+		               tryOpenReadOnly: readOnly;
+		               yourself.
 
-	silent
-		ifTrue: [ ^ changesFile ].
+	changesFile ifNil: [ self informProblemInChanges: self cannotLocateMsg ].
 
-	changesFile isOpen ifFalse: [
-		changesFile := nil.
-		^ nil ].
+	changesFile isOpen ifFalse: [ ^ nil ].
 
-	(changesFile isReadOnly and: [ self shouldInformAboutReadOnlyChanges ])
-		ifTrue: [ self informProblemInChanges: self cannotWriteMsg ].
-	((changesFile next: 200) includesSubstring: String crlf)
-		ifTrue: [ self informProblemInChanges: self badContentMsg ].
+	changesFile isReadOnly ifTrue: [ self informProblemInChanges: self cannotWriteMsg ].
+	((changesFile next: 200) includesSubstring: String crlf) ifTrue: [ self informProblemInChanges: self badContentMsg ].
 	^ changesFile
 ]
 
@@ -122,43 +109,27 @@ PharoFilesOpener >> changesName [
 	^ Smalltalk changesName
 ]
 
-{ #category : 'helper' }
-PharoFilesOpener >> ignoreIfFail: aBlock [
-	^ [ aBlock value ] onErrorDo: [  ]
-]
-
-{ #category : 'user interaction' }
-PharoFilesOpener >> inform: msg withChangesRef: fileRef [
-	self inform: msg withRef: 'the changes file named ' , fileRef
-]
-
 { #category : 'user interaction' }
 PharoFilesOpener >> inform: msg withRef: fileRef [
 
 	InformativeNotification signal: (msg copyReplaceAll: '&fileRef' with: fileRef)
 ]
 
-{ #category : 'user interaction' }
-PharoFilesOpener >> inform: msg withSourceRef: fileRef [
-	self inform: msg withRef: 'the sources file named ' , fileRef
-]
-
 { #category : 'open sources' }
 PharoFilesOpener >> informCannotLocateSources [
+
 	| msg |
 	msg := self cannotLocateMsg.
-	Smalltalk os isMacOS
-		ifTrue: [
-			msg := msg
-				,
-					'
+	Smalltalk os isMacOS ifTrue: [
+			msg := msg , '
 Make sure the sources file is not an Alias.' ].
-	self inform: msg withSourceRef: self sourcesName
+	self inform: msg withRef: 'the sources file named ' , self sourcesName
 ]
 
 { #category : 'user interaction' }
 PharoFilesOpener >> informProblemInChanges: msg [
-	self inform: msg withChangesRef: self changesName
+
+	self inform: msg withRef: 'the changes file named ' , self changesName
 ]
 
 { #category : 'delegated' }
@@ -189,38 +160,13 @@ PharoFilesOpener >> locateSources: fullSourcesName forImage: imagePath [
 	^ (SourceFile lookupFileNamed: fullSourcesName potentialLocations: locations)
 ]
 
-{ #category : 'open changes' }
-PharoFilesOpener >> openChanges: changesPath readOnly: readOnly [
-
-	^ (self locateSources: changesPath forImage: self lastImagePath)
-		  tryOpenReadOnly: readOnly;
-		  yourself
-]
-
 { #category : 'open sources' }
 PharoFilesOpener >> openSources [
-	^ self openSources: self sourcesName forImage: self lastImagePath
-]
-
-{ #category : 'open sources' }
-PharoFilesOpener >> openSources: fullSourcesName forImage: imagePath [
 	"Look in various places for a sources file, return an open stream to it."
 
-	^ (self locateSources: fullSourcesName forImage: imagePath)
-		tryOpenReadOnly: true;
-		yourself
-]
-
-{ #category : 'public' }
-PharoFilesOpener >> setInformAboutReadOnlyChanges [
-	"Make sure the user is informed when the .changes file can not be written to."
-	shouldInformAboutReadOnlyChanges := true
-]
-
-{ #category : 'public' }
-PharoFilesOpener >> shouldInformAboutReadOnlyChanges [
-	"Answer true if and only if the user must be informed when the .changes file can not be written to."
-	^ shouldInformAboutReadOnlyChanges ifNil: [ shouldInformAboutReadOnlyChanges := true ]
+	^ (self locateSources: self sourcesName forImage: self lastImagePath)
+		  tryOpenReadOnly: true;
+		  yourself
 ]
 
 { #category : 'public' }
@@ -237,10 +183,4 @@ PharoFilesOpener >> sourcesFileOrNil [
 { #category : 'accessing' }
 PharoFilesOpener >> sourcesName [
 	^ self class sourcesName
-]
-
-{ #category : 'public' }
-PharoFilesOpener >> unsetInformAboutReadOnlyChanges [
-	"Make sure the user is *not* informed when the .changes file can not be written to."
-	shouldInformAboutReadOnlyChanges := false
 ]

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -158,18 +158,14 @@ SourceFileArray >> ensureOpen [
 	Close them before re-opening them."
 
 	| aSourcesFile aChangesFile |
-
 	self close.
 
 	aSourcesFile := PharoFilesOpener default sourcesFileOrNil.
 	aChangesFile := PharoFilesOpener default changesFileOrNil.
 
-	aChangesFile ifNil: [
-		aChangesFile := PharoFilesOpener default changesFileOrNilReadOnly: true silent: false ].
+	aChangesFile ifNil: [ aChangesFile := PharoFilesOpener default changesFileOrNilReadOnly: true ].
 
-	files := Array
-		with: aSourcesFile
-		with: aChangesFile.
+	files := Array with: aSourcesFile with: aChangesFile.
 
 	readOnlyQueue := SharedQueue new
 ]


### PR DESCRIPTION
- Remove dead code
- Remove unused argument
- Inline some utility methods
- Remove an unused variable and simplify the code