### PR TITLE
New feature: Command + Driver for MoveInstanceVariableToClassTransformation

### DIFF
--- a/src/Refactoring-UI/ReMoveVariablesToClassSideDriver.class.st
+++ b/src/Refactoring-UI/ReMoveVariablesToClassSideDriver.class.st
@@ -1,0 +1,43 @@
+"
+I represent a driver that invokes RBMoveInstanceVariableToClassTransformation to move instance variables to their class side
+"
+Class {
+	#name : 'ReMoveVariablesToClassSideDriver',
+	#superclass : 'ReInteractionDriver',
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
+}
+
+{ #category : 'accessing' }
+ReMoveVariablesToClassSideDriver class >> driverName [
+
+	^ 'Move variable(s) to class side'
+]
+
+{ #category : 'initialization' }
+ReMoveVariablesToClassSideDriver class >> scopes: scopesList variables: aCollectionOfVariables [
+
+	^ self new scopes: scopesList variables: aCollectionOfVariables
+]
+
+{ #category : 'execution' }
+ReMoveVariablesToClassSideDriver >> runRefactoring [
+
+	self applyChanges
+]
+
+{ #category : 'execution' }
+ReMoveVariablesToClassSideDriver >> scopes: scopesList variables: variables [
+
+	scopes := scopesList.
+	model := self refactoringScopeOn: scopesList first.
+	refactoring := RBCompositeTransformation new
+		               model: model;
+		               transformations: (variables collect: [ :v |
+						                RBMoveInstanceVariableToClassTransformation
+							                model: model
+							                variable: v name
+							                fromClass: v definingClass
+							                toClass: v definingClass classSide ])
+]

--- a/src/SystemCommands-VariableCommands/SycMoveInstanceVariableToClassSideCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycMoveInstanceVariableToClassSideCommand.class.st
@@ -1,0 +1,38 @@
+"
+I am a command to move given instance variable to its class side
+"
+Class {
+	#name : 'SycMoveInstanceVariableToClassSideCommand',
+	#superclass : 'SycRefactorVariableCommand',
+	#instVars : [
+		'refactoringScopes'
+	],
+	#category : 'SystemCommands-VariableCommands',
+	#package : 'SystemCommands-VariableCommands'
+}
+
+{ #category : 'accessing' }
+SycMoveInstanceVariableToClassSideCommand >> defaultMenuIconName [
+	^ #smallRedo
+]
+
+{ #category : 'accessing' }
+SycMoveInstanceVariableToClassSideCommand >> defaultMenuItemName [
+
+	^ '(T) Move to class side'
+]
+
+{ #category : 'execution' }
+SycMoveInstanceVariableToClassSideCommand >> execute [
+
+	^ ((ReMoveVariablesToClassSideDriver newApplication: self application) scopes: refactoringScopes variables: variables)
+		  runRefactoring
+]
+
+{ #category : 'execution' }
+SycMoveInstanceVariableToClassSideCommand >> prepareFullExecutionInContext: aToolContext [
+
+	super prepareFullExecutionInContext: aToolContext.
+	toolContext := aToolContext.
+	refactoringScopes := toolContext refactoringScopes
+]


### PR DESCRIPTION

Since the transformation already existed + was tested I implemented a command + driver for users to be able to use it !
I did not put tests for the driver because all of driver tests are about refactorings (not transformations).
I could check for failed applicability preconditions in new tests, but this transformation calls other transformations that certainly already have those tests.

Fixes https://github.com/pharo-project/pharo/issues/19280