### PR TITLE
Move class initialization methods and shared variable accessor methods from CompiledMethod to CompiledCode

### DIFF
--- a/src/Kernel-CodeModel/CompiledCode.class.st
+++ b/src/Kernel-CodeModel/CompiledCode.class.st
@@ -39,12 +39,6 @@ Class {
 	#tag : 'Methods'
 }
 
-{ #category : 'class initialization' }
-CompiledCode class >> LargeFrame [
-
-	^ LargeFrame
-]
-
 { #category : 'instance creation' }
 CompiledCode class >> basicNew [
 
@@ -71,6 +65,27 @@ CompiledCode class >> basicNew: numberOfBytes header: headerWord [
 	ec == #'insufficient object memory' ifTrue:
 		[^self handleFailingNew: numberOfBytes header: headerWord].
 	^self primitiveFailed
+]
+
+{ #category : 'class initialization' }
+CompiledCode class >> checkBytecodeSetConflictsInMethodsWith: aBlock [
+
+	self allSubInstances
+		detect: aBlock
+		ifFound: [ Warning signal: 'There are existing CompiledMethods with a different encoderClass.' ]
+]
+
+{ #category : 'class initialization' }
+CompiledCode class >> checkIsValidBytecodeEncoder: aBytecodeEncoderSubclass [
+
+	(aBytecodeEncoderSubclass inheritsFrom: BytecodeEncoder) ifFalse:
+		[self error: 'A bytecode set encoder is expected to be a subclass of BytecodeEncoder']
+]
+
+{ #category : 'accessing' }
+CompiledCode class >> fullFrameSize [
+
+	^ LargeFrame
 ]
 
 { #category : 'private' }
@@ -117,6 +132,46 @@ CompiledCode class >> handleFailingNew: numberOfBytes header: headerWord [
 ]
 
 { #category : 'instance creation' }
+CompiledCode class >> headerFlagForEncoder: anEncoderClass [
+	anEncoderClass == PrimaryBytecodeSetEncoderClass ifTrue: [ ^ 0 ].
+	anEncoderClass == SecondaryBytecodeSetEncoderClass ifTrue: [ ^ SmallInteger minVal ].
+	self error: 'The encoder is not one of the two installed bytecode sets'
+]
+
+{ #category : 'class initialization' }
+CompiledCode class >> initialize [
+	"Initialize class variables specifying the size of the temporary frame
+	needed to run instances of me."
+
+	SmallFrame := 16.	"Context range for temps+stack"
+	LargeFrame := 56.
+	PrimaryBytecodeSetEncoderClass := nil. "Old encoder was removed"
+	SecondaryBytecodeSetEncoderClass := EncoderForSistaV1
+]
+
+{ #category : 'class initialization' }
+CompiledCode class >> installPrimaryBytecodeSet: aBytecodeEncoderSubclass [
+
+	PrimaryBytecodeSetEncoderClass == aBytecodeEncoderSubclass ifTrue:
+		[ ^self ].
+	self checkIsValidBytecodeEncoder: aBytecodeEncoderSubclass.
+	self checkBytecodeSetConflictsInMethodsWith: [:m|
+		m usesPrimaryBytecodeSet and: [m encoderClass ~~ aBytecodeEncoderSubclass]].
+	PrimaryBytecodeSetEncoderClass := aBytecodeEncoderSubclass
+]
+
+{ #category : 'class initialization' }
+CompiledCode class >> installSecondaryBytecodeSet: aBytecodeEncoderSubclass [
+
+	PrimaryBytecodeSetEncoderClass == aBytecodeEncoderSubclass ifTrue:
+		[ ^ self ].
+	self checkIsValidBytecodeEncoder: aBytecodeEncoderSubclass.
+	self checkBytecodeSetConflictsInMethodsWith: [ :m |
+		m usesSecondaryBytecodeSet and: [ m encoderClass ~~ aBytecodeEncoderSubclass ] ].
+	SecondaryBytecodeSetEncoderClass := aBytecodeEncoderSubclass
+]
+
+{ #category : 'instance creation' }
 CompiledCode class >> newFrom: aCompiledMethod [
 	"Create a method with the same bytecode and literals, but do not copy the source pointer, for a complete copy, use #clone"
 	| inst |
@@ -130,6 +185,12 @@ CompiledCode class >> newFrom: aCompiledMethod [
 	1 to: aCompiledMethod numLiterals do: [ :i | 
 		inst literalAt: i put: (aCompiledMethod literalAt: i)].
 	^ inst
+]
+
+{ #category : 'accessing' }
+CompiledCode class >> smallFrameSize [
+
+	^ SmallFrame
 ]
 
 { #category : 'constants' }

--- a/src/Kernel-CodeModel/CompiledMethod.class.st
+++ b/src/Kernel-CodeModel/CompiledMethod.class.st
@@ -21,20 +21,6 @@ CompiledMethod class >> abstractMarker [
 	^ #subclassResponsibility
 ]
 
-{ #category : 'class initialization' }
-CompiledMethod class >> checkBytecodeSetConflictsInMethodsWith: aBlock [
-
-	self allSubInstances
-		detect: aBlock
-		ifFound: [ Warning signal: 'There are existing CompiledMethods with a different encoderClass.' ]
-]
-
-{ #category : 'class initialization' }
-CompiledMethod class >> checkIsValidBytecodeEncoder: aBytecodeEncoderSubclass [
-	(aBytecodeEncoderSubclass inheritsFrom: BytecodeEncoder) ifFalse:
-		[self error: 'A bytecode set encoder is expected to be a subclass of BytecodeEncoder']
-]
-
 { #category : 'constants' }
 CompiledMethod class >> conflictMarker [
 	^ #traitConflict
@@ -48,49 +34,6 @@ CompiledMethod class >> disabledMarker [
 { #category : 'constants' }
 CompiledMethod class >> explicitRequirementMarker [
 	^ #explicitRequirement
-]
-
-{ #category : 'class initialization' }
-CompiledMethod class >> fullFrameSize [  "CompiledMethod fullFrameSize"
-	^ LargeFrame
-]
-
-{ #category : 'instance creation' }
-CompiledMethod class >> headerFlagForEncoder: anEncoderClass [
-	anEncoderClass == PrimaryBytecodeSetEncoderClass ifTrue: [ ^ 0 ].
-	anEncoderClass == SecondaryBytecodeSetEncoderClass ifTrue: [ ^ SmallInteger minVal ].
-	self error: 'The encoder is not one of the two installed bytecode sets'
-]
-
-{ #category : 'class initialization' }
-CompiledMethod class >> initialize [    "CompiledMethod initialize"
-	"Initialize class variables specifying the size of the temporary frame
-	needed to run instances of me."
-
-	SmallFrame := 16.	"Context range for temps+stack"
-	LargeFrame := 56.
-	PrimaryBytecodeSetEncoderClass := nil. "Old encoder was removed"
-	SecondaryBytecodeSetEncoderClass := EncoderForSistaV1
-]
-
-{ #category : 'class initialization' }
-CompiledMethod class >> installPrimaryBytecodeSet: aBytecodeEncoderSubclass [
-	PrimaryBytecodeSetEncoderClass == aBytecodeEncoderSubclass ifTrue:
-		[ ^self ].
-	self checkIsValidBytecodeEncoder: aBytecodeEncoderSubclass.
-	self checkBytecodeSetConflictsInMethodsWith: [:m|
-		m usesPrimaryBytecodeSet and: [m encoderClass ~~ aBytecodeEncoderSubclass]].
-	PrimaryBytecodeSetEncoderClass := aBytecodeEncoderSubclass
-]
-
-{ #category : 'class initialization' }
-CompiledMethod class >> installSecondaryBytecodeSet: aBytecodeEncoderSubclass [
-	PrimaryBytecodeSetEncoderClass == aBytecodeEncoderSubclass ifTrue:
-		[ ^ self ].
-	self checkIsValidBytecodeEncoder: aBytecodeEncoderSubclass.
-	self checkBytecodeSetConflictsInMethodsWith: [ :m |
-		m usesSecondaryBytecodeSet and: [ m encoderClass ~~ aBytecodeEncoderSubclass ] ].
-	SecondaryBytecodeSetEncoderClass := aBytecodeEncoderSubclass
 ]
 
 { #category : 'accessing - class hierarchy' }
@@ -115,12 +58,6 @@ CompiledMethod class >> resetPragmaCache [
 
 	"Useful in bootstrap process"
 	self allInstancesDo: [ :method | method cachePragmas ]
-]
-
-{ #category : 'class initialization' }
-CompiledMethod class >> smallFrameSize [
-
-	^ SmallFrame
 ]
 
 { #category : 'constants' }

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -568,7 +568,7 @@ OCASTTranslator >> visitAnnotationMarkNode: aAnnotationValueNode [
 OCASTTranslator >> visitArrayNode: anArrayNode [
 
 	| elementNodes stackLimit |
-	stackLimit := CompiledCode LargeFrame min: self compilationContext encoderClass arraySizeLimitForPushArrayInstruction.
+	stackLimit := CompiledCode fullFrameSize min: self compilationContext encoderClass arraySizeLimitForPushArrayInstruction.
 	methodBuilder stackSize + anArrayNode statements size > stackLimit ifTrue: [ ^ self visitLargeArrayNode: anArrayNode ].
 
 	elementNodes := anArrayNode children.


### PR DESCRIPTION
PR for #18876.

* The initialization of the shared variables defined by CompiledCode has been moved from CompiledMethod to CompiledCode.
* The `LargeFrame` method has been removed, as there is already a `fullFrameSize` method to access the shared variable. The single sender of `LargeFrame` has been adapted.
* The methods `installPrimaryBytecodeSet:` and `installSecondaryBytecodeSet:` have no senders, but this PR does not remove them, as it is unclear whether it is safe to remove them.