### PR TITLE
`RGMethodDefinition` deprecation API

### DIFF
--- a/src/Ring-Definitions-Core-Tests/RGMethodDefinitionTest.class.st
+++ b/src/Ring-Definitions-Core-Tests/RGMethodDefinitionTest.class.st
@@ -344,6 +344,16 @@ RGMethodDefinitionTest >> testIsAbstractNonExistingMethod [
 ]
 
 { #category : 'test - accessing source' }
+RGMethodDefinitionTest >> testIsDeprecatedExistingMethod [
+	"testing existing ring method isDeprecated"
+
+	| method |
+	method := (SUnitTest >> #deprecatedMessage) asRingDefinition.
+	self assert: method isDeprecated .
+
+]
+
+{ #category : 'test - accessing source' }
 RGMethodDefinitionTest >> testMessagesExistingMethod [
 	"accessing ring sent messages for active method"
 

--- a/src/Ring-Definitions-Core-Tests/RGMethodDefinitionTest.class.st
+++ b/src/Ring-Definitions-Core-Tests/RGMethodDefinitionTest.class.st
@@ -345,7 +345,6 @@ RGMethodDefinitionTest >> testIsAbstractNonExistingMethod [
 
 { #category : 'test - accessing source' }
 RGMethodDefinitionTest >> testIsDeprecatedExistingMethod [
-	"testing existing ring method isDeprecated"
 
 	| method |
 	method := (SUnitTest >> #deprecatedMessage) asRingDefinition.

--- a/src/Ring-Definitions-Core/RGMethodDefinition.class.st
+++ b/src/Ring-Definitions-Core/RGMethodDefinition.class.st
@@ -307,6 +307,12 @@ RGMethodDefinition >> isDefined [
 ]
 
 { #category : 'testing' }
+RGMethodDefinition >> isDeprecated [
+
+	^ self compiledMethod ifNotNil: [ :cm | cm isDeprecated ] ifNil: [ false ]
+]
+
+{ #category : 'testing' }
 RGMethodDefinition >> isDoIt [
 	^self selector isDoIt
 ]


### PR DESCRIPTION
- Updated the API to support deprecation, also added a unit test
- Fixes https://github.com/pharo-spec/NewTools/issues/1429