### PR TITLE
[ Refactoring ] Driver template methods migration

### DIFF
--- a/src/Refactoring-Core/ReAbstractTransformation.class.st
+++ b/src/Refactoring-Core/ReAbstractTransformation.class.st
@@ -232,6 +232,13 @@ ReAbstractTransformation >> execute [
 	self performChanges
 ]
 
+{ #category : 'scripting api - conditions' }
+ReAbstractTransformation >> failedApplicabilityErrorMessage [
+		
+	^ String streamContents: [ :stream | 
+		self failedApplicabilityPreconditions do: [ :cond | cond violationMessageOn: stream; cr. ] ]
+]
+
 { #category : 'preconditions' }
 ReAbstractTransformation >> failedApplicabilityPreconditions [
 	"Returne the failed preconditions without raising error. It should only be called by drivers."

--- a/src/Refactoring-Core/ReAbstractTransformation.class.st
+++ b/src/Refactoring-Core/ReAbstractTransformation.class.st
@@ -232,13 +232,6 @@ ReAbstractTransformation >> execute [
 	self performChanges
 ]
 
-{ #category : 'scripting api - conditions' }
-ReAbstractTransformation >> failedApplicabilityErrorMessage [
-		
-	^ String streamContents: [ :stream | 
-		self failedApplicabilityPreconditions do: [ :cond | cond violationMessageOn: stream; cr. ] ]
-]
-
 { #category : 'preconditions' }
 ReAbstractTransformation >> failedApplicabilityPreconditions [
 	"Returne the failed preconditions without raising error. It should only be called by drivers."

--- a/src/Refactoring-UI/ReConvertTemporaryToInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/ReConvertTemporaryToInstanceVariableDriver.class.st
@@ -104,19 +104,6 @@ ReConvertTemporaryToInstanceVariableDriver >> labelBasedOnBreakingChanges [
 			  stream nextPutAll: 'Select a strategy' ]
 ]
 
-{ #category : 'execution' }
-ReConvertTemporaryToInstanceVariableDriver >> runRefactoring [
-
-	self configureRefactoring.
-	refactoring failedApplicabilityPreconditions ifNotEmpty: [ :conditions |
-			self informConditions: conditions.
-			^ false ].
-	self hasFailedBehaviorPreservingPreconditions.
-	notMultipleTempOccurences check & noReadBeforeWritten check
-		ifTrue: [ self applyChanges ]
-		ifFalse: [ self handleBreakingChanges ]
-]
-
 { #category : 'instance creation' }
 ReConvertTemporaryToInstanceVariableDriver >> scopes: aScope class: aClass selector: aSelector variable: aVariable [
 

--- a/src/Refactoring-UI/ReConvertTemporaryToInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/ReConvertTemporaryToInstanceVariableDriver.class.st
@@ -79,6 +79,14 @@ ReConvertTemporaryToInstanceVariableDriver >> defaultSelectDialog [
 		  yourself
 ]
 
+{ #category : 'initialization' }
+ReConvertTemporaryToInstanceVariableDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	notMultipleTempOccurences := refactoring preconditionNoMultipleTempOccurences.
+	noReadBeforeWritten := refactoring preconditionNoReadBeforeWritten.
+	^ refactoring failedBreakingChangePreconditions isNotEmpty 
+]
+
 { #category : 'configuration' }
 ReConvertTemporaryToInstanceVariableDriver >> instantiateRefactoring [
 
@@ -103,7 +111,7 @@ ReConvertTemporaryToInstanceVariableDriver >> runRefactoring [
 	refactoring failedApplicabilityPreconditions ifNotEmpty: [ :conditions |
 			self informConditions: conditions.
 			^ false ].
-	self setBehaviorPreservingPreconditions.
+	self hasFailedBehaviorPreservingPreconditions.
 	notMultipleTempOccurences check & noReadBeforeWritten check
 		ifTrue: [ self applyChanges ]
 		ifFalse: [ self handleBreakingChanges ]
@@ -116,11 +124,4 @@ ReConvertTemporaryToInstanceVariableDriver >> scopes: aScope class: aClass selec
 	variable := aVariable.
 	selector := aSelector.
 	class := aClass
-]
-
-{ #category : 'initialization' }
-ReConvertTemporaryToInstanceVariableDriver >> setBehaviorPreservingPreconditions [
-
-	notMultipleTempOccurences := refactoring preconditionNoMultipleTempOccurences.
-	noReadBeforeWritten := refactoring preconditionNoReadBeforeWritten 
 ]

--- a/src/Refactoring-UI/ReConvertTemporaryToInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/ReConvertTemporaryToInstanceVariableDriver.class.st
@@ -103,7 +103,7 @@ ReConvertTemporaryToInstanceVariableDriver >> runRefactoring [
 	refactoring failedApplicabilityPreconditions ifNotEmpty: [ :conditions |
 			self informConditions: conditions.
 			^ false ].
-	self setBreakingChangesPreconditions.
+	self setBehaviorPreservingPreconditions.
 	notMultipleTempOccurences check & noReadBeforeWritten check
 		ifTrue: [ self applyChanges ]
 		ifFalse: [ self handleBreakingChanges ]
@@ -119,7 +119,7 @@ ReConvertTemporaryToInstanceVariableDriver >> scopes: aScope class: aClass selec
 ]
 
 { #category : 'initialization' }
-ReConvertTemporaryToInstanceVariableDriver >> setBreakingChangesPreconditions [
+ReConvertTemporaryToInstanceVariableDriver >> setBehaviorPreservingPreconditions [
 
 	notMultipleTempOccurences := refactoring preconditionNoMultipleTempOccurences.
 	noReadBeforeWritten := refactoring preconditionNoReadBeforeWritten 

--- a/src/Refactoring-UI/ReDuplicateClassDriver.class.st
+++ b/src/Refactoring-UI/ReDuplicateClassDriver.class.st
@@ -83,6 +83,20 @@ ReDuplicateClassDriver >> dialogTitleForClassSelection [
 	^ 'Duplicate class ' , className
 ]
 
+{ #category : 'execution' }
+ReDuplicateClassDriver >> gatherUserInput [
+
+	self requestNewClass.
+	requestDialog window isCancelled ifTrue: [ ^ false ].
+	refactoring
+		superclassName: requestDialog selectedSuperclass name;
+		className: requestDialog newClassName;
+		packageName: requestDialog packageName;
+		packageTagName: requestDialog tagName.
+
+	^ true
+]
+
 { #category : 'configuration' }
 ReDuplicateClassDriver >> instantiateRefactoring [
 
@@ -133,32 +147,6 @@ ReDuplicateClassDriver >> requestNewClass [
 	^ requestDialog
 		openModal;
 		yourself
-]
-
-{ #category : 'execution' }
-ReDuplicateClassDriver >> runRefactoring [
-
-	self configureRefactoring.
-	self requestNewClass.
-	requestDialog window isCancelled ifTrue: [ ^ nil ].
-	refactoring
-		superclassName: requestDialog selectedSuperclass name;
-		className: requestDialog newClassName;
-		packageName: requestDialog packageName;
-		packageTagName: requestDialog tagName.
-
-	self applyChanges
-]
-
-{ #category : 'execution' }
-ReDuplicateClassDriver >> runRefactoring: aReCopyClassRefactoring [ 
-	"This is the same as #runRefactoring, but instead of automatically configuring a new empty refactoring we use aReCopyClassRefactoring"
-
-	refactoring := aReCopyClassRefactoring.
-	self requestNewClass.
-	requestDialog window isCancelled
-		ifTrue: [ ^ nil ].
-	self applyChanges 
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReExtractMethodDriver.class.st
+++ b/src/Refactoring-UI/ReExtractMethodDriver.class.st
@@ -109,6 +109,23 @@ ReExtractMethodDriver >> extractMethod [
 	^ self applyChanges
 ]
 
+{ #category : 'execution' }
+ReExtractMethodDriver >> gatherUserInput [
+
+	newMessage := self requestNewMessage.
+	newMessage ifNil: [ "The user has cancelled the dialog" ^ false ].
+	refactoring newSelector: newMessage selector.
+	^ true
+]
+
+{ #category : 'execution' }
+ReExtractMethodDriver >> hasFailedApplicabilityPreconditions [ 
+	
+	refactoring failedApplicabilityPreconditions 
+		ifNotEmpty: [ self inform: self failedPreconditionsErrorString. ^ true ].
+	^ false
+]
+
 { #category : 'private exe' }
 ReExtractMethodDriver >> hasFailedBehaviorPreservingPreconditions [
 
@@ -181,21 +198,4 @@ ReExtractMethodDriver >> requestNewMessage [
 			dialog := self requestDialogWith: methodName.
 			dialog cancelled ifTrue: [ ^ nil ] ].
 	^ dialog methodName
-]
-
-{ #category : 'execution' }
-ReExtractMethodDriver >> runRefactoring [
-
-	self configureRefactoring.
-	
-	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ ^ self inform: self failedPreconditionsErrorString ].
-	newMessage := self requestNewMessage.
-	newMessage ifNil: [ "The user has cancelled the dialog" ^ self ].
-	refactoring newSelector: newMessage selector.
-	
-	self hasFailedBehaviorPreservingPreconditions. 
-	refactoring failedBreakingChangePreconditions
-		ifEmpty: [ self applyChanges ]
-		ifNotEmpty: [ self handleBreakingChanges ]
 ]

--- a/src/Refactoring-UI/ReExtractMethodDriver.class.st
+++ b/src/Refactoring-UI/ReExtractMethodDriver.class.st
@@ -109,6 +109,14 @@ ReExtractMethodDriver >> extractMethod [
 	^ self applyChanges
 ]
 
+{ #category : 'private exe' }
+ReExtractMethodDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	notOverride := refactoring preconditionNoOverrides.
+	sameExitPoint := refactoring preconditionHasSameExitPoint.
+	^ refactoring failedBreakingChangePreconditions isNotEmpty 
+]
+
 { #category : 'configuration' }
 ReExtractMethodDriver >> instantiateRefactoring [
 	"here we do not fully configure the refactoring because we are missing information such as the signature.
@@ -186,15 +194,8 @@ ReExtractMethodDriver >> runRefactoring [
 	newMessage ifNil: [ "The user has cancelled the dialog" ^ self ].
 	refactoring newSelector: newMessage selector.
 	
-	self setBehaviorPreservingPreconditions. 
+	self hasFailedBehaviorPreservingPreconditions. 
 	refactoring failedBreakingChangePreconditions
 		ifEmpty: [ self applyChanges ]
 		ifNotEmpty: [ self handleBreakingChanges ]
-]
-
-{ #category : 'configuration' }
-ReExtractMethodDriver >> setBehaviorPreservingPreconditions [
-
-	notOverride := refactoring preconditionNoOverrides.
-	sameExitPoint := refactoring preconditionHasSameExitPoint
 ]

--- a/src/Refactoring-UI/ReExtractMethodDriver.class.st
+++ b/src/Refactoring-UI/ReExtractMethodDriver.class.st
@@ -186,14 +186,14 @@ ReExtractMethodDriver >> runRefactoring [
 	newMessage ifNil: [ "The user has cancelled the dialog" ^ self ].
 	refactoring newSelector: newMessage selector.
 	
-	self setBreakingChangesPreconditions. 
+	self setBehaviorPreservingPreconditions. 
 	refactoring failedBreakingChangePreconditions
 		ifEmpty: [ self applyChanges ]
 		ifNotEmpty: [ self handleBreakingChanges ]
 ]
 
 { #category : 'configuration' }
-ReExtractMethodDriver >> setBreakingChangesPreconditions [
+ReExtractMethodDriver >> setBehaviorPreservingPreconditions [
 
 	notOverride := refactoring preconditionNoOverrides.
 	sameExitPoint := refactoring preconditionHasSameExitPoint

--- a/src/Refactoring-UI/ReExtractMethodDriver.class.st
+++ b/src/Refactoring-UI/ReExtractMethodDriver.class.st
@@ -118,14 +118,6 @@ ReExtractMethodDriver >> gatherUserInput [
 	^ true
 ]
 
-{ #category : 'execution' }
-ReExtractMethodDriver >> hasFailedApplicabilityPreconditions [ 
-	
-	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ self inform: self failedPreconditionsErrorString. ^ true ].
-	^ false
-]
-
 { #category : 'private exe' }
 ReExtractMethodDriver >> hasFailedBehaviorPreservingPreconditions [
 

--- a/src/Refactoring-UI/ReExtractTempDriver.class.st
+++ b/src/Refactoring-UI/ReExtractTempDriver.class.st
@@ -78,6 +78,13 @@ ReExtractTempDriver >> getVariableName: initialAnswer errorMessage: message [
 		  openModal
 ]
 
+{ #category : 'initialization' }
+ReExtractTempDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	notCheckVarName := refactoring preconditionCheckVariableName.
+	^ refactoring failedBreakingChangePreconditions isNotEmpty 
+]
+
 { #category : 'configuration' }
 ReExtractTempDriver >> instantiateRefactoring [
 
@@ -115,10 +122,4 @@ ReExtractTempDriver >> runRefactoring [
 		[ varName isEmptyOrNil not and: [ failed isEmpty ] ].
 	
 		refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
-]
-
-{ #category : 'initialization' }
-ReExtractTempDriver >> setBehaviorPreservingPreconditions [
-
-	notCheckVarName := refactoring preconditionCheckVariableName
 ]

--- a/src/Refactoring-UI/ReExtractTempDriver.class.st
+++ b/src/Refactoring-UI/ReExtractTempDriver.class.st
@@ -118,7 +118,7 @@ ReExtractTempDriver >> runRefactoring [
 ]
 
 { #category : 'initialization' }
-ReExtractTempDriver >> setBreakingChangesPreconditions [
+ReExtractTempDriver >> setBehaviorPreservingPreconditions [
 
 	notCheckVarName := refactoring preconditionCheckVariableName
 ]

--- a/src/Refactoring-UI/ReExtractTempDriver.class.st
+++ b/src/Refactoring-UI/ReExtractTempDriver.class.st
@@ -106,7 +106,7 @@ ReExtractTempDriver >> labelBasedOnBreakingChanges [
 ]
 
 { #category : 'execution' }
-ReExtractTempDriver >> runRefactoring [ 
+ReExtractTempDriver >> runRefactoring [
 
 	| varName failed errorString |
 	self configureRefactoring.
@@ -117,9 +117,9 @@ ReExtractTempDriver >> runRefactoring [
 		varName := self getVariableName: varName errorMessage: errorString.
 		varName ifNil: [ ^ self ].
 		refactoring variableName: varName.
-		failed := refactoring failedApplicabilityPreconditions.
-	] doWhileFalse: 
-		[ varName isEmptyOrNil not and: [ failed isEmpty ] ].
-	
-		refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
+		failed := refactoring failedApplicabilityPreconditions ] doWhileFalse: [ varName isEmptyOrNil not and: [ failed isEmpty ] ].
+
+	self hasFailedBehaviorPreservingPreconditions
+		ifTrue: [ self handleBreakingChanges ]
+		ifFalse: [ self applyChanges ]
 ]

--- a/src/Refactoring-UI/ReGenerateAccessorsDriver.class.st
+++ b/src/Refactoring-UI/ReGenerateAccessorsDriver.class.st
@@ -22,12 +22,12 @@ ReGenerateAccessorsDriver class >> driverName [
 ]
 
 { #category : 'configuration' }
-ReGenerateAccessorsDriver >> configureRefactoring [
+ReGenerateAccessorsDriver >> instantiateRefactoring [
 
-	refactoring := ReUpFrontPreconditionCheckingCompositeRefactoring new
-		               model: model;
-		               refactorings: (selectedVariables collect: [ :eachSlot | self refactoringForSlot: eachSlot ]);
-		               yourself
+	^ ReUpFrontPreconditionCheckingCompositeRefactoring new
+		  model: model;
+		  refactorings: (selectedVariables collect: [ :eachSlot | self refactoringForSlot: eachSlot ]);
+		  yourself
 ]
 
 { #category : 'execution' }
@@ -42,13 +42,6 @@ ReGenerateAccessorsDriver >> refactoringForSlot: aSlot [
 	^ scopeInstanceSide
 		  ifFalse: [ self refactoringClass model: model classVariable: aSlot class: self targetClass name ]
 		  ifTrue: [ self refactoringClass model: model instanceVariable: aSlot class: self targetClass name ]
-]
-
-{ #category : 'configuration' }
-ReGenerateAccessorsDriver >> runRefactoring [
-
-	self configureRefactoring.
-	self applyChanges
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReGenerateMethodDriver.class.st
+++ b/src/Refactoring-UI/ReGenerateMethodDriver.class.st
@@ -42,6 +42,25 @@ ReGenerateMethodDriver >> dialogTitle [
 	self subclassResponsibility 
 ]
 
+{ #category : 'execution' }
+ReGenerateMethodDriver >> gatherUserInput [
+
+	| dialog selection |
+	dialog := SpSelectMultipleDialog newApplication: self application.
+	dialog
+		title: self dialogTitle;
+		message: 'Please select the variable(s)';
+		items: self targetClass instanceVariableNames;
+		display: [ :each | each displayString ];
+		displayIcon: [ :each | self iconNamed: each systemIconName ];
+		yourself.
+	selection := dialog openModal.
+	selection ifNil: [ ^ false ].
+	selection ifEmpty: [ ^ false ].
+	selectedVariables := selection.
+	^ true
+]
+
 { #category : 'configuration' }
 ReGenerateMethodDriver >> instantiateRefactoring [
 
@@ -54,31 +73,6 @@ ReGenerateMethodDriver >> instantiateRefactoring [
 ReGenerateMethodDriver >> refactoringClass [
 
 	^ self subclassResponsibility
-]
-
-{ #category : 'execution' }
-ReGenerateMethodDriver >> runRefactoring [
-	| dialog selection |
-	
-"I do not use defaultSelectDialog because it is used mainly for choices selection 
-	when breaking changes. Here this is for doing something else. "
-
-	dialog := SpSelectMultipleDialog newApplication: self application.
-	dialog
-		title: self dialogTitle;
-		message: 'Please select the variable(s)';
-		items: self targetClass instanceVariableNames;
-		display: [ :each | each displayString ];
-		displayIcon: [ :each | self iconNamed: each systemIconName ];
-		yourself.
-	selection := dialog openModal.
-	selection ifNil: [ ^ false ].
-	selection ifEmpty: [ ^ self ].
-	selectedVariables := selection.
-	self configureRefactoring.
-	self applyChanges.
-	
-	^ true
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReGenerateMethodDriver.class.st
+++ b/src/Refactoring-UI/ReGenerateMethodDriver.class.st
@@ -58,6 +58,7 @@ ReGenerateMethodDriver >> gatherUserInput [
 	selection ifNil: [ ^ false ].
 	selection ifEmpty: [ ^ false ].
 	selectedVariables := selection.
+	self configureRefactoring.
 	^ true
 ]
 

--- a/src/Refactoring-UI/ReInsertSubclassDriver.class.st
+++ b/src/Refactoring-UI/ReInsertSubclassDriver.class.st
@@ -68,6 +68,14 @@ ReInsertSubclassDriver >> dialogTitleForClassSelection [
 	^ 'Insert subclass of ', superclass name
 ]
 
+{ #category : 'execution' }
+ReInsertSubclassDriver >> gatherUserInput [
+
+	subclass ifNil: [ self requestClass ].
+	subclass ifNil: [ ^ false ].
+	^ true
+]
+
 { #category : 'initialization' }
 ReInsertSubclassDriver >> initialize [
 
@@ -111,22 +119,6 @@ ReInsertSubclassDriver >> requestClass [
 				comment: dialog presenter commentPresenterText.
 			dialog close ];
 		openModal
-]
-
-{ #category : 'execution' }
-ReInsertSubclassDriver >> runRefactoring [
-
-	subclass ifNil: [ self requestClass ].
-	subclass ifNil: [ ^ false ].
-	self configureRefactoring.
-	
-	"We suspect that the this is impossible to have failed applicability preconditions. 
-	Because the dialog is checking already a lot and in particular that the newclass should not already
-	exist."
-	refactoring failedApplicabilityPreconditions
-		ifNotEmpty: [ :conditions | self informConditions: conditions. ^ false].
-	self applyChanges.
-	^ true
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReInsertSuperclassDriver.class.st
+++ b/src/Refactoring-UI/ReInsertSuperclassDriver.class.st
@@ -73,6 +73,14 @@ ReInsertSuperclassDriver >> dialogTitleForClassSelection [
 	^ 'Insert new superclass of ' , superclass name
 ]
 
+{ #category : 'execution' }
+ReInsertSuperclassDriver >> gatherUserInput [ 
+
+	subclass ifNil: [ self requestClass ].
+	subclass ifNil: [ ^ false ].
+	^ true
+]
+
 { #category : 'configuration' }
 ReInsertSuperclassDriver >> instantiateRefactoring [
 	"self ensureSuperclassInModel."
@@ -108,18 +116,6 @@ ReInsertSuperclassDriver >> requestClass [
 				comment: dialog presenter commentPresenterText.
 			dialog close ];
 		openModal
-]
-
-{ #category : 'execution' }
-ReInsertSuperclassDriver >> runRefactoring [
-
-	subclass ifNil: [ self requestClass ].
-	subclass ifNil: [ ^ false ].
-	self configureRefactoring.
-	refactoring failedApplicabilityPreconditions
-		ifNotEmpty: [ : conditions | self informConditions: conditions. ^ false ].
-	self applyChanges.
-	^ true
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -218,7 +218,7 @@ ReInteractionDriver >> hasFailedApplicabilityPreconditions [
 { #category : 'private exe' }
 ReInteractionDriver >> hasFailedBehaviorPreservingPreconditions [
 
-	^ self subclassResponsibility 
+	self subclassResponsibility 
 ]
 
 { #category : 'ui - requests' }
@@ -336,8 +336,7 @@ ReInteractionDriver >> runRefactoring [
 
 	self configureRefactoring.
 	self hasFailedApplicabilityPreconditions ifTrue: [ ^ self "applicability failed" ].
-	self gatherUserInput ifFalse: [ ^ self "user abandons" ]. 
-	self setBehaviorPreservingPreconditions.
+	self gatherUserInput ifFalse: [ ^ self "user abandons" ].
 	self hasFailedBehaviorPreservingPreconditions
 		ifTrue: [ self handleBreakingChanges ]
 		ifFalse: [ self applyChanges ]
@@ -367,10 +366,4 @@ ReInteractionDriver >> selectDialogForBreakingChanges: aDialog [
 	
 	selectDialogForBreakingChanges := aDialog 
 	
-]
-
-{ #category : 'private exe' }
-ReInteractionDriver >> setBehaviorPreservingPreconditions [
-
-	self subclassResponsibility 
 ]

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -191,6 +191,12 @@ ReInteractionDriver >> furtherActionFor: aReport [
 	aReport browse
 ]
 
+{ #category : 'as yet unclassified' }
+ReInteractionDriver >> handleApplicabilityPreconditions [
+
+	self subclassResponsibility 
+]
+
 { #category : 'execution' }
 ReInteractionDriver >> handleBreakingChanges [
 
@@ -200,6 +206,12 @@ ReInteractionDriver >> handleBreakingChanges [
 	selection ifNil: [ ^ false ].
 	selection action.
 	^ true
+]
+
+{ #category : 'testing' }
+ReInteractionDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	^ self subclassResponsibility 
 ]
 
 { #category : 'ui - requests' }
@@ -315,7 +327,12 @@ ReInteractionDriver >> requestDialog: aDialog [
 { #category : 'execution' }
 ReInteractionDriver >> runRefactoring [
 
-	self subclassResponsibility
+	self configureRefactoring.
+	self handleApplicabilityPreconditions.
+	self setBehaviorPreservingPreconditions.
+	self hasFailedBehaviorPreservingPreconditions
+		ifTrue: [ self handleBreakingChanges ]
+		ifFalse: [ self applyChanges ]
 ]
 
 { #category : 'accessing' }
@@ -342,4 +359,10 @@ ReInteractionDriver >> selectDialogForBreakingChanges: aDialog [
 	
 	selectDialogForBreakingChanges := aDialog 
 	
+]
+
+{ #category : 'initialization' }
+ReInteractionDriver >> setBehaviorPreservingPreconditions [
+
+	self subclassResponsibility 
 ]

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -192,6 +192,13 @@ ReInteractionDriver >> furtherActionFor: aReport [
 ]
 
 { #category : 'execution' }
+ReInteractionDriver >> gatherUserInput [
+	"In this hood driver gathers inputs from user.
+	Return false if opration was unsuccessful (like user wants to abandon), and true otherwise"
+	^ true
+]
+
+{ #category : 'execution' }
 ReInteractionDriver >> handleBreakingChanges [
 
 	| selection dialog |
@@ -328,7 +335,8 @@ ReInteractionDriver >> requestDialog: aDialog [
 ReInteractionDriver >> runRefactoring [
 
 	self configureRefactoring.
-	self handleApplicabilityPreconditions.
+	self hasFailedApplicabilityPreconditions ifTrue: [ ^ self "applicability failed" ].
+	self gatherUserInput ifFalse: [ ^ self "user abandons" ]. 
 	self setBehaviorPreservingPreconditions.
 	self hasFailedBehaviorPreservingPreconditions
 		ifTrue: [ self handleBreakingChanges ]

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -210,9 +210,11 @@ ReInteractionDriver >> handleBreakingChanges [
 ]
 
 { #category : 'private ex' }
-ReInteractionDriver >> hasFailedApplicabilityPreconditions [
-
-	self subclassResponsibility 
+ReInteractionDriver >> hasFailedApplicabilityPreconditions [ 
+	
+	refactoring failedApplicabilityPreconditions 
+		ifNotEmpty: [ self inform: self failedPreconditionsErrorString. ^ true ].
+	^ false
 ]
 
 { #category : 'private exe' }

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -191,12 +191,6 @@ ReInteractionDriver >> furtherActionFor: aReport [
 	aReport browse
 ]
 
-{ #category : 'private ex' }
-ReInteractionDriver >> handleApplicabilityPreconditions [
-
-	self subclassResponsibility 
-]
-
 { #category : 'execution' }
 ReInteractionDriver >> handleBreakingChanges [
 
@@ -206,6 +200,12 @@ ReInteractionDriver >> handleBreakingChanges [
 	selection ifNil: [ ^ false ].
 	selection action.
 	^ true
+]
+
+{ #category : 'private ex' }
+ReInteractionDriver >> hasFailedApplicabilityPreconditions [
+
+	self subclassResponsibility 
 ]
 
 { #category : 'private exe' }

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -191,7 +191,7 @@ ReInteractionDriver >> furtherActionFor: aReport [
 	aReport browse
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'private ex' }
 ReInteractionDriver >> handleApplicabilityPreconditions [
 
 	self subclassResponsibility 
@@ -208,7 +208,7 @@ ReInteractionDriver >> handleBreakingChanges [
 	^ true
 ]
 
-{ #category : 'testing' }
+{ #category : 'private exe' }
 ReInteractionDriver >> hasFailedBehaviorPreservingPreconditions [
 
 	^ self subclassResponsibility 
@@ -361,7 +361,7 @@ ReInteractionDriver >> selectDialogForBreakingChanges: aDialog [
 	
 ]
 
-{ #category : 'initialization' }
+{ #category : 'private exe' }
 ReInteractionDriver >> setBehaviorPreservingPreconditions [
 
 	self subclassResponsibility 

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -220,7 +220,7 @@ ReInteractionDriver >> hasFailedApplicabilityPreconditions [
 { #category : 'private exe' }
 ReInteractionDriver >> hasFailedBehaviorPreservingPreconditions [
 
-	self subclassResponsibility 
+	^ false
 ]
 
 { #category : 'ui - requests' }
@@ -337,8 +337,8 @@ ReInteractionDriver >> requestDialog: aDialog [
 ReInteractionDriver >> runRefactoring [
 
 	self configureRefactoring.
-	self hasFailedApplicabilityPreconditions ifTrue: [ ^ self "applicability failed" ].
 	self gatherUserInput ifFalse: [ ^ self "user abandons" ].
+	self hasFailedApplicabilityPreconditions ifTrue: [ ^ self "applicability failed" ].
 	self hasFailedBehaviorPreservingPreconditions
 		ifTrue: [ self handleBreakingChanges ]
 		ifFalse: [ self applyChanges ]

--- a/src/Refactoring-UI/ReMoveMethodsToClassSideDriver.class.st
+++ b/src/Refactoring-UI/ReMoveMethodsToClassSideDriver.class.st
@@ -68,15 +68,6 @@ ReMoveMethodsToClassSideDriver >> defaultSelectDialog [
 ]
 
 { #category : 'execution' }
-ReMoveMethodsToClassSideDriver >> runRefactoring [
-	
-	refactoring failedBreakingChangePreconditions
-		ifEmpty: [ self applyChanges ]
-		ifNotEmpty: [ self handleBreakingChanges ]
-
-]
-
-{ #category : 'execution' }
 ReMoveMethodsToClassSideDriver >> scopes: scopesList methods: methods [
 
 	scopes := scopesList.

--- a/src/Refactoring-UI/ReMoveTemporaryDefinitionDriver.class.st
+++ b/src/Refactoring-UI/ReMoveTemporaryDefinitionDriver.class.st
@@ -22,9 +22,9 @@ ReMoveTemporaryDefinitionDriver class >> driverName [
 ]
 
 { #category : 'resources' }
-ReMoveTemporaryDefinitionDriver >> configureRefactoring [
+ReMoveTemporaryDefinitionDriver >> instantiateRefactoring [ 
 
-	refactoring := RBMoveVariableDefinitionToSmallestValidScopeRefactoring 
+	^ RBMoveVariableDefinitionToSmallestValidScopeRefactoring 
 		bindTight: sourceNode sourceInterval 
 		in: method origin 
 		selector: method selector
@@ -41,19 +41,6 @@ ReMoveTemporaryDefinitionDriver >> method [
 ReMoveTemporaryDefinitionDriver >> method: anObject [
 
 	method := anObject
-]
-
-{ #category : 'execution' }
-ReMoveTemporaryDefinitionDriver >> runRefactoring [
-
-	self configureRefactoring.
-	refactoring prepareForExecution. 
-	"This is needed to set some info in the refactoring such as the parse tree or the defining node."
-	
-	[ refactoring eagerlyCheckApplicabilityPreconditions ] 
-		on: RBRefactoringError 
-		do: [ :ex| self application inform: 'The temp cannot be move closer'. ^ self ].
-	self applyChanges
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReMoveVariablesToClassSideDriver.class.st
+++ b/src/Refactoring-UI/ReMoveVariablesToClassSideDriver.class.st
@@ -22,12 +22,6 @@ ReMoveVariablesToClassSideDriver class >> scopes: scopesList variables: aCollect
 ]
 
 { #category : 'execution' }
-ReMoveVariablesToClassSideDriver >> runRefactoring [
-
-	self applyChanges
-]
-
-{ #category : 'execution' }
 ReMoveVariablesToClassSideDriver >> scopes: scopesList variables: variables [
 
 	scopes := scopesList.

--- a/src/Refactoring-UI/RePullUpMethodDriver.class.st
+++ b/src/Refactoring-UI/RePullUpMethodDriver.class.st
@@ -111,7 +111,7 @@ RePullUpMethodDriver >> configureAndRunRefactoring [
 	refactoring failedApplicabilityPreconditions 
 		ifNotEmpty: [ ^ self alertFailedPreconditions ].
 
-	self setBehaviorPreservingPreconditions.
+	self hasFailedBehaviorPreservingPreconditions.
 	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
 ]
 
@@ -169,6 +169,18 @@ RePullUpMethodDriver >> defaultSelectDialog [
 { #category : 'execution' }
 RePullUpMethodDriver >> gatherUserInput [
 	self selectMethodsAndClass
+]
+
+{ #category : 'initialization' }
+RePullUpMethodDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	notOverrides := refactoring preconditionNoOverrides.
+	notInstVarRefs := refactoring preconditionNoReferencesToInstVars.
+	notSharedVarRefs := refactoring preconditionNoReferencesToSharedVars.
+	notSupersendsSent := refactoring preconditionNoSupersendsSent.
+	notSupersendsReceived := refactoring preconditionNoSupersendsReceived.
+	notSuperclassDefiner := refactoring preconditionNoSuperclassDefiner.
+	^ refactoring failedBreakingChangePreconditions isNotEmpty 
 ]
 
 { #category : 'configuration' }
@@ -268,15 +280,4 @@ RePullUpMethodDriver >> selectMethodsAndClass [
 	
 	superclass := nil.
 	methods := nil
-]
-
-{ #category : 'initialization' }
-RePullUpMethodDriver >> setBehaviorPreservingPreconditions [
-
-	notOverrides := refactoring preconditionNoOverrides.
-	notInstVarRefs := refactoring preconditionNoReferencesToInstVars.
-	notSharedVarRefs := refactoring preconditionNoReferencesToSharedVars.
-	notSupersendsSent := refactoring preconditionNoSupersendsSent.
-	notSupersendsReceived := refactoring preconditionNoSupersendsReceived.
-	notSuperclassDefiner := refactoring preconditionNoSuperclassDefiner
 ]

--- a/src/Refactoring-UI/RePullUpMethodDriver.class.st
+++ b/src/Refactoring-UI/RePullUpMethodDriver.class.st
@@ -111,7 +111,7 @@ RePullUpMethodDriver >> configureAndRunRefactoring [
 	refactoring failedApplicabilityPreconditions 
 		ifNotEmpty: [ ^ self alertFailedPreconditions ].
 
-	self setBreakingChangesPreconditions.
+	self setBehaviorPreservingPreconditions.
 	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
 ]
 
@@ -271,7 +271,7 @@ RePullUpMethodDriver >> selectMethodsAndClass [
 ]
 
 { #category : 'initialization' }
-RePullUpMethodDriver >> setBreakingChangesPreconditions [
+RePullUpMethodDriver >> setBehaviorPreservingPreconditions [
 
 	notOverrides := refactoring preconditionNoOverrides.
 	notInstVarRefs := refactoring preconditionNoReferencesToInstVars.

--- a/src/Refactoring-UI/RePullUpMethodDriver.class.st
+++ b/src/Refactoring-UI/RePullUpMethodDriver.class.st
@@ -154,7 +154,8 @@ RePullUpMethodDriver >> defaultSelectDialog [
 { #category : 'execution' }
 RePullUpMethodDriver >> gatherUserInput [
 
-	self selectMethodsAndClass methods ifNil: [ ^ false ].
+	self selectMethodsAndClass.
+	methods ifNil: [ ^ false ].
 	^ true
 ]
 
@@ -233,6 +234,17 @@ RePullUpMethodDriver >> pullUpReferencedSharedVars [
 	notSharedVarRefs referencedSharedVariables do: [ :sharedVar | 
 		"We add the pushUpVariable transformation to the refactoring previous transformations"
 		refactoring pullUpSharedVariable: sharedVar ]
+]
+
+{ #category : 'execution' }
+RePullUpMethodDriver >> runRefactoring [
+
+	self gatherUserInput ifFalse: [ ^ self ].
+	self configureRefactoring.
+	self hasFailedApplicabilityPreconditions ifTrue: [ ^ self ].
+	self hasFailedBehaviorPreservingPreconditions
+		ifTrue: [ self handleBreakingChanges ]
+		ifFalse: [ self applyChanges ]
 ]
 
 { #category : 'execution' }

--- a/src/Refactoring-UI/RePullUpMethodDriver.class.st
+++ b/src/Refactoring-UI/RePullUpMethodDriver.class.st
@@ -100,21 +100,6 @@ RePullUpMethodDriver >> changes [
 
 ]
 
-{ #category : 'execution' }
-RePullUpMethodDriver >> configureAndRunRefactoring [
-
-	self configureRefactoring. 
-	"Pay attention that the applicability preconditions do  not include checking the superclass for a 
-	method with the same name because during an interaction we when to let the user the possibility to 
-	do actions to handle this specific case. This is why similarly method in direct superclass is checked 
-	but in the breaking change precondtions."
-	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ ^ self alertFailedPreconditions ].
-
-	self hasFailedBehaviorPreservingPreconditions.
-	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
-]
-
 { #category : 'copying' }
 RePullUpMethodDriver >> copyDownMethods [
 
@@ -168,7 +153,9 @@ RePullUpMethodDriver >> defaultSelectDialog [
 
 { #category : 'execution' }
 RePullUpMethodDriver >> gatherUserInput [
-	self selectMethodsAndClass
+
+	self selectMethodsAndClass methods ifNil: [ ^ false ].
+	^ true
 ]
 
 { #category : 'initialization' }
@@ -246,15 +233,6 @@ RePullUpMethodDriver >> pullUpReferencedSharedVars [
 	notSharedVarRefs referencedSharedVariables do: [ :sharedVar | 
 		"We add the pushUpVariable transformation to the refactoring previous transformations"
 		refactoring pullUpSharedVariable: sharedVar ]
-]
-
-{ #category : 'execution' }
-RePullUpMethodDriver >> runRefactoring [
-
-	"the user can still select if needed. Nil = cancel refactoring"
-	self gatherUserInput.
-	methods ifNil: [ ^ self ].
-	self configureAndRunRefactoring
 ]
 
 { #category : 'execution' }

--- a/src/Refactoring-UI/RePushDownInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/RePushDownInstanceVariableDriver.class.st
@@ -51,7 +51,7 @@ RePushDownInstanceVariableDriver >> browseMethods [
 RePushDownInstanceVariableDriver >> configureAndRunRefactoring [
 
 	self configureRefactoring.
-	self setBehaviorPreservingPreconditions.
+	self hasFailedBehaviorPreservingPreconditions.
 	refactoring refactorings do: [ :r |
 		r failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ] ]
 ]
@@ -72,6 +72,13 @@ RePushDownInstanceVariableDriver >> defaultSelectDialog [
 RePushDownInstanceVariableDriver >> gatherUserInput [
 
 	variables := self selectVariables.
+]
+
+{ #category : 'initialization' }
+RePushDownInstanceVariableDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	referencesInstanceVariableCollection := refactoring refactorings collect: [ :r | r preconditionReferencesInstanceVariable ].
+	^ refactoring failedBreakingChangePreconditions isNotEmpty 
 ]
 
 { #category : 'configuration' }
@@ -124,12 +131,6 @@ RePushDownInstanceVariableDriver >> selectVariables [
 	dialog isOk ifFalse: [ ^ nil ].
 
 	^ dialog presenter selectedItems
-]
-
-{ #category : 'initialization' }
-RePushDownInstanceVariableDriver >> setBehaviorPreservingPreconditions [
-
-	referencesInstanceVariableCollection := refactoring refactorings collect: [ :r | r preconditionReferencesInstanceVariable ]
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/RePushDownInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/RePushDownInstanceVariableDriver.class.st
@@ -51,7 +51,7 @@ RePushDownInstanceVariableDriver >> browseMethods [
 RePushDownInstanceVariableDriver >> configureAndRunRefactoring [
 
 	self configureRefactoring.
-	self setBreakingChangesPreconditions.
+	self setBehaviorPreservingPreconditions.
 	refactoring refactorings do: [ :r |
 		r failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ] ]
 ]
@@ -127,7 +127,7 @@ RePushDownInstanceVariableDriver >> selectVariables [
 ]
 
 { #category : 'initialization' }
-RePushDownInstanceVariableDriver >> setBreakingChangesPreconditions [
+RePushDownInstanceVariableDriver >> setBehaviorPreservingPreconditions [
 
 	referencesInstanceVariableCollection := refactoring refactorings collect: [ :r | r preconditionReferencesInstanceVariable ]
 ]

--- a/src/Refactoring-UI/RePushDownInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/RePushDownInstanceVariableDriver.class.st
@@ -47,15 +47,6 @@ RePushDownInstanceVariableDriver >> browseMethods [
 	(application toolNamed: #messageList) browse: violators
 ]
 
-{ #category : 'execution' }
-RePushDownInstanceVariableDriver >> configureAndRunRefactoring [
-
-	self configureRefactoring.
-	self hasFailedBehaviorPreservingPreconditions.
-	refactoring refactorings do: [ :r |
-		r failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ] ]
-]
-
 { #category : 'configuration' }
 RePushDownInstanceVariableDriver >> defaultSelectDialog [
 
@@ -72,6 +63,8 @@ RePushDownInstanceVariableDriver >> defaultSelectDialog [
 RePushDownInstanceVariableDriver >> gatherUserInput [
 
 	variables := self selectVariables.
+	variables ifNil: [ ^ false ].
+	^ true
 ]
 
 { #category : 'initialization' }
@@ -98,15 +91,6 @@ RePushDownInstanceVariableDriver >> labelBasedOnBreakingChanges [
 					  referencesInstanceVariableCollection first violationMessageOn: stream.
 					  stream cr ].
 			  stream nextPutAll: 'Select a strategy' ]
-]
-
-{ #category : 'execution' }
-RePushDownInstanceVariableDriver >> runRefactoring [
-	"the user can still select if needed. Nil = cancel refactoring"
-
-	self gatherUserInput.
-	variables ifNil: [ ^ self ].
-	self configureAndRunRefactoring
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/RePushDownMethodDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodDriver.class.st
@@ -82,7 +82,7 @@ RePushDownMethodDriver >> changes [
 RePushDownMethodDriver >> configureAndRunRefactoring [
 
 	self configureRefactoring.
-	self setBehaviorPreservingPreconditions.
+	self hasFailedBehaviorPreservingPreconditions.
 	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
 ]
 
@@ -102,6 +102,18 @@ RePushDownMethodDriver >> defaultSelectDialog [
 RePushDownMethodDriver >> gatherUserInput [
 
 	self selectMethods
+]
+
+{ #category : 'private exe' }
+RePushDownMethodDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	isAbstract := refactoring preconditionIsAbstract.
+	subclassesSendSuper := refactoring preconditionSubclassesDontSendSuper.
+	subclassDirectlyDefines := refactoring preconditionSubclassesDirectlyDefines.
+	refersToSelector := refactoring preconditionMethodsReferToSelector.
+	allSubclassesDirectlyDefines := refactoring preconditionAllSubclassesDirectlyDefines.
+	
+	^ isAbstract | subclassesSendSuper | subclassDirectlyDefines | refersToSelector | allSubclassesDirectlyDefines 
 ]
 
 { #category : 'configuration' }
@@ -198,14 +210,4 @@ RePushDownMethodDriver >> selectMethods [
 	dialog isOk ifTrue: [ ^ self ].
 
 	methods:= nil
-]
-
-{ #category : 'initialization' }
-RePushDownMethodDriver >> setBehaviorPreservingPreconditions [
-
-	isAbstract := refactoring preconditionIsAbstract.
-	subclassesSendSuper := refactoring preconditionSubclassesDontSendSuper.
-	subclassDirectlyDefines := refactoring preconditionSubclassesDirectlyDefines.
-	refersToSelector := refactoring preconditionMethodsReferToSelector.
-	allSubclassesDirectlyDefines := refactoring preconditionAllSubclassesDirectlyDefines 
 ]

--- a/src/Refactoring-UI/RePushDownMethodDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodDriver.class.st
@@ -82,7 +82,7 @@ RePushDownMethodDriver >> changes [
 RePushDownMethodDriver >> configureAndRunRefactoring [
 
 	self configureRefactoring.
-	self setBreakingChangesPreconditions.
+	self setBehaviorPreservingPreconditions.
 	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
 ]
 
@@ -201,7 +201,7 @@ RePushDownMethodDriver >> selectMethods [
 ]
 
 { #category : 'initialization' }
-RePushDownMethodDriver >> setBreakingChangesPreconditions [
+RePushDownMethodDriver >> setBehaviorPreservingPreconditions [
 
 	isAbstract := refactoring preconditionIsAbstract.
 	subclassesSendSuper := refactoring preconditionSubclassesDontSendSuper.

--- a/src/Refactoring-UI/RePushDownMethodDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodDriver.class.st
@@ -98,12 +98,6 @@ RePushDownMethodDriver >> gatherUserInput [
 	^ true
 ]
 
-{ #category : 'private ex' }
-RePushDownMethodDriver >> hasFailedApplicabilityPreconditions [ 
-
-	^ refactoring failedApplicabilityPreconditions isNotEmpty
-]
-
 { #category : 'private exe' }
 RePushDownMethodDriver >> hasFailedBehaviorPreservingPreconditions [
 

--- a/src/Refactoring-UI/RePushDownMethodDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodDriver.class.st
@@ -78,14 +78,6 @@ RePushDownMethodDriver >> changes [
 
 ]
 
-{ #category : 'execution' }
-RePushDownMethodDriver >> configureAndRunRefactoring [
-
-	self configureRefactoring.
-	self hasFailedBehaviorPreservingPreconditions.
-	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
-]
-
 { #category : 'configuration' }
 RePushDownMethodDriver >> defaultSelectDialog [
 
@@ -101,7 +93,15 @@ RePushDownMethodDriver >> defaultSelectDialog [
 { #category : 'execution' }
 RePushDownMethodDriver >> gatherUserInput [
 
-	self selectMethods
+	self selectMethods.
+	methods ifNil: [ ^ false ].
+	^ true
+]
+
+{ #category : 'private ex' }
+RePushDownMethodDriver >> hasFailedApplicabilityPreconditions [ 
+
+	^ refactoring failedApplicabilityPreconditions isNotEmpty
 ]
 
 { #category : 'private exe' }
@@ -113,7 +113,7 @@ RePushDownMethodDriver >> hasFailedBehaviorPreservingPreconditions [
 	refersToSelector := refactoring preconditionMethodsReferToSelector.
 	allSubclassesDirectlyDefines := refactoring preconditionAllSubclassesDirectlyDefines.
 	
-	^ isAbstract | subclassesSendSuper | subclassDirectlyDefines | refersToSelector | allSubclassesDirectlyDefines 
+	^ refactoring failedBreakingChangePreconditions isNotEmpty 
 ]
 
 { #category : 'configuration' }
@@ -183,15 +183,6 @@ RePushDownMethodDriver >> removeSuperclassMethod [
 	selectorsToRemove := selectorsToRemove asSet.
 	selectorsToRemove do: [ :each | refactoring generateChangesFor: (RBRemoveMethodTransformation selector: each from: class) ].
 	self openPreviewWithChanges: refactoring changes
-]
-
-{ #category : 'execution' }
-RePushDownMethodDriver >> runRefactoring [
-
-	"the user can still select if needed. Nil = cancel refactoring"
-	self gatherUserInput.
-	methods ifNil: [ ^ self ].
-	self configureAndRunRefactoring
 ]
 
 { #category : 'execution' }

--- a/src/Refactoring-UI/RePushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodInSomeClassesDriver.class.st
@@ -32,12 +32,14 @@ RePushDownMethodInSomeClassesDriver class >> driverName [
 RePushDownMethodInSomeClassesDriver >> gatherUserInput [
 
 	super gatherUserInput.
-	classes := self selectClasses
+	classes := self selectClasses.
+	classes ifNil: [ ^ false ].
+	^ true
 ]
 
 { #category : 'configuration' }
 RePushDownMethodInSomeClassesDriver >> instantiateRefactoring [
-
+	classes := {  }.
 	^ RBPushDownMethodRefactoring
 		model: model
 		pushDown: (methods collect: [ :each | each selector ])
@@ -62,15 +64,6 @@ RePushDownMethodInSomeClassesDriver >> refactoring [
 		pushDown: (methods collect: [ :each | each selector ])
 		from: class
 		in: classes.
-]
-
-{ #category : 'execution' }
-RePushDownMethodInSomeClassesDriver >> runRefactoring [
-
-	self gatherUserInput.
-	methods ifNil: [ ^ self ].
-	classes ifNil: [ ^ self ].
-	self configureAndRunRefactoring 
 ]
 
 { #category : 'execution' }

--- a/src/Refactoring-UI/RePushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodInSomeClassesDriver.class.st
@@ -39,8 +39,8 @@ RePushDownMethodInSomeClassesDriver >> gatherUserInput [
 { #category : 'configuration' }
 RePushDownMethodInSomeClassesDriver >> instantiateRefactoring [
 
-	^ RBPushDownMethodRefactoring
-		model: model
+	^ RePushDownMethodRefactoring
+		model: model 
 		pushDown: (methods collect: [ :each | each selector ])
 		from: class
 		in: classes.

--- a/src/Refactoring-UI/RePushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodInSomeClassesDriver.class.st
@@ -31,7 +31,6 @@ RePushDownMethodInSomeClassesDriver class >> driverName [
 { #category : 'execution' }
 RePushDownMethodInSomeClassesDriver >> gatherUserInput [
 
-	super gatherUserInput.
 	classes := self selectClasses.
 	classes ifNil: [ ^ false ].
 	^ true
@@ -39,7 +38,7 @@ RePushDownMethodInSomeClassesDriver >> gatherUserInput [
 
 { #category : 'configuration' }
 RePushDownMethodInSomeClassesDriver >> instantiateRefactoring [
-	classes := {  }.
+
 	^ RBPushDownMethodRefactoring
 		model: model
 		pushDown: (methods collect: [ :each | each selector ])
@@ -64,6 +63,17 @@ RePushDownMethodInSomeClassesDriver >> refactoring [
 		pushDown: (methods collect: [ :each | each selector ])
 		from: class
 		in: classes.
+]
+
+{ #category : 'execution' }
+RePushDownMethodInSomeClassesDriver >> runRefactoring [
+
+	self gatherUserInput ifFalse: [ ^ self ].
+	self configureRefactoring.
+	self hasFailedApplicabilityPreconditions ifTrue: [ ^ self ].
+	self hasFailedBehaviorPreservingPreconditions
+		ifTrue: [ self handleBreakingChanges ]
+		ifFalse: [ self applyChanges ]
 ]
 
 { #category : 'execution' }

--- a/src/Refactoring-UI/RePushUpVariableDriver.class.st
+++ b/src/Refactoring-UI/RePushUpVariableDriver.class.st
@@ -38,13 +38,6 @@ RePushUpVariableDriver >> refactoringClass [
 		  ifFalse: [ RePullUpInstanceVariableRefactoring ]
 ]
 
-{ #category : 'execution' }
-RePushUpVariableDriver >> runRefactoring [
-
-	self configureRefactoring.
-	self applyChanges
-]
-
 { #category : 'factory method' }
 RePushUpVariableDriver >> scopes: aCollection variable: varName shared: isSharedVar to: aClass [ 
 

--- a/src/Refactoring-UI/ReRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveClassDriver.class.st
@@ -74,14 +74,6 @@ ReRemoveClassDriver >> defaultSelectDialog [
 		yourself
 ]
 
-{ #category : 'execution' }
-ReRemoveClassDriver >> hasFailedApplicabilityPreconditions [ 
-
-	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ self inform: refactoring failedApplicabilityErrorMessage. ^ true ].
-	^ false
-]
-
 { #category : 'private ex' }
 ReRemoveClassDriver >> hasFailedBehaviorPreservingPreconditions [
 

--- a/src/Refactoring-UI/ReRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveClassDriver.class.st
@@ -109,7 +109,7 @@ ReRemoveClassDriver >> runRefactoring [
 	
 	self configureRefactoring.
 	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ ^ self inform: 'The class should exist and not be a metaclass' ].
+		ifNotEmpty: [ ^ self inform: refactoring failedApplicabilityErrorMessage ].
 	self setBreakingChangesPreconditions.
 	haveNoReferences check & emptyClasses check & noSubclasses check
 			ifTrue: [ self applyChanges ]

--- a/src/Refactoring-UI/ReRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveClassDriver.class.st
@@ -75,11 +75,11 @@ ReRemoveClassDriver >> defaultSelectDialog [
 ]
 
 { #category : 'execution' }
-ReRemoveClassDriver >> handleApplicabilityPreconditions [ 
+ReRemoveClassDriver >> hasFailedApplicabilityPreconditions [ 
 
 	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ ^ self inform: refactoring failedApplicabilityErrorMessage ]
-
+		ifNotEmpty: [ self inform: refactoring failedApplicabilityErrorMessage. ^ true ].
+	^ false
 ]
 
 { #category : 'private ex' }

--- a/src/Refactoring-UI/ReRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveClassDriver.class.st
@@ -74,6 +74,21 @@ ReRemoveClassDriver >> defaultSelectDialog [
 		yourself
 ]
 
+{ #category : 'execution' }
+ReRemoveClassDriver >> handleApplicabilityPreconditions [ 
+
+	refactoring failedApplicabilityPreconditions 
+		ifNotEmpty: [ ^ self inform: refactoring failedApplicabilityErrorMessage ]
+
+]
+
+{ #category : 'private ex' }
+ReRemoveClassDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	^ haveNoReferences check | emptyClasses check | noSubclasses check
+
+]
+
 { #category : 'configuration' }
 ReRemoveClassDriver >> instantiateRefactoring [
 
@@ -104,19 +119,6 @@ ReRemoveClassDriver >> removeClassAndPushStateToSubclasses [
 	self openPreviewWithChanges: refactoring removeClassesChanges
 ]
 
-{ #category : 'execution' }
-ReRemoveClassDriver >> runRefactoring [
-	
-	self configureRefactoring.
-	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ ^ self inform: refactoring failedApplicabilityErrorMessage ].
-	self setBreakingChangesPreconditions.
-	haveNoReferences check & emptyClasses check & noSubclasses check
-			ifTrue: [ self applyChanges ]
-			ifFalse: [ self handleBreakingChanges ]
-
-]
-
 { #category : 'initialization' }
 ReRemoveClassDriver >> scopes: refactoringScopes classes: aColclasses [
 
@@ -126,7 +128,7 @@ ReRemoveClassDriver >> scopes: refactoringScopes classes: aColclasses [
 ]
 
 { #category : 'private execution' }
-ReRemoveClassDriver >> setBreakingChangesPreconditions [
+ReRemoveClassDriver >> setBehaviorPreservingPreconditions [
 	
 	haveNoReferences := refactoring preconditionHaveNoReferences.
 	emptyClasses := refactoring preconditionEmptyClasses.

--- a/src/Refactoring-UI/ReRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveClassDriver.class.st
@@ -80,8 +80,7 @@ ReRemoveClassDriver >> hasFailedBehaviorPreservingPreconditions [
 	haveNoReferences := refactoring preconditionHaveNoReferences.
 	emptyClasses := refactoring preconditionEmptyClasses.
 	noSubclasses := refactoring preconditionHaveNoSubclasses.
-	^ refactoring failedBreakingChangePreconditions isNotEmpty 
-
+	^ (haveNoReferences check & emptyClasses check & noSubclasses check) not
 ]
 
 { #category : 'configuration' }

--- a/src/Refactoring-UI/ReRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveClassDriver.class.st
@@ -85,7 +85,10 @@ ReRemoveClassDriver >> hasFailedApplicabilityPreconditions [
 { #category : 'private ex' }
 ReRemoveClassDriver >> hasFailedBehaviorPreservingPreconditions [
 
-	^ haveNoReferences check | emptyClasses check | noSubclasses check
+	haveNoReferences := refactoring preconditionHaveNoReferences.
+	emptyClasses := refactoring preconditionEmptyClasses.
+	noSubclasses := refactoring preconditionHaveNoSubclasses.
+	^ refactoring failedBreakingChangePreconditions isNotEmpty 
 
 ]
 
@@ -125,14 +128,4 @@ ReRemoveClassDriver >> scopes: refactoringScopes classes: aColclasses [
 	scopes := refactoringScopes.
 	model := self refactoringScopeOn: scopes first.
 	classes := aColclasses
-]
-
-{ #category : 'private execution' }
-ReRemoveClassDriver >> setBehaviorPreservingPreconditions [
-	
-	haveNoReferences := refactoring preconditionHaveNoReferences.
-	emptyClasses := refactoring preconditionEmptyClasses.
-	noSubclasses := refactoring preconditionHaveNoSubclasses
-
-	
 ]

--- a/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
@@ -71,29 +71,6 @@ ReRemoveInstanceVariablesDriver >> instantiateRefactoring [
 		yourself
 ]
 
-{ #category : 'execution' }
-ReRemoveInstanceVariablesDriver >> runRefactoring [
-
-	self configureRefactoring.
-	
-	"Normally from the IDE we should not get bogus variables."
-	"we could call the violatorMessages here to let the applicability preconditions do the job."
-	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ 
-			| str |
-			str := String streamContents: [ :s | 
-				s << 'The variable '.
-				refactoring refactorings do: [:r | s <<  r variableName]
-					separatedBy: [ str space ].
-				s <<  ' do(es) not exist' ].
-			^ self inform: str contents ].
-	
-	(refactoring breakingChangePreconditions allSatisfy: [:each | each check])
-		ifTrue: [ self applyChanges ]
-		ifFalse: [ self handleBreakingChanges ]
-
-]
-
 { #category : 'initialization' }
 ReRemoveInstanceVariablesDriver >> scopes: refactoringScopes variables: aCollection for: aClass [
 	

--- a/src/Refactoring-UI/ReRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveMethodDriver.class.st
@@ -62,14 +62,6 @@ ReRemoveMethodDriver >> defaultSelectDialog [
 ]
 
 { #category : 'execution' }
-ReRemoveMethodDriver >> hasFailedApplicabilityPreconditions [ 
-
-	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ self inform: 'The method does not exist'. ^ true ].
-	^ false
-]
-
-{ #category : 'execution' }
 ReRemoveMethodDriver >> hasFailedBehaviorPreservingPreconditions [
 
 	haveNoSenders := refactoring preconditionHaveNoSenders.

--- a/src/Refactoring-UI/ReRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveMethodDriver.class.st
@@ -72,7 +72,8 @@ ReRemoveMethodDriver >> hasFailedApplicabilityPreconditions [
 { #category : 'execution' }
 ReRemoveMethodDriver >> hasFailedBehaviorPreservingPreconditions [
 
-	 ^ haveNoSenders check not
+	haveNoSenders := refactoring preconditionHaveNoSenders.
+	^ refactoring failedBreakingChangePreconditions isNotEmpty 
 ]
 
 { #category : 'configuration' }
@@ -100,10 +101,4 @@ ReRemoveMethodDriver >> scopes: refactoringScopes methods: aMethods [
 	scopes := refactoringScopes.
 	model := self refactoringScopeOn: scopes first.
 	methods := aMethods
-]
-
-{ #category : 'execution' }
-ReRemoveMethodDriver >> setBehaviorPreservingPreconditions [ 
-	
-	haveNoSenders := refactoring preconditionHaveNoSenders
 ]

--- a/src/Refactoring-UI/ReRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveMethodDriver.class.st
@@ -62,10 +62,11 @@ ReRemoveMethodDriver >> defaultSelectDialog [
 ]
 
 { #category : 'execution' }
-ReRemoveMethodDriver >> handleApplicabilityPreconditions [ 
+ReRemoveMethodDriver >> hasFailedApplicabilityPreconditions [ 
 
 	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ ^ self inform: 'The method does not exist' ]
+		ifNotEmpty: [ self inform: 'The method does not exist'. ^ true ].
+	^ false
 ]
 
 { #category : 'execution' }

--- a/src/Refactoring-UI/ReRemoveMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveMethodDriver.class.st
@@ -61,6 +61,19 @@ ReRemoveMethodDriver >> defaultSelectDialog [
 		yourself
 ]
 
+{ #category : 'execution' }
+ReRemoveMethodDriver >> handleApplicabilityPreconditions [ 
+
+	refactoring failedApplicabilityPreconditions 
+		ifNotEmpty: [ ^ self inform: 'The method does not exist' ]
+]
+
+{ #category : 'execution' }
+ReRemoveMethodDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	 ^ haveNoSenders check not
+]
+
 { #category : 'configuration' }
 ReRemoveMethodDriver >> instantiateRefactoring [
 
@@ -70,21 +83,6 @@ ReRemoveMethodDriver >> instantiateRefactoring [
 	^ ReRemoveMethodsRefactoring
        model: model
        classSelectorMapping: classSelectorMapping
-]
-
-{ #category : 'execution' }
-ReRemoveMethodDriver >> runRefactoring [
-
-	self configureRefactoring.
-
-	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ ^ self inform: 'The method does not exist' ].
-	
-	haveNoSenders := refactoring preconditionHaveNoSenders.
-
-	haveNoSenders check
-			ifTrue: [ self applyChanges ]
-			ifFalse: [ self handleBreakingChanges ]
 ]
 
 { #category : 'initialization' }
@@ -101,4 +99,10 @@ ReRemoveMethodDriver >> scopes: refactoringScopes methods: aMethods [
 	scopes := refactoringScopes.
 	model := self refactoringScopeOn: scopes first.
 	methods := aMethods
+]
+
+{ #category : 'execution' }
+ReRemoveMethodDriver >> setBehaviorPreservingPreconditions [ 
+	
+	haveNoSenders := refactoring preconditionHaveNoSenders
 ]

--- a/src/Refactoring-UI/ReRemoveSharedVariablesDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveSharedVariablesDriver.class.st
@@ -70,20 +70,6 @@ ReRemoveSharedVariablesDriver >> instantiateRefactoring [
 		yourself
 ]
 
-{ #category : 'execution' }
-ReRemoveSharedVariablesDriver >> runRefactoring [
-
-	self configureRefactoring.
-	
-	refactoring failedApplicabilityPreconditions 
-		ifNotEmpty: [ ^ self inform: 'The shared variable does not exist' ].
-
-	refactoring failedBreakingChangePreconditions
-		ifEmpty: [ self applyChanges ]
-		ifNotEmpty: [ self handleBreakingChanges ]
-
-]
-
 { #category : 'initialization' }
 ReRemoveSharedVariablesDriver >> scopes: refactoringScopes variables: aCollection for: aClass [
 	

--- a/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
+++ b/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
@@ -125,8 +125,6 @@ ReRenameArgumentOrTemporaryDriver >> runRefactoring [
 
 	| cancelled |
 	self configureRefactoring.
-	refactoring prepareForExecution. "This is needed to set some info in the refactoring such as the parse tree or the defining node."
-
 	(refactoring applicabilityPreconditionsIndependentOfTheNewName reject: [ :condition | condition check ]) ifNotEmpty: [
 		^ self inform: 'The interval selected is not right to rename a temporary variable.' ].
 
@@ -146,9 +144,9 @@ ReRenameArgumentOrTemporaryDriver >> runRefactoring [
 				detect: [ :condition | condition check ]
 				ifFound: [ :condition | self inform: condition errorString ] ].
 
-	self hasFailedBehaviorPreservingPreconditions.
-
-	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
+	self hasFailedBehaviorPreservingPreconditions
+		ifTrue: [ self handleBreakingChanges ]
+		ifFalse: [ self applyChanges ]
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
+++ b/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
@@ -139,13 +139,13 @@ ReRenameArgumentOrTemporaryDriver >> runRefactoring [
 				detect: [ :condition | condition check ]
 				ifFound: [ :condition | self inform: condition errorString ] ].
 
-	self setBreakingChangesPreconditions.
+	self setBehaviorPreservingPreconditions.
 
 	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
 ]
 
 { #category : 'initialization' }
-ReRenameArgumentOrTemporaryDriver >> setBreakingChangesPreconditions [
+ReRenameArgumentOrTemporaryDriver >> setBehaviorPreservingPreconditions [
 
 	notCheckVarName := refactoring preconditionCheckVariableName
 ]

--- a/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
+++ b/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
@@ -69,6 +69,13 @@ ReRenameArgumentOrTemporaryDriver >> defaultSelectDialog [
 		  yourself
 ]
 
+{ #category : 'initialization' }
+ReRenameArgumentOrTemporaryDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	notCheckVarName := refactoring preconditionCheckVariableName.
+	^ refactoring failedBreakingChangePreconditions isNotEmpty 
+]
+
 { #category : 'configuration' }
 ReRenameArgumentOrTemporaryDriver >> instantiateRefactoring [
 
@@ -139,15 +146,9 @@ ReRenameArgumentOrTemporaryDriver >> runRefactoring [
 				detect: [ :condition | condition check ]
 				ifFound: [ :condition | self inform: condition errorString ] ].
 
-	self setBehaviorPreservingPreconditions.
+	self hasFailedBehaviorPreservingPreconditions.
 
 	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
-]
-
-{ #category : 'initialization' }
-ReRenameArgumentOrTemporaryDriver >> setBehaviorPreservingPreconditions [
-
-	notCheckVarName := refactoring preconditionCheckVariableName
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReRenameClassDriver.class.st
+++ b/src/Refactoring-UI/ReRenameClassDriver.class.st
@@ -57,6 +57,38 @@ ReRenameClassDriver >> defaultSelectDialog [
 		yourself
 ]
 
+{ #category : 'execution' }
+ReRenameClassDriver >> gatherUserInput [ 
+	"usually we do not spawn a dialog out of the blue but we should ask the application.
+	It means that the driver should get the application from the tool that invoked it."
+	newName := self requestNewNameBasedOn: oldName.
+	shouldEscape ifTrue: [ ^ false "user wants to exit" ].
+
+	[ refactoring isValidClassName check & refactoring isNotGlobal check ] whileFalse: [ 
+			newName := self requestNewNameBasedOn: newName.
+			shouldEscape ifTrue: [ ^ false ] ].
+	^ true
+]
+
+{ #category : 'private ex' }
+ReRenameClassDriver >> hasFailedApplicabilityPreconditions [ 
+
+	refactoring doesClassToBeRenamedExist
+		ifFalse: [ self inform: 'The class ', oldName, ' does not exist.'. ^ true ].
+		
+	"if we see a metaclass then we could take the instance side"
+	refactoring isMetaclass 
+		ifTrue: [ self inform: 'Please provide a class and not a metaclass: ', oldName, ' is a metaclass.'. ^ true ].
+
+	^ false
+]
+
+{ #category : 'private exe' }
+ReRenameClassDriver >> hasFailedBehaviorPreservingPreconditions [ 
+
+	^ refactoring failedBreakingChangePreconditions isNotEmpty
+]
+
 { #category : 'initialization' }
 ReRenameClassDriver >> initialize [ 
 	
@@ -114,28 +146,9 @@ ReRenameClassDriver >> requestNewNameBasedOn: aName [
 	^ newName
 ]
 
-{ #category : 'execution' }
-ReRenameClassDriver >> runRefactoring [
-	
-	self configureRefactoring.
-	refactoring doesClassToBeRenamedExist
-		ifFalse: [ self inform: 'The class ', oldName, ' does not exist.'. ^ self ].
-	
-	"if we see a metaclass then we could take the instance side"
-	refactoring isMetaclass 
-		ifTrue: [ self inform: 'Please provide a class and not a metaclass: ', oldName, ' is a metaclass.'. ^ self ].
-	"usually we do not spawn a dialog out of the blue but we should ask the application.
-	It means that the driver should get the application from the tool that invoked it."
-
-	newName := self requestNewNameBasedOn: oldName.
-	shouldEscape ifTrue: [ ^ self ].
-
-	[ refactoring isValidClassName check & refactoring isNotGlobal check ] whileFalse: [ 
-			newName := self requestNewNameBasedOn: newName.
-			shouldEscape ifTrue: [ ^ self ] ].
-
-	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
-	
+{ #category : 'private exe' }
+ReRenameClassDriver >> setBehaviorPreservingPreconditions [
+	"There is only one and it doesn't impact the choices the user has"
 ]
 
 { #category : 'validation' }

--- a/src/Refactoring-UI/ReRenameClassDriver.class.st
+++ b/src/Refactoring-UI/ReRenameClassDriver.class.st
@@ -146,11 +146,6 @@ ReRenameClassDriver >> requestNewNameBasedOn: aName [
 	^ newName
 ]
 
-{ #category : 'private exe' }
-ReRenameClassDriver >> setBehaviorPreservingPreconditions [
-	"There is only one and it doesn't impact the choices the user has"
-]
-
 { #category : 'validation' }
 ReRenameClassDriver >> validateName: aName onPresenter: presenter [
 

--- a/src/Refactoring-UI/ReRenameClassDriver.class.st
+++ b/src/Refactoring-UI/ReRenameClassDriver.class.st
@@ -70,19 +70,6 @@ ReRenameClassDriver >> gatherUserInput [
 	^ true
 ]
 
-{ #category : 'private ex' }
-ReRenameClassDriver >> hasFailedApplicabilityPreconditions [ 
-
-	refactoring doesClassToBeRenamedExist
-		ifFalse: [ self inform: 'The class ', oldName, ' does not exist.'. ^ true ].
-		
-	"if we see a metaclass then we could take the instance side"
-	refactoring isMetaclass 
-		ifTrue: [ self inform: 'Please provide a class and not a metaclass: ', oldName, ' is a metaclass.'. ^ true ].
-
-	^ false
-]
-
 { #category : 'private exe' }
 ReRenameClassDriver >> hasFailedBehaviorPreservingPreconditions [ 
 

--- a/src/Refactoring-UI/ReRenameMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRenameMethodDriver.class.st
@@ -197,14 +197,13 @@ ReRenameMethodDriver >> runRefactoring [
 
 	| failedConditions |
 	self configureRefactoring.
-
 	failedConditions := OrderedCollection empty.
 	[
 		newMessage := self requestNewMessage.
 		self configureMessage.
 
 		refactoring isMethodDefinitionUnchanged ifTrue: [ ^ self ].
-		shouldEscape ifTrue: [ ^ self ]. "What is the use of this variable: shouldEscape?"
+		shouldEscape ifTrue: [ ^ self ].
 
 		failedConditions := refactoring failedApplicabilityPreconditions.
 		failedConditions do: [ :cond |
@@ -212,8 +211,9 @@ ReRenameMethodDriver >> runRefactoring [
 					message: cond errorString;
 					title: 'Invalid method name';
 					openModal ] ] doWhileFalse: [ failedConditions isEmpty ].
-
-	refactoring failedBreakingChangePreconditions ifEmpty: [ self applyChanges ] ifNotEmpty: [ self handleBreakingChanges ]
+	self hasFailedBehaviorPreservingPreconditions
+		ifTrue: [ self handleBreakingChanges ]
+		ifFalse: [ self applyChanges ]
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-UI/ReRenameVariableDriver.class.st
+++ b/src/Refactoring-UI/ReRenameVariableDriver.class.st
@@ -87,7 +87,6 @@ ReRenameVariableDriver >> requestNewNameBasedOn: aName [
 { #category : 'execution' }
 ReRenameVariableDriver >> runRefactoring [
 
-	self configureRefactoring.
 	shouldEscape := false.
 	"We cannot rename something that doesn'e exist.
 	If we don't check this before `prepareRefactoringInteractively` 
@@ -95,8 +94,9 @@ ReRenameVariableDriver >> runRefactoring [
 	refactoring preconditionDirectlyDefinesVariable check ifFalse: [ ^ self ].
 	self prepareRefactoringInteractively.
 	shouldEscape ifTrue: [ ^ self ].
+	self applyChanges 
 
-	self applyChanges
+
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-UI/ReRenameVariableDriver.class.st
+++ b/src/Refactoring-UI/ReRenameVariableDriver.class.st
@@ -87,16 +87,14 @@ ReRenameVariableDriver >> requestNewNameBasedOn: aName [
 { #category : 'execution' }
 ReRenameVariableDriver >> runRefactoring [
 
-	shouldEscape := false.
-	"We cannot rename something that doesn'e exist.
+	self configureRefactoring.
+	shouldEscape := false. "We cannot rename something that doesn'e exist.
 	If we don't check this before `prepareRefactoringInteractively` 
 	it will loop indefinetely since this precondition will always fail."
 	refactoring preconditionDirectlyDefinesVariable check ifFalse: [ ^ self ].
 	self prepareRefactoringInteractively.
 	shouldEscape ifTrue: [ ^ self ].
-	self applyChanges 
-
-
+	self applyChanges
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-UI/ReReplaceMessageSendDriver.class.st
+++ b/src/Refactoring-UI/ReReplaceMessageSendDriver.class.st
@@ -32,15 +32,6 @@ ReReplaceMessageSendDriver >> instantiateRefactoring [
 		   inAllClasses: true) newArgs: selector newArgs
 ]
 
-{ #category : 'execution' }
-ReReplaceMessageSendDriver >> runRefactoring [
-
-	self configureRefactoring.
-	refactoring failedApplicabilityPreconditions ifNotEmpty: [ :conditions |
-		^ RBRefactoringError signal: (String streamContents: [ :stream | conditions first violationMessageOn: stream ]) ].
-	self applyChanges
-]
-
 { #category : 'initialization' }
 ReReplaceMessageSendDriver >> scopes: refactoringScopes class: aClass selector: aSelector oldSelector: aSecondSelector [
 

--- a/src/Refactoring-UI/ReViolentRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReViolentRemoveClassDriver.class.st
@@ -77,7 +77,7 @@ ReViolentRemoveClassDriver >> hasFailedBehaviorPreservingPreconditions [
 { #category : 'configuration' }
 ReViolentRemoveClassDriver >> instantiateRefactoring [
 
-	^ RBRemoveClassesTransformation model: model classNames: (classes collect: [ :cl | cl name ])
+	^ ReRemoveClassesTransformation model: model classNames: (classes collect: [ :cl | cl name ])
 ]
 
 { #category : 'ui - dialogs' }
@@ -87,17 +87,6 @@ ReViolentRemoveClassDriver >> labelBasedOnBreakingChanges [
 			  haveNoReferences violationMessageOn: stream.
 			  stream cr.
 			  stream nextPutAll: 'Select a strategy' ]
-]
-
-{ #category : 'execution' }
-ReViolentRemoveClassDriver >> runRefactoring [
-
-	self configureRefactoring.
-	refactoring failedApplicabilityPreconditions ifNotEmpty: [ ^ self inform: 'The class should exist and not be a metaclass' ].
-	self hasFailedBehaviorPreservingPreconditions.
-	haveNoReferences check
-		ifTrue: [ self applyChanges ]
-		ifFalse: [ self handleBreakingChanges ]
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-UI/ReViolentRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReViolentRemoveClassDriver.class.st
@@ -86,7 +86,7 @@ ReViolentRemoveClassDriver >> runRefactoring [
 
 	self configureRefactoring.
 	refactoring failedApplicabilityPreconditions ifNotEmpty: [ ^ self inform: 'The class should exist and not be a metaclass' ].
-	self setBreakingChangesPreconditions.
+	self setBehaviorPreservingPreconditions.
 	haveNoReferences check
 		ifTrue: [ self applyChanges ]
 		ifFalse: [ self handleBreakingChanges ]
@@ -101,7 +101,7 @@ ReViolentRemoveClassDriver >> scopes: refactoringScopes classes: aColclasses [
 ]
 
 { #category : 'private execution' }
-ReViolentRemoveClassDriver >> setBreakingChangesPreconditions [
+ReViolentRemoveClassDriver >> setBehaviorPreservingPreconditions [
 	
 	haveNoReferences := refactoring preconditionHaveNoReferences.
 

--- a/src/Refactoring-UI/ReViolentRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReViolentRemoveClassDriver.class.st
@@ -66,6 +66,14 @@ ReViolentRemoveClassDriver >> defaultSelectDialog [
 yourself
 ]
 
+{ #category : 'private execution' }
+ReViolentRemoveClassDriver >> hasFailedBehaviorPreservingPreconditions [
+	
+	haveNoReferences := refactoring preconditionHaveNoReferences.
+
+	^ refactoring failedBreakingChangePreconditions isNotEmpty 
+]
+
 { #category : 'configuration' }
 ReViolentRemoveClassDriver >> instantiateRefactoring [
 
@@ -86,7 +94,7 @@ ReViolentRemoveClassDriver >> runRefactoring [
 
 	self configureRefactoring.
 	refactoring failedApplicabilityPreconditions ifNotEmpty: [ ^ self inform: 'The class should exist and not be a metaclass' ].
-	self setBehaviorPreservingPreconditions.
+	self hasFailedBehaviorPreservingPreconditions.
 	haveNoReferences check
 		ifTrue: [ self applyChanges ]
 		ifFalse: [ self handleBreakingChanges ]
@@ -98,12 +106,4 @@ ReViolentRemoveClassDriver >> scopes: refactoringScopes classes: aColclasses [
 	scopes := refactoringScopes.
 	model := self refactoringScopeOn: scopes first.
 	classes := aColclasses
-]
-
-{ #category : 'private execution' }
-ReViolentRemoveClassDriver >> setBehaviorPreservingPreconditions [
-	
-	haveNoReferences := refactoring preconditionHaveNoReferences.
-
-	
 ]


### PR DESCRIPTION
Thanks to @balsa-sarenac idea, here is a good improvement for the migration of driver architecture:

-Consolidated `runRefactoring` logic into gatherUserInput and hasFailedBehaviorPreservingPreconditions, using them as template methods at the top of hierarchy.
-Removed redundant `setBreakingChangesPreconditions` and `configureAndRunRefactoring` methods.

Some note: I implemented `runRefactoring` for Pull Up Method because its floz does the opposite: it gather user input and then configure its refactoring.

