### PR TITLE
add flatpak known paths (for linux)

### DIFF
--- a/src/UnifiedFFI/FFIUnix64LibraryFinder.class.st
+++ b/src/UnifiedFFI/FFIUnix64LibraryFinder.class.st
@@ -13,10 +13,19 @@ Class {
 FFIUnix64LibraryFinder >> knownPaths [
 
 	^ #(
+	"regular paths"
 	'/lib/x86_64-linux-gnu'
 	'/lib64'
 	'/usr/lib64'
 	'/usr/lib'
 	'/usr/lib/x86_64-linux-gnu'
-	'/usr/local/lib')
+	'/usr/local/lib'
+	"flatpak external paths"
+	'/run/host/lib/x86_64-linux-gnu'
+	'/run/host/lib64'
+	'/run/host/usr/lib64'
+	'/run/host/usr/lib'
+	'/run/host/usr/lib/x86_64-linux-gnu'
+	'/run/host/usr/local/lib'	
+)
 ]


### PR DESCRIPTION
as I am working on a flatpak for the pharo-vm, I figured out a correct known paths for the linux library finder requires some extension, I am adding them here.