### PR TITLE
Resolve refactoring broken tests

### DIFF
--- a/src/Refactoring-UI-Tests/StMethodsSelectionPresenterMock.class.st
+++ b/src/Refactoring-UI-Tests/StMethodsSelectionPresenterMock.class.st
@@ -5,12 +5,23 @@ Class {
 		'title',
 		'label',
 		'items',
-		'selecting'
+		'selecting',
+		'acceptBlock'
 	],
 	#category : 'Refactoring-UI-Tests-Mocks',
 	#package : 'Refactoring-UI-Tests',
 	#tag : 'Mocks'
 }
+
+{ #category : 'reflective operations' }
+StMethodsSelectionPresenterMock class >> doesNotUnderstand: aMessage [
+]
+
+{ #category : 'testing' }
+StMethodsSelectionPresenterMock class >> isOk [
+
+	^ true
+]
 
 { #category : 'initialization' }
 StMethodsSelectionPresenterMock class >> label: aString withItems: aCollection selecting: aCollection3 [
@@ -29,6 +40,17 @@ StMethodsSelectionPresenterMock class >> title: aTitle label: aString withItems:
 		  label: aString
 		  withItems: aCollection
 		  selecting: aCollection3
+]
+
+{ #category : 'initialization' }
+StMethodsSelectionPresenterMock class >> title: aTitle label: aString withItems: aCollection selecting: aCollection3 acceptBlock: aFullBlockClosure [
+
+	^ self new
+		  title: aTitle
+		  label: aString
+		  withItems: aCollection
+		  selecting: aCollection3
+		  acceptBlock: aFullBlockClosure
 ]
 
 { #category : 'testing' }
@@ -58,4 +80,14 @@ StMethodsSelectionPresenterMock >> title: aTitle label: aString withItems: aOrde
 	label := 'Push down methods from a class'.
 	items := aOrderedCollection.
 	selecting := aOrderedCollectionToo
+]
+
+{ #category : 'initialization' }
+StMethodsSelectionPresenterMock >> title: aTitle label: aString withItems: aOrderedCollection selecting: aOrderedCollectionToo acceptBlock: aFullBlockClosure [
+
+	title := aTitle.
+	label := 'Push down methods from a class'.
+	items := aOrderedCollection.
+	selecting := aOrderedCollectionToo.
+	acceptBlock:= aFullBlockClosure 
 ]

--- a/src/Refactoring-UI-Tests/StSelectClassAndMethodsPresenterMock.class.st
+++ b/src/Refactoring-UI-Tests/StSelectClassAndMethodsPresenterMock.class.st
@@ -21,6 +21,16 @@ StSelectClassAndMethodsPresenterMock class >> cancelled [
 	^ false
 ]
 
+{ #category : 'reflective operations' }
+StSelectClassAndMethodsPresenterMock class >> doesNotUnderstand: aMessage [
+]
+
+{ #category : 'testing' }
+StSelectClassAndMethodsPresenterMock class >> isOk [
+
+	^ true
+]
+
 { #category : 'initialization' }
 StSelectClassAndMethodsPresenterMock class >> label: aString dropLabel: aString2 withItems: aCollection selecting: aCollection4 dropItems: aCollection5 acceptBlock: aFullBlockClosure [
 

--- a/src/Refactoring-UI/RePushDownMethodDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodDriver.class.st
@@ -101,7 +101,7 @@ RePushDownMethodDriver >> defaultSelectDialog [
 { #category : 'execution' }
 RePushDownMethodDriver >> gatherUserInput [
 
-	methods := self selectMethods
+	self selectMethods
 ]
 
 { #category : 'configuration' }
@@ -184,20 +184,20 @@ RePushDownMethodDriver >> runRefactoring [
 
 { #category : 'execution' }
 RePushDownMethodDriver >> selectMethods [
+
 	| dialog |
 	
 	dialog := (self methodsSelectionPresenterClass newApplication: self application)
-		title: 'There are potential breaking changes!'
-		label: 'Push down methods from ' , class name
-		withItems:
-			(class methods sort: [ :a :b | a asString < b asString ])
-			  asOrderedCollection
-		selecting: methods asOrderedCollection;
-		openDialog.
-	
-	dialog isOk ifFalse: [ ^ nil ].
-	
-	^ dialog selectedItems
+		          title: 'There are potential breaking changes!'
+		          label: 'Push down methods from ' , class name
+		          withItems: (class methods sort: [ :a :b | a asString < b asString ]) asOrderedCollection
+		          selecting: methods asOrderedCollection
+		          acceptBlock: [ :selectedMethods | methods := selectedMethods ];
+		          openModal.
+
+	dialog isOk ifTrue: [ ^ self ].
+
+	methods:= nil
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
Modified API of dialog mock classes in order to fix broken tests, its linked to the changes made by Esteban adding newApplication: to the dialogs.
Fixes #19300