### PR TITLE
[Refactoring] Fix flow execution order for `Convert temp to IV`

### DIFF
--- a/src/Refactoring-Core/ReTemporaryToInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Core/ReTemporaryToInstanceVariableRefactoring.class.st
@@ -161,12 +161,12 @@ ReTemporaryToInstanceVariableRefactoring >> prepareForExecution [
 { #category : 'transforming' }
 ReTemporaryToInstanceVariableRefactoring >> privateTransform [
 
+	class addInstanceVariable: temporaryVariableName.
 	self removeTemporaryOfClass: class.
 	class allSubclasses do: [ :cls |
-			(cls definesInstanceVariable: temporaryVariableName)
+			(cls directlyDefinesInstanceVariable: temporaryVariableName)
 				ifTrue: [ cls removeInstanceVariable: temporaryVariableName ]
-				ifFalse: [ self removeTemporaryOfClass: cls ] ].
-	class addInstanceVariable: temporaryVariableName 
+				ifFalse: [ self removeTemporaryOfClass: cls ] ]
 ]
 
 { #category : 'removing' }

--- a/src/Refactoring-UI-Tests/ReGenerateEqualAndHashDriverTest.class.st
+++ b/src/Refactoring-UI-Tests/ReGenerateEqualAndHashDriverTest.class.st
@@ -29,7 +29,7 @@ ReGenerateEqualAndHashDriverTest >> testGenerateEqualAndHashExistingImplementors
 	| driver rbClass driverChanges |
 
 	testingEnvironment := RBClassEnvironment class: self classForEqualAndHashExistingImplementors. 	
-	driver := ReGenerateEqualAndHashDriver basicNew. 
+	driver := ReGenerateEqualAndHashDriver new. 
 	self setUpDriver: driver.
 	driver scopes: { testingEnvironment }.
 	rbClass := testingEnvironment class.
@@ -60,7 +60,7 @@ ReGenerateEqualAndHashDriverTest >> testGenerateEqualAndHashFirstGen [
 	| driver rbClass driverChanges |
 
 	testingEnvironment := RBClassEnvironment class: self classForEqualAndHash.
-	driver := ReGenerateEqualAndHashDriver basicNew.
+	driver := ReGenerateEqualAndHashDriver new.
 	self setUpDriver: driver.
 	driver scopes: { testingEnvironment }.
 	rbClass := testingEnvironment class.

--- a/src/Refactoring-UI-Tests/ReGeneratePrintOnDriverTest.class.st
+++ b/src/Refactoring-UI-Tests/ReGeneratePrintOnDriverTest.class.st
@@ -21,7 +21,8 @@ ReGeneratePrintOnDriverTest >> testGeneratePrintOn [
 	| driver rbClass driverChanges |
 
 	testingEnvironment := RBClassEnvironment class: self classForPrintOn. 	
-	driver := ReGeneratePrintOnDriver basicNew. 
+
+	driver := ReGeneratePrintOnDriver new. 
 	self setUpDriver: driver.
 	driver scopes: { testingEnvironment }.
 	rbClass := testingEnvironment class.

--- a/src/Refactoring-UI-Tests/StRequestDialogMock.class.st
+++ b/src/Refactoring-UI-Tests/StRequestDialogMock.class.st
@@ -1,22 +1,42 @@
 Class {
 	#name : 'StRequestDialogMock',
 	#superclass : 'Object',
+	#instVars : [
+		'response'
+	],
 	#category : 'Refactoring-UI-Tests',
 	#package : 'Refactoring-UI-Tests'
 }
 
+{ #category : 'accessing' }
+StRequestDialogMock >> message: aString [
+
+	^ self
+]
+
 { #category : 'api - showing' }
 StRequestDialogMock >> openModal [
 
-	
+	^ response
+]
+
+{ #category : 'accessing' }
+StRequestDialogMock >> response: aString [
+	response := aString
 ]
 
 { #category : 'accessing' }
 StRequestDialogMock >> text: aString [ 
-	^ ' doesnothing '
+	^ self
 ]
 
 { #category : 'accessing' }
 StRequestDialogMock >> title: aString [ 
-	^ ' doesnothing '
+	^ self
+]
+
+{ #category : 'api' }
+StRequestDialogMock >> validateAnswer: aBlock [
+
+	^ self
 ]

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -120,7 +120,8 @@ ReInteractionDriver >> application: anApplication [
 ReInteractionDriver >> applyChanges [
 
 	| applied |
-	forTesting ifTrue: [ ^ self changes ].
+
+	forTesting ifTrue: [ ^ self ].
 	applied := self openPreviewWithChanges: self changes "it looks like there is a bug in Spec" "stoppedBeforeApplyingRefactoring := applied isCancelled not
 	isCancelled returns always true so I will use it when this will be fixed in spec."
 ]

--- a/src/Refactoring-UI/ReInteractionDriver.class.st
+++ b/src/Refactoring-UI/ReInteractionDriver.class.st
@@ -21,7 +21,8 @@ Class {
 		'requestDialog',
 		'informDialog',
 		'stoppedBeforeApplyingRefactoring',
-		'selectDialogForBreakingChanges'
+		'selectDialogForBreakingChanges',
+		'forTesting'
 	],
 	#classInstVars : [
 		'shouldPreviewChanges'
@@ -119,7 +120,7 @@ ReInteractionDriver >> application: anApplication [
 ReInteractionDriver >> applyChanges [
 
 	| applied |
-
+	forTesting ifTrue: [ ^ self changes ].
 	applied := self openPreviewWithChanges: self changes "it looks like there is a bug in Spec" "stoppedBeforeApplyingRefactoring := applied isCancelled not
 	isCancelled returns always true so I will use it when this will be fixed in spec."
 ]
@@ -183,6 +184,18 @@ ReInteractionDriver >> failedPreconditionsErrorString: conditions [
 		  conditions do: [ :cond |
 				  cond violationMessageOn: stream.
 				  stream cr ] ]
+]
+
+{ #category : 'accessing' }
+ReInteractionDriver >> forTesting [
+
+	^ forTesting
+]
+
+{ #category : 'accessing' }
+ReInteractionDriver >> forTesting: aBoolean [
+
+	forTesting := aBoolean
 ]
 
 { #category : 'execution' }
@@ -255,8 +268,8 @@ ReInteractionDriver >> informDialog: aDialog [
 ReInteractionDriver >> initialize [
 
 	super initialize.
-	stoppedBeforeApplyingRefactoring := false.
-	"for now unused but we should soon use it. Check applyChanges"
+	forTesting := false.
+	stoppedBeforeApplyingRefactoring := false "for now unused but we should soon use it. Check applyChanges"
 ]
 
 { #category : 'configuration' }

--- a/src/Refactoring-UI/ReRenameClassDriver.class.st
+++ b/src/Refactoring-UI/ReRenameClassDriver.class.st
@@ -71,10 +71,11 @@ ReRenameClassDriver >> gatherUserInput [
 ]
 
 { #category : 'initialization' }
-ReRenameClassDriver >> initialize [ 
-	
+ReRenameClassDriver >> initialize [
+
 	super initialize.
-	shouldEscape := false.
+	requestDialog := self defaultRequestDialog.
+	shouldEscape := false
 ]
 
 { #category : 'configuration' }
@@ -109,7 +110,7 @@ ReRenameClassDriver >> renameClass [
 { #category : 'execution' }
 ReRenameClassDriver >> requestNewNameBasedOn: aName [
 
-	newName := self defaultRequestDialog
+	newName := requestDialog 
 		           title: 'Please provide a new class name';
 		           message: 'The new name should be valid and not the one of an existing class.';
 		           validateAnswer: [ :string :presenter | self validateName: string onPresenter: presenter ];


### PR DESCRIPTION
It was raising an error since we removed the temp before adding the IV.
Also new API for the driver to test the spec refactoring commands !
- `forTesting` IV creation used to return changes for tests, also updated the dialog mocks for tests to perform well