### PR TITLE
AST-Core :  Changed the senders of allChildren to use withAllChildren

### DIFF
--- a/src/AST-Core-Tests/OCProgramNodeTest.class.st
+++ b/src/AST-Core-Tests/OCProgramNodeTest.class.st
@@ -214,7 +214,7 @@ OCProgramNodeTest >> testAllParents [
 	| me parentsOf7 |
 	[ :a | a + 7 ].
 	me := self class >> #testAllParents.
-	parentsOf7 := (me ast allChildren select: [ :n |
+	parentsOf7 := (me ast withAllChildren select: [ :n |
 		               n isLiteralNode and: [ n value = 7 ] ]) first
 		              allParents.
 	self assert: parentsOf7 last selector equals: #+.
@@ -1320,7 +1320,7 @@ OCProgramNodeTest >> testWithAllParents [
 	| me parentsOf7 |
 	[ :a | a + 7 ].
 	me := self class >> #testAllParents.
-	parentsOf7 := (me ast allChildren select: [ :n |
+	parentsOf7 := (me ast withAllChildren select: [ :n |
 		               n isLiteralNode and: [ n value = 7 ] ]) first
 		              withAllParents.
 	self assert: parentsOf7 last value equals: 7.

--- a/src/AST-Core/OCMethodNode.class.st
+++ b/src/AST-Core/OCMethodNode.class.st
@@ -138,13 +138,13 @@ OCMethodNode >> allDefinedVariables [
 { #category : 'iterating' }
 OCMethodNode >> allMessageNodes [
 
-	^ self allChildren select: [ :aNode | aNode isMessage ]
+	^ self withAllChildren select: [ :aNode | aNode isMessage ]
 ]
 
 { #category : 'iterating' }
 OCMethodNode >> allSequenceNodes [
 
-	^ self allChildren select: #isSequence
+	^ self withAllChildren select: #isSequence
 ]
 
 { #category : 'accessing' }

--- a/src/AST-Core/OCProgramNode.class.st
+++ b/src/AST-Core/OCProgramNode.class.st
@@ -120,17 +120,16 @@ OCProgramNode >> allArgumentVariables [
 
 { #category : 'iterating' }
 OCProgramNode >> allChildren [
-	| children |
-	children := OrderedCollection new.
-	self nodesDo: [ :each | children addLast: each ].
-	^ children
+	" Alias for withAllChildren. Includes self and comments"
+	
+	^ self withAllChildren 
 ]
 
 { #category : 'accessing' }
 OCProgramNode >> allComments [
 	"Answer a collection of objects representing the comments in the method. Return an empty collection if the method's source code does not contain a comment."
 
-	^ self allChildren flatCollect: [:el| el comments]
+	^ self withAllChildren flatCollect: [:el| el comments]
 ]
 
 { #category : 'accessing' }
@@ -205,7 +204,7 @@ OCProgramNode >> allTemporaryVariables [
 OCProgramNode >> allVariables [
 	"Return all the variables in subnodes"
 
-	^ self allChildren select: [ :each | each isVariable ]
+	^ self withAllChildren select: [ :each | each isVariable ]
 ]
 
 { #category : 'replacing' }
@@ -264,7 +263,7 @@ OCProgramNode >> asSequenceNode [
 
 { #category : 'querying' }
 OCProgramNode >> assignmentNodes [
-	^self allChildren select: [:each | each isAssignment]
+	^self withAllChildren select: [:each | each isAssignment]
 ]
 
 { #category : 'testing' }
@@ -332,7 +331,7 @@ OCProgramNode >> bestNodeForPosition: aPosition [
 
 { #category : 'querying' }
 OCProgramNode >> blockNodes [
-	^self allChildren select: [:each | each isBlock]
+	^self withAllChildren select: [:each | each isBlock]
 ]
 
 { #category : 'accessing' }
@@ -1237,7 +1236,7 @@ OCProgramNode >> selfMessages [
 
 { #category : 'accessing' }
 OCProgramNode >> sendNodes [
-	^self allChildren select: [:each | each isMessage]
+	^self withAllChildren select: [:each | each isMessage]
 ]
 
 { #category : 'accessing' }
@@ -1374,14 +1373,14 @@ OCProgramNode >> treePathUpTo: aParent [
 
 { #category : 'querying' }
 OCProgramNode >> variableDefinitionNodes [
-	^ self allChildren select: [ :each |
+	^ self withAllChildren select: [ :each |
 		  each isVariable and: [ each isDefinition ] ]
 ]
 
 { #category : 'querying' }
 OCProgramNode >> variableNodes [
 
-	^ self allChildren select: [ :each |
+	^ self withAllChildren select: [ :each |
 		  each isVariable and: [ each isDefinition not ] ]
 ]
 

--- a/src/AST-Core/OCTypingVisitor.class.st
+++ b/src/AST-Core/OCTypingVisitor.class.st
@@ -50,7 +50,7 @@ OCTypingVisitor class >> bench: trees [
 		print: trees size;
 		cr.
 
-	valueNodes := (trees flatCollect: #allChildren) select: #isValue.
+	valueNodes := (trees flatCollect: #withAllChildren) select: #isValue.
 	report
 		nextPutAll: 'Number of value nodes: ';
 		print: valueNodes size;


### PR DESCRIPTION

- refactored `allChildren` into an alias for `withAllChildren`.
- Changed the senders of `allchildren` in the AST-Core packages into sending `withAllChildren`, including the tests.
- Added comments explaining the alias.
- We did not change the behavior for the comments, as `withAllChildren` sends `nodesDo:`, which includes the comments.
- Should we change the behavior of `allChildren` into not including comments like `children`, or should we deprecate it?
Change made with @JavierLarre for issue #19021. 