### PR TITLE
Enable "Line numbers" checkbox - Calypso 

### DIFF
--- a/src/Calypso-Browser/ClyTextLineNumbersSwitchMorph.class.st
+++ b/src/Calypso-Browser/ClyTextLineNumbersSwitchMorph.class.st
@@ -21,17 +21,6 @@ Class {
 }
 
 { #category : 'settings' }
-ClyTextLineNumbersSwitchMorph class >> settingsOn: aBuilder [
-	<systemsettings>
-	(aBuilder setting: #showLineNumbers)
-		label: 'Show lines numbers for all browsers';
-		parent: #Calypso;
-		default: false;
-		target: self;
-		description: 'If true, line numbers will appear in new system browsers for method editor'
-]
-
-{ #category : 'settings' }
 ClyTextLineNumbersSwitchMorph class >> showLineNumbers [
 	^ showLineNumbers ifNil: [ false ]
 ]

--- a/src/Calypso-Browser/ClyTextLineNumbersSwitchMorph.class.st
+++ b/src/Calypso-Browser/ClyTextLineNumbersSwitchMorph.class.st
@@ -22,7 +22,7 @@ Class {
 
 { #category : 'settings' }
 ClyTextLineNumbersSwitchMorph class >> showLineNumbers [
-	^ showLineNumbers ifNil: [ false ]
+	^ showLineNumbers ifNil: [ true ]
 ]
 
 { #category : 'settings' }

--- a/src/Calypso-Browser/ClyTextLineNumbersSwitchMorph.class.st
+++ b/src/Calypso-Browser/ClyTextLineNumbersSwitchMorph.class.st
@@ -21,8 +21,20 @@ Class {
 }
 
 { #category : 'settings' }
+ClyTextLineNumbersSwitchMorph class >> settingsOn: aBuilder [
+
+	<systemsettings>
+	(aBuilder setting: #showLineNumbers)
+		label: 'Show lines numbers for all browsers';
+		parent: #Calypso;
+		default: false;
+		target: self;
+		description: 'If true, line numbers will appear in new system browsers for method editor'
+]
+
+{ #category : 'settings' }
 ClyTextLineNumbersSwitchMorph class >> showLineNumbers [
-	^ showLineNumbers ifNil: [ true ]
+	^ showLineNumbers ifNil: [ false ]
 ]
 
 { #category : 'settings' }
@@ -62,15 +74,15 @@ ClyTextLineNumbersSwitchMorph >> attachToTextMorph [
 { #category : 'testing' }
 ClyTextLineNumbersSwitchMorph >> isEnabled [
 
-	self class showLineNumbers ifTrue: [ textMorph withLineNumbers ].
-
-	^ self class showLineNumbers
+	^ true
 ]
 
 { #category : 'testing' }
 ClyTextLineNumbersSwitchMorph >> isRuleActive [
 
-	^ textMorph lineNumbersRuler notNil
+	self class showLineNumbers ifTrue: [ textMorph withLineNumbers ].
+
+	^ self class showLineNumbers or: [ textMorph lineNumbersRuler notNil ]
 ]
 
 { #category : 'operations' }


### PR DESCRIPTION
Enable the checkbox "Line Numbers" in Calypso which was desabled by default.

Keep the setting to set if the checkbox is selected by default or not.

The checkbox is here: 
<img width="574" height="29" alt="image" src="https://github.com/user-attachments/assets/e7131171-beb4-4987-99bf-1de06c9d3515" />