### PR TITLE
refactor IconStyler

### DIFF
--- a/src/Calypso-SystemPlugins-DebugPoints-Browser/DebugPointIconStyler.class.st
+++ b/src/Calypso-SystemPlugins-DebugPoints-Browser/DebugPointIconStyler.class.st
@@ -14,65 +14,46 @@ DebugPointIconStyler class >> isStaticStyler [
 	^ true
 ]
 
-{ #category : 'styling' }
+{ #category : 'private' }
 DebugPointIconStyler >> addIconStyle: aNode from: start to: stop color: aColor [
-	"there probably is a better way that just adding a second row but i couldn't figure out rubric"
-	| conf |
-	(self shouldStyleNode: aNode) ifFalse: [ ^ self ].
 
-	"list options for each debug point"
+	(self shouldStyleNode: aNode) ifFalse: [ ^ self ].
 	(self allDebugPointsOn: aNode) do: [ :dp |
-		
-		conf := RubConfigurationChange new.
-	conf configurationBlock: [ :text | 
-		| r r2 |
-		r := self segmentMorphClass from: start to: stop + 1.
-		text addSegment: r.
-		r label: (self iconLabelBlock: dp).
-		r icon: (self iconFor: dp).
-		r iconBlock: (self iconBlock: dp).
-		r color: aColor.
-		r borderColor: self borderColor .
-		r2 := self segmentMorphClass from: start to: stop + 1.
-		text addSegment: r2.
-		r2 label: 'Remove'.
-		r2 icon: (self iconFor: dp ).
-		r2 iconBlock: (self iconBlockEdit: dp).
-		r2 color: aColor.
-		r2 borderColor: self borderColor .
-		].
-	
-	textModel announce: conf 
-	].
-	
-	
-	
-	"conf := RubConfigurationChange new.
-	conf configurationBlock: [ :text | 
-		| r r2 |
-		r := self segmentMorphClass from: start to: stop + 1.
-		text addSegment: r.
-		r label: (self iconLabelBlock: aNode).
-		r icon: (self iconFor: aNode).
-		r iconBlock: (self iconBlock: aNode).
-		r color: aColor.
-		r borderColor: self borderColor .
-		r2 := self segmentMorphClass from: start to: stop + 1.
-		text addSegment: r2.
-		r2 label: 'Remove'.
-		r2 icon: (self iconFor: aNode).
-		r2 iconBlock: (self iconBlockEdit: aNode).
-		r2 color: aColor.
-		r2 borderColor: self borderColor .
-		].
-	
-	textModel announce: conf"
+			renderer addDecoration: (IconStylerDecoration new
+					 name: self stylerName;
+					 interval: (start to: stop);
+					 highlightColor: aColor;
+					 icon: (self iconFor: dp);
+					 iconBlock: (self iconBlock: dp);
+					 title: (self iconLabel: dp);
+					 yourself).
+			renderer addDecoration: (IconStylerDecoration new
+					 name: self stylerName;
+					 interval: (start to: stop);
+					 highlightColor: aColor;
+					 icon: (self iconFor: dp);
+					 iconBlock: (self iconBlockEdit: dp);
+					 title: 'Remove';
+					 yourself) ]
 ]
 
 { #category : 'private' }
 DebugPointIconStyler >> allDebugPointsOn: aNode [
 
 	^(aNode links select: [ :link | link metaObject isKindOf: self forClass ]) collect: [:link | link metaObject].
+]
+
+{ #category : 'building' }
+DebugPointIconStyler >> buildIconStyleFor: dp to: aNode [
+
+	^ IconStylerDecoration new
+		  name: self stylerName;
+		  interval: (aNode start to: aNode stop + 1);
+		  highlightColor: self highlightColor;
+		  icon: (self iconFor: dp);
+		  iconBlock: (self iconBlock: dp);
+		  title: (self iconLabel: dp);
+		  yourself
 ]
 
 { #category : 'styling' }
@@ -144,4 +125,10 @@ DebugPointIconStyler >> iconLabel: dp [
 DebugPointIconStyler >> shouldStyleNode: aNode [
 
 	^aNode hasDebugPointOfType: self forClass
+]
+
+{ #category : 'private' }
+DebugPointIconStyler >> stylerName [
+
+	^ 'debug-point'
 ]

--- a/src/PharoDocComment/DocCommentIconStyler.class.st
+++ b/src/PharoDocComment/DocCommentIconStyler.class.st
@@ -76,6 +76,12 @@ DocCommentIconStyler >> shouldStyleNode: aNode [
 ]
 
 { #category : 'private' }
+DocCommentIconStyler >> stylerName [
+
+	^ 'doc-comment'
+]
+
+{ #category : 'private' }
 DocCommentIconStyler >> stylingEnabled [
 	^ PharoDocCommentNode docCommentEnabled
 ]

--- a/src/Reflectivity-Tools/BreakpointIconStyler.class.st
+++ b/src/Reflectivity-Tools/BreakpointIconStyler.class.st
@@ -42,3 +42,9 @@ BreakpointIconStyler >> iconLabel: aNode [
 BreakpointIconStyler >> shouldStyleNode: aNode [
 	^aNode hasBreakpoint and: [ aNode breakpoints anySatisfy: [:brkpt | brkpt isEnabled ]]
 ]
+
+{ #category : 'private' }
+BreakpointIconStyler >> stylerName [
+
+	^ 'breakpoint'
+]

--- a/src/Reflectivity-Tools/DisabledBreakpointIconStyler.class.st
+++ b/src/Reflectivity-Tools/DisabledBreakpointIconStyler.class.st
@@ -41,3 +41,9 @@ DisabledBreakpointIconStyler >> iconLabel: aNode [
 DisabledBreakpointIconStyler >> shouldStyleNode: aNode [
 	^aNode hasBreakpoint and: [ aNode breakpoints noneSatisfy: [:brkpt | brkpt isEnabled ]]
 ]
+
+{ #category : 'private' }
+DisabledBreakpointIconStyler >> stylerName [
+
+	^ 'breakpoint'
+]

--- a/src/Reflectivity-Tools/ErrorNodeStyler.class.st
+++ b/src/Reflectivity-Tools/ErrorNodeStyler.class.st
@@ -23,36 +23,30 @@ ErrorNodeStyler >> iconLabel: aNode [
 	^ aNode errorNotices first messageText
 ]
 
-{ #category : 'hooks' }
-ErrorNodeStyler >> segmentMorphClass [
-
-	^ RubUnderlinedSegmentMorph
-]
-
 { #category : 'visiting' }
 ErrorNodeStyler >> shouldStyleNode: aNode [
 	^ aNode isError and: [ aNode errorNotices isNotEmpty ]
 ]
 
+{ #category : 'private' }
+ErrorNodeStyler >> stylerName [
+
+	^ 'error'
+]
+
 { #category : 'visiting' }
 ErrorNodeStyler >> visitEnglobingErrorNode: anEnglobingNode [
 
-	| conf |
-
 	(self shouldStyleNode: anEnglobingNode) ifFalse: [ ^ super visitEnglobingErrorNode: anEnglobingNode ].
-
-	"Only add red underline at the error position (instead on the whole node)"
-	conf := RubConfigurationChange new.
-	conf configurationBlock: [ :text |
-		| r |
-		r := self segmentMorphClass from: anEnglobingNode errorPosition to: anEnglobingNode errorPosition.
-		text addSegment: r.
-		r label: (self iconLabelBlock: anEnglobingNode).
-		r icon: (self iconFor: anEnglobingNode).
-		r iconBlock: (self iconBlock: anEnglobingNode).
-		r color: self highlightColor.
-		r borderColor: self borderColor ].
-	textModel announce: conf.
-
+	renderer addDecoration: (IconStylerDecoration new
+			 name: self stylerName;
+			 interval: (anEnglobingNode errorPosition to: anEnglobingNode errorPosition);
+			 highlightColor: self highlightColor;
+			 isUnderline: true;
+			 underlineColor: Color red;
+			 icon: (self iconFor: anEnglobingNode);
+			 iconBlock: (self iconBlock: anEnglobingNode);
+			 title: (self iconLabel: anEnglobingNode);
+			 yourself).
 	anEnglobingNode contents do: [ :each | self visitNode: each ]
 ]

--- a/src/Reflectivity-Tools/FlagIconStyler.class.st
+++ b/src/Reflectivity-Tools/FlagIconStyler.class.st
@@ -34,3 +34,9 @@ FlagIconStyler >> iconFor: aNode [
 FlagIconStyler >> shouldStyleNode: aNode [
 	^aNode isMessage and: [aNode selector = #flag:]
 ]
+
+{ #category : 'private' }
+FlagIconStyler >> stylerName [
+
+	^ 'flag'
+]

--- a/src/Reflectivity-Tools/HaltIconStyler.class.st
+++ b/src/Reflectivity-Tools/HaltIconStyler.class.st
@@ -37,3 +37,9 @@ HaltIconStyler >> shouldStyleNode: aNode [
 	selectorsToBeHighlighted := { 'halt'. 'halt:'. 'haltIf:'. 'haltIfNil' }.
 	^aNode isMessage and: [ selectorsToBeHighlighted anySatisfy: [ :sel| sel = aNode selector ]]
 ]
+
+{ #category : 'private' }
+HaltIconStyler >> stylerName [
+
+	^ 'breakpoint'
+]

--- a/src/Reflectivity-Tools/HaltOnCountIconStyler.class.st
+++ b/src/Reflectivity-Tools/HaltOnCountIconStyler.class.st
@@ -26,3 +26,9 @@ HaltOnCountIconStyler >> shouldStyleNode: aNode [
 	^ aNode isMessage
 		and: [ #(#haltOnCount: #haltFromCount:) includes: aNode selector ]
 ]
+
+{ #category : 'private' }
+HaltOnCountIconStyler >> stylerName [
+
+	^ 'breakpoint'
+]

--- a/src/Reflectivity-Tools/HaltOnceIconStyler.class.st
+++ b/src/Reflectivity-Tools/HaltOnceIconStyler.class.st
@@ -25,3 +25,9 @@ HaltOnceIconStyler >> iconLabelBlock: aNode [
 HaltOnceIconStyler >> shouldStyleNode: aNode [
 	^aNode isMessage and: [ aNode selector = #haltOnce]
 ]
+
+{ #category : 'private' }
+HaltOnceIconStyler >> stylerName [
+
+	^ 'breakpoint'
+]

--- a/src/Reflectivity-Tools/IconStyler.class.st
+++ b/src/Reflectivity-Tools/IconStyler.class.st
@@ -152,7 +152,7 @@ IconStyler >> stylerClasses: anObject [
 { #category : 'private' }
 IconStyler >> stylerName [
 
-	^ 'styler'
+	^ 'icon'
 ]
 
 { #category : 'accessing' }

--- a/src/Reflectivity-Tools/IconStyler.class.st
+++ b/src/Reflectivity-Tools/IconStyler.class.st
@@ -7,7 +7,8 @@ Class {
 	#superclass : 'OCProgramNodeVisitor',
 	#instVars : [
 		'textModel',
-		'stylerClasses'
+		'stylerClasses',
+		'renderer'
 	],
 	#category : 'Reflectivity-Tools-Breakpoints',
 	#package : 'Reflectivity-Tools',
@@ -34,14 +35,16 @@ IconStyler class >> withStaticStylers [
 		  yourself
 ]
 
-{ #category : 'styling' }
+{ #category : 'private' }
 IconStyler >> addIconMethodStyle: aMethodNode [
-	self addIconStyle: aMethodNode from: 1 to: 0
+
+	self addIconStyle: aMethodNode from: 1 to: 1
 ]
 
-{ #category : 'styling' }
+{ #category : 'private' }
 IconStyler >> addIconStyle: aNode [
-	self addIconStyle: aNode from: aNode start to: aNode stop
+
+	self addIconStyle: aNode from: aNode start to: aNode stop + 1
 ]
 
 { #category : 'styling' }
@@ -50,27 +53,18 @@ IconStyler >> addIconStyle: aNode from: start to: stop [
 	self addIconStyle: aNode from: start to: stop color: self highlightColor
 ]
 
-{ #category : 'styling' }
+{ #category : 'private' }
 IconStyler >> addIconStyle: aNode from: start to: stop color: aColor [
 
-	| conf |
 	(self shouldStyleNode: aNode) ifFalse: [ ^ self ].
-	conf := RubConfigurationChange new.
-	conf configurationBlock: [ :text |
-		| r |
-		r := self segmentMorphClass from: start to: stop + 1.
-		text addSegment: r.
-		r label: (self iconLabelBlock: aNode).
-		r icon: (self iconFor: aNode).
-		r iconBlock: (self iconBlock: aNode).
-		r color: aColor.
-		r borderColor: self borderColor ].
-	textModel announce: conf
-]
-
-{ #category : 'defaults' }
-IconStyler >> borderColor [
-	^Color gray
+	renderer addDecoration: (IconStylerDecoration new
+			 name: self stylerName;
+			 interval: (start to: stop);
+			 highlightColor: aColor;
+			 icon: (self iconFor: aNode);
+			 iconBlock: (self iconBlock: aNode);
+			 title: (self iconLabel: aNode);
+			 yourself)
 ]
 
 { #category : 'defaults' }
@@ -100,19 +94,27 @@ IconStyler >> iconLabelBlock: aNode [
 
 { #category : 'initialization' }
 IconStyler >> initialize [
+
 	super initialize.
-	self resetStylerClasses
+	self resetStylerClasses.
+	renderer := RubricIconStylerRenderer new
+]
+
+{ #category : 'accessing' }
+IconStyler >> renderer [
+
+	^ renderer
+]
+
+{ #category : 'accessing' }
+IconStyler >> renderer: anObject [
+
+	renderer := anObject
 ]
 
 { #category : 'initialization' }
 IconStyler >> resetStylerClasses [
 	stylerClasses := OrderedCollection new
-]
-
-{ #category : 'hooks' }
-IconStyler >> segmentMorphClass [
-
-	^ RubTextSegmentMorph
 ]
 
 { #category : 'testing' }
@@ -124,16 +126,17 @@ IconStyler >> shouldStyleNode: aNode [
 IconStyler >> styleAst: ast [
 	"Style the AST using the textmodel of the receiver. Ask all the registered stylers to act."
 
-	stylerClasses do: [ :styleClass |
-			ast acceptVisitor: (styleClass new textModel: textModel) ]
+	renderer clearDecorations.
+	stylerClasses do: [ :styleClass | ast acceptVisitor: (styleClass new renderer: renderer) ]
 ]
 
 { #category : 'styling' }
 IconStyler >> styleText: aTextModel withAst: ast [
-	"style the AST using the textmodel passed as first argument. Ask all the registered stylers to act."
+	"Style the AST using the text model passed as first argument. Ask all the registered stylers to act."
 
-	stylerClasses do: [ :styleClass |
-		 ast acceptVisitor: (styleClass new textModel: aTextModel) ]
+	renderer textModel: aTextModel.
+	renderer clearDecorations.
+	stylerClasses do: [ :styleClass | ast acceptVisitor: (styleClass new renderer: renderer) ]
 ]
 
 { #category : 'accessing' }
@@ -146,6 +149,12 @@ IconStyler >> stylerClasses: anObject [
 	stylerClasses := anObject
 ]
 
+{ #category : 'private' }
+IconStyler >> stylerName [
+
+	^ 'styler'
+]
+
 { #category : 'accessing' }
 IconStyler >> textModel [
 	^ textModel
@@ -153,7 +162,9 @@ IconStyler >> textModel [
 
 { #category : 'accessing' }
 IconStyler >> textModel: anObject [
-	textModel := anObject
+
+	textModel := anObject.
+	renderer textModel: anObject
 ]
 
 { #category : 'accessing' }

--- a/src/Reflectivity-Tools/IconStylerDecoration.class.st
+++ b/src/Reflectivity-Tools/IconStylerDecoration.class.st
@@ -1,0 +1,118 @@
+"
+I am a value object describing a text decoration produced by an IconStyler.
+
+I hold all the properties needed to render a styled segment (icon, color, label, etc.) without depending on any backend framework. Renderer classes (SpIconStylerRenderer or RubricIconStylerRenderer) convert me into the appropriate native decoration.
+"
+Class {
+	#name : 'IconStylerDecoration',
+	#superclass : 'Object',
+	#instVars : [
+		'name',
+		'interval',
+		'highlightColor',
+		'icon',
+		'iconBlock',
+		'title',
+		'isUnderline',
+		'underlineColor'
+	],
+	#category : 'Reflectivity-Tools-Styler',
+	#package : 'Reflectivity-Tools',
+	#tag : 'Styler'
+}
+
+{ #category : 'accessing' }
+IconStylerDecoration >> highlightColor [
+
+	^ highlightColor
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> highlightColor: anObject [
+
+	highlightColor := anObject
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> icon [
+
+	^ icon
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> icon: anObject [
+
+	icon := anObject
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> iconBlock [
+
+	^ iconBlock
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> iconBlock: anObject [
+
+	iconBlock := anObject
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> interval [
+
+	^ interval
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> interval: anObject [
+
+	interval := anObject
+]
+
+{ #category : 'testing' }
+IconStylerDecoration >> isUnderline [
+
+	^ isUnderline ifNil: [ false ]
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> isUnderline: anObject [
+
+	isUnderline := anObject
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> name [
+
+	^ name
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> name: anObject [
+
+	name := anObject
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> title [
+
+	^ title
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> title: anObject [
+
+	title := anObject
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> underlineColor [
+
+	^ underlineColor ifNil: [ Color transparent ]
+]
+
+{ #category : 'accessing' }
+IconStylerDecoration >> underlineColor: anObject [
+
+	underlineColor := anObject
+]

--- a/src/Reflectivity-Tools/IconStylerRenderer.class.st
+++ b/src/Reflectivity-Tools/IconStylerRenderer.class.st
@@ -1,0 +1,39 @@
+"
+I convert IconStylerDecoration instances into native back-end decorations.
+
+Subclasses implement addDecoration: and clearDecorations for specific backends (Rubric, Spec).
+"
+Class {
+	#name : 'IconStylerRenderer',
+	#superclass : 'Object',
+	#instVars : [
+		'textModel'
+	],
+	#category : 'Reflectivity-Tools-Styler',
+	#package : 'Reflectivity-Tools',
+	#tag : 'Styler'
+}
+
+{ #category : 'rendering' }
+IconStylerRenderer >> addDecoration: anIconStylerDecoration [
+
+	self subclassResponsibility
+]
+
+{ #category : 'rendering' }
+IconStylerRenderer >> clearDecorations [
+
+	self subclassResponsibility
+]
+
+{ #category : 'accessing' }
+IconStylerRenderer >> textModel [
+
+	^ textModel
+]
+
+{ #category : 'accessing' }
+IconStylerRenderer >> textModel: anObject [
+
+	textModel := anObject
+]

--- a/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
+++ b/src/Reflectivity-Tools/MetaLinkIconStyler.class.st
@@ -41,3 +41,9 @@ MetaLinkIconStyler >> shouldStyleNode: aNode [
 	^ aNode hasMetaLinks and: [
 		  aNode links anySatisfy: [ :link | link hasOption: #optionStyler ] ]
 ]
+
+{ #category : 'private' }
+MetaLinkIconStyler >> stylerName [
+
+	^ 'metalink'
+]

--- a/src/Reflectivity-Tools/RubricIconStylerRenderer.class.st
+++ b/src/Reflectivity-Tools/RubricIconStylerRenderer.class.st
@@ -1,0 +1,39 @@
+"
+I convert IconStylerDecoration instances into Rubric text segments.
+
+Used for backward compatibility with Calypso Morphic tools.
+"
+Class {
+	#name : 'RubricIconStylerRenderer',
+	#superclass : 'IconStylerRenderer',
+	#category : 'Reflectivity-Tools-Styler',
+	#package : 'Reflectivity-Tools',
+	#tag : 'Styler'
+}
+
+{ #category : 'rendering' }
+RubricIconStylerRenderer >> addDecoration: aDecoration [
+	"Backward compat with Calypso — remove with Calypso migration to Spec."
+
+	| conf |
+	conf := RubConfigurationChange new.
+	conf configurationBlock: [ :text |
+			| segment |
+			segment := (aDecoration isUnderline
+				            ifTrue: [ RubUnderlinedSegmentMorph ]
+				            ifFalse: [ RubTextSegmentMorph ]) from: aDecoration interval first to: aDecoration interval last.
+			text addSegment: segment.
+			segment label: aDecoration title.
+			segment icon: aDecoration icon.
+			segment iconBlock: aDecoration iconBlock.
+			segment color: aDecoration highlightColor.
+			aDecoration isUnderline ifTrue: [ segment underlineColor: aDecoration underlineColor ] ].
+	textModel announce: conf
+]
+
+{ #category : 'rendering' }
+RubricIconStylerRenderer >> clearDecorations [
+	"Segments are cleared externally by Calypso callers."
+
+	
+]

--- a/src/Reflectivity-Tools/SemanticWarningIconStyler.class.st
+++ b/src/Reflectivity-Tools/SemanticWarningIconStyler.class.st
@@ -37,3 +37,9 @@ SemanticWarningIconStyler >> iconLabel: aNode [
 SemanticWarningIconStyler >> shouldStyleNode: aNode [
 	^aNode warningNotices isNotEmpty
 ]
+
+{ #category : 'private' }
+SemanticWarningIconStyler >> stylerName [
+
+	^ 'warning'
+]


### PR DESCRIPTION
separated morphic specific logic from the styler to be able to use it with other backends.
(I will commit a spec renderer to be used with the StMethodBrowser and others without rubric dependencies)