### PR TITLE
Speedup Epicea logging

### DIFF
--- a/src/Epicea/EpMonitor.class.st
+++ b/src/Epicea/EpMonitor.class.st
@@ -141,6 +141,12 @@ EpMonitor class >> shutDown: isImageQuitting [
 				self current sessionStore flush. ]
 ]
 
+{ #category : 'system startup' }
+EpMonitor class >> startUp: isImageLaunching [
+
+	(isImageLaunching and: [ self hasCurrent ]) ifTrue: [ self current imageRestarted ]
+]
+
 { #category : 'private' }
 EpMonitor >> addEvent: anEvent [
 
@@ -360,6 +366,13 @@ EpMonitor >> enabled: aBoolean [
 	aBoolean
 		ifTrue: [ self enable ]
 		ifFalse: [ self disable ]
+]
+
+{ #category : 'private' }
+EpMonitor >> imageRestarted [
+	"When the image restart we tell the store to check if it needs to be reseted."
+
+	self log store imageRestarted
 ]
 
 { #category : 'initialization' }

--- a/src/Ombu/OmSessionStore.class.st
+++ b/src/Ombu/OmSessionStore.class.st
@@ -153,6 +153,13 @@ OmSessionStore >> imagePathString [
 	^ SmalltalkImage current imagePath
 ]
 
+{ #category : 'private' }
+OmSessionStore >> imageRestarted [
+	"I am called on the current session store at startup. If the path changed we need to reset the store."
+
+	currentImagePathString ~= self imagePathString ifTrue: [ self resetWithNextStoreName ]
+]
+
 { #category : 'initialization' }
 OmSessionStore >> initializeWithBaseLocator: aDirectoryFileLocator [
 
@@ -176,7 +183,6 @@ OmSessionStore >> lowLevelFileStoreIfNone: aBlock [
 OmSessionStore >> needsReset [
 
 	^ currentSession ~~ Smalltalk session
-		or: [ currentImagePathString ~= self imagePathString ]
 ]
 
 { #category : 'writing' }


### PR DESCRIPTION
Each time we log an event in Epicea we are checking if the ombu file needs to be reseted. It has two conditions:
- The image path changed 
- The smalltalk session changed

But it takes some time to get the image path. Since we need to relaunch the image when we move it, I moved the check about the path from each logging to the image startup. Like this we do it only once. 

I tried to check the speedup on a script doing 5000 class creation and it is 2.1 times faster to add an entry to an EpLog with this.

To be honest, I'm not sure that we need to check the image path because I think that the session change at every boot, so even if the image path changed, the session will also have changed. I need to talk to Christophe about that.