### PR TITLE
Fix extract method from class side

### DIFF
--- a/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
@@ -150,7 +150,7 @@ ReCompositeExtractMethodRefactoring >> buildTransformationFor: newMethodName [
 		  add: (ReRemoveUnusedTemporaryVariableRefactoring
 				   model: self model
 				   inMethod: selector
-				   inClass: class name);
+				   inClass: class realClass name);
 		  yourself
 ]
 

--- a/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
@@ -150,7 +150,7 @@ ReCompositeExtractMethodRefactoring >> buildTransformationFor: newMethodName [
 		  add: (ReRemoveUnusedTemporaryVariableRefactoring
 				   model: self model
 				   inMethod: selector
-				   inClass: class realClass name);
+				   inClass: (class realClass ifNil: [ class name ] ifNotNil: [ :rc | rc name ]));
 		  yourself
 ]
 


### PR DESCRIPTION
The Remove unused var refactoring was given the wrong class name when extracting a method on class side. It works still for instance side too :)

Fixes #16890