### PR TITLE
Refactoring smelly code

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -2217,13 +2217,14 @@ String >> normalizeCamelCase [
 	
 	"'TheRollingStones' normalizeCamelCase >>> 'The Rolling Stones'"
 	"'The Rolling Stones' normalizeCamelCase >>> 'The Rolling Stones'"
-	
-	^ self class streamContents: [ : stream |
-		self do: [ : char |
-			(char isUppercase and: [
-				(stream position > 0 and: [ stream peekLast isUppercase not ])
-					and: [ stream peekLast isSpaceSeparator not  ] ])
-						ifTrue: [ stream nextPut: Character space ].
+
+	^ self class streamContents: [ :stream |
+		self do: [ :char |
+			(char isUppercase and:
+				[ stream position > 0 and:
+					[ stream peekLast isUppercase not and:
+						[ stream peekLast isSpaceSeparator not  ] ] ])
+							ifTrue: [ stream nextPut: Character space ].
 			stream nextPut: char ] ]
 ]
 


### PR DESCRIPTION
It seems like multiple developers where working on the code and there was no unified way the code was written.

Svoboda's map is:

| AB \ CD |    00 | 01 | 11 | 10 |
| ------- | ----: | -: | -: | -: |
| 00      |     0 |  0 |  0 |  0 |
| 01      |     0 |  0 |  0 |  0 |
| 11      | **1** |  0 |  0 |  0 |
| 10      |     0 |  0 |  0 |  0 |

That means that there is only one true case (**11**):
```
A = 1  character is uppercase
B = 1  stream position > 0
C = 0  character at position `peekLast` is not uppercase
D = 0  character at position `peekLast` is not a space separator
```
That should leave us with minimal code
```Smalltalk
...
char isUppercase
  and: [
    stream position > 0
      and: [
        stream peekLast isUppercase not
          and: [ stream peekLast isSpaceSeparator not ]]]
...
```
Which is presented by the patch (removes any superfluous characters).  The logic is identical.