### PR TITLE
[ Refactoring ] Clean driver migration

### DIFF
--- a/src/Refactoring-UI/ReExtractTempDriver.class.st
+++ b/src/Refactoring-UI/ReExtractTempDriver.class.st
@@ -65,6 +65,21 @@ ReExtractTempDriver >> extract: anInterval from: aSelector in: aClass [
 	class := aClass
 ]
 
+{ #category : 'execution' }
+ReExtractTempDriver >> gatherUserInput [
+
+	| varName failed errorString |
+	varName := ''.
+	failed := nil.
+	[
+		errorString := failed ifNil: [ '' ] ifNotNil: [ self failedPreconditionsErrorString: failed ].
+		varName := self getVariableName: varName errorMessage: errorString.
+		varName ifNil: [ ^ false ].
+		refactoring variableName: varName.
+		failed := refactoring failedApplicabilityPreconditions ] doWhileFalse: [ varName isEmptyOrNil not and: [ failed isEmpty ] ].
+	^ true
+]
+
 { #category : 'user requests' }
 ReExtractTempDriver >> getVariableName: initialAnswer errorMessage: message [
 
@@ -103,23 +118,4 @@ ReExtractTempDriver >> labelBasedOnBreakingChanges [
 							  cond violationMessageOn: stream.
 							  stream cr ] ].
 			  stream nextPutAll: 'Select the strategies to apply' ]
-]
-
-{ #category : 'execution' }
-ReExtractTempDriver >> runRefactoring [
-
-	| varName failed errorString |
-	self configureRefactoring.
-	varName := ''.
-	failed := nil.
-	[
-		errorString := failed ifNil: [ '' ] ifNotNil: [ self failedPreconditionsErrorString: failed ].
-		varName := self getVariableName: varName errorMessage: errorString.
-		varName ifNil: [ ^ self ].
-		refactoring variableName: varName.
-		failed := refactoring failedApplicabilityPreconditions ] doWhileFalse: [ varName isEmptyOrNil not and: [ failed isEmpty ] ].
-
-	self hasFailedBehaviorPreservingPreconditions
-		ifTrue: [ self handleBreakingChanges ]
-		ifFalse: [ self applyChanges ]
 ]

--- a/src/Refactoring-UI/ReInlineTemporaryDriver.class.st
+++ b/src/Refactoring-UI/ReInlineTemporaryDriver.class.st
@@ -26,17 +26,6 @@ ReInlineTemporaryDriver >> instantiateRefactoring [
 	^ ReInlineTemporaryRefactoring inline: interval from: selector in: class
 ]
 
-{ #category : 'execution' }
-ReInlineTemporaryDriver >> runRefactoring [
-
-	self configureRefactoring.
-
-	refactoring failedApplicabilityPreconditions ifNotEmpty: [ :conditions |
-			self informConditions: conditions.
-			^ false ].
-	self applyChanges
-]
-
 { #category : 'instance creation' }
 ReInlineTemporaryDriver >> scopes: refactoringScopes interval: anInterval selector: aSelector class: aClass [
 

--- a/src/Refactoring-UI/ReInsertSubclassDriver.class.st
+++ b/src/Refactoring-UI/ReInsertSubclassDriver.class.st
@@ -73,6 +73,7 @@ ReInsertSubclassDriver >> gatherUserInput [
 
 	subclass ifNil: [ self requestClass ].
 	subclass ifNil: [ ^ false ].
+	refactoring className: subclass.
 	^ true
 ]
 

--- a/src/Refactoring-UI/ReInsertSuperclassDriver.class.st
+++ b/src/Refactoring-UI/ReInsertSuperclassDriver.class.st
@@ -74,10 +74,11 @@ ReInsertSuperclassDriver >> dialogTitleForClassSelection [
 ]
 
 { #category : 'execution' }
-ReInsertSuperclassDriver >> gatherUserInput [ 
+ReInsertSuperclassDriver >> gatherUserInput [
 
 	subclass ifNil: [ self requestClass ].
 	subclass ifNil: [ ^ false ].
+	refactoring className: subclass.
 	^ true
 ]
 

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -341,7 +341,8 @@ ReInteractionDriver >> runRefactoring [
 	self hasFailedApplicabilityPreconditions ifTrue: [ ^ self "applicability failed" ].
 	self hasFailedBehaviorPreservingPreconditions
 		ifTrue: [ self handleBreakingChanges ]
-		ifFalse: [ self applyChanges ]
+		ifFalse: [ self applyChanges ].
+	^ true
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -342,7 +342,7 @@ ReInteractionDriver >> runRefactoring [
 	self hasFailedBehaviorPreservingPreconditions
 		ifTrue: [ self handleBreakingChanges ]
 		ifFalse: [ self applyChanges ].
-	^ true
+
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReProtectInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/ReProtectInstanceVariableDriver.class.st
@@ -25,16 +25,6 @@ ReProtectInstanceVariableDriver >> instantiateRefactoring [
 	^ ReProtectInstanceVariableRefactoring variable: variable name class: class
 ]
 
-{ #category : 'execution' }
-ReProtectInstanceVariableDriver >> runRefactoring [
-
-	self configureRefactoring.
-	refactoring failedApplicabilityPreconditions ifNotEmpty: [ :conditions |
-			self informConditions: conditions.
-			^ false ].
-	self applyChanges
-]
-
 { #category : 'instance creation' }
 ReProtectInstanceVariableDriver >> scopes: aScope variable: aVariable class: aClass [
 

--- a/src/Refactoring-UI/RePullUpMethodDriver.class.st
+++ b/src/Refactoring-UI/RePullUpMethodDriver.class.st
@@ -156,6 +156,8 @@ RePullUpMethodDriver >> gatherUserInput [
 
 	self selectMethodsAndClass.
 	methods ifNil: [ ^ false ].
+	refactoring selectors: (methods collect: [ :each | each selector ]).
+	refactoring superClass: superclass.
 	^ true
 ]
 
@@ -176,9 +178,9 @@ RePullUpMethodDriver >> instantiateRefactoring [
 
 	^ RePullUpMethodRefactoring
        model: model
-       pullUp: (methods collect: [ :each | each selector ])
+       pullUp: #()
        from: class name
-       to: superclass name
+       to: ''
 ]
 
 { #category : 'ui - dialogs' }
@@ -234,17 +236,6 @@ RePullUpMethodDriver >> pullUpReferencedSharedVars [
 	notSharedVarRefs referencedSharedVariables do: [ :sharedVar | 
 		"We add the pushUpVariable transformation to the refactoring previous transformations"
 		refactoring pullUpSharedVariable: sharedVar ]
-]
-
-{ #category : 'execution' }
-RePullUpMethodDriver >> runRefactoring [
-
-	self gatherUserInput ifFalse: [ ^ self ].
-	self configureRefactoring.
-	self hasFailedApplicabilityPreconditions ifTrue: [ ^ self ].
-	self hasFailedBehaviorPreservingPreconditions
-		ifTrue: [ self handleBreakingChanges ]
-		ifFalse: [ self applyChanges ]
 ]
 
 { #category : 'execution' }

--- a/src/Refactoring-UI/RePushDownInstanceVariableDriver.class.st
+++ b/src/Refactoring-UI/RePushDownInstanceVariableDriver.class.st
@@ -28,7 +28,7 @@ RePushDownInstanceVariableDriver >> breakingChoices [
 
 	| choices |
 	choices := OrderedCollection new.
-	choices add: (RePushDownMethodTransformationChoice new driver: self).
+	choices add: (RePushDownInstanceVariableTransformationChoice new driver: self).
 	(referencesInstanceVariableCollection anySatisfy: [ :precond | precond isFalse ]) ifTrue: [
 		choices add: (ReBrowseMethodsChoice new driver: self) ].
 
@@ -64,6 +64,7 @@ RePushDownInstanceVariableDriver >> gatherUserInput [
 
 	variables := self selectVariables.
 	variables ifNil: [ ^ false ].
+	self configureRefactoring.
 	^ true
 ]
 
@@ -91,6 +92,13 @@ RePushDownInstanceVariableDriver >> labelBasedOnBreakingChanges [
 					  referencesInstanceVariableCollection first violationMessageOn: stream.
 					  stream cr ].
 			  stream nextPutAll: 'Select a strategy' ]
+]
+
+{ #category : 'execution' }
+RePushDownInstanceVariableDriver >> pushDownInstanceVariable [
+
+	refactoring privateTransform.
+	self openPreviewWithChanges: refactoring changes
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/RePushDownInstanceVariableTransformationChoice.class.st
+++ b/src/Refactoring-UI/RePushDownInstanceVariableTransformationChoice.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'RePushDownInstanceVariableTransformationChoice',
+	#superclass : 'ReMethodChoice',
+	#category : 'Refactoring-UI-Choices',
+	#package : 'Refactoring-UI',
+	#tag : 'Choices'
+}
+
+{ #category : 'accessing' }
+RePushDownInstanceVariableTransformationChoice >> action [
+
+	driver pushDownInstanceVariable
+]
+
+{ #category : 'accessing' }
+RePushDownInstanceVariableTransformationChoice >> description [
+
+	^ 'Push down instance variable anyway'
+]

--- a/src/Refactoring-UI/RePushDownMethodDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodDriver.class.st
@@ -95,6 +95,7 @@ RePushDownMethodDriver >> gatherUserInput [
 
 	self selectMethods.
 	methods ifNil: [ ^ false ].
+	refactoring selectors: (methods collect: [ :each | each selector ]).
 	^ true
 ]
 
@@ -115,7 +116,7 @@ RePushDownMethodDriver >> instantiateRefactoring [
 
 	^ RePushDownMethodRefactoring
 		  model: model
-		  pushDown: (methods collect: [ :each | each selector ])
+		  pushDown: #()
 		  from: class name
 ]
 

--- a/src/Refactoring-UI/RePushDownMethodInSomeClassesDriver.class.st
+++ b/src/Refactoring-UI/RePushDownMethodInSomeClassesDriver.class.st
@@ -33,6 +33,7 @@ RePushDownMethodInSomeClassesDriver >> gatherUserInput [
 
 	classes := self selectClasses.
 	classes ifNil: [ ^ false ].
+	refactoring classes: classes.
 	^ true
 ]
 
@@ -43,7 +44,7 @@ RePushDownMethodInSomeClassesDriver >> instantiateRefactoring [
 		model: model 
 		pushDown: (methods collect: [ :each | each selector ])
 		from: class
-		in: classes.
+		in: #().
 ]
 
 { #category : 'initialization' }
@@ -53,27 +54,6 @@ RePushDownMethodInSomeClassesDriver >> model: aRBNamespace scopes: refactoringSc
 	scopes := refactoringScopes.
 	methods := methodsList.
 	class := methods first origin
-]
-
-{ #category : 'resources' }
-RePushDownMethodInSomeClassesDriver >> refactoring [
-
-	refactoring :=  RePushDownMethodRefactoring
-		model: model
-		pushDown: (methods collect: [ :each | each selector ])
-		from: class
-		in: classes.
-]
-
-{ #category : 'execution' }
-RePushDownMethodInSomeClassesDriver >> runRefactoring [
-
-	self gatherUserInput ifFalse: [ ^ self ].
-	self configureRefactoring.
-	self hasFailedApplicabilityPreconditions ifTrue: [ ^ self ].
-	self hasFailedBehaviorPreservingPreconditions
-		ifTrue: [ self handleBreakingChanges ]
-		ifFalse: [ self applyChanges ]
 ]
 
 { #category : 'execution' }

--- a/src/Refactoring-UI/ReRemoveClassDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveClassDriver.class.st
@@ -80,7 +80,10 @@ ReRemoveClassDriver >> hasFailedBehaviorPreservingPreconditions [
 	haveNoReferences := refactoring preconditionHaveNoReferences.
 	emptyClasses := refactoring preconditionEmptyClasses.
 	noSubclasses := refactoring preconditionHaveNoSubclasses.
-	^ (haveNoReferences check & emptyClasses check & noSubclasses check) not
+	haveNoReferences check.
+	emptyClasses check.
+	noSubclasses check.
+	^ refactoring failedBreakingChangePreconditions isNotEmpty
 ]
 
 { #category : 'configuration' }

--- a/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
+++ b/src/Refactoring-UI/ReRenameArgumentOrTemporaryDriver.class.st
@@ -69,6 +69,39 @@ ReRenameArgumentOrTemporaryDriver >> defaultSelectDialog [
 		  yourself
 ]
 
+{ #category : 'execution' }
+ReRenameArgumentOrTemporaryDriver >> gatherUserInput [
+
+	| cancelled |
+	cancelled := false.
+	[
+		refactoring newName: (self defaultRequestDialog
+				 title: 'Rename a temp variable';
+				 message: 'New name of the variable';
+				 text: sourceNode name;
+				 "We cannot return in this block so we save the result as a boolean to check it later."onCancel: [ cancelled := true ];
+				 openModal).
+
+		cancelled ifTrue: [
+				self inform: 'Refactoring cancelled'.
+				^ false ].
+
+		refactoring applicabilityPreconditionsOfTheNewName allSatisfy: [ :condition | condition check ] ] whileFalse: [
+			refactoring applicabilityPreconditionsOfTheNewName
+				detect: [ :condition | condition check not ]
+				ifFound: [ :condition | self inform: condition errorString ] ].
+	^ true
+]
+
+{ #category : 'private ex' }
+ReRenameArgumentOrTemporaryDriver >> hasFailedApplicabilityPreconditions [
+
+	(refactoring applicabilityPreconditionsIndependentOfTheNewName reject: [ :condition | condition check ]) ifNotEmpty: [
+			self inform: 'The interval selected is not right to rename a temporary variable.'.
+			^ true ].
+	^ false
+]
+
 { #category : 'initialization' }
 ReRenameArgumentOrTemporaryDriver >> hasFailedBehaviorPreservingPreconditions [
 
@@ -118,35 +151,6 @@ ReRenameArgumentOrTemporaryDriver >> newName [
 ReRenameArgumentOrTemporaryDriver >> newName: anObject [
 
 	newName := anObject
-]
-
-{ #category : 'execution' }
-ReRenameArgumentOrTemporaryDriver >> runRefactoring [
-
-	| cancelled |
-	self configureRefactoring.
-	(refactoring applicabilityPreconditionsIndependentOfTheNewName reject: [ :condition | condition check ]) ifNotEmpty: [
-		^ self inform: 'The interval selected is not right to rename a temporary variable.' ].
-
-	cancelled := false.
-	[
-		refactoring newName: (self defaultRequestDialog
-				 title: 'Rename a temp variable';
-				 message: 'New name of the variable';
-				 text: sourceNode name;
-				 "We cannot return in this block so we save the result as a boolean to check it later."onCancel: [ cancelled := true ];
-				 openModal).
-
-		cancelled ifTrue: [ ^ self inform: 'Refactoring cancelled' ].
-
-		refactoring applicabilityPreconditionsOfTheNewName allSatisfy: [ :condition | condition check ] ] whileFalse: [
-			refactoring applicabilityPreconditionsOfTheNewName
-				detect: [ :condition | condition check not ]
-				ifFound: [ :condition | self inform: condition errorString ] ].
-
-	self hasFailedBehaviorPreservingPreconditions
-		ifTrue: [ self handleBreakingChanges ]
-		ifFalse: [ self applyChanges ]
 ]
 
 { #category : 'accessing' }

--- a/src/Refactoring-UI/ReRenameMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRenameMethodDriver.class.st
@@ -91,6 +91,29 @@ ReRenameMethodDriver >> defaultSelectDialog [
 		yourself
 ]
 
+{ #category : 'execution' }
+ReRenameMethodDriver >> gatherUserInput [
+
+	| failedConditions |
+	failedConditions := OrderedCollection empty.
+	[
+		newMessage := self requestNewMessage.
+		shouldEscape ifTrue: [ ^ false ].
+		self configureMessage.
+
+		refactoring isMethodDefinitionUnchanged ifTrue: [ ^ false ].
+		shouldEscape ifTrue: [ ^ false ].
+
+		failedConditions := refactoring failedApplicabilityPreconditions.
+		failedConditions do: [ :cond |
+				self informDialog
+					message: cond errorString;
+					title: 'Invalid method name';
+					openModal ] ] doWhileFalse: [ failedConditions isEmpty ].
+
+	^ true
+]
+
 { #category : 'initialization' }
 ReRenameMethodDriver >> initialize [ 
 	
@@ -190,31 +213,6 @@ ReRenameMethodDriver >> requestNewMessage [
 	dialog cancelled ifTrue: [ shouldEscape := true. ^ self ].
 
 	^ dialog methodName
-]
-
-{ #category : 'execution' }
-ReRenameMethodDriver >> runRefactoring [
-
-	| failedConditions |
-	self configureRefactoring.
-	failedConditions := OrderedCollection empty.
-	[
-		newMessage := self requestNewMessage.
-		shouldEscape ifTrue: [ ^ self ].
-		self configureMessage.
-
-		refactoring isMethodDefinitionUnchanged ifTrue: [ ^ self ].
-		shouldEscape ifTrue: [ ^ self ].
-
-		failedConditions := refactoring failedApplicabilityPreconditions.
-		failedConditions do: [ :cond |
-				self informDialog
-					message: cond errorString;
-					title: 'Invalid method name';
-					openModal ] ] doWhileFalse: [ failedConditions isEmpty ].
-	self hasFailedBehaviorPreservingPreconditions
-		ifTrue: [ self handleBreakingChanges ]
-		ifFalse: [ self applyChanges ]
 ]
 
 { #category : 'initialization' }

--- a/src/Refactoring-UI/ReRenameVariableDriver.class.st
+++ b/src/Refactoring-UI/ReRenameVariableDriver.class.st
@@ -31,12 +31,12 @@ ReRenameVariableDriver class >> shouldPreviewChangesByDefault [
 ReRenameVariableDriver >> gatherUserInput [
 
 	| failedConditions newName |
+	refactoring preconditionDirectlyDefinesVariable check ifFalse: [ ^ false ].
 	[
 		shouldEscape := false.
 		newName := self requestNewNameBasedOn: previouslyProposedName.
 		shouldEscape ifTrue: [ ^ false ].
 		refactoring newName: newName.
-		refactoring preconditionDirectlyDefinesVariable check ifFalse: [ ^ false ].
 		failedConditions := refactoring failedApplicabilityPreconditions.
 		failedConditions isEmpty ] whileFalse: [ failedConditions do: [ :cond | self informError: cond ] ].
 

--- a/src/Refactoring-UI/ReRenameVariableDriver.class.st
+++ b/src/Refactoring-UI/ReRenameVariableDriver.class.st
@@ -28,10 +28,26 @@ ReRenameVariableDriver class >> shouldPreviewChangesByDefault [
 ]
 
 { #category : 'private' }
+ReRenameVariableDriver >> gatherUserInput [
+
+	| failedConditions newName |
+	[
+		shouldEscape := false.
+		newName := self requestNewNameBasedOn: previouslyProposedName.
+		shouldEscape ifTrue: [ ^ false ].
+		refactoring newName: newName.
+		refactoring preconditionDirectlyDefinesVariable check ifFalse: [ ^ false ].
+		failedConditions := refactoring failedApplicabilityPreconditions.
+		failedConditions isEmpty ] whileFalse: [ failedConditions do: [ :cond | self informError: cond ] ].
+
+	^ true
+]
+
+{ #category : 'private' }
 ReRenameVariableDriver >> informError: cond [
 
 	self informDialog
-		label: cond errorString;
+		message: cond errorString;
 		title: 'Invalid name';
 		openModal
 ]
@@ -43,21 +59,6 @@ ReRenameVariableDriver >> instantiateRefactoring [
 		model: model 
 		variable: oldName 
 		class: class
-]
-
-{ #category : 'private' }
-ReRenameVariableDriver >> prepareRefactoringInteractively [
-
-	| failedConditions newName |
-	[
-	newName := self requestNewNameBasedOn: previouslyProposedName.
-	shouldEscape ifTrue: [ ^ self ].
-	refactoring newName: newName.
-	failedConditions := refactoring failedApplicabilityPreconditions.
-	failedConditions isEmpty ] whileFalse: [
-		failedConditions do: [ :cond |
-			self informError: cond 
-			 ] ]
 ]
 
 { #category : 'factory method' }
@@ -82,19 +83,6 @@ ReRenameVariableDriver >> requestNewNameBasedOn: aName [
 	previouslyProposedName := newName.
 
 	^ newName
-]
-
-{ #category : 'execution' }
-ReRenameVariableDriver >> runRefactoring [
-
-	self configureRefactoring.
-	shouldEscape := false. "We cannot rename something that doesn'e exist.
-	If we don't check this before `prepareRefactoringInteractively` 
-	it will loop indefinetely since this precondition will always fail."
-	refactoring preconditionDirectlyDefinesVariable check ifFalse: [ ^ self ].
-	self prepareRefactoringInteractively.
-	shouldEscape ifTrue: [ ^ self ].
-	self applyChanges
 ]
 
 { #category : 'initialization' }

--- a/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand2.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSubclassCommand2.class.st
@@ -30,7 +30,7 @@ SycCmInsertSubclassCommand2 >> executeRefactoring [
 	dialog openModal.
 	driver := (ReInsertSubclassDriver superclass: self targetClass packageNames: self packageNames) scopes: refactoringScopes .
 	choice = 'Add' ifTrue: [ driver beSibling ].
-	driver runRefactoring ifFalse: [ ^ self ].
+	driver runRefactoring. 
 	newClassName := driver subclass
 ]
 

--- a/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand2.class.st
+++ b/src/SystemCommands-ClassCommands/SycCmInsertSuperclassCommand2.class.st
@@ -13,17 +13,15 @@ Class {
 { #category : 'executing' }
 SycCmInsertSuperclassCommand2 >> executeRefactoring [
 	"The class name is necessary so the browser can select the new subclass"
-	
-	| driver | 
-	driver := (ReInsertSuperclassDriver 
-		superclass: self targetClass 
-		superclassParent: self targetClass superclass
-		packageNames: self packageNames) scopes: refactoringScopes.
-	"Pay attention superclass meansthe class above which the new class was inserted"
 
-	driver runRefactoring
-		ifFalse: [ ^ self ].
-	newClassName := driver superclass name.
+	| driver |
+	driver := (ReInsertSuperclassDriver
+		           superclass: self targetClass
+		           superclassParent: self targetClass superclass
+		           packageNames: self packageNames) scopes: refactoringScopes. "Pay attention superclass meansthe class above which the new class was inserted"
+
+	driver runRefactoring.
+	newClassName := driver superclass name
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
I did a few changes based on @balsa-sarenac reviews. 
Also I changed a bit `RePushDownInstanceVariableDriver` as a choice was not working. 
Now all `gatherUserInput` methods actually fully instantiate their refactoring, as it was not done before due to old execution flow order