### PR TITLE
Fix line evaluation in code browser

### DIFF
--- a/src/Rubric/RubSmalltalkEditor.class.st
+++ b/src/Rubric/RubSmalltalkEditor.class.st
@@ -555,10 +555,9 @@ RubSmalltalkEditor >> evaluateSelectionAndDo: aBlock [
 	"Treat the current selection as an expression; evaluate it and invoke aBlock with the result.
 	If no selection is present select the current line."
 
-	self expressionSelectAndEmptyCheck: [^ ''].
-	^ self
-		evaluate: self selection
-		andDo: aBlock
+	self selectLine.
+	self selection ifEmpty: [ ^ '' ].
+	^ self evaluate: self selection andDo: aBlock
 ]
 
 { #category : 'do-its' }


### PR DESCRIPTION
Because it was selecting the last node using the AST when there was no selection. Now it selects the whole line as expected.

Fixed #18453