### PR TITLE
[ Driver ] Fix Remove IV implementation

### DIFF
--- a/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
@@ -61,6 +61,12 @@ ReRemoveInstanceVariablesDriver >> defaultSelectDialog [
 		yourself
 ]
 
+{ #category : 'private exe' }
+ReRemoveInstanceVariablesDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	^ refactoring failedBreakingChangePreconditions isNotEmpty
+]
+
 { #category : 'configuration' }
 ReRemoveInstanceVariablesDriver >> instantiateRefactoring [
 


### PR DESCRIPTION
Since driver template methods migration, breaking choices were not proposed as `hasFailedBehaviorPreservingPreconditions` was missing