### PR TITLE
Fix: Trait new should have nil superclass

### DIFF
--- a/src/Fuel-Core/FLTraitCluster.class.st
+++ b/src/Fuel-Core/FLTraitCluster.class.st
@@ -38,9 +38,6 @@ FLTraitCluster >> materializePostInstance: aTrait with: aDecoder [
 
 	aTrait
 		initialize;
-		"#initialize sets Object as the superclass
-		but the superclass of traits is nil"
-		basicSuperclass: nil;
 		setName: name;
 		environment: environment.
 

--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -769,6 +769,12 @@ TraitTest >> testTraitHaveUsersInstanceVariable [
 ]
 
 { #category : 'tests' }
+TraitTest >> testTraitInitialize [
+	"this tests that #intialize is correctly setting the superclass to nil"
+	self assert: Trait new superclass isNil
+]
+
+{ #category : 'tests' }
 TraitTest >> testTraitRemoval [
 
 	| aClass aTrait |

--- a/src/Traits/Trait.class.st
+++ b/src/Traits/Trait.class.st
@@ -122,6 +122,12 @@ Trait >> expandedDefinitionStringFor: aPrinter [
 	^ aPrinter expandedTraitDefinitionString
 ]
 
+{ #category : 'initialization' }
+Trait >> initialize [
+	super initialize.
+	self basicSuperclass: nil
+]
+
 { #category : 'testing' }
 Trait >> isBaseTrait [
 	<reflection: 'Class structural inspection - Class kind testing'>


### PR DESCRIPTION
Fuel had a workaround to set the superclass of new Trait instances to nil. The reason was a missing #initialize.

This PR makes sure that "Trait new" superclass is nil and not Object