### PR TITLE
Review taskbar item sizes

### DIFF
--- a/src/Morphic-Widgets-Taskbar/TaskbarItemMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarItemMorph.class.st
@@ -29,6 +29,12 @@ TaskbarItemMorph >> addEmphaseTo: lab [
 	lab emphasis: 1
 ]
 
+{ #category : 'accessing' }
+TaskbarItemMorph >> buildLabelMorph [
+
+	^ self theme buttonLabelForText: self model taskbarLabel
+]
+
 { #category : 'style - border' }
 TaskbarItemMorph >> disabledBorderStyle [
 	"Return the disabled borderStyle of the receiver."
@@ -58,10 +64,8 @@ TaskbarItemMorph >> initializeAnnouncements [
 
 { #category : 'initialization' }
 TaskbarItemMorph >> initializeFor: aTaskbar [
-	| lm lab labSize |
-
-	labSize := self labelSizeIn: aTaskbar.
-	lab := self labelOfSize: labSize.
+	| lm lab |
+	lab := self buildLabelMorph.
 	self addEmphaseTo: lab.
 	lm := self theme
 		newRowIn: aTaskbar
@@ -70,6 +74,7 @@ TaskbarItemMorph >> initializeFor: aTaskbar [
 			lab}.
 
 	lm cellInset: 2.
+
 	self
 		label: lm font: self theme buttonFont;
 		extent: self minExtent;
@@ -77,22 +82,19 @@ TaskbarItemMorph >> initializeFor: aTaskbar [
 		vResizing: #rigid;
 		useSquareCorners;
 		getMenuSelector: #taskbarButtonMenu:.
+		
+	"The following code works like this:
+	- A Task takes at least 100px.
+	- A Task takes maximum 175px.
+	- If possible, we try to have 15 tasks on one level of the taskbar."
+	self width: (((aTaskbar innerBounds width // 15) min: 175) max: 100).
+	
 	self initializeAnnouncements.
 	lab
 		color:
 			(self model isCollapsed
 				ifTrue: [ self theme taskbarItemLabelColorForCollapsed: self ]
 				ifFalse: [ self theme taskbarItemLabelColorForExpanded: self ])
-]
-
-{ #category : 'accessing' }
-TaskbarItemMorph >> labelOfSize: labSize [
-	^ self theme	buttonLabelForText: (self model taskbarLabel truncateWithElipsisTo: labSize)
-]
-
-{ #category : 'accessing' }
-TaskbarItemMorph >> labelSizeIn: aTaskbar [
-	^ (150 // (aTaskbar tasks size + 1) max: 10) min: 30
 ]
 
 { #category : 'style - border' }

--- a/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
+++ b/src/Morphic-Widgets-Taskbar/TaskbarMorph.class.st
@@ -189,7 +189,7 @@ TaskbarMorph >> initializeLayout [
 		layoutInset: 2;
 		cellInset: 2;
 		listDirection: #leftToRight;
-		wrapDirection: #none;
+		wrapDirection: #topToBottom;
 		hResizing: #spaceFill;
 		vResizing: #shrinkWrap;
 		extent: self minimumExtent
@@ -245,18 +245,6 @@ TaskbarMorph >> isTaskbar [
 	"Answer true."
 
 	^true
-]
-
-{ #category : 'private - layout' }
-TaskbarMorph >> layoutButtonsEvenly [
-
-	| per |
-	self submorphs isEmpty ifTrue: [ ^ self ].
-	per := self innerBounds width // self submorphs size.
-
-	self submorphs do: [ :b |
-			b hResizing: #rigid.
-			b width: per ]
 ]
 
 { #category : 'geometry' }
@@ -389,7 +377,6 @@ TaskbarMorph >> updateBounds [
 
 	self
 		width: self owner width;
-		layoutButtonsEvenly;
 		snapToEdgeIfAppropriate
 ]
 
@@ -425,8 +412,7 @@ TaskbarMorph >> updateTaskButtons [
 	(self orderedTasks copyFrom: (size - self class maximumButtons + 1 max: 1) to: size) do: [ :t |
 			| button |
 			button := t taskbarButtonFor: self.
-			button ifNotNil: [ self addMorphBack: button ] ].
-	self layoutButtonsEvenly
+			button ifNotNil: [ self addMorphBack: button ] ]
 ]
 
 { #category : 'taskbar' }


### PR DESCRIPTION
This is a follow up of what Alexis did to do some improvements.

- Now we get back the multi line taskbar when we have a lot of items
- Now we do not base the size of the item based on its label
- Now the minimal size of a taskitem is 100px
- Now the maximal size of a taskitem is 175px
- When possible we try to fit 15 tasks on one line (if the screen is too small we will fit less. If the screen is really larke we will fit more)