### PR TITLE
ClassDefinitionPrinter should not depend on Traits

### DIFF
--- a/src/ClassDefinitionPrinters/AbstractClassDefinitionCustomizer.class.st
+++ b/src/ClassDefinitionPrinters/AbstractClassDefinitionCustomizer.class.st
@@ -1,0 +1,41 @@
+"
+I am an abstract class to define the API of the definition customizers.
+
+A definition customizer allows to customize the printing of a class definition. It will be used for example by Traits to add traits to the class printing.
+"
+Class {
+	#name : 'AbstractClassDefinitionCustomizer',
+	#superclass : 'Object',
+	#category : 'ClassDefinitionPrinters',
+	#package : 'ClassDefinitionPrinters'
+}
+
+{ #category : 'internal' }
+AbstractClassDefinitionCustomizer class >> extendedFluidClassDefinitionFor: forClass on: stream [
+
+	self subclassResponsibility
+]
+
+{ #category : 'internal' }
+AbstractClassDefinitionCustomizer class >> fluidClassDefinitionFor: forClass on: stream [
+
+	self subclassResponsibility
+]
+
+{ #category : 'internal' }
+AbstractClassDefinitionCustomizer class >> fluidMetaclassDefinitionFor: forClass on: stream [
+
+	self subclassResponsibility
+]
+
+{ #category : 'internal' }
+AbstractClassDefinitionCustomizer class >> legacyClassDefinitionFor: forClass on: stream [
+
+	self subclassResponsibility
+]
+
+{ #category : 'internal' }
+AbstractClassDefinitionCustomizer class >> oldClassDefinitionFor: forClass on: stream [
+
+	self subclassResponsibility
+]

--- a/src/ClassDefinitionPrinters/ClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/ClassDefinitionPrinter.class.st
@@ -67,6 +67,12 @@ Class {
 }
 
 { #category : 'accessing' }
+ClassDefinitionPrinter class >> addCustomizer: aClass [
+
+	(self customizers includes: aClass) ifFalse: [ self customizers add: aClass ]
+]
+
+{ #category : 'accessing' }
 ClassDefinitionPrinter class >> customizers [
 	"I can be use to add classes to me that will be able to print more informations to the class definition.
 	For example, when Traits are in the system, they can add a customizer to print themselves"

--- a/src/ClassDefinitionPrinters/ClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/ClassDefinitionPrinter.class.st
@@ -139,13 +139,3 @@ ClassDefinitionPrinter >> for: aClass [
 ClassDefinitionPrinter >> metaclassDefinitionString [
 	^ self subclassResponsibility
 ]
-
-{ #category : 'public api' }
-ClassDefinitionPrinter >> traitDefinitionString [
-	^ self subclassResponsibility
-]
-
-{ #category : 'accessing' }
-ClassDefinitionPrinter >> traitedMetaclassDefinitionString [
-	^ self subclassResponsibility
-]

--- a/src/ClassDefinitionPrinters/ClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/ClassDefinitionPrinter.class.st
@@ -59,11 +59,20 @@ Class {
 		'forClass'
 	],
 	#classVars : [
+		'Customizers',
 		'DisplayEmptySlots'
 	],
 	#category : 'ClassDefinitionPrinters',
 	#package : 'ClassDefinitionPrinters'
 }
+
+{ #category : 'accessing' }
+ClassDefinitionPrinter class >> customizers [
+	"I can be use to add classes to me that will be able to print more informations to the class definition.
+	For example, when Traits are in the system, they can add a customizer to print themselves"
+
+	^ Customizers ifNil: [ Customizers := OrderedCollection new ]
+]
 
 { #category : 'configure' }
 ClassDefinitionPrinter class >> displayEmptySlots [

--- a/src/ClassDefinitionPrinters/FluidClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/FluidClassDefinitionPrinter.class.st
@@ -52,7 +52,7 @@ FluidClassDefinitionPrinter >> classDefinitionString [
 		  forClass classLayout isFixedLayout
 				ifFalse: [ self layoutOn: s ].
 
-			self traitsOn: s.
+			self class customizers do: [ :customizer | customizer fluidClassDefinitionFor: forClass on: s ].
 			self class displayEmptySlots
 				ifTrue: [ self slotsOn: s ]
 		  		ifFalse: [forClass slots ifNotEmpty: [ self slotsOn: s ]].
@@ -135,56 +135,43 @@ FluidClassDefinitionPrinter >> compactClassDefinitionTemplateInPackage: aPackage
 FluidClassDefinitionPrinter >> expandedDefinitionString [
 
 	^ String streamContents: [ :s | "in case of ProtoObject"
-		  forClass superclass
-			  ifNil: [ s nextPutAll: 'nil' ]
-			  ifNotNil: [ s nextPutAll: forClass superclass name ].
-		  self msgAndClassNameOn: s.
-		  self layoutOn: s.
-		  s crtab.
-		  s nextPutAll: 'traits: '.
-		  forClass hasTraitComposition
-			  ifTrue: [
-				  s
-					  nextPutAll: '{';
-					  nextPutAll: forClass traitCompositionString;
-					  nextPutAll: '};' ]
-			  ifFalse: [ s nextPutAll: '{};' ].
-		  self slotsOn: s.
-		  self sharedVariablesOn: s.
-		  self sharedPoolsOn: s.
-		  forClass packageTag isRoot
-			  ifTrue: [
-				  s
-					  crtab;
-					  nextPutAll: 'tag: '''';' ]
-			  ifFalse: [ self tagOn: s ].
-		  self packageOn: s ]
+			  forClass superclass
+				  ifNil: [ s nextPutAll: 'nil' ]
+				  ifNotNil: [ s nextPutAll: forClass superclass name ].
+			  self msgAndClassNameOn: s.
+			  self layoutOn: s.
+
+			  self class customizers do: [ :customizer | customizer extendedFluidClassDefinitionFor: forClass on: s ].
+			  self slotsOn: s.
+			  self sharedVariablesOn: s.
+			  self sharedPoolsOn: s.
+			  forClass packageTag isRoot
+				  ifTrue: [
+						  s
+							  crtab;
+							  nextPutAll: 'tag: '''';' ]
+				  ifFalse: [ self tagOn: s ].
+			  self packageOn: s ]
 ]
 
 { #category : 'expanded double dispatch API' }
 FluidClassDefinitionPrinter >> expandedMetaclassDefinitionString [
 
 	^ String streamContents: [ :s |
-		  forClass soleInstance = ProtoObject
-			  ifTrue: [ "we are on the class of ProtoObject class.
+			  forClass soleInstance = ProtoObject
+				  ifTrue: [ "we are on the class of ProtoObject class.
 				Yes this is strange but the fluid printer is printing
 				this."
-				  s nextPutAll: 'Class class << ProtoObject class' ]
-			  ifFalse: [
-				  s nextPutAll: forClass superclass name.
-				  s nextPutAll: ' << '.
-				  s nextPutAll: forClass name ].
-		  s crtab.
-		  forClass hasTraitComposition
-			  ifTrue: [
-				  s
-					  nextPutAll: 'traits: ';
-					  nextPutAll: forClass traitCompositionString;
-					  nextPutAll: ';' ]
-			  ifFalse: [ s nextPutAll: 'traits: {};' ].
-		  s crtab.
-		  s nextPutAll: 'slots: '.
-		  self slotDefinitionsOn: s ]
+					  s nextPutAll: 'Class class << ProtoObject class' ]
+				  ifFalse: [
+						  s nextPutAll: forClass superclass name.
+						  s nextPutAll: ' << '.
+						  s nextPutAll: forClass name ].
+
+			  self class customizers do: [ :customizer | customizer extendedFluidClassDefinitionFor: forClass on: s ].
+			  s crtab.
+			  s nextPutAll: 'slots: '.
+			  self slotDefinitionsOn: s ]
 ]
 
 { #category : 'elementary operations' }
@@ -193,19 +180,6 @@ FluidClassDefinitionPrinter >> lastSlotsOn: s [
 	s crtab.
 	s nextPutAll: 'slots: '.
 	self slotDefinitionsOn: s
-]
-
-{ #category : 'elementary operations' }
-FluidClassDefinitionPrinter >> lastTraitsOn: strm [
-	"uses: can the last part of a definition so watch out for terminating ;"
-
-	forClass hasTraitComposition ifTrue: [
-		strm
-			crtab;
-			nextPutAll: 'traits: {';
-			nextPutAll: forClass traitCompositionString;
-			nextPutAll: '}'.
-	forClass slots	ifNotEmpty: [ strm nextPutAll: ';' ] ]
 ]
 
 { #category : 'elementary operations' }
@@ -233,7 +207,7 @@ FluidClassDefinitionPrinter >> metaclassDefinitionString [
 									nextPutAll: 'Class class << ';
 									nextPutAll: forClass name ] ]
 			ifNil: [ strm nextPutAll: 'ProtoObject ' ].
-		self lastTraitsOn: strm.
+		self class customizers do: [ :customizer | customizer fluidMetaclassDefinitionFor: forClass on: strm ].
 		self class displayEmptySlots
 				ifTrue: [ self lastSlotsOn: strm ]
 		  		ifFalse: [forClass slots ifNotEmpty: [ self lastSlotsOn: strm ]]]
@@ -363,18 +337,4 @@ FluidClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aPackageNam
 			  nextPutAll: ''' ;';
 			  crtab;
 			  nextPutAll: 'package: ''' , aPackageName , '''' ]
-]
-
-{ #category : 'elementary operations' }
-FluidClassDefinitionPrinter >> traitsOn: strm [
-	"uses: can the last part of a definition so watch out for terminating ;"
-
-	forClass hasTraitComposition ifTrue: [
-		"forClass traitComposition innerClass = TEmpty ifTrue: [ ^ self ]."
-		"isEmpty traitComposition should probably moved to Trait."
-		strm
-			crtab;
-			nextPutAll: 'traits: {';
-			nextPutAll: forClass traitCompositionString;
-			nextPutAll: '};' ]
 ]

--- a/src/ClassDefinitionPrinters/FluidClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/FluidClassDefinitionPrinter.class.st
@@ -131,29 +131,6 @@ FluidClassDefinitionPrinter >> compactClassDefinitionTemplateInPackage: aPackage
 			  nextPutAll: '''' ]
 ]
 
-{ #category : 'template' }
-FluidClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aPackageName tag: aTagName [
-
-	^ String streamContents: [ :s |
-		  s
-			  nextPutAll: 'Trait << #TMyTrait';
-			  crtab;
-			  nextPutAll: 'traits: {};';
-			  crtab;
-			  nextPutAll: 'slots: {};';
-			  crtab.
-		  aTagName ifNotNil: [
-			  s
-				  nextPutAll: 'tag: ';
-				  print: aTagName;
-				  nextPutAll: ';';
-				  crtab ].
-		  s
-			  nextPutAll: 'package: ''';
-			  nextPutAll: aPackageName;
-			  nextPutAll: '''' ]
-]
-
 { #category : 'expanded double dispatch API' }
 FluidClassDefinitionPrinter >> expandedDefinitionString [
 
@@ -208,76 +185,6 @@ FluidClassDefinitionPrinter >> expandedMetaclassDefinitionString [
 		  s crtab.
 		  s nextPutAll: 'slots: '.
 		  self slotDefinitionsOn: s ]
-]
-
-{ #category : 'expanded double dispatch API' }
-FluidClassDefinitionPrinter >> expandedTraitClassDefinitionString [
-
-	^ String streamContents: [ :s |
-		  s nextPutAll: 'Trait << '.
-		  s nextPutAll: forClass name.
-
-		  s crtab.
-		  s nextPutAll: 'traits: '.
-		  forClass hasTraitComposition
-			  ifTrue: [
-				  s
-					  nextPutAll: '{';
-					  nextPutAll: forClass traitCompositionString;
-					  nextPutAll: '};' ]
-			  ifFalse: [ s nextPutAll: '{};' ].
-		  s crtab.
-		  s nextPutAll: 'slots: '.
-		  self slotDefinitionsOn: s ]
-]
-
-{ #category : 'expanded double dispatch API' }
-FluidClassDefinitionPrinter >> expandedTraitDefinitionString [
-
-	^ String streamContents: [ :s |
-		  | tag |
-		  s nextPutAll: 'Trait'.
-		  self msgAndClassNameOn: s.
-
-		  s crtab.
-		  s nextPutAll: 'traits: '.
-		  forClass hasTraitComposition
-			  ifTrue: [
-				  s
-					  nextPutAll: '{';
-					  nextPutAll: forClass traitCompositionString;
-					  nextPutAll: '};' ]
-			  ifFalse: [ s nextPutAll: '{};' ].
-		  self slotsOn: s.
-		  s crtab.
-
-		  forClass packageTag ifNotNil: [ :t |
-			  tag := t name.
-			  tag = forClass package name ifFalse: [
-				  s
-					  nextPutAll: 'tag: ';
-					  nextPut: $';
-					  nextPutAll: tag asString;
-					  nextPutAll: ''';'.
-				  s crtab ] ].
-
-		  s
-			  nextPutAll: 'package: ''';
-			  nextPutAll: forClass package name;
-			  nextPutAll: '''' ]
-]
-
-{ #category : 'definition double dispatch API' }
-FluidClassDefinitionPrinter >> expandedTraitedMetaclassDefinitionString [
-
-	^ String streamContents:
-		[:strm |
-		strm
-			nextPutAll: forClass superclass name;
-			nextPutAll: ' << ';
-			nextPutAll: forClass name.
-		self traitsOn: strm.
-		self lastSlotsOn: strm]
 ]
 
 { #category : 'elementary operations' }
@@ -456,53 +363,6 @@ FluidClassDefinitionPrinter >> testClassDefinitionTemplateInPackage: aPackageNam
 			  nextPutAll: ''' ;';
 			  crtab;
 			  nextPutAll: 'package: ''' , aPackageName , '''' ]
-]
-
-{ #category : 'definition double dispatch API' }
-FluidClassDefinitionPrinter >> traitDefinitionString [
-
-	^ String streamContents: [ :strm |
-			strm nextPutAll: 'Trait'.
-			self msgAndClassNameOn: strm.
-			self traitsOn: strm.
-
-		   forClass slots ifNotEmpty: [ self slotsOn: strm ].
-			self tagOn: strm.
-			self packageOn: strm ]
-]
-
-{ #category : 'template' }
-FluidClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName tag: aTagName named: aTraitName [
-
-	^ String streamContents: [ :s |
-		  s
-			  nextPutAll: 'Trait << ';
-			  print: aTraitName asSymbol;
-			  crtab;
-			  nextPutAll: 'traits: {};';
-			  crtab;
-			  nextPutAll: 'slots: {};';
-			  crtab;
-			  nextPutAll: 'tag: ''';
-			  nextPutAll: (aTagName ifNil: [ '' ]);
-			  nextPutAll: ''' ;';
-			  crtab;
-			  nextPutAll: 'package: ''';
-			  nextPutAll: aPackageName;
-			  nextPutAll: '''' ]
-]
-
-{ #category : 'definition double dispatch API' }
-FluidClassDefinitionPrinter >> traitedMetaclassDefinitionString [
-
-	^ String streamContents:
-		[:strm |
-		strm
-			nextPutAll: forClass superclass name;
-			nextPutAll: ' << ';
-			nextPutAll: forClass name.
-		self lastTraitsOn: strm.
-		forClass slots ifNotEmpty: [ self lastSlotsOn: strm ]]
 ]
 
 { #category : 'elementary operations' }

--- a/src/ClassDefinitionPrinters/LegacyClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/LegacyClassDefinitionPrinter.class.st
@@ -61,27 +61,3 @@ LegacyClassDefinitionPrinter >> metaclassDefinitionString [
 			nextPutAll: 'instanceVariableNames: ';
 			store: forClass instanceVariablesString ]
 ]
-
-{ #category : 'public API' }
-LegacyClassDefinitionPrinter >> traitDefinitionString [
-
-	^ String streamContents: [ :s |
-		s
-			nextPutAll: 'Trait named: ';
-			nextPutAll:	forClass name printString;
-			cr; tab;
-			nextPutAll: ' uses: ';
-			nextPutAll: forClass traitComposition traitCompositionExpression;
-			cr;
-			tab;
-			nextPutAll: ' package: ';
-			print: forClass category asString
-			"we do not want the # if category returns a symbol"
-	]
-]
-
-{ #category : 'public API' }
-LegacyClassDefinitionPrinter >> traitedMetaclassDefinitionString [
-
-	^ self metaclassDefinitionString
-]

--- a/src/ClassDefinitionPrinters/LegacyClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/LegacyClassDefinitionPrinter.class.st
@@ -12,6 +12,12 @@ Class {
 	#package : 'ClassDefinitionPrinters'
 }
 
+{ #category : 'internal' }
+LegacyClassDefinitionPrinter >> applyCustomizersOn: stream [
+
+	self class customizers do: [ :customizer | customizer legacyClassDefinitionFor: forClass on: stream ]
+]
+
 { #category : 'public API' }
 LegacyClassDefinitionPrinter >> classDefinitionString [
 
@@ -31,9 +37,7 @@ LegacyClassDefinitionPrinter >> classDefinitionString [
 		ifNotNil: [aStream nextPutAll: forClass superclass name].
 	aStream nextPutAll: forClass kindOfSubclass;
 			store: forClass name.
-	(forClass hasTraitComposition) ifTrue: [
-		aStream cr; tab; nextPutAll: 'uses: ';
-			nextPutAll: forClass traitCompositionString].
+	self applyCustomizersOn: aStream.
 	aStream cr; tab; nextPutAll: 'instanceVariableNames: ';
 			store: forClass instanceVariablesString.
 	aStream cr; tab; nextPutAll: 'classVariableNames: ';

--- a/src/ClassDefinitionPrinters/ManifestClassDefinitionPrinters.class.st
+++ b/src/ClassDefinitionPrinters/ManifestClassDefinitionPrinters.class.st
@@ -1,0 +1,17 @@
+"
+Please describe the package using the class comment of the included manifest class. The manifest class also includes other additional metadata for the package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : 'ManifestClassDefinitionPrinters',
+	#superclass : 'PackageManifest',
+	#category : 'ClassDefinitionPrinters-Manifest',
+	#package : 'ClassDefinitionPrinters',
+	#tag : 'Manifest'
+}
+
+{ #category : 'meta-data - dependency analyser' }
+ManifestClassDefinitionPrinters class >> manuallyResolvedDependencies [
+
+	<ignoreForCoverage>
+	^ #(#'Collections-Streams' #'Collections-Abstract')
+]

--- a/src/ClassDefinitionPrinters/OldPharoClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/OldPharoClassDefinitionPrinter.class.st
@@ -50,32 +50,6 @@ OldPharoClassDefinitionPrinter >> basicMetaclassDefinitionString [
 		  self instanceVariablesOn: stream ]
 ]
 
-{ #category : 'internal' }
-OldPharoClassDefinitionPrinter >> basicTraitDefinitionString [
-
-	"Pay attention this definition is fragile in presence of complex slots. Use the public API i.e., classDefinitionString"
-
-	forClass instanceSide name == #Trait ifTrue: [
-		^ self classDefinitionString ].
-
-	^ String streamContents: [ :s |
-		  s
-			  nextPutAll: 'Trait named: ';
-			  nextPutAll: forClass name printString.
-		  self traitCompositionOn: s.
-		  self instanceVariablesOn: s.
-		  self packageOn: s ]
-]
-
-{ #category : 'internal' }
-OldPharoClassDefinitionPrinter >> basicTraitedMetaclassDefinitionString [
-
-	^ String streamContents: [:strm |
-			strm print: forClass.
-			self traitCompositionOn: strm.
-			self instanceVariablesOn: strm ]
-]
-
 { #category : 'public API' }
 OldPharoClassDefinitionPrinter >> classDefinitionString [
 
@@ -141,20 +115,4 @@ OldPharoClassDefinitionPrinter >> traitCompositionOn: stream [
 			crtab;
 			nextPutAll: 'uses: ';
 			nextPutAll: forClass traitCompositionString ]
-]
-
-{ #category : 'public API' }
-OldPharoClassDefinitionPrinter >> traitDefinitionString [
-
-	^ forClass needsSlotClassDefinition
-		ifTrue: [ (ClassDefinitionPrinter fluid for: forClass) traitDefinitionString ]
-		ifFalse: [ self basicTraitDefinitionString ]
-]
-
-{ #category : 'public API' }
-OldPharoClassDefinitionPrinter >> traitedMetaclassDefinitionString [
-
-	^ forClass needsSlotClassDefinition
-		ifTrue: [ (ClassDefinitionPrinter fluid for: forClass) traitedMetaclassDefinitionString ]
-		ifFalse: [ self basicTraitedMetaclassDefinitionString ]
 ]

--- a/src/ClassDefinitionPrinters/OldPharoClassDefinitionPrinter.class.st
+++ b/src/ClassDefinitionPrinters/OldPharoClassDefinitionPrinter.class.st
@@ -12,8 +12,13 @@ Class {
 }
 
 { #category : 'internal' }
-OldPharoClassDefinitionPrinter >> basicClassDefinitionString [
+OldPharoClassDefinitionPrinter >> applyCustomizersOn: stream [
 
+	self class customizers do: [ :customizer | customizer oldClassDefinitionFor: forClass on: stream ]
+]
+
+{ #category : 'internal' }
+OldPharoClassDefinitionPrinter >> basicClassDefinitionString [
 	"Pay attention this definition is fragile in presence of complex slots. Use the public API i.e., classDefinitionString"
 
 	| stream |
@@ -24,19 +29,19 @@ OldPharoClassDefinitionPrinter >> basicClassDefinitionString [
 	stream
 		nextPutAll: forClass kindOfSubclass;
 		store: forClass name.
-	self traitCompositionOn: stream.
+	self applyCustomizersOn: stream.
 	self instanceVariablesOn: stream.
 	self classVariablesOn: stream.
 	self poolOn: stream.
 	self packageOn: stream.
 	forClass superclass ifNil: [
-		stream
-			nextPutAll: '.';
-			cr.
-		stream nextPutAll: forClass name.
-		stream
-			space;
-			nextPutAll: 'superclass: nil' ].
+			stream
+				nextPutAll: '.';
+				cr.
+			stream nextPutAll: forClass name.
+			stream
+				space;
+				nextPutAll: 'superclass: nil' ].
 	^ stream contents
 ]
 
@@ -105,14 +110,4 @@ OldPharoClassDefinitionPrinter >> poolOn: stream [
 			crtab;
 			nextPutAll: 'poolDictionaries: ';
 			store: poolString ]
-]
-
-{ #category : 'low-level elements' }
-OldPharoClassDefinitionPrinter >> traitCompositionOn: stream [
-
-	forClass hasTraitComposition ifTrue: [
-		stream
-			crtab;
-			nextPutAll: 'uses: ';
-			nextPutAll: forClass traitCompositionString ]
 ]

--- a/src/Traits/ClassDefinitionPrinter.extension.st
+++ b/src/Traits/ClassDefinitionPrinter.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'ClassDefinitionPrinter' }
+
+{ #category : '*Traits' }
+ClassDefinitionPrinter >> traitDefinitionString [
+	^ self subclassResponsibility
+]
+
+{ #category : '*Traits' }
+ClassDefinitionPrinter >> traitedMetaclassDefinitionString [
+	^ self subclassResponsibility
+]

--- a/src/Traits/FluidClassDefinitionPrinter.extension.st
+++ b/src/Traits/FluidClassDefinitionPrinter.extension.st
@@ -27,57 +27,42 @@ FluidClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aPackage
 FluidClassDefinitionPrinter >> expandedTraitClassDefinitionString [
 
 	^ String streamContents: [ :s |
-		  s nextPutAll: 'Trait << '.
-		  s nextPutAll: forClass name.
+			  s nextPutAll: 'Trait << '.
+			  s nextPutAll: forClass name.
 
-		  s crtab.
-		  s nextPutAll: 'traits: '.
-		  forClass hasTraitComposition
-			  ifTrue: [
-				  s
-					  nextPutAll: '{';
-					  nextPutAll: forClass traitCompositionString;
-					  nextPutAll: '};' ]
-			  ifFalse: [ s nextPutAll: '{};' ].
-		  s crtab.
-		  s nextPutAll: 'slots: '.
-		  self slotDefinitionsOn: s ]
+			  self class customizers do: [ :customizer | customizer extendedFluidClassDefinitionFor: forClass on: s ].
+			  s crtab.
+			  s nextPutAll: 'slots: '.
+			  self slotDefinitionsOn: s ]
 ]
 
 { #category : '*Traits' }
 FluidClassDefinitionPrinter >> expandedTraitDefinitionString [
 
 	^ String streamContents: [ :s |
-		  | tag |
-		  s nextPutAll: 'Trait'.
-		  self msgAndClassNameOn: s.
+			  | tag |
+			  s nextPutAll: 'Trait'.
+			  self msgAndClassNameOn: s.
 
-		  s crtab.
-		  s nextPutAll: 'traits: '.
-		  forClass hasTraitComposition
-			  ifTrue: [
-				  s
-					  nextPutAll: '{';
-					  nextPutAll: forClass traitCompositionString;
-					  nextPutAll: '};' ]
-			  ifFalse: [ s nextPutAll: '{};' ].
-		  self slotsOn: s.
-		  s crtab.
 
-		  forClass packageTag ifNotNil: [ :t |
-			  tag := t name.
-			  tag = forClass package name ifFalse: [
-				  s
-					  nextPutAll: 'tag: ';
-					  nextPut: $';
-					  nextPutAll: tag asString;
-					  nextPutAll: ''';'.
-				  s crtab ] ].
+			  self class customizers do: [ :customizer | customizer extendedFluidClassDefinitionFor: forClass on: s ].
+			  self slotsOn: s.
+			  s crtab.
 
-		  s
-			  nextPutAll: 'package: ''';
-			  nextPutAll: forClass package name;
-			  nextPutAll: '''' ]
+			  forClass packageTag ifNotNil: [ :t |
+					  tag := t name.
+					  tag = forClass package name ifFalse: [
+							  s
+								  nextPutAll: 'tag: ';
+								  nextPut: $';
+								  nextPutAll: tag asString;
+								  nextPutAll: ''';'.
+							  s crtab ] ].
+
+			  s
+				  nextPutAll: 'package: ''';
+				  nextPutAll: forClass package name;
+				  nextPutAll: '''' ]
 ]
 
 { #category : '*Traits' }
@@ -89,7 +74,7 @@ FluidClassDefinitionPrinter >> expandedTraitedMetaclassDefinitionString [
 			nextPutAll: forClass superclass name;
 			nextPutAll: ' << ';
 			nextPutAll: forClass name.
-		self traitsOn: strm.
+		self class customizers do: [ :customizer | customizer fluidClassDefinitionFor: forClass on: strm ].
 		self lastSlotsOn: strm]
 ]
 
@@ -99,7 +84,7 @@ FluidClassDefinitionPrinter >> traitDefinitionString [
 	^ String streamContents: [ :strm |
 			strm nextPutAll: 'Trait'.
 			self msgAndClassNameOn: strm.
-			self traitsOn: strm.
+			self class customizers do: [ :customizer | customizer fluidClassDefinitionFor: forClass on: strm ].
 
 		   forClass slots ifNotEmpty: [ self slotsOn: strm ].
 			self tagOn: strm.
@@ -136,6 +121,7 @@ FluidClassDefinitionPrinter >> traitedMetaclassDefinitionString [
 			nextPutAll: forClass superclass name;
 			nextPutAll: ' << ';
 			nextPutAll: forClass name.
-		self lastTraitsOn: strm.
+		
+		self class customizers do: [ :customizer | customizer fluidMetaclassDefinitionFor: forClass on: strm ].
 		forClass slots ifNotEmpty: [ self lastSlotsOn: strm ]]
 ]

--- a/src/Traits/FluidClassDefinitionPrinter.extension.st
+++ b/src/Traits/FluidClassDefinitionPrinter.extension.st
@@ -1,0 +1,141 @@
+Extension { #name : 'FluidClassDefinitionPrinter' }
+
+{ #category : '*Traits' }
+FluidClassDefinitionPrinter >> compactTraitDefinitionTemplateInPackage: aPackageName tag: aTagName [
+
+	^ String streamContents: [ :s |
+		  s
+			  nextPutAll: 'Trait << #TMyTrait';
+			  crtab;
+			  nextPutAll: 'traits: {};';
+			  crtab;
+			  nextPutAll: 'slots: {};';
+			  crtab.
+		  aTagName ifNotNil: [
+			  s
+				  nextPutAll: 'tag: ';
+				  print: aTagName;
+				  nextPutAll: ';';
+				  crtab ].
+		  s
+			  nextPutAll: 'package: ''';
+			  nextPutAll: aPackageName;
+			  nextPutAll: '''' ]
+]
+
+{ #category : '*Traits' }
+FluidClassDefinitionPrinter >> expandedTraitClassDefinitionString [
+
+	^ String streamContents: [ :s |
+		  s nextPutAll: 'Trait << '.
+		  s nextPutAll: forClass name.
+
+		  s crtab.
+		  s nextPutAll: 'traits: '.
+		  forClass hasTraitComposition
+			  ifTrue: [
+				  s
+					  nextPutAll: '{';
+					  nextPutAll: forClass traitCompositionString;
+					  nextPutAll: '};' ]
+			  ifFalse: [ s nextPutAll: '{};' ].
+		  s crtab.
+		  s nextPutAll: 'slots: '.
+		  self slotDefinitionsOn: s ]
+]
+
+{ #category : '*Traits' }
+FluidClassDefinitionPrinter >> expandedTraitDefinitionString [
+
+	^ String streamContents: [ :s |
+		  | tag |
+		  s nextPutAll: 'Trait'.
+		  self msgAndClassNameOn: s.
+
+		  s crtab.
+		  s nextPutAll: 'traits: '.
+		  forClass hasTraitComposition
+			  ifTrue: [
+				  s
+					  nextPutAll: '{';
+					  nextPutAll: forClass traitCompositionString;
+					  nextPutAll: '};' ]
+			  ifFalse: [ s nextPutAll: '{};' ].
+		  self slotsOn: s.
+		  s crtab.
+
+		  forClass packageTag ifNotNil: [ :t |
+			  tag := t name.
+			  tag = forClass package name ifFalse: [
+				  s
+					  nextPutAll: 'tag: ';
+					  nextPut: $';
+					  nextPutAll: tag asString;
+					  nextPutAll: ''';'.
+				  s crtab ] ].
+
+		  s
+			  nextPutAll: 'package: ''';
+			  nextPutAll: forClass package name;
+			  nextPutAll: '''' ]
+]
+
+{ #category : '*Traits' }
+FluidClassDefinitionPrinter >> expandedTraitedMetaclassDefinitionString [
+
+	^ String streamContents:
+		[:strm |
+		strm
+			nextPutAll: forClass superclass name;
+			nextPutAll: ' << ';
+			nextPutAll: forClass name.
+		self traitsOn: strm.
+		self lastSlotsOn: strm]
+]
+
+{ #category : '*Traits' }
+FluidClassDefinitionPrinter >> traitDefinitionString [
+
+	^ String streamContents: [ :strm |
+			strm nextPutAll: 'Trait'.
+			self msgAndClassNameOn: strm.
+			self traitsOn: strm.
+
+		   forClass slots ifNotEmpty: [ self slotsOn: strm ].
+			self tagOn: strm.
+			self packageOn: strm ]
+]
+
+{ #category : '*Traits' }
+FluidClassDefinitionPrinter >> traitDefinitionTemplateInPackage: aPackageName tag: aTagName named: aTraitName [
+
+	^ String streamContents: [ :s |
+		  s
+			  nextPutAll: 'Trait << ';
+			  print: aTraitName asSymbol;
+			  crtab;
+			  nextPutAll: 'traits: {};';
+			  crtab;
+			  nextPutAll: 'slots: {};';
+			  crtab;
+			  nextPutAll: 'tag: ''';
+			  nextPutAll: (aTagName ifNil: [ '' ]);
+			  nextPutAll: ''' ;';
+			  crtab;
+			  nextPutAll: 'package: ''';
+			  nextPutAll: aPackageName;
+			  nextPutAll: '''' ]
+]
+
+{ #category : '*Traits' }
+FluidClassDefinitionPrinter >> traitedMetaclassDefinitionString [
+
+	^ String streamContents:
+		[:strm |
+		strm
+			nextPutAll: forClass superclass name;
+			nextPutAll: ' << ';
+			nextPutAll: forClass name.
+		self lastTraitsOn: strm.
+		forClass slots ifNotEmpty: [ self lastSlotsOn: strm ]]
+]

--- a/src/Traits/LegacyClassDefinitionPrinter.extension.st
+++ b/src/Traits/LegacyClassDefinitionPrinter.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : 'LegacyClassDefinitionPrinter' }
+
+{ #category : '*Traits' }
+LegacyClassDefinitionPrinter >> traitDefinitionString [
+
+	^ String streamContents: [ :s |
+		s
+			nextPutAll: 'Trait named: ';
+			nextPutAll:	forClass name printString;
+			cr; tab;
+			nextPutAll: ' uses: ';
+			nextPutAll: forClass traitComposition traitCompositionExpression;
+			cr;
+			tab;
+			nextPutAll: ' package: ';
+			print: forClass category asString
+			"we do not want the # if category returns a symbol"
+	]
+]
+
+{ #category : '*Traits' }
+LegacyClassDefinitionPrinter >> traitedMetaclassDefinitionString [
+
+	^ self metaclassDefinitionString
+]

--- a/src/Traits/OldPharoClassDefinitionPrinter.extension.st
+++ b/src/Traits/OldPharoClassDefinitionPrinter.extension.st
@@ -1,0 +1,43 @@
+Extension { #name : 'OldPharoClassDefinitionPrinter' }
+
+{ #category : '*Traits' }
+OldPharoClassDefinitionPrinter >> basicTraitDefinitionString [
+
+	"Pay attention this definition is fragile in presence of complex slots. Use the public API i.e., classDefinitionString"
+
+	forClass instanceSide name == #Trait ifTrue: [
+		^ self classDefinitionString ].
+
+	^ String streamContents: [ :s |
+		  s
+			  nextPutAll: 'Trait named: ';
+			  nextPutAll: forClass name printString.
+		  self traitCompositionOn: s.
+		  self instanceVariablesOn: s.
+		  self packageOn: s ]
+]
+
+{ #category : '*Traits' }
+OldPharoClassDefinitionPrinter >> basicTraitedMetaclassDefinitionString [
+
+	^ String streamContents: [:strm |
+			strm print: forClass.
+			self traitCompositionOn: strm.
+			self instanceVariablesOn: strm ]
+]
+
+{ #category : '*Traits' }
+OldPharoClassDefinitionPrinter >> traitDefinitionString [
+
+	^ forClass needsSlotClassDefinition
+		ifTrue: [ (ClassDefinitionPrinter fluid for: forClass) traitDefinitionString ]
+		ifFalse: [ self basicTraitDefinitionString ]
+]
+
+{ #category : '*Traits' }
+OldPharoClassDefinitionPrinter >> traitedMetaclassDefinitionString [
+
+	^ forClass needsSlotClassDefinition
+		ifTrue: [ (ClassDefinitionPrinter fluid for: forClass) traitedMetaclassDefinitionString ]
+		ifFalse: [ self basicTraitedMetaclassDefinitionString ]
+]

--- a/src/Traits/OldPharoClassDefinitionPrinter.extension.st
+++ b/src/Traits/OldPharoClassDefinitionPrinter.extension.st
@@ -2,28 +2,28 @@ Extension { #name : 'OldPharoClassDefinitionPrinter' }
 
 { #category : '*Traits' }
 OldPharoClassDefinitionPrinter >> basicTraitDefinitionString [
-
 	"Pay attention this definition is fragile in presence of complex slots. Use the public API i.e., classDefinitionString"
 
-	forClass instanceSide name == #Trait ifTrue: [
-		^ self classDefinitionString ].
+	forClass instanceSide name == #Trait ifTrue: [ ^ self classDefinitionString ].
 
 	^ String streamContents: [ :s |
-		  s
-			  nextPutAll: 'Trait named: ';
-			  nextPutAll: forClass name printString.
-		  self traitCompositionOn: s.
-		  self instanceVariablesOn: s.
-		  self packageOn: s ]
+			  s
+				  nextPutAll: 'Trait named: ';
+				  nextPutAll: forClass name printString.
+
+			  self applyCustomizersOn: s.
+			  self instanceVariablesOn: s.
+			  self packageOn: s ]
 ]
 
 { #category : '*Traits' }
 OldPharoClassDefinitionPrinter >> basicTraitedMetaclassDefinitionString [
 
-	^ String streamContents: [:strm |
-			strm print: forClass.
-			self traitCompositionOn: strm.
-			self instanceVariablesOn: strm ]
+	^ String streamContents: [ :strm |
+			  strm print: forClass.
+
+			  self applyCustomizersOn: strm.
+			  self instanceVariablesOn: strm ]
 ]
 
 { #category : '*Traits' }

--- a/src/Traits/TraitClassDefinitionCustomizer.class.st
+++ b/src/Traits/TraitClassDefinitionCustomizer.class.st
@@ -1,0 +1,79 @@
+"
+I am used to customize the ClassDefinitionPrinter to print informations about traits
+
+"
+Class {
+	#name : 'TraitClassDefinitionCustomizer',
+	#superclass : 'AbstractClassDefinitionCustomizer',
+	#category : 'Traits',
+	#package : 'Traits'
+}
+
+{ #category : 'internal' }
+TraitClassDefinitionCustomizer class >> extendedFluidClassDefinitionFor: forClass on: stream [
+
+	stream crtab.
+	stream nextPutAll: 'traits: '.
+	forClass hasTraitComposition
+		ifTrue: [
+				stream
+					nextPutAll: '{';
+					nextPutAll: forClass traitCompositionString;
+					nextPutAll: '};' ]
+		ifFalse: [ stream nextPutAll: '{};' ]
+]
+
+{ #category : 'internal' }
+TraitClassDefinitionCustomizer class >> fluidClassDefinitionFor: forClass on: stream [
+	"uses: can the last part of a definition so watch out for terminating ;"
+
+	forClass hasTraitComposition ifTrue: [
+			"forClass traitComposition innerClass = TEmpty ifTrue: [ ^ self ]."
+			"isEmpty traitComposition should probably moved to Trait."
+			stream
+				crtab;
+				nextPutAll: 'traits: {';
+				nextPutAll: forClass traitCompositionString;
+				nextPutAll: '};' ]
+]
+
+{ #category : 'internal' }
+TraitClassDefinitionCustomizer class >> fluidMetaclassDefinitionFor: forClass on: stream [
+	"uses: can the last part of a definition so watch out for terminating ;"
+
+	forClass hasTraitComposition ifTrue: [
+			"forClass traitComposition innerClass = TEmpty ifTrue: [ ^ self ]."
+			"isEmpty traitComposition should probably moved to Trait."
+			stream
+				crtab;
+				nextPutAll: 'traits: {';
+				nextPutAll: forClass traitCompositionString;
+				nextPutAll: '};'.
+			forClass slots ifNotEmpty: [ stream nextPutAll: ';' ] ]
+]
+
+{ #category : 'class initialization' }
+TraitClassDefinitionCustomizer class >> initialize [
+
+	ClassDefinitionPrinter customizers add: self
+]
+
+{ #category : 'internal' }
+TraitClassDefinitionCustomizer class >> legacyClassDefinitionFor: forClass on: stream [
+
+	forClass hasTraitComposition ifTrue: [
+			stream
+				crtab;
+				nextPutAll: 'uses: ';
+				nextPutAll: forClass traitCompositionString ]
+]
+
+{ #category : 'internal' }
+TraitClassDefinitionCustomizer class >> oldClassDefinitionFor: forClass on: stream [
+
+	forClass hasTraitComposition ifTrue: [
+			stream
+				crtab;
+				nextPutAll: 'uses: ';
+				nextPutAll: forClass traitCompositionString ]
+]

--- a/src/Traits/TraitClassDefinitionCustomizer.class.st
+++ b/src/Traits/TraitClassDefinitionCustomizer.class.st
@@ -55,7 +55,7 @@ TraitClassDefinitionCustomizer class >> fluidMetaclassDefinitionFor: forClass on
 { #category : 'class initialization' }
 TraitClassDefinitionCustomizer class >> initialize [
 
-	ClassDefinitionPrinter customizers add: self
+	ClassDefinitionPrinter addCustomizer: self
 ]
 
 { #category : 'internal' }


### PR DESCRIPTION
ClassDefinitionPrinter are now loaded with the kernel. They are present when traits are not present in the system, but they still manage traits in the printing. 

This change is here to remove this dependency. This is done in 2 ways:
- Move some methods as extensions of Traits
- Introduce a customizer and create a Trait customizer to be able to customize the class printing

With this ClassDefinitionPrinter will not depend on Traits anymore and I should be able to progress with the sources cleaning