### PR TITLE
[Refactoring] Remove parameter check fixes

### DIFF
--- a/src/Refactoring-Core/RBParameterRemovalRefactoring.class.st
+++ b/src/Refactoring-Core/RBParameterRemovalRefactoring.class.st
@@ -24,21 +24,13 @@ RBParameterRemovalRefactoring class >> isAbstract [
 RBParameterRemovalRefactoring >> applyValidations [
 
 	| tree |
-	(class directlyDefinesMethod: oldSelector) ifFalse: [
-		self refactoringError: 'Method doesn''t exist' ].
 	tree := class parseTreeForSelector: oldSelector.
 	tree ifNil: [ self refactoringError: 'Cannot parse sources' ].
-	argument ifNil: [
-		self refactoringError: 'This method does not have an argument' ].
-	parameterIndex := tree argumentNames
-		                  indexOf: argument
-		                  ifAbsent: [
-		                  self refactoringError: 'Select a parameter!!' ].
-	oldSelector numArgs == 0 ifTrue: [
-		self refactoringError: 'This method contains no arguments' ].
-	oldSelector isInfix ifTrue: [
-		self refactoringError:
-			'Cannot remove parameters of infix selectors' ]
+	parameterIndex ifNil: [
+			argument ifNil: [ self refactoringError: 'This method does not have an argument' ].
+			parameterIndex := tree argumentNames indexOf: argument ifAbsent: [ self refactoringError: 'Select a parameter!!' ] ].
+	oldSelector numArgs == 0 ifTrue: [ self refactoringError: 'This method contains no arguments' ].
+	oldSelector isInfix ifTrue: [ self refactoringError: 'Cannot remove parameters of infix selectors' ]
 ]
 
 { #category : 'private' }

--- a/src/Refactoring-Core/RBRemoveParameterRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveParameterRefactoring.class.st
@@ -25,6 +25,18 @@ RBRemoveParameterRefactoring class >> model: aRBSmalltalk removeParameter: aStri
 ]
 
 { #category : 'instance creation' }
+RBRemoveParameterRefactoring class >> model: aRBSmalltalk removeParameter: aString in: aClass selector: aSelector index: anIndex [
+
+	^ self new
+		  model: aRBSmalltalk;
+		  removeParameter: aString
+		  in: aClass
+		  selector: aSelector
+		  index: anIndex;
+		  yourself
+]
+
+{ #category : 'instance creation' }
 RBRemoveParameterRefactoring class >> removeParameter: aString in: aClass selector: aSelector [
 	^ self new
 		removeParameter: aString
@@ -64,4 +76,13 @@ RBRemoveParameterRefactoring >> removeParameter: aString in: aClass selector: aS
 	oldSelector := aSelector.
 	class := self classObjectFor: aClass.
 	argument := aString
+]
+
+{ #category : 'initialization' }
+RBRemoveParameterRefactoring >> removeParameter: aString in: aClass selector: aSelector index: anIndex [
+
+	oldSelector := aSelector.
+	class := self classObjectFor: aClass.
+	argument := aString.
+	parameterIndex := anIndex
 ]

--- a/src/SystemCommands-MessageCommands/SycRemoveMessageArgumentCommand.class.st
+++ b/src/SystemCommands-MessageCommands/SycRemoveMessageArgumentCommand.class.st
@@ -47,13 +47,13 @@ SycRemoveMessageArgumentCommand >> computeArgumentName [
 
 { #category : 'execution' }
 SycRemoveMessageArgumentCommand >> createRefactoring [
-	
-	^(RBRemoveParameterRefactoring
-		model: model
-		removeParameter: argumentName
-		in: refactoredClass
-		selector: originalMessage selector)
-		newSelector: self resultMessageSelector
+
+	^ (RBRemoveParameterRefactoring
+		   model: model
+		   removeParameter: argumentName 
+		   in: refactoredClass
+		   selector: originalMessage selector
+		   index: (originalMessage argumentNames indexOf: argumentName)) newSelector: self resultMessageSelector
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
- It was checking if the method exist in the class, meaning we can't use it from a callsite in test class for example
- It was not given an index, meaning if we wanted to remove a parameter from a call site and the arg was called `tmp` but the arg in the method source code was called `arg`, refactoring couldn't find it and raised an error. This PR fixes these problems !