### PR TITLE
Fix Calypso index out of range error

### DIFF
--- a/src/Calypso-Browser/ClyNotebookMorph.class.st
+++ b/src/Calypso-Browser/ClyNotebookMorph.class.st
@@ -111,12 +111,11 @@ ClyNotebookMorph >> toolbarMorph [
 
 { #category : 'private' }
 ClyNotebookMorph >> updateContentMorph: aMorph with: newMorph [
-	| pageBounds |
 
+	| pageBounds |
 	pageBounds := self pageMorph bounds.
 	"We should replace aMorph which comes from pageMorph ONLY if it is present in the contentMorph (a PanelMorph), which is a container in the receiver"
-	(self contentMorph findA: aMorph class)
-		ifNotNil: [ : replaceMorph | self contentMorph replaceSubmorph: aMorph by: newMorph ].
+	self contentMorph submorphs detect: [ :morph | morph = aMorph ] ifFound: [ :replaceMorph | self contentMorph replaceSubmorph: aMorph by: newMorph ].
 	self pageMorph bounds: pageBounds.
 	self pageMorph layoutChanged
 ]


### PR DESCRIPTION
Since a few years we often have an error "Index out of range" while developing in Calypso.  I am not 100% sure of my fix but it seems to work. 

To update itself calypso was looking for a morph checking the kind of the morph and replacing it later. But it is possible to have a morph of the right kind but a different instance in some cases. So now I'm checking by identity.

If this works well we could backport it

This complement this fix: https://github.com/pharo-project/pharo/pull/14942

Fixes #13532