### PR TITLE
Use same shuffle seed for all test suites in a CLI run

### DIFF
--- a/src/SUnit-Basic-CLI/HDTestReport.class.st
+++ b/src/SUnit-Basic-CLI/HDTestReport.class.st
@@ -20,6 +20,7 @@ Class {
 	],
 	#classVars : [
 		'CurrentStageName',
+		'RunSeed',
 		'ShuffleSeed'
 	],
 	#category : 'SUnit-Basic-CLI',
@@ -41,7 +42,7 @@ HDTestReport class >> runClasses: aCollectionOfClasses named: packageName [
 
 	| suite classes time result |
 	suite := TestSuite named: packageName.
-	ShuffleSeed ifNotNil: [ suite shuffleSeed: ShuffleSeed asInteger ].
+	suite shuffleSeed: self seedForRun.
 	classes := (aCollectionOfClasses select: [ :class |
 		            class isTestCase and: [ class isAbstract not ] ])
 		           asSortedCollection: [ :a :b | a name <= b name ].
@@ -72,7 +73,34 @@ HDTestReport class >> runSuite: aTestSuite [
 
 { #category : 'running' }
 HDTestReport class >> shuffleSeed: aSeed [
-	ShuffleSeed := aSeed
+	ShuffleSeed := aSeed.
+	RunSeed := nil
+]
+
+{ #category : 'running' }
+HDTestReport class >> seedForRun [
+	"Return the seed to use for shuffling tests. If a seed was explicitly set via the command line, use it. Otherwise, generate a random seed once and reuse it for all suites in the same run, ensuring reproducibility."
+
+	^ RunSeed ifNil: [
+		RunSeed := ShuffleSeed
+			ifNotNil: [ :seed | seed asInteger ]
+			ifNil: [ Random new seed ] ]
+]
+
+{ #category : 'running' }
+HDTestReport class >> resetRunSeed [
+	"Reset the cached run seed. Should be called at the start of a new test run."
+
+	RunSeed := nil
+]
+
+{ #category : 'running' }
+HDTestReport class >> runPackages: aCollectionOfStrings [
+	"Override to reset and log the shared seed at the beginning of a full test run."
+
+	self resetRunSeed.
+	('Using shared shuffle seed for all suites: ' , self seedForRun asString , OSPlatform current lineEnding) traceCr.
+	^ aCollectionOfStrings collect: [ :packageName | self runPackage: packageName ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
When running tests via command line, each package's test suite was getting its own random seed, making it impossible to reproduce the exact test ordering across all packages.

Added a seedForRun class method that generates or retrieves a single seed to be shared across all suites. The seed is computed once per run (lazily on first access) and reused for all subsequent packages.

Also overrides runPackages: to reset and log the shared seed at the beginning of each full test run.

Resolves #19743