### PR TITLE
comment: Improve help text for Abstract accessors command

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -598,6 +598,12 @@ DebugSession >> stepToFirstInterestingBytecodeInContext: aContext [
 	^ aContext
 ]
 
+{ #category : 'accessing' }
+DebugSession >> suspendedContext: aContext [ 
+	
+	interruptedContext := aContext
+]
+
 { #category : 'debugging actions' }
 DebugSession >> terminate [
 	"Action that needs to be executed after the window containing this debug session is closed,

--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -598,12 +598,6 @@ DebugSession >> stepToFirstInterestingBytecodeInContext: aContext [
 	^ aContext
 ]
 
-{ #category : 'accessing' }
-DebugSession >> suspendedContext: aContext [ 
-	
-	interruptedContext := aContext
-]
-
 { #category : 'debugging actions' }
 DebugSession >> terminate [
 	"Action that needs to be executed after the window containing this debug session is closed,

--- a/src/SystemCommands-VariableCommands/SycAbstractVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycAbstractVariableCommand.class.st
@@ -1,3 +1,8 @@
+"
+This command replaces direct accesses to a selected instance variable with calls to its getter and setter methods.
+
+If the corresponding accessor methods do not exist, they will be generated automatically.
+"
 Class {
 	#name : 'SycAbstractVariableCommand',
 	#superclass : 'SycRefactorVariableCommand',
@@ -26,6 +31,11 @@ SycAbstractVariableCommand >> defaultMenuIconName [
 SycAbstractVariableCommand >> defaultMenuItemName [
 
 	^'Abstract accessors'
+]
+
+{ #category : 'accessing' }
+SycAbstractVariableCommand >> description [
+    ^ 'Replace direct accesses to an instance variable with calls to its getter or setter. Missing accessor methods will be generated automatically.'
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
Improve the help text for the “Abstract accessors” command to clearly explain its behavior.

### Changes

- Add explicit description/tooltip explaining that:
`Direct instance variable accesses are replaced with calls to getter/setter methods. Missing accessor methods are generated automatically.`

- Updated comment for `SycAbstractVariableCommand`

Fixes #19308