### PR TITLE
Fix evaluation of code with undeclareds

### DIFF
--- a/src/AST-Core-Tests/OCCodeSnippet.class.st
+++ b/src/AST-Core-Tests/OCCodeSnippet.class.st
@@ -1512,10 +1512,10 @@ OCCodeSnippet class >> badScanner [
 			         formattedCode: '#( # ## #ab # 10 # #''.'' 10 )';
 			         isFaulty: true;
 			         notices:
-				         #( #( 3 3 4 'Literal expected' )
-				            #( 5 6 7 'Literal expected' )
-				            #( 12 12 13 'Literal expected' )
-				            #( 16 16 17 'Literal expected' )
+				         #( #( 3 3 4 'Literal Array, ByteArray or Symbol expected' )
+				            #( 5 6 7 'Literal Array, ByteArray or Symbol expected' )
+				            #( 12 12 13 'Literal Array, ByteArray or Symbol expected' )
+				            #( 16 16 17 'Literal Array, ByteArray or Symbol expected' )
 				            #( 17 17 17 'Use a proper symbol literal' ) )). "Lonely # are errors"
 		        (self new
 			         source: '#(#"A"##"B")';
@@ -1524,8 +1524,8 @@ OCCodeSnippet class >> badScanner [
 			         formattedCode: '#( # ## )';
 			         isFaulty: true;
 			         notices:
-				         #( #( 3 3 4 'Literal expected' )
-				            #( 7 8 9 'Literal expected' ) )). "Check if comments are lost"
+				         #( #( 3 3 4 'Literal Array, ByteArray or Symbol expected' )
+				            #( 7 8 9 'Literal Array, ByteArray or Symbol expected' ) )). "Check if comments are lost"
 		        (self new
 			         source: '#(:=aa:=:==bb:==#cc:==)';
 			         nodeAt: '00112223445666778888990';
@@ -2245,7 +2245,7 @@ OCCodeSnippet class >> badTokens [
 			         source: '#';
 			         nodeAt: '0';
 			         styled: 'X';
-			         notices: #( #( 1 1 2 'Literal expected' ) )).
+			         notices: #( #( 1 1 2 'Literal Array, ByteArray or Symbol expected' ) )).
 		        (self new
 			         source: '$';
 			         nodeAt: '0';
@@ -2292,20 +2292,20 @@ OCCodeSnippet class >> badTokens [
 			         nodeAt: '12';
 			         styled: 'XX';
 			         formattedCode: '#. 1';
-			         notices: #( #( 1 1 2 'Literal expected' ) )). "Become a bad sequence"
+			         notices: #( #( 1 1 2 'Literal Array, ByteArray or Symbol expected' ) )). "Become a bad sequence"
 		        (self new
 			         source: '#1r0';
 			         nodeAt: '1322';
 			         styled: 'XXXu';
 			         formattedCode: '#. 1 r0';
 			         notices:
-				         #( #( 1 1 2 'Literal expected' )
+				         #( #( 1 1 2 'Literal Array, ByteArray or Symbol expected' )
 				            #( 2 2 3 'an integer greater than 1 as valid radix expected' ) )). "Two bad sequences"
 		        (self new
 			         source: '##';
 			         nodeAt: '00';
 			         styled: 'XX';
-			         notices: #( #( 1 2 3 'Literal expected' ) )).
+			         notices: #( #( 1 2 3 'Literal Array, ByteArray or Symbol expected' ) )).
 		        "Note: if quotes, same thing than strings"
 		        (self new
 			         source: '#''hello';
@@ -2577,7 +2577,7 @@ OCCodeSnippet class >> badTokens [
 			         styled: 'XX';
 			         formattedCode: '#. →';
 			         notices:
-				         #( #( 1 1 2 'Literal expected' )
+				         #( #( 1 1 2 'Literal Array, ByteArray or Symbol expected' )
 				            #( 2 2 2 'Unknown character' ) )) "Two independent errors" }.
 	"Setup default values"
 	self new

--- a/src/AST-Core-Tests/OCScannerTest.class.st
+++ b/src/AST-Core-Tests/OCScannerTest.class.st
@@ -816,7 +816,7 @@ OCScannerTest >> testNextLiteralBeginningWithDigitThrowsError [
 	token := scanner next.
 	self assert: token isError.
 	self assert: token value equals: '#'.
-	self assert: token cause equals: 'Literal expected'
+	self assert: token cause equals: 'Literal Array, ByteArray or Symbol expected'
 ]
 
 { #category : 'tests - Error' }
@@ -826,7 +826,7 @@ OCScannerTest >> testNextLiteralBeginningWithSpecialThrowsError [
 	token := scanner next.
 	self assert: token isError.
 	self assert: token value equals: '#'.
-	self assert: token cause equals: 'Literal expected'
+	self assert: token cause equals: 'Literal Array, ByteArray or Symbol expected'
 ]
 
 { #category : 'tests - Error' }
@@ -836,7 +836,7 @@ OCScannerTest >> testNextLiteralBeginningWithUnknownThrowsError [
 	token := scanner next.
 	self assert: token isError.
 	self assert: token value equals: '#'.
-	self assert: token cause equals: 'Literal expected'
+	self assert: token cause equals: 'Literal Array, ByteArray or Symbol expected'
 ]
 
 { #category : 'tests - Literal' }
@@ -1540,7 +1540,7 @@ OCScannerTest >> testNextWithAWrongSymbolGetError [
 	source := '#^'.
 	scanner := self buildScannerForText: source.
 	scannedToken := scanner next.
-	self verifyErrorToken: scannedToken message: 'Literal expected' translated valueExpected: '#'
+	self verifyErrorToken: scannedToken message: 'Literal Array, ByteArray or Symbol expected' translated valueExpected: '#'
 ]
 
 { #category : 'tests' }

--- a/src/AST-Core/OCScanner.class.st
+++ b/src/AST-Core/OCScanner.class.st
@@ -410,7 +410,7 @@ OCScanner >> scanLiteral [
 	"Accept multiple #."
 	currentCharacter = $#
 		ifTrue: [ ^ self scanLiteral ].
-	^ self scanError: 'Literal expected'
+	^ self scanError: 'Literal Array, ByteArray or Symbol expected'
 ]
 
 { #category : 'private - scanning' }

--- a/src/Kernel-CodeModel/OCMethodInstaller.class.st
+++ b/src/Kernel-CodeModel/OCMethodInstaller.class.st
@@ -22,9 +22,6 @@ OCMethodInstaller >> addAndClassifyMethod: compiledMethod into: behavior [
 { #category : 'accessing' }
 OCMethodInstaller >> changeStamp [
 
-	"Lazy initialized.
-	Remember the stamp set at the moment of the installation.
-	Useful for testing and logging"
 	^ changeStamp
 ]
 

--- a/src/OpalCompiler-UI/OCCodeReparator.class.st
+++ b/src/OpalCompiler-UI/OCCodeReparator.class.st
@@ -174,7 +174,6 @@ OCCodeReparator >> openMenu [
 		          chooseFrom: labels
 		          lines: lines
 		          title: caption.
-	1halt.
 	(actions at: choice ifAbsent: [ ^ false ]) value.
 	^ true
 ]

--- a/src/OpalCompiler-UI/OCInteractiveAPI.class.st
+++ b/src/OpalCompiler-UI/OCInteractiveAPI.class.st
@@ -56,6 +56,11 @@ OCInteractiveAPI >> checkNotice: aNotice requestor: aRequestor [
 		^ nil ].
 
 	"Quirks mode: Then leave"
+	aRequestor
+			notify: aNotice messageText , ' ->'
+			at: aNotice position
+			in: aNotice node source.
+
 	^ false
 ]
 
@@ -81,7 +86,7 @@ OCInteractiveAPI >> compile: sourceCode notifying: requestor in: behavior [
 							check ifNil: [ "Flush the AST and restart"
 									theCompiler source: requestor text asString.
 									^ self compile: requestor text asString notifying: requestor in: behavior ].
-							check ifFalse: [ ^ theCompiler failBlock ifNotNil: [ theCompiler failBlock value: n ] ifNil: [ nil ] ] ] ].
+							check ifFalse: [ ^ theCompiler failBlock ifNotNil: [ theCompiler failBlock cull: n ] ifNil: [ nil ] ] ] ].
 			^ nil ].
 
 	^ compilationResult compiledMethod

--- a/src/OpalCompiler-UI/OCInteractiveAPI.class.st
+++ b/src/OpalCompiler-UI/OCInteractiveAPI.class.st
@@ -46,6 +46,8 @@ OCInteractiveAPI >> checkNotice: aNotice requestor: aRequestor [
 		res := reparator
 			requestor: aRequestor;
 			repair.
+		res ifNil: [ ^ true
+			"reparation unneded, let AST as is" ].
 		res ifFalse: [ 
 			"operation cancelled, fail"
 			^ false].

--- a/src/OpalCompiler-UI/OCInteractiveAPI.class.st
+++ b/src/OpalCompiler-UI/OCInteractiveAPI.class.st
@@ -74,16 +74,14 @@ OCInteractiveAPI >> compile: sourceCode notifying: requestor in: behavior [
 	compilationResult isError ifTrue: [
 			theCompiler ast allNotices sorted do: [ :n |
 					| check |
-					theCompiler failBlock ifNotNil: [  theCompiler failBlock value: n ].
 					shouldSignalErrors ifTrue: [ n signalError ].
 
 					requestor ifNil: [ n signalError ] ifNotNil: [
 							check := self checkNotice: n requestor: requestor.
-							check ifNil: [
-								"Flush the AST and restart"
-								theCompiler source: requestor text asString.
-								^ self compile: requestor text asString notifying: requestor in: behavior ].
-							check ifFalse: [ ^ nil ] ] ].
+							check ifNil: [ "Flush the AST and restart"
+									theCompiler source: requestor text asString.
+									^ self compile: requestor text asString notifying: requestor in: behavior ].
+							check ifFalse: [ ^ theCompiler failBlock ifNotNil: [ theCompiler failBlock value: n ] ifNil: [ nil ] ] ] ].
 			^ nil ].
 
 	^ compilationResult compiledMethod

--- a/src/OpalCompiler-UI/OpalCompiler.extension.st
+++ b/src/OpalCompiler-UI/OpalCompiler.extension.st
@@ -30,7 +30,6 @@ OpalCompiler >> evaluate [
 	| value doItMethod |
 	self isScripting: true.
 	doItMethod := OCInteractiveAPI new
-		shouldSignalErrors: true;
 		compiler: self;
 		compile: source
 		notifying: requestor


### PR DESCRIPTION
Several fixes to evaluation error handling:

Fix #19654
Fix #19717

Also, remove leftover halt breaking tests.
