### PR TITLE
Fix: extract Method new name picker accepts invalid names

### DIFF
--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -83,17 +83,19 @@ SycExtractMethodCommand >> setUpOptionToChangeExtractionClass: refactoring [
 { #category : 'execution' }
 SycExtractMethodCommand >> setUpOptionToChangeMethodNameDuring: refactoring [
 
-	| dialog |
-	refactoring setOption: #methodName toUse: [ :methodName :ref | | invalidArgs |
-		invalidArgs := self computeInvalidArgNamesForSelector: method selector.
-		dialog := StMethodNameEditorPresenter
-			openOn: methodName
-			withInvalidArgs: invalidArgs
-			canRenameArgs: true
-			canRemoveArgs: false
-			canAddArgs: false.
-		dialog cancelled ifTrue: [ CmdCommandAborted signal ].
-		methodName ]
+	| dialog invalidArgs |
+	invalidArgs := self computeInvalidArgNamesForSelector: method selector.
+	refactoring setOption: #methodName toUse: [ :methodName :ref |
+			dialog := nil.
+			[ dialog isNil or: [ dialog presenter methodName isValid not ] ] whileTrue: [
+					dialog := StMethodNameEditorPresenter
+						          openOn: methodName
+						          withInvalidArgs: invalidArgs
+						          canRenameArgs: true
+						          canRemoveArgs: false
+						          canAddArgs: false.
+					dialog cancelled ifTrue: [ CmdCommandAborted signal ] ].
+			methodName ]
 ]
 
 { #category : 'execution' }

--- a/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycExtractMethodCommand.class.st
@@ -83,9 +83,9 @@ SycExtractMethodCommand >> setUpOptionToChangeExtractionClass: refactoring [
 { #category : 'execution' }
 SycExtractMethodCommand >> setUpOptionToChangeMethodNameDuring: refactoring [
 
-	| dialog invalidArgs |
-	invalidArgs := self computeInvalidArgNamesForSelector: method selector.
 	refactoring setOption: #methodName toUse: [ :methodName :ref |
+			| dialog invalidArgs |
+			invalidArgs := self computeInvalidArgNamesForSelector: method selector.
 			dialog := nil.
 			[ dialog isNil or: [ dialog presenter methodName isValid not ] ] whileTrue: [
 					dialog := StMethodNameEditorPresenter


### PR DESCRIPTION
Now it goes through the same validation loop as the driver uses for the new Extract method refactoring, requesting a new name to the user if te input is invalid.

Fixes #18442