### PR TITLE
Speed up MessageSend evaluation

### DIFF
--- a/src/Kernel/MessageSend.class.st
+++ b/src/Kernel/MessageSend.class.st
@@ -81,27 +81,24 @@ MessageSend >> collectArguments: anArgArray [
 ]
 
 { #category : 'evaluating' }
-MessageSend >> cull: arg [
+MessageSend >> cull: arg1 [
+
 	<reflection: 'Message sending and code execution - Runtime and Evaluation'>
-	^ selector numArgs = 0
-		ifTrue: [ self value ]
-		ifFalse: [ self value: arg ]
+	^ self valueWithEnoughArguments: { arg1 }
 ]
 
 { #category : 'evaluating' }
 MessageSend >> cull: arg1 cull: arg2 [
+
 	<reflection: 'Message sending and code execution - Runtime and Evaluation'>
-	^ selector numArgs < 2
-		ifTrue: [ self cull: arg1]
-		ifFalse: [ self value: arg1 value: arg2 ]
+	^ self valueWithEnoughArguments: { arg1. arg2 }
 ]
 
 { #category : 'evaluating' }
 MessageSend >> cull: arg1 cull: arg2 cull: arg3 [
+
 	<reflection: 'Message sending and code execution - Runtime and Evaluation'>
-	^ selector numArgs < 3
-		ifTrue: [ self cull: arg1 cull: arg2 ]
-		ifFalse: [ self value: arg1 value: arg2 value: arg3 ]
+	^ self valueWithEnoughArguments: { arg1. arg2. arg3 }
 ]
 
 { #category : 'comparing' }


### PR DESCRIPTION
MessageSend is used in some parts of the system such as the Announcement framework.

This change speeds up some evaluation methods of MessageSend.

#cull: is unchanged.
#cull:cull: is twice as fast (this is used by Announcer)
#cull:cull:cull: is 3 times faster

On my machine:

```st
message := MessageSend receiver: 1 selector: #+.
 
[ message cull: 2 ] bench.

"After: 17,149,377 iterations in 5 seconds 2 milliseconds. 3428503.998 per second"

"Before: 17,904,265 iterations in 5 seconds 2 milliseconds. 3579421.232 per second"

[ message cull: 2 cull: 3 ] bench.

"After: 19,578,441 iterations in 5 seconds 3 milliseconds. 3913340.196 per second"

"Before: 9,273,523 iterations in 5 seconds 4 milliseconds. 1853222.022 per second"


[ message cull: 2 cull: 3 cull: 4 ] bench.

"After: 19,206,897 iterations in 5 seconds 2 milliseconds. 3839843.463 per second"

"Before: 6,219,492 iterations in 5 seconds 3 milliseconds. 1243152.508 per second"
```