### PR TITLE
Speed up #isReferenced

### DIFF
--- a/src/Kernel-CodeModel/Slot.class.st
+++ b/src/Kernel-CodeModel/Slot.class.st
@@ -198,10 +198,13 @@ Slot >> isReadIn: aCompiledCode [
 
 { #category : 'testing' }
 Slot >> isReferenced [
+
 	^ self owningClass
-		ifNil: [ false ]
-		ifNotNil: [ :class |
-		  class withAllSubclasses anySatisfy: [ :subclass | subclass hasMethodAccessingVariable: self ] ]
+		  ifNil: [ false ]
+		  ifNotNil: [ :class |
+		"We do not use #withAllSubclasses because it often put the owning class last and most of the time variables are referenced by the owning class and not the subclasses. And it is really costly to check the references since it builds the AST of each methods.
+		You can check the speed of NoUnusedVariablesLeftTest>>#testNoUnusedInstanceVariablesLeft to see the difference."
+		  (class hasMethodAccessingVariable: self) or: [ class allSubclasses anySatisfy: [ :subclass | subclass hasMethodAccessingVariable: self ] ] ]
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
#isReferenced was checking the owning class and all subclasses to see if variables are referenced using #withAllSubclasses. But this put the owning class last while it is often the only class referencing the variable.

Now I'm checking the owning class first and it is much faster in most cases.

For example the test NoUnusedVariablesLeftTest>>#testNoUnusedInstanceVariablesLeft went from 6sec on my machine to 250ms :)

On the CI the test went from 7.5sec to 0.35sec

