### PR TITLE
add back tests ShiftClassBuilder

### DIFF
--- a/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
@@ -57,6 +57,23 @@ ShClassInstallerTest >> tearDown [
 ]
 
 { #category : 'tests' }
+ShClassInstallerTest >> testBuildingClassesWithSlotsClassifiesItsMethods [
+	"This is a regression test. 
+	What was happening before was that the slots were generating a method to initialize themselves and after that the old class organization was copied. The problem is that during the first class creation, this was reseting the protocol of the generated slot methods."
+
+	newClass := self newClass: #ShCITestClass slots: { (#anInstanceVariable => ObservableSlot) }.
+
+	self assertCollection: newClass selectors hasSameElements: { #initialize }.
+	self assert: (newClass protocolOfSelector: #initialize) isNotNil.
+
+	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
+
+	self assertCollection: newClass2 selectors hasSameElements: { #initialize }.
+	self assert: (newClass2 protocolOfSelector: #initialize) isNotNil
+	
+]
+
+{ #category : 'tests' }
 ShClassInstallerTest >> testChangingASharedPoolUpdatesCorrectlyUsers [
 
 	newClass := ShiftClassInstaller make: [ :builder |
@@ -217,6 +234,13 @@ ShClassInstallerTest >> testCreatedClassWithAllElements [
 ]
 
 { #category : 'tests' }
+ShClassInstallerTest >> testDuplicateClassError [
+
+ 	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable => InstanceVariableSlot}.
+ 	self should: [ newClass duplicateClassWithNewName: #OrderedDictionary ] raise: TestResult error
+]
+
+{ #category : 'tests' }
 ShClassInstallerTest >> testDuplicateClassPreserveClassSlots [
 
 	newClass := ShiftClassInstaller make: [ :builder |
@@ -230,6 +254,19 @@ ShClassInstallerTest >> testDuplicateClassPreserveClassSlots [
 
 	self assert: (newClass2 class hasSlotNamed: #aClassInstanceVariable).
 	self assert: (newClass2 class slotNamed: #aClassInstanceVariable) class equals: InstanceVariableSlot
+]
+
+{ #category : 'tests' }
+ShClassInstallerTest >> testDuplicateClassPreserveMethods [
+
+	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable => InstanceVariableSlot}.
+	newClass compile: 'm1 ^ 42'.
+	newClass class compile: 'm2 ^ 42'.
+
+	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
+
+	self assert: (newClass2 includesSelector: #m1).
+	self assert: (newClass2 class includesSelector: #m2)
 ]
 
 { #category : 'tests' }
@@ -264,6 +301,19 @@ ShClassInstallerTest >> testDuplicateClassPreserveSharedVariables [
 	"Did we copy the Class Variables?"
 	self assert: (newClass2 classVariableNamed: #ShVariable) definingClass equals: newClass2.
 	self assert: (newClass classVariableNamed: #ShVariable) definingClass equals: newClass
+]
+
+{ #category : 'tests' }
+ShClassInstallerTest >> testDuplicateClassPreserveSlots [
+
+	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable => ObservableSlot}.
+	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
+
+	self assert: (newClass2 hasSlotNamed: #anInstanceVariable).
+	self assert: (newClass2 slotNamed: #anInstanceVariable) class equals: ObservableSlot.
+	"Make sure the slots are copied"
+	self assert: (newClass slotNamed: #anInstanceVariable) definingClass equals: newClass.
+	self assert: (newClass2 slotNamed: #anInstanceVariable) definingClass equals: newClass2
 ]
 
 { #category : 'tests' }

--- a/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/ShClassInstallerTest.class.st
@@ -61,7 +61,7 @@ ShClassInstallerTest >> testBuildingClassesWithSlotsClassifiesItsMethods [
 	"This is a regression test. 
 	What was happening before was that the slots were generating a method to initialize themselves and after that the old class organization was copied. The problem is that during the first class creation, this was reseting the protocol of the generated slot methods."
 
-	newClass := self newClass: #ShCITestClass slots: { (#anInstanceVariable => ObservableSlot) }.
+	newClass := self newClass: #ShCITestClass slots: { (#anInstanceVariable => SlotWithInitForTest) }.
 
 	self assertCollection: newClass selectors hasSameElements: { #initialize }.
 	self assert: (newClass protocolOfSelector: #initialize) isNotNil.
@@ -306,11 +306,11 @@ ShClassInstallerTest >> testDuplicateClassPreserveSharedVariables [
 { #category : 'tests' }
 ShClassInstallerTest >> testDuplicateClassPreserveSlots [
 
-	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable => ObservableSlot}.
+	newClass := self newClass: #ShCITestClass slots: {#anInstanceVariable => SlotWithInitForTest}.
 	newClass2 := newClass duplicateClassWithNewName: #ShCITestClass2.
 
 	self assert: (newClass2 hasSlotNamed: #anInstanceVariable).
-	self assert: (newClass2 slotNamed: #anInstanceVariable) class equals: ObservableSlot.
+	self assert: (newClass2 slotNamed: #anInstanceVariable) class equals: SlotWithInitForTest.
 	"Make sure the slots are copied"
 	self assert: (newClass slotNamed: #anInstanceVariable) definingClass equals: newClass.
 	self assert: (newClass2 slotNamed: #anInstanceVariable) definingClass equals: newClass2

--- a/src/Shift-ClassBuilder-Tests/SlotWithInitForTest.class.st
+++ b/src/Shift-ClassBuilder-Tests/SlotWithInitForTest.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : 'SlotWithInitForTest',
+	#superclass : 'IndexedSlot',
+	#category : 'Shift-ClassBuilder-Tests-Mock',
+	#package : 'Shift-ClassBuilder-Tests',
+	#tag : 'Mock'
+}
+
+{ #category : 'meta-object-protocol' }
+SlotWithInitForTest >> wantsInitialization [
+	^ true
+]


### PR DESCRIPTION
add backs some tests that we removed as they relied on Slots from  a package loaded late (BooleanSlot)

I replaced it with InstanceVariableSlot and ObservableSlot