### PR TITLE
Adding implicit prefix to Complishon

### DIFF
--- a/src/NECompletion-Preferences/NECPreferences.class.st
+++ b/src/NECompletion-Preferences/NECPreferences.class.st
@@ -224,6 +224,10 @@ NECPreferences class >> settingsOn: aBuilder [
 						label: 'Case Sensitive';
 						default: true;
 						description: 'Decide if you want eCompletion to be case sensitive or not.'.
+					(aBuilder setting: #expandPrefixes)
+						label: 'Expand inferred package prefixes';
+						default: true;
+						description: 'Allow suffix-only matching such as Pre -> SpPresenter when a package prefix is implied.'.
 					(aBuilder setting: #smartCharacters)
 						label: 'Smart Characters';
 						default: true;

--- a/src/NECompletion/NECEntry.class.st
+++ b/src/NECompletion/NECEntry.class.st
@@ -76,6 +76,12 @@ NECEntry >> browse [
 	self subclassResponsibility
 ]
 
+{ #category : 'matching' }
+NECEntry >> completionMatchText [
+
+	^ self contents
+]
+
 { #category : 'accessing' }
 NECEntry >> contents [
 	^ contents

--- a/src/NECompletion/NECPrefixExpandableGlobalEntry.class.st
+++ b/src/NECompletion/NECPrefixExpandableGlobalEntry.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : 'NECPrefixExpandableGlobalEntry',
+	#superclass : 'NECGlobalEntry',
+	#instVars : [
+		'implicitPrefix'
+	],
+	#category : 'NECompletion-Model',
+	#package : 'NECompletion',
+	#tag : 'Model'
+}
+
+{ #category : 'as yet unclassified' }
+NECPrefixExpandableGlobalEntry class >> contents: aString node: aNode implicitPrefix: aPrefix [
+
+	^ self new
+		contents: aString node: aNode;
+		implicitPrefix: aPrefix;
+		yourself
+]
+
+{ #category : 'matching' }
+NECPrefixExpandableGlobalEntry >> completionMatchText [
+
+	(NECPreferences expandPrefixes
+		and: [ implicitPrefix isNotNil
+		and: [ implicitPrefix notEmpty
+		and: [ self contents size > implicitPrefix size
+		and: [ self contents beginsWith: implicitPrefix ] ] ] ])
+		ifTrue: [ ^ self contents allButFirst: implicitPrefix size ].
+
+	^ super completionMatchText
+]
+
+{ #category : 'matching' }
+NECPrefixExpandableGlobalEntry >> implicitPrefix [
+
+	^ implicitPrefix
+]
+
+{ #category : 'matching' }
+NECPrefixExpandableGlobalEntry >> implicitPrefix: aString [
+
+	implicitPrefix := aString
+]


### PR DESCRIPTION
It’s simple: today the engine both searches and inserts using the same full class name, so `SpPresenter` only appears if you type `Sp...`; the filter checks whether the candidate starts with what you typed, and accepting a result inserts the full `contents` into the editor.

The role of this PR is to keep the real completion as `SpPresenter`, but in package context let the matcher look at a shortened searchable form like `Presenter`, so typing `Pre` can still find `SpPresenter` while accepting it still inserts the full class name; that way we change only how a result is found, not how it is inserted.

<img width="912" height="648" alt="Capture d’écran 2026-03-24 à 11 57 22" src="https://github.com/user-attachments/assets/82ac9d22-2635-48d4-be40-7d3d8cfac4e0" />
