### PR TITLE
Find & Replace selection/tab improval

### DIFF
--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
@@ -158,7 +158,7 @@ SpRubFindReplaceDialog >> initializeDialogWindow: aDialogWindowPresenter [
 	aDialogWindowPresenter
 		title: self title;
 		initialExtent: 430 @ 220.
-
+	aDialogWindowPresenter whenOpenedDo: [ findInput selectAll ].
 	aDialogWindowPresenter whenClosedDo: [
 			service findText: ''.
 			service discardDialog.
@@ -185,6 +185,8 @@ SpRubFindReplaceDialog >> initializePresenters [
 	entireCheckBox := self newCheckBox label: 'Entire words only'.
 	self updateFromService.
 	replaceTextInput := self newTextInput autoAccept: true.
+	self selectAllOnFocusIn: replaceTextInput.
+
 	self closeWindowOnEscIn: replaceTextInput.
 
 	replaceTextInput text: self replacingText.
@@ -232,6 +234,16 @@ SpRubFindReplaceDialog >> replacingText [
 SpRubFindReplaceDialog >> replacingText: aText [
 
 	^ self class replacingText: aText
+]
+
+{ #category : 'morphic dependencies' }
+SpRubFindReplaceDialog >> selectAllOnFocusIn: aPresenter [
+	"Morphic dependent!"
+
+	aPresenter whenBuiltDo: [ :built |
+			| w |
+			w := built widget.
+			w announcer when: MorphGotFocus do: [ :ann | w selectAll ] for: self ]
 ]
 
 { #category : 'accessing' }

--- a/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
+++ b/src/Rubric-SpecFindReplaceDialog/SpRubFindReplaceDialog.class.st
@@ -238,12 +238,8 @@ SpRubFindReplaceDialog >> replacingText: aText [
 
 { #category : 'morphic dependencies' }
 SpRubFindReplaceDialog >> selectAllOnFocusIn: aPresenter [
-	"Morphic dependent!"
 
-	aPresenter whenBuiltDo: [ :built |
-			| w |
-			w := built widget.
-			w announcer when: MorphGotFocus do: [ :ann | w selectAll ] for: self ]
+	aPresenter eventHandler whenFocusReceivedDo: [ :anEvent | replaceTextInput selectAll ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
By default the find text is now highlighted and the replace text too when focus switch, which will help the user gain time. 
I added a Morphic dependency for now so if anyone find its too much, help me to get the same result using spec please. 

Fixes #18554. Fixes #18560