### PR TITLE
Fix display bug in the progress bars and do some small optimisations

### DIFF
--- a/src/Jobs/Collection.extension.st
+++ b/src/Jobs/Collection.extension.st
@@ -29,31 +29,21 @@ Collection >> do: aBlock displayingProgress: aStringOrBlock every: msecs [
                        every: 0."
 
 	| size labelBlock oldLabel lastUpdate |
-	self isEmpty ifTrue: [ ^ self ].
+	self ifEmpty: [ ^ self ].
 	oldLabel := nil.
 	lastUpdate := 0.
 	size := self size.
-	
-	[ : job |	
-		| newLabel |
-		job max: size.
-		self doWithIndex: [ : each : index |
-			"Handle String or Block progress label"
-			labelBlock := aStringOrBlock isString
-				ifTrue: [
-					job title: aStringOrBlock.
-					[ :dummyItem | aStringOrBlock] ]
-				ifFalse: [ aStringOrBlock ].
 
-			(index = 1 or: [ index + 1 = size or: [(Time millisecondsSince: lastUpdate) >= msecs]]) 
-				ifTrue: [ 
-					job currentValue: index.
-					oldLabel = (newLabel := (labelBlock cull: each) ifNil: [oldLabel]) 
-						ifFalse: [
-							job title: newLabel.
-							oldLabel := newLabel ].
-				lastUpdate := Time millisecondClockValue ].
-			aBlock value: each ] 
-	] asJob run
-	
+	[ :job |
+		job max: size.
+		self doWithIndex: [ :each :index |
+				"Handle String or Block progress label"
+				labelBlock := aStringOrBlock isString
+					              ifTrue: [ [ :dummyItem | aStringOrBlock ] ]
+					              ifFalse: [ aStringOrBlock ].
+
+				(index = 1 or: [ index + 1 = size or: [ (Time millisecondsSince: lastUpdate) >= msecs ] ]) ifTrue: [
+						job currentValue: index title: (labelBlock cull: each).
+						lastUpdate := Time millisecondClockValue ].
+				aBlock value: each ] ] asJob run
 ]

--- a/src/Jobs/Job.class.st
+++ b/src/Jobs/Job.class.st
@@ -4,10 +4,12 @@ A Job is a task to run and potentially notified to the user.
 [:job | job title: 'Let us get started'.
 	1 to: 10 do: [:each |
 		job
-			progress: (0.1 * each);
-			title: 'Youpi ', each printString.
+			progress: (0.1 * each) title: 'Youpi ', each printString.
 		(Delay forMilliseconds: 100) wait.
 		] ]  asJob run
+
+
+Note: The morphic implementation of the progress bar updates itself only if it was not updated since 60ms. This means that if you set the progress and the title in two different call, the bar will be updated only once. Please use #progress:title: or #currentValue:title: in order to update both at the same time.
 "
 Class {
 	#name : 'Job',
@@ -87,11 +89,10 @@ Job class >> exampleDebug [
 			title: 'aTitle';
 			max: 10.
 		1 to: 10 do: [ :i|
-			job title: 'Fib ', i asString.
-			"do some hard work"
-			40 benchFib.
 			"update the job progress"
-			job currentValue: i. ]
+			job currentValue: i title: 'Fib ', i asString.
+			"do some hard work"
+			40 benchFib ]
 	] asJob.
 	
 	"run a different thread to interrupt the job"
