### PR TITLE
deprecate method selectorsWithArgs (issue #19467)

### DIFF
--- a/src/Kernel-CodeModel/Behavior.class.st
+++ b/src/Kernel-CodeModel/Behavior.class.st
@@ -1678,6 +1678,7 @@ Behavior >> selectorsDo: selectorBlock [
 Behavior >> selectorsWithArgs: numberOfArgs [
 	"Return all selectors defined in this class that take this number of arguments"
 	<reflection: 'Class structural inspection - Selectors and methods inspection'>
+	self deprecated: 'issue #19467'.
 	^ self selectors select: [:selector | selector numArgs = numberOfArgs]
 ]
 


### PR DESCRIPTION
Deprecate the method selectorsWithArgs according to the issue #19467.