### PR TITLE
Do not announce method announcements on class recompilation

### DIFF
--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -99,3 +99,12 @@ Behavior >> recompile: selector from: oldClass [
 		self compile: selector from: oldClass 
 	]
 ]
+
+{ #category : '*OpalCompiler-Core' }
+Behavior >> recompileAllFrom: oldClass [
+	"Compile silently all the methods in the receiver's method dictionary.
+	This validates sourceCode and variable references and forces
+	all methods to use the current bytecode set"
+
+	self codeChangeAnnouncer suspendAllWhile: [ self compileAllFrom: oldClass ]
+]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -208,7 +208,7 @@ ShiftClassBuilder >> compareWithOldClass [
 ShiftClassBuilder >> compileMethods [
 
 	newClass
-		compileAllFrom: self oldClass;
+		recompileAllFrom: self oldClass;
 		removeNonexistentSelectorsFromProtocols
 ]
 


### PR DESCRIPTION
When recompiling a class we should not announce method announcements while moving the methods from an old to a new class instance

Fixes #19270