### PR TITLE
Fix tests relying on non clean closures

### DIFF
--- a/src/DebugInfo-Tests/DebugInfoTest.class.st
+++ b/src/DebugInfo-Tests/DebugInfoTest.class.st
@@ -39,8 +39,10 @@ DebugInfoTest >> methodWithArgumentCapturingContext: anArgument [
 { #category : 'helpers' }
 DebugInfoTest >> methodWithArgumentCapturingFullBlockContext: anArgument [
 
+	<compilerOptions: #(- optionCleanBlockClosure)>
+
 	"anArgument is unused, but the context should capture it"
-	^ [  thisContext copy ] value
+	^ [ self. thisContext copy ] value
 ]
 
 { #category : 'helpers' }
@@ -706,6 +708,7 @@ DebugInfoTest >> testRangeForSendInInlinedBlock [
 { #category : 'tests - read variables' }
 DebugInfoTest >> testReadLocalBlockArgumentVariable [
 
+	<compilerOptions: #(- optionCleanBlockClosure)>
 	| debugInfo context |
 	context := [ :blockArgument | thisContext copy ] value: 7.
 
@@ -783,6 +786,7 @@ DebugInfoTest >> testReadLocalBlockTempVectorTemporaryVariableFromMethod [
 { #category : 'tests - read variables' }
 DebugInfoTest >> testReadLocalBlockTemporaryVariable [
 
+	<compilerOptions: #(- optionCleanBlockClosure)>
 	| debugInfo context |
 	context := [ :blockArgument |
 		           | tempInBlock |
@@ -901,6 +905,7 @@ DebugInfoTest >> testReadNonExistingVariableRaisesError [
 { #category : 'tests - read variables' }
 DebugInfoTest >> testReadOuterBlockArgumentVariableFromClosure [
 
+	<compilerOptions: #(- optionCleanBlockClosure)>
 	| debugInfo context |
 	context := [ :blockArgument | [ thisContext copy ] value ] value: 7.
 
@@ -915,6 +920,7 @@ DebugInfoTest >> testReadOuterBlockArgumentVariableFromClosure [
 { #category : 'tests - read variables' }
 DebugInfoTest >> testReadOuterBlockArgumentVariableFromOptimizedBlock [
 
+	<compilerOptions: #(- optionCleanBlockClosure)>
 	| debugInfo context |
 	context := [ :blockArgument | true ifTrue: [ thisContext copy ] ]
 		           value: 7.
@@ -1125,6 +1131,8 @@ DebugInfoTest >> testReadOuterMethodArgumentVariableFromOptimizedBlock [
 { #category : 'tests - read variables' }
 DebugInfoTest >> testReadOuterMethodTemporaryVariableFromClosure [
 
+	<compilerOptions: #(- optionCleanBlockClosure)>
+	
 	| debugInfo contextWithArguments |
 	contextWithArguments := [ thisContext copy ] value.
 	debugInfo := self newDebugInfoFor: contextWithArguments method.

--- a/src/Debugger-Model-Tests/AssignmentAndLiteralDebuggerTest.class.st
+++ b/src/Debugger-Model-Tests/AssignmentAndLiteralDebuggerTest.class.st
@@ -8,6 +8,7 @@ Class {
 
 { #category : 'running' }
 AssignmentAndLiteralDebuggerTest >> setUp [
+	<compilerOptions: #(- optionCleanBlockClosure)>
 	super setUp.
 	self settingUpSessionAndProcessAndContextForBlock: [ |var| var:=4]
 ]


### PR DESCRIPTION
We have many tests that depend on non-clean closures, and get broken by them.

Disable the optimization for those tests so far