### PR TITLE
Sources: some cleanups

### DIFF
--- a/src/CodeExport/ChunkWriteStream.class.st
+++ b/src/CodeExport/ChunkWriteStream.class.st
@@ -8,6 +8,9 @@ symbols
 Class {
 	#name : 'ChunkWriteStream',
 	#superclass : 'DecoratorStream',
+	#instVars : [
+		'flushChanges'
+	],
 	#category : 'CodeExport',
 	#package : 'CodeExport'
 }
@@ -15,7 +18,7 @@ Class {
 { #category : 'writing' }
 ChunkWriteStream >> afterNexPut [
 
-	decoratedStream flush
+	flushChanges ifTrue: [ decoratedStream flush ]
 ]
 
 { #category : 'writing' }
@@ -65,6 +68,19 @@ ChunkWriteStream >> duplicateTerminatorMarkOn: aString [
 	newStringStream nextPut: self terminatorMark. "one extra"
 
 	^ newStringStream contents
+]
+
+{ #category : 'accessing' }
+ChunkWriteStream >> flushChanges: aBoolean [
+
+	flushChanges := aBoolean
+]
+
+{ #category : 'initialization' }
+ChunkWriteStream >> initialize [
+
+	super initialize.
+	flushChanges := true
 ]
 
 { #category : 'accessing' }

--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -603,8 +603,9 @@ Package >> removeEmptyTags [
 Package >> removeFromSystem [
 	"Copy to not remove collection over which we are iterating."
 
-	self tags copy do: [ :tag | tag removeFromSystem ].
-	self extensionMethods do: [ :method | method removeFromSystem ].
+	SourcesManager current deferFlushDuring: [
+			self tags copy do: [ :tag | tag removeFromSystem ].
+			self extensionMethods do: [ :method | method removeFromSystem ] ].
 
 	self organizer unregisterPackage: self
 ]

--- a/src/Kernel/NoSourcesManager.class.st
+++ b/src/Kernel/NoSourcesManager.class.st
@@ -1,3 +1,12 @@
+"
+I am a null source code manager. I will not register anything and will not retrieve anything. 
+
+You can use me to deploy a Pharo application without shipping a .changes and .sources file as long as the application does not access source code. In order to do that you can execute:
+
+```st
+	NoSourcesManager beCurrent
+```
+"
 Class {
 	#name : 'NoSourcesManager',
 	#superclass : 'SourcesManager',

--- a/src/Kernel/SourcesManager.class.st
+++ b/src/Kernel/SourcesManager.class.st
@@ -1,3 +1,15 @@
+"
+I am an abstract class to manage sources in Pharo.
+
+I define the API a sources manager should have and hold the current sources manager.
+
+I can have different subclasses with different ways to store the source code:
+- A null sources manager
+- A sources manager saving the code in files
+- A source manager saving the code in a database...
+
+For more detail, check my subclasses
+"
 Class {
 	#name : 'SourcesManager',
 	#superclass : 'Object',

--- a/src/System-Sources-Files/FilesSourcesManager.class.st
+++ b/src/System-Sources-Files/FilesSourcesManager.class.st
@@ -1,13 +1,33 @@
 "
-This is a variation on StandardSourceFileArray that provides a larger maximum changes file size.
+I am a sources manager saving and retrieving code in a .sources and a .changes file. 
 
-The available address space for source pointers in a traditional CompiledMethod is 16r1000000 through 16r4FFFFFF. StandardSourceFileArray maps positions in the sources file to address range 16r1000000 through 16r1FFFFFF and 16r3000000 through 16r3FFFFFF, and positions in the changes file to address range 16r2000000 through 16r2FFFFFF and 16r4000000 through 16r4FFFFFF. This permits a maximum file size of 16r2000000 (32MB) for both the sources file and the changes file.
+.sources file contains the code of Pharo while the .changes file contains the code compiled in the Pharo environment.
+
+## Storing informations
+
+For each entities complied we will save a preambul with metadatas such as the methods protocol and the source code.
+The entities will store a source pointer that is used to know if the source code is stored in the .sources or .changes and the position of the source code beginning.
+Since we access the source code more than the metadata it is more effective.
+The format of the exporter is Chunk format (See the package Code-Export)
+
+## Source pointers
+
+I maps positions in the sources file to address range 16r1000000 through 16r1FFFFFF and 16r3000000 through 16r3FFFFFF, and positions in the changes file to address range 16r2000000 through 16r2FFFFFF and 16r4000000 through 16r4FFFFFF. This permits a maximum file size of 16r2000000 (32MB) for both the sources file and the changes file.
 
 This implementation extends the source pointer address space using bit 25 of the source pointer to identify the external sources and changes files, with the remaining high order bits treated as address extension. This limits the number of external file references to two (the traditional sources and changes files). If additional external file references are needed in the future, some higher order bits in the source pointer address space should be allocated for that purpose.
 
 The use of bit 25 of the source pointer for file references permits backward compatibility with StandardSourceFileArray, with essentially unlimited address space expansion for the sources and changes files.
 
+## Implementation details
 
+In order to avoid concurency problems I use a queue to manage the accesses. 
+
+I can have multiple modes:
+- Read/Write
+- Read only 
+- No source at all
+
+This will depend on the state of the sources and changes stream state. If they are nil, we consider there is no source. If they are read only, we are in read only. Else we are in read/write.
 "
 Class {
 	#name : 'FilesSourcesManager',
@@ -18,9 +38,8 @@ Class {
 		'flushChanges',
 		'exporterClass'
 	],
-	#category : 'System-Sources-Files-Sources',
-	#package : 'System-Sources-Files',
-	#tag : 'Sources'
+	#category : 'System-Sources-Files',
+	#package : 'System-Sources-Files'
 }
 
 { #category : 'class initialization' }

--- a/src/System-Sources-Files/FilesSourcesManager.class.st
+++ b/src/System-Sources-Files/FilesSourcesManager.class.st
@@ -280,7 +280,9 @@ FilesSourcesManager >> logChange: aString [
 				changesFile
 					cr;
 					cr.
-				(ChunkWriteStream on: changesFile) nextPut: aString.
+				(ChunkWriteStream on: changesFile)
+					flushChanges: flushChanges;
+					nextPut: aString.
 				position ]
 		onSuccess: [ :sourcePointer | "Ignore" ]
 		onFail: [ "Ignore" ]

--- a/src/System-Sources-Files/PharoFilesOpener.class.st
+++ b/src/System-Sources-Files/PharoFilesOpener.class.st
@@ -1,5 +1,5 @@
 "
-My role is to open the .sources and .changes files. My only public methods are in the 'public' protocol. The most important method is #checkAndOpenSourcesAndChanges.
+My role is to open the .sources and .changes files. My only public methods are in the 'public' protocol.
 "
 Class {
 	#name : 'PharoFilesOpener',

--- a/src/System-Sources-Tests/FilesSourcesManagerTest.class.st
+++ b/src/System-Sources-Tests/FilesSourcesManagerTest.class.st
@@ -21,10 +21,10 @@ FilesSourcesManagerTest >> ensureChangesFileOpenedInProcess [
 
 	| sourcePointer fileIndex filePosition string |
 	sourcePointer := thisContext method sourcePointer.
-	fileIndex := self globalFilesManager fileIndexFromSourcePointer: sourcePointer.
-	filePosition := self globalFilesManager filePositionFromSourcePointer: sourcePointer.
+	fileIndex := self globalFilesSourcesManager fileIndexFromSourcePointer: sourcePointer.
+	filePosition := self globalFilesSourcesManager filePositionFromSourcePointer: sourcePointer.
 
-	string := self globalFilesManager
+	string := self globalFilesSourcesManager
 		          readStreamAtFileIndex: fileIndex
 		          atPosition: filePosition
 		          ifPresent: [ :readStream | (ChunkReadStream on: readStream) next ]
@@ -34,7 +34,7 @@ FilesSourcesManagerTest >> ensureChangesFileOpenedInProcess [
 ]
 
 { #category : 'helpers' }
-FilesSourcesManagerTest >> globalFilesManager [
+FilesSourcesManagerTest >> globalFilesSourcesManager [
 	"This is bad. Tests should not use a global instance"
 
 	SourcesManager current class = FilesSourcesManager ifFalse: [ self error: 'This test can only pass if the sources manager is the FilesSourcesManager.' ].
@@ -57,7 +57,7 @@ FilesSourcesManagerTest >> testAddressRange [
 { #category : 'tests' }
 FilesSourcesManagerTest >> testChangesFileStream [
 
-	self assert: self globalFilesManager changesFileStream isNotNil
+	self assert: self globalFilesSourcesManager changesFileStream isNotNil
 ]
 
 { #category : 'tests' }
@@ -102,7 +102,7 @@ FilesSourcesManagerTest >> testForkedRead [
 		readSemaphore wait.
 
 		"Read the string that was written in other process."
-		readString := self globalFilesManager
+		readString := self globalFilesSourcesManager
 			readStreamAtFileIndex: 2 "changes"
 			atPosition: position
 			ifPresent: [ :readStream | (ChunkReadStream on: readStream) next ]
@@ -111,7 +111,7 @@ FilesSourcesManagerTest >> testForkedRead [
 		] fork.
 
 	"Write the string, that will be read in other process."
-	self globalFilesManager writeChangesDuring: [ :theFile |
+	self globalFilesSourcesManager writeChangesDuring: [ :theFile |
 		theFile cr.
 		position := theFile position.
 		(ChunkWriteStream on: theFile) nextPut: originalString.
@@ -140,7 +140,7 @@ FilesSourcesManagerTest >> testForkedWrite [
 		readSemaphore wait.
 
 		"Write the string, that will be read in other process."
-		self globalFilesManager writeChangesDuring: [ :theFile |
+		self globalFilesSourcesManager writeChangesDuring: [ :theFile |
 			theFile cr.
 			position := theFile position.
 			(ChunkWriteStream on: theFile) nextPut: originalString.
@@ -154,7 +154,7 @@ FilesSourcesManagerTest >> testForkedWrite [
 	testSemaphore wait.
 
 	"Read the string that was written in other process."
-	readString := self globalFilesManager
+	readString := self globalFilesSourcesManager
 		readStreamAtFileIndex: 2 "changes"
 		atPosition: position
 		ifPresent: [ :readStream | (ChunkReadStream on: readStream) next ]
@@ -211,11 +211,11 @@ FilesSourcesManagerTest >> testProtocol [
 
 	| okCm notOkCm |
 	okCm := Point >> #dotProduct:.
-	self assert: ((self globalFilesManager sourcedDataAt: okCm sourcePointer) beginsWith: 'Point methodsFor: ''point functions''').
-	self assert: (self globalFilesManager protocolAt: okCm sourcePointer) equals: 'point functions'.
+	self assert: ((self globalFilesSourcesManager sourcedDataAt: okCm sourcePointer) beginsWith: 'Point methodsFor: ''point functions''').
+	self assert: (self globalFilesSourcesManager protocolAt: okCm sourcePointer) equals: 'point functions'.
 
 	notOkCm := Behavior >> #superclass.
-	self assert: (self globalFilesManager protocolAt: notOkCm sourcePointer) equals: 'accessing - class hierarchy'
+	self assert: (self globalFilesSourcesManager protocolAt: notOkCm sourcePointer) equals: 'accessing - class hierarchy'
 ]
 
 { #category : 'tests' }
@@ -238,7 +238,7 @@ FilesSourcesManagerTest >> testSourcePointerFromFileIndexAndPosition [
 { #category : 'tests' }
 FilesSourcesManagerTest >> testSourcesFileStream [
 
-	self assert: self globalFilesManager sourcesFileStream isNotNil
+	self assert: self globalFilesSourcesManager sourcesFileStream isNotNil
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
This change brings 4 things:
- Class comments for new classes
- Rename a method from Christophe's comments
- FilesSourcesManager has a #deferFlushingDuring: feature that was respected only for method compilation but not for classes addition/removal or methods removal. Now it's the case all the time.
- defer the sources flushing during package removal