### PR TITLE
Mark DNU methods as entry points for the debugger

### DIFF
--- a/src/Kernel/Object.class.st
+++ b/src/Kernel/Object.class.st
@@ -640,6 +640,7 @@ Object >> doesNotUnderstand: aMessage [
 
 	<reflection: 'Message sending and code execution - Control message passing'>
 	<debuggerCompleteToSender>
+	<dnuEntryPoint>
 	 "Handle the fact that there was an attempt to send the given message to the receiver but the receiver does not understand this message (typically sent from the machine when a message is sent to the receiver and no method is defined for that selector)."
 
 	^ aMessage selector handleDoesNotUnderstand: aMessage to: self

--- a/src/Kernel/ProtoObject.class.st
+++ b/src/Kernel/ProtoObject.class.st
@@ -98,6 +98,7 @@ ProtoObject >> doesNotUnderstand: aMessage [
 
 	<reflection: 'Message sending and code execution - Control message passing'>
 	<debuggerCompleteToSender>
+	<dnuEntryPoint>
 
 	^ MessageNotUnderstood new
 		message: aMessage;


### PR DESCRIPTION
We mark the DNU methods to be able to find them and rewrite them when clicking the "implement missing method" in the debugger.