### PR TITLE
System-Sources: Don't expose the writer in the system

### DIFF
--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -388,22 +388,13 @@ Class >> comment: aString [
 Class >> comment: aString stamp: aStamp [
 	"Store the comment, aString or Text or RemoteString, associated with the class we are organizing.  Empty string gets stored only if had a non-empty one before."
 
-	| pointer oldComment oldStamp |
+	| oldComment oldStamp |
 	oldComment := self comment.
 	oldStamp := self commentStamp.
 
 	aString string = oldComment string ifTrue: [ ^ self ].
 
-	pointer := self commentSourcePointer ifNil: [ 0 ].
-
-	SourceFileArray default newWriter
-		metadata: ' ';
-		timestamp: aStamp;
-		prior: pointer;
-		successBlock: [ :newSourcePointer | self commentSourcePointer: newSourcePointer ];
-		failBlock: [ "ignore" ];
-		writeComment: aString
-		ofClass: self.
+	SourceFileArray default writeComment: aString stamp: aStamp  of: self.
 
 	self codeChangeAnnouncer
 		class: self

--- a/src/System-Sources-Tests/SourceFileTest.class.st
+++ b/src/System-Sources-Tests/SourceFileTest.class.st
@@ -109,7 +109,6 @@ SourceFileTest >> testWriteClassDefinitionOnFormatV100 [
 	self deny: file exists.
 
 	(SourceFile createFileNamed: file version: ChunkFileFormatParserV100) tryOpen newWriter
-		successBlock: [ :x | ];
 		failBlock: [ self error ];
 		writeClassDefinition: 'ASDASD'.
 
@@ -133,8 +132,6 @@ SourceFileTest >> testWriteClassDefinitionOnFormatV200 [
 	self deny: file exists.
 
 	(SourceFile createFileNamed: file version: ChunkFileFormatParserV200) tryOpen newWriter
-		successBlock: [ :x | ];
-		failBlock: [  ];
 		writeClassDefinition: 'ASDASD'.
 	
 	importer := CodeImporter withParserClass: ChunkFileFormatParserV200.

--- a/src/System-Sources/CompiledMethod.extension.st
+++ b/src/System-Sources/CompiledMethod.extension.st
@@ -4,15 +4,11 @@ Extension { #name : 'CompiledMethod' }
 CompiledMethod >> putSource: source withFooter: footer protocol: protocol timestamp: aTimestamp priorSourcePointer: priorSourcePointer [
 	"Store the source code for the receiver on an external file."
 
-	SourceFileArray default newWriter
-		metadata: footer;
-		timestamp: aTimestamp;
-		prior: priorSourcePointer;
-		successBlock: [ :newSourcePointer |
-			"Update with new source pointer"
-			self sourcePointer: newSourcePointer ];
-		failBlock: [
-			"if we can not store the source pointer, we put back the property"
-			self propertyAt: #source put: source ];
-		writeSource: source ofMethod: self protocol: protocol
+	SourceFileArray default
+		writeSource: source
+		of: self
+		withFooter: footer
+		protocol: protocol
+		timestamp: aTimestamp
+		priorSourcePointer: priorSourcePointer
 ]

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -268,10 +268,7 @@ SourceFileArray >> logChange: aStringOrText [
 { #category : 'event-listening' }
 SourceFileArray >> logClassAdded: announcement [
 
-	self newWriter
-		successBlock: [ :sourcePointer | "Ignore" ];
-		failBlock: [ "Ignore" ];
-		writeClassDefinition: announcement classAdded definitionString
+	self newWriter writeClassDefinition: announcement classAdded definitionString
 ]
 
 { #category : 'event-listening' }
@@ -568,11 +565,9 @@ SourceFileArray >> writeChangesDuring: aBlock onSuccess: successBlock onFail: fa
 SourceFileArray >> writeComment: aString stamp: aStamp of: aClass [
 
 	self newWriter
-		metadata: ' ';
 		timestamp: aStamp;
 		prior: (aClass commentSourcePointer ifNil: [ 0 ]);
 		successBlock: [ :newSourcePointer | aClass commentSourcePointer: newSourcePointer ];
-		failBlock: [ "ignore" ];
 		writeComment: aString ofClass: aClass
 ]
 

--- a/src/System-Sources/SourceFileArray.class.st
+++ b/src/System-Sources/SourceFileArray.class.st
@@ -563,3 +563,27 @@ SourceFileArray >> writeChangesDuring: aBlock onSuccess: successBlock onFail: fa
 
 	self flushChangesFile
 ]
+
+{ #category : 'public - string writing' }
+SourceFileArray >> writeComment: aString stamp: aStamp of: aClass [
+
+	self newWriter
+		metadata: ' ';
+		timestamp: aStamp;
+		prior: (aClass commentSourcePointer ifNil: [ 0 ]);
+		successBlock: [ :newSourcePointer | aClass commentSourcePointer: newSourcePointer ];
+		failBlock: [ "ignore" ];
+		writeComment: aString ofClass: aClass
+]
+
+{ #category : 'public - string writing' }
+SourceFileArray >> writeSource: source of: aMethod withFooter: footer protocol: protocol timestamp: aTimestamp priorSourcePointer: priorSourcePointer [
+
+	self newWriter
+		metadata: footer;
+		timestamp: aTimestamp;
+		prior: priorSourcePointer;
+		successBlock: [ :newSourcePointer | "Update with new source pointer" aMethod sourcePointer: newSourcePointer ];
+		failBlock: [ "if we can not store the source pointer, we put back the property" aMethod propertyAt: #source put: source ];
+		writeSource: source ofMethod: aMethod protocol: protocol
+]

--- a/src/System-Sources/SourceFileWriter.class.st
+++ b/src/System-Sources/SourceFileWriter.class.st
@@ -23,7 +23,7 @@ SourceFileWriter >> exporterClass [
 { #category : 'accessing' }
 SourceFileWriter >> failBlock [
 
-	^ failBlock
+	^ failBlock ifNil: [ [ "Do nothing" ] ]
 ]
 
 { #category : 'accessing' }
@@ -35,7 +35,7 @@ SourceFileWriter >> failBlock: anObject [
 { #category : 'accessing' }
 SourceFileWriter >> metadata [
 
-	^ metadata
+	^ metadata ifNil: [ '' ]
 ]
 
 { #category : 'accessing' }
@@ -71,7 +71,7 @@ SourceFileWriter >> sourceFile: anObject [
 { #category : 'accessing' }
 SourceFileWriter >> successBlock [
 
-	^ successBlock
+	^ successBlock ifNil: [ [ :sourcePointer | "Do nothing" ] ]
 ]
 
 { #category : 'accessing' }
@@ -97,13 +97,12 @@ SourceFileWriter >> writeClassDefinition: aClassDefinition [
 
 	sourceFile
 		writeChangesDuring: [ :file |
-			| position |
-			position := file position.
-			(self exporterClass onStream: file)
-				writeClassDefinition: aClassDefinition.
-			position ]
-		onSuccess: successBlock
-		onFail: failBlock
+				| position |
+				position := file position.
+				(self exporterClass onStream: file) writeClassDefinition: aClassDefinition.
+				position ]
+		onSuccess: self successBlock
+		onFail: self failBlock
 ]
 
 { #category : 'writing' }
@@ -115,10 +114,10 @@ SourceFileWriter >> writeComment: aComment ofClass: aClass [
 					writeComment: aComment
 					ofClass: aClass
 					stamp: timestamp
-					withMetadata: metadata
+					withMetadata: self metadata
 					priorSourcePointer: prior ]
-		onSuccess: successBlock
-		onFail: failBlock
+		onSuccess: self successBlock
+		onFail: self failBlock
 ]
 
 { #category : 'writing' }
@@ -132,8 +131,8 @@ SourceFileWriter >> writeSource: source ofMethod: method protocol: protocol [
 					source: source
 					protocol: protocol
 					stamp: timestamp
-					withMetadata: metadata
+					withMetadata: self metadata
 					priorSourcePointer: prior ]
-		onSuccess: successBlock
-		onFail: failBlock
+		onSuccess: self successBlock
+		onFail: self failBlock
 ]

--- a/src/System-Support/SmalltalkImage.class.st
+++ b/src/System-Support/SmalltalkImage.class.st
@@ -1053,12 +1053,10 @@ SmalltalkImage >> openLog [
 { #category : 'sources, change log' }
 SmalltalkImage >> openSourceFiles [
 
+	self imagePath = LastImagePath ifFalse: [ "Reset the author full name to blank when the image gets moved" LastImagePath := self imagePath ].
 
-	self imagePath = LastImagePath ifFalse: [ "Reset the author full name to blank when the image gets moved"
-		LastImagePath := self imagePath ].
-
-	SourceFiles class ensureSourceFilesCreated.
-	SourceFiles ensureOpen
+	SourceFileArray ensureSourceFilesCreated.
+	SourceFileArray default ensureOpen
 ]
 
 { #category : 'system attribute' }


### PR DESCRIPTION
My goal is to abstract the source managements so we should not expose how the source manager is saving the code. 
This PR is moving the writing from Class and CompiledMethod to SourcesFileArray like this I'll be able to introduce other kind of source managers

Also remove the usage of a deprecated global