### PR TITLE
SDL2: do not ignore the focus-gain click

### DIFF
--- a/src/OSWindow-SDL2/SDL2.class.st
+++ b/src/OSWindow-SDL2/SDL2.class.st
@@ -244,7 +244,8 @@ SDL2 class >> initLibrary [
 
 	self
 		setHint: SDL_HINT_VIDEO_ALLOW_SCREENSAVER value: '1';
-		setHint: SDL_HINT_NO_SIGNAL_HANDLERS value: '1'.
+		setHint: SDL_HINT_NO_SIGNAL_HANDLERS value: '1';
+		setHint: SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH value: '1'.
 
 	self init: SDL_INIT_NOPARACHUTE.
 	Session := Smalltalk session


### PR DESCRIPTION
Where "focus-gain click" is the click that focuses a window that was at background.

Back-port of: https://github.com/pharo-project/pharo/pull/19302
See: https://github.com/pharo-graphics/Bloc/issues/842