### PR TITLE
Result return for `debug:`

### DIFF
--- a/src/SUnit-Core/TestSuite.class.st
+++ b/src/SUnit-Core/TestSuite.class.st
@@ -76,14 +76,14 @@ TestSuite >> cleanTestSuite: aTestSuite [
 
 { #category : 'running' }
 TestSuite >> debug [
+
 	| result |
-	
 	result := TestResult new.
-	self runWith: [ :test | 
-		[ test debug: result ]
-		ensure: [
-			result dispatchResultsIntoHistory.
-			self testSuiteAnnouncer announce: (TestSuiteEnded result: result) ] ]
+	self runWith: [ :test |
+			[ test debug: result ] ensure: [
+					result dispatchResultsIntoHistory.
+					self testSuiteAnnouncer announce: (TestSuiteEnded result: result) ] ].
+	^ result
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
It is done like that for `run`, and it is useful when creating a TestSuite (for the Method Browser for example)