### PR TITLE
Insert superclass improval

### DIFF
--- a/src/Refactoring-UI-Tests/ReInsertSuperclassDriverTest.class.st
+++ b/src/Refactoring-UI-Tests/ReInsertSuperclassDriverTest.class.st
@@ -42,9 +42,9 @@ ReInsertSuperclassDriverTest >> testInsertSuperclass [
 
 	driver runRefactoring.
 
-	self assert: driver refactoring changes changes size equals: 3. "one because the subclasses got a new root the new subclass of the superclass"
+	self assert: driver refactoring changes changes size equals: 2. "one because the subclasses got a new root the new subclass of the superclass"
 	self assert: rbLeafClass subclasses size equals: 0.
-	self assert: rbLeafClass superclass subclasses size equals: 2.
+	self assert: rbLeafClass superclass subclasses size equals: 1.
 
 
 	self assert: rbLeafClass superclass name equals: self newSuperclassName

--- a/src/Refactoring-UI/ReInsertSuperclassDriver.class.st
+++ b/src/Refactoring-UI/ReInsertSuperclassDriver.class.st
@@ -75,12 +75,12 @@ ReInsertSuperclassDriver >> dialogTitleForClassSelection [
 
 { #category : 'configuration' }
 ReInsertSuperclassDriver >> instantiateRefactoring [
-
 	"self ensureSuperclassInModel."
+
 	^ (RBInsertNewClassRefactoring className: self subclass asString)
 		  model: model;
 		  superclass: superclassParent;
-		  subclasses: (superclassParent subclasses collect: [ :each | each name ]);
+		  subclasses: { superclass };
 		  packageName: self packageName;
 		  tagName: self tagName;
 		  comment: self comment;


### PR DESCRIPTION
The refactoring was imposing the new superclass to all siblings of user target class. 
This fix brings only the target class as the only subclass of the created superclass. 
Fixes #19288
