### PR TITLE
Fix call to method browser tool

### DIFF
--- a/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
@@ -42,12 +42,10 @@ ClyTextEditor >> implementorsOfIt [
 ClyTextEditor >> methodSourceContainingIt [
 	"Open a browser class comments which contain the current selection somewhere in them."
 
-	| query pattern |
-	
-	self lineSelectAndEmptyCheck: [^ self].
+	| pattern |
+	self lineSelectAndEmptyCheck: [ ^ self ].
 	pattern := self selection string.
-	query := (ClyMethodSourcesQuery withString: pattern), (ClyClassCommentsQuery withString: pattern).
-	self browser spawnQueryBrowserOn: query
+	(Smalltalk tools toolNamed: #messageList) browseMethodsWithSourceString: pattern
 ]
 
 { #category : '*Calypso-SystemTools-QueryBrowser' }

--- a/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
@@ -53,14 +53,15 @@ ClyTextEditor >> methodSourceContainingIt [
 { #category : '*Calypso-SystemTools-QueryBrowser' }
 ClyTextEditor >> referencesTo: aVariableName [
 	"Open a references browser on the given symbol"
-	| class var |
+
+	| class |
 	" ugly dispatch, but current Browser protocol names aren't really cool "
 	class := self modelCurrentSelectedClass.
-
+ 
 	class isBehavior ifTrue: [
-		class slotNamed: aVariableName ifFound: [:slot |
-			var := ClyInstanceVariable on: slot visibleFrom: class.
-			^self browser spawnQueryBrowserOn: (ClyVariableReferencesQuery of: var)]].
+			class
+				slotNamed: aVariableName
+				ifFound: [ :slot | ^ (Smalltalk tools toolNamed: #messageList) browseReferencesToVariable: slot inClass: class ] ].
 
 	self browser browseReferencesTo: aVariableName asSymbol inNameResolver: class
 ]

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -2,17 +2,13 @@ Extension { #name : 'SystemNavigation' }
 
 { #category : '*Tool-Base' }
 SystemNavigation >> allMethodsWithSourceString: aString matchCase: caseSensitive [
-	"Answer a SortedCollection of all the methods that contain, in source code, aString as a substring.  Search the class comments also"
 
-	| list addMethod addComment |
+	| list addMethod |
 	list := OrderedCollection new.
-	addMethod := [ :mrClass :mrSel | list add: (mrClass>>mrSel)].
-	addComment := [ :mrClass | list add: (RGCommentDefinition realClass: mrClass)].
-	self allBehaviorsDo: [:each |
-		each selectorsDo: [:sel |
-			((each >> sel) sourceCode includesSubstring: aString caseSensitive: caseSensitive)
-					ifTrue: [ addMethod value: each value: sel ]].
-			(each comment includesSubstring: aString caseSensitive: caseSensitive) ifTrue: [ addComment value: each]	].
+	addMethod := [ :mrClass :mrSel | list add: mrClass >> mrSel ].
+	self allBehaviorsDo: [ :each |
+			each selectorsDo: [ :sel |
+				((each >> sel) sourceCode includesSubstring: aString caseSensitive: caseSensitive) ifTrue: [ addMethod value: each value: sel ] ] ].
 	^ list
 ]
 
@@ -262,7 +258,7 @@ SystemNavigation >> browseMessageList: messageList name: labelString autoSelect:
 	^ (self tools toolNamed: #messageList) new
 		  methods: methods;
 		  title: labelString;
-		  autoSelect: autoSelectString;
+		  highlight: autoSelectString;
 		  refreshingBlock: aBlock;
 		  open
 ]


### PR DESCRIPTION
Changed the call since I implemented browse references to slot for the method browser, linked to https://github.com/pharo-spec/NewTools/pull/1371.
Also added support for `Method source containing it` removing class comments, which is linked to https://github.com/pharo-spec/NewTools/pull/1368