### PR TITLE
Add inferred receiver message completion.

### DIFF
--- a/src/HeuristicCompletion-Model/CoASTHeuristicsResultSetBuilder.class.st
+++ b/src/HeuristicCompletion-Model/CoASTHeuristicsResultSetBuilder.class.st
@@ -46,6 +46,7 @@ CoASTHeuristicsResultSetBuilder class >> initializeMessagesHeuristic [
 				                      CoSuperMessageHeuristic new.
 				                      CoDependencyMessageHeuristics new .
 				                      CoTypedReceiverMessageHeuristic  new .
+											CoInferredReceiverMessageHeuristic new.
 				                      CoInitializeInferencedMessageHeuristic  new .
 				                      CoLiteralMessageHeuristic  new . 
 				                      CoGlobalVariableMessageHeuristic new  .

--- a/src/HeuristicCompletion-Model/CoInferredReceiverMessageHeuristic.class.st
+++ b/src/HeuristicCompletion-Model/CoInferredReceiverMessageHeuristic.class.st
@@ -1,0 +1,67 @@
+"
+I ask the type inferencer for the type of that receiver expression, then propose selectors from the inferred type hierarchy.
+
+"
+Class {
+	#name : 'CoInferredReceiverMessageHeuristic',
+	#superclass : 'CoASTNodeFetcherHeuristic',
+	#category : 'HeuristicCompletion-Model-Heuristics',
+	#package : 'HeuristicCompletion-Model',
+	#tag : 'Heuristics'
+}
+
+{ #category : 'requests' }
+CoInferredReceiverMessageHeuristic >> appliesForNode: aMessageNode inContext: aContext [
+
+	^ aMessageNode isMessage
+		and: [ aMessageNode receiver isMessage ]
+]
+
+{ #category : 'requests' }
+CoInferredReceiverMessageHeuristic >> buildFetcherFor: aMessageNode inContext: aContext [
+
+	| receiverTypes fetcher |
+
+	receiverTypes := self
+		inferredTypesOf: aMessageNode receiver
+		inContext: aContext.
+
+	receiverTypes := receiverTypes select: [ :each |
+		self canCompleteMessagesFor: each ].
+
+	receiverTypes ifEmpty: [ ^ CoEmptyFetcher new ].
+
+	fetcher := CoEmptyFetcher new.
+
+	receiverTypes do: [ :each |
+		fetcher := (self
+			newMessageInHierarchyFetcherForClass: each
+			inASTNode: aMessageNode), fetcher ].
+
+	^ fetcher
+]
+
+{ #category : 'requests' }
+CoInferredReceiverMessageHeuristic >> canCompleteMessagesFor: aType [
+
+	^ aType notNil
+		and: [
+			(aType isKindOf: CoUnknownType) not
+				and: [ aType respondsTo: #selectorsDo ] ]
+]
+
+{ #category : 'requests' }
+CoInferredReceiverMessageHeuristic >> inferredTypesOf: aReceiverNode inContext: aContext [
+
+	| inferer |
+
+	inferer := CoTypeInferencer new.
+	inferer receiverClass: (aContext completionClass ifNil: [ Object ]).
+
+	^ [
+		(aReceiverNode acceptVisitor: inferer) asSet asOrderedCollection
+	] on: Error do: [ :error |
+		"Completion must never break the editor. If inference fails,
+		let the next heuristic, usually CoUnknownMessageHeuristic, answer."
+		#() ]
+]


### PR DESCRIPTION
Add inferred receiver message completion.

Before this change, completion worked well for direct receivers, but lost precision when the receiver was itself a message expression, for example:

	`Point current degree`

In that case, the receiver of the current completion is `Point current`, not `Point` directly. The new heuristic infers the type of that receiver expression using the existing type inferencer, then proposes selectors from the inferred type hierarchy.

This avoids hardcoding selectors such as `current` or `default`, and keeps the behavior generic for any class-side factory/accessor method whose return type can be inferred.