### PR TITLE
Refactor commonSuperclassWith implementation and update tests

### DIFF
--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -428,13 +428,6 @@ Class >> commentStamp: changeStamp [
 	self comment: self comment stamp: changeStamp
 ]
 
-{ #category : 'accessing - class hierarchy' }
-Class >> commonSuperclassWith: aClass [
-	"return the next common superclass between me and aClass. If I am the superclass of aClass, that is me"
-	<reflection: 'Class structural inspection - Iterating and querying hierarchy'>
-	^ self withAllSuperclasses detect: [ :class | (aClass allSuperclasses includes: class) ] ifNone: nil
-]
-
 { #category : 'copying' }
 Class >> copyForAnnouncement [
 	"Answer a copy of the receiver to be used in the announcement of changes.

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -304,6 +304,13 @@ ClassDescription >> commentStamp [
 	self subclassResponsibility
 ]
 
+{ #category : 'accessing - class hierarchy' }
+ClassDescription >> commonSuperclassWith: aClass [
+	"return the next common superclass between me and aClass. If I am the superclass of aClass, that is me"
+	<reflection: 'Class structural inspection - Iterating and querying hierarchy'>
+	^ self withAllSuperclasses detect: [ :class | (aClass allSuperclasses includes: class) ] ifNone: nil
+]
+
 { #category : 'slots' }
 ClassDescription >> definesSlot: aSlot [
 	"Return true whether the receiver defines an instance variable named aString"

--- a/src/Kernel-Extended-Tests/ClassTest.class.st
+++ b/src/Kernel-Extended-Tests/ClassTest.class.st
@@ -292,7 +292,9 @@ ClassTest >> testCommonSuperclassWith [
 	"but the other way this is not true"
 	self assert: (Object commonSuperclassWith: ProtoObject) equals: nil.
 	"as nil is the terminator of the hierarchy, we have to support it"
-	self assert: (nil commonSuperclassWith: ProtoObject) equals: nil
+	self assert: (nil commonSuperclassWith: ProtoObject) equals: nil.
+	"metaclass case"
+   self assert: (Array class commonSuperclassWith: Interval class) equals: SequenceableCollection class.
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
### Changes

* Moved the implementation of `commonSuperclassWith:` from `Class` to `ClassDescription`.
* Adjusted `ClassTest` accordingly

Fixes #18449
