### PR TITLE
Speed up some package related features

### DIFF
--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -208,6 +208,12 @@ Package >> definedClasses [
 ]
 
 { #category : 'accessing' }
+Package >> definedClassesDo: aBlock [
+
+	^ self tags do: [ :tag | tag classesDo: aBlock ]
+]
+
+{ #category : 'accessing' }
 Package >> definedMethodsForClass: aClass [
 
 	^ (self definedSelectorsForClass: aClass) asOrderedCollection collect: [ :each | aClass >> each ]
@@ -408,7 +414,8 @@ Package >> includesClass: aClass [
 Package >> includesClassNamed: aSymbol [
 	"Returns true if the receiver includes class named aSymbol in the classes that are defined within it: only class definition are considered - not class extensions"
 
-	^ self definedClasses anySatisfy: [ :class | class name = aSymbol ]
+	self definedClassesDo: [ :class | class name = aSymbol ifTrue: [ ^ true ] ].
+	^ false
 ]
 
 { #category : 'testing' }
@@ -594,9 +601,10 @@ Package >> organizer: anObject [
 
 { #category : 'accessing' }
 Package >> packageManifestOrNil [
-	^ self definedClasses
-		detect: [ :each | each isManifest ]
-		ifNone: [ nil ]
+
+	self definedClassesDo: [ :class | class isManifest ifTrue: [ ^ class ] ].
+
+	^ nil
 ]
 
 { #category : 'system compatibility' }

--- a/src/Kernel-CodeModel/PackageTag.class.st
+++ b/src/Kernel-CodeModel/PackageTag.class.st
@@ -60,6 +60,12 @@ PackageTag >> classes [
 ]
 
 { #category : 'accessing' }
+PackageTag >> classesDo: aBlock [
+
+	^ classes do: aBlock
+]
+
+{ #category : 'accessing' }
 PackageTag >> codeChangeAnnouncer [
 
 	^ self environment codeChangeAnnouncer

--- a/src/Manifest-Core/Package.extension.st
+++ b/src/Manifest-Core/Package.extension.st
@@ -25,7 +25,7 @@ Package >> packageComment: aDescription [
 
 { #category : '*Manifest-Core' }
 Package >> packageManifest [
-	^ self definedClasses
-		detect: [ :each | each isManifest ]
-		ifNone: [ TheManifestBuilder new createManifestNamed: self name]
+
+	self definedClassesDo: [ :class | class isManifest ifTrue: [ ^ class ] ].
+	TheManifestBuilder new createManifestNamed: self name
 ]


### PR DESCRIPTION
While profiling some Moose code I found out that some methods could be optimized.

When we look for a specific class in a package we do not need to first create a full list of classes before beginning the check.