### PR TITLE
Fix: Add temp var refactoring precondition flow

### DIFF
--- a/src/Refactoring-Transformations/RBAddTemporaryVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddTemporaryVariableTransformation.class.st
@@ -66,23 +66,29 @@ RBAddTemporaryVariableTransformation class >> variable: aString inMethod: aSelec
 RBAddTemporaryVariableTransformation >> applicabilityPreconditions [
 
 	^ {
-		  (RBCondition
-			   withBlock: [ self definingClass isNotNil ]
-			   errorString: 'No such class or trait named ' , className).
+		  self preconditionMethodAlreadyDefines.
+		  (RBCondition withBlock: [ self definingClass isNotNil ] errorString: 'No such class or trait named ' , className).
 		  (RBCondition definesSelector: selector in: self definingClass).
 		  (RBCondition
-			   withBlock: [
-				   (self definingMethod allArgumentVariables includes:
-					    variableName) not ]
-			   errorString:
-				   'Method named ' , selector
-				   , ' already defines an argument named ' , variableName) }
+			   withBlock: [ (self definingMethod allArgumentVariables includes: variableName) not ]
+			   errorString: 'Method named ' , selector , ' already defines an argument named ' , variableName) }
 ]
 
 { #category : 'scripting api - conditions' }
 RBAddTemporaryVariableTransformation >> checkPreconditions [ 
 
 	self eagerlyCheckApplicabilityPreconditions 
+]
+
+{ #category : 'preconditions' }
+RBAddTemporaryVariableTransformation >> preconditionMethodAlreadyDefines [
+
+	^ RBCondition
+		  withBlock: [
+			  (self definingMethod allTemporaryVariables includes: variableName)
+				  not ]
+		  errorString: 'Method named ' , selector
+			  , ' already defines a temporary variable named ' , variableName
 ]
 
 { #category : 'executing' }
@@ -97,22 +103,10 @@ RBAddTemporaryVariableTransformation >> privateTransform [
 		nodeInInterval := methodTree bestNodeFor: interval.
 		nodeInInterval isSequence ifTrue: [ parseTree := nodeInInterval ] ].
 
-	self flag: #skippingPreconditions.
 	(parseTree allTemporaryVariables includes: variableName) ifTrue: [ ^ self ].
 	
 	parseTree addTemporaryNamed: variableName.
 	class compileTree: methodTree
-]
-
-{ #category : 'preconditions' }
-RBAddTemporaryVariableTransformation >> skippingPreconditions [
-
-	^ RBCondition
-		  withBlock: [
-			  (self definingMethod allTemporaryVariables includes: variableName)
-				  not ]
-		  errorString: 'Method named ' , selector
-			  , ' already defines a temporary variable named ' , variableName
 ]
 
 { #category : 'api' }


### PR DESCRIPTION
There was a precondition call in privateTransform method which is bad. 
Anyways this refactoring is only called by `RBMoveTemporaryVariableDefinitionTransformation` which is never used, we should give it an utility and show it to the user.

FIxes #18897