### PR TITLE
Fix:  Removing a class should ignore reference to the class by the class itself

### DIFF
--- a/src/Refactoring-Core-Tests/ReClassesHaveNoReferencesTest.class.st
+++ b/src/Refactoring-Core-Tests/ReClassesHaveNoReferencesTest.class.st
@@ -31,7 +31,7 @@ ReClassesHaveNoReferencesTest >> testClassHasReferences [
 		        classes: { referenced }.
 	self deny: cond check.
 
-	self assert: cond violators size equals: 1.
+	self assert: cond violators size equals: 2.
 
 	violator := cond violators first.
 	self assert: violator selector equals: #accessingSuperclass.

--- a/src/Refactoring-Core/ReClassesHaveNoReferencesCondition.class.st
+++ b/src/Refactoring-Core/ReClassesHaveNoReferencesCondition.class.st
@@ -41,12 +41,13 @@ ReClassesHaveNoReferencesCondition >> violators [
 	^ violators ifNil: [
 			  violators := Set new.
 			  referencingClassesDictionary := Dictionary new.
+
 			  classes do: [ :aClass |
 					  | referrers |
-					  referrers := (model methodsReferencingClass: aClass) reject: [ :each |
-						               (classes includes: each methodClass) or: [ each methodClass isManifest ] ].
+					  referrers := (model methodsReferencingClass: aClass) , (model methodsReferencingClass: aClass classSide) reject: [ :each |
+						               (classes includes: each methodClass instanceSide) or: [ each methodClass isManifest ] ].
 					  referrers ifNotEmpty: [
 							  referencingClassesDictionary at: aClass put: referrers.
-							  referrers do: [ :aRef | violators add: aRef ] ] ].
+							  violators addAll: (referrers collect: [ :aRef | aRef ]) ] ].
 			  violators := violators asArray ]
 ]


### PR DESCRIPTION
It was just looking for instance side references, modified the conditions to update so.

Fixes #19411