### PR TITLE
make test of debuggerCLI pass

### DIFF
--- a/src/Debugger-CLI-Tests/CommandLineDebuggerBasicCommandsTest.class.st
+++ b/src/Debugger-CLI-Tests/CommandLineDebuggerBasicCommandsTest.class.st
@@ -80,6 +80,7 @@ CommandLineDebuggerBasicCommandsTest >> testPrintCode [
 
 	response := debugger parsesAndExecuteCommand: 'printCode'.
 
+
 	self assert: (response includesSubstring: 'mockMethodForTesting').
 	self assert: (response includesSubstring: '"Fake method to test printCode"').
 	self assert: (response includesSubstring: 'a := --->42<---.').

--- a/src/Debugger-CLI/StepRelatedCommand.class.st
+++ b/src/Debugger-CLI/StepRelatedCommand.class.st
@@ -16,7 +16,7 @@ StepRelatedCommand >> executeOn: aDebugger with: args [
 
 	aDebugger context ifNil: [ ^ aDebugger finishedDebugging ].
 
-	self printResultFor: aDebugger
+	^ self printResultFor: aDebugger
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
As i made some changes in https://github.com/pharo-project/pharo/pull/19778, I forgot a return statement.
So obviously the tests are failing