### PR TITLE
Improvements for the taskbar

### DIFF
--- a/src/Morphic-Base/UITheme.class.st
+++ b/src/Morphic-Base/UITheme.class.st
@@ -3282,7 +3282,7 @@ UITheme >> newTaskbarThumbnailIn: aThemedMorph for: aWindow [
 		cellInset: 4 scaledByDisplayScaleFactor;
 		addMorphBack: thumb;
 		addMorphBack: ((self
-			buttonLabelForText: (aWindow labelString truncateWithElipsisTo: 50))
+			buttonLabelForText: (aWindow labelString ))
 				color: Color white).
 	answer
 		extent: answer minExtent;

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -189,7 +189,7 @@ TaskbarMorph >> initializeLayout [
 		layoutInset: 2;
 		cellInset: 2;
 		listDirection: #leftToRight;
-		wrapDirection: #topToBottom;
+		wrapDirection: #none;
 		hResizing: #spaceFill;
 		vResizing: #shrinkWrap;
 		extent: self minimumExtent
@@ -245,6 +245,18 @@ TaskbarMorph >> isTaskbar [
 	"Answer true."
 
 	^true
+]
+
+{ #category : 'private - layout' }
+TaskbarMorph >> layoutButtonsEvenly [
+
+	| per |
+	self submorphs isEmpty ifTrue: [ ^ self ].
+	per := self innerBounds width // self submorphs size.
+
+	self submorphs do: [ :b |
+			b hResizing: #rigid.
+			b width: per ]
 ]
 
 { #category : 'geometry' }
@@ -377,6 +389,7 @@ TaskbarMorph >> updateBounds [
 
 	self
 		width: self owner width;
+		layoutButtonsEvenly;
 		snapToEdgeIfAppropriate
 ]
 
@@ -406,12 +419,14 @@ TaskbarMorph >> updateTaskButtons [
 	| oldButtons size |
 	oldButtons := self submorphs copy.
 	self removeAllMorphs.
-	self defer: [oldButtons do: [:b | b model: nil]]. "release dependency after event handling"
+	self defer: [ oldButtons do: [ :b | b model: nil ] ]. "release dependency after event handling"
 
 	size := self orderedTasks size.
-	(self orderedTasks copyFrom: ( size - self class maximumButtons + 1 max: 1 ) to: size) do: [:t | | button |
-		button := t taskbarButtonFor: self.
-		button ifNotNil: [self addMorphBack: button]]
+	(self orderedTasks copyFrom: (size - self class maximumButtons + 1 max: 1) to: size) do: [ :t |
+			| button |
+			button := t taskbarButtonFor: self.
+			button ifNotNil: [ self addMorphBack: button ] ].
+	self layoutButtonsEvenly
 ]
 
 { #category : 'taskbar' }


### PR DESCRIPTION
There are 2 improvements based on UI problems:
- Hovering a task display the full name now (as it was truncating it before)
- A task takes the full width of the world now ( divided by number of tasks ). It really fills the world's width now as before the tasks width was very small

@jecisc I think we can merge this  for now because the drag and drop feature will take quite more time, I will open an other PR in the future