### PR TITLE
Returning current clean block context when looking for an argument variable's defining context

### DIFF
--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -135,7 +135,10 @@ OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aCo
 
 	| nextContext |
 	nextContext := self nextOuterScopeContextOf: aContext.
-	nextContext ifNil: [ self error: var name, ' optimized out' ].
+	nextContext
+	 ifNil: [  (var isArgumentVariable )
+        ifTrue: [ ^aContext ]
+        ifFalse: [ self error: var name, ' optimized out' ] ].
 	^self = var scope
 		ifFalse: [ self outerScope lookupDefiningContextForVariable: var startingFrom: nextContext ]
 		ifTrue: [ aContext ]


### PR DESCRIPTION
adding a check to see if the current variable is an argument to the block with the missing outer context.  

#19489