### PR TITLE
Provide breaking choices for extract temp refactoring

### DIFF
--- a/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
@@ -62,8 +62,13 @@ RBExtractToTemporaryRefactoring >> applicabilityPreconditions [
 	^ {
 		  (ReDefinesSelectorsCondition new definesSelectors: (Array with: selector) in: class).
 		  (ReIsValidInstanceVariableName new name: newVariableName).
-		  (ReCheckVariableNameShadowingCondition class: class variableName: newVariableName parseTree: parseTree).
 		  (ReLocalNameConflictCondition class: class variableName: newVariableName parseTree: parseTree) }
+]
+
+{ #category : 'preconditions' }
+RBExtractToTemporaryRefactoring >> breakingChangePreconditions [
+
+	^ { self preconditionCheckVariableName }
 ]
 
 { #category : 'transforming' }
@@ -114,6 +119,12 @@ RBExtractToTemporaryRefactoring >> insertTemporary [
 		addTemporaryNamed: newVariableName.
 	nodeReferences do: [ :each |
 		each replaceWith: (OCVariableNode named: newVariableName) ]
+]
+
+{ #category : 'preconditions' }
+RBExtractToTemporaryRefactoring >> preconditionCheckVariableName [
+
+	^ ReCheckVariableNameShadowingCondition class: class variableName: newVariableName parseTree: parseTree
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-DataForTesting/RBClassDataForRefactoringTest.class.st
+++ b/src/Refactoring-DataForTesting/RBClassDataForRefactoringTest.class.st
@@ -331,6 +331,12 @@ RBClassDataForRefactoringTest >> inlineTemporary [
 ]
 
 { #category : 'lint' }
+RBClassDataForRefactoringTest >> justExpression [
+
+	^ 2 + 3
+]
+
+{ #category : 'lint' }
 RBClassDataForRefactoringTest >> justSendsSuper [
 	super justSendsSuper
 ]

--- a/src/Refactoring-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractToTemporaryParametrizedTest.class.st
@@ -129,3 +129,13 @@ RBExtractToTemporaryParametrizedTest >> testFailureNonExistantSelector [
 		( self createRefactoringWithArguments:
 			{ (14 to: 23) . 'asdf' . #checkClass1: . RBClassDataForRefactoringTest })
 ]
+
+{ #category : 'tests' }
+RBExtractToTemporaryParametrizedTest >> testWarningExistingInstanceVariable [
+
+	self shouldWarn: (self createRefactoringWithArguments: {
+				 (20 to: 24).
+				 'instanceVariable'.
+				 #justExpression .
+				 RBClassDataForRefactoringTest })
+]

--- a/src/Refactoring-UI-Tests/ReExtractTempDriverTest.class.st
+++ b/src/Refactoring-UI-Tests/ReExtractTempDriverTest.class.st
@@ -13,23 +13,20 @@ ReExtractTempDriverTest >> testInvalidNameAndAbandon [
 	rbclasses := RBClassEnvironment classes: { MyClassA }.
 	driver := ReExtractTempDriver new
 		          scopes: { rbclasses };
-		          extract: (23 to: 24)
-					from: #methodForPushDown
-		          in: MyClassA.
+		          extract: (23 to: 24) from: #methodForPushDown in: MyClassA.
 	self setUpDriver: driver.
 
 	request := MockObject new.
 	request on: #title: respond: 2.
-	request on: #label: respond: 2.
+	request on: #message: respond: 2.
 	request on: #text: respond: 2.
 	request on: #acceptLabel: respond: 2.
 	request on: #cancelLabel: respond: 2.
-	request on: #onAccept: respond: 3. 
-	request on: #openModal respond: nil. 
+	request on: #onAccept: respond: 3.
+	request on: #openModal respond: nil.
 	driver requestDialog: request.
-	
-	driver runRefactoring.
-	"Renaming the references to the variable is not encapsulated in change objects, therefore the only change is the renaming of the variable itself."
+
+	driver runRefactoring. "Renaming the references to the variable is not encapsulated in change objects, therefore the only change is the renaming of the variable itself."
 
 
 	self assert: driver refactoring changes changes size equals: 0
@@ -49,7 +46,7 @@ ReExtractTempDriverTest >> testValidNameSuccessfulRename [
 
 	request := MockObject new.
 	request on: #title: respond: 2.
-	request on: #label: respond: 2.
+	request on: #message: respond: 2.
 	request on: #text: respond: 2.
 	request on: #acceptLabel: respond: 2.
 	request on: #cancelLabel: respond: 2.

--- a/src/Refactoring-UI/ReExtractTempDriver.class.st
+++ b/src/Refactoring-UI/ReExtractTempDriver.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'interval',
 		'selector',
-		'class'
+		'class',
+		'notCheckVarName'
 	],
 	#category : 'Refactoring-UI-Drivers',
 	#package : 'Refactoring-UI',
@@ -15,6 +16,45 @@ Class {
 ReExtractTempDriver class >> driverName [
 
 	^ 'Extract to temporary'
+]
+
+{ #category : 'execution' }
+ReExtractTempDriver >> breakingChoices [
+
+	| choices |
+	choices := OrderedCollection new.
+	notCheckVarName isFalse ifTrue: [
+			choices add: (ReRenameTemporaryVariableChoice new driver: self).
+			choices add: (ReNewVariableNameChoice new driver: self).
+			choices add: (ReConvertTemporaryToExistingVariableChoice new driver: self) ].
+
+
+	^ choices
+]
+
+{ #category : 'action' }
+ReExtractTempDriver >> convertTemporaryToExistingVariable [
+
+	| transformation |
+	self applyChanges.
+	transformation := RBRemoveTemporaryVariableTransformation
+		                  variable: notCheckVarName violators first
+		                  inMethod: (class compiledMethodAt: selector) selector
+		                  inClass: class name.
+	transformation privateTransform.
+	self openPreviewWithChanges: transformation changes
+]
+
+{ #category : 'configuration' }
+ReExtractTempDriver >> defaultSelectDialog [
+
+	^ super defaultSelectDialog
+		  title: 'There are potential breaking changes!';
+		  message: self labelBasedOnBreakingChanges;
+		  items: self breakingChoices;
+		  display: [ :each | each description ];
+		  displayIcon: [ :each | self iconNamed: each systemIconName ];
+		  yourself
 ]
 
 { #category : 'instance creation' }
@@ -28,17 +68,14 @@ ReExtractTempDriver >> extract: anInterval from: aSelector in: aClass [
 { #category : 'user requests' }
 ReExtractTempDriver >> getVariableName: initialAnswer errorMessage: message [
 
-	^ self requestDialog 
-		title: 'Extract code to temp variable';
-		label: 'New temp name: ' , message;
-		text: initialAnswer;
-		acceptLabel: 'Ok!';
-		cancelLabel: 'Cancel';
-		onAccept: [ :dialog | dialog presenter text ];
-		openModal
-	
-	
-		
+	^ self requestDialog
+		  title: 'Extract code to temp variable';
+		  message: 'New temp name: ' , message;
+		  text: initialAnswer;
+		  acceptLabel: 'Ok!';
+		  cancelLabel: 'Cancel';
+		  onAccept: [ :dialog | dialog presenter text ];
+		  openModal
 ]
 
 { #category : 'configuration' }
@@ -48,6 +85,17 @@ ReExtractTempDriver >> instantiateRefactoring [
 		extract: interval
 		from: selector 
 		in: class
+]
+
+{ #category : 'ui - dialogs' }
+ReExtractTempDriver >> labelBasedOnBreakingChanges [
+
+	^ String streamContents: [ :stream |
+			  refactoring failedBreakingChangePreconditions do: [ :cond |
+					  cond check ifFalse: [
+							  cond violationMessageOn: stream.
+							  stream cr ] ].
+			  stream nextPutAll: 'Select the strategies to apply' ]
 ]
 
 { #category : 'execution' }
@@ -66,5 +114,11 @@ ReExtractTempDriver >> runRefactoring [
 	] doWhileFalse: 
 		[ varName isEmptyOrNil not and: [ failed isEmpty ] ].
 	
-	self applyChanges
+		refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
+]
+
+{ #category : 'initialization' }
+ReExtractTempDriver >> setBreakingChangesPreconditions [
+
+	notCheckVarName := refactoring preconditionCheckVariableName
 ]


### PR DESCRIPTION
As it could have the same shadowing behavior as rename temp refactoring, I did the same as #19351, providing the same choices for user and adding tests for newest breaking change precondition.
