### PR TITLE
[ Driver Migration ] Fix missing method implementation

### DIFF
--- a/src/Refactoring-UI/ReInlineMethodDriver.class.st
+++ b/src/Refactoring-UI/ReInlineMethodDriver.class.st
@@ -48,6 +48,16 @@ ReInlineMethodDriver >> defaultSelectDialog [
 		  yourself
 ]
 
+{ #category : 'initialization' }
+ReInlineMethodDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	noOverridden := refactoring preconditionIsMethodOverridden.
+	notExecutionOrder := refactoring preconditionExecutionOrder.
+	noSuperMessage := refactoring preconditionSuperMessages.
+
+	^ refactoring failedBreakingChangePreconditions isNotEmpty
+]
+
 { #category : 'action' }
 ReInlineMethodDriver >> inlineMethod [
 
@@ -72,20 +82,6 @@ ReInlineMethodDriver >> labelBasedOnBreakingChanges [
 			  stream nextPutAll: 'Select a strategy' ]
 ]
 
-{ #category : 'execution' }
-ReInlineMethodDriver >> runRefactoring [
-
-	self configureRefactoring.
-	refactoring failedApplicabilityPreconditions ifNotEmpty: [ :conditions |
-			self informConditions: conditions.
-			^ false ].
-	self setBreakingChangesPreconditions.
-
-	noOverridden check & notExecutionOrder check & noSuperMessage check
-		ifTrue: [ self applyChanges ]
-		ifFalse: [ self handleBreakingChanges ]
-]
-
 { #category : 'instance creation' }
 ReInlineMethodDriver >> scopes: aScope interval: anInterval selector: aSelector class: aClass [
 
@@ -94,13 +90,4 @@ ReInlineMethodDriver >> scopes: aScope interval: anInterval selector: aSelector 
 	interval := anInterval.
 	selector := aSelector.
 	class := aClass
-]
-
-{ #category : 'initialization' }
-ReInlineMethodDriver >> setBreakingChangesPreconditions [
-
-	noOverridden := refactoring preconditionIsMethodOverridden.
-	notExecutionOrder := refactoring preconditionExecutionOrder.
-	noSuperMessage := refactoring  preconditionSuperMessages.
-
 ]

--- a/src/Refactoring-UI/ReMoveMethodsToClassSideDriver.class.st
+++ b/src/Refactoring-UI/ReMoveMethodsToClassSideDriver.class.st
@@ -70,6 +70,12 @@ ReMoveMethodsToClassSideDriver >> defaultSelectDialog [
 		  yourself
 ]
 
+{ #category : 'private exe' }
+ReMoveMethodsToClassSideDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	^ refactoring failedBreakingChangePreconditions isNotEmpty
+]
+
 { #category : 'configuration' }
 ReMoveMethodsToClassSideDriver >> instantiateRefactoring [
 

--- a/src/Refactoring-UI/ReRemoveSharedVariablesDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveSharedVariablesDriver.class.st
@@ -60,6 +60,12 @@ ReRemoveSharedVariablesDriver >> defaultSelectDialog [
 		yourself
 ]
 
+{ #category : 'private exe' }
+ReRemoveSharedVariablesDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	^ refactoring failedBreakingChangePreconditions isNotEmpty
+]
+
 { #category : 'configuration' }
 ReRemoveSharedVariablesDriver >> instantiateRefactoring [
 

--- a/src/Refactoring-UI/ReRenameMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRenameMethodDriver.class.st
@@ -114,6 +114,12 @@ ReRenameMethodDriver >> gatherUserInput [
 	^ true
 ]
 
+{ #category : 'private exe' }
+ReRenameMethodDriver >> hasFailedBehaviorPreservingPreconditions [
+
+	^ refactoring failedBreakingChangePreconditions isNotEmpty
+]
+
 { #category : 'initialization' }
 ReRenameMethodDriver >> initialize [ 
 	


### PR DESCRIPTION
Following the migration concerning template methods in drivers, some of them missed `hasFailedBehaviorPreservingPreconditions` to propose the choices to the user