### PR TITLE
Fix breaking choice for `Remove IV Refactoring`

### DIFF
--- a/src/Refactoring-Core/ReInstanceVariableHasNoReferences.class.st
+++ b/src/Refactoring-Core/ReInstanceVariableHasNoReferences.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : 'ReInstanceVariableHasNoReferences',
+	#superclass : 'RBNewAbstractCondition',
+	#instVars : [
+		'violators',
+		'aClass',
+		'instanceVariable'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'checking' }
+ReInstanceVariableHasNoReferences >> check [
+
+	^ self violators isEmpty
+]
+
+{ #category : 'accessing' }
+ReInstanceVariableHasNoReferences >> errorString [ 
+
+	^ ' Variable ', instanceVariable , ' is still referenced'
+]
+
+{ #category : 'instance creation' }
+ReInstanceVariableHasNoReferences >> hierarchyOf: aRBClass referencesInstanceVariable: variableName [ 
+	aClass := aRBClass.
+	instanceVariable := variableName 
+]
+
+{ #category : 'initialization' }
+ReInstanceVariableHasNoReferences >> initialize [ 
+	super initialize.
+	violators := OrderedCollection new
+]
+
+{ #category : 'accessing' }
+ReInstanceVariableHasNoReferences >> violators [
+
+	violators := OrderedCollection new.
+	aClass withAllSubclasses do: [ :each |
+			| res |
+			res := each whichMethodsReferToInstanceVariable: instanceVariable.
+
+			res isNotEmpty ifTrue: [ violators addAll: res ] ].
+
+	^ violators
+]

--- a/src/Refactoring-Core/ReInstanceVariableHasNoReferences.class.st
+++ b/src/Refactoring-Core/ReInstanceVariableHasNoReferences.class.st
@@ -35,6 +35,17 @@ ReInstanceVariableHasNoReferences >> initialize [
 	violators := OrderedCollection new
 ]
 
+{ #category : 'displaying' }
+ReInstanceVariableHasNoReferences >> violationMessageOn: aStream [
+
+	violators ifEmpty: [ ^ self ].
+	^ aStream
+		  nextPutAll: 'The variable variable ';
+		  nextPutAll: instanceVariable;
+		  nextPutAll: 'is referenced in:';
+		  nextPutAll: (violators collect: [ :m | m selector ]) asArray asString
+]
+
 { #category : 'accessing' }
 ReInstanceVariableHasNoReferences >> violators [
 

--- a/src/Refactoring-Core/ReRemoveInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/ReRemoveInstanceVariableRefactoring.class.st
@@ -39,9 +39,13 @@ ReRemoveInstanceVariableRefactoring >> applicabilityPreconditions [
 { #category : 'preconditions' }
 ReRemoveInstanceVariableRefactoring >> breakingChangePreconditions [
 
-	^ { (ReInstanceVariableHasReferences new
-		   hierarchyOf: class
-		   referencesInstanceVariable: variableName) not }
+	^ { self preconditionHasReferences }
+]
+
+{ #category : 'preconditions' }
+ReRemoveInstanceVariableRefactoring >> preconditionHasReferences [
+
+	^ (ReInstanceVariableHasNoReferences new hierarchyOf: class referencesInstanceVariable: variableName) 
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
@@ -39,8 +39,10 @@ ReRemoveInstanceVariablesDriver >> breakingChoices [
 { #category : 'execution' }
 ReRemoveInstanceVariablesDriver >> browseInstanceVariableReferences [
 
-	(Smalltalk tools toolNamed: #messageList) browse: refactoring violators
-		
+	| violators |
+	violators := refactoring refactorings flatCollect: [ :each | each preconditionHasReferences violators ].
+
+	(Smalltalk tools toolNamed: #messageList) browse: violators
 ]
 
 { #category : 'configuration' }

--- a/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
+++ b/src/Refactoring-UI/ReRemoveInstanceVariablesDriver.class.st
@@ -56,11 +56,12 @@ ReRemoveInstanceVariablesDriver >> configureRefactoring [
 ReRemoveInstanceVariablesDriver >> defaultSelectDialog [
 
 	^ super defaultSelectDialog
-		title: 'There are references to variables!';
-		items: self breakingChoices;
-		display: [ :each | each description ];
-		displayIcon: [ :each | self iconNamed: each systemIconName ];
-		yourself
+		  title: 'There are references to variables!';
+		  message: self labelBasedOnBreakingChanges;
+		  items: self breakingChoices;
+		  display: [ :each | each description ];
+		  displayIcon: [ :each | self iconNamed: each systemIconName ];
+		  yourself
 ]
 
 { #category : 'configuration' }
@@ -71,6 +72,17 @@ ReRemoveInstanceVariablesDriver >> instantiateRefactoring [
 		refactorings: (variables collect: [:each | 
 				ReRemoveInstanceVariableRefactoring model: model remove: each from: class]);
 		yourself
+]
+
+{ #category : 'ui - dialogs' }
+ReRemoveInstanceVariablesDriver >> labelBasedOnBreakingChanges [
+
+	^ String streamContents: [ :stream |
+			  refactoring failedBreakingChangePreconditions do: [ :cond |
+					  cond check ifFalse: [
+							  cond violationMessageOn: stream.
+							  stream cr ] ].
+			  stream nextPutAll: 'Select the strategies to apply' ]
 ]
 
 { #category : 'initialization' }


### PR DESCRIPTION
It was leading to errors because the condition was checking the opposite.

Fixes #18220