### PR TITLE
Rename messages into methods in message browser

### DIFF
--- a/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
+++ b/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
@@ -23,11 +23,11 @@ Class {
 	#name : 'ClyOldMessageBrowserAdapter',
 	#superclass : 'Object',
 	#instVars : [
-		'messages',
 		'title',
 		'autoSelect',
 		'refreshingBlock',
-		'openedBrowser'
+		'openedBrowser',
+		'methods'
 	],
 	#category : 'Calypso-SystemTools-OldToolCompatibillity',
 	#package : 'Calypso-SystemTools-OldToolCompatibillity'
@@ -42,15 +42,16 @@ ClyOldMessageBrowserAdapter class >> beDefaultBrowser [
 
 { #category : 'opening' }
 ClyOldMessageBrowserAdapter class >> browse: methods [
+
 	^ self new
-		messages: methods;
-		open
+		  methods: methods;
+		  open
 ]
 
 { #category : 'opening' }
 ClyOldMessageBrowserAdapter class >> browse: methods title: aString [
 	^ self new
-		messages: methods;
+		methods: methods;
 		title: aString;
 		open
 ]
@@ -58,7 +59,7 @@ ClyOldMessageBrowserAdapter class >> browse: methods title: aString [
 { #category : 'opening' }
 ClyOldMessageBrowserAdapter class >> browse: methods title: aString autoSelect: aSelectString [
 	^ self new
-		messages: methods;
+		methods: methods;
 		title: aString;
 		autoSelect: aSelectString;
 		open
@@ -119,25 +120,25 @@ ClyOldMessageBrowserAdapter >> initialize [
 ]
 
 { #category : 'accessing' }
-ClyOldMessageBrowserAdapter >> messages [
-	^ messages
+ClyOldMessageBrowserAdapter >> methods [
+	^ methods
 ]
 
 { #category : 'accessing' }
-ClyOldMessageBrowserAdapter >> messages: anObject [
-	messages := anObject
+ClyOldMessageBrowserAdapter >> methods: anObject [
+	methods := anObject
 ]
 
 { #category : 'opening' }
 ClyOldMessageBrowserAdapter >> open [
-	| query methods comments |
-	methods := messages
+	| query compiledMethods comments |
+	compiledMethods := methods
 		select: [:each | (each isRingObject and: [ each isMethod ]) or: [ each isCompiledMethod  ] ]
 		thenCollect: [ :each | each compiledMethod ].
-	comments := messages
+	comments := methods
 		select: [:each | each isRingObject and: [ each isComment  ]]
 		thenCollect: [ :each | ClyClassComment of: each realParent ].
-	query := ClyOldMessageBrowserQuery named: title with: methods asOrderedCollection, comments.
+	query := ClyOldMessageBrowserQuery named: title with: compiledMethods asOrderedCollection, comments.
 	query
 		criteriaString: autoSelect;
 		criteriaBlock: refreshingBlock.

--- a/src/Deprecated14/ClyOldMessageBrowserAdapter.extension.st
+++ b/src/Deprecated14/ClyOldMessageBrowserAdapter.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : 'ClyOldMessageBrowserAdapter' }
+
+{ #category : '*Deprecated14' }
+ClyOldMessageBrowserAdapter >> messages [
+
+	self deprecated: 'Use #methods instead' transformWith: '`@rcv messages' -> '`@rcv methods'.
+	^ methods
+]
+
+{ #category : '*Deprecated14' }
+ClyOldMessageBrowserAdapter >> messages: anObject [
+
+	self deprecated: 'Use #messages: instead' transformWith: '`@rcv messages: `@arg' -> '`@rcv methods: `@arg'.
+	methods := anObject
+]

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -252,17 +252,15 @@ SystemNavigation >> browseMessageList: messageList name: labelString autoSelect:
 
 { #category : '*Tool-Base' }
 SystemNavigation >> browseMessageList: messageList name: labelString autoSelect: autoSelectString refreshingBlock: aBlock [
-
 	"Create and schedule a MessageSet browser on the message list."
 
 	| methods |
 	"Do not show trait methods"
 	methods := messageList reject: [ :each | each isFromTrait ].
-	methods isEmpty ifTrue: [
-		^ InformativeNotification signal: 'There are no ' , String cr , labelString ].
+	methods isEmpty ifTrue: [ ^ InformativeNotification signal: 'There are no ' , String cr , labelString ].
 
 	^ (self tools toolNamed: #messageList) new
-		  messages: methods;
+		  methods: methods;
 		  title: labelString;
 		  autoSelect: autoSelectString;
 		  refreshingBlock: aBlock;


### PR DESCRIPTION
If we enable the StMethodBrowser we cannot open it because the current Message browser is using #messages: as API and the StMethodBrowser is using #methods:.

This change is renaming #messages: into #methods: so that we can use both browsers without crashing the tool