### PR TITLE
reduce the usage of superclass with nil argument

### DIFF
--- a/src/Fuel-Core/FLTraitCluster.class.st
+++ b/src/Fuel-Core/FLTraitCluster.class.st
@@ -40,7 +40,7 @@ FLTraitCluster >> materializePostInstance: aTrait with: aDecoder [
 		initialize;
 		"#initialize sets Object as the superclass
 		but the superclass of traits is nil"
-		superclass: nil;
+		basicSuperclass: nil;
 		setName: name;
 		environment: environment.
 

--- a/src/Traits-Tests/AbstractTraitsOnPreparedModelTest.class.st
+++ b/src/Traits-Tests/AbstractTraitsOnPreparedModelTest.class.st
@@ -235,10 +235,8 @@ AbstractTraitsOnPreparedModelTest >> setUp [
 AbstractTraitsOnPreparedModelTest >> setUpTranslatingRequiresFixture [
 	self c6: (self
 				newClass: #C6
-				superclass: ProtoObject
+				superclass: nil
 				traits: { }).
-	ProtoObject removeSubclass: self c6.
-	self c6 superclass: nil.
 	self c7: (self
 				newClass: #C7
 				superclass: self c6
@@ -257,10 +255,8 @@ AbstractTraitsOnPreparedModelTest >> setUpTranslatingRequiresFixture [
 AbstractTraitsOnPreparedModelTest >> setUpTrivialRequiresFixture [
 	self c3: (self
 				newClass: #C3
-				superclass: ProtoObject
+				superclass: nil
 				traits: { }).
-	ProtoObject removeSubclass: self c3.
-	self c3 superclass: nil.
 	self c3 compile: 'foo ^self bla' classified: #accessing
 ]
 
@@ -268,10 +264,8 @@ AbstractTraitsOnPreparedModelTest >> setUpTrivialRequiresFixture [
 AbstractTraitsOnPreparedModelTest >> setUpTwoLevelRequiresFixture [
 	self c4: (self
 				newClass: #C4
-				superclass: ProtoObject
+				superclass: nil
 				traits: { }).
-	ProtoObject removeSubclass: self c4.
-	self c4 superclass: nil.
 	self c5: (self
 				newClass: #C5
 				superclass: self c4


### PR DESCRIPTION
- Fuel should use #basicSuperclass: nil;
- AbstractTraitsOnPreparedModelTest setup can just create nil sublcasses direclty now

This should fix the problem in #19510