### PR TITLE
Improve management of #initializeSlots:

### DIFF
--- a/src/General-Rules/ReNoUselessInitializeSlotsRule.class.st
+++ b/src/General-Rules/ReNoUselessInitializeSlotsRule.class.st
@@ -1,0 +1,40 @@
+"
+Some Pharo's slots needs initialization and are sending #initializeSlots: in the initialization method of their classes. But it happens that the slots get removed and the #initializeSlots: method call does not get removed. This causes performance issues on objects instatiated a lot.
+"
+Class {
+	#name : 'ReNoUselessInitializeSlotsRule',
+	#superclass : 'ReAbstractRule',
+	#category : 'General-Rules-Optimization',
+	#package : 'General-Rules',
+	#tag : 'Optimization'
+}
+
+{ #category : 'testing' }
+ReNoUselessInitializeSlotsRule class >> checksClass [
+
+	^ true
+]
+
+{ #category : 'accessing' }
+ReNoUselessInitializeSlotsRule class >> group [
+
+	^ self optimizationGroup
+]
+
+{ #category : 'accessing' }
+ReNoUselessInitializeSlotsRule class >> ruleName [
+
+	^ 'Unused #initializeSlots: call'
+]
+
+{ #category : 'running' }
+ReNoUselessInitializeSlotsRule >> check: aClass forCritiquesDo: aCriticBlock [
+
+	aClass compiledMethodAt: #initialize ifPresent: [ :initialize | (initialize refersToLiteral: #initializeSlots:) ifFalse: [ ^ self ] ] ifAbsent: [ ^ self ].
+
+	(aClass allSlots anySatisfy: [ :slot | slot wantsInitialization ]) ifTrue: [ ^ self ].
+
+	(aClass hasSubclasses and: [ Class subclasses allSatisfy: [ :subclass | subclass slots anySatisfy: [ :slot | slot wantsInitialization ] ] ]) ifTrue: [ ^ self ].
+
+	aCriticBlock cull: (self critiqueFor: aClass about: aClass name)
+]

--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -418,12 +418,6 @@ OSSDL2BackendWindow >> initWithHandle: aHandle attributes: attributes [
 	self fetchDPI
 ]
 
-{ #category : 'initialization' }
-OSSDL2BackendWindow >> initialize [
-	super initialize.
-	self class initializeSlots: self
-]
-
 { #category : 'text input' }
 OSSDL2BackendWindow >> isTextInputActive [
 	"See https://wiki.libsdl.org/SDL_IsTextInputActive"

--- a/src/ReleaseTests/ReleaseTest.class.st
+++ b/src/ReleaseTests/ReleaseTest.class.st
@@ -211,6 +211,22 @@ ReleaseTest >> testExplicitRequirementMethodsShouldBeImplementedInTheirUsers [
 	self assertValidLintRule: ReExplicitRequirementMethodsRule new
 ]
 
+{ #category : 'tests - variables' }
+ReleaseTest >> testInitializeSlotsAreUseful [
+	"When a class has a slot that needs initialization, an #initializeSlots: method call is added to the initialize method. But sometimes we remove the slots without removing the initialization. This test checkes it"
+
+	| senders violators |
+	senders := #initializeSlots: senders select: [ :method | method selector = #initialize ]. "A sender is wrong if the class has no slots to initialize and its subclasses don't have such slots."
+
+	violators := senders reject: [ :sender |
+			             | class |
+			             class := sender methodClass.
+			             (class allSlots anySatisfy: [ :slot | slot wantsInitialization ]) or: [
+				             class hasSubclasses and: [ class subclasses allSatisfy: [ :subclass | subclass slots anySatisfy: [ :slot | slot wantsInitialization ] ] ] ] ].
+
+	self assertEmpty: violators
+]
+
 { #category : 'tests' }
 ReleaseTest >> testInstanceSideMethodsWithNilKeyInLastLiteral [
 	| instanceSideMethodsWithNilKeyInLastLiteral |


### PR DESCRIPTION
We had in the image multiple cases of #initializeSlots: called on classes that does not need it anymore. This change:
- removes the last one
- Add a release test
- Add a rule against that