### PR TITLE
Extract precondition objects and add tests for RBPushDownSharedVariableRefactoring

### DIFF
--- a/src/Refactoring-Core-Tests/ReDirectlyDefinesSharedVariableConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/ReDirectlyDefinesSharedVariableConditionTest.class.st
@@ -1,0 +1,42 @@
+Class {
+	#name : 'ReDirectlyDefinesSharedVariableConditionTest',
+	#superclass : 'ReClassesConditionTest',
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
+}
+
+{ #category : 'tests' }
+ReDirectlyDefinesSharedVariableConditionTest >> testDirectlyDefinesSharedVariable [
+
+    | myClassAlpha condition |
+
+    myClassAlpha := self model classNamed: #MyClassAlpha.
+    condition := ReDirectlyDefinesSharedVariableCondition
+        class: myClassAlpha
+        sharedVariables: { #SharedVarA }.
+    self assert: condition check
+]
+
+{ #category : 'tests' }
+ReDirectlyDefinesSharedVariableConditionTest >> testDoesNotDefineSharedVariable [
+
+    | myClassAlpha condition |
+    myClassAlpha := self model classNamed: #MyClassAlpha.
+    condition := ReDirectlyDefinesSharedVariableCondition
+        class: myClassAlpha
+        sharedVariables: { #SharedVarB }.
+    self deny: condition check
+]
+
+{ #category : 'tests' }
+ReDirectlyDefinesSharedVariableConditionTest >> testInheritedSharedVariableFails [
+
+    | myClassBeta condition |
+    myClassBeta := self model classNamed: #MyClassBeta.
+    "SharedVarA comes from MyClassAlpha"
+    condition := ReDirectlyDefinesSharedVariableCondition
+        class: myClassBeta
+        sharedVariables: { #SharedVarA }.
+    self deny: condition check
+]

--- a/src/Refactoring-Core-Tests/ReSharedVariableHasReferencesInDefiningClassTest.class.st
+++ b/src/Refactoring-Core-Tests/ReSharedVariableHasReferencesInDefiningClassTest.class.st
@@ -16,3 +16,14 @@ ReSharedVariableHasReferencesInDefiningClassTest >> testDefinedSharedVariableHas
     self deny: condition check.
     self assert: condition violators isEmpty
 ]
+
+{ #category : 'tests' }
+ReSharedVariableHasReferencesInDefiningClassTest >> testDefinedSharedVariableHasReferences [
+
+    | condition |
+    condition := ReSharedVariableHasReferencesInDefiningClass new
+        class: (self model classNamed: #MyClassBeta)
+        referencesToSharedVariable: #SharedVarB.
+    self assert: condition check.
+    self assert: condition violators isNotEmpty
+]

--- a/src/Refactoring-Core-Tests/ReSharedVariableHasReferencesInDefiningClassTest.class.st
+++ b/src/Refactoring-Core-Tests/ReSharedVariableHasReferencesInDefiningClassTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : 'ReSharedVariableHasReferencesInDefiningClassTest',
+	#superclass : 'ReClassesConditionTest',
+	#category : 'Refactoring-Core-Tests-Conditions',
+	#package : 'Refactoring-Core-Tests',
+	#tag : 'Conditions'
+}
+
+{ #category : 'tests' }
+ReSharedVariableHasReferencesInDefiningClassTest >> testClassHasNoReferences [
+
+    | condition |
+
+    condition := ReSharedVariableHasReferencesInDefiningClass new
+        class: (self model classNamed: #MyClassB)
+        referencesToSharedVariable: #SharedVarA.
+
+    self deny: condition check.
+    self assert: condition violators isEmpty.
+]

--- a/src/Refactoring-Core-Tests/ReSharedVariableHasReferencesInDefiningClassTest.class.st
+++ b/src/Refactoring-Core-Tests/ReSharedVariableHasReferencesInDefiningClassTest.class.st
@@ -7,14 +7,12 @@ Class {
 }
 
 { #category : 'tests' }
-ReSharedVariableHasReferencesInDefiningClassTest >> testClassHasNoReferences [
+ReSharedVariableHasReferencesInDefiningClassTest >> testDefinedSharedVariableHasNoReferences [
 
     | condition |
-
     condition := ReSharedVariableHasReferencesInDefiningClass new
-        class: (self model classNamed: #MyClassB)
+        class: (self model classNamed: #MyClassAlpha)
         referencesToSharedVariable: #SharedVarA.
-
     self deny: condition check.
-    self assert: condition violators isEmpty.
+    self assert: condition violators isEmpty
 ]

--- a/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
@@ -18,7 +18,7 @@ RBPushDownClassVariableRefactoring >> applicabilityPreconditions [
     	(ReDirectlyDefinesSharedVariableCondition 
         	class: class 
         	sharedVariables: { variableName }).
-		self preconditionHasAnySubclass
+		self preconditionHasSubclass
 	 }
 ]
 
@@ -39,19 +39,19 @@ RBPushDownClassVariableRefactoring >> findDestinationClasses [
 ]
 
 { #category : 'preconditions' }
-RBPushDownClassVariableRefactoring >> preconditionHasAnySubclass [
-
-    ^ (ReClassesHaveNoSubclassesCondition new
-            classes: { class }) not
-]
-
-{ #category : 'preconditions' }
 RBPushDownClassVariableRefactoring >> preconditionHasNoReferences [
 
     ^ (ReSharedVariableHasReferencesInDefiningClass
             new
             class: class
             referencesToSharedVariable: variableName) not
+]
+
+{ #category : 'preconditions' }
+RBPushDownClassVariableRefactoring >> preconditionHasSubclass [
+
+    ^ (ReClassesHaveNoSubclassesCondition new
+            classes: { class }) not
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
+++ b/src/Refactoring-Core/RBPushDownClassVariableRefactoring.class.st
@@ -14,19 +14,18 @@ Class {
 { #category : 'preconditions' }
 RBPushDownClassVariableRefactoring >> applicabilityPreconditions [
 
-	^ { (RBCondition definesClassVariable: variableName in: class) }
+	^ {
+    	(ReDirectlyDefinesSharedVariableCondition 
+        	class: class 
+        	sharedVariables: { variableName }).
+		self preconditionHasAnySubclass
+	 }
 ]
 
 { #category : 'preconditions' }
 RBPushDownClassVariableRefactoring >> breakingChangePreconditions [
 
-	| references |
-
-	references := RBCondition referencesClassVariable: variableName in: class.
-	class realClass
-		ifNil: [ references errorMacro: ('<1s> is referenced.' expandMacrosWith: variableName) ]
-		ifNotNil: [ references errorMacro: ('<1s> is referenced.<n>Browse references?' expandMacrosWith: variableName) ].
-	^ { references not }
+    ^ { self preconditionHasNoReferences }
 ]
 
 { #category : 'preconditions' }
@@ -40,9 +39,19 @@ RBPushDownClassVariableRefactoring >> findDestinationClasses [
 ]
 
 { #category : 'preconditions' }
-RBPushDownClassVariableRefactoring >> preconditions [
+RBPushDownClassVariableRefactoring >> preconditionHasAnySubclass [
 
-	^ self applicabilityPreconditions & self breakingChangePreconditions
+    ^ (ReClassesHaveNoSubclassesCondition new
+            classes: { class }) not
+]
+
+{ #category : 'preconditions' }
+RBPushDownClassVariableRefactoring >> preconditionHasNoReferences [
+
+    ^ (ReSharedVariableHasReferencesInDefiningClass
+            new
+            class: class
+            referencesToSharedVariable: variableName) not
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Core/ReSharedVariableHasReferencesInDefiningClass.class.st
+++ b/src/Refactoring-Core/ReSharedVariableHasReferencesInDefiningClass.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : 'ReSharedVariableHasReferencesInDefiningClass',
+	#superclass : 'RBNewAbstractCondition',
+	#instVars : [
+		'aClass',
+		'variable',
+		'violators'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'checking' }
+ReSharedVariableHasReferencesInDefiningClass >> check [ 
+    ^ self violators isNotEmpty
+]
+
+{ #category : 'initialization' }
+ReSharedVariableHasReferencesInDefiningClass >> class: definingClass referencesToSharedVariable: aSharedVarName [ 
+
+    aClass := definingClass.
+    variable := aSharedVarName.
+    violators := nil
+
+]
+
+{ #category : 'displaying' }
+ReSharedVariableHasReferencesInDefiningClass >> violationMessageOn: aStream [
+
+    self violators do: [ :method |
+        aStream
+            nextPutAll: method printString;
+            nextPutAll: ' references shared variable ';
+            nextPutAll: variable;
+            nextPut: Character cr ]
+]
+
+{ #category : 'accessing' }
+ReSharedVariableHasReferencesInDefiningClass >> violators [ 
+
+	 | res |
+    violators ifNil: [
+    	violators := OrderedCollection new.
+    	res := aClass whichMethodsReferToSharedVariable: variable.
+    	res isNotEmpty ifTrue: [ violators addAll: res ].
+
+    	res := aClass classSide whichMethodsReferToSharedVariable: variable.
+    	res isNotEmpty ifTrue: [ violators addAll: res ].
+	].
+
+	^ violators
+]


### PR DESCRIPTION
### Changes:
- extracted precondition objects for `ReSharedVariableHasReferencesInDefiningClass`
- reused existing precondition object - `ReClassesHaveNoSubclassesCondition` and `ReDirectlyDefinesSharedVariableCondition`
- added tests for `ReDirectlyDefinesSharedVariableCondition` and `ReSharedVariableHasReferencesInDefiningClassTest`

### What is left:
- add more tests for `ReSharedVariableHasReferencesInDefiningClassTest`
- Handle negation of preconditions
- driver