### PR TITLE
Behavior: use #recompileAllFrom: in #recompile

### DIFF
--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -82,7 +82,7 @@ Behavior >> outerScope [
 
 { #category : '*OpalCompiler-Core' }
 Behavior >> recompile [
-	self compileAll
+	 ^ self recompileAllFrom: self
 ]
 
 { #category : '*OpalCompiler-Core' }


### PR DESCRIPTION
As we now have #recompileAllFrom: we should use this in #recompile on Behavior.

With systemnotification stopped, it is *much* faster