### PR TITLE
[ Driver] Cleaning code

### DIFF
--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -220,7 +220,7 @@ ReInteractionDriver >> hasFailedApplicabilityPreconditions [
 { #category : 'private exe' }
 ReInteractionDriver >> hasFailedBehaviorPreservingPreconditions [
 
-	^ false
+	^ refactoring failedBreakingChangePreconditions isNotEmpty
 ]
 
 { #category : 'ui - requests' }

--- a/src/Refactoring-UI/ReMoveMethodsToClassSideDriver.class.st
+++ b/src/Refactoring-UI/ReMoveMethodsToClassSideDriver.class.st
@@ -70,12 +70,6 @@ ReMoveMethodsToClassSideDriver >> defaultSelectDialog [
 		  yourself
 ]
 
-{ #category : 'private exe' }
-ReMoveMethodsToClassSideDriver >> hasFailedBehaviorPreservingPreconditions [
-
-	^ refactoring failedBreakingChangePreconditions isNotEmpty
-]
-
 { #category : 'configuration' }
 ReMoveMethodsToClassSideDriver >> instantiateRefactoring [
 

--- a/src/Refactoring-UI/ReMoveVariablesToClassSideDriver.class.st
+++ b/src/Refactoring-UI/ReMoveVariablesToClassSideDriver.class.st
@@ -4,6 +4,9 @@ I represent a driver that invokes RBMoveInstanceVariableToClassTransformation to
 Class {
 	#name : 'ReMoveVariablesToClassSideDriver',
 	#superclass : 'ReInteractionDriver',
+	#instVars : [
+		'variables'
+	],
 	#category : 'Refactoring-UI-Drivers',
 	#package : 'Refactoring-UI',
 	#tag : 'Drivers'
@@ -22,16 +25,22 @@ ReMoveVariablesToClassSideDriver class >> scopes: scopesList variables: aCollect
 ]
 
 { #category : 'execution' }
-ReMoveVariablesToClassSideDriver >> scopes: scopesList variables: variables [
+ReMoveVariablesToClassSideDriver >> instantiateRefactoring [
+
+	^ RBCompositeTransformation new
+		  model: model;
+		  transformations: (variables collect: [ :v |
+						   RBMoveInstanceVariableToClassTransformation
+							   model: model
+							   variable: v name
+							   fromClass: v definingClass
+							   toClass: v definingClass classSide ])
+]
+
+{ #category : 'execution' }
+ReMoveVariablesToClassSideDriver >> scopes: scopesList variables: aVariableCollection [
 
 	scopes := scopesList.
 	model := self refactoringScopeOn: scopesList first.
-	refactoring := RBCompositeTransformation new
-		               model: model;
-		               transformations: (variables collect: [ :v |
-						                RBMoveInstanceVariableToClassTransformation
-							                model: model
-							                variable: v name
-							                fromClass: v definingClass
-							                toClass: v definingClass classSide ])
+	variables:= aVariableCollection 
 ]

--- a/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
@@ -61,12 +61,6 @@ ReRemoveInstanceVariablesDriver >> defaultSelectDialog [
 		yourself
 ]
 
-{ #category : 'private exe' }
-ReRemoveInstanceVariablesDriver >> hasFailedBehaviorPreservingPreconditions [
-
-	^ refactoring failedBreakingChangePreconditions isNotEmpty
-]
-
 { #category : 'configuration' }
 ReRemoveInstanceVariablesDriver >> instantiateRefactoring [
 

--- a/src/Refactoring-UI/ReRemoveSharedVariablesDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveSharedVariablesDriver.class.st
@@ -60,12 +60,6 @@ ReRemoveSharedVariablesDriver >> defaultSelectDialog [
 		yourself
 ]
 
-{ #category : 'private exe' }
-ReRemoveSharedVariablesDriver >> hasFailedBehaviorPreservingPreconditions [
-
-	^ refactoring failedBreakingChangePreconditions isNotEmpty
-]
-
 { #category : 'configuration' }
 ReRemoveSharedVariablesDriver >> instantiateRefactoring [
 

--- a/src/Refactoring-UI/ReRenameClassDriver.class.st
+++ b/src/Refactoring-UI/ReRenameClassDriver.class.st
@@ -70,12 +70,6 @@ ReRenameClassDriver >> gatherUserInput [
 	^ true
 ]
 
-{ #category : 'private exe' }
-ReRenameClassDriver >> hasFailedBehaviorPreservingPreconditions [ 
-
-	^ refactoring failedBreakingChangePreconditions isNotEmpty
-]
-
 { #category : 'initialization' }
 ReRenameClassDriver >> initialize [ 
 	

--- a/src/Refactoring-UI/ReRenameMethodDriver.class.st
+++ b/src/Refactoring-UI/ReRenameMethodDriver.class.st
@@ -114,12 +114,6 @@ ReRenameMethodDriver >> gatherUserInput [
 	^ true
 ]
 
-{ #category : 'private exe' }
-ReRenameMethodDriver >> hasFailedBehaviorPreservingPreconditions [
-
-	^ refactoring failedBreakingChangePreconditions isNotEmpty
-]
-
 { #category : 'initialization' }
 ReRenameMethodDriver >> initialize [ 
 	

--- a/src/SystemCommands-VariableCommands/SycMoveInstanceVariableToClassSideCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycMoveInstanceVariableToClassSideCommand.class.st
@@ -8,6 +8,20 @@ Class {
 	#package : 'SystemCommands-VariableCommands'
 }
 
+{ #category : 'activation' }
+SycMoveInstanceVariableToClassSideCommand class >> fullBrowserMenuActivation [
+
+	<classAnnotation>
+	^ CmdContextMenuActivation byRootGroupItemFor: ClyFullBrowserVariableContext
+]
+
+{ #category : 'activation' }
+SycMoveInstanceVariableToClassSideCommand class >> sourceCodeMenuActivation [
+	<classAnnotation>
+
+	^SycSourceCodeMenuActivation byRootGroupItemOrder: 1.6 for: ClySourceCodeContext
+]
+
 { #category : 'accessing' }
 SycMoveInstanceVariableToClassSideCommand >> defaultMenuIconName [
 	^ #smallRedo

--- a/src/SystemCommands-VariableCommands/SycPushUpVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycPushUpVariableCommand.class.st
@@ -4,8 +4,6 @@ I am a command to push up given variables
 Class {
 	#name : 'SycPushUpVariableCommand',
 	#superclass : 'SycRefactorVariableCommand',
-	#instVars : [
-	],
 	#category : 'SystemCommands-VariableCommands',
 	#package : 'SystemCommands-VariableCommands'
 }


### PR DESCRIPTION
Refactored `hasFailedBehaviorPreservingPreconditions` template method to `^ refactoring failedBreakingChangePreconditions isNotEmpty`. 
It is more representative to default behavior since most of the drivers return false on this. 

I also displayed the `Move Variable to Class Side` command into the menus because it was not the case. 
Also for now, we are not able to apply it to a Shared variable, we should fix this in the future