### PR TITLE
[RB] Fix: generate accessor with new name based on superclass

### DIFF
--- a/src/Refactoring-Core/RBAbstractClass.class.st
+++ b/src/Refactoring-Core/RBAbstractClass.class.st
@@ -450,8 +450,10 @@ RBAbstractClass >> hierarchyDefinesInstanceVariable: aString [
 
 { #category : 'testing' }
 RBAbstractClass >> hierarchyDefinesMethod: aSelector [
-	(self definesMethod: aSelector) ifTrue: [^true].
-	^self subclassRedefines: aSelector
+
+	(self definesMethod: aSelector) ifTrue: [ ^ true ].
+	(self superclassRedefines: aSelector) ifTrue: [ ^ true ].
+	^ self subclassRedefines: aSelector
 ]
 
 { #category : 'testing' }

--- a/src/Refactoring-DataForTesting/RBBasicLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBBasicLintRuleTestData.class.st
@@ -326,6 +326,12 @@ RBBasicLintRuleTestData >> newResultClass: aClass [
 	result := aClass new
 ]
 
+{ #category : 'initialization' }
+RBBasicLintRuleTestData >> noUnused [
+
+	accessor := 'toto'
+]
+
 { #category : 'accessing' }
 RBBasicLintRuleTestData >> onlyReferenceToSomeDemoMethod [
 

--- a/src/Refactoring-DataForTesting/RBBasicLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBBasicLintRuleTestData.class.st
@@ -5,7 +5,8 @@ Class {
 		'methodBlock',
 		'result',
 		'classBlock',
-		'anInstVar'
+		'anInstVar',
+		'accessor'
 	],
 	#category : 'Refactoring-DataForTesting-LittleHierarchy',
 	#package : 'Refactoring-DataForTesting',

--- a/src/Refactoring-DataForTesting/RBLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBLintRuleTestData.class.st
@@ -53,6 +53,12 @@ RBLintRuleTestData class >> someOtherFooMethod [
 	^ 'does nothing here even better:)'
 ]
 
+{ #category : 'as yet unclassified' }
+RBLintRuleTestData >> accessor [
+
+	^ nil
+]
+
 { #category : 'accessing' }
 RBLintRuleTestData >> checkClass: aSmalllintContext [
 ]

--- a/src/Refactoring-DataForTesting/RBLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBLintRuleTestData.class.st
@@ -53,7 +53,7 @@ RBLintRuleTestData class >> someOtherFooMethod [
 	^ 'does nothing here even better:)'
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 RBLintRuleTestData >> accessor [
 
 	^ nil

--- a/src/Refactoring-Transformations-Tests/RBAddVariableAccessorsParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBAddVariableAccessorsParametrizedTest.class.st
@@ -99,3 +99,23 @@ RBAddVariableAccessorsParametrizedTest >> testNewInstanceVariableAccessors [
 		assert: (class parseTreeForSelector: #foo1:)
 		equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
 ]
+
+{ #category : 'tests' }
+RBAddVariableAccessorsParametrizedTest >> testNewInstanceVariableAccessorsSuperclassAlreadyDefines [
+
+	| refactoring class |
+	refactoring := rbClass
+		               instanceVariable: 'result'
+		               class: #RBBasicLintRuleTestData.
+
+	self executeRefactoring: refactoring.
+
+	class := refactoring model classNamed: #RBLintRuleTestData.
+	self denyEmpty: refactoring changes changes.
+	self
+		assert: (class parseTreeForSelector: #foo1)
+		equals: (self parseMethod: 'foo1 ^foo1').
+	self
+		assert: (class parseTreeForSelector: #foo1:)
+		equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
+]

--- a/src/Refactoring-Transformations-Tests/RBAddVariableAccessorsParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBAddVariableAccessorsParametrizedTest.class.st
@@ -102,20 +102,17 @@ RBAddVariableAccessorsParametrizedTest >> testNewInstanceVariableAccessors [
 
 { #category : 'tests' }
 RBAddVariableAccessorsParametrizedTest >> testNewInstanceVariableAccessorsSuperclassAlreadyDefines [
-
 	| refactoring class |
 	refactoring := rbClass
-		               instanceVariable: 'result'
+		               instanceVariable: 'accessor'
 		               class: #RBBasicLintRuleTestData.
-
 	self executeRefactoring: refactoring.
-
-	class := refactoring model classNamed: #RBLintRuleTestData.
+	class := refactoring model classNamed: #RBBasicLintRuleTestData.
 	self denyEmpty: refactoring changes changes.
 	self
-		assert: (class parseTreeForSelector: #foo1)
-		equals: (self parseMethod: 'foo1 ^foo1').
+		assert: (class parseTreeForSelector: #accessor1)
+		equals: (self parseMethod: 'accessor1 ^accessor').
 	self
-		assert: (class parseTreeForSelector: #foo1:)
-		equals: (self parseMethod: 'foo1: anObject foo1 := anObject')
+		assert: (class parseTreeForSelector: #accessor:)
+		equals: (self parseMethod: 'accessor: anObject accessor := anObject')
 ]

--- a/src/Refactoring-UI/ReGenerateAccessorsDriver.class.st
+++ b/src/Refactoring-UI/ReGenerateAccessorsDriver.class.st
@@ -57,8 +57,11 @@ ReGenerateAccessorsDriver >> scopeInstanceSide: aBoolean [
 	scopeInstanceSide := aBoolean
 ]
 
-{ #category : 'configuration' }
-ReGenerateAccessorsDriver >> selectedVariables: aCollection [
+{ #category : 'initialization' }
+ReGenerateAccessorsDriver >> scopes: scopesList scopeInstanceSide: aBoolean selectedVariables: aCollection [
 
-	selectedVariables := aCollection
+	scopeInstanceSide := aBoolean.
+	selectedVariables := aCollection.
+	scopes := scopesList.
+	model := self refactoringScopeOn: scopesList first
 ]

--- a/src/SystemCommands-VariableCommands/SycGenerateVariableAccessorCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycGenerateVariableAccessorCommand.class.st
@@ -25,8 +25,8 @@ SycGenerateVariableAccessorCommand >> execute [
 
 	(ReGenerateAccessorsDriver new
 		 targetClass: variables first definingClass;
-		 scopes: toolContext refactoringScopes;
-		 scopeInstanceSide: variables first definingClass isInstanceSide;
+		 scopes: toolContext refactoringScopes
+		 scopeInstanceSide: variables first definingClass isInstanceSide
 		 selectedVariables: (variables collect: [ :each | each name ])) runRefactoring
 ]
 


### PR DESCRIPTION
Expected behaviour was if the superclass define a method xxx and we were generating an accessor xxx, the setter would be xxx1. Two fixes here: -the driver was given scopes but didnt give it to its model.
- `hierarchyDefinesMethod:` now looks in the superclass too (was not done before).

So now expected behaviour happens :)
Fixes #17294