### PR TITLE
Fix refactoring AddTemporary tests

### DIFF
--- a/src/Refactoring-Transformations/RBAddTemporaryVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBAddTemporaryVariableTransformation.class.st
@@ -66,7 +66,6 @@ RBAddTemporaryVariableTransformation class >> variable: aString inMethod: aSelec
 RBAddTemporaryVariableTransformation >> applicabilityPreconditions [
 
 	^ {
-		  self preconditionMethodAlreadyDefines.
 		  (RBCondition withBlock: [ self definingClass isNotNil ] errorString: 'No such class or trait named ' , className).
 		  (RBCondition definesSelector: selector in: self definingClass).
 		  (RBCondition
@@ -107,6 +106,12 @@ RBAddTemporaryVariableTransformation >> privateTransform [
 	
 	parseTree addTemporaryNamed: variableName.
 	class compileTree: methodTree
+]
+
+{ #category : 'preconditions' }
+RBAddTemporaryVariableTransformation >> skippingPreconditions [
+
+	self preconditionMethodAlreadyDefines
 ]
 
 { #category : 'api' }


### PR DESCRIPTION
In #19315 I created a precondition because the flow wasn't good for this refactoring. 
Anyways it breaks some tests because we have a combo of remove/add temp in move definition refactoring and the precondition checks if the temporary already exists in the class. 
For now I moved the precondition to `skippingPreconditions` as it was before to fix tests but we could give a look at the whole flow. 

This refactoring is still unused for the moment by the way