### PR TITLE
Move loading of Network-MIME out of Monticello

### DIFF
--- a/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
+++ b/src/BaselineOfBasicTools/BaselineOfBasicTools.class.st
@@ -66,8 +66,8 @@ BaselineOfBasicTools >> baseline: spec [
 			spec package: 'System-Sources-Tests'. "<= Not sure this one should be here but it is where the classes were loaded before been extracted from Tests package."
 
 			spec package: 'ClassDefinitionPrinters-Tests'.
+			spec package: 'Network-MIME'.
 			spec package: 'Network-Mail'.
-			spec package: 'Network-Mail-Tests'.
 
 			spec package: 'OpalCompiler-ToolFeatures'.
 			spec package: 'OpalCompiler-ToolFeatures-Tests'.

--- a/src/BaselineOfMonticello/BaselineOfMonticello.class.st
+++ b/src/BaselineOfMonticello/BaselineOfMonticello.class.st
@@ -40,7 +40,6 @@ BaselineOfMonticello >> baseline: spec [
 			
 			package: 'Network-Kernel';
 			package: 'Network-Protocols';
-			package: 'Network-MIME';
 			package: 'Zinc-Resource-Meta-Core';
 			package: 'Zinc-HTTP';
 			package: 'MonticelloRemoteRepositories';
@@ -57,6 +56,6 @@ BaselineOfMonticello >> baseline: spec [
 
 		spec 
 			group: 'Core' with: #('Ring-Definitions-Core' 'Ring-OldChunkImporter' 'Jobs' 'Random-Core' 'System-Hashing' 'Compression' 'Monticello-Model' 'Monticello' 'STON-Core' 'MonticelloFileTree-Core' 'Ring-Definitions-Monticello');
-			group: 'RemoteRepositories' with: #( 'Network-Kernel' 'Network-Protocols' 'Network-MIME' 'Zinc-Resource-Meta-Core' 'Zinc-HTTP' 'MonticelloRemoteRepositories' 'Zodiac-Core' );
+			group: 'RemoteRepositories' with: #( 'Network-Kernel' 'Network-Protocols' 'Zinc-Resource-Meta-Core' 'Zinc-HTTP' 'MonticelloRemoteRepositories' 'Zodiac-Core' );
 			group: 'Tests' with: #( 'Compression-Tests' 'Jobs-Tests' 'Random-Tests' 'Ring-Definitions-Core-Tests' 'Monticello-Tests' 'MonticelloMocks' 'Ring-Definitions-Monticello-Tests' 'Ring-Definitions-Tests-Containers') ].
 ]


### PR DESCRIPTION
Currently this package is loaded by hermes in Monticello but it is not used by it. I propose to load it with Network-Mail. I also remove the loading of a test package that was loaded twice.