### PR TITLE
Fix test bubble update when running tests

### DIFF
--- a/src/SUnit-Core/TestResult.class.st
+++ b/src/SUnit-Core/TestResult.class.st
@@ -72,11 +72,12 @@ TestResult class >> newTestDictionary [
 
 { #category : 'history' }
 TestResult class >> removeFromTestHistory: aSelector in: aTestCaseClass [
-	| lastRun |
 
+	| lastRun |
 	lastRun := self historyFor: aTestCaseClass.
-	#(#passed #failures #errors) do:
-		[ :set | (lastRun at: set) remove: aSelector ifAbsent: []]
+
+	#( #passed #failures #errors ) do: [ :set | (lastRun at: set) remove: aSelector ifAbsent: [ ] ].
+	aTestCaseClass historyAnnouncer announce: (TestSuiteEnded result: aTestCaseClass)
 ]
 
 { #category : 'exceptions' }

--- a/src/SUnit-Tests/TestResultTest.class.st
+++ b/src/SUnit-Tests/TestResultTest.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : 'TestResultTest',
+	#superclass : 'TestCase',
+	#category : 'SUnit-Tests-Core',
+	#package : 'SUnit-Tests',
+	#tag : 'Core'
+}
+
+{ #category : 'tests' }
+TestResultTest >> testRemoveFromTestHistoryFiresHistoryAnnouncement [
+	"Removing a method from test history should announce TestSuiteEnded
+     on the class historyAnnouncer so the class-level bubble turns grey."
+
+	| unitTest announcements selector |
+	unitTest := ClassFactoryForTestCaseTest.
+	unitTest resetAnnouncer.
+	unitTest resetHistory.
+	unitTest suite run.
+	selector := (unitTest history at: #passed) anyOne.
+
+	announcements := OrderedCollection new.
+	unitTest historyAnnouncer when: TestSuiteEnded do: [ :ann | announcements add: ann ] for: self.
+	TestResult removeFromTestHistory: selector in: unitTest.
+	self deny: ((unitTest history at: #passed) includes: selector).
+	self assert: announcements size equals: 1.
+	self assert: (announcements first isKindOf: TestSuiteEnded).
+	unitTest historyAnnouncer unsubscribe: self.
+	unitTest resetHistory
+]


### PR DESCRIPTION
When `Method Modified` was sent to the `TestCase` class, the test bubbles were not updated at the class level. 
Fixes #17713