### PR TITLE
Fix for `Insert superclass` checkbox comment error

### DIFF
--- a/src/Refactoring-UI-Tests/StRefactoringAddClassPresenterTest.class.st
+++ b/src/Refactoring-UI-Tests/StRefactoringAddClassPresenterTest.class.st
@@ -16,3 +16,16 @@ StRefactoringAddClassPresenterTest >> newPresenter [
 			   superclass: Object;
 			   yourself)
 ]
+
+{ #category : 'tests' }
+StRefactoringAddClassPresenterTest >> testCommentTemplateActivationFillsComment [
+
+	| checkbox comment |
+	checkbox := presenter instVarNamed: 'useTemplateCheckPresenter'.
+	comment := presenter instVarNamed: 'commentPresenter'.
+	self assert: comment text isEmpty.
+	checkbox state: true.
+
+	self deny: comment text isEmpty.
+	self assert: comment text equals: Object classCommentBlank
+]

--- a/src/Refactoring-UI/StRefactoringAddClassPresenter.class.st
+++ b/src/Refactoring-UI/StRefactoringAddClassPresenter.class.st
@@ -67,7 +67,7 @@ StRefactoringAddClassPresenter >> initializeCommentPresenter [
 		state: false;
 		help: 'When checked, the comment will be prefilled with a generic class comment';
 		label: 'Use comment template';
-		whenActivatedDo: [ commentPresenter text: driver superclass classCommentBlank ];
+		whenActivatedDo: [ commentPresenter text: driver superclass realClass  classCommentBlank ];
 		whenDeactivatedDo: [ commentPresenter text: String empty ];
 		yourself.
 	commentPresenter := self newText


### PR DESCRIPTION
It was looking for classCommentBlank in RBClass, I gave it the realClass instead to work.

Fixes #19417