### PR TITLE
Speed up PackageTag>>#isEmpty and Package>>#sortTopologically:

### DIFF
--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -751,7 +751,7 @@ Package >> selectorsForClass: aClass [
 Package >> sortTopologically: allBehaviors [
 
 	| toSort sorted changed |
-	toSort := allBehaviors copy asOrderedCollection.
+	toSort := allBehaviors copy asSet.
 	sorted := OrderedCollection new.
 	changed := true.
 

--- a/src/Kernel-CodeModel/PackageTag.class.st
+++ b/src/Kernel-CodeModel/PackageTag.class.st
@@ -92,7 +92,7 @@ PackageTag >> initialize [
 
 { #category : 'testing' }
 PackageTag >> isEmpty [
-	^ self classNames isEmpty
+	^ self classes isEmpty
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
#isEmpty is called when removing a package and can take quite a while. There is no need to collect the class names to know if a packageTag is empty or not.

```st
tags := PackageTag allInstances.

[ tags collect: #isEmpty ] bench.

 "After: 66,264 iterations in 5 seconds 3 milliseconds. 13244.853 per second"

"Before: 1,260 iterations in 5 seconds 4 milliseconds. 251.799 per second"
```

=========================

Package>>#sortTopologically: is also taking a lot of time while removing a package but it can be made faster by using a Set instead of an OrderedCollection in it.

Before the change it was taking 3sec in my image to apply on a package of 5000 classes. After the change it takes 7ms