### PR TITLE
19484-InspectingPrinting-a-variable-outside-a-clean-block-crashes-the-VM

### DIFF
--- a/src/AST-Core/OCBlockNode.class.st
+++ b/src/AST-Core/OCBlockNode.class.st
@@ -386,6 +386,21 @@ OCBlockNode >> scope: aScopedNode [
 ]
 
 { #category : 'accessing' }
+OCBlockNode >> scopeForContext: aContext [
+
+	"When we are creating a AST scope from a context, and the context is for a clean block. 
+	We need to return an scope with only the block scope, detached from the outerscope. 
+	I return a copy, because the scopes are kept in the AST cache and changing it will affect the 
+	compilation of the whole method"
+
+	self isClean ifFalse: [ ^ self scope ].
+	
+	^ self scope copy
+		outerScope: nil;
+		yourself
+]
+
+{ #category : 'accessing' }
 OCBlockNode >> startWithoutParentheses [
 	^ left
 ]

--- a/src/OpalCompiler-Core/Context.extension.st
+++ b/src/OpalCompiler-Core/Context.extension.st
@@ -10,12 +10,13 @@ Context >> astScope [
 	we still end up getting the scope we want"
 
 	| node |
+
 	node :=  self sourceNodeExecuted.
 	"if we get back a block, this is a block that just got pushed. We are not interested in
 	that but it's outer block"
 	^node isBlock
-		ifTrue: [ node parent methodOrBlockNode scope ]
-		ifFalse: [node methodOrBlockNode scope ]
+		ifTrue: [ node parent methodOrBlockNode scopeForContext: self ]
+		ifFalse: [ node methodOrBlockNode scopeForContext: self ]
 ]
 
 { #category : '*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/OCProgramNode.extension.st
+++ b/src/OpalCompiler-Core/OCProgramNode.extension.st
@@ -34,3 +34,9 @@ OCProgramNode >> owningScope [
 OCProgramNode >> scope [
 	^ self methodOrBlockNode scope
 ]
+
+{ #category : '*OpalCompiler-Core' }
+OCProgramNode >> scopeForContext: aContext [
+
+	^ self scope
+]

--- a/src/OpalCompiler-Tests/OCScopeTest.class.st
+++ b/src/OpalCompiler-Tests/OCScopeTest.class.st
@@ -23,3 +23,25 @@ OCScopeTest >> ivarForTesting [
 
 	^ ivarForTesting
 ]
+
+{ #category : 'tests - scope from contexts' }
+OCScopeTest >> testASTContextFromACleanBlockShouldNotExposeOuterVariables [
+
+	| myVariable ctx |
+	myVariable := 27.
+	
+	ctx := [ Object new ] asContext.
+	
+	self assert: (ctx astScope lookupVar: 'myVariable') isNil.
+]
+
+{ #category : 'tests - scope from contexts' }
+OCScopeTest >> testASTContextFromANonCleanBlockShouldExposeOuterVariables [
+
+	| myVariable ctx |
+	myVariable := 27.
+	
+	ctx := [ Object new. self ] asContext.
+	
+	self assert: (ctx astScope lookupVar: 'myVariable') isNotNil.
+]


### PR DESCRIPTION
When debugging we obtain the astScope from the context.
This scope is built from the AST.
In a clean block, we cannot evaluate variables that are in the outer context, so we need to return a new scope with only the block scope (cutting out the outer scope)