### PR TITLE
Fix remove refactoring occurences check

### DIFF
--- a/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
+++ b/src/Refactoring-Core/RBRemoveMethodRefactoring.class.st
@@ -196,8 +196,11 @@ RBRemoveMethodRefactoring >> sendersExcluding: aSelectorsCollection [
 
 { #category : 'preconditions' }
 RBRemoveMethodRefactoring >> sendersOf: aSelector [
-	
-	^ self model allReferencesTo: aSelector
+
+	| occurrences |
+	occurrences := OrderedCollection new.
+	self model allReferencesTo: aSelector do: [ :aRBMethod | occurrences add: aRBMethod selector -> aRBMethod ]. 
+	^ occurrences
 ]
 
 { #category : 'preconditions' }


### PR DESCRIPTION
- `checkBrowserAllOccurences:` needed an Association to do its checks but got a Collection, that is way it raised a DNU when removing a method with a super
- Fixes #19657