### PR TITLE
Addition of new precondition for `RbInlineTemporaryRefactoring`

### DIFF
--- a/src/Refactoring-Core/RBInlineTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBInlineTemporaryRefactoring.class.st
@@ -38,16 +38,20 @@ RBInlineTemporaryRefactoring class >> model: aRBSmalltalk inline: anInterval fro
 ]
 
 { #category : 'preconditions' }
-RBInlineTemporaryRefactoring >> applicabilityPreconditions [ 
-	
+RBInlineTemporaryRefactoring >> applicabilityPreconditions [
+
 	^ {
-		(ReDefinesSelectorsCondition new definesSelectors: (Array with: selector) in: class).
-		(ReIsValidInstanceVariableName new name: assignmentNode variable name).
-		(ReSingleAssignmentCondition new
-			variableName: assignmentNode variable name; definingNode: sourceTree).
-		(ReVariablesNotReadBeforeWrittenCondition new 
-			variables: {assignmentNode variable name}; subtree: sourceTree)
-	}
+		  (ReDefinesSelectorsCondition new definesSelectors: (Array with: selector) in: class).
+		  (ReIsValidInstanceVariableName new name: assignmentNode variable name).
+		  (ReSingleAssignmentCondition new
+			   variableName: assignmentNode variable name;
+			   definingNode: sourceTree).
+		  (ReSingleReadCondition new
+			   variableName: assignmentNode variable name;
+			   definingNode: sourceTree).
+		  (ReVariablesNotReadBeforeWrittenCondition new
+			   variables: { assignmentNode variable name };
+			   subtree: sourceTree) }
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/ReSingleReadCondition.class.st
+++ b/src/Refactoring-Core/ReSingleReadCondition.class.st
@@ -1,0 +1,50 @@
+"
+I'm a condition to check that given variable name is not read more than once in given defining node.
+"
+Class {
+	#name : 'ReSingleReadCondition',
+	#superclass : 'ReReifiedCondition',
+	#instVars : [
+		'variableName',
+		'definingNode'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'checking' }
+ReSingleReadCondition >> check [
+
+	| searcher assignSearcher |
+	searcher := ReAbstractTransformation new parseTreeSearcher.
+	searcher matches: variableName do: [ :aNode :answer | answer + 1 ].
+
+	assignSearcher := ReAbstractTransformation new parseTreeSearcher.
+	assignSearcher matches: variableName , ' := ``@object' do: [ :aNode :answer | answer + 1 ].
+
+	^ (searcher executeTree: definingNode initialAnswer: 0) - (assignSearcher executeTree: definingNode initialAnswer: 0) <= 1
+]
+
+{ #category : 'accessing' }
+ReSingleReadCondition >> definingNode: aDefiningNode [
+
+	definingNode := aDefiningNode
+]
+
+{ #category : 'accessing' }
+ReSingleReadCondition >> variableName: aVariableName [
+
+	variableName := aVariableName 
+]
+
+{ #category : 'displaying' }
+ReSingleReadCondition >> violationMessageOn: aStream [
+
+	aStream
+		nextPutAll: 'Cannot inline ''';
+		nextPutAll: variableName;
+		nextPutAll: ''': it is referenced more than once.';
+		cr;
+		nextPutAll: 'Inlining would duplicate the initializer expression and may change program behavior.'
+]

--- a/src/Refactoring-Transformations-Tests/RBInlineTemporaryParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBInlineTemporaryParametrizedTest.class.st
@@ -28,6 +28,15 @@ RBInlineTemporaryParametrizedTest >> testFailureInlineTemporaryBadInterval [
 ]
 
 { #category : 'failure tests' }
+RBInlineTemporaryParametrizedTest >> testFailureInlineTemporaryMultipleRead [
+
+	self shouldFail: (self createRefactoringWithArguments: {
+				 (38 to: 62).
+				 #inlineFoo:.
+				 RBClassDataForRefactoringTest })
+]
+
+{ #category : 'failure tests' }
 RBInlineTemporaryParametrizedTest >> testFailureInlineTemporaryMutlipleAssignment [
 
 	self shouldFail: (self createRefactoringWithArguments: {


### PR DESCRIPTION
The refactoring could break some code by inlining a temporary that is being read multiple times, as it can't handle cascades. 
Therefore, I added a new applicability precondition to check if a temporary is read multiple times. If it is the case, it aborts providing a feedback message to the user.
I also added a test for this specific check

This refactoring could also be migrated to the driver architecture !
Also as @jecisc said in the issue, we could inline the code as a cascade in the future if the temporary being inlined is the receiver of all statements.

Fixes #6056