### PR TITLE
The max time limit of a test cannot be 0

### DIFF
--- a/src/SUnit-Core/DefaultExecutionEnvironment.extension.st
+++ b/src/SUnit-Core/DefaultExecutionEnvironment.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : 'DefaultExecutionEnvironment' }
 
 { #category : '*SUnit-Core' }
-DefaultExecutionEnvironment >> maxTimeForTest: aDuration [
-
-	"just for compatibility with TestExecutionEnvironment, do nothing"
-]
-
-{ #category : '*SUnit-Core' }
 DefaultExecutionEnvironment >> runTestCase: aTestCase [
 
 	| testEnv |

--- a/src/SUnit-Core/ExecutionEnvironment.extension.st
+++ b/src/SUnit-Core/ExecutionEnvironment.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : 'ExecutionEnvironment' }
 
 { #category : '*SUnit-Core' }
+ExecutionEnvironment >> maxTimeForTest: aDuration [
+	"just for compatibility with TestExecutionEnvironment"
+
+	
+]
+
+{ #category : '*SUnit-Core' }
 ExecutionEnvironment >> runTestCase: aTestCase [
 
 	self subclassResponsibility

--- a/src/SUnit-Core/TestExecutionEnvironment.class.st
+++ b/src/SUnit-Core/TestExecutionEnvironment.class.st
@@ -238,10 +238,12 @@ TestExecutionEnvironment >> maxTimeForTest [
 
 { #category : 'accessing' }
 TestExecutionEnvironment >> maxTimeForTest: aDuration [
+
+	aDuration < 0.5 second ifTrue: [
+			self error:
+				'The maximum time limit of a test cannot be inferior to 0.5second because a watchdog process of the test is running in testing environment with high timing priority which requires a sleep time to time to allow other processed to run. If the watch dog does not have the time to sleep, the image will crash.' ].
 	maxTimeForTest := aDuration.
-	watchDogSemaphore ifNotNil: [
-		"we need restart watch dog timer for new timeout"
-		watchDogSemaphore signal ]
+	watchDogSemaphore ifNotNil: [ "we need restart watch dog timer for new timeout" watchDogSemaphore signal ]
 ]
 
 { #category : 'controlling' }

--- a/src/SUnit-Core/TestExecutionEnvironment.class.st
+++ b/src/SUnit-Core/TestExecutionEnvironment.class.st
@@ -239,9 +239,9 @@ TestExecutionEnvironment >> maxTimeForTest [
 { #category : 'accessing' }
 TestExecutionEnvironment >> maxTimeForTest: aDuration [
 
-	aDuration < 0.5 second ifTrue: [
+	aDuration < 0.1 second ifTrue: [
 			self error:
-				'The maximum time limit of a test cannot be inferior to 0.5second because a watchdog process of the test is running in testing environment with high timing priority which requires a sleep time to time to allow other processed to run. If the watch dog does not have the time to sleep, the image will crash.' ].
+				'The maximum time limit of a test cannot be inferior to 0.1second because a watchdog process of the test is running in testing environment with high timing priority which requires a sleep time to time to allow other processed to run. If the watch dog does not have the time to sleep, the image will crash.' ].
 	maxTimeForTest := aDuration.
 	watchDogSemaphore ifNotNil: [ "we need restart watch dog timer for new timeout" watchDogSemaphore signal ]
 ]

--- a/src/SUnit-Tests/SUnitTest.class.st
+++ b/src/SUnit-Tests/SUnitTest.class.st
@@ -126,11 +126,11 @@ SUnitTest >> hangedChildProcessTest [
 
 { #category : 'private' }
 SUnitTest >> hangedTestDueToFailedChildProcess [
-	self timeLimit: 10 milliSeconds.
+	self timeLimit: 100 milliSeconds.
 
 	self failedChildProcessTest.
 
-	20 milliSeconds wait
+	150 milliSeconds wait
 ]
 
 { #category : 'accessing' }
@@ -636,11 +636,6 @@ SUnitTest >> testRunningLongTime [
 ]
 
 { #category : 'testing' }
-SUnitTest >> testSelectorWithArg: anObject [
-	"should not result in error"
-]
-
-{ #category : 'testing' }
 SUnitTest >> testShould [
 
 	self
@@ -653,9 +648,9 @@ SUnitTest >> testShouldIgnoreTimeLimitWhenTestProcessIsSuspended [
 	"If you open debugger on test (by halt or error) and will not close it more then test time limit then following interaction with debugger will fail.
 	As simple fix watch dog should check that test process is not suspended. It of course will open possibility to hang test execution when tested code will suspend active process by incident. But we could live with it and probably it could be addressed too in future"
 	| testProcess |
-	self timeLimit: 30 milliSeconds.
+	self timeLimit: 100 milliSeconds.
 	testProcess := Processor activeProcess.
-	[ 50 milliSeconds wait. testProcess resume ] fork.
+	[ 150 milliSeconds wait. testProcess resume ] fork.
 	testProcess suspend.
 	self assert: true
 ]

--- a/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
+++ b/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
@@ -240,7 +240,7 @@ TestExecutionEnvironmentTest >> testIgnoreLongTestWhenItIsSuspendedAsUnderDebug 
 	testProcess := [
 		executionEnvironment activated.
 		[ self runTestWith: [
-				executionEnvironment maxTimeForTest: 10 milliSeconds.
+				executionEnvironment maxTimeForTest: 0.2 seconds.
 				Processor activeProcess suspend "it simulates the under debugger condition"]
 		] on: TestTookTooMuchTime do: [ :err | timeOutSignaled := true ]
 	] forkAt: Processor activePriority + 1.
@@ -294,7 +294,7 @@ TestExecutionEnvironmentTest >> testIsMainTestProcessFailed [
 
 { #category : 'tests' }
 TestExecutionEnvironmentTest >> testMaxTimeForTestCannotBeTooShort [
-	"The maximum time limit of a test cannot be inferior to 0.5second because a watchdog process of the test is running in testing environment with high timing priority which requires a sleep time to time to allow other processed to run. If the watch dog does not have the time to sleep, the image will crash."
+	"The maximum time limit of a test cannot be inferior to 0.1second because a watchdog process of the test is running in testing environment with high timing priority which requires a sleep time to time to allow other processed to run. If the watch dog does not have the time to sleep, the image will crash."
 
 	self should: [ executionEnvironment maxTimeForTest: 0 second ] raise: Error.
 	self should: [ executionEnvironment maxTimeForTest: -1 second ] raise: Error.
@@ -423,7 +423,7 @@ TestExecutionEnvironmentTest >> testRunningTooLongTest [
 	self
 		should: [
 			self runTestWith: [
-				executionEnvironment maxTimeForTest: 10 milliSeconds.
-				20 milliSeconds wait]]
+				executionEnvironment maxTimeForTest: 0.2 seconds.
+				0.3 seconds wait]]
 		raise: TestTookTooMuchTime
 ]

--- a/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
+++ b/src/SUnit-Tests/TestExecutionEnvironmentTest.class.st
@@ -293,6 +293,15 @@ TestExecutionEnvironmentTest >> testIsMainTestProcessFailed [
 ]
 
 { #category : 'tests' }
+TestExecutionEnvironmentTest >> testMaxTimeForTestCannotBeTooShort [
+	"The maximum time limit of a test cannot be inferior to 0.5second because a watchdog process of the test is running in testing environment with high timing priority which requires a sleep time to time to allow other processed to run. If the watch dog does not have the time to sleep, the image will crash."
+
+	self should: [ executionEnvironment maxTimeForTest: 0 second ] raise: Error.
+	self should: [ executionEnvironment maxTimeForTest: -1 second ] raise: Error.
+	self shouldnt: [ executionEnvironment maxTimeForTest: 1 second ] raise: Error
+]
+
+{ #category : 'tests' }
 TestExecutionEnvironmentTest >> testNotifyOnlyEnabledTestServices [
 	| testService2 testService3 |
 	testService disable.


### PR DESCRIPTION
If the time limit for a test is too short, the image will crash. To prevent that, I propose to raise an error if the time limit provided is less than 0.1sec

Fixes #6754