### PR TITLE
Remove usage of `openBrowserOn:`

### DIFF
--- a/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
@@ -21,22 +21,11 @@ RBPushDownClassVariableRefactoring >> applicabilityPreconditions [
 RBPushDownClassVariableRefactoring >> breakingChangePreconditions [
 
 	| references |
-	references := RBCondition
-		              referencesClassVariable: variableName
-		              in: class.
+
+	references := RBCondition referencesClassVariable: variableName in: class.
 	class realClass
-		ifNil: [
-			references errorMacro:
-				('<1s> is referenced.' expandMacrosWith: variableName) ]
-		ifNotNil: [
-			references
-				errorMacro:
-					('<1s> is referenced.<n>Browse references?' expandMacrosWith:
-							 variableName);
-				errorBlock: [
-					self openBrowserOn: (RBBrowserEnvironment new
-								 classVarRefsTo: variableName
-								 in: class realClass) ] ].
+		ifNil: [ references errorMacro: ('<1s> is referenced.' expandMacrosWith: variableName) ]
+		ifNotNil: [ references errorMacro: ('<1s> is referenced.<n>Browse references?' expandMacrosWith: variableName) ].
 	^ { references not }
 ]
 

--- a/src/Refactoring-Core/RBPushDownInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownInstanceVariableRefactoring.class.st
@@ -21,22 +21,10 @@ RBPushDownInstanceVariableRefactoring >> applicabilityPreconditions [
 RBPushDownInstanceVariableRefactoring >> breakingChangePreconditions [
 
 	| references |
-	references := RBCondition
-		              referencesInstanceVariable: variableName
-		              in: class.
+	references := RBCondition referencesInstanceVariable: variableName in: class.
 	class realClass
-		ifNil: [
-			references errorMacro:
-				('<1s> is referenced.' expandMacrosWith: variableName) ]
-		ifNotNil: [
-			references
-				errorMacro:
-					('<1s> is referenced.<n>Browse references?' expandMacrosWith:
-							 variableName);
-				errorBlock: [
-					self openBrowserOn: (RBBrowserEnvironment new
-								 instVarRefsTo: variableName
-								 in: class realClass) ] ].
+		ifNil: [ references errorMacro: ('<1s> is referenced.' expandMacrosWith: variableName) ]
+		ifNotNil: [ references errorMacro: ('<1s> is referenced.<n>Browse references?' expandMacrosWith: variableName) ].
 	^ { references not }
 ]
 

--- a/src/Refactoring-Core/RBPushDownInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownInstanceVariableRefactoring.class.st
@@ -20,12 +20,13 @@ RBPushDownInstanceVariableRefactoring >> applicabilityPreconditions [
 { #category : 'preconditions' }
 RBPushDownInstanceVariableRefactoring >> breakingChangePreconditions [
 
-	| references |
-	references := RBCondition referencesInstanceVariable: variableName in: class.
-	class realClass
-		ifNil: [ references errorMacro: ('<1s> is referenced.' expandMacrosWith: variableName) ]
-		ifNotNil: [ references errorMacro: ('<1s> is referenced.<n>Browse references?' expandMacrosWith: variableName) ].
-	^ { references not }
+	^ { self preconditionReferencesInstanceVariable }
+]
+
+{ #category : 'preconditions' }
+RBPushDownInstanceVariableRefactoring >> preconditionReferencesInstanceVariable [
+
+	^ ReReferencesInstanceVariableCondition class: class inModel: self model instanceVariables: { variableName }
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
@@ -49,36 +49,27 @@ RBRemoveMethodRefactoring >> breakingChangePreconditions [
 
 { #category : 'preconditions' }
 RBRemoveMethodRefactoring >> checkBrowseAllOccurrences: anCollectionOfOccurrences [
+
 	| methods callers |
 	methods := anCollectionOfOccurrences collect: [ :c | c key ] as: Set.
 	callers := anCollectionOfOccurrences collect: [ :v | v value ].
 	methods size = 1
 		ifTrue: [
-			self
-				refactoringWarning:
-					('Possible call to <2s> in <1p> methods.<n>Browse references?'
-						expandMacrosWith: anCollectionOfOccurrences size
-						with: methods anyOne)
-				with: [ self openBrowserOn: (RBBrowserEnvironment new referencesTo: methods anyOne) ] ]
+				self refactoringWarning: ('Possible call to <2s> in <1p> methods.<n>Browse references?'
+						 expandMacrosWith: anCollectionOfOccurrences size
+						 with: methods anyOne) ]
 		ifFalse: [
-			self
-				refactoringWarning:
+				self refactoringWarning:
 					('Possible call to the <2p> selectors in <1p> methods.<n>Browse references?'
-						expandMacrosWith: callers size
-						with: methods size)
-				with: [
-					| env |
-					env := RBSelectorEnvironment new.
-					callers do: [ :d | env addMethod: d method ].
-					self openBrowserOn: env ] ]
+						 expandMacrosWith: callers size
+						 with: methods size) ]
 ]
 
 { #category : 'preconditions' }
 RBRemoveMethodRefactoring >> checkBrowseOccurrenceOf: aSelector in: aRBMethod [
-	self
-		refactoringWarning:
-			('Possible call to <2s> in <1p><n>Browse references?' expandMacrosWith: aRBMethod modelClass with: aSelector)
-		with: [ self openBrowserOn: (RBBrowserEnvironment new referencesTo: aSelector) ]
+
+	self refactoringWarning:
+		('Possible call to <2s> in <1p><n>Browse references?' expandMacrosWith: aRBMethod modelClass with: aSelector)
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Core/ReReferencesInstanceVariableCondition.class.st
+++ b/src/Refactoring-Core/ReReferencesInstanceVariableCondition.class.st
@@ -1,0 +1,48 @@
+"
+I'm a condition that checks if any of given instance variables is referenced in given class
+"
+Class {
+	#name : 'ReReferencesInstanceVariableCondition',
+	#superclass : 'ReClassCondition',
+	#instVars : [
+		'instanceVariables'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'instance creation' }
+ReReferencesInstanceVariableCondition class >> class: aRBAbstractClass inModel: aRBNamespace instanceVariables: aCollection [
+
+	^ self new
+		  class: aRBAbstractClass inModel: aRBNamespace instanceVariables: aCollection;
+		  yourself
+]
+
+{ #category : 'checking' }
+ReReferencesInstanceVariableCondition >> check [
+
+	violators := instanceVariables flatCollect: [ :v | class whichSelectorsReferToInstanceVariable: v ].
+
+	^ violators isEmpty
+]
+
+{ #category : 'instance creation' }
+ReReferencesInstanceVariableCondition >> class: aRBAbstractClass inModel: aRBNamespace instanceVariables: aCollection [
+
+	class := aRBAbstractClass.
+	model := aRBNamespace.
+	instanceVariables := aCollection
+]
+
+{ #category : 'displaying' }
+ReReferencesInstanceVariableCondition >> violationMessageOn: aStream [
+
+	^ violators do: [ :violator |
+			  aStream
+				  nextPutAll: ('The selector {1} references an instance variable in the class {2}' format: {
+								   violator.
+								   class name });
+				  nextPut: Character cr ]
+]

--- a/src/Refactoring-Transformations-Tests/RBPushDownInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPushDownInstanceVariableParametrizedTest.class.st
@@ -112,6 +112,7 @@ RBPushDownInstanceVariableParametrizedTest >> testPushDownInstanceVariable [
 { #category : 'tests' }
 RBPushDownInstanceVariableParametrizedTest >> testPushDownInstanceVariableWithReferences [
 
-	self shouldWarn: (self createRefactoringWithModel: model andArguments:
-			 { 'name'. #RBBasicLintRuleTestData })
+	| refactoring |
+	refactoring := self createRefactoringWithModel: model andArguments: { 'name'. #RBBasicLintRuleTestData }.
+	(refactoring isKindOf: RBPushDownInstanceVariableRefactoring) ifTrue: [ self shouldWarn: refactoring ]
 ]

--- a/src/Refactoring-Transformations-Tests/RBPushDownInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPushDownInstanceVariableParametrizedTest.class.st
@@ -108,3 +108,10 @@ RBPushDownInstanceVariableParametrizedTest >> testPushDownInstanceVariable [
 	(refactoring model classNamed: #RBLintRuleTestData) subclasses do:
 		[ :each | self assert: (each directlyDefinesInstanceVariable: 'foo1') ]
 ]
+
+{ #category : 'tests' }
+RBPushDownInstanceVariableParametrizedTest >> testPushDownInstanceVariableWithReferences [
+
+	self shouldWarn: (self createRefactoringWithModel: model andArguments:
+			 { 'name'. #RBBasicLintRuleTestData })
+]

--- a/src/Refactoring-UI/RePushDownInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/RePushDownInstanceVariableDriver.class.st
@@ -1,0 +1,151 @@
+"
+I represent a driver that invokes `PushDownInstanceVariables` refactoring.
+
+I am responsible for asking user which variables to push down.
+
+"
+Class {
+	#name : 'RePushDownInstanceVariableDriver',
+	#superclass : 'ReInteractionDriver',
+	#instVars : [
+		'variables',
+		'methodSelectionPresenterClass',
+		'referencesInstanceVariableCollection'
+	],
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
+}
+
+{ #category : 'accessing' }
+RePushDownInstanceVariableDriver class >> driverName [
+
+	^ 'Push down instance variable(s)'
+]
+
+{ #category : 'execution' }
+RePushDownInstanceVariableDriver >> breakingChoices [
+
+	| choices |
+	choices := OrderedCollection new.
+	choices add: (RePushDownMethodTransformationChoice new driver: self).
+	(referencesInstanceVariableCollection anySatisfy: [ :precond | precond isFalse ]) ifTrue: [
+		choices add: (ReBrowseMethodsChoice new driver: self) ].
+
+
+	^ choices
+]
+
+{ #category : 'actions' }
+RePushDownInstanceVariableDriver >> browseMethods [
+
+	| violators |
+	violators := referencesInstanceVariableCollection flatCollect: [ :c |
+		             (c violators collect: [ :method | variables first definingClass compiledMethodAt: method ]) asSet ].
+
+
+	(application toolNamed: #messageList) browse: violators
+]
+
+{ #category : 'execution' }
+RePushDownInstanceVariableDriver >> configureAndRunRefactoring [
+
+	self configureRefactoring.
+	self setBreakingChangesPreconditions.
+	refactoring refactorings do: [ :r |
+		r failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ] ]
+]
+
+{ #category : 'configuration' }
+RePushDownInstanceVariableDriver >> defaultSelectDialog [
+
+	^ super defaultSelectDialog
+		  title: 'There are potential breaking changes!';
+		  message: self labelBasedOnBreakingChanges;
+		  items: self breakingChoices;
+		  display: [ :each | each description ];
+		  displayIcon: [ :each | self iconNamed: each systemIconName ];
+		  yourself
+]
+
+{ #category : 'execution' }
+RePushDownInstanceVariableDriver >> gatherUserInput [
+
+	variables := self selectVariables.
+]
+
+{ #category : 'configuration' }
+RePushDownInstanceVariableDriver >> instantiateRefactoring [
+
+	^ ReCompositeRefactoring new
+		  model: model;
+		  refactorings: (variables collect: [ :v |
+					   RBPushDownInstanceVariableRefactoring model: model variable: v name class: variables first definingClass ])
+]
+
+{ #category : 'ui - dialogs' }
+RePushDownInstanceVariableDriver >> labelBasedOnBreakingChanges [
+
+	^ String streamContents: [ :stream |
+			  (referencesInstanceVariableCollection anySatisfy: [ :precond | precond isFalse ]) ifTrue: [
+					  referencesInstanceVariableCollection first violationMessageOn: stream.
+					  stream cr ].
+			  stream nextPutAll: 'Select a strategy' ]
+]
+
+{ #category : 'execution' }
+RePushDownInstanceVariableDriver >> runRefactoring [
+	"the user can still select if needed. Nil = cancel refactoring"
+
+	self gatherUserInput.
+	variables ifNil: [ ^ self ].
+	self configureAndRunRefactoring
+]
+
+{ #category : 'accessing' }
+RePushDownInstanceVariableDriver >> scopes: scopesList [ 
+
+	scopes := scopesList.
+	model := self refactoringScopeOn: scopesList first.
+
+]
+
+{ #category : 'execution' }
+RePushDownInstanceVariableDriver >> selectVariables [
+
+	| dialog |
+	dialog := (self variablesSelectionPresenterClass newApplication: self application)
+		          title: 'There are potential breaking changes!'
+		          label: 'Push down variables from ' , variables first definingClass name
+		          withItems: (variables sort: [ :a :b | a asString < b asString ]) asOrderedCollection
+		          selecting: variables asOrderedCollection;
+		          openModal.
+
+	dialog isOk ifFalse: [ ^ nil ].
+
+	^ dialog presenter selectedItems
+]
+
+{ #category : 'initialization' }
+RePushDownInstanceVariableDriver >> setBreakingChangesPreconditions [
+
+	referencesInstanceVariableCollection := refactoring refactorings collect: [ :r | r preconditionReferencesInstanceVariable ]
+]
+
+{ #category : 'accessing' }
+RePushDownInstanceVariableDriver >> variables: aCollectionOfVariables [
+
+	variables := aCollectionOfVariables
+]
+
+{ #category : 'for mocks' }
+RePushDownInstanceVariableDriver >> variablesSelectionPresenterClass [
+
+	^ methodSelectionPresenterClass ifNil: [ methodSelectionPresenterClass := StVariablesSelectionPresenter ]
+]
+
+{ #category : 'for mocks' }
+RePushDownInstanceVariableDriver >> variablesSelectionPresenterClass: aClass [
+
+	methodSelectionPresenterClass := aClass
+]

--- a/src/Refactoring-UI/ReRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveMethodDriver.class.st
@@ -83,6 +83,7 @@ ReRemoveMethodDriver >> instantiateRefactoring [
 ReRemoveMethodDriver >> runRefactoring [
 
 	self configureRefactoring.
+
 	refactoring failedApplicabilityPreconditions 
 		ifNotEmpty: [ ^ self inform: 'The method does not exist' ].
 	

--- a/src/SystemCommands-VariableCommands/SycPushDownVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycPushDownVariableCommand.class.st
@@ -15,13 +15,6 @@ SycPushDownVariableCommand class >> sourceCodeMenuActivation [
 	^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.4 for: ClySourceCodeContext
 ]
 
-{ #category : 'execution' }
-SycPushDownVariableCommand >> asRefactorings [
-
-	^self
-		createRefactorings: RBPushDownInstanceVariableRefactoring
-]
-
 { #category : 'accessing' }
 SycPushDownVariableCommand >> defaultMenuIconName [
 	^ #down
@@ -33,18 +26,19 @@ SycPushDownVariableCommand >> defaultMenuItemName [
 ]
 
 { #category : 'execution' }
+SycPushDownVariableCommand >> execute [
+
+	^ ((RePushDownInstanceVariableDriver newApplication: self application)
+		   scopes: toolContext refactoringScopes;
+		   variables: variables) runRefactoring
+]
+
+{ #category : 'execution' }
 SycPushDownVariableCommand >> prepareFullExecutionInContext: aToolContext [
-	"Private - If one of the selected variables belongs to a leaf class, without subclasses, abort the command"
-	
+
 	super prepareFullExecutionInContext: aToolContext.
 
-	(aToolContext selectedVariables allSatisfy: [ : selectedVar | selectedVar definingClass hasSubclasses ])
-		ifFalse: [ 
-			self inform: 'One of the selected variables belongs to a class that has no subclasses to push down the selection(s)'.
-			CmdCommandAborted signal ]
-		ifTrue: [ 
-			| noUsers |
-			noUsers := aToolContext confirmUnusedVariablesInDefiningClass: variables.
-			noUsers ifFalse: [ CmdCommandAborted signal ] ].
-
+	(aToolContext selectedVariables allSatisfy: [ :selectedVar | selectedVar definingClass hasSubclasses ]) ifTrue: [ ^ self ].
+	self inform: 'One of the selected variables belongs to a class that has no subclasses to push down the selection(s)'.
+	CmdCommandAborted signal
 ]


### PR DESCRIPTION
It should be handled by drivers if possible and not being used at all, as it brings choices to the user.
This feature should not be present in a refactoring.
I also added a driver for pushDownInstanceVariableRefactoring + 1 test with breaking precondition !