### PR TITLE
Remove executable comments from deprecated methods.

### DIFF
--- a/src/Deprecated13-Kernel/Collection.extension.st
+++ b/src/Deprecated13-Kernel/Collection.extension.st
@@ -5,12 +5,6 @@ Collection >> asCommaString [
 
 	"Return collection printed as 'a, b, c' "
 
-	"#('a' 'b' 'c') asCommaString >>> 'a, b, c'"
-	"#('a') asCommaString >>> 'a'"
-	"#() asCommaString >>> ''"
-	"'foo' asCommaString >>> 'f, o, o'"
-	"(10 to: 25 by: 5) asCommaString >>> '10, 15, 20, 25'"
-
 	self deprecated: 'Use #join: instead'.
 
 	^ String streamContents: [ :s | self asStringOn: s delimiter: ', ' ]
@@ -20,12 +14,6 @@ Collection >> asCommaString [
 Collection >> asCommaStringAnd [
 
 	"Return collection printed as 'a, b and c' "
-
-	"#( 'a' 'b' 'c') asCommaStringAnd >>> 'a, b and c'"
-	"#('a') asCommaStringAnd >>> 'a'"
-	"#() asCommaStringAnd >>> ''"
-	"'foo' asCommaStringAnd >>> 'f, o and o'"
-	"(10 to: 25 by: 5) asCommaStringAnd >>> '10, 15, 20 and 25'"
 	
 	self deprecated: 'Use #join: instead'.
 
@@ -38,10 +26,6 @@ Collection >> asStringOn: aStream delimiter: delimString [
 	"Print elements on a stream separated
 	with a delimiter String like: 'a, b, c'
 	Uses #asString instead of #print:."
-
-	"(String streamContents: [:s|
-		'abcd' asStringOn: s delimiter: '->'])
-	>>> 'a->b->c->d'"
 	
 	self deprecated: 'Use #do:separatedBy: instead'.
 
@@ -60,10 +44,6 @@ Collection >> asStringOn: aStream delimiter: delimString last: lastDelimString [
 
 	Note: Feel free to improve the code to detect the last element."
 
-	"(String streamContents: [:s|
-		'abcd' asStringOn: s delimiter: ', ' last: ' and '])
-	>>> 'a, b, c and d'"
-
 	| n sz |
 	
 	self deprecated: 'Use #do:separatedBy: instead'.
@@ -81,10 +61,6 @@ Collection >> asStringOn: aStream delimiter: delimString last: lastDelimString [
 Collection >> printOn: aStream delimiter: delimString [
 	"Print elements on a stream separated
 	with a delimiter String like: 'a, b, c'"
-
-	"(String streamContents: [:s|
-		{ 10. 'hello'. $x } printOn: s delimiter: ', '])
-		>>> '10, ''hello'', $x'"
 		
 	self deprecated: 'Use #do:separatedBy: instead'.
 
@@ -96,10 +72,6 @@ Collection >> printOn: aStream delimiter: delimString last: lastDelimString [
 	"Print elements on a stream separated
 	with a delimiter between all the elements and with
 	a special one before the last like: 'a, b and c'"
-
-	"(String streamContents: [:s|
-		{ 10. 'hello'. $x } printOn: s delimiter: ', ' last: ' & '])
-		>>> '10, ''hello'' & $x'"
 
 	"Note: Feel free to improve the code to detect the last element."
 

--- a/src/Deprecated13-Kernel/ManifestDeprecated13Kernel.class.st
+++ b/src/Deprecated13-Kernel/ManifestDeprecated13Kernel.class.st
@@ -7,7 +7,7 @@ Class {
 	#superclass : 'PackageManifest',
 	#category : 'Deprecated13-Kernel-Manifest',
 	#package : 'Deprecated13-Kernel',
-	#tag: 'Manifest'
+	#tag : 'Manifest'
 }
 
 { #category : 'testing' }

--- a/src/Deprecated14-Kernel/String.extension.st
+++ b/src/Deprecated14-Kernel/String.extension.st
@@ -11,10 +11,6 @@ String >> asDate [
 String >> trimmed [
 	"Trim separators from both sides of the receiving string."
 
-	"'  hello  ' trimmed >>> 'hello'"
-	"'hello' trimmed >>> 'hello'"
-	"'' trimmed >>> ''"
-
 	self
 		backwardCompatible: 'Use trimBoth instead -> https://github.com/pharo-project/pharo/issues/18307'
 		on: '28 June 2025'


### PR DESCRIPTION
PR for #19269

The problem is that the test for running all executable comments evaluates executable comments of deprecated methods.

This PR removes the executable comments from deprecated methods and also from `String>>#trimmed`, which is marked with `#backwardCompatible:on:in:transformWith:`. This fix has been discussed with Stephane, Guille and Marcus.