### PR TITLE
Bootstrap: Move FFI-Kernel and ClassDefinitionPrinter out of Espell phase

### DIFF
--- a/bootstrap/scripts/4-build.sh
+++ b/bootstrap/scripts/4-build.sh
@@ -160,7 +160,7 @@ zip "${MC_BOOTSTRAP_IMAGE_NAME}.zip" ${MC_BOOTSTRAP_IMAGE_NAME}.*
 echo "[Metacello] Bootstrapping Metacello"
 ${VM} "${MC_BOOTSTRAP_IMAGE_NAME}.image" save ${METACELLO_IMAGE_NAME}
 echo "Loading packages: $(cat hermesMetacelloPackages.txt)"
-${VM} "${METACELLO_IMAGE_NAME}.image" loadHermes $(cat hermesMetacelloPackages.txt) --save --no-fail-on-undeclared
+${VM} "${METACELLO_IMAGE_NAME}.image" loadHermes $(cat hermesMetacelloPackages.txt) --save
 ${VM} "${METACELLO_IMAGE_NAME}.image" st ${BOOTSTRAP_REPOSITORY}/bootstrap/scripts/4-build-scripts/03-bootstrapMonticello.st --save --quit
 git clone https://github.com/pharo-vcs/tonel.git -b "Pharo${PHARO_MAJOR}" "${BOOTSTRAP_CACHE}/tonel"
 ${VM} "${METACELLO_IMAGE_NAME}.image" metacello install --save --signalErrorOnWarning "filetree://${BOOTSTRAP_CACHE}/tonel" Tonel --groups core

