### PR TITLE
affect the failBlock so it can be return in case of error 

### DIFF
--- a/src/Kernel-Tests/IntegerTest.class.st
+++ b/src/Kernel-Tests/IntegerTest.class.st
@@ -1223,6 +1223,14 @@ IntegerTest >> testReadFrom [
 	self assert: '.s could be confused with a ScaledDecimal' equals: s
 ]
 
+{ #category : 'tests - converting' }
+IntegerTest >> testReadFromFail [ 
+
+	self assert: (Integer readFrom: '_1' ifFail: [nil]) isNil.
+	self assert: (Integer readFrom: '\\\' ifFail: [nil]) isNil.
+	self assert: (Integer readFrom: 'hey' ifFail: [false]) not.
+]
+
 { #category : 'tests - instance creation' }
 IntegerTest >> testReadFromWithError [
 	"Ensure that a string that does not represent an integer raises an error."

--- a/src/NumberParser/Integer.extension.st
+++ b/src/NumberParser/Integer.extension.st
@@ -29,7 +29,9 @@ Integer class >> readFrom: aStringOrStream ifFail: aBlock [
 	"(self readFrom: '_1' ifFail: [nil]) >>> nil"
 	"(self readFrom: '1' ifFail: [nil]) >>> 1"
 	"(self readFrom: '\\\' ifFail: [false]) >>> false"
-	
+	"(Integer readFrom: '_1' ifFail: [nil]) >>> nil"
+	"(Integer readFrom: '1' ifFail: [nil]) >>> 1"
+	"(Integer readFrom: '\\\' ifFail: [false]) >>> false"
 	^(NumberParser on: aStringOrStream) nextIntegerBase: 10 ifFail: aBlock
 ]
 

--- a/src/NumberParser/Integer.extension.st
+++ b/src/NumberParser/Integer.extension.st
@@ -31,7 +31,8 @@ Integer class >> readFrom: aStringOrStream ifFail: aBlock [
 	"(self readFrom: '\\\' ifFail: [false]) >>> false"
 	"(Integer readFrom: '_1' ifFail: [nil]) >>> nil"
 	"(Integer readFrom: '1' ifFail: [nil]) >>> 1"
-	"(Integer readFrom: '\\\' ifFail: [false]) >>> false"
+	"(Integer readFrom: '_1' ifFail: [nil]) >>> nil"
+	"(Integer readFrom: '1' ifFail: [nil]) >>> 1"
 	^(NumberParser on: aStringOrStream) nextIntegerBase: 10 ifFail: aBlock
 ]
 

--- a/src/NumberParser/Integer.extension.st
+++ b/src/NumberParser/Integer.extension.st
@@ -26,13 +26,11 @@ Integer class >> readFrom: aStringOrStream ifFail: aBlock [
 	Imbedded radix specifiers not allowed;  use Number
 	class readFrom: for that.
 	Execute aBlock if there are no digits."
-	"(self readFrom: '_1' ifFail: [nil]) >>> nil"
-	"(self readFrom: '1' ifFail: [nil]) >>> 1"
-	"(self readFrom: '\\\' ifFail: [false]) >>> false"
+
 	"(Integer readFrom: '_1' ifFail: [nil]) >>> nil"
 	"(Integer readFrom: '1' ifFail: [nil]) >>> 1"
-	"(Integer readFrom: '_1' ifFail: [nil]) >>> nil"
-	"(Integer readFrom: '1' ifFail: [nil]) >>> 1"
+	"(Integer readFrom: '\\\' ifFail: [false]) >>> false"
+
 	^(NumberParser on: aStringOrStream) nextIntegerBase: 10 ifFail: aBlock
 ]
 

--- a/src/NumberParser/Integer.extension.st
+++ b/src/NumberParser/Integer.extension.st
@@ -26,9 +26,9 @@ Integer class >> readFrom: aStringOrStream ifFail: aBlock [
 	Imbedded radix specifiers not allowed;  use Number
 	class readFrom: for that.
 	Execute aBlock if there are no digits."
-	"self readFrom: '_1' ifFail: [nil] >>> nil"
-	"self readFrom: '1' ifFail: [nil] >>> 1"
-	"self readFrom: '\\\' ifFail: [false] >>> false"
+	"(self readFrom: '_1' ifFail: [nil]) >>> nil"
+	"(self readFrom: '1' ifFail: [nil]) >>> 1"
+	"(self readFrom: '\\\' ifFail: [false]) >>> false"
 	
 	^(NumberParser on: aStringOrStream) nextIntegerBase: 10 ifFail: aBlock
 ]

--- a/src/NumberParser/Integer.extension.st
+++ b/src/NumberParser/Integer.extension.st
@@ -26,7 +26,10 @@ Integer class >> readFrom: aStringOrStream ifFail: aBlock [
 	Imbedded radix specifiers not allowed;  use Number
 	class readFrom: for that.
 	Execute aBlock if there are no digits."
-
+	"self readFrom: '_1' ifFail: [nil] >>> nil"
+	"self readFrom: '1' ifFail: [nil] >>> 1"
+	"self readFrom: '\\\' ifFail: [false] >>> false"
+	
 	^(NumberParser on: aStringOrStream) nextIntegerBase: 10 ifFail: aBlock
 ]
 

--- a/src/NumberParser/NumberParser.class.st
+++ b/src/NumberParser/NumberParser.class.st
@@ -314,7 +314,7 @@ NumberParser >> nextIntegerBase: aRadix ifFail: aBlock [
 	"Form an integer with optional sign and following digits from sourceStream."
 
 	| isNeg value |
-	failBlock := [ aBlock value ].
+	failBlock := [ ^ aBlock value ].
 	
 	isNeg := self peekSignIsMinus.
 	value := self nextUnsignedIntegerOrNilBase: aRadix.

--- a/src/NumberParser/NumberParser.class.st
+++ b/src/NumberParser/NumberParser.class.st
@@ -314,6 +314,8 @@ NumberParser >> nextIntegerBase: aRadix ifFail: aBlock [
 	"Form an integer with optional sign and following digits from sourceStream."
 
 	| isNeg value |
+	failBlock := [ aBlock value ].
+	
 	isNeg := self peekSignIsMinus.
 	value := self nextUnsignedIntegerOrNilBase: aRadix.
 	value ifNil: [^aBlock value].


### PR DESCRIPTION
we applied the suggested correction! :)
``` st
nextIntegerBase: aRadix ifFail: aBlock
	"Form an integer with optional sign and following digits from sourceStream."

	| isNeg value |
	failBlock := [ aBlock value ].
	
	isNeg := self peekSignIsMinus.
	value := self nextUnsignedIntegerOrNilBase: aRadix.
	value ifNil: [^aBlock value].
	^isNeg
		ifTrue: [value negated]
		ifFalse: [value]
```

@Solomanoa 

Close #19618 