### PR TITLE
Cancel button on rename method dialog fix

### DIFF
--- a/src/Refactoring-UI-Tests/ReRenameMethodDriverTest.class.st
+++ b/src/Refactoring-UI-Tests/ReRenameMethodDriverTest.class.st
@@ -10,21 +10,15 @@ ReRenameMethodDriverTest >> setUpMocksOn: driver [
 
 	| requestClass dialog |
 	dialog := MockObject new.
-	dialog
-		on: #methodName
-		respond: (RBMethodName selector: '2a' asSymbol arguments: #(  )).
-	dialog
-		on: #methodName
-		respond: (RBMethodName selector: #testName arguments: #(  )).
+	dialog on: #cancelled respond: false.
+	dialog on: #methodName respond: (RBMethodName selector: '2a' asSymbol arguments: #(  )).
+	dialog on: #cancelled respond: false.
+	dialog on: #methodName respond: (RBMethodName selector: #testName arguments: #(  )).
 	driver requestDialog: dialog.
 	requestClass := MockObject new.
 	requestClass
-		on:
-		#openOn:withInvalidArgs:canRenameArgs:canRemoveArgs:canAddArgs:canEditName:
-		respond: dialog;
-		on:
-		#openOn:withInvalidArgs:canRenameArgs:canRemoveArgs:canAddArgs:canEditName:
-		respond: dialog.
+		on: #openOn:withInvalidArgs:canRenameArgs:canRemoveArgs:canAddArgs:canEditName: respond: dialog;
+		on: #openOn:withInvalidArgs:canRenameArgs:canRemoveArgs:canAddArgs:canEditName: respond: dialog.
 	driver methodNameEditorPresenterClass: requestClass
 ]
 
@@ -51,8 +45,8 @@ ReRenameMethodDriverTest >> testInvalidNameFollowedByAValidNameExpectSuccess [
 
 { #category : 'tests' }
 ReRenameMethodDriverTest >> testValidNameExpectSuccess [
+
 	| rbclasses driver model method dialog requestClass |
-	
 	rbclasses := RBClassEnvironment classes: { MyClassARoot }.
 	model := RBNamespace onEnvironment: rbclasses.
 	method := (model classObjectFor: MyClassARoot) methodFor: 'accessingSharedVariable' asSymbol.
@@ -63,16 +57,13 @@ ReRenameMethodDriverTest >> testValidNameExpectSuccess [
 		          in: MyClassARoot.
 
 	self setUpDriver: driver.
-	
+
 	dialog := MockObject new.
-	dialog
-		on: #methodName
-		respond: (RBMethodName selector: #newName arguments: #(  )).
+	dialog on: #cancelled respond: false.
+	dialog on: #methodName respond: (RBMethodName selector: #newName arguments: #(  )).
 	driver requestDialog: dialog.
 	requestClass := MockObject new.
-	requestClass
-		on: #openOn:withInvalidArgs:canRenameArgs:canRemoveArgs:canAddArgs:canEditName:
-		respond: dialog.
+	requestClass on: #openOn:withInvalidArgs:canRenameArgs:canRemoveArgs:canAddArgs:canEditName: respond: dialog.
 	driver methodNameEditorPresenterClass: requestClass.
 
 	driver runRefactoring.

--- a/src/Refactoring-UI/ReRenameMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRenameMethodDriver.class.st
@@ -187,7 +187,7 @@ ReRenameMethodDriver >> requestNewMessage [
 		              arguments: parameters.
 	dialog := self requestDialogWith: methodName.
 	
-	dialog ifNil: [ shouldEscape := true. ^ self ].
+	dialog cancelled ifTrue: [ shouldEscape := true. ^ self ].
 
 	^ dialog methodName
 ]
@@ -201,10 +201,10 @@ ReRenameMethodDriver >> runRefactoring [
 	failedConditions := OrderedCollection empty.
 	[
 		newMessage := self requestNewMessage.
+		shouldEscape ifTrue: [ ^ self ].
 		self configureMessage.
 
 		refactoring isMethodDefinitionUnchanged ifTrue: [ ^ self ].
-		shouldEscape ifTrue: [ ^ self ]. "What is the use of this variable: shouldEscape?"
 
 		failedConditions := refactoring failedApplicabilityPreconditions.
 		failedConditions do: [ :cond |
@@ -212,7 +212,6 @@ ReRenameMethodDriver >> runRefactoring [
 					message: cond errorString;
 					title: 'Invalid method name';
 					openModal ] ] doWhileFalse: [ failedConditions isEmpty ].
-
 	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
 ]
 


### PR DESCRIPTION
`requestDialogWith:` never returned nil even if the user pressed cancel so I changed the check. Also the check for `shouldEscape ifTrue:` was put too late in the code, looking to configure message even if there was none.

So this fludify the flow :).
Fixes #19440