### PR TITLE
Introduce ZnCharacterEncoder>>#numberOfCharactersFrom:

### DIFF
--- a/src/Zinc-Character-Encoding-Core/ZnCharacterEncoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCharacterEncoder.class.st
@@ -324,6 +324,19 @@ ZnCharacterEncoder >> nextPutCodePoint: codePoint toStream: stream [
 ]
 
 { #category : 'convenience' }
+ZnCharacterEncoder >> numberOfCharactersFrom: bytes [
+	"Return the number of characters represented by a byte array"
+
+	| byteStream count |
+	byteStream := bytes readStream.
+	count := 0.
+	[ byteStream atEnd ] whileFalse: [
+			count := count + 1.
+			self nextCodePointFromStream: byteStream ].
+	^ count
+]
+
+{ #category : 'convenience' }
 ZnCharacterEncoder >> readInto: string startingAt: offset count: requestedCount fromStream: stream [
 	"Read requestedCount characters into string starting at offset,
 	returning the number read, there could be less available when stream is atEnd"

--- a/src/Zinc-Character-Encoding-Core/ZnCharacterEncoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnCharacterEncoder.class.st
@@ -254,6 +254,13 @@ ZnCharacterEncoder >> errorOutsideRange [
 	^ self error: 'Character Unicode code point outside encoder range'
 ]
 
+{ #category : 'encoding - decoding' }
+ZnCharacterEncoder >> forwardOnStream: aStream [
+	"I should move from 1 character forward on the stream. The stream is over a ByteArray."
+
+	self subclassResponsibility
+]
+
 { #category : 'comparing' }
 ZnCharacterEncoder >> hash [
 	^ self class hash
@@ -325,14 +332,14 @@ ZnCharacterEncoder >> nextPutCodePoint: codePoint toStream: stream [
 
 { #category : 'convenience' }
 ZnCharacterEncoder >> numberOfCharactersFrom: bytes [
-	"Return the number of characters represented by a byte array"
+	"Return the number of characters represented by a byte array. We avoid creating code points, characters or string for speed reasons. Instead we use #forwardOnStream: that will just skip the bytes correspondin to one character."
 
 	| byteStream count |
 	byteStream := bytes readStream.
 	count := 0.
 	[ byteStream atEnd ] whileFalse: [
 			count := count + 1.
-			self nextCodePointFromStream: byteStream ].
+			self forwardOnStream: byteStream ].
 	^ count
 ]
 

--- a/src/Zinc-Character-Encoding-Core/ZnNullEncoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnNullEncoder.class.st
@@ -98,6 +98,13 @@ ZnNullEncoder >> ensureAtBeginOfCodePointOnStream: stream [
 	"Nothing to be done, I am a byte encoding: each code point is encoded in a single byte"
 ]
 
+{ #category : 'encoding - decoding' }
+ZnNullEncoder >> forwardOnStream: aStream [
+	"I should move from 1 character forward on the stream. The stream is over a ByteArray."
+
+	aStream next
+]
+
 { #category : 'accessing' }
 ZnNullEncoder >> identifier [
 	^ #ascii

--- a/src/Zinc-Character-Encoding-Core/ZnSimplifiedByteEncoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnSimplifiedByteEncoder.class.st
@@ -206,6 +206,13 @@ ZnSimplifiedByteEncoder >> ensureAtBeginOfCodePointOnStream: stream [
 	"Nothing to be done, I am a byte encoding: each code point is encoded in a single byte"
 ]
 
+{ #category : 'encoding - decoding' }
+ZnSimplifiedByteEncoder >> forwardOnStream: aStream [
+	"I should move from 1 character forward on the stream. The stream is over a ByteArray."
+
+	aStream next
+]
+
 { #category : 'comparing' }
 ZnSimplifiedByteEncoder >> hash [
 	^ self identifier hash

--- a/src/Zinc-Character-Encoding-Core/ZnUTF16Encoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnUTF16Encoder.class.st
@@ -79,6 +79,26 @@ ZnUTF16Encoder >> errorIncomplete [
 	self error: 'Incomplete utf-16 encoding'
 ]
 
+{ #category : 'encoding - decoding' }
+ZnUTF16Encoder >> forwardOnStream: aStream [
+	"Move the stream forward by one Unicode character encoded in UTF‑16."
+
+	| firstUnit lowByte highByte |
+	
+	"Read the first 16‑bit code unit because character are on 2 or 4 bytes."
+	lowByte := aStream next ifNil: [ self error: 'Cannot move forward once at the end' ].
+	highByte := aStream next ifNil: [ self error: 'Cannot move forward once at the end' ].
+
+	firstUnit := self isBigEndian
+		             ifTrue: [  (lowByte bitShift: 8) + highByte ] "BE: high byte first"
+		             ifFalse: [ (highByte bitShift: 8) + lowByte ]. "LE: low byte first"
+		
+	"If we have a surrogate code point, we need to read two more bytes."	
+	(self isSurrogateCodePoint: firstUnit) ifTrue: [
+			lowByte := aStream next ifNil: [ self error: 'Last character is truncated' ].
+			highByte := aStream next ifNil: [ self error: 'Last character is truncated' ] ]
+]
+
 { #category : 'accessing' }
 ZnUTF16Encoder >> identifier [
 	^ #utf16

--- a/src/Zinc-Character-Encoding-Core/ZnUTF32Encoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnUTF32Encoder.class.st
@@ -60,6 +60,12 @@ ZnUTF32Encoder >> errorIncomplete [
 	self error: 'Incomplete utf-32 encoding'
 ]
 
+{ #category : 'encoding - decoding' }
+ZnUTF32Encoder >> forwardOnStream: aStream [
+
+	aStream skip: 4
+]
+
 { #category : 'accessing' }
 ZnUTF32Encoder >> identifier [
 	^ #utf32

--- a/src/Zinc-Character-Encoding-Core/ZnUTF8Encoder.class.st
+++ b/src/Zinc-Character-Encoding-Core/ZnUTF8Encoder.class.st
@@ -126,6 +126,24 @@ ZnUTF8Encoder >> findFirstNonASCIIIn: string startingAt: offset [
 		startingAt: offset
 ]
 
+{ #category : 'encoding - decoding' }
+ZnUTF8Encoder >> forwardOnStream: stream [
+	"Move forward one character on a binary stream following the UTF8 encoding.."
+
+	| firstByte |
+	(firstByte := stream next) ifNil: [ self error: 'Cannot move forward once at the end' ].
+	
+	(firstByte bitAnd: 2r10000000) = 0 ifTrue: [ ^ self ]. "In UTF8, if a byte lead by 0xxxxxxx, it means it is an ascii character on 1 byte."
+
+	(firstByte bitAnd: 2r11100000) = 2r11000000 ifTrue: [ ^ stream skip: 1 ]. "Byte leaded by 110xxxxx means we have a 2 bytes character. Skip one more byte."
+
+	(firstByte bitAnd: 2r11110000) = 2r11100000 ifTrue: [ ^ stream skip: 2 ]. "Byte leaded by 1110xxxx means we have a 3 bytes character. Skip two more bytes."
+
+	(firstByte bitAnd: 2r11111000) = 2r11110000 ifTrue: [ ^ stream skip: 3 ]. "Byte leaded by 11110xxx means we have a 4 bytes character. Skip three more bytes."
+	
+	self error: 'We should not get here. Maybe the position of your stream was in the middle of a character or the encoder it not the right one?'
+]
+
 { #category : 'accessing' }
 ZnUTF8Encoder >> identifier [
 	^ #utf8

--- a/src/Zinc-Character-Encoding-Tests/ZnCharacterEncoderTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnCharacterEncoderTest.class.st
@@ -254,6 +254,20 @@ ZnCharacterEncoderTest >> testNullEncoder [
 ]
 
 { #category : 'testing' }
+ZnCharacterEncoderTest >> testNumberOfCharactersFrom [
+
+	| bytes |
+	bytes := 'Düsseldorf Königsallee' utf8Encoded.
+	self assert: (#utf8 asZnCharacterEncoder numberOfCharactersFrom: bytes) equals: 22.
+	bytes := 'Düsseldorf Königsallee' encodeWith: #utf16.
+	self assert: (#utf16 asZnCharacterEncoder numberOfCharactersFrom: bytes) equals: 22.
+	bytes := 'Test' encodeWith: #ascii.
+	self assert: (#ascii asZnCharacterEncoder numberOfCharactersFrom: bytes) equals: 4.
+	bytes := 'Test' encodeWith: #latin1.
+	self assert: (#latin1 asZnCharacterEncoder numberOfCharactersFrom: bytes) equals: 4
+]
+
+{ #category : 'testing' }
 ZnCharacterEncoderTest >> testReadIntoStartingAtCountFromStream [
 	| encoder |
 	encoder := ZnUTF8Encoder new.

--- a/src/Zinc-Character-Encoding-Tests/ZnCharacterEncoderTest.class.st
+++ b/src/Zinc-Character-Encoding-Tests/ZnCharacterEncoderTest.class.st
@@ -426,6 +426,26 @@ ZnCharacterEncoderTest >> testUTF16EncoderWide1 [
 ]
 
 { #category : 'testing' }
+ZnCharacterEncoderTest >> testUTF16Forward [
+	"
+	Ω -> 2 bytes (0x03A9)
+	𐍈 -> 4 bytes (0xD800 0xDF48)
+	"
+
+	| encoder stream |
+	encoder := ZnUTF16Encoder new.
+	stream := (encoder encodeString: 'Ω𐍈') readStream.
+	self assert: stream position equals: 0.
+	encoder forwardOnStream: stream.
+	self assert: stream position equals: 2.
+	encoder forwardOnStream: stream.
+	self assert: stream position equals: 6.
+	self should: [ encoder forwardOnStream: stream ] raise: Error. "Fail if at the end."
+	stream position: 4.
+	self should: [ encoder forwardOnStream: stream ] raise: Error "Fail if in the middle of a character."
+]
+
+{ #category : 'testing' }
 ZnCharacterEncoderTest >> testUTF32EncoderExampleFromD100 [
 	| string bytes encoder |
 	string := #(16r0000004D 16r00000430 16r00004E8C 16r00010302) collect: #asCharacter as: String.
@@ -492,6 +512,23 @@ ZnCharacterEncoderTest >> testUTF32EncoderWide [
 			| bytes |
 			bytes := self encodeString: each with: encoder.
 			self assert: (encoder decodeBytesIntoWideString: bytes) equals: each ]
+]
+
+{ #category : 'testing' }
+ZnCharacterEncoderTest >> testUTF32Forward [
+	"All characters are on 4 bytes"
+
+	| encoder stream |
+	encoder := ZnUTF32Encoder new.
+	stream := (encoder encodeString: 'té') readStream.
+	self assert: stream position equals: 0.
+	encoder forwardOnStream: stream.
+	self assert: stream position equals: 4.
+	encoder forwardOnStream: stream.
+	self assert: stream position equals: 8.
+	self should: [ encoder forwardOnStream: stream ] raise: Error. "Fail if at the end."
+	stream position: 7.
+	self should: [ encoder forwardOnStream: stream ] raise: Error
 ]
 
 { #category : 'testing' }
@@ -624,6 +661,32 @@ ZnCharacterEncoderTest >> testUTF8EncoderWide [
 		do: [ :each | | bytes |
 			bytes := self encodeString: each with: encoder.
 			self assert: (encoder decodeBytesIntoWideString: bytes) equals: each ]
+]
+
+{ #category : 'testing' }
+ZnCharacterEncoderTest >> testUTF8Forward [
+	"
+	A -> 1 byte
+	¢ -> 2 bytes
+	€ -> 3 bytes
+	𝄞 ->_4 bytes
+	"
+
+	| encoder stream |
+	encoder := ZnUTF8Encoder new.
+	stream := (encoder encodeString: 'A¢€𝄞') readStream.
+	self assert: stream position equals: 0.
+	encoder forwardOnStream: stream.
+	self assert: stream position equals: 1.
+	encoder forwardOnStream: stream.
+	self assert: stream position equals: 3.
+	encoder forwardOnStream: stream.
+	self assert: stream position equals: 6.
+	encoder forwardOnStream: stream.
+	self assert: stream position equals: 10.
+	self should: [ encoder forwardOnStream: stream ] raise: Error. "Fail if at the end."
+	stream position: 7.
+	self should: [ encoder forwardOnStream: stream ] raise: Error "Fail if in the middle of a character."
 ]
 
 { #category : 'testing' }


### PR DESCRIPTION
This method takes a byte array and return the number of characters it represent.  This method is useful if we do not need to decoded byte array because it is much faster than `(bytes decodeWith: #utf8) size`,

This will be useful for Moose.

@svenvc maybe this can interest you?