### PR TITLE
Fix uncategorizied in RecompileTest

### DIFF
--- a/src/Debugger-Model-Tests/RecompileTest.class.st
+++ b/src/Debugger-Model-Tests/RecompileTest.class.st
@@ -6,10 +6,6 @@ Class {
 	#tag : 'Core'
 }
 
-{ #category : 'as yet unclassified' }
-RecompileTest >> foo [ | c | c := 43
-]
-
 { #category : 'tests' }
 RecompileTest >> testRecompileDoIt [
 


### PR DESCRIPTION
the test already removes the method, but it seems it was comited by accident