### PR TITLE
Cleanup clean block and variable resolution.

### DIFF
--- a/bootstrap/scripts/4-installMetacello.sh
+++ b/bootstrap/scripts/4-installMetacello.sh
@@ -118,6 +118,7 @@ zip "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.zip" "${BOOTSTRAP_ARCHIVE_IMAGE_NAME}.image
 cp "${BOOTSTRAP_IMAGE_NAME}.image" "${COMPILER_IMAGE_NAME}.image"
 
 # Archive binary Hermes packages
+zip "monticello-src-packages.zip" pharo-local/package-cache/*.mcz
 zip "${HERMES_ARCHIVE_NAME}.zip" *.hermes hermesSUnitPackages.txt
 
 echo $(date -u) "[Compiler] Adding more Kernel packages"

--- a/src/AST-Core-Tests/OCBlockNodeTest.class.st
+++ b/src/AST-Core-Tests/OCBlockNodeTest.class.st
@@ -32,26 +32,26 @@ OCBlockNodeTest >> testHasNonLocalReturn [
 OCBlockNodeTest >> testIsClean [
 	| escpWrite escpRead |
 	escpRead := escpWrite := 1.
-	self deny: [ self yourself ] sourceNode isClean.
-	self deny: [ ^ 1 ] sourceNode isClean.
-	self deny: [ { 1 . ^2 }  ] sourceNode isClean.
-	self deny: [ testSelector foo ] sourceNode isClean.
-	self deny: [ escpRead foo ] sourceNode isClean.
-	self deny: [ escpWrite := 2 ] sourceNode isClean.
+	self deny: [ self yourself ] sourceNode scope isClean.
+	self deny: [ ^ 1 ] sourceNode scope isClean.
+	self deny: [ { 1 . ^2 }  ] sourceNode scope isClean.
+	self deny: [ testSelector foo ] sourceNode scope isClean.
+	self deny: [ escpRead foo ] sourceNode scope isClean.
+	self deny: [ escpWrite := 2 ] sourceNode scope isClean.
 
-	self deny: [[ self yourself ]] sourceNode isClean.
-	self deny: [[ ^ 1 ]] sourceNode isClean.
-	self deny: [[ testSelector foo ]] sourceNode isClean.
-	self deny: [[ escpRead foo ]] sourceNode isClean.
-	self deny: [[ escpWrite := 2 ]] sourceNode isClean.
-	self assert: [  ] sourceNode isClean.
-	self assert: [ thisContext ] sourceNode isClean.
-	self assert: [ 1 + 2 ] sourceNode isClean.
-	self assert: [ :a | a + 2 ] sourceNode isClean.
-	self assert: [ :a :b | a + b + 3 ] sourceNode isClean.
-	self assert: [ | a | a := 1. a + 3 ] sourceNode isClean.
+	self deny: [[ self yourself ]] sourceNode scope isClean.
+	self deny: [[ ^ 1 ]] sourceNode scope isClean.
+	self deny: [[ testSelector foo ]] sourceNode scope isClean.
+	self deny: [[ escpRead foo ]] sourceNode scope isClean.
+	self deny: [[ escpWrite := 2 ]] sourceNode scope isClean.
+	self assert: [  ] sourceNode scope isClean.
+	self assert: [ thisContext ] sourceNode scope isClean.
+	self assert: [ 1 + 2 ] sourceNode scope isClean.
+	self assert: [ :a | a + 2 ] sourceNode scope isClean.
+	self assert: [ :a :b | a + b + 3 ] sourceNode scope isClean.
+	self assert: [ | a | a := 1. a + 3 ] sourceNode scope isClean.
 
-	self assert: [ true ifTrue: [  ] ]  sourceNode isClean.
+	self assert: [ true ifTrue: [  ] ]  sourceNode scope isClean.
 	"optimized blocks"
 	self assert: [
 		| local2 | true ifTrue: [local2 := 1 ] ] isClean. "optimized blocks are clean"

--- a/src/AST-Core/OCBlockNode.class.st
+++ b/src/AST-Core/OCBlockNode.class.st
@@ -386,21 +386,6 @@ OCBlockNode >> scope: aScopedNode [
 ]
 
 { #category : 'accessing' }
-OCBlockNode >> scopeForContext: aContext [
-
-	"When we are creating a AST scope from a context, and the context is for a clean block. 
-	We need to return an scope with only the block scope, detached from the outerscope. 
-	I return a copy, because the scopes are kept in the AST cache and changing it will affect the 
-	compilation of the whole method"
-
-	self isClean ifFalse: [ ^ self scope ].
-	
-	^ self scope copy
-		outerScope: nil;
-		yourself
-]
-
-{ #category : 'accessing' }
 OCBlockNode >> startWithoutParentheses [
 	^ left
 ]

--- a/src/DebugInfo-Tests/DebugInfoTest.class.st
+++ b/src/DebugInfo-Tests/DebugInfoTest.class.st
@@ -721,6 +721,20 @@ DebugInfoTest >> testReadLocalBlockArgumentVariable [
 ]
 
 { #category : 'tests - read variables' }
+DebugInfoTest >> testReadLocalBlockArgumentVariableCleanBlock [
+
+	| debugInfo context |
+	context := [ :blockArgument | thisContext copy ] value: 7.
+
+	debugInfo := self newDebugInfoFor: context method.
+
+	self
+		assert:
+		(debugInfo readVariableNamed: #blockArgument fromContext: context)
+		equals: 7
+]
+
+{ #category : 'tests - read variables' }
 DebugInfoTest >> testReadLocalBlockTempVectorTemporaryVariableFromClosure [
 	"This test is tricky.
 	

--- a/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
+++ b/src/Kernel-BytecodeEncoders/EncoderForSistaV1.class.st
@@ -490,7 +490,7 @@ EncoderForSistaV1 class >> isCreateBlockAt: pc in: method [
 	| byte |
 	byte := self nonExtensionBytecodeAt: pc in: method.
 	^ byte = 250 or: [
-		  (method sourceNodeForPC: pc) in: [ :node | "Clean blocks are created as PushConstant" node isBlock and: [ node isClean ] ] ]
+		  (method sourceNodeForPC: pc) in: [ :node | "Clean blocks are created as PushConstant" node isBlock and: [ node scope isClean ] ] ]
 ]
 
 { #category : 'block closure support' }

--- a/src/Kernel-CodeModel/BlockClosure.class.st
+++ b/src/Kernel-CodeModel/BlockClosure.class.st
@@ -330,9 +330,12 @@ BlockClosure >> isBlock [
 
 { #category : 'testing' }
 BlockClosure >> isClean [
-	"for now we forward to the AST. When clean blocks are enabled, we can just return false
-	as CleanBlockClosure returns true"
-	^self sourceNode isClean
+	
+	"Returns true if the receiver has been compiled as a clean block.
+	By default, I have an outer context, thus I'm not clean.
+	
+	If you want to check if the block's source *could have been* compiled as a clean block, use the compiler API"
+	^ false
 ]
 
 { #category : 'testing' }

--- a/src/OpalCompiler-Core/Context.extension.st
+++ b/src/OpalCompiler-Core/Context.extension.st
@@ -15,8 +15,8 @@ Context >> astScope [
 	"if we get back a block, this is a block that just got pushed. We are not interested in
 	that but it's outer block"
 	^node isBlock
-		ifTrue: [ node parent methodOrBlockNode scopeForContext: self ]
-		ifFalse: [ node methodOrBlockNode scopeForContext: self ]
+		ifTrue: [ node parent methodOrBlockNode scope ]
+		ifFalse: [ node methodOrBlockNode scope ]
 ]
 
 { #category : '*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -8,7 +8,9 @@ Class {
 	#instVars : [
 		'scope',
 		'currentBlockIsClean',
-		'currentBlockAccessesSelf'
+		'currentBlockAccessesSelf',
+		'currentBlockHasNonLocalReturn',
+		'currentBlockHasIncomingVariables'
 	],
 	#category : 'OpalCompiler-Core-Semantics',
 	#package : 'OpalCompiler-Core',
@@ -35,11 +37,14 @@ OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	"By default, block closures are clean.
 	We now prove by checking the children that it is still the case.
 	If not the case, we will mark it as not clean"
-	| parentBlockIsClean parentBlockAccessesSelf |
+	| parentBlockAccessesSelf parentBlockHasIncomingVariables parentBlockHasNonLocalReturn |
 	parentBlockAccessesSelf := currentBlockAccessesSelf.
-	parentBlockIsClean := currentBlockIsClean.
-	currentBlockIsClean := true.
+	parentBlockHasIncomingVariables := currentBlockHasIncomingVariables.
+	parentBlockHasNonLocalReturn := currentBlockHasNonLocalReturn.
+	
 	currentBlockAccessesSelf := false.
+	currentBlockHasIncomingVariables := false.
+	currentBlockHasNonLocalReturn := false.
 	
 	self visitArgumentNodes: aBlockNode arguments.
 	scope := aBlockNode scope.
@@ -48,14 +53,16 @@ OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	self visitNode: aBlockNode body.
 	aBlockNode temporaries do: [ :each | self lookupAndFixBinding: each ].
 	
-	scope hasEscapingVars ifTrue: [ currentBlockIsClean := false ].
-	scope isClean: currentBlockIsClean.
+	scope hasEscapingVars ifTrue: [ currentBlockHasIncomingVariables := true ].
+	scope isClean: (currentBlockHasIncomingVariables not and: [ currentBlockHasNonLocalReturn not and: [ currentBlockAccessesSelf not ] ]).
 
 	"We come back to the parent scope.
 	Restore the value of the analysis for the current scope"
 	scope := scope popScope.
-	currentBlockIsClean := parentBlockIsClean ifNotNil: [ parentBlockIsClean and: [ currentBlockAccessesSelf not ] ].
-	currentBlockAccessesSelf := parentBlockAccessesSelf
+	currentBlockAccessesSelf := parentBlockAccessesSelf ifNotNil: [ parentBlockAccessesSelf or: [ currentBlockAccessesSelf ] ].
+	currentBlockHasNonLocalReturn := parentBlockHasNonLocalReturn ifNotNil: [ parentBlockHasNonLocalReturn or: [ currentBlockHasNonLocalReturn ] ].
+	currentBlockHasIncomingVariables := parentBlockHasIncomingVariables.
+	
 ]
 
 { #category : 'visiting' }
@@ -86,7 +93,7 @@ OCASTClosureAnalyzer >> visitMethodNode: aMethodNode [
 { #category : 'visiting' }
 OCASTClosureAnalyzer >> visitReturnNode: aReturnNode [
 
-	currentBlockIsClean := false.
+	currentBlockHasNonLocalReturn := true.
 	^ super visitReturnNode: aReturnNode
 ]
 
@@ -98,8 +105,8 @@ OCASTClosureAnalyzer >> visitVariableNode: aVariableNode [
 	accessesSelf := variableBinding isInstanceVariable or: [ variableBinding isSelfVariable or: [ variableBinding isSuperVariable ] ].
 	
 	accessesSelf ifTrue: [ currentBlockAccessesSelf := true ].
-	(accessesSelf or: [ variableBinding isLocalVariable and: [ variableBinding scope ~= scope ] ])
-		ifTrue: [ currentBlockIsClean := false ].
+	(variableBinding isLocalVariable and: [ variableBinding scope ~= scope ])
+		ifTrue: [ currentBlockHasIncomingVariables := true ].
 
 	^ super visitVariableNode: aVariableNode
 ]

--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -7,7 +7,6 @@ Class {
 	#superclass : 'OCProgramNodeVisitor',
 	#instVars : [
 		'scope',
-		'currentBlockIsClean',
 		'currentBlockAccessesSelf',
 		'currentBlockHasNonLocalReturn',
 		'currentBlockHasIncomingVariables'

--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -6,7 +6,8 @@ Class {
 	#name : 'OCASTClosureAnalyzer',
 	#superclass : 'OCProgramNodeVisitor',
 	#instVars : [
-		'scope'
+		'scope',
+		'currentBlockIsClean'
 	],
 	#category : 'OpalCompiler-Core-Semantics',
 	#package : 'OpalCompiler-Core',
@@ -29,12 +30,22 @@ OCASTClosureAnalyzer >> visitArgumentNode: aVariableNode [
 { #category : 'visiting' }
 OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	"here look at the temps and make copying vars / tempVector out of them"
+	
+	"By default, block closures are clean.
+	We now prove by checking the children that it is still the case.
+	If not the case, we will mark it as not clean"
+	currentBlockIsClean := true.
+	
 	self visitArgumentNodes: aBlockNode arguments.
 	scope := aBlockNode scope.
 	scope moveEscapingWritesToTempVector.
 	scope copyEscapingReads.
 	self visitNode: aBlockNode body.
 	aBlockNode temporaries do: [ :each | self lookupAndFixBinding: each ].
+	
+	scope hasEscapingVars ifTrue: [ currentBlockIsClean := false ].
+	scope isClean: currentBlockIsClean.
+	
 	scope := scope popScope
 ]
 
@@ -58,4 +69,22 @@ OCASTClosureAnalyzer >> visitMethodNode: aMethodNode [
 	scope copyEscapingReads.
 	self visitNode: aMethodNode body.
 	aMethodNode temporaries do: [ :each | self lookupAndFixBinding: each ]
+]
+
+{ #category : 'visiting' }
+OCASTClosureAnalyzer >> visitReturnNode: aReturnNode [
+
+	currentBlockIsClean := false.
+	^ super visitReturnNode: aReturnNode
+]
+
+{ #category : 'visiting' }
+OCASTClosureAnalyzer >> visitVariableNode: aVariableNode [
+
+	| accessesSelf variableBinding |
+	variableBinding := aVariableNode variable.
+	accessesSelf := variableBinding isInstanceVariable or: [ variableBinding isSelfVariable or: [ variableBinding isSuperVariable ] ].
+	accessesSelf ifTrue: [ currentBlockIsClean := false ].
+
+	^ super visitVariableNode: aVariableNode
 ]

--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -34,6 +34,8 @@ OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	"By default, block closures are clean.
 	We now prove by checking the children that it is still the case.
 	If not the case, we will mark it as not clean"
+	| parentBlockIsClean |
+	parentBlockIsClean := currentBlockIsClean.
 	currentBlockIsClean := true.
 	
 	self visitArgumentNodes: aBlockNode arguments.
@@ -45,8 +47,11 @@ OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	
 	scope hasEscapingVars ifTrue: [ currentBlockIsClean := false ].
 	scope isClean: currentBlockIsClean.
-	
-	scope := scope popScope
+
+	"We come back to the parent scope.
+	Restore the value of the analysis for the current scope"
+	scope := scope popScope.
+	currentBlockIsClean := parentBlockIsClean 
 ]
 
 { #category : 'visiting' }
@@ -57,7 +62,10 @@ OCASTClosureAnalyzer >> visitLocalVariableNode: aVariableNode [
 	var isTempVectorTemp ifTrue: [ | vectorVar |
 		vectorVar := scope lookupVar: var vectorName.
 		scope addCopyingTempToAllScopesUpToDefTemp: vectorVar].
-	var isCopying ifTrue: [scope addCopyingTempToAllScopesUpToDefTemp: var]
+	var isCopying ifTrue: [scope addCopyingTempToAllScopesUpToDefTemp: var].
+	
+	"Continue the iteration so we call other defined hooks"
+	super visitLocalVariableNode: aVariableNode
 ]
 
 { #category : 'visiting' }
@@ -84,7 +92,9 @@ OCASTClosureAnalyzer >> visitVariableNode: aVariableNode [
 	| accessesSelf variableBinding |
 	variableBinding := aVariableNode variable.
 	accessesSelf := variableBinding isInstanceVariable or: [ variableBinding isSelfVariable or: [ variableBinding isSuperVariable ] ].
-	accessesSelf ifTrue: [ currentBlockIsClean := false ].
+	
+	(accessesSelf or: [ variableBinding isLocalVariable and: [ variableBinding scope ~= scope ] ])
+		ifTrue: [ currentBlockIsClean := false ].
 
 	^ super visitVariableNode: aVariableNode
 ]

--- a/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
+++ b/src/OpalCompiler-Core/OCASTClosureAnalyzer.class.st
@@ -7,7 +7,8 @@ Class {
 	#superclass : 'OCProgramNodeVisitor',
 	#instVars : [
 		'scope',
-		'currentBlockIsClean'
+		'currentBlockIsClean',
+		'currentBlockAccessesSelf'
 	],
 	#category : 'OpalCompiler-Core-Semantics',
 	#package : 'OpalCompiler-Core',
@@ -34,9 +35,11 @@ OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	"By default, block closures are clean.
 	We now prove by checking the children that it is still the case.
 	If not the case, we will mark it as not clean"
-	| parentBlockIsClean |
+	| parentBlockIsClean parentBlockAccessesSelf |
+	parentBlockAccessesSelf := currentBlockAccessesSelf.
 	parentBlockIsClean := currentBlockIsClean.
 	currentBlockIsClean := true.
+	currentBlockAccessesSelf := false.
 	
 	self visitArgumentNodes: aBlockNode arguments.
 	scope := aBlockNode scope.
@@ -51,7 +54,8 @@ OCASTClosureAnalyzer >> visitBlockNode: aBlockNode [
 	"We come back to the parent scope.
 	Restore the value of the analysis for the current scope"
 	scope := scope popScope.
-	currentBlockIsClean := parentBlockIsClean 
+	currentBlockIsClean := parentBlockIsClean ifNotNil: [ parentBlockIsClean and: [ currentBlockAccessesSelf not ] ].
+	currentBlockAccessesSelf := parentBlockAccessesSelf
 ]
 
 { #category : 'visiting' }
@@ -93,6 +97,7 @@ OCASTClosureAnalyzer >> visitVariableNode: aVariableNode [
 	variableBinding := aVariableNode variable.
 	accessesSelf := variableBinding isInstanceVariable or: [ variableBinding isSelfVariable or: [ variableBinding isSuperVariable ] ].
 	
+	accessesSelf ifTrue: [ currentBlockAccessesSelf := true ].
 	(accessesSelf or: [ variableBinding isLocalVariable and: [ variableBinding scope ~= scope ] ])
 		ifTrue: [ currentBlockIsClean := false ].
 

--- a/src/OpalCompiler-Core/OCASTTranslator.class.st
+++ b/src/OpalCompiler-Core/OCASTTranslator.class.st
@@ -601,7 +601,7 @@ OCASTTranslator >> visitBlockNode: aBlockNode [
 
 	aBlockNode isInlined ifTrue: [^ self visitInlinedBlockNode: aBlockNode ].
 	(self compilationContext optionConstantBlockClosure and: [aBlockNode isConstant and: [ aBlockNode numArgs < 4  ]]) ifTrue: [ ^ self visitConstantBlockNode: aBlockNode].
-	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ]) ifTrue: [ ^ self visitCleanBlockNode: aBlockNode].
+	(self compilationContext optionCleanBlockClosure and: [ aBlockNode scope isClean ]) ifTrue: [ ^ self visitCleanBlockNode: aBlockNode].
 
 	compiledBlock := self subTranslator translateFullBlock: aBlockNode.
 

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -150,14 +150,12 @@ OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aCo
 	"Is this the definition context for var? If it not, we look in the outer context using the corresponding outer scope. If found, we return the context"
 
 	| nextContext |
+	self = var scope ifTrue: [ ^ aContext ].
+	
 	nextContext := self nextOuterScopeContextOf: aContext.
-	nextContext
-	 ifNil: [  (var isArgumentVariable )
-        ifTrue: [ ^aContext ]
-        ifFalse: [ self error: var name, ' optimized out' ] ].
-	^self = var scope
-		ifFalse: [ self outerScope lookupDefiningContextForVariable: var startingFrom: nextContext ]
-		ifTrue: [ aContext ]
+	nextContext ifNil: [ self error: var name, ' optimized out' ].
+	
+	^ self outerScope lookupDefiningContextForVariable: var startingFrom: nextContext
 ]
 
 { #category : 'lookup' }

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -161,7 +161,6 @@ OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aCo
 { #category : 'lookup' }
 OCAbstractMethodScope >> lookupVar: name [
 
-	| found |
 	"Return a variable or nil if not found"
 
 	"Be aware that this method is used in two different phases:
@@ -177,24 +176,7 @@ OCAbstractMethodScope >> lookupVar: name [
 	tempVars at: name ifPresent: [:v | ^ v].
 	name = self tempVectorName ifTrue: [ ^ self tempVectorVar ].
 	
-	"Otherwise, look it up in the enclosing context.
-	But be careful of satisfying the clean block rules."
-	
-	found := super lookupVar: name.
-	found ifNil: [ ^ found ].
-	
-	(self isBlockScope and: [ self isClean ])
-		ifFalse: [ ^ found ].
-	
-	"We are in a block scope, do not return self, super, ivar, temps nor args"
-	(found isSelfVariable or: [ found isSuperVariable ])
-		ifTrue: [ ^ nil ].
-	
-	found isInstanceVariable ifTrue: [ ^ nil ].
-	found isLocalVariable ifTrue: [ ^ nil ].
-	
-	"The rest of variables (e.g., globals, thisContext) are visible!"
-	^ found
+	^ super lookupVar: name
 ]
 
 { #category : 'scope' }

--- a/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
+++ b/src/OpalCompiler-Core/OCAbstractMethodScope.class.st
@@ -10,7 +10,8 @@ Class {
 		'tempVector',
 		'id',
 		'tempVectorVar',
-		'node'
+		'node',
+		'isClean'
 	],
 	#category : 'OpalCompiler-Core-Semantics',
 	#package : 'OpalCompiler-Core',
@@ -109,7 +110,22 @@ OCAbstractMethodScope >> initialize [
 	tempVars :=  OrderedDictionary new.
 	tempVector  := OrderedDictionary new.
 	copiedVars := OrderedDictionary new.
-	id := 0
+	id := 0.
+	
+	"Closures are not clean unless proven otherwise"
+	isClean := false.
+]
+
+{ #category : 'accessing' }
+OCAbstractMethodScope >> isClean [
+
+	^ isClean
+]
+
+{ #category : 'accessing' }
+OCAbstractMethodScope >> isClean: anObject [
+
+	isClean := anObject
 ]
 
 { #category : 'temp vars' }
@@ -147,11 +163,40 @@ OCAbstractMethodScope >> lookupDefiningContextForVariable: var startingFrom: aCo
 { #category : 'lookup' }
 OCAbstractMethodScope >> lookupVar: name [
 
+	| found |
+	"Return a variable or nil if not found"
+
+	"Be aware that this method is used in two different phases:
+	 - at compile time, it's first called to do name resolution. 
+	   During this phase, no block scope is marked as clean, so we do a full name resolution.
+	   We return self/super/instvars/outer vars even if the block *will* be clean.	
+	 - at runtime, after block scopes are marked as clean/not clean, we cut the variable lookup"
+
+
+	"If the variable is defined locally, just return it"
 	copiedVars at: name ifPresent: [:v | ^ v].
 	tempVector at: name ifPresent: [:v | ^ v].
 	tempVars at: name ifPresent: [:v | ^ v].
 	name = self tempVectorName ifTrue: [ ^ self tempVectorVar ].
-	^ super lookupVar: name
+	
+	"Otherwise, look it up in the enclosing context.
+	But be careful of satisfying the clean block rules."
+	
+	found := super lookupVar: name.
+	found ifNil: [ ^ found ].
+	
+	(self isBlockScope and: [ self isClean ])
+		ifFalse: [ ^ found ].
+	
+	"We are in a block scope, do not return self, super, ivar, temps nor args"
+	(found isSelfVariable or: [ found isSuperVariable ])
+		ifTrue: [ ^ nil ].
+	
+	found isInstanceVariable ifTrue: [ ^ nil ].
+	found isLocalVariable ifTrue: [ ^ nil ].
+	
+	"The rest of variables (e.g., globals, thisContext) are visible!"
+	^ found
 ]
 
 { #category : 'scope' }

--- a/src/OpalCompiler-Core/OCBlockNode.extension.st
+++ b/src/OpalCompiler-Core/OCBlockNode.extension.st
@@ -25,19 +25,6 @@ OCBlockNode >> ir: aIRMethodNode [
 ]
 
 { #category : '*OpalCompiler-Core' }
-OCBlockNode >> isClean [
-	"a block is clean if..."
-	"it or any embedded blocks do not need self"
-	self isAccessingSelf ifTrue: [ ^ false ].
-	"it or any embedded blocks do not need the outer context to return"
-	self hasNonLocalReturn ifTrue: [ ^ false ].
-	"there are no escaping vars accessed from the outer"
-	self scope hasEscapingVars ifTrue: [ ^ false ].
-	^true
-
-]
-
-{ #category : '*OpalCompiler-Core' }
 OCBlockNode >> isInlined [
 	parent isMessage ifFalse: [ ^ false ].
 	parent methodCompilationContextOrNil ifNotNil:[:c | c optionInlineNone ifTrue: [ ^false ]].

--- a/src/OpalCompiler-Core/OCBlockScope.class.st
+++ b/src/OpalCompiler-Core/OCBlockScope.class.st
@@ -37,6 +37,30 @@ OCBlockScope >> isOptimized [
 ]
 
 { #category : 'lookup' }
+OCBlockScope >> lookupVar: name [
+
+	"Look up the variable in the current scope and satisfy the clean block rules.
+	In particular, we do not care about inlined blocks, since they actually live in their enclosing context"
+	
+	| found |
+	found := super lookupVar: name.
+	found ifNil: [ ^ found ].
+	
+	(self isOptimized or: [ self isClean not ])
+		ifTrue: [ ^ found ].
+	
+	"We are in a non-inlined clean block scope: do not return self, super, ivar, temps nor args"
+	(found isSelfVariable or: [ found isSuperVariable ])
+		ifTrue: [ ^ nil ].
+	
+	found isInstanceVariable ifTrue: [ ^ nil ].
+	(found isLocalVariable and: [ found scope = self ]) ifFalse: [ ^ nil ].
+	
+	"The rest of variables (e.g., globals, thisContext) are visible!"
+	^ found
+]
+
+{ #category : 'lookup' }
 OCBlockScope >> nextOuterScopeContextOf: aContext [
 
 	"Returns the next context to lookup a variable name from within outer scope.

--- a/src/OpalCompiler-Core/OCProgramNode.extension.st
+++ b/src/OpalCompiler-Core/OCProgramNode.extension.st
@@ -34,9 +34,3 @@ OCProgramNode >> owningScope [
 OCProgramNode >> scope [
 	^ self methodOrBlockNode scope
 ]
-
-{ #category : '*OpalCompiler-Core' }
-OCProgramNode >> scopeForContext: aContext [
-
-	^ self scope
-]

--- a/src/Reflectivity/RFASTTranslator.class.st
+++ b/src/Reflectivity/RFASTTranslator.class.st
@@ -117,7 +117,7 @@ RFASTTranslator >> visitBlockNode: aBlockNode [
 				ifTrue: [ self emitMetaLinkInstead: aBlockNode ]
 				ifFalse: [
 	compiledBlock := self subTranslator translateFullBlock: aBlockNode.
-	(self compilationContext optionCleanBlockClosure and: [ aBlockNode isClean ])
+	(self compilationContext optionCleanBlockClosure and: [ aBlockNode scope isClean ])
 		ifTrue: [ methodBuilder pushLiteral: (CleanBlockClosure compiledBlock: compiledBlock)]
 		ifFalse: [methodBuilder pushFullClosureCompiledBlock: compiledBlock copiedValues: aBlockNode scope inComingCopiedVarNames  ].
 	].

--- a/src/Slot-Tests/SelfVariableTest.class.st
+++ b/src/Slot-Tests/SelfVariableTest.class.st
@@ -19,14 +19,10 @@ SelfVariableTest >> testReadInContext [
 { #category : 'tests' }
 SelfVariableTest >> testReadInContextClean [
 	<compilerOptions: #( +optionCleanBlockClosure)>
-	| var block |
-	"if context is one stack we can read"
-	block := [ (thisContext lookupVar: #self) readInContext: thisContext ].
-	self assert: block value equals: self.
-	"but no chance if not, then it is nil"
-	var := self class lookupVar: #self.
-	block :=  [ thisContext ].
-	self assert: (var readInContext: block value ) equals: nil
+	| block |
+
+	block := [ (thisContext lookupVar: #self) ].
+	self assert: block value equals: nil
 ]
 
 { #category : 'tests' }

--- a/src/Slot-Tests/SuperVariableTest.class.st
+++ b/src/Slot-Tests/SuperVariableTest.class.st
@@ -19,14 +19,10 @@ SuperVariableTest >> testReadInContext [
 { #category : 'tests' }
 SuperVariableTest >> testReadInContextClean [
 	<compilerOptions: #( +optionCleanBlockClosure)>
-	| var block |
-	"if context is one stack we can read"
-	block := [ (thisContext lookupVar: #super) readInContext: thisContext ].
-	self assert: block value equals: super.
-	"but no chance if not, then it is nil"
-	var := self class lookupVar: #self.
-	block :=  [ thisContext ].
-	self assert: (var readInContext: block value ) equals: nil
+	| block |
+
+	block := [ (thisContext lookupVar: #super) ].
+	self assert: block value equals: nil
 ]
 
 { #category : 'tests' }

--- a/src/Slot-Tests/TemporaryVariableTest.class.st
+++ b/src/Slot-Tests/TemporaryVariableTest.class.st
@@ -61,6 +61,24 @@ TemporaryVariableTest >> testReadNodes [
 ]
 
 { #category : 'tests' }
+TemporaryVariableTest >> testReadTemporaryVariableInCleanBlock [
+	
+	| context |
+	context := [ | b | b := 2 . thisContext copy ] value.
+	
+	self assert: (context readVariableNamed: #b) equals: 2
+]
+
+{ #category : 'tests' }
+TemporaryVariableTest >> testReadTemporaryVariableInNonCleanBlock [
+	
+	| context outer |
+	context := [ | b | b := 2 . outer . thisContext copy ] value.
+	
+	self assert: (context readVariableNamed: #b) equals: 2
+]
+
+{ #category : 'tests' }
 TemporaryVariableTest >> testReadTemporaryVariablesMethod [
 	| tempVar |
 	tempVar := thisContext lookupVar: #tempVar.

--- a/src/SystemCommands-PackageCommands/SycRenamePackageCommand.class.st
+++ b/src/SystemCommands-PackageCommands/SycRenamePackageCommand.class.st
@@ -12,7 +12,6 @@ Class {
 	#superclass : 'CmdCommand',
 	#instVars : [
 		'package',
-		'newName',
 		'refactoringScopes'
 	],
 	#category : 'SystemCommands-PackageCommands',

--- a/src/SystemCommands-SourceCodeCommands/SycInlineTempCommand.class.st
+++ b/src/SystemCommands-SourceCodeCommands/SycInlineTempCommand.class.st
@@ -4,9 +4,6 @@ I am a command to inline selected temp variable (represented by source node)
 Class {
 	#name : 'SycInlineTempCommand',
 	#superclass : 'SycSourceCodeRefactoringCommand',
-	#instVars : [
-		'refactoringScopes'
-	],
 	#category : 'SystemCommands-SourceCodeCommands',
 	#package : 'SystemCommands-SourceCodeCommands'
 }


### PR DESCRIPTION
Block scopes are marked as clean during semantic analysis. Make lookupVar: work correctly before and after analysis.

Fixes #19552