### PR TITLE
Double click improvement on class comment

### DIFF
--- a/src/BeautifulComments/ClyRichTextClassCommentEditorToolMorph.class.st
+++ b/src/BeautifulComments/ClyRichTextClassCommentEditorToolMorph.class.st
@@ -97,7 +97,7 @@ ClyRichTextClassCommentEditorToolMorph >> printContext [
 { #category : 'event handling' }
 ClyRichTextClassCommentEditorToolMorph >> reactToRubTextAreaDoubleClick: anEvent [
 
-	self toggleMode
+	self switchToEditMode
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
We couldnt double click on a selector when editing a class comment because of the double click feature, now the feature only work when we are not in edit mode :) Fixes #19199