### PR TITLE
Fix missing items in Dr Test  when selecting multiple packages or all.

### DIFF
--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -304,7 +304,8 @@ DTDefaultPluginPresenter >> resultsList [
 { #category : 'api' }
 DTDefaultPluginPresenter >> selectAllInPackageList [
 
-	packagesList selectAll
+	packagesList selectAll.
+
 ]
 
 { #category : 'api' }
@@ -433,17 +434,16 @@ DTDefaultPluginPresenter >> whenItemsSelectionChanged: itemsSelected [
 { #category : 'private' }
 DTDefaultPluginPresenter >> whenPackagesSelectionChanged: packagesSelected [
 
-	| allClasses |
-	allClasses := packagesSelected flatCollect: [ :package | package classes ].
+	| allClasses analysable |
+	allClasses := packagesSelected flatCollect: #classes.
+	analysable := plugin itemsToBeAnalysedFor: packagesSelected.
+
 	itemsList
-		roots: (((plugin itemsToBeAnalysedFor: packagesSelected) reject: [ :aClass | allClasses includes: aClass superclass ]) sorted:
-					 #name ascending);
-		children: [ :aClass | aClass subclasses & allClasses sorted: #name ascending ];
+		roots: ((analysable reject: [ :aClass | analysable includes: aClass superclass ]) sorted: #name ascending);
+		children: [ :aClass | aClass subclasses & analysable sorted: #name ascending ];
 		expandAll.
+
 	itemsList roots: itemsList items.
 	itemsList selectAll.
-	self updatePackagesListLabel.
-
-
-
+	self updatePackagesListLabel
 ]

--- a/src/DrTests/DTDefaultPluginPresenter.class.st
+++ b/src/DrTests/DTDefaultPluginPresenter.class.st
@@ -434,15 +434,12 @@ DTDefaultPluginPresenter >> whenItemsSelectionChanged: itemsSelected [
 { #category : 'private' }
 DTDefaultPluginPresenter >> whenPackagesSelectionChanged: packagesSelected [
 
-	| allClasses analysable |
-	allClasses := packagesSelected flatCollect: #classes.
-	analysable := plugin itemsToBeAnalysedFor: packagesSelected.
-
+	| testClasses |
+	testClasses := plugin itemsToBeAnalysedFor: packagesSelected.
 	itemsList
-		roots: ((analysable reject: [ :aClass | analysable includes: aClass superclass ]) sorted: #name ascending);
-		children: [ :aClass | aClass subclasses & analysable sorted: #name ascending ];
+		roots: ((testClasses reject: [ :aClass | testClasses includes: aClass superclass ]) sorted: #name ascending);
+		children: [ :aClass | aClass subclasses & testClasses sorted: #name ascending ];
 		expandAll.
-
 	itemsList roots: itemsList items.
 	itemsList selectAll.
 	self updatePackagesListLabel


### PR DESCRIPTION
Root classes were incorrectly filtered  if their superclasses belonged to any selected package. The filtering now only applies when the superclass is also part of the analysable items set. 
Fixes #19279