### PR TITLE
OSWindow-SDL2: Move handling of file drop event to window

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
+++ b/src/OSWindow-SDL2/OSSDL2BackendWindow.class.st
@@ -689,6 +689,24 @@ OSSDL2BackendWindow >> verticalDPI [
 ]
 
 { #category : 'event handling' }
+OSSDL2BackendWindow >> visitDropEvent: dropEvent [
+
+	"The dragged file name comes as a C-string of utf8 encoded bytes.
+	Get the string, and decode it to a string using a utf8 decoder"
+	| fileName |
+	fileName := dropEvent file utf8StringFromCString.
+
+	"Free the file handle after it has been read, as specified by SDL2
+	https://wiki.libsdl.org/SDL_DropEvent"
+	dropEvent file free.
+
+	^ (OSWindowDropEvent for: osWindow)
+			timestamp: dropEvent timestamp;
+			filePath: fileName;
+			deliver
+]
+
+{ #category : 'event handling' }
 OSSDL2BackendWindow >> visitKeyDownEvent: event [
 	| osEvent keysym |
 	keysym := event keysym.

--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -419,23 +419,6 @@ OSSDL2Driver >> visitControllerDeviceRemovedEvent: controllerEvent [
 		hasMapping: true
 ]
 
-{ #category : 'global events' }
-OSSDL2Driver >> visitDropEvent: dropEvent [
-
-	"The dragged file name comes as a C-string of utf8 encoded bytes.
-	Get the string, and decode it to a string using a utf8 decoder"
-	| fileName |
-	fileName := dropEvent file utf8StringFromCString.
-
-	"Free the file handle after it has been read, as specified by SDL2
-	https://wiki.libsdl.org/SDL_DropEvent"
-	dropEvent file free.
-
-	^ OSWindowDropEvent new
-		timestamp: dropEvent timestamp;
-		filePath: fileName
-]
-
 { #category : 'events-processing' }
 OSSDL2Driver >> visitFingerDownEvent: event [
 	^OSTouchActionPointerDownEvent new

--- a/src/OSWindow-SDL2/SDL_DropEvent.class.st
+++ b/src/OSWindow-SDL2/SDL_DropEvent.class.st
@@ -7,7 +7,8 @@ Class {
 	#classVars : [
 		'OFFSET_FILE',
 		'OFFSET_TIMESTAMP',
-		'OFFSET_TYPE'
+		'OFFSET_TYPE',
+		'OFFSET_WINDOWID'
 	],
 	#category : 'OSWindow-SDL2-Bindings',
 	#package : 'OSWindow-SDL2',
@@ -22,12 +23,13 @@ SDL_DropEvent class >> eventType [
 { #category : 'fields description' }
 SDL_DropEvent class >> fieldsDesc [
 	"
-	self initializeAccessors
+	self rebuildFieldAccessors
 	"
 	^ #(
     Uint32 type;
     Uint32 timestamp;
     char* file;
+    Uint32 windowID;
  	)
 ]
 
@@ -70,4 +72,16 @@ SDL_DropEvent >> type [
 SDL_DropEvent >> type: anObject [
 	"This method was automatically generated"
 	handle unsignedLongAt: OFFSET_TYPE put: anObject
+]
+
+{ #category : 'accessing - structure variables' }
+SDL_DropEvent >> windowID [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_WINDOWID
+]
+
+{ #category : 'accessing - structure variables' }
+SDL_DropEvent >> windowID: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_WINDOWID put: anObject
 ]


### PR DESCRIPTION
With this change, the `#visitDropEvent:` method belongs to `OSSDL2BackendWindow` instead of `OSSDL2Driver`.

**What was the problem?** `SDL_DropEvent`'s `fieldsDesc` ignored the `windowID` field. Then the event was dispatched to the driver (as a global event). But in fact, the user drops the file into a specific window, so it makes sense that the window decides how to handle the event. 

**Why fixing this?** This will allow Bloc spaces handle the event (see https://github.com/pharo-graphics/Bloc/issues/843).