### PR TITLE
Change "Step into" to go to the first bytecode

### DIFF
--- a/src/Debugger-Model/DebugSession.class.st
+++ b/src/Debugger-Model/DebugSession.class.st
@@ -514,11 +514,12 @@ DebugSession >> stepInto [
 DebugSession >> stepInto: aContext [
 	"Send the selected message in selectedContext, and take control in
 	the method invoked to allow further step or send."
-
-	(self isContextPostMortem: aContext) ifTrue: [^ self].
+	
+	(self isContextPostMortem: aContext) ifTrue: [ ^ self ].
 
 	interruptedProcess step: aContext.
-	self updateContextTo: (self stepToFirstInterestingBytecodeIn: interruptedProcess).
+	interruptedProcess suspendedContext isDead ifTrue: [ self error: 'Cannot step into dead context' ].
+	self updateContextTo: interruptedProcess suspendedContext.
 
 	self triggerEvent: #stepInto
 ]


### PR DESCRIPTION
Before, the "Step Into" was going to the first "interesting bytecode". However, as the granularity of Pharo's Debugger is bytecode, it should go to the first bytecode.

So, we did that change. 

closes #19026 