### PR TITLE
Insert new class keeps trait composition

### DIFF
--- a/src/Refactoring-Core/RBClass.class.st
+++ b/src/Refactoring-Core/RBClass.class.st
@@ -325,8 +325,8 @@ RBClass >> tagName: anObject [
 
 { #category : 'accessing' }
 RBClass >> traitComposition [
-	
-	^ traitComposition
+
+	^ traitComposition ifNil: [ TaEmptyComposition new ]
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-Core/RBNamespace.class.st
+++ b/src/Refactoring-Core/RBNamespace.class.st
@@ -713,6 +713,7 @@ RBNamespace >> reparentClasses: aRBClassCollection to: newClass [
 						sharedVariables: aClass classVariableNames;
 						sharedPools: aClass sharedPoolNames;
 						package: aClass packageName;
+						traits: aClass traitComposition;
 						tag: aClass tagName;
 						classSlots: aClass classSide instanceVariableNames ] ]
 ]


### PR DESCRIPTION
Traits were not given to reparent classes when inserting a new class, meaning classes lots their traits before.

Fixes #18869