### PR TITLE
introduce tolerance to Pharo

### DIFF
--- a/src/HeuristicCompletion-Model/CoBeginsWithFilter.class.st
+++ b/src/HeuristicCompletion-Model/CoBeginsWithFilter.class.st
@@ -17,13 +17,23 @@ Class {
 CoBeginsWithFilter class >> caseSensitive: aBoolean filterString: aString [
 
 	aBoolean ifTrue: [
-		^ CoCaseSensitiveBeginsWithFilter new
-			completionString: aString;
-			yourself ]
+		^ CoToleranceFilter new 
+			decoree: (CoCaseSensitiveBeginsWithFilter new
+				completionString: aString; yourself) 
+				; yourself ]
 		ifFalse: [
-		^ CoCaseInsensitiveBeginsWithFilter new
+		^ CoToleranceFilter new 
+			decoree: (CoCaseInsensitiveBeginsWithFilter new
 			completionString: aString;
-			yourself	]
+			yourself); yourself 	]
+]
+
+{ #category : 'testing' }
+CoBeginsWithFilter >> complementResults: aCollection [ 
+	"give a chance to the filter to complement results after the fact.
+	Called by fetch:. By default do nothing."
+	
+	^ aCollection
 ]
 
 { #category : 'accessing' }

--- a/src/HeuristicCompletion-Model/CoCaseSensitiveBeginsWithFilter.class.st
+++ b/src/HeuristicCompletion-Model/CoCaseSensitiveBeginsWithFilter.class.st
@@ -26,6 +26,11 @@ CoCaseSensitiveBeginsWithFilter >> accepts: aCandidate [
 ]
 
 { #category : 'testing' }
+CoCaseSensitiveBeginsWithFilter >> isCaseSensitive [ 
+	self shouldBeImplemented.
+]
+
+{ #category : 'testing' }
 CoCaseSensitiveBeginsWithFilter >> isLessNarrowThanCaseInsensitive: anotherFilter [
 
 	^ false

--- a/src/HeuristicCompletion-Model/CoResultSet.class.st
+++ b/src/HeuristicCompletion-Model/CoResultSet.class.st
@@ -73,7 +73,7 @@ CoResultSet >> fetch: anInteger [
 
 	| newResults |
 	newResults := fetcher next: anInteger.
-	results addAll: "(sorter sortCompletionList:" newResults
+	results addAll: (filter complementResults: newResults )
 ]
 
 { #category : 'fetching' }
@@ -100,9 +100,9 @@ CoResultSet >> filter [
 ]
 
 { #category : 'accessing' }
-CoResultSet >> filter: anObject [
+CoResultSet >> filter: aFilter [
 
-	filter := anObject.
+	filter := aFilter.
 	fetcher filter: filter
 ]
 

--- a/src/HeuristicCompletion-Model/CoToleranceFilter.class.st
+++ b/src/HeuristicCompletion-Model/CoToleranceFilter.class.st
@@ -1,0 +1,293 @@
+"
+I let the user enter typos. I have a rate of acceptance. I use an edit distance to propose alternative.
+"
+Class {
+	#name : 'CoToleranceFilter',
+	#superclass : 'CoFilter',
+	#instVars : [
+		'decoree'
+	],
+	#classVars : [
+		'MinimumTokenSize',
+		'Rate'
+	],
+	#category : 'HeuristicCompletion-Model-Core',
+	#package : 'HeuristicCompletion-Model',
+	#tag : 'Core'
+}
+
+{ #category : 'algorithms' }
+CoToleranceFilter class >> damerauLevenshteinDistanceBetween: source and: target maxDistance: maxDistance [ 
+
+	| previousRow currentRow twoRowsBack minInRow cost insertion deletion substitution value |
+	source = target ifTrue: [ ^ 0 ].
+
+	previousRow := Array new: target size + 1.
+	1 to: (target size + 1) do: [ :j |
+		previousRow at: j put: j - 1 ].
+
+	1 to: source size do: [ :i |
+		currentRow := Array new: target size + 1.
+		currentRow at: 1 put: i.
+		minInRow := i.
+
+		1 to: target size do: [ :j |
+			cost := ((source at: i) = (target at: j))
+				ifTrue: [ 0 ]
+				ifFalse: [ 1 ].
+				
+		insertion := (currentRow at: j) + 1.
+			deletion := (previousRow at: (j + 1)) + 1.
+			substitution := (previousRow at: j) + cost.
+
+			value := insertion min: deletion.
+			value := value min: substitution.
+			
+		(i > 1 and: [ j > 1 and: [
+				(source at: i) = (target at: (j - 1))
+					and: [ (source at: (i - 1)) = (target at: j) ] ] ]) ifTrue: [
+						twoRowsBack ifNotNil: [
+							value := value min: ((twoRowsBack at: (j - 1)) + 1) ] ].
+
+			currentRow at: (j + 1) put: value.
+			minInRow := minInRow min: value ].
+
+		minInRow > maxDistance ifTrue: [ ^ 0 ].
+		twoRowsBack := previousRow.
+		previousRow := currentRow ].
+	
+		^ (previousRow last <= maxDistance)
+		ifTrue: [ previousRow last ]
+		ifFalse: [ 0 ]
+]
+
+{ #category : 'default values' }
+CoToleranceFilter class >> defaultMinimumTokenSize [ 
+
+	^ 2
+]
+
+{ #category : 'default values' }
+CoToleranceFilter class >> defaultRate [ 
+
+	^ 0.6
+]
+
+{ #category : 'configuration' }
+CoToleranceFilter class >> disable [ 
+
+	Rate := -1
+]
+
+{ #category : 'configuration' }
+CoToleranceFilter class >> enable [ 
+
+	Rate := self defaultRate 
+]
+
+{ #category : 'configuration' }
+CoToleranceFilter class >> enabled [ 
+
+	^ Rate > 0.0
+]
+
+{ #category : 'class initialize' }
+CoToleranceFilter class >> initialize [ 
+
+	self reset
+]
+
+{ #category : 'configuration' }
+CoToleranceFilter class >> minimumTokenSize [ 
+
+	^ MinimumTokenSize
+]
+
+{ #category : 'configuration' }
+CoToleranceFilter class >> minimumTokenSize: anInteger [ 
+
+	MinimumTokenSize := (anInteger ifNil: [ self defaultMinimumTokenSize ]) max: 1
+]
+
+{ #category : 'configuration' }
+CoToleranceFilter class >> rate [ 
+
+	^ Rate
+]
+
+{ #category : 'configuration' }
+CoToleranceFilter class >> rate: aNumber [ 
+
+	| value |
+	value := (aNumber ifNil: [ self defaultRate ]) asFloat.
+	Rate := (value max: 0.0) min: 1.0
+]
+
+{ #category : 'configuration' }
+CoToleranceFilter class >> reset [ 
+
+	Rate := self defaultRate.
+	MinimumTokenSize := self defaultMinimumTokenSize
+]
+
+{ #category : 'algorithms' }
+CoToleranceFilter class >> scoreForCandidate: aCandidateString token: aTokenString caseSensitive: aBoolean tolerance: aTolerance [ 
+
+	| candidate token maxSize maxEdits distance |
+	candidate := aCandidateString asString.
+	token := aTokenString asString.
+
+	token isEmpty ifTrue: [ ^ 0.0 ].
+	candidate = token ifTrue: [ ^ 0.0 ].
+
+	candidate := aBoolean
+		ifTrue: [ candidate ]
+		ifFalse: [ candidate asLowercase ].
+	token := aBoolean
+		ifTrue: [ token ]
+		ifFalse: [ token asLowercase ].
+
+	(candidate beginsWith: token) ifTrue: [ ^ 0.0 ].
+	(self shouldTryFuzzyFor: token candidate: candidate tolerance: aTolerance) ifFalse: [ ^ 0 ].
+	
+maxSize := token size max: candidate size.
+	maxEdits := (aTolerance * maxSize) ceiling.
+	maxEdits <= 0 ifTrue: [ ^ 0 ].
+
+	distance := self
+		damerauLevenshteinDistanceBetween: token
+		and: candidate
+		maxDistance: maxEdits.
+
+	distance ifNil: [ ^ 0 ].
+	^ distance asFloat / maxSize
+]
+
+{ #category : 'algorithms' }
+CoToleranceFilter class >> shouldTryFuzzyFor: token candidate: candidate tolerance: aTolerance [ 
+
+	| maxSize maxEdits |
+	(self enabled not or: [ aTolerance <= 0.0 ]) ifTrue: [ ^ false ].
+	token isEmpty ifTrue: [ ^ false ].
+	candidate isEmpty ifTrue: [ ^ false ].
+	token size < self minimumTokenSize ifTrue: [ ^ false ].
+
+	"Keep keyword arity stable"
+	((token includes: $:) or: [ candidate includes: $: ]) ifTrue: [
+		(token occurrencesOf: $:) = (candidate occurrencesOf: $:)
+			ifFalse: [ ^ false ] ].
+
+	"Cheap guardrails to avoid noisy matches"
+	token first = candidate first ifFalse: [ ^ false ].
+	
+	maxSize := token size max: candidate size.
+	maxEdits := (aTolerance * maxSize) ceiling.
+	^ (token size - candidate size) abs <= maxEdits
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> accepts: aCandidate [ 
+
+	^ (decoree accepts: aCandidate) or: [ self class enabled and: [ self fuzzyAccepts: aCandidate ]]
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> complementResults: aCollection [ 
+
+	| exact fuzzy |
+	self requiresFallbackEnumeration ifFalse: [ ^ aCollection ].
+
+	exact := OrderedCollection new.
+	fuzzy := OrderedCollection new.
+
+	aCollection do: [ :each |
+		(self fuzzyAccepts: each)
+			ifTrue: [ exact add: each ]
+			ifFalse: [ fuzzy add: each ] ].
+
+	fuzzy isEmpty ifTrue: [ ^ aCollection ].
+
+	fuzzy sort: [ :a :b |
+		| scoreA scoreB |
+		scoreA := self fuzzyScoreFor: a.
+		scoreB := self fuzzyScoreFor: b.
+		scoreA = scoreB
+			ifTrue: [ a contents <= b contents ]
+			ifFalse: [ scoreA < scoreB ] ].
+
+	^ OrderedCollection new
+		addAll: exact;
+		addAll: fuzzy;
+		yourself
+
+]
+
+{ #category : 'accessing' }
+CoToleranceFilter >> completionString [ 
+
+	^ decoree completionString
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> decoree [ 
+
+	^ decoree 
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> decoree: aFilter [ 
+
+	decoree := aFilter 
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> fuzzyAccepts: aCandidate [ 
+
+	^ (self fuzzyScoreFor: aCandidate) isZero not
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> fuzzyScoreFor: aCandidate [ 
+
+	^ self class scoreForCandidate: aCandidate contents
+		token: decoree completionString
+		caseSensitive: (decoree class = CoCaseSensitiveBeginsWithFilter)
+		tolerance: Rate
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> isCaseSensitive [ 
+
+	^ decoree isCaseSensitive
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> isLessNarrowThanCaseInsensitive: anotherFilter [ 
+
+	^ decoree isLessNarrowThanCaseInsensitive: anotherFilter
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> isLessNarrowThanCaseSensitive: anotherFilter [ 
+
+	^ decoree isLessNarrowThanCaseSensitive: anotherFilter
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> isLessNarrowThanNegation: anotherFilter [ 
+
+	^ decoree isLessNarrowThanNegation: anotherFilter
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> isMoreNarrowThan: anotherFilter [ 
+
+	^ decoree isMoreNarrowThan: anotherFilter
+]
+
+{ #category : 'testing' }
+CoToleranceFilter >> requiresFallbackEnumeration [ 
+
+	^ self class  enabled
+		and: [ decoree completionString size >= self class minimumTokenSize ]
+]

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -17,6 +17,19 @@ CoCompletionEngineTest >> hasBindingOf: aSymbol [
 	^ false
 ]
 
+{ #category : 'running' }
+CoCompletionEngineTest >> setUp [
+	super setUp.
+
+	"Disable the CoToleranceFilter"
+	CoToleranceFilter disable.
+	editor := RubSmalltalkEditor forTextArea: RubEditingArea new beForSmalltalkCode.
+	interactionEngine := self newCompletionEngine.
+	interactionEngine setEditor: editor.
+	editor completionEngine: interactionEngine.
+	editor textArea model: self
+]
+
 { #category : 'tests - interaction' }
 CoCompletionEngineTest >> testCmdCtrlLeft [
 

--- a/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoCompletionEngineTest.class.st
@@ -1,6 +1,10 @@
 Class {
 	#name : 'CoCompletionEngineTest',
 	#superclass : 'CompletionEngineTest',
+	#instVars : [
+		'oldRate',
+		'oldMinimumTokenSize'
+	],
 	#category : 'HeuristicCompletion-Tests-Core',
 	#package : 'HeuristicCompletion-Tests',
 	#tag : 'Core'
@@ -21,13 +25,24 @@ CoCompletionEngineTest >> hasBindingOf: aSymbol [
 CoCompletionEngineTest >> setUp [
 	super setUp.
 
-	"Disable the CoToleranceFilter"
+	"Save the old configuration then Disable the CoToleranceFilter"
+	oldRate := CoToleranceFilter rate. 
+	oldMinimumTokenSize := CoToleranceFilter minimumTokenSize.
 	CoToleranceFilter disable.
+	
 	editor := RubSmalltalkEditor forTextArea: RubEditingArea new beForSmalltalkCode.
 	interactionEngine := self newCompletionEngine.
 	interactionEngine setEditor: editor.
 	editor completionEngine: interactionEngine.
 	editor textArea model: self
+]
+
+{ #category : 'running' }
+CoCompletionEngineTest >> tearDown [ 
+	CoToleranceFilter rate: oldRate. 
+	CoToleranceFilter minimumTokenSize: oldMinimumTokenSize. 
+	
+	super tearDown
 ]
 
 { #category : 'tests - interaction' }

--- a/src/HeuristicCompletion-Tests/CoDependencyPackageScopedSelectorTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoDependencyPackageScopedSelectorTest.class.st
@@ -1,6 +1,10 @@
 Class {
 	#name : 'CoDependencyPackageScopedSelectorTest',
 	#superclass : 'CoMiniTestCase',
+	#instVars : [
+		'oldRate',
+		'oldMinimumTokenSize'
+	],
 	#category : 'HeuristicCompletion-Tests-Core',
 	#package : 'HeuristicCompletion-Tests',
 	#tag : 'Core'
@@ -11,7 +15,18 @@ CoDependencyPackageScopedSelectorTest >> setUp [
 	super setUp.
 
 	"Put here a common initialization logic for tests"
-	CoToleranceFilter disable
+	"Save the old configuration then Disable the CoToleranceFilter"
+	oldRate := CoToleranceFilter rate. 
+	oldMinimumTokenSize := CoToleranceFilter minimumTokenSize.
+	CoToleranceFilter disable.
+]
+
+{ #category : 'running' }
+CoDependencyPackageScopedSelectorTest >> tearDowm [ 
+	CoToleranceFilter rate: oldRate. 
+	CoToleranceFilter minimumTokenSize: oldMinimumTokenSize. 
+	
+	super tearDown
 ]
 
 { #category : 'tests' }

--- a/src/HeuristicCompletion-Tests/CoDependencyPackageScopedSelectorTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoDependencyPackageScopedSelectorTest.class.st
@@ -6,6 +6,14 @@ Class {
 	#tag : 'Core'
 }
 
+{ #category : 'running' }
+CoDependencyPackageScopedSelectorTest >> setUp [
+	super setUp.
+
+	"Put here a common initialization logic for tests"
+	CoToleranceFilter disable
+]
+
 { #category : 'tests' }
 CoDependencyPackageScopedSelectorTest >> testAppliesForMessageWithVariableReceiver [
     | heuristic node |

--- a/src/HeuristicCompletion-Tests/CoRepositoryPackagedScopedGlobalVariableFetcherTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoRepositoryPackagedScopedGlobalVariableFetcherTest.class.st
@@ -37,6 +37,7 @@ CoRepositoryPackagedScopedGlobalVariableFetcherTest >> setUp [
 	
 	| classesInP1 classesInP2 classesInP3 dict |
 	super setUp.
+	CoToleranceFilter disable.
 	completionClass := CoMockClass new name: 'CoInP1'. 
 	ai12 := CoMockClass new name: 'Ai12'.
 	ai13 := CoMockClass new name: 'Ai13'.

--- a/src/HeuristicCompletion-Tests/CoRepositoryPackagedScopedGlobalVariableFetcherTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoRepositoryPackagedScopedGlobalVariableFetcherTest.class.st
@@ -17,7 +17,9 @@ Class {
 		'a33',
 		'blop',
 		'aiGlobal1',
-		'aiGlobal2'
+		'aiGlobal2',
+		'oldRate',
+		'oldMinimumTokenSize'
 	],
 	#category : 'HeuristicCompletion-Tests-Core',
 	#package : 'HeuristicCompletion-Tests',
@@ -37,7 +39,12 @@ CoRepositoryPackagedScopedGlobalVariableFetcherTest >> setUp [
 	
 	| classesInP1 classesInP2 classesInP3 dict |
 	super setUp.
+	
+	"Save the old configuration then Disable the CoToleranceFilter"
+	oldRate := CoToleranceFilter rate. 
+	oldMinimumTokenSize := CoToleranceFilter minimumTokenSize.
 	CoToleranceFilter disable.
+	
 	completionClass := CoMockClass new name: 'CoInP1'. 
 	ai12 := CoMockClass new name: 'Ai12'.
 	ai13 := CoMockClass new name: 'Ai13'.
@@ -101,6 +108,14 @@ CoRepositoryPackagedScopedGlobalVariableFetcherTest >> setUp [
 		CoGlobalEntry contents: 'Ai23' node: nil .
 		CoGlobalEntry contents: 'Ai3' node: nil 
 		}
+]
+
+{ #category : 'running' }
+CoRepositoryPackagedScopedGlobalVariableFetcherTest >> tearDown [  
+	CoToleranceFilter rate: oldRate. 
+	CoToleranceFilter minimumTokenSize: oldMinimumTokenSize.
+	
+	super tearDown 
 ]
 
 { #category : 'one local one global' }

--- a/src/HeuristicCompletion-Tests/CoSinglePackageScopedGlobalVariableFetcherAlternateTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoSinglePackageScopedGlobalVariableFetcherAlternateTest.class.st
@@ -38,7 +38,7 @@ CoSinglePackageScopedGlobalVariableFetcherAlternateTest >> setUp [
 	| classesInP1 classesInP2 classesInP3 dict |
 	super setUp.
 	
-	CoToleranceFilter disable.
+	"CoToleranceFilter disable."
 	completionClass := CoMockClass new name: 'CoInP1'. 
 	ai12 := CoMockClass new name: 'Ai12'.
 	ai13 := CoMockClass new name: 'Ai13'.

--- a/src/HeuristicCompletion-Tests/CoSinglePackageScopedGlobalVariableFetcherAlternateTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoSinglePackageScopedGlobalVariableFetcherAlternateTest.class.st
@@ -37,6 +37,8 @@ CoSinglePackageScopedGlobalVariableFetcherAlternateTest >> setUp [
 	
 	| classesInP1 classesInP2 classesInP3 dict |
 	super setUp.
+	
+	CoToleranceFilter disable.
 	completionClass := CoMockClass new name: 'CoInP1'. 
 	ai12 := CoMockClass new name: 'Ai12'.
 	ai13 := CoMockClass new name: 'Ai13'.

--- a/src/HeuristicCompletion-Tests/CoSinglePackageScopedGlobalVariableFetcherTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoSinglePackageScopedGlobalVariableFetcherTest.class.st
@@ -16,7 +16,6 @@ Class {
 CoSinglePackageScopedGlobalVariableFetcherTest >> setUp [
 	
 	super setUp.
-	CoToleranceFilter disable.
 	completionClass := CoMockClass new name: 'CoInP1'. 
 	a := CoMockClass new name: 'AInP1'.
 	b := CoMockClass new name: 'AAInP1'.

--- a/src/HeuristicCompletion-Tests/CoSinglePackageScopedGlobalVariableFetcherTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoSinglePackageScopedGlobalVariableFetcherTest.class.st
@@ -16,6 +16,7 @@ Class {
 CoSinglePackageScopedGlobalVariableFetcherTest >> setUp [
 	
 	super setUp.
+	CoToleranceFilter disable.
 	completionClass := CoMockClass new name: 'CoInP1'. 
 	a := CoMockClass new name: 'AInP1'.
 	b := CoMockClass new name: 'AAInP1'.

--- a/src/HeuristicCompletion-Tests/CoToleranceFilterTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoToleranceFilterTest.class.st
@@ -1,8 +1,15 @@
 Class {
 	#name : 'CoToleranceFilterTest',
 	#superclass : 'TestCase',
-	#category : 'HeuristicCompletion-Tests',
-	#package : 'HeuristicCompletion-Tests'
+	#instVars : [
+		'oldRate',
+		'oldMinimumTokenize',
+		'filter',
+		'entries'
+	],
+	#category : 'HeuristicCompletion-Tests-Core',
+	#package : 'HeuristicCompletion-Tests',
+	#tag : 'Core'
 }
 
 { #category : 'running' }
@@ -10,7 +17,77 @@ CoToleranceFilterTest >> setUp [
 	super setUp.
 
 	"Put here a common initialization logic for tests"
+	oldRate := CoToleranceFilter rate. 
+	oldMinimumTokenize := CoToleranceFilter minimumTokenSize. 
 	CoToleranceFilter enable.
+	
+	filter := CoToleranceFilter new.
+	
+	entries := OrderedCollection new.
+]
+
+{ #category : 'running' }
+CoToleranceFilterTest >> tearDown [ 
+	
+	CoToleranceFilter rate: oldRate. 
+	CoToleranceFilter minimumTokenSize: oldMinimumTokenize. 
+	
+	super tearDown 
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testComplementResultExactAppearBeforeFuzzy [
+	| result |
+	entries add: 'foo'; add: 'for'; add: 'fuzzy'. 
+	filter decoree: (CoCaseSensitiveBeginsWithFilter new completionString: 'fo'). 
+	result := (filter complementResults: entries). 
+	self assert: result first equals: 'foo'.
+	self assert: result second equals: 'for'.
+	self assert: result third equals: 'fuzzy'.
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testComplementResultSortFuzzy [
+	| result |
+	entries add: 'fuzzy'; add: 'fuzz'. 
+	filter decoree: (CoCaseSensitiveBeginsWithFilter new completionString: 'fo'). 
+	result := (filter complementResults: entries). 
+	"We should get fuzz before fuzzy since fuzz is closer to the token"
+	self assert: result first equals: 'fuzz'.
+	self assert: result second equals: 'fuzzy'.
+
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testComplementResultWhenNoFallbackEnumerationBecauseDisabled [
+	CoToleranceFilter disable. 
+	
+	entries add: 'foo'; add: 'bar'.
+	
+	self assert: (filter complementResults: entries) equals: (entries).
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testComplementResultWhenNoFallbackEnumerationBecauseSmallTokenSize [
+	filter decoree: (CoCaseSensitiveBeginsWithFilter new completionString: 'f').
+	
+	entries add: 'foo'; add: 'bar'.
+	
+	self assert: (filter complementResults: entries) equals: (entries).
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testRequiresFallbackEnumerationWhenTokenSizeIsLessThanMinimumTokenSize [
+	filter decoree: CoCaseInsensitiveBeginsWithFilter new.
+	filter decoree completionString: 'a'.
+	self deny: (filter requiresFallbackEnumeration ) .
+	
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testRequiresFallbackEnumerationWhenToleranceDisabled [
+	CoToleranceFilter disable. 
+	self deny: (filter requiresFallbackEnumeration )
 ]
 
 { #category : 'tests' }

--- a/src/HeuristicCompletion-Tests/CoToleranceFilterTest.class.st
+++ b/src/HeuristicCompletion-Tests/CoToleranceFilterTest.class.st
@@ -1,0 +1,99 @@
+Class {
+	#name : 'CoToleranceFilterTest',
+	#superclass : 'TestCase',
+	#category : 'HeuristicCompletion-Tests',
+	#package : 'HeuristicCompletion-Tests'
+}
+
+{ #category : 'running' }
+CoToleranceFilterTest >> setUp [
+	super setUp.
+
+	"Put here a common initialization logic for tests"
+	CoToleranceFilter enable.
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testScoreForCandidatesWWhenTransposition [ 
+	"distance = 1/5, max edits = 0.4 * 5 = 2, with one transposition "
+	self assert: (CoToleranceFilter scoreForCandidate: 'hlelo' token:'hello'  caseSensitive: false tolerance: 0.2) equals: 0.2
+
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testScoreForCandidatesWhenExactMatch [ 
+	self assert: (CoToleranceFilter scoreForCandidate: 'foo' token:'foo'  caseSensitive: false tolerance: 0.3) equals: 0
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testScoreForCandidatesWhenExactMatchWhenCaseSensitive [ 
+	self assert: (CoToleranceFilter scoreForCandidate: 'FoO' token:'FoO'  caseSensitive: true tolerance: 0.3) equals: 0
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testScoreForCandidatesWhenOneInsertion [
+	self assert: (CoToleranceFilter scoreForCandidate: 'helo' token:'hello'  caseSensitive: false tolerance: 0.4) equals: 0.2
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testScoreForCandidatesWhenOneSubstitution [ 
+	self assert: (CoToleranceFilter scoreForCandidate: 'hello' token:'hallo'  caseSensitive: false tolerance: 0.4) equals: 0.2
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testScoreForCandidatesWhenOneSubstitutionWithLowToleranceReturnZero [
+	
+	self assert: (CoToleranceFilter scoreForCandidate: 'hello' token:'hallo'  caseSensitive: false tolerance: 0) equals: 0
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testScoreForCandidatesWhenTranspositionWithFirstCaracterDoesNotMustShouldReturnZero [ 
+	"distance = 1/5, max edits = 0.4 * 5 = 2, with one transposition "
+	self assert: (CoToleranceFilter scoreForCandidate: 'Hello' token:'hello'  caseSensitive: true tolerance: 0.4) equals: 0
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testShouldTryFuzzyForWhenEmptyCandidate [ 
+	self assert: (CoToleranceFilter shouldTryFuzzyFor: 'foo' candidate: '' tolerance: 0.4) equals: false
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testShouldTryFuzzyForWhenEmptyToken [ 
+	self assert: (CoToleranceFilter shouldTryFuzzyFor: '' candidate: 'foo' tolerance: 0.4) equals: false
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testShouldTryFuzzyForWhenFirstCaracterMismatch [ 
+	self assert: (CoToleranceFilter shouldTryFuzzyFor: 'At:put:ifAbsent:' candidate: 'at:put:IfAbsent:' tolerance: 0.4) equals: false
+
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testShouldTryFuzzyForWhenKeywordStructureIsDifferent [ 
+	
+	self assert: (CoToleranceFilter shouldTryFuzzyFor: 'at:put:ifAbsent:' candidate: 'at:putIfAbsent:' tolerance: 0.4) equals: false
+
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testShouldTryFuzzyForWhenKeywordStructureIsSimilar [ 
+
+	self assert: (CoToleranceFilter shouldTryFuzzyFor: 'at:put:ifAbsent:' candidate: 'at:put:IfAbsent:' tolerance: 0.4) equals: true
+
+
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testShouldTryFuzzyForWhenLengthExceedsToleranceBound [ 
+	"maxEdits = 0.4 * 32 ≈ 13.
+	Length difference = 32 - 5 = 27.
+	Since 27 > maxEdits, fuzzy matching should be rejected."
+	self assert: (CoToleranceFilter shouldTryFuzzyFor: 'CoAST' candidate: 'CoASTHeuristicsResultSetBuilder' tolerance: 0.4) equals: false
+
+]
+
+{ #category : 'tests' }
+CoToleranceFilterTest >> testShouldTryFuzzyForWhenTokenTooShort [ 
+	"The minimum token size is 2"
+	self assert: (CoToleranceFilter shouldTryFuzzyFor: 'f' candidate: 'foo' tolerance: 0.4) equals: false
+]


### PR DESCRIPTION
We have the ability to enable / disable fuzzy matching, We also disabled the ``CoToleranceFilter`` in the ``setUp`` of the following tests because fuzzy matching breaks them : 

```
[osx-64 / Tests-osx-64 / MacOSX64.Tests-osx-64.HeuristicCompletion.Tests.CoCompletionEngineTest.testCompleteSuper](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/PR-19679/1/testReport/junit/MacOSX64.Tests-osx-64.HeuristicCompletion.Tests/CoCompletionEngineTest/osx_64___Tests_osx_64___testCompleteSuper/)
[osx-64 / Tests-osx-64 / MacOSX64.Tests-osx-64.HeuristicCompletion.Tests.CoDependencyPackageScopedSelectorTest.testLocalFirstThenDependent](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/PR-19679/1/testReport/junit/MacOSX64.Tests-osx-64.HeuristicCompletion.Tests/CoDependencyPackageScopedSelectorTest/osx_64___Tests_osx_64___testLocalFirstThenDependent/)
[osx-64 / Tests-osx-64 / MacOSX64.Tests-osx-64.HeuristicCompletion.Tests.CoRepositoryPackagedScopedGlobalVariableFetcherTest.testFirstPackageOfCompletionClass](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/PR-19679/1/testReport/junit/MacOSX64.Tests-osx-64.HeuristicCompletion.Tests/CoRepositoryPackagedScopedGlobalVariableFetcherTest/osx_64___Tests_osx_64___testFirstPackageOfCompletionClass/)
[osx-64 / Tests-osx-64 / MacOSX64.Tests-osx-64.HeuristicCompletion.Tests.CoRepositoryPackagedScopedGlobalVariableFetcherTest.testFirstPackageOfCompletionClassThenAllProjectLevelPackage](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/PR-19679/1/testReport/junit/MacOSX64.Tests-osx-64.HeuristicCompletion.Tests/CoRepositoryPackagedScopedGlobalVariableFetcherTest/osx_64___Tests_osx_64___testFirstPackageOfCompletionClassThenAllProjectLevelPackage/)
[osx-64 / Tests-osx-64 / MacOSX64.Tests-osx-64.HeuristicCompletion.Tests.CoRepositoryPackagedScopedGlobalVariableFetcherTest.testFirstPackageOfCompletionClassThenAllProjectLevelPackageThenNoGlobals](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/PR-19679/1/testReport/junit/MacOSX64.Tests-osx-64.HeuristicCompletion.Tests/CoRepositoryPackagedScopedGlobalVariableFetcherTest/osx_64___Tests_osx_64___testFirstPackageOfCompletionClassThenAllProjectLevelPackageThenNoGlobals/)
[osx-64 / Tests-osx-64 / MacOSX64.Tests-osx-64.HeuristicCompletion.Tests.CoRepositoryPackagedScopedGlobalVariableFetcherTest.testFirstPackageOfCompletionClassThenProjectLevelPackage](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/PR-19679/1/testReport/junit/MacOSX64.Tests-osx-64.HeuristicCompletion.Tests/CoRepositoryPackagedScopedGlobalVariableFetcherTest/osx_64___Tests_osx_64___testFirstPackageOfCompletionClassThenProjectLevelPackage/)
[osx-64 / Tests-osx-64 / MacOSX64.Tests-osx-64.HeuristicCompletion.Tests.CoRepositoryPackagedScopedGlobalVariableFetcherTest.testRequestMoreThanAvailableOnlyReturnAvailable](https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/PR-19679/1/testReport/junit/MacOSX64.Tests-osx-64.HeuristicCompletion.Tests/CoRepositoryPackagedScopedGlobalVariableFetcherTest/osx_64___Tests_osx_64___testRequestMoreThanAvailableOnlyReturnAvailable/)
```

## Example

<img width="598" height="451" alt="Screenshot 2026-05-12 at 09 57 53" src="https://github.com/user-attachments/assets/103a59a3-1c27-4738-b606-bc1e953bf417" />


