### PR TITLE
FileBrowser: Fix a bypass of the "open on last directory" option

### DIFF
--- a/src/Morphic-Base/UITheme.class.st
+++ b/src/Morphic-Base/UITheme.class.st
@@ -747,11 +747,15 @@ UITheme >> chooseDirectoryIn: aThemedMorph title: title path: path [
 	"Answer the result of a file dialog with the given title, choosing directories only."
 
 	| dialog |
-	dialog := self directoryDialogWindowClass new
-		          defaultFolder: (path ifNil: [ StFileSystemModel defaultDirectory ]);
-		          title: (title ifNil: [ 'Choose Directory' translated ]);
-		          openModal;
-		          yourself.
+	dialog := self directoryDialogWindowClass new.
+
+	path ifNotNil: [ dialog defaultFolder: path ].
+
+	dialog
+		title: (title ifNil: [ 'Choose Directory' translated ]);
+		openModal;
+		yourself.
+
 
 	^ dialog cancelled
 		  ifTrue: [ nil ]


### PR DESCRIPTION
FileBrowser has a setting to open on the last directory if we do not provide one at the opening. But this option is bypassed in UITheme.  This removes the bypass so that our option can work