### PR TITLE
Speedup Package>>#mcWorkingCopy

### DIFF
--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -95,9 +95,15 @@ MCWorkingCopy class >> forPackage: aPackage [
 { #category : 'accessing' }
 MCWorkingCopy class >> forPackageNamed: aPackageName [
 
-	^ self registry values
-		  detect: [ :workingCopy | workingCopy packageName = aPackageName ]
-		  ifNone: [ NotFound signalFor: aPackageName in: self ]
+	^ self forPackageNamed: aPackageName ifNone: [ NotFound signalFor: aPackageName in: self ]
+]
+
+{ #category : 'accessing' }
+MCWorkingCopy class >> forPackageNamed: aPackageName ifNone: aBlock [
+
+	self registry valuesDo: [ :workingCopy | workingCopy packageName = aPackageName ifTrue: [ ^ workingCopy ] ].
+
+	^ aBlock value
 ]
 
 { #category : 'system changes' }

--- a/src/Monticello/MCWorkingCopy.class.st
+++ b/src/Monticello/MCWorkingCopy.class.st
@@ -81,9 +81,7 @@ MCWorkingCopy class >> ensureForPackageNamed: aPackageName [
 { #category : 'accessing' }
 MCWorkingCopy class >> ensureForPackageNamed: aPackageName packageOrganizer: aPackageOrganizer [
 
-	^ (self hasPackageNamed: aPackageName)
-		  ifTrue: [ self forPackageNamed: aPackageName ]
-		  ifFalse: [ self registerPackage: (MCPackage named: aPackageName) packageOrganizer: aPackageOrganizer ]
+	^ self forPackageNamed: aPackageName ifNone: [ self registerPackage: (MCPackage named: aPackageName) packageOrganizer: aPackageOrganizer ]
 ]
 
 { #category : 'accessing' }

--- a/src/Monticello/Package.extension.st
+++ b/src/Monticello/Package.extension.st
@@ -24,7 +24,5 @@ Package >> mcPackage [
 { #category : '*Monticello' }
 Package >> mcWorkingCopy [
 
-	^ (MCWorkingCopy hasPackageNamed: self name)
-		  ifTrue: [ MCWorkingCopy forPackageNamed: self name ]
-		  ifFalse: [ nil ]
+	^ MCWorkingCopy forPackageNamed: self name ifNone: [ nil ]
 ]


### PR DESCRIPTION
This method is called often from Monticello while listening to system announcements.

Here is a speed up.

```st
[ self packageOrganizer packages collect: #mcWorkingCopy ] bench.

"After: 357 iterations in 5 seconds 13 milliseconds. 71.215 per second"

"Before: 106 iterations in 5 seconds 26 milliseconds. 21.090 per second"
```

I also did the same for MCWorkingCopy class>>#ensureForPackageNamed:packageOrganizer:. But it is called only on PackageAdded announcement so it has way less impact.

But I am wondering, I have the impression that we are already listening to announcements in Iceberg, do we need to listen in two places?