### PR TITLE
Fix FFIUint64>>basicHandle:at: and test

### DIFF
--- a/src/UnifiedFFI-Tests/FFITypesTest.class.st
+++ b/src/UnifiedFFI-Tests/FFITypesTest.class.st
@@ -164,7 +164,10 @@ FFITypesTest >> testSignedLong [
 		|ref|
 		ref := ByteArray new: FFIInt32 externalTypeSize.
 		ref signedLongAt: 1 put: int.
-		self assert: (ref signedLongAt: 1) equals: int ]
+		self assert: (ref signedLongAt: 1) equals: int.
+		self
+			assert: ((FFIExternalType resolveType: FFIInt32) handle: ref at: 1)
+			equals: int ]
 ]
 
 { #category : 'tests' }
@@ -173,7 +176,10 @@ FFITypesTest >> testSignedLongLong [
 		|ref|
 		ref := ByteArray new: FFIInt64 externalTypeSize.
 		ref signedLongLongAt: 1 put: int.
-		self assert: (ref signedLongLongAt: 1) equals: int ]
+		self assert: (ref signedLongLongAt: 1) equals: int.
+		self
+			assert: ((FFIExternalType resolveType: FFIInt64) handle: ref at: 1)
+			equals: int ]
 ]
 
 { #category : 'tests' }
@@ -227,7 +233,10 @@ FFITypesTest >> testUnsignedLong [
 		|ref|
 		ref := ByteArray new: FFIUInt32 externalTypeSize.
 		ref unsignedLongAt: 1 put: int.
-		self assert: (ref unsignedLongAt: 1) equals: int ]
+		self assert: (ref unsignedLongAt: 1) equals: int.
+		self
+			assert: ((FFIExternalType resolveType: FFIUInt32) handle: ref at: 1)
+			equals: int ]
 ]
 
 { #category : 'tests' }
@@ -236,7 +245,10 @@ FFITypesTest >> testUnsignedLongLong [
 		|ref|
 		ref := ByteArray new: FFIUInt64 externalTypeSize.
 		ref unsignedLongLongAt: 1 put: int.
-		self assert: (ref unsignedLongLongAt: 1) equals: int ]
+		self assert: (ref unsignedLongLongAt: 1) equals: int.
+		self
+			assert: ((FFIExternalType resolveType: FFIUInt64) handle: ref at: 1)
+			equals: int ]
 ]
 
 { #category : 'tests' }

--- a/src/UnifiedFFI/FFIInt64.class.st
+++ b/src/UnifiedFFI/FFIInt64.class.st
@@ -14,3 +14,13 @@ Class {
 FFIInt64 class >> externalType [
 	^ ExternalType signedLongLong
 ]
+
+{ #category : 'private' }
+FFIInt64 >> basicHandle: aHandle at: index [
+	^ aHandle signedLongLongAt: index
+]
+
+{ #category : 'private' }
+FFIInt64 >> basicHandle: aHandle at: index put: value [
+	^ aHandle signedLongLongAt: index	put: value
+]

--- a/src/UnifiedFFI/FFIUInt64.class.st
+++ b/src/UnifiedFFI/FFIUInt64.class.st
@@ -27,10 +27,10 @@ FFIUInt64 class >> externalTypeSize [
 
 { #category : 'private' }
 FFIUInt64 >> basicHandle: aHandle at: index [
-	^ aHandle signedLongLongAt: index
+	^ aHandle unsignedLongLongAt: index
 ]
 
 { #category : 'private' }
 FFIUInt64 >> basicHandle: aHandle at: index put: value [
-	^ aHandle signedLongLongAt: index	put: value
+	^ aHandle unsignedLongLongAt: index	put: value
 ]


### PR DESCRIPTION
`FFIUInt64` must use `unsignedLongLongAt:` instead of `signedLongLongAt:`:
```
 { #category : 'private' } 
 FFIUInt64 >> basicHandle: aHandle at: index [ 
 	^ aHandle signedLongLongAt: index 
 ] 
  
 { #category : 'private' } 
 FFIUInt64 >> basicHandle: aHandle at: index put: value [ 
 	^ aHandle signedLongLongAt: index	put: value 
 ] 
```

In the other hand, `FFIInt64` (it's subclass) must override these methods using `signedLongLongAt:` :

Already applied here: https://github.com/pharo-cig/UnifiedFFI/pull/7