--- a/src/BaselineOfCompiler/BaselineOfCompiler.class.st
+++ b/src/BaselineOfCompiler/BaselineOfCompiler.class.st
@@ -27,6 +27,7 @@ BaselineOfCompiler >> baseline: spec [
 				package: 'Collections-Arithmetic';
 				package: 'Collections-Atomic';
 				package: 'Collections-Stack';
+				package: 'ClassDefinitionPrinters';
 				package: 'CodeExport';
 				package: 'CodeImport';
 				package: 'CodeImport-Commands';
@@ -47,7 +48,7 @@ BaselineOfCompiler >> baseline: spec [
 			spec
 				group: 'Core'
 				with:
-					{ 'AST-Core'. 'Collections-Arithmetic'. 'Collections-Atomic'. 'Collections-Stack'. 'CodeExport'. 'CodeImport'. 'CodeImport-Commands'. 'DebugInfo'.
+					{ 'AST-Core'. 'Collections-Arithmetic'. 'Collections-Atomic'. 'Collections-Stack'. 'ClassDefinitionPrinters'. 'CodeExport'. 'CodeImport'. 'CodeImport-Commands'. 'DebugInfo'.
 					'OpalCompiler-Core'. 'ParseTreeRewriter'. 'Deprecation' };
 				group: 'Tests'
 				with:

--- a/src/BaselineOfFileSystem/BaselineOfFileSystem.class.st
+++ b/src/BaselineOfFileSystem/BaselineOfFileSystem.class.st
@@ -23,6 +23,7 @@ BaselineOfFileSystem >> baseline: spec [
 	<baseline>
 	spec for: #common do: [
 			spec
+				package: 'FFI-Kernel';
 				package: 'FileSystem-Path';
 				package: 'FileSystem-Core';
 				package: 'FileSystem-Disk';
@@ -33,6 +34,6 @@ BaselineOfFileSystem >> baseline: spec [
 				package: 'FileSystem-Tests-Attributes'.
 
 			spec
-				group: 'Core' with: { 'FileSystem-Path'. 'FileSystem-Core'. 'FileSystem-Disk'. 'System-Sources-Files'};
+				group: 'Core' with: {'FFI-Kernel'. 'FileSystem-Path'. 'FileSystem-Core'. 'FileSystem-Disk'. 'System-Sources-Files'};
 				group: 'Tests' with: { 'FileSystem-Core-Tests'. 'FileSystem-Disk-Tests'. 'FileSystem-Tests-Attributes' } ]
 ]

--- a/src/BaselineOfKernel/BaselineOfKernel.class.st
+++ b/src/BaselineOfKernel/BaselineOfKernel.class.st
@@ -52,10 +52,8 @@ BaselineOfKernel >> baseline: spec [
 				package: 'System-Finalization';
 				package: 'System-Platforms';
 				package: 'System-SessionManager';
-				package: 'ClassDefinitionPrinters';
 				package: 'System-Support';
 				package: 'Zinc-Character-Encoding-Core';
-				
 				package: 'Hermes-Extensions';
 				package: 'Clap-Core';
 				package: 'Clap-Commands-Pharo';
@@ -91,7 +89,7 @@ BaselineOfKernel >> baseline: spec [
 				with: { 'Announcements-Core'. 'Collections-Abstract'. 'Collections-DoubleLinkedList'. 'Collections-Native'. 'Collections-Sequenceable'.
 					'Collections-Streams'. 'Collections-Strings'. 'Collections-Support'. 'Collections-Unordered'. 'Collections-Weak'. 'Files'. 'Hermes'. 'Kernel'. 'Kernel-CodeModel'.
 					'Kernel-BytecodeEncoders'. 'Transcript-NonInteractive'. 'PharoBootstrap-Initialization'. 'Shift-ClassBuilder'. 'System-Announcements'.
-					'System-CommandLineHandler'. 'System-Finalization'. 'System-Platforms'. 'System-SessionManager'. 'ClassDefinitionPrinters'.
+					'System-CommandLineHandler'. 'System-Finalization'. 'System-Platforms'. 'System-SessionManager'.
 					'System-Support'. 'Zinc-Character-Encoding-Core' };
 				group: 'AdditionalPackages'
 				with: { 'Clap-Core'. 'Clap-Commands-Pharo'. 'Hermes-Extensions'. 'NumberParser'. 'ReflectionMirrors-Primitives'. 'System-Time'. 'Math-Operations-Extensions'.

--- a/src/BaselineOfKernel/BaselineOfKernel.class.st
+++ b/src/BaselineOfKernel/BaselineOfKernel.class.st
@@ -29,7 +29,6 @@ BaselineOfKernel >> baseline: spec [
 	<baseline>
 	spec for: #common do: [
 			spec
-				package: 'FFI-Kernel';
 				package: 'Announcements-Core';
 				package: 'Collections-Abstract';
 				package: 'Collections-DoubleLinkedList';
@@ -89,7 +88,7 @@ BaselineOfKernel >> baseline: spec [
 			"The order of packages in the groups are important for the bootstrap! It define the load order."
 			spec
 				group: 'Core'
-				with: { 'FFI-Kernel'. 'Announcements-Core'. 'Collections-Abstract'. 'Collections-DoubleLinkedList'. 'Collections-Native'. 'Collections-Sequenceable'.
+				with: { 'Announcements-Core'. 'Collections-Abstract'. 'Collections-DoubleLinkedList'. 'Collections-Native'. 'Collections-Sequenceable'.
 					'Collections-Streams'. 'Collections-Strings'. 'Collections-Support'. 'Collections-Unordered'. 'Collections-Weak'. 'Files'. 'Hermes'. 'Kernel'. 'Kernel-CodeModel'.
 					'Kernel-BytecodeEncoders'. 'Transcript-NonInteractive'. 'PharoBootstrap-Initialization'. 'Shift-ClassBuilder'. 'System-Announcements'.
 					'System-CommandLineHandler'. 'System-Finalization'. 'System-Platforms'. 'System-SessionManager'. 'ClassDefinitionPrinters'.

--- a/src/FFI-Kernel/ExternalAddress.class.st
+++ b/src/FFI-Kernel/ExternalAddress.class.st
@@ -473,6 +473,13 @@ ExternalAddress >> pointerAtOffset: zeroBasedOffset put: value [
 	^value
 ]
 
+{ #category : 'printing' }
+ExternalAddress >> printOn: aStream [
+	"print this as a hex address ('@ 16rFFFFFFFF') to distinguish it from ByteArrays"
+
+	aStream nextPutAll: '@ '; nextPutAll: (self asInteger storeStringBase: 16 length: 11 padded: true)
+]
+
 { #category : 'copying' }
 ExternalAddress >> replaceFrom: start to: stop with: replacement startingAt: repStart [
 	| dstAddress srcAddress repSize |

--- a/src/FFI-Kernel/ExternalObject.class.st
+++ b/src/FFI-Kernel/ExternalObject.class.st
@@ -17,7 +17,8 @@ Class {
 { #category : 'class initialization' }
 ExternalObject class >> initialize [
 
-	Smalltalk recreateSpecialObjectsArray
+	Smalltalk recreateSpecialObjectsArray.
+	SessionManager default registerSystemClassNamed: self name atPriority: 60
 ]
 
 { #category : 'system startup' }

--- a/src/FFI-Kernel/FFIBackend.class.st
+++ b/src/FFI-Kernel/FFIBackend.class.st
@@ -25,6 +25,12 @@ FFIBackend class >> detectFFIBackend [
 		ifNone: [ ^ NullFFIBackend ]) new
 ]
 
+{ #category : 'class initialization' }
+FFIBackend class >> initialize [
+
+	SessionManager default registerSystemClassNamed: self name atPriority: 60
+]
+
 { #category : 'testing' }
 FFIBackend class >> isAvailable [
 

--- a/src/FFI-Kernel/String.extension.st
+++ b/src/FFI-Kernel/String.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : 'String' }
 
-{ #category : '*System-Platforms-Windows' }
+{ #category : '*FFI-Kernel' }
 String >> asWin32WideString [
 
 	^ Win32WideString fromString: self

--- a/src/FFI-Kernel/Win32WideString.class.st
+++ b/src/FFI-Kernel/Win32WideString.class.st
@@ -12,9 +12,8 @@ The rationale is that the kernel should not be tied to UFFI (which depends on th
 Class {
 	#name : 'Win32WideString',
 	#superclass : 'ExternalObject',
-	#category : 'System-Platforms-Windows',
-	#package : 'System-Platforms',
-	#tag : 'Windows'
+	#category : 'FFI-Kernel',
+	#package : 'FFI-Kernel'
 }
 
 { #category : 'instance creation' }

--- a/src/FFI-Kernel/WinPlatform.extension.st
+++ b/src/FFI-Kernel/WinPlatform.extension.st
@@ -1,0 +1,27 @@
+Extension { #name : 'WinPlatform' }
+
+{ #category : '*FFI-Kernel' }
+WinPlatform >> getErrorMessage: anInteger [
+
+    | buffer |
+    buffer := (String new: 500) asWin32WideString.
+    self formatMessage: 16r1000 "Format Message From System"
+                        _: ExternalAddress null
+                        _: anInteger
+                        _: 0
+                        _: buffer
+                        _: 500
+                        _: ExternalAddress null.
+
+    ^ buffer asString
+]
+
+{ #category : '*FFI-Kernel' }
+WinPlatform >> getTempPath [
+
+  | buffer length |
+	length := self defaultMaximumPathLength.
+	buffer := (String new: length) asWin32WideString.
+	self getTempPath: length buffer: buffer.
+	^buffer asString
+]

--- a/src/Kernel/ManifestKernel.class.st
+++ b/src/Kernel/ManifestKernel.class.st
@@ -11,7 +11,7 @@ Class {
 
 { #category : 'meta-data' }
 ManifestKernel class >> dependencies [
-	^ #(#'System-Announcements' #'Collections-Strings' #'Collections-Unordered' #'Collections-Streams' #Files #'System-Object Events' #'Collections-Abstract' #'Collections-Native' #'Collections-Support' #'System-Support' #'Multilingual-Encodings' #'Collections-Sequenceable' #'NewValueHolder-Core' #'System-Sources' #Compiler #'OpalCompiler-Core' #'System-Finalization' #Traits #'Collections-Weak' #UIManager)
+	^ #(#'System-Announcements' #'Collections-Strings' #'Collections-Unordered' #'Collections-Streams' #Files #'System-Object Events' #'Collections-Abstract' #'Collections-Native' #'Collections-Support' #'System-Support' #'Multilingual-Encodings' #'Collections-Sequenceable' #'NewValueHolder-Core' #Compiler #'OpalCompiler-Core' #'System-Finalization' #Traits #'Collections-Weak' #UIManager)
 ]
 
 { #category : 'meta-data - dependency analyser' }

--- a/src/Monticello-Model/MCMethodDefinition.class.st
+++ b/src/Monticello-Model/MCMethodDefinition.class.st
@@ -239,15 +239,15 @@ MCMethodDefinition >> loadWithLoader: aLoader [
 
 { #category : 'installing' }
 MCMethodDefinition >> postloadOver: aDefinition [
+
 	super postloadOver: aDefinition.
 	self class initializersEnabled ifTrue: [
-		(self isInitializer
-			and: [ self actualClass isTrait not 
-					and: [ aDefinition isNil or: [ self source ~= aDefinition source ]]]) ifTrue: [
+			(self isInitializer and: [ self actualClass isTrait not and: [ aDefinition isNil or: [ self source ~= aDefinition source ] ] ]) ifTrue: [
 				self actualClass instanceSide initialize ] ].
+		
 	"Postloading of FFI fields. This code will be called when loading FFI structures that are not by default in the image. This is NOT dead code."
-	self isExternalStructureFieldDefinition
-		ifTrue: [self actualClass instanceSide compileFields].
+	self class environment at: #ExternalStructure ifPresent: [
+		self isExternalStructureFieldDefinition ifTrue: [ self actualClass instanceSide compileFields ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/Monticello-Model/ManifestMonticelloModel.class.st
+++ b/src/Monticello-Model/ManifestMonticelloModel.class.st
@@ -13,5 +13,5 @@ Class {
 ManifestMonticelloModel class >> manuallyResolvedDependencies [
 
 	<ignoreForCoverage>
-	^ #(#'OpalCompiler-Core' #'Collections-Abstract' #'Collections-Streams' #'System-Support' #'Shift-ClassBuilder' #'FFI-Kernel')
+	^ #(#'OpalCompiler-Core' #'Collections-Abstract' #'Collections-Streams' #'System-Support' #'Shift-ClassBuilder')
 ]

--- a/src/OpalCompiler-Core/ManifestOpalCompilerCore.class.st
+++ b/src/OpalCompiler-Core/ManifestOpalCompilerCore.class.st
@@ -10,7 +10,7 @@ Class {
 ManifestOpalCompilerCore class >> manuallyResolvedDependencies [
 
 	<ignoreForCoverage>
-	^ #(#'System-Announcements' #'System-Sources' #'Collections-Abstract')
+	^ #(#'System-Announcements' #'Collections-Abstract')
 ]
 
 { #category : 'code-critics' }

--- a/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
+++ b/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
@@ -150,11 +150,6 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 	(Smalltalk class classVariableNamed: 'LastImagePath') value: Smalltalk imagePath. "set the default value"
 	SourcesManager initialize.
 
-	'InitializingFFI' traceCr.
-	"FFI"
-	ExternalObject initialize.
-	ExternalType initialize.
-
 	'Initializing Session Manager' traceCr.
 	SessionManager initialize.
 	SessionManager initializeKernelRegistrations.

--- a/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
+++ b/src/PharoBootstrap-Initialization/PharoBootstrapInitialization.class.st
@@ -147,7 +147,6 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 	PackageConflictError initialize.
 
 	'Initializing sources' traceCr.
-	(Smalltalk class classVariableNamed: 'LastImagePath') value: Smalltalk imagePath. "set the default value"
 	SourcesManager initialize.
 
 	'Initializing Session Manager' traceCr.
@@ -159,6 +158,8 @@ PharoBootstrapInitialization class >> initializeCommandLineHandlerAndErrorHandli
 	"Initialize basic command line behaviour"
 	NonInteractiveTranscript initialize.
 	PerformMessageCommandLineHandler registerAsCommandLinehandler.
+	
+	self undeclaredRegistry ifNotEmpty: [ self error: 'There should be no undeclared after loading the BaselineOfKernel. List of undeclared: ', self undeclaredRegistry keys printString ].
 
 	Smalltalk snapshot: true andQuit: true.
 	Processor terminateActive

--- a/src/PharoBootstrap/PBAbstractImageBuilder.class.st
+++ b/src/PharoBootstrap/PBAbstractImageBuilder.class.st
@@ -149,16 +149,21 @@ PBAbstractImageBuilder >> bindingOf: aName [
 
 { #category : 'running' }
 PBAbstractImageBuilder >> bootstrap [
+	"During the bootstrap we disable the assertions for speed."
 
-	self
-		initializeBootstrapEnvironment;
-		createVMStubs;
-		flushNewSpace;
-		createInitialObjects;
-		createClasses;
-		installMethods;
-		installExtensionMethods;
-		initializeImage
+	| oldCode |
+	oldCode := (Object >> #assert:) sourceCode.
+	Object compile: 'assert: arg "Do nothing during the bootstrap"'.
+	[
+		self
+			initializeBootstrapEnvironment;
+			createVMStubs;
+			flushNewSpace;
+			createInitialObjects;
+			createClasses;
+			installMethods;
+			installExtensionMethods;
+			initializeImage ] ensure: [ Object compile: oldCode ]
 ]
 
 { #category : 'accessing' }

--- a/src/System-NumberPrinting/ExternalAddress.extension.st
+++ b/src/System-NumberPrinting/ExternalAddress.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : 'ExternalAddress' }
-
-{ #category : '*System-NumberPrinting' }
-ExternalAddress >> printOn: aStream [
-	"print this as a hex address ('@ 16rFFFFFFFF') to distinguish it from ByteArrays"
-
-	aStream nextPutAll: '@ '; nextPutAll: (self asInteger storeStringBase: 16 length: 11 padded: true)
-]

--- a/src/System-Platforms/ManifestSystemPlatforms.class.st
+++ b/src/System-Platforms/ManifestSystemPlatforms.class.st
@@ -11,5 +11,5 @@ Class {
 
 { #category : 'meta-data - dependency analyser' }
 ManifestSystemPlatforms class >> manuallyResolvedDependencies [
-	^ #(#'Collections-Streams' #'Collections-Abstract')
+	^ #( #'Collections-Abstract')
 ]

--- a/src/System-Platforms/WinPlatform.class.st
+++ b/src/System-Platforms/WinPlatform.class.st
@@ -57,32 +57,6 @@ WinPlatform >> getEnvironmentVariable: lpName into: lpBuffer size: nSize [
 	^ self ffiCall: #(ulong GetEnvironmentVariableW (Win32WideString lpName, Win32WideString  lpBuffer, ulong nSize))
 ]
 
-{ #category : 'error handling' }
-WinPlatform >> getErrorMessage: anInteger [
-
-    | buffer |
-    buffer := (String new: 500) asWin32WideString.
-    self formatMessage: 16r1000 "Format Message From System"
-                        _: ExternalAddress null
-                        _: anInteger
-                        _: 0
-                        _: buffer
-                        _: 500
-                        _: ExternalAddress null.
-
-    ^ buffer asString
-]
-
-{ #category : 'file paths' }
-WinPlatform >> getTempPath [
-
-  | buffer length |
-	length := self defaultMaximumPathLength.
-	buffer := (String new: length) asWin32WideString.
-	self getTempPath: length buffer: buffer.
-	^buffer asString
-]
-
 { #category : 'file paths' }
 WinPlatform >> getTempPath: bufferLength buffer: buffer [
 

--- a/src/System-SessionManager/SessionManager.class.st
+++ b/src/System-SessionManager/SessionManager.class.st
@@ -153,8 +153,6 @@ SessionManager class >> initializeKernelRegistrations [
 		registerSystemClassNamed: #Delay atPriority: 20;
 		registerSystemClassNamed: #ProcessorScheduler atPriority: 30;
 		registerSystemClassNamed: #OSPlatform atPriority: 50;
-		registerSystemClassNamed: #ExternalObject atPriority: 60;
-		registerSystemClassNamed: #FFIBackend atPriority: 60;
 		registerSystemClassNamed: #File atPriority: 90;
 		registerSystemClassNamed: #SmalltalkImage atPriority: 90;
 		registerSystemClassNamed: #SourcesManager; 

--- a/src/Traits/ManifestTraits.class.st
+++ b/src/Traits/ManifestTraits.class.st
@@ -8,10 +8,3 @@ Class {
 	#package : 'Traits',
 	#tag : 'Manifest'
 }
-
-{ #category : 'meta-data - dependency analyser' }
-ManifestTraits class >> manuallyResolvedDependencies [
-
-	<ignoreForCoverage>
-	^ #(#'System-Sources')
-]


### PR DESCRIPTION
- Move FFI-Kernel from BaselineOfKernel to BaselineOfFileSystem. Ideally I would like to have it in BaselineOfUFFI but currently the bootstrap does not build if I do that even if I do not find any dependency
- Move ClassDefinitionPrinter from BaselineOfKernel to BaselineOfCompiler right before the package CodeExport because it is the first user
- Add some code to throw an error if we have an undeclared in the image produces by Espell
- Remove the `-no-fail-on-undeclared` option of Metacello loading to make it strict

This reduces the number of classes loaded by espell from 491 to 461 :)