### PR TITLE
Refactor `assert:closeTo:precision:`

### DIFF
--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -331,7 +331,7 @@ TestAsserter >> comparingStringBetween: actual and: expected [
 			  nextPut: $. ]
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 TestAsserter >> defaultComparisonPrecision [
 
 	^ Float defaultComparisonPrecision

--- a/src/SUnit-Core/TestAsserter.class.st
+++ b/src/SUnit-Core/TestAsserter.class.st
@@ -107,7 +107,7 @@ TestAsserter >> assert: actualNumber closeTo: expectedNumber [
 	self
 		assert: actualNumber
 		closeTo: expectedNumber
-		precision: Float defaultComparisonPrecision
+		precision: self defaultComparisonPrecision
 ]
 
 { #category : 'asserting' }
@@ -329,6 +329,12 @@ TestAsserter >> comparingStringBetween: actual and: expected [
 			  nextPutAll: ' instead of ';
 			  print: expected;
 			  nextPut: $. ]
+]
+
+{ #category : 'as yet unclassified' }
+TestAsserter >> defaultComparisonPrecision [
+
+	^ Float defaultComparisonPrecision
 ]
 
 { #category : 'factory' }


### PR DESCRIPTION
Refactor to allow test classes to define their own precision for comparison