### PR TITLE
[Method Browser] Fix call site for class references

### DIFF
--- a/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
@@ -58,8 +58,7 @@ ClyBrowserMorph >> browseUppercasedReferencesTo: aSymbol inNameRespolver: anEnvi
 	anEnvironment 
 		ifNil: [
 			^ {
-				  (self spawnQueryBrowserOn: (ClyClassReferencesQuery of: (self class environment at: aSymbol))) .
-				  #SendersWithouEnvironment 
+				  (Smalltalk tools toolNamed: #messageList) browseReferencesToClass: (self class environment at: aSymbol) 
 				} ].
 
 	(anEnvironment bindingOf: aSymbol) 


### PR DESCRIPTION
When looking for class references using the shortcut CMD + shift + n, it was raising DNU on the new method browser.

Fixes [#1414](https://github.com/pharo-spec/NewTools/issues/1414)