### PR TITLE
18932-Endless-stream-of-debuggers-when-a-does-not-understand-error-happens-in-an-ensure-block

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -546,6 +546,10 @@ DebugSession >> terminate [
 	
 	"Assume the user closed the debugger. 
 	Simply kill the interrupted process."
+	
+	(exception isKindOf: MessageNotUnderstood)
+		ifTrue: [ exception stopResendingMessage ].
+	
 	self interruptedProcess terminate.
 	self clear.
 	Smalltalk installLowSpaceWatcher "restart low space handler"

--- a/src/Kernel/MessageNotUnderstood.class.st
+++ b/src/Kernel/MessageNotUnderstood.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'message',
 		'receiver',
-		'reachedDefaultHandler'
+		'hasToResend'
 	],
 	#category : 'Kernel-Exceptions',
 	#package : 'Kernel',
@@ -17,7 +17,7 @@ Class {
 { #category : 'accessing' }
 MessageNotUnderstood >> defaultAction [
 
-	reachedDefaultHandler := true.
+	hasToResend := true.
 	super defaultAction
 ]
 
@@ -34,11 +34,17 @@ MessageNotUnderstood >> description [
 	  , ' did not understand ' , message selector printString
 ]
 
+{ #category : 'accessing' }
+MessageNotUnderstood >> hasToResend [
+
+	^ hasToResend 
+]
+
 { #category : 'initialization' }
 MessageNotUnderstood >> initialize [
 
 	super initialize.
-	reachedDefaultHandler := false
+	hasToResend := false
 ]
 
 { #category : 'private - testing' }
@@ -76,11 +82,6 @@ MessageNotUnderstood >> messageText [
 ]
 
 { #category : 'accessing' }
-MessageNotUnderstood >> reachedDefaultHandler [
-	^reachedDefaultHandler
-]
-
-{ #category : 'accessing' }
 MessageNotUnderstood >> receiver [
 	"Answer the receiver that did not understand the message"
 
@@ -91,4 +92,10 @@ MessageNotUnderstood >> receiver [
 MessageNotUnderstood >> receiver: obj [
 
 	receiver := obj
+]
+
+{ #category : 'accessing' }
+MessageNotUnderstood >> stopResendingMessage [
+
+	hasToResend := false
 ]

--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -766,7 +766,8 @@ Object >> doesNotUnderstand: aMessage [
 		message: aMessage;
 		receiver: self.
 	resumeValue := exception signal.
-	^exception reachedDefaultHandler
+		
+	^exception hasToResend 
 		ifTrue: [aMessage sentTo: self]
 		ifFalse: [resumeValue]
 ]


### PR DESCRIPTION
When we terminate a process, we should mark the MessageNotUnderstood so it is not resend the message

FIx #18932