@@ -103,13 +104,11 @@ Job class >> exampleDebug [
 { #category : 'examples' }
 Job class >> exampleProgress [
 
-	[:job | job title: 'Let us get started'.
-		1 to: 10 do: [:each | 
-			job 
-				progress: (0.1 * each); 
-				title: 'Youpi ', each printString.
-			(Delay forMilliseconds: 100) wait. 
-			] ]  asJob run
+	[ :job |
+		job title: 'Let us get started'.
+		1 to: 10 do: [ :each |
+				job progress: 0.1 * each title: 'Youpi ' , each printString.
+				(Delay forMilliseconds: 100) wait ] ] asJob run
 ]
 
 { #category : 'announcing' }
@@ -207,7 +206,16 @@ Job >> currentValue [
 
 { #category : 'accessing' }
 Job >> currentValue: aNumber [
-	
+	"WARNING: If you want to update the progress and the message, use #currentValue:title: instead because the progress bar framework accept edits only each 60ms. If you do it in two steps, the last one will not update."
+
+	currentValue := aNumber.
+	self announceChange
+]
+
+{ #category : 'accessing' }
+Job >> currentValue: aNumber title: aString [
+
+	title := aString.
 	currentValue := aNumber.
 	self announceChange
 ]
@@ -367,10 +375,21 @@ Job >> progress [
 
 { #category : 'progress' }
 Job >> progress: aNormalizedFloat [
-	"Set the progress: 0.0 - 1.0"
+	"Set the progress: 0.0 - 1.0
+	
+	WARNING: If you want to update the progress and the message, use #progress:title: instead because the progress bar framework accept edits only each 60ms. If you do it in two steps, the last one will not update."
 
-	currentValue := (min + ((max - min) * aNormalizedFloat)).
-	self announceChange.
+	self setProgressTo: aNormalizedFloat.
+	self announceChange
+]
+
+{ #category : 'progress' }
+Job >> progress: aNormalizedFloat title: aString [
+	"We change the title and progress announcing only once."
+
+	self setProgressTo: aNormalizedFloat.
+	title := aString.
+	self announceChange
 ]
 
 { #category : 'private' }
@@ -390,6 +409,12 @@ Job >> run [
 		self cleanupAfterRunning ]
 ]
 
+{ #category : 'private' }
+Job >> setProgressTo: aNormalizedFloat [
+
+	^ currentValue := min + (max - min * aNormalizedFloat)
+]
+
 { #category : 'running' }
 Job >> terminate [
 
@@ -404,9 +429,10 @@ Job >> title [
 
 { #category : 'accessing' }
 Job >> title: anObject [
-	
+	"WARNING: If you want to update the progress and the message, use #progress:title: instead because the progress bar framework accept edits only each 60ms. If you do it in two steps, the last one will not update."
+
 	title := anObject.
-	self announceChange.
+	self announceChange
 ]
 
 { #category : 'compatibility' }

--- a/src/Metacello-Core/MetacelloFetchTarget.class.st
+++ b/src/Metacello-Core/MetacelloFetchTarget.class.st
@@ -6,12 +6,6 @@ Class {
 	#tag : 'Targets'
 }
 
-{ #category : 'accessing' }
-MetacelloFetchTarget >> actionLabel [
-
-	^'Fetching '
-]
-
 { #category : 'visiting' }
 MetacelloFetchTarget >> visitAtomicLoadDirective: aMetacelloAtomicLoadDirective [
 

--- a/src/Metacello-Core/MetacelloLoadTarget.class.st
+++ b/src/Metacello-Core/MetacelloLoadTarget.class.st
@@ -7,12 +7,6 @@ Class {
 }
 
 { #category : 'accessing' }
-MetacelloLoadTarget >> actionLabel [
-
-	^'Loading '
-]
-
-{ #category : 'accessing' }
 MetacelloLoadTarget >> baselineFor: aDirective [
 
 	^ aDirective spec project baseline

--- a/src/Metacello-Core/MetacelloRecordTarget.class.st
+++ b/src/Metacello-Core/MetacelloRecordTarget.class.st
@@ -10,12 +10,6 @@ Class {
 	#tag : 'Targets'
 }
 
-{ #category : 'accessing' }
-MetacelloRecordTarget >> actionLabel [
-
-	^'Recording '
-]
-
 { #category : 'private' }
 MetacelloRecordTarget >> atomicLoadPackages: packages ofSpec: spec [
 

--- a/src/Morphic-Base/JobProgressMorph.class.st
+++ b/src/Morphic-Base/JobProgressMorph.class.st
@@ -139,20 +139,17 @@ JobProgressMorph >> label [
 { #category : 'API' }
 JobProgressMorph >> label: aString [
 
-	self label isEmpty ifTrue: [
-		aString isEmptyOrNil
-			ifTrue: [ ^self ].
-		self removeAllMorphs.
-		self labelMorph contents: aString.
-		self updateLayout.
-		self changed: #width ].
+	self label = aString ifTrue: [ ^ self ].
 
-	self labelMorph contents = aString
-		ifFalse: [
+	self label ifEmpty: [
+			aString isEmptyOrNil ifTrue: [ ^ self ].
+			self removeAllMorphs.
 			self labelMorph contents: aString.
-			aString isEmptyOrNil
-				ifTrue: [ self removeMorph: self labelMorph ].
-			self changed: #width ].
+			self updateLayout ].
+
+	aString isEmptyOrNil
+		ifTrue: [ self removeMorph: self labelMorph ]
+		ifFalse: [ self labelMorph contents: aString ].
 
 	self changed: #width
 ]
@@ -185,8 +182,35 @@ JobProgressMorph >> progress [
 JobProgressMorph >> progress: aNormalizedNumber [
 
 	bar progress = aNormalizedNumber ifFalse: [
-		bar progress: aNormalizedNumber.
-		self changed: #progressValue ]
+			bar progress: aNormalizedNumber.
+			self changed ]
+]
+
+{ #category : 'API' }
+JobProgressMorph >> progress: aNormalizedNumber label: aString [
+	"I am here to have a version updating only once the progress bar when we change label and progress. This method should call #change: or #change only once."
+
+	| changed |
+	changed := false.
+
+	bar progress = aNormalizedNumber ifFalse: [
+			bar progress: aNormalizedNumber.
+			changed := true ].
+
+	self label = aString
+		ifTrue: [ changed ifTrue: [ self changed ] ]
+		ifFalse: [
+				self label ifEmpty: [
+						aString isEmptyOrNil ifTrue: [ ^ self ].
+						self removeAllMorphs.
+						self labelMorph contents: aString.
+						self updateLayout ].
+
+				aString isEmptyOrNil
+					ifTrue: [ self removeMorph: self labelMorph ]
+					ifFalse: [ self labelMorph contents: aString ].
+
+				self changed: #width ]
 ]
 
 { #category : 'private' }

--- a/src/Morphic-Base/SystemProgressMorph.class.st
+++ b/src/Morphic-Base/SystemProgressMorph.class.st
@@ -176,13 +176,8 @@ SystemProgressMorph class >> uniqueInstance [
 
 { #category : 'job subscription' }
 SystemProgressMorph class >> updateJob: aJobChange [
-	| bars |
-	bars := self uniqueInstance bars.
-	bars isEmpty
-		ifFalse: [
-			bars last
-				label: aJobChange title;
-				progress: aJobChange progress ]
+
+	self uniqueInstance bars ifNotEmpty: [ :bars | bars last progress: aJobChange progress label: aJobChange title ]
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
+++ b/src/Refactoring-Core/RBCopyPackageRefactoring.class.st
@@ -59,19 +59,16 @@ RBCopyPackageRefactoring >> applicabilityPreconditions [
 { #category : 'preconditions' }
 RBCopyPackageRefactoring >> changeReferencesOf: classes with: copyClasses [
 
-	[ : job |
+	[ :job |
 		| jobIndex |
 		jobIndex := 1.
 		job max: classes size.
 		classes with: copyClasses do: [ :cls :copiedClass |
-			| rbClass |
-			job
-				currentValue: jobIndex;
-				title: 'Changing reference of ' , copiedClass printString.
-			rbClass := self model classNamed: cls.
-			self renameReferencesOf: rbClass with: copiedClass.
-			jobIndex := jobIndex + 1 ]
-	] asJob run
+				| rbClass |
+				job currentValue: jobIndex title: 'Changing reference of ' , copiedClass printString.
+				rbClass := self model classNamed: cls.
+				self renameReferencesOf: rbClass with: copiedClass.
+				jobIndex := jobIndex + 1 ] ] asJob run
 ]
 
 { #category : 'accessing' }
@@ -152,21 +149,22 @@ RBCopyPackageRefactoring >> renameReferencesOf: aClass1 with: aClass2 [
 ]
 
 { #category : 'preconditions' }
-RBCopyPackageRefactoring >> reparent: classes  with: copyClasses [
+RBCopyPackageRefactoring >> reparent: classes with: copyClasses [
 
-	[ : job | | jobIndex subclasses dict |
+	[ :job |
+		| jobIndex subclasses dict |
 		jobIndex := 1.
 		dict := Dictionary newFromKeys: classes andValues: copyClasses.
 		subclasses := copyClasses
-			collect: [ :cls | self model classNamed: cls]
-			thenSelect: [ :rb | classes includes: rb superclass name ].
+			              collect: [ :cls | self model classNamed: cls ]
+			              thenSelect: [ :rb | classes includes: rb superclass name ].
 		subclasses do: [ :cls |
-			self model reparentClasses: { cls } to: (self model classNamed: (dict at: cls superclass name)).
-			job
-				currentValue: jobIndex;
-				title: (String streamContents: [ : stream | stream << 'Reparent class '; << cls printString ]).
-			jobIndex := jobIndex + 1 ]
-		] asJob run
+				self model reparentClasses: { cls } to: (self model classNamed: (dict at: cls superclass name)).
+				job currentValue: jobIndex title: (String streamContents: [ :stream |
+							 stream
+								 << 'Reparent class ';
+								 << cls printString ]).
+				jobIndex := jobIndex + 1 ] ] asJob run
 ]
 
 { #category : 'storing' }

--- a/src/System-Settings-Browser/SettingBrowser.class.st
+++ b/src/System-Settings-Browser/SettingBrowser.class.st
@@ -412,26 +412,18 @@ SettingBrowser >> exportAllSettings: actions by: groupSize withBasename: aString
 SettingBrowser >> exportSettings [
 
 	| nodes actions |
-
 	nodes := self treeHolder nodeList.
-	[: job | 
-		| title  |
+	[ :job |
+		| title |
 		title := 'Exporting settings'.
 		job title: title.
-		1 to: nodes size do: [ : each |
-			actions := nodes collectWithIndex: [ : e : i |
-			job
-				progress: i;
-				title: (String streamContents: [:s |
-					s << title << ' (' << (e item label) << ')']).			
-				e item exportSettingAction ] ] 
-	]  asJob run.
+		1 to: nodes size do: [ :each |
+				actions := nodes collectWithIndex: [ :e :i |
+						           job progress: i title: (String streamContents: [ :s | s << title << ' (' << e item label << ')' ]).
+						           e item exportSettingAction ] ] ] asJob run.
 
-	actions := actions reject: [:e | e isNil ].
-	self 
-		exportAllSettings: actions 
-		by: 50 
-		withBasename: 'exported_settings'
+	actions := actions reject: [ :e | e isNil ].
+	self exportAllSettings: actions by: 50 withBasename: 'exported_settings'
 ]
 
 { #category : 'export' }

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -181,13 +181,12 @@ PharoChangesCondenser >> swapSourcePointerOfMethod: method [
 
 { #category : 'private - 2 swapping' }
 PharoChangesCondenser >> swapSourcePointers [
-	job
-		title: 'Swapping source pointers';
-		currentValue: 0.
+
+	job currentValue: 0 title: 'Swapping source pointers'.
 
 	Smalltalk allClassesAndTraitsDo: [ :classOrTrait |
-		job increment.
-		self swapSourcePointerOfClassOrTrait: classOrTrait ]
+			job increment.
+			self swapSourcePointerOfClassOrTrait: classOrTrait ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Fixes #2815

The progress bars done via Jobs in Pharo can update themselves only once every 60ms to not spam the UI but this causes some weird behavior. If we set the label and the progress of a job in two calls, the second one is ignore until we update the job once again because of the refresh rate.

Ideally, jobs should have a queue of updates instead of accepting updates only once every 60ms but it would be too long for me to learn to do that. I'm proposing an alternative with an API to update both the progress and the title at the same time. I also update #do:displayingProgress:every: in order to fix this bug