### PR TITLE
Fix: inspect variable for Calypso commands

### DIFF
--- a/src/Calypso-SystemQueries/ClyClassVariable.class.st
+++ b/src/Calypso-SystemQueries/ClyClassVariable.class.st
@@ -74,5 +74,11 @@ ClyClassVariable >> isLive [
 { #category : 'operations' }
 ClyClassVariable >> openInspector [
 
+	actualVariable inspect
+]
+
+{ #category : 'operations' }
+ClyClassVariable >> openValueInspector [
+
 	actualVariable value inspect
 ]

--- a/src/Calypso-SystemQueries/ClyGlobalVariable.class.st
+++ b/src/Calypso-SystemQueries/ClyGlobalVariable.class.st
@@ -50,5 +50,11 @@ ClyGlobalVariable >> openBrowser [
 { #category : 'operations' }
 ClyGlobalVariable >> openInspector [
 
+	actualVariable inspect
+]
+
+{ #category : 'operations' }
+ClyGlobalVariable >> openValueInspector [
+
 	actualVariable value inspect
 ]

--- a/src/Calypso-SystemQueries/ClyInstanceVariable.class.st
+++ b/src/Calypso-SystemQueries/ClyInstanceVariable.class.st
@@ -57,9 +57,9 @@ ClyInstanceVariable >> isLive [
 ]
 
 { #category : 'operations' }
-ClyInstanceVariable >> openInspector [
-	definingClass isClassSide ifTrue: [
-		^(actualVariable read: definingClass instanceSide) inspect].
+ClyInstanceVariable >> openValueInspector [
+
+	definingClass isClassSide ifTrue: [ ^ (actualVariable read: definingClass instanceSide) inspect ].
 
 	super openInspector
 ]

--- a/src/Calypso-SystemTools-Core/SycInspectVariableValueCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycInspectVariableValueCommand.extension.st
@@ -1,14 +1,14 @@
-Extension { #name : 'SycInspectVariableCommand' }
+Extension { #name : 'SycInspectVariableValueCommand' }
 
 { #category : '*Calypso-SystemTools-Core' }
-SycInspectVariableCommand class >> sourceCodeMenuActivation [
+SycInspectVariableValueCommand class >> sourceCodeMenuActivation [
 	<classAnnotation>
 
 	^SycSourceCodeMenuActivation byItemOf: ClyQueryMenuGroup for: ClySourceCodeContext
 ]
 
 { #category : '*Calypso-SystemTools-Core' }
-SycInspectVariableCommand class >> sourceCodeShortcutActivation [
+SycInspectVariableValueCommand class >> sourceCodeShortcutActivation [
 	<classAnnotation>
 
 	^CmdShortcutActivation

--- a/src/Calypso-SystemTools-FullBrowser/SycInspectVariableValueCommand.extension.st
+++ b/src/Calypso-SystemTools-FullBrowser/SycInspectVariableValueCommand.extension.st
@@ -1,7 +1,7 @@
-Extension { #name : 'SycInspectVariableCommand' }
+Extension { #name : 'SycInspectVariableValueCommand' }
 
 { #category : '*Calypso-SystemTools-FullBrowser' }
-SycInspectVariableCommand class >> fullBrowserDoubleClickActivation [
+SycInspectVariableValueCommand class >> fullBrowserDoubleClickActivation [
 	<classAnnotation>
 
 	^(CmdDoubleClickActivation for: ClyFullBrowserVariableContext)
@@ -9,14 +9,14 @@ SycInspectVariableCommand class >> fullBrowserDoubleClickActivation [
 ]
 
 { #category : '*Calypso-SystemTools-FullBrowser' }
-SycInspectVariableCommand class >> fullBrowserMenuActivation [
+SycInspectVariableValueCommand class >> fullBrowserMenuActivation [
 	<classAnnotation>
 
 	^CmdContextMenuActivation byItemOf: ClyQueryMenuGroup for: ClyFullBrowserVariableContext
 ]
 
 { #category : '*Calypso-SystemTools-FullBrowser' }
-SycInspectVariableCommand class >> fullBrowserShortcutActivation [
+SycInspectVariableValueCommand class >> fullBrowserShortcutActivation [
 	<classAnnotation>
 
 	^(CmdShortcutActivation

--- a/src/SystemCommands-VariableCommands/SycInspectVariableCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycInspectVariableCommand.class.st
@@ -1,8 +1,6 @@
 "
 I am a command to inspect given variable.
-For live variables lile globals or class variables I open inspector on variable value.
-Also I open inspector on instance variable of class side because they also have live values.
-For instance side instance variable I inspect slot definition instance.
+
 "
 Class {
 	#name : 'SycInspectVariableCommand',
@@ -11,31 +9,32 @@ Class {
 	#package : 'SystemCommands-VariableCommands'
 }
 
-{ #category : 'testing' }
-SycInspectVariableCommand class >> canBeExecutedInContext: aToolContext [
-	(super canBeExecutedInContext: aToolContext) ifFalse: [ ^false ].
+{ #category : 'activation' }
+SycInspectVariableCommand class >> browserContextMenuActivation [
 
-	^aToolContext lastSelectedVariable isLive
+	<classAnnotation>
+	^ CmdContextMenuActivation byItemOf: CmdExtraMenuGroup for: ClyVariableMethodGroup asCalypsoItemContext
 ]
 
 { #category : 'accessing' }
 SycInspectVariableCommand >> defaultMenuIconName [
-	^#inspect
+
+	^ #inspect
 ]
 
 { #category : 'accessing' }
 SycInspectVariableCommand >> defaultMenuItemName [
-	^'Inspect'
+	^'Inspect variable'
 ]
 
 { #category : 'accessing' }
 SycInspectVariableCommand >> description [
 
-	^ 'Inspect variable value'
+	^ 'Inspect variable'
 ]
 
 { #category : 'execution' }
 SycInspectVariableCommand >> execute [
 
-	variables last openInspector
+	variables last openInspector 
 ]

--- a/src/SystemCommands-VariableCommands/SycInspectVariableValueCommand.class.st
+++ b/src/SystemCommands-VariableCommands/SycInspectVariableValueCommand.class.st
@@ -1,0 +1,40 @@
+"
+I am a command to inspect given variable value.
+For live variables lile globals or class variables I open inspector on variable value.
+Also I open inspector on instance variable of class side because they also have live values.
+"
+Class {
+	#name : 'SycInspectVariableValueCommand',
+	#superclass : 'SycVariableCommand',
+	#category : 'SystemCommands-VariableCommands',
+	#package : 'SystemCommands-VariableCommands'
+}
+
+{ #category : 'testing' }
+SycInspectVariableValueCommand class >> canBeExecutedInContext: aToolContext [
+	(super canBeExecutedInContext: aToolContext) ifFalse: [ ^false ].
+
+	^aToolContext lastSelectedVariable isLive
+]
+
+{ #category : 'accessing' }
+SycInspectVariableValueCommand >> defaultMenuIconName [
+	^#inspect
+]
+
+{ #category : 'accessing' }
+SycInspectVariableValueCommand >> defaultMenuItemName [
+	^'Inspect value'
+]
+
+{ #category : 'accessing' }
+SycInspectVariableValueCommand >> description [
+
+	^ 'Inspect variable value'
+]
+
+{ #category : 'execution' }
+SycInspectVariableValueCommand >> execute [
+
+	variables last openValueInspector
+]


### PR DESCRIPTION
- Inspect command for a variable always inspected the value instead of the variable object itself
- We now have a command for each inspeciton, and move the `Inspect variable obkect` command to the extra menu
- Fixes #19710