### PR TITLE
`browseReferences` error fix

### DIFF
--- a/src/Refactoring-UI/ReRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveClassDriver.class.st
@@ -51,8 +51,7 @@ ReRemoveClassDriver >> breakingChoices [
 { #category : 'actions' }
 ReRemoveClassDriver >> browseReferences [
 
-	haveNoReferences violators do: [ :references |
-		(application toolNamed: #messageList) browse: (references collect: [ :ref | ref compiledMethod ]) ]
+	(application toolNamed: #messageList) browse: (haveNoReferences violators collect: [ :ref | ref compiledMethod ])
 ]
 
 { #category : 'actions' }

--- a/src/Refactoring-UI/ReViolentRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReViolentRemoveClassDriver.class.st
@@ -43,8 +43,7 @@ ReViolentRemoveClassDriver >> breakingChoices [
 { #category : 'actions' }
 ReViolentRemoveClassDriver >> browseReferences [
 
-	haveNoReferences violators do: [ :references |
-		(application toolNamed: #messageList) browse: (references collect: [ :ref | ref compiledMethod ]) ]
+	(application toolNamed: #messageList) browse: (haveNoReferences violators collect: [ :ref | ref compiledMethod ])
 ]
 
 { #category : 'actions' }


### PR DESCRIPTION
It was iterating 2 times on the violators, so we could not get the compiled method, now it is fixed and the choice works well !