### PR TITLE
Fix: UI inconsistency for test status

### DIFF
--- a/src/SUnit-Core/TestCase.class.st
+++ b/src/SUnit-Core/TestCase.class.st
@@ -658,12 +658,18 @@ TestCase >> debug [
 	"During the execution, if the receiver fails
 	due to an error or an assertion failure,
 	I open the debuger so user can see the context of failure"
-	| result |
 
+	| result |
 	result := self classForTestResult new.
-	^ [ self debug: result ] 
-	ensure: [ 
-		result updateResultsInHistory ].
+	[ self debug: result ]
+		on: Exception
+		do: [ :exception |
+				result updateResultsInHistory.
+				exception pass ].
+
+
+	result updateResultsInHistory.
+	^ result
 ]
 
 { #category : 'running' }

--- a/src/SUnit-Tests/TestResultTest.class.st
+++ b/src/SUnit-Tests/TestResultTest.class.st
@@ -7,6 +7,30 @@ Class {
 }
 
 { #category : 'tests' }
+TestResultTest >> testDebugFiresNotificationBeforeAndAfter [
+
+	| unitTestClass historyAnnouncements |
+	unitTestClass := ClassFactoryForTestCaseTest.
+	unitTestClass resetAnnouncer.
+	unitTestClass resetHistory.
+
+	unitTestClass compile: 'testFailing self assert: false'.
+
+
+	historyAnnouncements := OrderedCollection new.
+	unitTestClass historyAnnouncer when: TestSuiteEnded do: [ :announcement | historyAnnouncements add: announcement ] for: self.
+	[ unitTestClass debug: #testFailing ]
+		on: Exception
+		do: [ :ex | self assert: historyAnnouncements isNotEmpty ].
+
+	self assert: historyAnnouncements size equals: 2.
+
+	unitTestClass historyAnnouncer unsubscribe: self.
+	unitTestClass resetHistory.
+	unitTestClass removeSelector: #testFailing
+]
+
+{ #category : 'tests' }
 TestResultTest >> testRemoveFromTestHistoryFiresHistoryAnnouncement [
 	"Removing a method from test history should announce TestSuiteEnded
      on the class historyAnnouncer so the class-level bubble turns grey."

--- a/src/SUnit-Tests/TestResultTest.class.st
+++ b/src/SUnit-Tests/TestResultTest.class.st
@@ -10,24 +10,19 @@ Class {
 TestResultTest >> testDebugFiresNotificationBeforeAndAfter [
 
 	| unitTestClass historyAnnouncements |
-	unitTestClass := ClassFactoryForTestCaseTest.
-	unitTestClass resetAnnouncer.
-	unitTestClass resetHistory.
+	[
+		unitTestClass := SUnitTest.
+		unitTestClass resetAnnouncer.
+		unitTestClass resetHistory.
+		historyAnnouncements := OrderedCollection new.
+		unitTestClass historyAnnouncer when: TestSuiteEnded do: [ :announcement | historyAnnouncements add: announcement ] for: self.
+		[ unitTestClass debug: #expectedFailureFails ]
+			on: Exception
+			do: [ :ex | self denyEmpty: historyAnnouncements ].
 
-	unitTestClass compile: 'testFailing self assert: false'.
-
-
-	historyAnnouncements := OrderedCollection new.
-	unitTestClass historyAnnouncer when: TestSuiteEnded do: [ :announcement | historyAnnouncements add: announcement ] for: self.
-	[ unitTestClass debug: #testFailing ]
-		on: Exception
-		do: [ :ex | self assert: historyAnnouncements isNotEmpty ].
-
-	self assert: historyAnnouncements size equals: 2.
-
-	unitTestClass historyAnnouncer unsubscribe: self.
-	unitTestClass resetHistory.
-	unitTestClass removeSelector: #testFailing
+		self assert: historyAnnouncements size equals: 2 ] ensure: [
+			unitTestClass historyAnnouncer unsubscribe: self.
+			unitTestClass resetHistory ]
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
- The main problem was that `debug` called `result updateResultsInHistory` in the ensure block when the debugger is closed. But the result that is used is the failing one, it has not been updated.
- Now we catch the exception directly, updating the result even before the debugger is opened. This lead to two things: the test icon is already updated in the background, and the UI inconsistency is fixed since the result used by the debugger is now the good one!
- Fixes #19736