### PR TITLE
fix Replace Senders transformation

### DIFF
--- a/src/SystemCommands-MessageCommands/SycReplaceMessageCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycReplaceMessageCommand.class.st
@@ -78,3 +78,9 @@ SycReplaceMessageCommand >> refactoringClass [
 
 	^ RBReplaceMessageSendTransformation
 ]
+
+{ #category : 'execution' }
+SycReplaceMessageCommand >> resultMessageSelector [
+
+	^ newSelector selector
+]


### PR DESCRIPTION
It needed to implement `resultMessageSelector` in the command to work.

Fixes #19201