### PR TITLE
Speed up PharoSourcesCondenser

### DIFF
--- a/src/Kernel-Extended-Tests/ClassTest.class.st
+++ b/src/Kernel-Extended-Tests/ClassTest.class.st
@@ -240,8 +240,9 @@ ClassTest >> testCommentSourcePointer [
 
 { #category : 'tests - accessing - comments' }
 ClassTest >> testCommentStamp [
-	self assert: Object commentStamp equals: ''.
-	self assert: Object class commentStamp equals: ''.
+
+	self denyEmpty: Object commentStamp.
+	self denyEmpty: Object class commentStamp
 ]
 
 { #category : 'tests' }

--- a/src/Monticello-Tests/MCStWriterTest.class.st
+++ b/src/Monticello-Tests/MCStWriterTest.class.st
@@ -45,21 +45,23 @@ MCStWriterTest >> assertMethodChunkIsWellFormed: chunk [
 
 { #category : 'data' }
 MCStWriterTest >> expectedClassDefinitionA [
- ^ '
+
+	^ '
 MCMock subclass: #MCMockClassA
 	instanceVariableNames: ''ivar''
 	classVariableNames: ''CVar InitializationOrder''
 	poolDictionaries: ''''
 	category: ''MonticelloMocks''!
 
-!MCMockClassA commentStamp: '''' prior: 0!
+!MCMockClassA commentStamp: ''' , MCMockClassA commentStamp , ''' prior: 0!
 This is a mock class. The Monticello tests manipulated it to simulate a developer modifying code in the image.!
 '
 ]
 
 { #category : 'data' }
 MCStWriterTest >> expectedClassDefinitionB [
- ^ '
+
+	^ '
 MCMock subclass: #MCMockClassB
 	instanceVariableNames: ''ivarb''
 	classVariableNames: ''CVar''
@@ -69,7 +71,7 @@ MCMock subclass: #MCMockClassB
 MCMockClassB class
 	instanceVariableNames: ''ciVar''!
 
-!MCMockClassB commentStamp: '''' prior: 0!
+!MCMockClassB commentStamp: ''' , MCMockClassB commentStamp , ''' prior: 0!
 This comment has a bang!! Bang!! Bang!!!
 '
 ]

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -9,7 +9,11 @@ Class {
 		'stream',
 		'job',
 		'remoteStringMap',
-		'sourceStreams'
+		'sourceStreams',
+		'condensationStamp'
+	],
+	#classVars : [
+		'ConserveTimestamps'
 	],
 	#category : 'System-SourcesCondenser',
 	#package : 'System-SourcesCondenser'
@@ -19,6 +23,19 @@ Class {
 PharoChangesCondenser class >> condense [
 	^ self new
 		condense
+]
+
+{ #category : 'accessing' }
+PharoChangesCondenser class >> conserveTimestamp [
+	"It takes a lot of time to access the timestamp of all methods in the sources file, so by default we do not save a new timestamp because the Pharo Boostrap happens in a few minutes, there is no need to save at the second."
+
+	^ ConserveTimestamps ifNil: [ ConserveTimestamps := false ]
+]
+
+{ #category : 'accessing' }
+PharoChangesCondenser class >> conserveTimestamp: aBoolean [
+
+	ConserveTimestamps := aBoolean
 ]
 
 { #category : 'private - 3 installing' }
@@ -38,6 +55,13 @@ PharoChangesCondenser >> basicCondense [
 		condenseClassesAndTraits;
 		swapSourcePointers.
 	stream flush
+]
+
+{ #category : 'accessing' }
+PharoChangesCondenser >> condensationStamp [
+	"Used if we do not conserve the timestamp of the methods in the system"
+
+	^ condensationStamp ifNil: [ condensationStamp := DateAndTime now printString ]
 ]
 
 { #category : 'public' }
@@ -196,6 +220,14 @@ PharoChangesCondenser >> temporaryFile [
 	^ (FileLocator changes , 'new') nextVersion
 ]
 
+{ #category : 'accessing' }
+PharoChangesCondenser >> timestampFor: aMethod [
+	"It takes a lot of time to access the timestamp of all methods in the sources file, so by default we do not save a new timestamp because the Pharo Boostrap happens in a few minutes, there is no need to save at the second."
+
+	self class conserveTimestamp ifFalse: [ ^ self condensationStamp ].
+	^ aMethod timeStamp
+]
+
 { #category : 'private - 1 writing' }
 PharoChangesCondenser >> writeClassComment: aClass [
 
@@ -218,18 +250,18 @@ PharoChangesCondenser >> writeClassComment: aClass [
 PharoChangesCondenser >> writeMethodSource: aMethod [
 
 	self nextCommentChunkDo: [ :strm |
-		strm
-			nextPutAll: aMethod methodClass name;
-			nextPutAll: ' methodsFor: ';
-			store: aMethod protocolName asString;
-			nextPutAll: ' stamp: ';
-			store: aMethod timeStamp ].
+			strm
+				nextPutAll: aMethod methodClass name;
+				nextPutAll: ' methodsFor: ';
+				store: aMethod protocolName asString;
+				nextPutAll: ' stamp: ';
+				store: (self timestampFor: aMethod) ].
 
-	self
-		writeRemoteString: aMethod sourceCode
-		for: aMethod.
+	self writeRemoteString: aMethod sourceCode for: aMethod.
 
-	stream nextPutAll: ' !'; cr
+	stream
+		nextPutAll: ' !';
+		cr
 ]
 
 { #category : 'private - 1 writing' }

--- a/src/System-SourcesCondenser/PharoChangesCondenser.class.st
+++ b/src/System-SourcesCondenser/PharoChangesCondenser.class.st
@@ -221,7 +221,15 @@ PharoChangesCondenser >> temporaryFile [
 ]
 
 { #category : 'accessing' }
-PharoChangesCondenser >> timestampFor: aMethod [
+PharoChangesCondenser >> timestampForClass: aClass [
+	"It takes a lot of time to access the timestamp of all methods in the sources file, so by default we do not save a new timestamp because the Pharo Boostrap happens in a few minutes, there is no need to save at the second."
+
+	self class conserveTimestamp ifFalse: [ ^ self condensationStamp ].
+	^ aClass commentStamp
+]
+
+{ #category : 'accessing' }
+PharoChangesCondenser >> timestampForMethod: aMethod [
 	"It takes a lot of time to access the timestamp of all methods in the sources file, so by default we do not save a new timestamp because the Pharo Boostrap happens in a few minutes, there is no need to save at the second."
 
 	self class conserveTimestamp ifFalse: [ ^ self condensationStamp ].
@@ -240,7 +248,7 @@ PharoChangesCondenser >> writeClassComment: aClass [
 			strm
 				nextPutAll: aClass name;
 				nextPutAll: ' commentStamp: '.
-			stamp := aClass commentStamp ifNil: [ '<historical>' ].
+			stamp := (self timestampForClass: aClass).
 			stamp storeOn: strm ].
 
 	self writeRemoteString: aClass comment for: aClass
@@ -255,7 +263,7 @@ PharoChangesCondenser >> writeMethodSource: aMethod [
 				nextPutAll: ' methodsFor: ';
 				store: aMethod protocolName asString;
 				nextPutAll: ' stamp: ';
-				store: (self timestampFor: aMethod) ].
+				store: (self timestampForMethod: aMethod) ].
 
 	self writeRemoteString: aMethod sourceCode for: aMethod.
 


### PR DESCRIPTION
Currently it take 43sec on my machine to condense the source code because for each methods it accesses the timestamp in the sources file.

In the sources produced by the bootstrap we do not care about the exact stamp of methods so I propose to use the time of the condensation instead.

This reduced the condensation time from 43sec to 4.5sec on my machine which should speed up the bootstrap

A big thank you to **Guille** that helped me find this way to speed up the operation! \0/