### PR TITLE
[P13] Fix bug while using #superclassName: when updating a class

### DIFF
--- a/src/Shift-ClassBuilder-Tests/ShiftClassBuilderTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShiftClassBuilderTest.class.st
@@ -356,6 +356,22 @@ ShiftClassBuilderTest >> testExistingClassWithClassSlotThenWeRemoveIt [
 	self assert: newClass class slots equals: #(  )
 ]
 
+{ #category : 'tests - class creation' }
+ShiftClassBuilderTest >> testExistingClassWithSuperclassName [
+	"Regression test for https://github.com/pharo-project/pharo/issues/19572"
+
+	| class |
+	class := self class classInstaller make: [ :b |
+			         b
+				         name: 'Toto';
+				         superclassName: 'Object';
+				         package: self packageNameForTest ].
+
+	class := self class classInstaller update: class to: [ :b | b superclassName: 'TestCase' ].
+
+	self assert: class superclass name equals: 'TestCase'
+]
+
 { #category : 'tests - classBuilder generation' }
 ShiftClassBuilderTest >> testFillShiftClassBuilder [
 

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -630,6 +630,7 @@ ShiftClassBuilder >> superclassName [
 { #category : 'accessing' }
 ShiftClassBuilder >> superclassName: anObject [
 
+	superclass := nil. "In the case we update a class and use #superclassName:, we should flush the superclass saved."
 	superclassName := anObject ifNotNil: [ anObject asSymbol ]
 ]
 


### PR DESCRIPTION
I'm proposing to backporting to Pharo 13 because I'll need this fix for a future Moose update