### PR TITLE
Bootstrap: Speed up espell phase by disabling assertions

### DIFF
--- a/src/PharoBootstrap/PBAbstractImageBuilder.class.st
+++ b/src/PharoBootstrap/PBAbstractImageBuilder.class.st
@@ -149,16 +149,21 @@ PBAbstractImageBuilder >> bindingOf: aName [
 
 { #category : 'running' }
 PBAbstractImageBuilder >> bootstrap [
+	"During the bootstrap we disable the assertions for speed."
 
-	self
-		initializeBootstrapEnvironment;
-		createVMStubs;
-		flushNewSpace;
-		createInitialObjects;
-		createClasses;
-		installMethods;
-		installExtensionMethods;
-		initializeImage
+	| oldCode |
+	oldCode := (Object >> #assert:) sourceCode.
+	Object compile: 'assert: arg "Do nothing during the bootstrap"'.
+	[
+		self
+			initializeBootstrapEnvironment;
+			createVMStubs;
+			flushNewSpace;
+			createInitialObjects;
+			createClasses;
+			installMethods;
+			installExtensionMethods;
+			initializeImage ] ensure: [ Object compile: oldCode ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Building the bootstrap in my machine I have 20sec spent in the assertions of the VM. But since the bootstrap was introduced, there was never an assertion that failed. I think it is safe for now to disable the assertions to have a faster bootstrap