### PR TITLE
restore warning icon for halts

### DIFF
--- a/src/Calypso-SystemPlugins-Reflectivity-Queries/ClyBreakpointMethodGroupProvider.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Queries/ClyBreakpointMethodGroupProvider.class.st
@@ -1,0 +1,20 @@
+"
+I provide ""breakpoints"" method group when classes include methods with breakpoints or halts
+"
+Class {
+	#name : 'ClyBreakpointMethodGroupProvider',
+	#superclass : 'ClySingleMethodGroupProvider',
+	#category : 'Calypso-SystemPlugins-Reflectivity-Queries-Breakpoints',
+	#package : 'Calypso-SystemPlugins-Reflectivity-Queries',
+	#tag : 'Breakpoints'
+}
+
+{ #category : 'building groups' }
+ClyBreakpointMethodGroupProvider >> createMethodGroupFor: aMethodQuery from: aClassScope [
+	^ClyMethodGroup named: 'breakpoints' priority: 8.4 on: aMethodQuery
+]
+
+{ #category : 'building groups' }
+ClyBreakpointMethodGroupProvider >> createMethodQueryFrom: aClassScope [
+	^ClyActiveBreakpointsQuery from: aClassScope
+]

--- a/src/Calypso-SystemPlugins-Reflectivity-Queries/ClyReflectiveEnvironmentPlugin.class.st
+++ b/src/Calypso-SystemPlugins-Reflectivity-Queries/ClyReflectiveEnvironmentPlugin.class.st
@@ -1,0 +1,45 @@
+"
+I am special plugin which decorate methods with various kind of metalinks: halts and breakpoint.
+And I provide related method groups
+- breakpoints
+They group related methods together
+"
+Class {
+	#name : 'ClyReflectiveEnvironmentPlugin',
+	#superclass : 'ClySystemEnvironmentPlugin',
+	#category : 'Calypso-SystemPlugins-Reflectivity-Queries-Plugin',
+	#package : 'Calypso-SystemPlugins-Reflectivity-Queries',
+	#tag : 'Plugin'
+}
+
+{ #category : 'groups collecting' }
+ClyReflectiveEnvironmentPlugin >> collectMethodGroupProviders [
+
+	^{ ClyBreakpointMethodGroupProvider new }
+]
+
+{ #category : 'item decoration' }
+ClyReflectiveEnvironmentPlugin >> decorateBrowserItem: anItem ofMethod: aMethod [
+
+	aMethod containsHalt ifTrue: [ anItem markWith: ClyMethodWithHaltTag ].
+	aMethod hasBreakpoint ifTrue: [ anItem markWith: ClyMethodWithBreakpointTag ]
+]
+
+{ #category : 'item decoration' }
+ClyReflectiveEnvironmentPlugin >> doesAnyManager: metalinkManagers belongsTo: aMethod [
+
+	^ metalinkManagers anySatisfy: [ :each | 
+		each isNotNil and: [ self doesNodeOf: each belongsTo: aMethod ] ]
+]
+
+{ #category : 'item decoration' }
+ClyReflectiveEnvironmentPlugin >> doesNodeOf: aMetalinkManager belongsTo: aMethod [
+	| methodNode |
+
+	methodNode := aMetalinkManager node methodNode.
+	methodNode selector == aMethod selector ifFalse: [ ^ false ].
+	methodNode methodClass == aMethod methodClass ifFalse: [ ^ false ].
+	methodNode == aMethod ast ifFalse: [ ^ false ].
+	
+	^ true
+]


### PR DESCRIPTION
it reintroduces a simplified class that was removed because wrongly mixing layers (it should be fine now... let's cross fingers ;) .

fixes https://github.com/pharo-project/pharo/issues/19132