### PR TITLE
Migration of RenamePackageRefactoring to its driver

### DIFF
--- a/src/Refactoring-Core/ReRenamePackageRefactoring.class.st
+++ b/src/Refactoring-Core/ReRenamePackageRefactoring.class.st
@@ -14,7 +14,7 @@ Example
 ```
 "
 Class {
-	#name : 'RBRenamePackageRefactoring',
+	#name : 'ReRenamePackageRefactoring',
 	#superclass : 'RBPackageRefactoring',
 	#instVars : [
 		'package'
@@ -25,7 +25,7 @@ Class {
 }
 
 { #category : 'instance creation' }
-RBRenamePackageRefactoring class >> model: aRBSmalltalk rename: aSymbol to: aNewName [
+ReRenamePackageRefactoring class >> model: aRBSmalltalk rename: aSymbol to: aNewName [
 	^ self new
 		model: aRBSmalltalk;
 		packageName: aSymbol newName: aNewName;
@@ -33,13 +33,13 @@ RBRenamePackageRefactoring class >> model: aRBSmalltalk rename: aSymbol to: aNew
 ]
 
 { #category : 'instance creation' }
-RBRenamePackageRefactoring class >> rename: aString to: aNewName [
+ReRenamePackageRefactoring class >> rename: aString to: aNewName [
 	^ self new
 		packageName: aString newName: aNewName
 ]
 
 { #category : 'preconditions' }
-RBRenamePackageRefactoring >> applicabilityPreconditions [
+ReRenamePackageRefactoring >> applicabilityPreconditions [
 
 	^ super applicabilityPreconditions, {
 		 (RBCondition
@@ -54,28 +54,33 @@ RBRenamePackageRefactoring >> applicabilityPreconditions [
 ]
 
 { #category : 'transforming' }
-RBRenamePackageRefactoring >> manifestClassNameFor: aPackageName [
+ReRenamePackageRefactoring >> manifestClassNameFor: aPackageName [
 	"Returns a symbol representing a suitable name for a Manifest class for the given package"
 
 	^('Manifest', (aPackageName select: [:each | each isAlphaNumeric ])) asSymbol
 ]
 
 { #category : 'initialization' }
-RBRenamePackageRefactoring >> packageName: aName newName: aNewName [
+ReRenamePackageRefactoring >> packageName: aName newName: aNewName [
 	packageName := aName asSymbol.
 	package := self model packageNamed: packageName.
 	newName := aNewName asSymbol
 ]
 
 { #category : 'transforming' }
-RBRenamePackageRefactoring >> privateTransform [
+ReRenamePackageRefactoring >> prepareForExecution [
+    package := self model packageNamed: packageName
+]
+
+{ #category : 'transforming' }
+ReRenamePackageRefactoring >> privateTransform [
 
 	self renamePackage.
 	self renameManifestClass
 ]
 
 { #category : 'transforming' }
-RBRenamePackageRefactoring >> renameManifestClass [
+ReRenamePackageRefactoring >> renameManifestClass [
 	|refactoring manifest|
 	manifest := package realPackage packageManifestOrNil.
 	manifest ifNotNil: [
@@ -87,6 +92,6 @@ RBRenamePackageRefactoring >> renameManifestClass [
 ]
 
 { #category : 'transforming' }
-RBRenamePackageRefactoring >> renamePackage [
+ReRenamePackageRefactoring >> renamePackage [
 	self model renamePackage: package to: newName
 ]

--- a/src/Refactoring-Transformations-Tests/RBRenamePackageParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRenamePackageParametrizedTest.class.st
@@ -9,7 +9,7 @@ Class {
 { #category : 'tests' }
 RBRenamePackageParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
-		addCase: { #rbClass -> RBRenamePackageRefactoring };
+		addCase: { #rbClass -> ReRenamePackageRefactoring };
 		addCase: { #rbClass -> RBRenamePackageTransformation };
 		yourself
 ]

--- a/src/Refactoring-UI/ReRenamePackageDriver.class.st
+++ b/src/Refactoring-UI/ReRenamePackageDriver.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : 'ReInteractionDriver',
 	#instVars : [
 		'packageName',
-		'newName'
+		'newName',
+		'shouldEscape'
 	],
 	#category : 'Refactoring-UI-Drivers',
 	#package : 'Refactoring-UI',
@@ -16,30 +17,42 @@ ReRenamePackageDriver class >> driverName [
 	^ 'Rename package'
 ]
 
+{ #category : 'execution' }
+ReRenamePackageDriver >> gatherUserInput [
+	 
+	 shouldEscape := false.
+    newName := self requestNewNameBasedOn: packageName.
+    shouldEscape ifTrue: [ ^ false ].
+    ^ true
+]
+
 { #category : 'configuration' }
 ReRenamePackageDriver >> instantiateRefactoring [
+    ^ ReRenamePackageRefactoring new
+        model: model;
+        rename: packageName;
+        yourself
+]
 
-	^ (ReRenamePackageRefactoring
-		model: model
-		rename: packageName
-		to: newName)
+{ #category : 'private' }
+ReRenamePackageDriver >> requestNewNameBasedOn: aName [
+
+    newName := self defaultRequestDialog
+        title: 'Rename a package';
+        message: 'Enter new package name';
+        text: aName;
+        openModal.
+    newName ifNil: [
+        shouldEscape := true.
+        ^ self ].
+    refactoring newName: newName.
+    ^ newName
 ]
 
 { #category : 'execution' }
-ReRenamePackageDriver >> runRefactoring [
-
-	self configureRefactoring.
-	refactoring failedApplicabilityPreconditions ifNotEmpty: [ :conditions |
-		self informConditions: conditions.
-		^ false ].
-	self applyChanges
-]
-
-{ #category : 'execution' }
-ReRenamePackageDriver >> scopes: refactoringScopes packageName: aName newName: aNewName [
+ReRenamePackageDriver >> scopes: refactoringScopes packageName: aName [
 
 	scopes := refactoringScopes.
 	model := self refactoringScopeOn: scopes first.
 	packageName := aName.
-	newName := aNewName
 ]

--- a/src/Refactoring-UI/ReRenamePackageDriver.class.st
+++ b/src/Refactoring-UI/ReRenamePackageDriver.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : 'ReRenamePackageDriver',
+	#superclass : 'ReInteractionDriver',
+	#instVars : [
+		'packageName',
+		'newName'
+	],
+	#category : 'Refactoring-UI-Drivers',
+	#package : 'Refactoring-UI',
+	#tag : 'Drivers'
+}
+
+{ #category : 'accessing' }
+ReRenamePackageDriver class >> driverName [
+
+	^ 'Rename package'
+]
+
+{ #category : 'configuration' }
+ReRenamePackageDriver >> instantiateRefactoring [
+
+	^ (ReRenamePackageRefactoring
+		model: model
+		rename: packageName
+		to: newName)
+]
+
+{ #category : 'execution' }
+ReRenamePackageDriver >> runRefactoring [
+
+	self configureRefactoring.
+	refactoring failedApplicabilityPreconditions ifNotEmpty: [ :conditions |
+		self informConditions: conditions.
+		^ false ].
+	self applyChanges
+]
+
+{ #category : 'execution' }
+ReRenamePackageDriver >> scopes: refactoringScopes packageName: aName newName: aNewName [
+
+	scopes := refactoringScopes.
+	model := self refactoringScopeOn: scopes first.
+	packageName := aName.
+	newName := aNewName
+]

--- a/src/SystemCommands-PackageCommands/SycRenamePackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycRenamePackageCommand.class.st
@@ -45,19 +45,13 @@ SycRenamePackageCommand >> execute [
 
 	^ ((ReRenamePackageDriver newApplication: self application)
 		scopes: refactoringScopes
-		packageName: package name
-		newName: newName) runRefactoring
+		packageName: package name) runRefactoring
 ]
 
 { #category : 'execution' }
 SycRenamePackageCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
-
 	package := aToolContext lastSelectedPackage.
 	refactoringScopes := aToolContext refactoringScopes.
-	newName := self morphicUIManager
-		request: 'New name of the package'
-		initialAnswer: package name
-		title: 'Rename a package'.
-	newName isEmptyOrNil ifTrue: [ ^ CmdCommandAborted signal ]
+	
 ]

--- a/src/SystemCommands-PackageCommands/SycRenamePackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycRenamePackageCommand.class.st
@@ -12,7 +12,8 @@ Class {
 	#superclass : 'CmdCommand',
 	#instVars : [
 		'package',
-		'newName'
+		'newName',
+		'refactoringScopes'
 	],
 	#category : 'SystemCommands-PackageCommands',
 	#package : 'SystemCommands-PackageCommands'
@@ -42,7 +43,10 @@ SycRenamePackageCommand >> description [
 { #category : 'execution' }
 SycRenamePackageCommand >> execute [
 
-	(RBRenamePackageRefactoring rename: package name to: newName) execute
+	^ ((ReRenamePackageDriver newApplication: self application)
+		scopes: refactoringScopes
+		packageName: package name
+		newName: newName) runRefactoring
 ]
 
 { #category : 'execution' }
@@ -50,9 +54,10 @@ SycRenamePackageCommand >> prepareFullExecutionInContext: aToolContext [
 	super prepareFullExecutionInContext: aToolContext.
 
 	package := aToolContext lastSelectedPackage.
+	refactoringScopes := aToolContext refactoringScopes.
 	newName := self morphicUIManager
 		request: 'New name of the package'
 		initialAnswer: package name
 		title: 'Rename a package'.
-	newName isEmptyOrNil | (newName = package name) ifTrue: [ ^ CmdCommandAborted signal ]
+	newName isEmptyOrNil ifTrue: [ ^ CmdCommandAborted signal ]
 ]


### PR DESCRIPTION
- moved UI from command to driver
- uses new architecture
- #19541 should be merged before this.


(moved from #19518)