### PR TITLE
19625-Error-sending-flatCollect-to-OrderedDictionary 

### DIFF
--- a/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
+++ b/src/Collections-Sequenceable-Tests/OrderedDictionaryTest.class.st
@@ -874,6 +874,15 @@ OrderedDictionaryTest >> testEqualsWhenKeyArentInTheSameOrder [
 		assertDictionary: dictionaryOne doesNotEqual: dictionaryTwo.
 ]
 
+{ #category : 'testing' }
+OrderedDictionaryTest >> testFlatCollect [
+
+	| res |
+ 	res := {#first -> -1. #second -> 5 . #three -> -33} as: OrderedDictionary.
+	res := res flatCollect: [ :e | { e abs } ].
+ 	self assert: res asSet equals: #(1 5 33) asSet
+]
+
 { #category : 'tests' }
 OrderedDictionaryTest >> testHash [
 	| dictionary otherDictionary internalDictionary otherInternalDictionary |

--- a/src/Collections-Sequenceable/OrderedDictionary.class.st
+++ b/src/Collections-Sequenceable/OrderedDictionary.class.st
@@ -306,6 +306,16 @@ OrderedDictionary >> errorInvalidIndex: anIndex [
 	SubscriptOutOfBounds signalFor: anIndex
 ]
 
+{ #category : 'enumerating' }
+OrderedDictionary >> flatCollect: aBlock [
+	"Evaluate aBlock for each of the receiver's values (by opposition to keys) and answer the
+	list of all resulting values flatten one level. Assumes that aBlock returns some kind
+	of collection for each element. Equivalent to the lisp's mapcan"
+	"If you want to have keys use associations collect: or associations flatCollect: "
+
+	^ self flatCollect: aBlock as: OrderedCollection
+]
+
 { #category : 'private' }
 OrderedDictionary >> growOrderedKeys [
 	orderedKeys :=


### PR DESCRIPTION
add #flatCollect: and test. fixes  #19625