### PR TITLE
Rename class preview changes fix

### DIFF
--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -642,22 +642,30 @@ RBNamespace >> removeProtocolNamed: aString in: aClass [
 { #category : 'changes' }
 RBNamespace >> renameClass: aRBClass to: aSymbol around: aBlock [
 
-	| change value dict |
+	| change value dict oldChanges |
 	change := changeFactory renameClass: aRBClass to: aSymbol.
-	self perform: aBlock onlyWithChange: change.
+	changes addChange: change.
+	oldChanges := changes.
+	aBlock ensure: [ changes := oldChanges ].
 	self flushCaches.
+
 	dict := (newClasses includesKey: aRBClass name)
 		        ifTrue: [ newClasses ]
 		        ifFalse: [ changedClasses ].
+
 	self markAsRemoved: aRBClass name.
 	self unmarkAsRemoved: aSymbol.
+
 	value := dict at: aRBClass name.
 	dict removeKey: aRBClass name.
 	dict at: aSymbol put: value.
+
 	value first name: aSymbol.
 	value last name: aSymbol.
+
 	value first subclasses do: [ :each | each superclass: value first ].
 	value last subclasses do: [ :each | each superclass: value last ].
+
 	^ change
 ]
 

--- a/src/Refactoring-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRenameAndDeprecateClassTransformationTest.class.st
@@ -15,7 +15,7 @@ RBRenameAndDeprecateClassTransformationTest >> testTransform [
 		                  to: #RBRefactoringChangeMock2.
 	transformation generateChanges.
 
-	self assert: transformation model changes changes size equals: 3.
+	self assert: transformation model changes changes size equals: 12.
 
 	"old class"
 	class := transformation model classNamed: self changeMockClass name.

--- a/src/Refactoring-Transformations-Tests/RBTransformationsTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBTransformationsTest.class.st
@@ -353,7 +353,7 @@ RBTransformationsTest >> testRenameClassTransform [
 		                  to: newClassName.
 	transformation generateChanges.
 
-	self assert: transformation model changes changes size equals: 1.
+	self assert: transformation model changes changes size equals: 11.
 
 	class := transformation model classNamed: newClassName.
 	self


### PR DESCRIPTION
When renaming a class with multiple references before there was only one composite change with the whole changes. Now it is more convenient: we have 1 change for each method with the name Class>>selector so it is useful for the user. 
Fixes #19216