### PR TITLE
Unify API for command migration

### DIFF
--- a/src/AST-Core-Tests/OCMessageNodeTest.class.st
+++ b/src/AST-Core-Tests/OCMessageNodeTest.class.st
@@ -7,48 +7,52 @@ Class {
 }
 
 { #category : 'tests' }
-OCMessageNodeTest >> testArgumentPartsForBinaryMessages [
+OCMessageNodeTest >> testArgumentNamesForBinaryMessages [
+
 	| tree message |
 	tree := self parseMethod: 'test 1 + 2 '.
 	message := tree sendNodes first.
-	self assert: message argumentPartStrings equals: #('2')
+	self assert: message argumentNames equals: #( '2' )
 ]
 
 { #category : 'tests' }
-OCMessageNodeTest >> testArgumentPartsForKeywordMessages [
+OCMessageNodeTest >> testArgumentNamesForKeywordMessages [
+
 	| tree message |
 	tree := self parseMethod: 'test self between: x + 2 and: (y foo: 3)'.
 	message := tree sendNodes first.
-	self assert: message argumentPartStrings asArray equals: #('x + 2' '(y foo: 3)')
+	self assert: message argumentNames asArray equals: #( 'x + 2' '(y foo: 3)' )
 ]
 
 { #category : 'tests' }
-OCMessageNodeTest >> testArgumentPartsForKeywordMessages1 [
+OCMessageNodeTest >> testArgumentNamesForKeywordMessages1 [
+
 	| tree message |
 	tree := self parseMethod: 'test self between: 2 and: 3'.
 	message := tree sendNodes first.
-	self assert: message argumentPartStrings asArray equals: #('2' '3')
+	self assert: message argumentNames asArray equals: #( '2' '3' )
 ]
 
 { #category : 'tests' }
-OCMessageNodeTest >> testArgumentPartsForKeywordMessages2 [
+OCMessageNodeTest >> testArgumentNamesForKeywordMessages2 [
 
-		| tree message |
-		tree := self parseMethod: 'test self between: x and: y'.
-		message := tree sendNodes first.
-		self assert: message argumentPartStrings asArray equals: #('x' 'y').
+	| tree message |
+	tree := self parseMethod: 'test self between: x and: y'.
+	message := tree sendNodes first.
+	self assert: message argumentNames asArray equals: #( 'x' 'y' ).
 
-		tree := self parseMethod: 'test self between: x and: y and: zzz'.
-		message := tree sendNodes first.
-		self assert: message argumentPartStrings asArray equals: #('x' 'y' 'zzz')
+	tree := self parseMethod: 'test self between: x and: y and: zzz'.
+	message := tree sendNodes first.
+	self assert: message argumentNames asArray equals: #( 'x' 'y' 'zzz' )
 ]
 
 { #category : 'tests' }
-OCMessageNodeTest >> testArgumentPartsForUnaryMessages [
+OCMessageNodeTest >> testArgumentNamesForUnaryMessages [
+
 	| tree message |
 	tree := self parseMethod: 'test 1 foo '.
 	message := tree sendNodes first.
-	self assert: message argumentPartStrings equals: #()
+	self assert: message argumentNames equals: #(  )
 ]
 
 { #category : 'tests' }

--- a/src/AST-Core/OCMessageNode.class.st
+++ b/src/AST-Core/OCMessageNode.class.st
@@ -69,7 +69,7 @@ OCMessageNode >> acceptVisitor: aProgramNodeVisitor [
 ]
 
 { #category : 'accessing' }
-OCMessageNode >> argumentPartStrings [
+OCMessageNode >> argumentNames [
 	"Return a collection of string representing the code of the argument."
 	^ arguments collect: [ :each | each sourceCode asString
 			"strangely enough literal formatted code is not a string" ]

--- a/src/AST-Core/OCMessageNode.class.st
+++ b/src/AST-Core/OCMessageNode.class.st
@@ -76,13 +76,6 @@ OCMessageNode >> argumentNames [
 ]
 
 { #category : 'accessing' }
-OCMessageNode >> argumentPartStrings [
-
-	self deprecated: 'Use argumentNames instead' transformWith: '`@rcv argumentPartStrings' -> '`@rcv argumentNames'.
-	^ self argumentNames
-]
-
-{ #category : 'accessing' }
 OCMessageNode >> arguments [
 	^arguments ifNil: [#()] ifNotNil: [arguments]
 ]

--- a/src/AST-Core/OCMessageNode.class.st
+++ b/src/AST-Core/OCMessageNode.class.st
@@ -76,6 +76,13 @@ OCMessageNode >> argumentNames [
 ]
 
 { #category : 'accessing' }
+OCMessageNode >> argumentPartStrings [
+
+	self deprecated: 'Use argumentNames instead' transformWith: '`@rcv argumentPartStrings' -> '`@rcv argumentNames'.
+	^ self argumentNames
+]
+
+{ #category : 'accessing' }
 OCMessageNode >> arguments [
 	^arguments ifNil: [#()] ifNotNil: [arguments]
 ]

--- a/src/Deprecated14-Kernel/OCMessageNode.extension.st
+++ b/src/Deprecated14-Kernel/OCMessageNode.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'OCMessageNode' }
+
+{ #category : '*Deprecated14-Kernel' }
+OCMessageNode >> argumentPartStrings [
+
+	self deprecated: 'Use argumentNames instead' transformWith: '`@rcv argumentPartStrings' -> '`@rcv argumentNames'.
+	^ self argumentNames
+]


### PR DESCRIPTION
When doing the refactoring command migration in Spec, I discovered that `argumentPartStrings` was used for `OCMessageNode`, as every other object (compiled methods, OCMethodNode..) call it `argumentNames`.

So to not duplicate anything and make it work, I renamed it to unify API ( since the command I'm migrating use a `OCMessageNode` and calls for `argumentNames`