### PR TITLE
Modify how the doubleclick bug fix works

### DIFF
--- a/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
+++ b/src/Morphic-Widgets-FastTable/FTTableMorph.class.st
@@ -48,7 +48,8 @@ Class {
 		'needToggleAtMouseUp',
 		'function',
 		'resizable',
-		'selectionModeStrategy'
+		'selectionModeStrategy',
+		'lastIndexOnMouseDown'
 	],
 	#category : 'Morphic-Widgets-FastTable-Base',
 	#package : 'Morphic-Widgets-FastTable',
@@ -307,27 +308,11 @@ FTTableMorph >> disableFunction [
 
 { #category : 'event handling' }
 FTTableMorph >> doubleClick: event [
-
-	(self selectionModeStrategy selectableIndexContainingPoint:
-		 event cursorPoint) ifNotNil: [ :firstClickedIndex |
-		| pdcEvent |
-		pdcEvent := event asPseudoDoubleClickEvent.
-		(self selectionModeStrategy selectableIndexContainingPoint:
-			 pdcEvent secondEvent position) ifNotNil: [ :secondClickedIndex |
-			firstClickedIndex = secondClickedIndex
-				ifFalse: [
-					self selectionStrategy
-						selectIndex: secondClickedIndex
-						event: pdcEvent secondEvent ]
-				ifTrue: [
-					self selectedIndexes
-						detect: [ :i | i = secondClickedIndex ]
-						ifNone: [
-							self selectionStrategy
-								selectIndex: secondClickedIndex
-								event: pdcEvent secondEvent ].
-					self doAnnounce:
-						(FTStrongSelectionChanged index: secondClickedIndex event: event) ] ] ]
+	
+	(self selectionModeStrategy selectableIndexContainingPoint: event cursorPoint) 
+		ifNotNil: [ :index | 
+			lastIndexOnMouseDown = index ifTrue: [ 
+				self doAnnounce: (FTStrongSelectionChanged index: index event: event) ] ]
 ]
 
 { #category : 'drawing' }
@@ -791,6 +776,14 @@ FTTableMorph >> minWidth [
 FTTableMorph >> mouseDown: event [
 	"perform the click"
 
+	"I need to keep the index of the selected cell (row, most of the times) on mousedown 
+	 because there is a bug: rapid click on two different items in a list gets interpreted 
+	 as a double-click on the first item. This works because mouseDown: is triggered the 
+	 first time, but not the second (that goes directly to doubleClick:)
+	 https://github.com/pharo-project/pharo/issues/14168"
+	lastIndexOnMouseDown :=  self selectionModeStrategy 
+		selectableIndexContainingPoint: event cursorPoint.
+		
 	needToggleAtMouseUp ifTrue: [ ^ self ].
 
 	(self selectionModeStrategy selectableIndexContainingPoint: event cursorPoint)


### PR DESCRIPTION
(that two fast clicks on slightly different rows can trigger also a doubleclick event) by registering the first mousedown: event and comparing.

The old fix was causing that a list inside a scroll pane was not  receiving double click events. While is highly probably that the real bug resides on the bubbling on events, this thing is easy and works :)

fixes https://github.com/pharo-project/pharo/issues/14168 
fixes https://github.com/pharo-spec/NewTools/issues/1364