### PR TITLE
Respecring the windows size

### DIFF
--- a/src/Morphic-Widgets-MissionControl/MissionControlMorph.class.st
+++ b/src/Morphic-Widgets-MissionControl/MissionControlMorph.class.st
@@ -117,7 +117,7 @@ MissionControlMorph >> deactivate [
 MissionControlMorph >> deactivateAndShowWindow: window [
 
 	self deactivate.
-	window unexpandedFrame: window fullFrame; activate; fullscreen
+	window unexpandedFrame: window fullFrame; activate
 ]
 
 { #category : 'drawing' }


### PR DESCRIPTION
The mission control feature was forcing the full screen of a selected window ( I had designed to do that on purpose ).

Now, I revert it to respect its size.