### PR TITLE
allow eval command to eval a file

### DIFF
--- a/src/Clap-Tests/ClapCodeEvaluatorTest.class.st
+++ b/src/Clap-Tests/ClapCodeEvaluatorTest.class.st
@@ -7,6 +7,22 @@ Class {
 }
 
 { #category : 'tests' }
+ClapCodeEvaluatorTest >> testCanEvaluateAStFile [
+	| command file |
+	file := 	(self temporaryDirectory / 'foo.st') ensureCreateFile.
+	file writeStreamDo: [ :stream | stream nextPutAll: 'ClapSTFileEvaluatorTest testValue: 5' ].
+	context := ClapCodeEvaluator commandSpecification activationWith: { 'eval' . file fullName }.
+	command := context command.
+	
+	self assert: command isEvaluatingFile.
+	command execute.
+	
+	self
+		assert: ClapSTFileEvaluatorTest testValue
+		equals: 5
+]
+
+{ #category : 'tests' }
 ClapCodeEvaluatorTest >> testEvaluateAliasMultipleArguments [
 	context := ClapCodeEvaluator commandSpecification activateWith: #('eval'
 		'''(2+3)''' 'class' 'printString' ', String space ,' '(2+3)' 'class' 'printString').
@@ -57,4 +73,36 @@ ClapCodeEvaluatorTest >> testEvaluateShouldBeKeptAliveWhenNoQuitFlagPresent [
 	command := context command.
 	
 	self deny: command shouldQuit
+]
+
+{ #category : 'tests' }
+ClapCodeEvaluatorTest >> testEvaluatingNonExistingStFileRaiseError [
+	| command nonExistingFile |
+	nonExistingFile := 'testCanEvalNonExistingStFileRaiseError-non-existing.st'.
+	nonExistingFile asFileReference ensureDelete.
+	context := ClapCodeEvaluator commandSpecification activationWith: {'eval' . nonExistingFile }.
+	command := context command.
+	
+	self 
+		should: [ command execute ] 
+		raise: FileDoesNotExistException
+]
+
+{ #category : 'tests' }
+ClapCodeEvaluatorTest >> testIsEvaluatingFileIsFalseWhenMoreThanOneArgument [
+	| command |
+	context := ClapCodeEvaluator commandSpecification activationWith: #('eval' 'foo.st' '1').
+	command := context command.
+	
+	self deny: command isEvaluatingFile
+]
+
+{ #category : 'tests' }
+ClapCodeEvaluatorTest >> testIsEvaluatingFileIsTrueWhenFileSpecified [
+	| command file |
+	file := 	(self temporaryDirectory / 'foo.st') ensureCreateFile.
+	context := ClapCodeEvaluator commandSpecification activationWith: { 'eval' . file fullName }.
+	command := context command.
+	
+	self assert: command isEvaluatingFile
 ]

--- a/src/Clap-Tests/ClapSTFileEvaluatorTest.class.st
+++ b/src/Clap-Tests/ClapSTFileEvaluatorTest.class.st
@@ -44,13 +44,10 @@ ClapSTFileEvaluatorTest >> testCanGetStFile [
 { #category : 'tests' }
 ClapSTFileEvaluatorTest >> testCanRunStFile [
 	| file |
-	file := FileLocator temp / 'pharo-tests-' , UUID new asString / 'dummy.st'.
-	
-	[ file parent ensureCreateDirectory.
+	file := self temporaryDirectory / 'dummy.st'.
 	file writeStreamDo: [ :stream | stream nextPutAll: 'ClapSTFileEvaluatorTest testValue: 3' ].
 	
-	context := ClapSTFileEvaluator commandSpecification activateWith: {'st' . file fullName} ]
-		ensure: [ file parent deleteAll ].
+	context := ClapSTFileEvaluator commandSpecification activateWith: {'st' . file fullName}.
 	
 	self
 		assert: self class testValue
@@ -60,14 +57,12 @@ ClapSTFileEvaluatorTest >> testCanRunStFile [
 { #category : 'tests' }
 ClapSTFileEvaluatorTest >> testCanSkipShebang [
 	| file |
-	file := FileLocator temp / 'pharo-tests-' , UUID new asString / 'dummy.st'.
+	file := self temporaryDirectory / 'dummy.st'.
 	
-	[ file parent ensureCreateDirectory.
 	file writeStreamDo: [ :stream | stream nextPutAll: '#!/usr/bin/env pharo
 		ClapSTFileEvaluatorTest testValue: 4' ].
 	
-	context := ClapSTFileEvaluator commandSpecification activateWith: {'st' . file fullName} ]
-		ensure: [ file parent deleteAll ].
+	context := ClapSTFileEvaluator commandSpecification activateWith: {'st' . file fullName}.
 	
 	self
 		assert: self class testValue
@@ -90,8 +85,7 @@ ClapSTFileEvaluatorTest >> testGetManyFilesToProcessWheManyFuelFilesGivenInArgum
 ClapSTFileEvaluatorTest >> testGetOneFileToProcessWheOneStFileGivenInArguments [
 
 	| command |
-	context := ClapSTFileEvaluator commandSpecification activationWith:
-		           #( 'st' 'foo.st' ).
+	context := ClapSTFileEvaluator commandSpecification activationWith: #( 'st' 'foo.st' ).
 	command := context command.
 
 	self

--- a/src/CodeImport-Commands/ClapCodeEvaluator.class.st
+++ b/src/CodeImport-Commands/ClapCodeEvaluator.class.st
@@ -158,10 +158,17 @@ ClapCodeEvaluator >> handleError: error reference: aReference [
 	error pass
 ]
 
+{ #category : 'private - testing' }
+ClapCodeEvaluator >> hasOneArgument [
+
+	^ self expression size = 1
+]
+
 { #category : 'testing' }
 ClapCodeEvaluator >> isEvaluatingFile [
 
-	^ self expression size = 1 and: [ self file extension = 'st' ]
+	"Do not use FileReference here since eval is used in Pharo boostrap and when FileSystem package not yet loaded"
+	^ self expression size = 1 and: [ self expression first endsWith: '.st' ]
 ]
 
 { #category : 'asserting' }

--- a/src/CodeImport-Commands/ClapCodeEvaluator.class.st
+++ b/src/CodeImport-Commands/ClapCodeEvaluator.class.st
@@ -4,6 +4,9 @@ I evaluate code passed via standard input or as arguments from the command line.
 Class {
 	#name : 'ClapCodeEvaluator',
 	#superclass : 'ClapPharoApplication',
+	#instVars : [
+		'expression'
+	],
 	#category : 'CodeImport-Commands',
 	#package : 'CodeImport-Commands'
 }
@@ -118,6 +121,18 @@ ClapCodeEvaluator >> execute [
 		ifTrue: [ self outputStreamDo: [ :out | out print: result; lf ] ]
 ]
 
+{ #category : 'accessing' }
+ClapCodeEvaluator >> expression [
+
+	^ expression ifNil: [ expression := self positional: #EXPR ]
+]
+
+{ #category : 'private - accessing' }
+ClapCodeEvaluator >> file [
+
+	^ self expression first asFileReference
+]
+
 { #category : 'error handling' }
 ClapCodeEvaluator >> handleError: error [
 	"for syntax errors we print more detailed error informations"
@@ -143,6 +158,12 @@ ClapCodeEvaluator >> handleError: error reference: aReference [
 	error pass
 ]
 
+{ #category : 'testing' }
+ClapCodeEvaluator >> isEvaluatingFile [
+
+	^ self expression size = 1 and: [ self file extension = 'st' ]
+]
+
 { #category : 'asserting' }
 ClapCodeEvaluator >> shouldLogEvaluationResult [
 
@@ -152,7 +173,9 @@ ClapCodeEvaluator >> shouldLogEvaluationResult [
 
 { #category : 'accessing' }
 ClapCodeEvaluator >> source [
-	^ String space join: (self positional: #EXPR)
+	^ self isEvaluatingFile 
+		ifTrue: [ self file contents ]
+		ifFalse: [ String space join: self expression ] 
 ]
 
 { #category : 'validating' }

--- a/tests/pharo-cli-eval-tests.bats
+++ b/tests/pharo-cli-eval-tests.bats
@@ -32,10 +32,10 @@ teardown() {
 }
 
 @test "eval can evaluate a valid Smalltalk expression from a file and quit" {
-  echo 'Transcript show: 'Hello World!'; cr' > "$WORKDIR/test-code.st"
+  echo "Transcript show: 'Hello World!'; cr" > "$WORKDIR/test-code.st"
   run_pharo eval "$WORKDIR/test-code.st"
   assert_success
-  assert_output "Hello World!"
+  assert_line "Hello World!"
 }
 
 @test "eval outputs error if any when evaluating a valid Smalltalk expression with runtime error" {

--- a/tests/pharo-cli-eval-tests.bats
+++ b/tests/pharo-cli-eval-tests.bats
@@ -31,6 +31,13 @@ teardown() {
   assert_output "8"
 }
 
+@test "eval can evaluate a valid Smalltalk expression from a file and quit" {
+  echo 'Transcript show: 'Hello World!'; cr' > "$WORKDIR/test-code.st"
+  run_pharo eval "$WORKDIR/test-code.st"
+  assert_success
+  assert_output "Hello World!"
+}
+
 @test "eval outputs error if any when evaluating a valid Smalltalk expression with runtime error" {
   run_pharo eval 1 / 0
   assert_failure


### PR DESCRIPTION
st command also evaluate a file but in chunk format. It will avoid ! character escaping.
fixes #19235