### PR TITLE
[ Refactoring ] Fix generate accessors error

### DIFF
--- a/src/Refactoring-Core/ReAccessorsMissingCondition.class.st
+++ b/src/Refactoring-Core/ReAccessorsMissingCondition.class.st
@@ -1,0 +1,41 @@
+"
+I check if given transformation can find an existing accessor for its variable name
+"
+Class {
+	#name : 'ReAccessorsMissingCondition',
+	#superclass : 'ReVariableNameCondition',
+	#instVars : [
+		'transformation'
+	],
+	#category : 'Refactoring-Core-Conditions',
+	#package : 'Refactoring-Core',
+	#tag : 'Conditions'
+}
+
+{ #category : 'checking' }
+ReAccessorsMissingCondition >> check [
+
+	violator ifNil: [
+			violator := OrderedCollection new.
+			transformation findGetterMethod ifNotNil: [ :sel | violator add: sel ].
+			transformation findSetterMethod ifNotNil: [ :sel | violator add: sel ].
+			violator ].
+	^ violator size < 2
+]
+
+{ #category : 'accessing' }
+ReAccessorsMissingCondition >> transformation: aTransformation [
+    transformation := aTransformation
+]
+
+{ #category : 'displaying' }
+ReAccessorsMissingCondition >> violationMessageOn: aStream [
+
+	violator do: [ :sel |
+			aStream
+				nextPutAll: sel;
+				nextPutAll: ' already exists as an accessor for ';
+				nextPutAll: transformation variableName;
+				nextPutAll: '.';
+				space ]
+]

--- a/src/Refactoring-Core/ReCreateAccessorsForVariableTransformation.class.st
+++ b/src/Refactoring-Core/ReCreateAccessorsForVariableTransformation.class.st
@@ -98,11 +98,11 @@ ReCreateAccessorsForVariableTransformation class >> variable: aVarName class: aC
 { #category : 'preconditions' }
 ReCreateAccessorsForVariableTransformation >> applicabilityPreconditions [
 
-	^ { (classVariable
-		   ifTrue: [
-				RBCondition definesClassVariable: variableName asSymbol in: class ]
-		   ifFalse: [
-				RBCondition definesInstanceVariable: variableName in: class ]) }
+	^ {
+		  (classVariable
+			   ifTrue: [ RBCondition definesClassVariable: variableName asSymbol in: class ]
+			   ifFalse: [ RBCondition definesInstanceVariable: variableName in: class ]).
+		  self preconditionMissingAccessor }
 ]
 
 { #category : 'printing' }
@@ -256,6 +256,14 @@ ReCreateAccessorsForVariableTransformation >> possibleGetterSelectors [
 { #category : 'private - accessing' }
 ReCreateAccessorsForVariableTransformation >> possibleSetterSelectors [
 	^self methodsReferencingVariable select: [:each | each numArgs == 1]
+]
+
+{ #category : 'preconditions' }
+ReCreateAccessorsForVariableTransformation >> preconditionMissingAccessor [
+
+	^ ReAccessorsMissingCondition new
+		  transformation: self;
+		  yourself
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-UI/ReGenerateAccessorsDriver.class.st
+++ b/src/Refactoring-UI/ReGenerateAccessorsDriver.class.st
@@ -21,6 +21,12 @@ ReGenerateAccessorsDriver class >> driverName [
 	^ 'Generate accessors'
 ]
 
+{ #category : 'execution' }
+ReGenerateAccessorsDriver >> gatherUserInput [
+
+	^ true
+]
+
 { #category : 'configuration' }
 ReGenerateAccessorsDriver >> instantiateRefactoring [
 

--- a/src/Refactoring-UI/ReGenerateMethodDriver.class.st
+++ b/src/Refactoring-UI/ReGenerateMethodDriver.class.st
@@ -28,14 +28,6 @@ ReGenerateMethodDriver class >> isAbstract [
 	^ self = ReGenerateMethodDriver
 ]
 
-{ #category : 'execution' }
-ReGenerateMethodDriver >> configureRefactoring [
-
-	refactoring := self refactoringClass 
-		className: self targetClass name
-		variables: selectedVariables
-]
-
 { #category : 'configuration' }
 ReGenerateMethodDriver >> dialogTitle [
 


### PR DESCRIPTION
The superclass was breaking the execution flow and called `gatherUserInput` when this refactoring does not need it. I also created a new applicability precondition to check if both accessors already exist. Because before if it was the case, the user just had a window with no changes at all !

Fixes #19537