### PR TITLE
Refactoring UI refresh fix in class code definition

### DIFF
--- a/src/Calypso-SystemQueries/ClyClassChange.class.st
+++ b/src/Calypso-SystemQueries/ClyClassChange.class.st
@@ -1,3 +1,23 @@
+"
+I represent all possible changes with class.
+I am used to subscribe with single subscription to any changes related to classes.
+So you can write code like this: 
+
+	SystemAnnouncer uniqueInstance when: (ClyClassChange of: MyClass) do: [ :ann | ann logCr ].
+	
+I provide more general subscription logic than subscribing on base ClassAnnouncement class. Many other events can be also related to class changes like renaming package or running class tests. They are not covered by ClassAnnouncement hierarchy.
+I reuse logic of queries how they detect that their result is affected by system changes: 
+	
+	ClyClassChange>>handlesAnnouncement: anAnnouncement 
+ 		^anAnnouncement affectsClass: affectedClass	
+
+I am used by class editor tools to be updated when editing class is changed.
+	
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	affectedClass:		<Class>
+"
 Class {
 	#name : 'ClyClassChange',
 	#superclass : 'Object',

--- a/src/Calypso-SystemQueries/ClyClassChange.class.st
+++ b/src/Calypso-SystemQueries/ClyClassChange.class.st
@@ -1,0 +1,34 @@
+Class {
+	#name : 'ClyClassChange',
+	#superclass : 'Object',
+	#instVars : [
+		'affectedClass'
+	],
+	#category : 'Calypso-SystemQueries-Domain',
+	#package : 'Calypso-SystemQueries',
+	#tag : 'Domain'
+}
+
+{ #category : 'instance creation' }
+ClyClassChange class >> of: aClass [
+
+	^ self new affectedClass: aClass
+]
+
+{ #category : 'accessing' }
+ClyClassChange >> affectedClass [
+
+	^ affectedClass
+]
+
+{ #category : 'accessing' }
+ClyClassChange >> affectedClass: anObject [
+
+	affectedClass := anObject
+]
+
+{ #category : 'testing' }
+ClyClassChange >> handlesAnnouncement: anAnnouncement [
+
+	^ anAnnouncement affectsClass: affectedClass
+]

--- a/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
+++ b/src/Calypso-SystemTools-Core/ClyClassEditorToolMorph.class.st
@@ -42,6 +42,12 @@ ClyClassEditorToolMorph class >> tabOrder [
 	^ 10
 ]
 
+{ #category : 'controlling' }
+ClyClassEditorToolMorph >> attachToSystem [
+
+	browser system when: (ClyClassChange of: editingClass) send: #triggerUpdate to: self
+]
+
 { #category : 'testing' }
 ClyClassEditorToolMorph >> belongsToCurrentBrowserContext [
 


### PR DESCRIPTION
It seems `ClyClassChange` class has been removed since Pharo 13.
Therefore each class change was not announced to the System announcer (but methods, package still exist... why only class?)
So I added it back and now we have a dynamic refresh when applying refactorings in the class code definition.