### PR TITLE
Fixing CompilerMethod properties issues

### DIFF
--- a/src/Kernel-CodeModel/CompiledMethod.class.st
+++ b/src/Kernel-CodeModel/CompiledMethod.class.st
@@ -724,10 +724,18 @@ CompiledMethod >> removeFromSystem [
 
 { #category : 'accessing - pragmas & properties' }
 CompiledMethod >> removeProperty: propName [
+
+	^ self removeProperty: propName ifAbsent: [ nil ]
+]
+
+{ #category : 'accessing - pragmas & properties' }
+CompiledMethod >> removeProperty: propName ifAbsent: aBlock [
 	"Remove the property propName if it exists.
-	 Do _not_ raise an error if the property is missing."
+	 Answer the evaluation of aBlock if the property is missing."
+
 	| value |
-	value := self propertyAt: propName ifAbsent: [^nil].
+
+	value := self propertyAt: propName ifAbsent: [^aBlock value].
 	self penultimateLiteral: (self penultimateLiteral copyWithout:
 									(Association
 										key: propName
@@ -735,19 +743,6 @@ CompiledMethod >> removeProperty: propName [
 
 	"Remove unneded AdditionalMethodState"
 	self penultimateLiteral size = 0 ifTrue: [ self penultimateLiteral: self selector ].
-	^value
-]
-
-{ #category : 'accessing - pragmas & properties' }
-CompiledMethod >> removeProperty: propName ifAbsent: aBlock [
-	"Remove the property propName if it exists.
-	 Answer the evaluation of aBlock if the property is missing."
-	| value |
-	value := self propertyAt: propName ifAbsent: [^aBlock value].
-	self penultimateLiteral: (self penultimateLiteral copyWithout:
-									(Association
-										key: propName
-										value: value)).
 	^value
 ]
 

--- a/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
+++ b/src/Kernel-Extended-Tests/CompiledMethodTest.class.st
@@ -52,6 +52,8 @@ CompiledMethodTest >> tearDown [
 
 	self packageOrganizer removePackage: self packageNameForTests.
 	class ifNotNil: [ class removeFromSystem ].
+	
+	(self someClass >> #returnTrue) recompile.
 	super tearDown
 ]
 
@@ -724,6 +726,44 @@ CompiledMethodTest >> testRecompilingDoesNotRemoveExtensions [
 	self assert: method isExtension ] ensure: [
 		self packageOrganizer removePackage: 'GeneratedPackageForTest'.
 		self class compiledMethodAt: #isExtensionTestMethod ifPresent: [ :method | method removeFromSystem ] ]
+]
+
+{ #category : 'tests - accessing - pragmas & properties' }
+CompiledMethodTest >> testRemovePropertyIfAbsentRemovesAdditionalMethodStateIfEmpty [
+
+	| method |
+	
+	method := self someClass >> #returnTrue.
+	method propertyAt: #aTestProperty put: 42.
+	
+	self assert: (method hasProperty: #aTestProperty).
+	self assert: method penultimateLiteral isMethodProperties.
+	self assert: method penultimateLiteral size equals: 1.
+	
+	method removeProperty: #aTestProperty ifAbsent: [ self fail ].
+	
+	self deny: (method hasProperty: #aTestProperty).
+	self deny: method penultimateLiteral isMethodProperties.
+
+]
+
+{ #category : 'tests - accessing - pragmas & properties' }
+CompiledMethodTest >> testRemovePropertyRemovesAdditionalMethodStateIfEmpty [
+
+	| method |
+	
+	method := self someClass >> #returnTrue.
+	method propertyAt: #aTestProperty put: 42.
+	
+	self assert: (method hasProperty: #aTestProperty).
+	self assert: method penultimateLiteral isMethodProperties.
+	self assert: method penultimateLiteral size equals: 1.
+	
+	method removeProperty: #aTestProperty.
+	
+	self deny: (method hasProperty: #aTestProperty).
+	self deny: method penultimateLiteral isMethodProperties.
+
 ]
 
 { #category : 'tests - accessing' }

--- a/src/OpalCompiler-Core/OCCompilationContext.class.st
+++ b/src/OpalCompiler-Core/OCCompilationContext.class.st
@@ -30,7 +30,8 @@ Class {
 		'compiledMethodClass',
 		'semanticScope',
 		'compiledBlockClass',
-		'semanticAnalysisNeeded'
+		'semanticAnalysisNeeded',
+		'storeSourcesAsProperty'
 	],
 	#classVars : [
 		'DefaultOptions',
@@ -710,4 +711,16 @@ OCCompilationContext >> semanticScope: anObject [
 { #category : 'options' }
 OCCompilationContext >> setOptions: opts [
 	options := opts
+]
+
+{ #category : 'accessing' }
+OCCompilationContext >> storeSourcesAsProperty [
+	
+	^ storeSourcesAsProperty ifNil: [ true ]
+]
+
+{ #category : 'accessing' }
+OCCompilationContext >> storeSourcesAsProperty: aBoolean [ 
+	
+	storeSourcesAsProperty := aBoolean
 ]

--- a/src/OpalCompiler-Core/OpalCompiler.class.st
+++ b/src/OpalCompiler-Core/OpalCompiler.class.st
@@ -526,7 +526,8 @@ OpalCompiler >> generateMethod [
 
 	ast compiledMethod: method.
 	ast propertyAt: #Undeclareds ifPresent: [ :undeclareds | undeclareds do: [ :var | var registerMethod: method ] ].
-	method propertyAt: #source put: source.
+	
+	compilationContext storeSourcesAsProperty ifTrue: [ method propertyAt: #source put: source ].
 	self isScripting ifTrue: [ method propertyAt: #ast put: ast ]. "Keep AST for scripts (for the moment)"
 
 	^ method
@@ -793,4 +794,10 @@ OpalCompiler >> source: aString [
 
 	source := aString contents asString.
 	ast := nil
+]
+
+{ #category : 'accessing' }
+OpalCompiler >> storeSourcesAsProperty: aBoolean [ 
+	
+	compilationContext storeSourcesAsProperty: aBoolean
 ]


### PR DESCRIPTION
- Fix #19342 

   - Adding option to decide if the generated method has or not the source property

- Fix #19341 

   - #removeProperty:ifAbsent: removes the additionalMethodState if empty as it was done by #removeProperty:
   - #removeProperty: is implemented by delegating to #removeProperty:IfAbsent:
   - Adding tests