### PR TITLE
Fix metacello force load baseline

### DIFF
--- a/src/Metacello-Core/MetacelloMonticelloLoader.class.st
+++ b/src/Metacello-Core/MetacelloMonticelloLoader.class.st
@@ -84,24 +84,32 @@ MetacelloMonticelloLoader >> loadAtomicPackageDirectives: packageDirectives engi
 
 { #category : 'loading' }
 MetacelloMonticelloLoader >> loadProject: aMetacelloProjectSpec engine: anEngine [
-	"Loads the project BaselineOf and creates a project from it"
-	"There is no need at loading a project twice as long as it has the same version."
-
+	"Loads the project BaselineOf and creates a project from it 
+	 There is no need at loading a project twice as long as it has the same version.
+	 But if ignoreImage is true, then we want to load it anyway."
 	| projectClass projectClassInstance project |
-	projectCache
-		at: aMetacelloProjectSpec className
-		ifPresent: [ :found | ^ found ].
+	
+	anEngine ignoreImage ifFalse: [ 
+		projectCache 
+			at: aMetacelloProjectSpec className 
+			ifPresent: [ :found | ^ found ] ].
 
-	(self lookupProjectClassNamed: aMetacelloProjectSpec className) ifNil: [
-		self loadAtomicPackageDirectives: { (MetacelloPackageLoadDirective spec: aMetacelloProjectSpec projectPackage) } engine: anEngine ].
+	(anEngine ignoreImage 
+		or: [ (self lookupProjectClassNamed: aMetacelloProjectSpec className) isNil ]) 
+		ifTrue: [
+			self
+				loadAtomicPackageDirectives: { (MetacelloPackageLoadDirective spec: aMetacelloProjectSpec projectPackage) }
+				engine: anEngine ].
 
-	projectClass := self lookupProjectClassNamed:  aMetacelloProjectSpec className asSymbol.
-	projectClassInstance := projectClass new.
+	projectClass := self lookupProjectClassNamed: aMetacelloProjectSpec className asSymbol.
+	
+	projectClassInstance := projectClass new. 
 	"Subclasses typically change the load type of the project to #atomic"
 	projectClassInstance initalizeProjectWithRepositoryDescription: aMetacelloProjectSpec repositoryDescriptions.
 	project := projectClassInstance project.
-	projectCache
-		at: aMetacelloProjectSpec className
+	
+	projectCache 
+		at: aMetacelloProjectSpec className 
 		put: project.
 	^ project
 ]

--- a/src/Metacello-Tests/MetacelloMonticelloLoaderTest.class.st
+++ b/src/Metacello-Tests/MetacelloMonticelloLoaderTest.class.st
@@ -1,0 +1,51 @@
+"
+Tests for MetacelloMonticelloLoader behavior, especially ignoreImage flag propagation through project cache and class-existence guards.
+"
+Class {
+	#name : 'MetacelloMonticelloLoaderTest',
+	#superclass : 'TestCase',
+	#category : 'Metacello-Tests-Monticello',
+	#package : 'Metacello-Tests',
+	#tag : 'Monticello'
+}
+
+{ #category : 'tests' }
+MetacelloMonticelloLoaderTest >> testCacheBypassWithIgnoreImage [
+	| loader spec engine1 engine2 project1 |
+	
+	loader := MetacelloMonticelloLoader new.
+	spec := MetacelloProjectSpec new
+		className: 'BaselineOfTestToLock2';
+		yourself.
+
+	engine1 := MetacelloScriptEngine new.
+	engine1 options at: #ignoreImage put: false.
+	project1 := loader loadProject: spec engine: engine1. 
+	
+	"Without ignoreImage: cache returns same object"
+	self assert: (loader loadProject: spec engine: engine1) == project1. 
+	
+	"With ignoreImage: cache bypassed, download attempted.
+	Since no repository is configured, download fails with Error.
+	If cache were NOT bypassed, this would return cached project silently."
+	engine2 := MetacelloScriptEngine new.
+	engine2 options at: #ignoreImage put: true.
+	self should: [ loader loadProject: spec engine: engine2 ] raise: Error
+]
+
+{ #category : 'tests' }
+MetacelloMonticelloLoaderTest >> testIgnoreImageDefaultIsFalse [
+	| loader spec engine project1 project2 |
+	
+	loader := MetacelloMonticelloLoader new.
+	spec := MetacelloProjectSpec new
+		className: 'BaselineOfTestToLock2';
+		yourself.
+
+	engine := MetacelloScriptEngine new. 
+	
+	"engine has no ignoreImage key set"
+	project1 := loader loadProject: spec engine: engine.
+	project2 := loader loadProject: spec engine: engine.
+	self assert: project2 identicalTo: project1
+]


### PR DESCRIPTION
loading of baselines in metacello is being ignored if baseline is already in the image. This is fine for most of the cases, but when the baseline itself change, updating of a project becomes an annoyance and  you need to first manually remove the baseline to be able to proceed...

But metacello implements the flag "ignoreImage", whis is meant to bypass what is present on the image and reload the project... a flag that was being ignored in the case of baselines !
 
This PR makes baselines behave coherently with the flag: if set, metacello will ignore what is in the image and will load it again, solving the defined problem. 

fixes https://github.com/pharo-project/pharo/issues/18743