### PR TITLE
[ Driver Migration ] New driver for `ReProtectInstanceVariableRefactoring

### DIFF
--- a/src/Refactoring-Core/ReProtectInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/ReProtectInstanceVariableRefactoring.class.st
@@ -6,7 +6,7 @@ I take subclasses and sibling classes into account, preventing breaking changes.
 Also if any subclass redefines an accessor for the variable, I will not apply changes for it. 
 "
 Class {
-	#name : 'RBProtectInstanceVariableRefactoring',
+	#name : 'ReProtectInstanceVariableRefactoring',
 	#superclass : 'RBVariableRefactoring',
 	#category : 'Refactoring-Core-Refactorings',
 	#package : 'Refactoring-Core',
@@ -14,13 +14,16 @@ Class {
 }
 
 { #category : 'preconditions' }
-RBProtectInstanceVariableRefactoring >> applicabilityPreconditions [
+ReProtectInstanceVariableRefactoring >> applicabilityPreconditions [
 
-	^ { (RBCondition definesInstanceVariable: variableName in: class) }
+	^ { (ReDirectlyDefinesInstanceVariableCondition
+		   classNamed: class name
+		   inModel: self model
+		   instanceVariables: { variableName }) }
 ]
 
 { #category : 'private - accessing' }
-RBProtectInstanceVariableRefactoring >> getterSetterMethods [
+ReProtectInstanceVariableRefactoring >> getterSetterMethods [
 	"Getter/setters are methods are accessors that are not redefined in subclasses."
 	
 	| matcher |
@@ -43,7 +46,7 @@ RBProtectInstanceVariableRefactoring >> getterSetterMethods [
 ]
 
 { #category : 'transforming' }
-RBProtectInstanceVariableRefactoring >> inline: aSelector [
+ReProtectInstanceVariableRefactoring >> inline: aSelector [
 	self onError:
 			[self generateChangesFor: (RBInlineAllSendersRefactoring
 						model: self model
@@ -53,7 +56,7 @@ RBProtectInstanceVariableRefactoring >> inline: aSelector [
 ]
 
 { #category : 'transforming' }
-RBProtectInstanceVariableRefactoring >> privateTransform [
+ReProtectInstanceVariableRefactoring >> privateTransform [
 	self setOption: #shouldNotCreateExtraBindings toUse: [:ref :string | true].
 	self getterSetterMethods do: [:each | self inline: each]
 ]

--- a/src/Refactoring-Transformations-Tests/ReInlineMethodParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReInlineMethodParametrizedTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'RBInlineMethodParametrizedTest',
+	#name : 'ReInlineMethodParametrizedTest',
 	#superclass : 'RBAbstractRefactoringTest',
 	#category : 'Refactoring-Transformations-Tests-SingleParametrized',
 	#package : 'Refactoring-Transformations-Tests',
@@ -7,19 +7,19 @@ Class {
 }
 
 { #category : 'tests' }
-RBInlineMethodParametrizedTest class >> testParameters [
+ReInlineMethodParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RBInlineMethodRefactoring };
 		yourself
 ]
 
 { #category : 'accessing' }
-RBInlineMethodParametrizedTest >> constructor [
+ReInlineMethodParametrizedTest >> constructor [
 	^ #inline:inMethod:forClass:
 ]
 
 { #category : 'mocking' }
-RBInlineMethodParametrizedTest >> rbModelForInliningMethodTest [
+ReInlineMethodParametrizedTest >> rbModelForInliningMethodTest [
 
 	| newModel |
 	newModel := self modelWithoutRealClasses:
@@ -227,7 +227,7 @@ RBInlineMethodParametrizedTest >> rbModelForInliningMethodTest [
 ]
 
 { #category : 'failure tests' }
-RBInlineMethodParametrizedTest >> testFailureBadInterval [
+ReInlineMethodParametrizedTest >> testFailureBadInterval [
 	self shouldFail:
 		(self createRefactoringWithArguments: { (13 to: 23) . #testMethod . RBClassDataForRefactoringTest }).
 	self shouldFail:
@@ -239,7 +239,7 @@ RBInlineMethodParametrizedTest >> testFailureBadInterval [
 ]
 
 { #category : 'failure tests' }
-RBInlineMethodParametrizedTest >> testFailureInlineMethodForSuperSendThatAlsoSendsSuper [
+ReInlineMethodParametrizedTest >> testFailureInlineMethodForSuperSendThatAlsoSendsSuper [
 
 	| refactoring |
 	model := self rbModelForInliningMethodTest.
@@ -251,13 +251,13 @@ RBInlineMethodParametrizedTest >> testFailureInlineMethodForSuperSendThatAlsoSen
 ]
 
 { #category : 'failure tests' }
-RBInlineMethodParametrizedTest >> testFailureNonExistantSelector [
+ReInlineMethodParametrizedTest >> testFailureNonExistantSelector [
 	self shouldFail: (self createRefactoringWithArguments:
 		{ (14 to: 17) . #checkClass1: . RBClassDataForRefactoringTest })
 ]
 
 { #category : 'failure tests' }
-RBInlineMethodParametrizedTest >> testFailureOverriden [
+ReInlineMethodParametrizedTest >> testFailureOverriden [
 
 	self shouldWarn: (self createRefactoringWithArguments: {
 				 (15 to: 26).
@@ -266,7 +266,7 @@ RBInlineMethodParametrizedTest >> testFailureOverriden [
 ]
 
 { #category : 'failure tests' }
-RBInlineMethodParametrizedTest >> testFailurePrimitive [
+ReInlineMethodParametrizedTest >> testFailurePrimitive [
 
 	self shouldFail: (self createRefactoringWithArguments: {
 				 (14 to: 23).
@@ -275,7 +275,7 @@ RBInlineMethodParametrizedTest >> testFailurePrimitive [
 ]
 
 { #category : 'failure tests' }
-RBInlineMethodParametrizedTest >> testFailureReturn [
+ReInlineMethodParametrizedTest >> testFailureReturn [
 
 	self shouldFail: (self createRefactoringWithArguments: {
 				 (418 to: 485).
@@ -284,7 +284,7 @@ RBInlineMethodParametrizedTest >> testFailureReturn [
 ]
 
 { #category : 'tests' }
-RBInlineMethodParametrizedTest >> testInlineMethod [
+ReInlineMethodParametrizedTest >> testInlineMethod [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
 		{ (500 to: 549) .#sentNotImplementedInApplication . RBBasicLintRuleTestData class }.
@@ -333,7 +333,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod [
 ]
 
 { #category : 'tests' }
-RBInlineMethodParametrizedTest >> testInlineMethod1 [
+ReInlineMethodParametrizedTest >> testInlineMethod1 [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
 		{ (39 to: 84) . #caller . RBClassDataForRefactoringTest }.
@@ -353,7 +353,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod1 [
 ]
 
 { #category : 'tests' }
-RBInlineMethodParametrizedTest >> testInlineMethod2 [
+ReInlineMethodParametrizedTest >> testInlineMethod2 [
 	| refactoring methodName |
 	methodName := #caller1.
 	refactoring := self createRefactoringWithArguments:
@@ -375,7 +375,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod2 [
 ]
 
 { #category : 'tests' }
-RBInlineMethodParametrizedTest >> testInlineMethod3 [
+ReInlineMethodParametrizedTest >> testInlineMethod3 [
 	| refactoring methodName |
 	methodName := #caller2.
 	refactoring := self createRefactoringWithArguments:
@@ -389,7 +389,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod3 [
 ]
 
 { #category : 'tests' }
-RBInlineMethodParametrizedTest >> testInlineMethod4 [
+ReInlineMethodParametrizedTest >> testInlineMethod4 [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
 		{ (31 to: 112) . #inlineJunk . RBClassDataForRefactoringTest }.
@@ -415,7 +415,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod4 [
 ]
 
 { #category : 'tests' }
-RBInlineMethodParametrizedTest >> testInlineMethod5 [
+ReInlineMethodParametrizedTest >> testInlineMethod5 [
 	| refactoring |
 
 	refactoring := self createRefactoringWithArguments:
@@ -427,7 +427,7 @@ RBInlineMethodParametrizedTest >> testInlineMethod5 [
 ]
 
 { #category : 'tests' }
-RBInlineMethodParametrizedTest >> testInlineMethodForSuperSend [
+ReInlineMethodParametrizedTest >> testInlineMethodForSuperSend [
 	| refactoring |
 	model := self rbModelForInliningMethodTest.
 	(model classNamed: #ReRenameVariableChange)
@@ -452,7 +452,7 @@ RBInlineMethodParametrizedTest >> testInlineMethodForSuperSend [
 ]
 
 { #category : 'tests' }
-RBInlineMethodParametrizedTest >> testInlineRecursiveCascadedMethod [
+ReInlineMethodParametrizedTest >> testInlineRecursiveCascadedMethod [
 	| refactoring |
 	refactoring := self createRefactoringWithArguments:
 		{ (33 to: 62) . #inlineMethod . RBClassDataForRefactoringTest }.
@@ -468,7 +468,7 @@ RBInlineMethodParametrizedTest >> testInlineRecursiveCascadedMethod [
 ]
 
 { #category : 'tests' }
-RBInlineMethodParametrizedTest >> testModelInlineRecursiveMethod [
+ReInlineMethodParametrizedTest >> testModelInlineRecursiveMethod [
 	| refactoring class |
 	class := model classNamed: #Object.
 	class compile: 'foo self bar. self foo. self bar' classified: #(#accessing).

--- a/src/Refactoring-Transformations-Tests/ReProtectInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/ReProtectInstanceVariableParametrizedTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'RBProtectInstanceVariableParametrizedTest',
+	#name : 'ReProtectInstanceVariableParametrizedTest',
 	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
 	#category : 'Refactoring-Transformations-Tests-SingleParametrized',
 	#package : 'Refactoring-Transformations-Tests',
@@ -7,18 +7,17 @@ Class {
 }
 
 { #category : 'tests' }
-RBProtectInstanceVariableParametrizedTest class >> testParameters [
-self flag: 'need change tranformation to have the same behavior of ref'.
+ReProtectInstanceVariableParametrizedTest class >> testParameters [
+
 	^ ParametrizedTestMatrix new
-		addCase: { #rbClass -> RBProtectInstanceVariableRefactoring .
-					  #constructor -> #variable:class: };
-	"	addCase: { #rbClass -> RBProtectVariableTransformation .
-					  #constructor -> #instanceVariable:class: };
-	"	yourself
+		  addCase: {
+				  (#rbClass -> ReProtectInstanceVariableRefactoring).
+				  (#constructor -> #variable:class:) };
+		  yourself
 ]
 
 { #category : 'running' }
-RBProtectInstanceVariableParametrizedTest >> setUp [
+ReProtectInstanceVariableParametrizedTest >> setUp [
 
 	super setUp.
 	model := self modelOnClasses: {
@@ -29,7 +28,7 @@ RBProtectInstanceVariableParametrizedTest >> setUp [
 ]
 
 { #category : 'failure tests' }
-RBProtectInstanceVariableParametrizedTest >> testFailureVariableNotDefined [
+ReProtectInstanceVariableParametrizedTest >> testFailureVariableNotDefined [
 
 	self shouldFail: (self createRefactoringWithModel: model andArguments:
 			 { 'rewrite'. #RBSubclassOfClassToRename }).
@@ -38,7 +37,7 @@ RBProtectInstanceVariableParametrizedTest >> testFailureVariableNotDefined [
 ]
 
 { #category : 'tests' }
-RBProtectInstanceVariableParametrizedTest >> testProtectInstanceVariable [
+ReProtectInstanceVariableParametrizedTest >> testProtectInstanceVariable [
 	| refactoring class |
 	refactoring := self createRefactoringWithModel: model andArguments:
 		{('rewrite' , 'Rule1') . #RBSubclassOfClassToRename}.
@@ -53,7 +52,7 @@ RBProtectInstanceVariableParametrizedTest >> testProtectInstanceVariable [
 ]
 
 { #category : 'tests' }
-RBProtectInstanceVariableParametrizedTest >> testProtectInstanceVariableWithAccessorFromTheSuperclass [
+ReProtectInstanceVariableParametrizedTest >> testProtectInstanceVariableWithAccessorFromTheSuperclass [
 
 	| refactoring sibling |
 	refactoring := self createRefactoringWithModel: model andArguments: {
@@ -65,7 +64,7 @@ RBProtectInstanceVariableParametrizedTest >> testProtectInstanceVariableWithAcce
 ]
 
 { #category : 'tests' }
-RBProtectInstanceVariableParametrizedTest >> testProtectInstanceVariableWithAccessorInSubclass [
+ReProtectInstanceVariableParametrizedTest >> testProtectInstanceVariableWithAccessorInSubclass [
 
 	| refactoring subclass |
 	refactoring := self createRefactoringWithModel: model andArguments: {

--- a/src/Refactoring-UI/ReProtectInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/ReProtectInstanceVariableDriver.class.st
@@ -13,6 +13,12 @@ Class {
 	#tag : 'Drivers'
 }
 
+{ #category : 'accessing' }
+ReProtectInstanceVariableDriver class >> driverName [
+
+	^ 'Protect Instance Variable'
+]
+
 { #category : 'configuration' }
 ReProtectInstanceVariableDriver >> instantiateRefactoring [
 

--- a/src/Refactoring-UI/ReProtectInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/ReProtectInstanceVariableDriver.class.st
@@ -1,0 +1,39 @@
+"
+I handle the interaction for the user when calling `Protect Instance Variable` refactoring
+"
+Class {
+	#name : 'ReProtectInstanceVariableDriver',
+	#superclass : 'ReInteractionDriver',
+	#instVars : [
+		'class',
+		'variable'
+	],
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
+}
+
+{ #category : 'configuration' }
+ReProtectInstanceVariableDriver >> instantiateRefactoring [
+
+	^ ReProtectInstanceVariableRefactoring variable: variable name class: class
+]
+
+{ #category : 'execution' }
+ReProtectInstanceVariableDriver >> runRefactoring [
+
+	self configureRefactoring.
+	refactoring failedApplicabilityPreconditions ifNotEmpty: [ :conditions |
+			self informConditions: conditions.
+			^ false ].
+	self applyChanges
+]
+
+{ #category : 'instance creation' }
+ReProtectInstanceVariableDriver >> scopes: aScope variable: aVariable class: aClass [
+
+	scopes := aScope.
+	model := self refactoringScopeOn: scopes first.
+	variable := aVariable.
+	class := aClass
+]

--- a/src/SystemCommands-VariableCommands/SycMoveInstanceVariableToClassSideCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycMoveInstanceVariableToClassSideCommand.class.st
@@ -4,9 +4,6 @@ I am a command to move given instance variable to its class side
 Class {
 	#name : 'SycMoveInstanceVariableToClassSideCommand',
 	#superclass : 'SycRefactorVariableCommand',
-	#instVars : [
-		'refactoringScopes'
-	],
 	#category : 'SystemCommands-VariableCommands',
 	#package : 'SystemCommands-VariableCommands'
 }
@@ -34,5 +31,5 @@ SycMoveInstanceVariableToClassSideCommand >> prepareFullExecutionInContext: aToo
 
 	super prepareFullExecutionInContext: aToolContext.
 	toolContext := aToolContext.
-	refactoringScopes := toolContext refactoringScopes
+
 ]

--- a/src/SystemCommands-VariableCommands/SycProtectVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycProtectVariableCommand.class.st
@@ -4,6 +4,9 @@ I am a command to protect given variables
 Class {
 	#name : 'SycProtectVariableCommand',
 	#superclass : 'SycRefactorVariableCommand',
+	#instVars : [
+		'selectedClass'
+	],
 	#category : 'SystemCommands-VariableCommands',
 	#package : 'SystemCommands-VariableCommands'
 }
@@ -15,15 +18,6 @@ SycProtectVariableCommand class >> sourceCodeMenuActivation [
 	^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.2 for: ClySourceCodeContext
 ]
 
-{ #category : 'execution' }
-SycProtectVariableCommand >> asRefactorings [
-
-	^self
-		createRefactorings: RBProtectInstanceVariableRefactoring
-		using: [ :refactoring :var |
-			refactoring variable: var name class: var definingClass ]
-]
-
 { #category : 'accessing' }
 SycProtectVariableCommand >> defaultMenuIconName [
 	^ #group
@@ -32,4 +26,20 @@ SycProtectVariableCommand >> defaultMenuIconName [
 { #category : 'accessing' }
 SycProtectVariableCommand >> defaultMenuItemName [
 	^'Protect'
+]
+
+{ #category : 'execution' }
+SycProtectVariableCommand >> execute [ 
+
+	^ ((ReProtectInstanceVariableDriver newApplication: self application)
+		   scopes: refactoringScopes 
+		   variable: variables first
+		   class: selectedClass) runRefactoring
+]
+
+{ #category : 'execution' }
+SycProtectVariableCommand >> prepareFullExecutionInContext: aToolContext [
+
+	super prepareFullExecutionInContext: aToolContext.
+	selectedClass := aToolContext selectedVariables first definingClass.
 ]

--- a/src/SystemCommands-VariableCommands/SycPushUpVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycPushUpVariableCommand.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : 'SycPushUpVariableCommand',
 	#superclass : 'SycRefactorVariableCommand',
 	#instVars : [
-		'refactoringScopes',
 		'variable'
 	],
 	#category : 'SystemCommands-VariableCommands',
@@ -50,7 +49,6 @@ SycPushUpVariableCommand >> executeRefactorings [
 SycPushUpVariableCommand >> prepareFullExecutionInContext: aToolContext [
 
 	super prepareFullExecutionInContext: aToolContext.
-	refactoringScopes := aToolContext refactoringScopes.
 	toolContext := aToolContext.
 	variable := toolContext lastSelectedVariable
 ]

--- a/src/SystemCommands-VariableCommands/SycRefactorVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycRefactorVariableCommand.class.st
@@ -17,6 +17,9 @@ Look at #createVariableRefactoring: implementors for details.
 Class {
 	#name : 'SycRefactorVariableCommand',
 	#superclass : 'SycVariableCommand',
+	#instVars : [
+		'refactoringScopes'
+	],
 	#category : 'SystemCommands-VariableCommands',
 	#package : 'SystemCommands-VariableCommands'
 }
@@ -51,4 +54,11 @@ SycRefactorVariableCommand >> createRefactorings: variableRefactoringClass using
 SycRefactorVariableCommand >> execute [
 
 	self executeRefactorings
+]
+
+{ #category : 'execution' }
+SycRefactorVariableCommand >> prepareFullExecutionInContext: aToolContext [
+
+	super prepareFullExecutionInContext: aToolContext.
+	refactoringScopes := toolContext refactoringScopes
 ]


### PR DESCRIPTION
Again no tests for the driver as it don't have breaking preconditions. 
I also renamed the test class of InlineMethod refactoring (not RB anymore).