### PR TITLE
Compile a blank method raises an error

### DIFF
--- a/src/Kernel-CodeModel/Behavior.class.st
+++ b/src/Kernel-CodeModel/Behavior.class.st
@@ -628,18 +628,17 @@ Behavior >> compile: sourceCode classified: protocol withStamp: changeStamp noti
 	"Return the selector of the compiled method"
 
 	| method |
-
+	sourceCode ifEmpty: [ Error signal: 'The source code should not be empty' ].
 	method := self compiler
-		source: sourceCode;
-		requestor: requestor;
-		failBlock: (requestor ifNotNil: [ [ ^ nil ] ]); "no failblock if no requestor"
-		"compatibility: permit faulty code if no requestor"
-		permitFaulty: requestor isNil;
-		permitUndeclared: (requestor isNil);
-		protocol: protocol;
-		changeStamp: changeStamp;
-		logged: logSource;
-		install.
+		          source: sourceCode;
+		          requestor: requestor;
+		          failBlock: (requestor ifNotNil: [ [ ^ nil ] ]);
+		          "no failblock if no requestor""compatibility: permit faulty code if no requestor"permitFaulty: requestor isNil;
+		          permitUndeclared: requestor isNil;
+		          protocol: protocol;
+		          changeStamp: changeStamp;
+		          logged: logSource;
+		          install.
 
 	^ method selector
 ]


### PR DESCRIPTION
We shouldn't be able to compile a blank method in our system at the moment.
Done with @DurieuxPol 
Fixes #19363