### PR TITLE
Fix dependency of BaselineOfFiles tests

### DIFF
--- a/src/BaselineOfKernel/BaselineOfKernel.class.st
+++ b/src/BaselineOfKernel/BaselineOfKernel.class.st
@@ -29,7 +29,12 @@ BaselineOfKernel >> baseline: spec [
 	<baseline>
 	spec for: #common do: [
 			spec
-				baseline: 'Files' with: [ spec repository: 'github://NathanMalenge/pharo/src' ];
+				baseline: 'Files-Tests' with: [ 
+					spec
+						className: 'BaselineOfFiles';
+						repository: (self packageRepositoryURLForSpec: spec);
+						loads: #( 'Tests' )];
+
 				package: 'Announcements-Core';
 				package: 'Collections-Abstract';
 				package: 'Collections-DoubleLinkedList';
@@ -77,7 +82,6 @@ BaselineOfKernel >> baseline: spec [
 				package: 'Collections-Weak-Tests' with: [ spec requires: #( 'Collections-Unordered-Tests' ) ];
 				package: 'Kernel-Tests';
 				package: 'Kernel-CodeModel-Tests';
-				package: 'Files-Tests' with: [spec requires: #('Files')];
 				package: 'Announcements-Core-Tests';
 				package: 'System-Platforms-Tests';
 				package: 'System-Finalization-Tests';


### PR DESCRIPTION
Fixed an issue with the baseline of kernel: 
 - properly declare that the baseline is in the same repo
 - make the file dependency only load test
 - remove duplicated 'Files-Tests'  package