### PR TITLE
Fix scope detection in refactoring condition class

### DIFF
--- a/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBExtractToTemporaryRefactoring.class.st
@@ -62,7 +62,7 @@ RBExtractToTemporaryRefactoring >> applicabilityPreconditions [
 	^ {
 		  (ReDefinesSelectorsCondition new definesSelectors: (Array with: selector) in: class).
 		  (ReIsValidInstanceVariableName new name: newVariableName).
-		  (ReLocalNameConflictCondition class: class variableName: newVariableName parseTree: parseTree) }
+		  (ReLocalNameConflictCondition class: class variableName: newVariableName definingNode: selectedParseTree parseTree: parseTree) }
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
+++ b/src/Refactoring-Core/RBRenameArgumentOrTemporaryRefactoring.class.st
@@ -79,7 +79,7 @@ RBRenameArgumentOrTemporaryRefactoring >> applicabilityPreconditions [
 RBRenameArgumentOrTemporaryRefactoring >> applicabilityPreconditionsIndependentOfTheNewName [
 	"Those are the preconditions that should be checked before even asking to the user a new name for the temporary."
 
-	^ { (RBCondition definesSelector: selector in: class) }
+	^ { (ReDefinesSelectorsCondition new definesSelectors: (Array with: selector) in: class) }
 ]
 
 { #category : 'preconditions' }
@@ -87,8 +87,12 @@ RBRenameArgumentOrTemporaryRefactoring >> applicabilityPreconditionsOfTheNewName
 	"Those are the preconditions that should be checked after asking to the user a new name for the temporary."
 
 	^ {
-		  (RBCondition isValidInstanceVariableName: newName for: class).
-		  (ReLocalNameConflictCondition class: class variableName: newName parseTree: parseTree) }
+		  (ReIsValidInstanceVariableName name: newName).
+		  (ReLocalNameConflictCondition
+			   class: class
+			   variableName: newName
+			   definingNode: definingNode
+			   parseTree: parseTree) } 
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Core/ReIsValidInstanceVariableName.class.st
+++ b/src/Refactoring-Core/ReIsValidInstanceVariableName.class.st
@@ -65,8 +65,8 @@ ReIsValidInstanceVariableName >> initialize [
 { #category : 'accessing' }
 ReIsValidInstanceVariableName >> violationMessageOn: aStream [
 
-	^ aStream
-		  nextPutAll: violator;
-		  nextPutAll:
-			  ' the name musn''t start in uppercase or be a reserved word.'
+	violator ifNotNil: [
+			^ aStream
+				  nextPutAll: violator;
+				  nextPutAll: ' the name musn''t start in uppercase or be a reserved word.' ]
 ]

--- a/src/Refactoring-Core/ReLocalNameConflictCondition.class.st
+++ b/src/Refactoring-Core/ReLocalNameConflictCondition.class.st
@@ -6,12 +6,21 @@ Class {
 	#superclass : 'ReClassCondition',
 	#instVars : [
 		'variableName',
+		'definingNode',
 		'parseTree'
 	],
 	#category : 'Refactoring-Core-Conditions',
 	#package : 'Refactoring-Core',
 	#tag : 'Conditions'
 }
+
+{ #category : 'instance creation' }
+ReLocalNameConflictCondition class >> class: aClass variableName: aNewName definingNode: aNode parseTree: aParseTree [
+    ^ self new
+        class: aClass;
+        variableName: aNewName definingNode: aNode parseTree: aParseTree;
+        yourself
+]
 
 { #category : 'instance creation' }
 ReLocalNameConflictCondition class >> class: aRBAbstractClass variableName: aVariableName parseTree: aParseTree [ 
@@ -29,14 +38,17 @@ ReLocalNameConflictCondition class >> classNamed: aString inModel: aRBNamespace 
 { #category : 'checking' }
 ReLocalNameConflictCondition >> check [
 
-    (parseTree whichUpNodeDefines: variableName) ifNotNil: [
-        violators addIfNotPresent: variableName ].
+	(definingNode exactNodeDefines: variableName) ifTrue: [ violators addIfNotPresent: variableName ].
+	(parseTree whichUpNodeDefines: variableName) ifNotNil: [ violators addIfNotPresent: variableName ].
+	^ violators isEmpty
+]
 
-    (parseTree allDefinedVariables includes: variableName) ifTrue: [
-        violators addIfNotPresent: variableName ].
+{ #category : 'instance creation' }
+ReLocalNameConflictCondition >> variableName: aNewName definingNode: aNode parseTree: aParseTree [
 
-    ^ violators isEmpty
-
+	variableName := aNewName.
+	definingNode := aNode.
+	parseTree := aParseTree
 ]
 
 { #category : 'instance creation' }

--- a/src/Refactoring-Core/ReLocalNameConflictCondition.class.st
+++ b/src/Refactoring-Core/ReLocalNameConflictCondition.class.st
@@ -38,9 +38,16 @@ ReLocalNameConflictCondition class >> classNamed: aString inModel: aRBNamespace 
 { #category : 'checking' }
 ReLocalNameConflictCondition >> check [
 
-	(definingNode exactNodeDefines: variableName) ifTrue: [ violators addIfNotPresent: variableName ].
-	(parseTree whichUpNodeDefines: variableName) ifNotNil: [ violators addIfNotPresent: variableName ].
-	^ violators isEmpty
+    (definingNode exactNodeDefines: variableName) ifTrue: [
+        violators addIfNotPresent: variableName ].
+
+    (parseTree withAllChildren anySatisfy: [ :node |
+        (node exactNodeDefines: variableName) and: [
+            (node withAllChildren includes: definingNode) 
+            or: [ definingNode withAllChildren includes: node ] ] ]) 
+        ifTrue: [ violators addIfNotPresent: variableName ].
+
+    ^ violators isEmpty
 ]
 
 { #category : 'instance creation' }

--- a/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
+++ b/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
@@ -136,7 +136,7 @@ ReRenameArgumentOrTemporaryDriver >> runRefactoring [
 
 		refactoring applicabilityPreconditionsOfTheNewName allSatisfy: [ :condition | condition check ] ] whileFalse: [
 			refactoring applicabilityPreconditionsOfTheNewName
-				detect: [ :condition | condition check ]
+				detect: [ :condition | condition check not ]
 				ifFound: [ :condition | self inform: condition errorString ] ].
 
 	self setBreakingChangesPreconditions.


### PR DESCRIPTION
Renaming a temp or block argument would incorrectly report a conflict when the new name appeared in a sibling block. 
The condition only received the new name as a string, so it couldn't locate the actual defining scope and fell back to scanning the entire method tree.
Fix: pass `definingNode` directly to the condition. `check` now uses `definingNode exactNodeDefines:` for same-scope conflicts, and goes through the tree via `withAllChildren` restricted to ancestors and descendants of definingNode to catch shadowing — leaving sibling blocks fully transparent.

Also fixed:
  -Inverted `detect:` predicate in the driver (was showing error for passing conditions)
  -Migration off deprecated RBCondition precondition helpers
  -Nil guard in ReIsValidInstanceVariableName >> violationMessageOn:

Fixes #18547