### PR TITLE
Tolerance rate in Complishon

### DIFF
--- a/src/HeuristicCompletion-Model/CoBeginsWithFilter.class.st
+++ b/src/HeuristicCompletion-Model/CoBeginsWithFilter.class.st
@@ -39,7 +39,72 @@ CoBeginsWithFilter >> completionString: anObject [
 ]
 
 { #category : 'testing' }
+CoBeginsWithFilter >> fuzzyAcceptsContents: aString [
+
+	^ (self fuzzyScoreForContents: aString) isNotNil
+]
+
+{ #category : 'testing' }
+CoBeginsWithFilter >> fuzzyScoreForContents: aString [
+
+	^ CoFuzzyMatcher
+		scoreForCandidate: aString
+		token: completionString
+		caseSensitive: self isCaseSensitive
+		tolerance: CoCompletionTolerance rate
+]
+
+{ #category : 'testing' }
+CoBeginsWithFilter >> isCaseSensitive [
+
+	self subclassResponsibility
+]
+
+{ #category : 'testing' }
 CoBeginsWithFilter >> isLessNarrowThanNegation: anotherFilter [
 
 	^ false
+]
+
+{ #category : 'testing' }
+CoBeginsWithFilter >> prefixAcceptsContents: aString [
+
+	self subclassResponsibility
+]
+
+{ #category : 'testing' }
+CoBeginsWithFilter >> requiresFallbackEnumeration [
+
+	^ CoCompletionTolerance enabled
+		and: [ completionString size >= CoCompletionTolerance minimumTokenSize ]
+]
+
+{ #category : 'testing' }
+CoBeginsWithFilter >> sortEntries: aCollection [
+
+	| exact fuzzy |
+	self requiresFallbackEnumeration ifFalse: [ ^ aCollection ].
+
+	exact := OrderedCollection new.
+	fuzzy := OrderedCollection new.
+
+	aCollection do: [ :each |
+		(self prefixAcceptsContents: each contents)
+			ifTrue: [ exact add: each ]
+			ifFalse: [ fuzzy add: each ] ].
+
+	fuzzy isEmpty ifTrue: [ ^ aCollection ].
+
+	fuzzy sort: [ :a :b |
+		| scoreA scoreB |
+		scoreA := self fuzzyScoreForContents: a contents.
+		scoreB := self fuzzyScoreForContents: b contents.
+		scoreA = scoreB
+			ifTrue: [ a contents <= b contents ]
+			ifFalse: [ scoreA < scoreB ] ].
+
+	^ OrderedCollection new
+		addAll: exact;
+		addAll: fuzzy;
+		yourself
 ]

--- a/src/HeuristicCompletion-Model/CoCaseInsensitiveBeginsWithFilter.class.st
+++ b/src/HeuristicCompletion-Model/CoCaseInsensitiveBeginsWithFilter.class.st
@@ -22,7 +22,9 @@ CoCaseInsensitiveBeginsWithFilter class >> filterString: aString [
 { #category : 'testing' }
 CoCaseInsensitiveBeginsWithFilter >> accepts: aCandidate [
 
-	^ aCandidate contents asLowercase beginsWith: completionString asLowercase
+	^ (self prefixAcceptsContents: aCandidate contents)
+		or: [ CoCompletionTolerance enabled
+			and: [ self fuzzyAcceptsContents: aCandidate contents ] ]
 ]
 
 { #category : 'testing' }

--- a/src/HeuristicCompletion-Model/CoCaseInsensitiveBeginsWithFilter.class.st
+++ b/src/HeuristicCompletion-Model/CoCaseInsensitiveBeginsWithFilter.class.st
@@ -28,6 +28,12 @@ CoCaseInsensitiveBeginsWithFilter >> accepts: aCandidate [
 ]
 
 { #category : 'testing' }
+CoCaseInsensitiveBeginsWithFilter >> isCaseSensitive [
+
+	^ false
+]
+
+{ #category : 'testing' }
 CoCaseInsensitiveBeginsWithFilter >> isLessNarrowThanCaseInsensitive: anotherFilter [
 
 	^ anotherFilter completionString beginsWith: self completionString
@@ -43,4 +49,10 @@ CoCaseInsensitiveBeginsWithFilter >> isLessNarrowThanCaseSensitive: anotherFilte
 CoCaseInsensitiveBeginsWithFilter >> isMoreNarrowThan: anotherFilter [
 
 	^ anotherFilter isLessNarrowThanCaseInsensitive: self
+]
+
+{ #category : 'testing' }
+CoCaseInsensitiveBeginsWithFilter >> prefixAcceptsContents: aString [
+
+	^ aString asLowercase beginsWith: completionString asLowercase
 ]

--- a/src/HeuristicCompletion-Model/CoCaseSensitiveBeginsWithFilter.class.st
+++ b/src/HeuristicCompletion-Model/CoCaseSensitiveBeginsWithFilter.class.st
@@ -22,7 +22,15 @@ CoCaseSensitiveBeginsWithFilter class >> filterString: aString [
 { #category : 'testing' }
 CoCaseSensitiveBeginsWithFilter >> accepts: aCandidate [
 
-	^ aCandidate contents beginsWith: completionString
+	^ (self prefixAcceptsContents: aCandidate contents)
+		or: [ CoCompletionTolerance enabled
+			and: [ self fuzzyAcceptsContents: aCandidate contents ] ]
+]
+
+{ #category : 'testing' }
+CoCaseSensitiveBeginsWithFilter >> isCaseSensitive [
+
+	^ false
 ]
 
 { #category : 'testing' }
@@ -41,4 +49,10 @@ CoCaseSensitiveBeginsWithFilter >> isLessNarrowThanCaseSensitive: anotherFilter 
 CoCaseSensitiveBeginsWithFilter >> isMoreNarrowThan: anotherFilter [
 
 	^ anotherFilter isLessNarrowThanCaseSensitive: self
+]
+
+{ #category : 'testing' }
+CoCaseSensitiveBeginsWithFilter >> prefixAcceptsContents: aString [
+
+	^ aString asLowercase beginsWith: completionString asLowercase
 ]

--- a/src/HeuristicCompletion-Model/CoCaseSensitiveBeginsWithFilter.class.st
+++ b/src/HeuristicCompletion-Model/CoCaseSensitiveBeginsWithFilter.class.st
@@ -30,7 +30,7 @@ CoCaseSensitiveBeginsWithFilter >> accepts: aCandidate [
 { #category : 'testing' }
 CoCaseSensitiveBeginsWithFilter >> isCaseSensitive [
 
-	^ false
+	^ true
 ]
 
 { #category : 'testing' }
@@ -54,5 +54,5 @@ CoCaseSensitiveBeginsWithFilter >> isMoreNarrowThan: anotherFilter [
 { #category : 'testing' }
 CoCaseSensitiveBeginsWithFilter >> prefixAcceptsContents: aString [
 
-	^ aString asLowercase beginsWith: completionString asLowercase
+	^ aString beginsWith: completionString
 ]

--- a/src/HeuristicCompletion-Model/CoCompletionTolerance.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionTolerance.class.st
@@ -1,3 +1,7 @@
+"
+Stores the runtime settings for fuzzy completion, such as the allowed typo rate and the minimum token size.
+
+"
 Class {
 	#name : 'CoCompletionTolerance',
 	#superclass : 'Object',

--- a/src/HeuristicCompletion-Model/CoCompletionTolerance.class.st
+++ b/src/HeuristicCompletion-Model/CoCompletionTolerance.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : 'CoCompletionTolerance',
+	#superclass : 'Object',
+	#classInstVars : [
+		'minimumTokenSize',
+		'rate'
+	],
+	#category : 'HeuristicCompletion-Model-Core',
+	#package : 'HeuristicCompletion-Model',
+	#tag : 'Core'
+}
+
+{ #category : 'accessing' }
+CoCompletionTolerance class >> enabled [
+
+	^ self rate > 0.0
+]
+
+{ #category : 'accessing' }
+CoCompletionTolerance class >> minimumTokenSize [
+	^ minimumTokenSize ifNil: [ minimumTokenSize := 2 ]
+]
+
+{ #category : 'accessing' }
+CoCompletionTolerance class >> minimumTokenSize: anInteger [
+	minimumTokenSize := (anInteger ifNil: [ 4 ]) max: 1
+]
+
+{ #category : 'accessing' }
+CoCompletionTolerance class >> rate [
+
+	^ rate ifNil: [ rate := 0.0 ]
+]
+
+{ #category : 'accessing' }
+CoCompletionTolerance class >> rate: aNumber [
+
+	| value |
+	value := (aNumber ifNil: [ 0.0 ]) asFloat.
+	rate := (value max: 0.0) min: 1.0
+]
+
+{ #category : 'accessing' }
+CoCompletionTolerance class >> reset [
+
+	<script>
+	rate := 0.0.
+	minimumTokenSize := 2
+]

--- a/src/HeuristicCompletion-Model/CoFilter.class.st
+++ b/src/HeuristicCompletion-Model/CoFilter.class.st
@@ -53,3 +53,9 @@ CoFilter >> negated [
 		negatedFilter: self;
 		yourself
 ]
+
+{ #category : 'sorting' }
+CoFilter >> sortEntries: aCollection [
+
+	^ aCollection
+]

--- a/src/HeuristicCompletion-Model/CoFuzzyMatcher.class.st
+++ b/src/HeuristicCompletion-Model/CoFuzzyMatcher.class.st
@@ -1,3 +1,7 @@
+"
+Computes fuzzy match scores between the typed token and a candidate using Damerau-Levenshtein distance
+
+"
 Class {
 	#name : 'CoFuzzyMatcher',
 	#superclass : 'Object',

--- a/src/HeuristicCompletion-Model/CoFuzzyMatcher.class.st
+++ b/src/HeuristicCompletion-Model/CoFuzzyMatcher.class.st
@@ -1,0 +1,107 @@
+Class {
+	#name : 'CoFuzzyMatcher',
+	#superclass : 'Object',
+	#category : 'HeuristicCompletion-Model-Core',
+	#package : 'HeuristicCompletion-Model',
+	#tag : 'Core'
+}
+
+{ #category : 'matching' }
+CoFuzzyMatcher class >> damerauLevenshteinDistanceBetween: source and: target maxDistance: maxDistance [
+
+	| previousRow currentRow twoRowsBack minInRow cost insertion deletion substitution value |
+	source = target ifTrue: [ ^ 0 ].
+
+	previousRow := Array new: target size + 1.
+	1 to: (target size + 1) do: [ :j |
+		previousRow at: j put: j - 1 ].
+	twoRowsBack := nil.
+
+	1 to: source size do: [ :i |
+		currentRow := Array new: target size + 1.
+		currentRow at: 1 put: i.
+		minInRow := i.
+
+		1 to: target size do: [ :j |
+			cost := ((source at: i) = (target at: j))
+				ifTrue: [ 0 ]
+				ifFalse: [ 1 ].
+
+			insertion := (currentRow at: j) + 1.
+			deletion := (previousRow at: (j + 1)) + 1.
+			substitution := (previousRow at: j) + cost.
+
+			value := insertion min: deletion.
+			value := value min: substitution.
+
+			(i > 1 and: [ j > 1 and: [
+				(source at: i) = (target at: (j - 1))
+					and: [ (source at: (i - 1)) = (target at: j) ] ] ]) ifTrue: [
+						twoRowsBack ifNotNil: [
+							value := value min: ((twoRowsBack at: (j - 1)) + 1) ] ].
+
+			currentRow at: (j + 1) put: value.
+			minInRow := minInRow min: value ].
+
+		minInRow > maxDistance ifTrue: [ ^ nil ].
+		twoRowsBack := previousRow.
+		previousRow := currentRow ].
+
+	^ (previousRow last <= maxDistance)
+		ifTrue: [ previousRow last ]
+		ifFalse: [ nil ]
+]
+
+{ #category : 'matching' }
+CoFuzzyMatcher class >> scoreForCandidate: aCandidateString token: aTokenString caseSensitive: aBoolean tolerance: aTolerance [
+	| candidate token maxSize maxEdits distance |
+	candidate := aCandidateString asString.
+	token := aTokenString asString.
+
+	token isEmpty ifTrue: [ ^ 0.0 ].
+	candidate = token ifTrue: [ ^ 0.0 ].
+
+	candidate := aBoolean
+		ifTrue: [ candidate ]
+		ifFalse: [ candidate asLowercase ].
+	token := aBoolean
+		ifTrue: [ token ]
+		ifFalse: [ token asLowercase ].
+
+	(candidate beginsWith: token) ifTrue: [ ^ 0.0 ].
+	(self shouldTryFuzzyFor: token candidate: candidate tolerance: aTolerance) ifFalse: [ ^ nil ].
+
+	maxSize := token size max: candidate size.
+	maxEdits := (aTolerance * maxSize) ceiling.
+	maxEdits <= 0 ifTrue: [ ^ nil ].
+
+	distance := self
+		damerauLevenshteinDistanceBetween: token
+		and: candidate
+		maxDistance: maxEdits.
+
+	distance ifNil: [ ^ nil ].
+	^ distance asFloat / maxSize
+]
+
+{ #category : 'matching' }
+CoFuzzyMatcher class >> shouldTryFuzzyFor: token candidate: candidate tolerance: aTolerance [
+
+	| maxSize maxEdits |
+	(CoCompletionTolerance enabled not or: [ aTolerance <= 0.0 ]) ifTrue: [ ^ false ].
+	token isEmpty ifTrue: [ ^ false ].
+	candidate isEmpty ifTrue: [ ^ false ].
+	token size < CoCompletionTolerance minimumTokenSize ifTrue: [ ^ false ].
+
+	"Keep keyword arity stable"
+	((token includes: $:) or: [ candidate includes: $: ]) ifTrue: [
+		(token occurrencesOf: $:) = (candidate occurrencesOf: $:)
+			ifFalse: [ ^ false ] ].
+
+	"Cheap guardrails to avoid noisy matches"
+	token first = candidate first ifFalse: [ ^ false ].
+
+	maxSize := token size max: candidate size.
+	maxEdits := (aTolerance * maxSize) ceiling.
+	^ (token size - candidate size) abs <= maxEdits
+]

--- a/src/HeuristicCompletion-Model/CoGlobalSelectorFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoGlobalSelectorFetcher.class.st
@@ -27,23 +27,24 @@ CoGlobalSelectorFetcher >> entriesDo: aBlock [
 	"
 	
 	astNode ifNotNil: [ :node |
-			node parent ifNotNil: [ :parent | "Try first to continue the parent keyword message"
-					(parent isMessage and: [ parent isKeyword ]) ifTrue: [
-						
-							self systemNavigation 
-								allSelectorsStartingWith: parent selector , filter completionString 
-								do: [ :e |
-									aBlock value: (NECSelectorEntry new
-											  displayedContents:
-												  '(' , (e copyFrom: 1 to: parent selector size) , ')' , 
-													(e copyFrom: parent selector size + 1 to: e size); 
-												contents: (e copyFrom: parent selector size + 1 to: e size);
-											  	node: astNode; 
-											 fetcher: self;
-											 selector: e) ] ] ] ]. "Otherwise, just go wide"
+		node parent ifNotNil: [ :parent |
+			(parent isMessage and: [ parent isKeyword ]) ifTrue: [
+				self systemNavigation
+					allSelectorsStartingWith: parent selector , filter completionString
+					do: [ :e |
+						aBlock value: (NECSelectorEntry new
+							displayedContents:
+								'(' , (e copyFrom: 1 to: parent selector size) , ')',
+								(e copyFrom: parent selector size + 1 to: e size);
+							contents: (e copyFrom: parent selector size + 1 to: e size);
+							node: astNode;
+							fetcher: self;
+							selector: e) ] ] ] ].
 							
-	self systemNavigation allSelectorsStartingWith: filter completionString do: [ :e |
+	self systemNavigation
+		allSelectorsStartingWith: filter completionString
+		do: [ :e |
 			aBlock value: ((NECSelectorEntry contents: e node: astNode)
-					 fetcher: self;
-					 yourself) ]
+				fetcher: self;
+				yourself) ]
 ]

--- a/src/HeuristicCompletion-Model/CoGlobalVariableFetcher.class.st
+++ b/src/HeuristicCompletion-Model/CoGlobalVariableFetcher.class.st
@@ -20,8 +20,10 @@ CoGlobalVariableFetcher >> entriesDo: aBlock [
 
 	self systemNavigation
 		allGlobalNamesStartingWith: filter completionString
-		do: [ :e | aBlock value:
-				((NECGlobalEntry contents: e node: astNode) 
-					fetcher: self; yourself) ]
-		caseSensitive: (NECPreferences caseSensitive)
+		do: [ :e |
+			aBlock value: ((NECGlobalEntry contents: e node: astNode)
+				fetcher: self;
+				yourself) ]
+		caseSensitive: NECPreferences caseSensitive
+
 ]

--- a/src/HeuristicCompletion-Model/CoResultSet.class.st
+++ b/src/HeuristicCompletion-Model/CoResultSet.class.st
@@ -73,13 +73,13 @@ CoResultSet >> fetch: anInteger [
 
 	| newResults |
 	newResults := fetcher next: anInteger.
-	results addAll: "(sorter sortCompletionList:" newResults
+	results addAll: (filter sortEntries: newResults)
 ]
 
 { #category : 'fetching' }
 CoResultSet >> fetchAll [
 
-	results addAll: fetcher upToEnd
+	results addAll: (filter sortEntries: fetcher upToEnd)
 ]
 
 { #category : 'accessing' }

--- a/src/NECompletion-Preferences/NECPreferences.class.st
+++ b/src/NECompletion-Preferences/NECPreferences.class.st
@@ -62,8 +62,44 @@ NECPreferences class >> caseSensitive: aBoolean [
 ]
 
 { #category : 'defaults' }
+NECPreferences class >> completionToleranceMinimumTokenSize [
+
+	^ CoCompletionTolerance minimumTokenSize
+]
+
+{ #category : 'defaults' }
+NECPreferences class >> completionToleranceMinimumTokenSize: anInteger [
+
+	CoCompletionTolerance minimumTokenSize: anInteger
+]
+
+{ #category : 'defaults' }
+NECPreferences class >> completionToleranceRate [
+
+	^ CoCompletionTolerance rate
+]
+
+{ #category : 'defaults' }
+NECPreferences class >> completionToleranceRate: aNumber [
+
+	CoCompletionTolerance rate: aNumber
+]
+
+{ #category : 'defaults' }
 NECPreferences class >> defaultBackgroundColor [
 	^ self theme menuColor
+]
+
+{ #category : 'defaults' }
+NECPreferences class >> defaultCompletionToleranceMinimumTokenSize [
+
+	^ 2
+]
+
+{ #category : 'defaults' }
+NECPreferences class >> defaultCompletionToleranceRate [
+
+	^ 0.0
 ]
 
 { #category : 'defaults' }
@@ -224,6 +260,16 @@ NECPreferences class >> settingsOn: aBuilder [
 						label: 'Case Sensitive';
 						default: true;
 						description: 'Decide if you want eCompletion to be case sensitive or not.'.
+					(aBuilder setting: #completionToleranceRate)
+						target: self;
+						label: 'Typo tolerance rate';
+						default: self defaultCompletionToleranceRate;
+						description: '0.0 disables fuzzy typo tolerance. Higher values allow more edits.'.
+					(aBuilder setting: #completionToleranceMinimumTokenSize)
+						target: self;
+						label: 'Typo tolerance minimum token size';
+						default: self defaultCompletionToleranceMinimumTokenSize;
+						description: 'Minimum token length before fuzzy matching is allowed.'.
 					(aBuilder setting: #smartCharacters)
 						label: 'Smart Characters';
 						default: true;


### PR DESCRIPTION
 This PR adds typo-tolerant completion to the completion engine.
At the moment, completion depends on exact prefix matching. This means that a small typo can prevent the expected completion from appearing, even when the intended candidate is obvious. That makes completion less helpful in one of the situations where it should help the most: while the user is actively typing and makes a minor mistake.

To improve this, this PR introduces approximate matching based on the normalized Damerau-Levenshtein distance. When enabled, the completion engine can tolerate small typing errors and still propose close candidates. Exact prefix matches are preserved and still ranked first, while fuzzy matches are only considered as a fallback and are sorted by similarity.

For example, `CoCompletionTolerance rate:0.4` 
- if the intended varibale is `Color` and the user types a close but incorrect form such as `Clor` or `Colr`, completion can still suggest `Color`
<img width="489" height="367" alt="Capture d’écran 2026-03-23 à 12 00 49" src="https://github.com/user-attachments/assets/f1a9a31e-ef74-49a6-9b38-f8824e792e0a" />

or 

- if the intended selector is printOn: and the user types a close but incorrect form such as prntOn:, completion can still suggest printOn:.

<img width="577" height="334" alt="Capture d’écran 2026-03-23 à 12 01 08" src="https://github.com/user-attachments/assets/620e1904-cc86-43ad-8f50-8f6d421c2bdc" />


P.S: The main trade-off is that increasing the tolerance too much can cause incorrect matches, so completion becomes noisy.



