### PR TITLE
Fix bug where recompiling a trait with no change

### DIFF
--- a/src/Traits-Tests/TraitCompositionChangedDetectorTest.class.st
+++ b/src/Traits-Tests/TraitCompositionChangedDetectorTest.class.st
@@ -1,0 +1,42 @@
+"
+I am a class to tests the trait composition detector of the shift class builder. 
+
+I ensure that I detect a change if we update a trait composition and that I do not find any change if the trait composition stay the same
+"
+Class {
+	#name : 'TraitCompositionChangedDetectorTest',
+	#superclass : 'ShAbstractChangeDetectorTest',
+	#category : 'Traits-Tests',
+	#package : 'Traits-Tests'
+}
+
+{ #category : 'tests' }
+TraitCompositionChangedDetectorTest >> testChangeInTraitCompositionIsDetected [
+
+	| newTrait |
+	newBuilder := ShiftClassBuilder new
+		              fillFor: usedTrait;
+		              yourself.
+	[
+		newTrait := self class classInstaller make: [ :builder |
+				            builder
+					            beTrait;
+					            name: #TToUseForChangeComparison;
+					            package: self packageName ].
+		newBuilder traits: newTrait.
+
+		self denyEmpty: self newComparer compareClass.
+		self assertChangeAreDetected ] ensure: [ newTrait ifNotNil: [ newTrait removeFromSystem ] ]
+]
+
+{ #category : 'tests' }
+TraitCompositionChangedDetectorTest >> testNoChangeInTraitCompositionIsDetected [
+
+	newBuilder := ShiftClassBuilder new
+		              fillFor: usedTrait;
+		              yourself.
+	newBuilder traits: {  }.
+
+	self assertEmpty: self newComparer compareClass.
+	self assertChangeArentDetected
+]

--- a/src/Traits/TraitBuilderEnhancer.class.st
+++ b/src/Traits/TraitBuilderEnhancer.class.st
@@ -142,8 +142,9 @@ TraitBuilderEnhancer >> classTraitCompositionOf: aBuilder [
 
 { #category : 'utilities' }
 TraitBuilderEnhancer >> classTraitCompositionOfClass: aClass [
+	"We are using #basicTraitComposition and not #traitCompostion because #traitComposition adds TraitedClass to the trait composition and we do not have it in the builder's trait."
 
-	^ aClass class traitComposition asTraitComposition
+	^ aClass class basicTraitComposition asTraitComposition
 ]
 
 { #category : 'class modifications' }


### PR DESCRIPTION
Before this change, if we recompiled a trait that did not change, we still recompiled it. This was because #traitComposition on a trait adds TraitedClass in the trait composition. Instead I am now using #basicTraitedClass