### PR TITLE
Remove logs

### DIFF
--- a/src/OSWindow-SDL2/OSSDL2Driver.class.st
+++ b/src/OSWindow-SDL2/OSSDL2Driver.class.st
@@ -66,15 +66,14 @@ OSSDL2Driver >> beforeMainPharoWindowClosed: osWindow [
 OSSDL2Driver >> closeRemovedController: index [
 	"TODO: What should I do here?"
 
-	self
-		traceCr: ('Game controller <1s> removed' expandMacrosWith: index asString)
+	
 ]
 
 { #category : 'private' }
 OSSDL2Driver >> closeRemovedJoystick: index [
 	"TODO: What should I do here?"
 
-	self traceCr: ('Joystick <1s> removed' expandMacrosWith: index asString)
+	
 ]
 
 { #category : 'window creation and deletion' }


### PR DESCRIPTION
Some methods of the SDL driver are logging things in the transcript. I'm not sure it is useful to mess with the user's log for an unimplemented feature