### PR TITLE
Backport  #18989 to Pharo13: ByteArray related speedups

### DIFF
--- a/src/Collections-Native/ByteArray.class.st
+++ b/src/Collections-Native/ByteArray.class.st
@@ -58,21 +58,20 @@ ByteArray >> asByteArray [
 
 { #category : 'converting' }
 ByteArray >> asByteArrayOfSize: size [
-	"
-		'34523' asByteArray asByteArrayOfSize: 100.
 
-	(((
-		| repeats bytes |
-		repeats := 1000000.
-		bytes := '123456789123456789123456789123456789123456789123456789' asByteArray.
-		 [repeats timesRepeat: (bytes asByteArrayOfSize: 1024) ] timeToRun.
-	)))"
+	"(#[51 52 53] asByteArrayOfSize: 10 ) >>> #[0 0 0 0 0 0 0 51 52 53]"
+	"(#[51 52 53] asByteArrayOfSize: 3 ) >>> #[51 52 53]"
 
-	| bytes |
-	size < self size
+	| answer selfSize |
+	selfSize := self size.
+	size == selfSize ifTrue: [ ^self].
+
+	size < selfSize
 		ifTrue: [^ self error: 'bytearray bigger than ', size asString].
-	bytes := self asByteArray.
-	^ (ByteArray new: (size - bytes size)), bytes
+	
+	answer := ByteArray new: size.
+	answer replaceFrom: size - selfSize + 1 to: size with: self startingAt: 1.
+	^answer
 ]
 
 { #category : 'private' }
@@ -85,11 +84,12 @@ ByteArray >> asByteArrayPointer [
 ByteArray >> asInteger [
 	"Convert me to an Integer, network byte order, most significant byte first, big endian"
 
-	| integer |
+	| integer size |
+	size := self size.
 	integer := 0.
-	1 to: self size do: [ :index |
+	1 to: size do: [ :index |
 		"we use inlined to:do: instead of #withIndexDo:"
-		integer := integer + ((self at: index) bitShift: (self size - index) * 8) ].
+		integer := integer + ((self at: index) bitShift: (size - index) * 8) ].
 	^ integer
 ]
 

--- a/src/Collections-Strings/WideString.class.st
+++ b/src/Collections-Strings/WideString.class.st
@@ -57,12 +57,13 @@ WideString class >> fromString: aString [
 { #category : 'converting' }
 WideString >> asByteArray [
 	"Convert to a ByteArray with the ascii values of the string."
-	"'a' asByteArray >>> #[97]"
-	"'A' asByteArray >>> #[65]"
-	"'ABA' asByteArray >>> #[65 66 65]"
-	| b |
-	b := ByteArray new: self byteSize.
-	1 to: self size * 4 do: [:i |
+	"'a' asWideString asByteArray >>> #[0 0 0 97]"
+	"'A' asWideString asByteArray >>> #[0 0 0 65]"
+	
+	| b s |
+	s := self byteSize.
+	b := ByteArray new: s.
+	1 to: s do: [:i |
 		b at: i put: (self byteAt: i)].
 	^ b
 ]

--- a/src/Kernel/Integer.class.st
+++ b/src/Kernel/Integer.class.st
@@ -290,23 +290,43 @@ Integer >> anyMask: mask [
 
 { #category : 'converting - arrays' }
 Integer >> asByteArray [
+	"Answer a ByteArray with my value, most-significant byte first.
+	Warning: Sign is not encoded"
 
-	| stream |
-	stream := ByteArray new writeStream.
-	self bytesCount to: 1 by: -1 do: [:digitIndex |
-		stream nextPut: (self byteAt: digitIndex)].
-	^ stream contents
+	"1 asByteArray >>> #[1]"
+	"-1 asByteArray >>> #[1]"
+
+	| answer digitPos bytesCount |
+	bytesCount := self bytesCount.
+	answer := ByteArray new: bytesCount.
+	
+	digitPos := 1.
+	bytesCount
+		to: 1
+		by: -1
+		do: [ :pos |
+			answer
+				at: pos
+				put: (self byteAt: digitPos).
+			digitPos := digitPos + 1 ].
+	^ answer
 ]
 
 { #category : 'converting - arrays' }
 Integer >> asByteArrayOfSize: aSize [
-	"Answer a ByteArray of aSize with my value, most-significant byte first."
-	| answer digitPos |
-	aSize < self bytesCount ifTrue: [ self error: 'number to large for byte array' ].
+	"Answer a ByteArray of aSize with my value, most-significant byte first.
+	Warning: Sign is not encoded"
+	"(1 asByteArrayOfSize: 1) >>> #[1]"
+	"(-1 asByteArrayOfSize: 1) >>> #[1]"
+	
+	| answer digitPos bytesCount |
+	bytesCount := self bytesCount.
+	
+	aSize < bytesCount ifTrue: [ self error: 'number to large for byte array' ].
 	answer := ByteArray new: aSize.
 	digitPos := 1.
 	aSize
-		to: aSize - self bytesCount + 1
+		to: aSize - bytesCount + 1
 		by: -1
 		do:
 			[ :pos |


### PR DESCRIPTION
Backport  #18989:
- faster Integer>>#asByteArray do not use writeStream, but an optimized loop like #asByteArrayOfSize:
- little bit faster WideString>>#asByteArray calculate size once
- faster Integer>>#asByteArrayOfSize: by calling #bytesCount once
- faster ByteArray>>#asByteArrayOfSize: use primitive instead of concatenation (used by ByteArray>>#asIndexKeyOfSize:)
- little bit faster ByteArray>>#asInteger by calculating size once (and not in the loop)