### PR TITLE
Correct Smalltalk platform deprecation

### DIFF
--- a/src/Deprecated14/SmalltalkImage.extension.st
+++ b/src/Deprecated14/SmalltalkImage.extension.st
@@ -7,10 +7,10 @@ SmalltalkImage >> os [
 	^ OSPlatform current
 ]
 
-{ #category : '*System-Platforms' }
+{ #category : '*Deprecated14' }
 SmalltalkImage >> platform [
 	"Answer the object to query about os."
-
+	self deprecated: 'Use `OSPlatform current` instead'.
 	^ OSPlatform current
 ]
 

--- a/src/Morphic-Core/UserInputEvent.class.st
+++ b/src/Morphic-Core/UserInputEvent.class.st
@@ -129,7 +129,7 @@ UserInputEvent >> handler: anObject [
 { #category : 'modifier state' }
 UserInputEvent >> metaKeyPressed [
 
-	^ Smalltalk platform isMacOS
+	^ OSPlatform current isMacOS
 		  ifTrue: [ self commandKeyPressed ]
 		  ifFalse: [ self controlKeyPressed ]
 ]


### PR DESCRIPTION
Due to a bad rebase/merge, an extension ended up with an incorrect protocol.

Which is strange. The extension is in package X, but it should also have protocol `*X`!

Anyways, here's the fix