### PR TITLE
Fix: `ReCompositeExtractMethodRefactoring` fails when extracting block with return node

### DIFF
--- a/src/Refactoring-DataForTesting/RBLintRuleTestData.class.st
+++ b/src/Refactoring-DataForTesting/RBLintRuleTestData.class.st
@@ -111,6 +111,13 @@ RBLintRuleTestData >> junk [
 ]
 
 { #category : 'accessing' }
+RBLintRuleTestData >> methodWithBlockContainingReturn [
+    | b |
+    b := [ ^ 42 ].
+    ^ b value 
+]
+
+{ #category : 'accessing' }
 RBLintRuleTestData >> name [
 	^name
 ]

--- a/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBExtractMethodTransformationTest.class.st
@@ -15,6 +15,31 @@ RBExtractMethodTransformationTest >> sourceCodeAt: anInterval forMethod: aSelect
 ]
 
 { #category : 'tests' }
+RBExtractMethodTransformationTest >> testExtractBlockWithReturnNode [
+
+	| refactoring class |
+	model := self modelOnClasses: { RBLintRuleTestData }.
+	refactoring := ReCompositeExtractMethodRefactoring
+		               model: model
+		               extractSource:
+		               (self sourceCodeAt: (52 to: 59) forMethod: #methodWithBlockContainingReturn in: RBLintRuleTestData)
+		               from: #methodWithBlockContainingReturn
+		               to: #foo
+		               in: #RBLintRuleTestData.
+	refactoring generateChanges.
+
+	class := refactoring model classNamed: #RBLintRuleTestData.
+	self
+		assert: (class parseTreeForSelector: #methodWithBlockContainingReturn)
+		equals: (self parseMethod: 'methodWithBlockContainingReturn
+				| b |
+				b := self foo.
+				^ b value').
+	self assert: (class parseTreeForSelector: #foo) equals: (self parseMethod: 'foo
+				^ [ ^ 42 ]')
+]
+
+{ #category : 'tests' }
 RBExtractMethodTransformationTest >> testExtractUsingExistingMethodRefactoring [
 
 	| transformation class |

--- a/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReCompositeExtractMethodRefactoring.class.st
@@ -213,11 +213,12 @@ ReCompositeExtractMethodRefactoring >> calculateAssignments [
 ReCompositeExtractMethodRefactoring >> calculateIfReturnIsNeededInCaller [
 
 	| searcher |
+	subtree isBlock ifTrue: [ ^ false ].
 	searcher := self parseTreeSearcher.
 	searcher
-		matches: '^self' do: [:aNode :answer | answer];
-		matches: '^`@anything' do: [:aNode :answer | true].
-	^ (searcher executeTree: subtree initialAnswer: false)
+		matches: '^self' do: [ :aNode :answer | answer ];
+		matches: '^`@anything' do: [ :aNode :answer | true ].
+	^ searcher executeTree: subtree initialAnswer: false
 ]
 
 { #category : 'querying' }


### PR DESCRIPTION
I added a simple check  beofre using the parseTreeSearcher: if the whol subtree is a return node, don't put the `needsReturn` to true, meaning it don't add one to the new extracted method.

Fixes #18686 and its bug :)