### PR TITLE
Deprecate string as time 19455

### DIFF
--- a/src/Deprecation/BackwardCompatibility.class.st
+++ b/src/Deprecation/BackwardCompatibility.class.st
@@ -54,13 +54,13 @@ BackwardCompatibility class >> backwardsCompatibilityWhile: aBlock [
 
 { #category : 'handling' }
 BackwardCompatibility >> defaultAction [
-
-	self class addLog: self.
-	self showWarning ifTrue: [ self logTranscript ].
-	self raiseWarning ifTrue: [ super defaultAction ].
-	self shouldTransform ifTrue: [ self transform ]
+    RecursionStopper during: [
+        self class addLog: self.
+        self showWarning ifTrue: [ self logTranscript ].
+        self raiseWarning ifTrue: [ super defaultAction ].
+        self shouldTransform ifTrue: [ self transform ]
+    ]
 ]
-
 { #category : 'private' }
 BackwardCompatibility >> logTranscript [
 

--- a/src/Deprecation/Deprecation.class.st
+++ b/src/Deprecation/Deprecation.class.st
@@ -52,11 +52,12 @@ Deprecation class >> deprecationsWhile: aBlock [
 
 { #category : 'handling' }
 Deprecation >> defaultAction [
-
-	self class addLog: self.
-	self showWarning ifTrue: [ self logTranscript ].
-	self raiseWarning ifTrue: [ super defaultAction ].
-	self shouldTransform ifTrue: [ self transform ]
+    RecursionStopper during: [
+        self class addLog: self.
+        self showWarning ifTrue: [ self logTranscript ].
+        self raiseWarning ifTrue: [ super defaultAction ].
+        self shouldTransform ifTrue: [ self transform ]
+    ]
 ]
 
 { #category : 'private' }

--- a/src/Kernel-Extended-Tests/DeprecationTest.class.st
+++ b/src/Kernel-Extended-Tests/DeprecationTest.class.st
@@ -43,3 +43,24 @@ DeprecationTest >> testTransformingDeprecation [
 	ExampleForDeprecationTest 
 		removeSelector: #sendsDeprecatedMessageWithTransform
 ]
+{ #category : 'tests' }
+DeprecationTest >> testNoInfiniteLoopWhenShowWarningIsTrue [
+    "Regression test for https://github.com/pharo-project/pharo/issues/19396"
+    
+    | oldShowWarning oldActivateTransformations classFactory |
+    classFactory := ClassFactoryForTestCase new.
+    classFactory
+        silentlyCompile: 'sendsDeprecatedMessageWithTransform ^ self deprecatedMessageWithTransform'
+        in: ExampleForDeprecationTest.
+    [
+        oldShowWarning := Deprecation showWarning.
+        oldActivateTransformations := Deprecation activateTransformations.
+        Deprecation showWarning: true.
+        Deprecation activateTransformations: true.
+        ExampleForDeprecationTest new sendsDeprecatedMessageWithTransform
+    ] ensure: [
+        Deprecation showWarning: oldShowWarning.
+        Deprecation activateTransformations: oldActivateTransformations ].
+    ExampleForDeprecationTest
+        removeSelector: #sendsDeprecatedMessageWithTransform
+]

--- a/src/Kernel-Extended-Tests/DeprecationTest.class.st
+++ b/src/Kernel-Extended-Tests/DeprecationTest.class.st
@@ -45,6 +45,7 @@ DeprecationTest >> testTransformingDeprecation [
 ]
 { #category : 'tests' }
 DeprecationTest >> testNoInfiniteLoopWhenShowWarningIsTrue [
+	<ignoreNotImplementedSelectors: #(sendsDeprecatedMessageWithTransform)>
     "Regression test for https://github.com/pharo-project/pharo/issues/19396"
     
     | oldShowWarning oldActivateTransformations classFactory |

--- a/src/System-Time/String.extension.st
+++ b/src/System-Time/String.extension.st
@@ -2,21 +2,25 @@ Extension { #name : 'String' }
 
 { #category : '*System-Time' }
 String >> asDateAndTime [
- 	"Convert from UTC format"
+	"Convert from UTC format"
 
 	^ DateAndTime fromString: self
 ]
 
 { #category : '*System-Time' }
 String >> asDuration [
- 	"Convert from [-]D:HH:MM:SS[.S] format. What is between [] implies optional elements"
+	"Convert from [-]D:HH:MM:SS[.S] format. What is between [] implies optional elements"
 
- 	^ Duration fromString: self
+	^ Duration fromString: self
 ]
 
 { #category : '*System-Time' }
 String >> asTime [
 	"Many allowed forms, see Time>>readFrom:"
-
+	self
+		deprecated: 'Use Time fromString: instead'
+		on: '27/03/2025'
+		in: 'Pharo14'
+		transformWith: '`@receiver asTime' -> 'Time fromString: `@receiver'.
 	^ Time fromString: self
 ]


### PR DESCRIPTION
Fixes #19455

## Problem
`String>>asTime` should not exist as String does not need to be 
polymorphic with Date, DateAndTime, and Time. 
`asTime` makes sense on those classes but not on String.

## Fix
Added deprecation to `String>>asTime` with an automatic 
transformWith: rewrite so callers are automatically 
updated to use `Time fromString:` instead.

## Example
Before:
```smalltalk
'12:00:00' asTime
```
After automatic rewrite:
```smalltalk
Time fromString: '12:00:00'
```