### PR TITLE
Extension isolation

### DIFF
--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -1340,7 +1340,7 @@ EFFormatter >> formatSelectorAndArguments: aMessageNode firstSeparator: firstBlo
   i := 0.
   separatorBlock := firstBlock.
   aMessageNode isUnary ifTrue: [ self indentAround: [ self handleLineForSelector: aMessageNode selector withSeparatorBlock: separatorBlock.
-              codeStream nextPutAll: aMessageNode selector ] ] ifFalse: [ aMessageNode selectorParts with: aMessageNode arguments do: [:selector :argument |  i := i + 1.
+              codeStream nextPutAll: aMessageNode selector asString ] ] ifFalse: [ aMessageNode selectorParts with: aMessageNode arguments do: [:selector :argument |  i := i + 1.
               self handleLineForSelector: selector withSeparatorBlock: separatorBlock.
               separatorBlock := restBlock.
               self indent: ((((self willBeMultiline: argument) and: [ i < aMessageNode selectorParts size or: [ self newLineBefore ] ]) or: [ self isInCascadeNode ]) ifTrue: [ 1 ] ifFalse: [ 0 ]) around: [ codeStream nextPutAll: selector.
@@ -1434,7 +1434,7 @@ EFFormatter >> handleLineForArgument: anArgument [
 
 { #category : 'private' }
 EFFormatter >> handleLineForSelector: selector withSeparatorBlock: aBlock [
-	(self isLineTooLongWithString: selector)
+	(self isLineTooLongWithString: selector asString)
 		ifTrue: [ self newLine ]
 		ifFalse: [ aBlock value ]
 ]
@@ -1620,7 +1620,7 @@ EFFormatter >> isMultiLineMessage: aMessageNode [
 	self numberOfArgumentsForMultiLine <= aMessageNode arguments size
 		ifTrue: [ ^ true ].
 	aMessageNode isUnary
-		ifTrue: [ ^ self isLineTooLongWithString: aMessageNode selector ].
+		ifTrue: [ ^ self isLineTooLongWithString: aMessageNode selector asString ].
 	^ self isLineTooLongWithString: (self formatMessageNode: aMessageNode) contents
 ]
 

--- a/src/Kernel-CodeModel-Tests/AbstractExtensionTest.class.st
+++ b/src/Kernel-CodeModel-Tests/AbstractExtensionTest.class.st
@@ -1,0 +1,77 @@
+Class {
+	#name : 'AbstractExtensionTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'environment',
+		'isolatingRoot',
+		'definerPackage',
+		'userPackage',
+		'extendedPackage'
+	],
+	#category : 'Kernel-CodeModel-Tests-Extensions',
+	#package : 'Kernel-CodeModel-Tests',
+	#tag : 'Extensions'
+}
+
+{ #category : 'compiling' }
+AbstractExtensionTest >> compile: aString on: aClass [
+
+	^ aClass
+		compile: aString
+		classified: nil
+		withStamp: DateAndTime now
+		logSource: false
+]
+
+{ #category : 'running' }
+AbstractExtensionTest >> createClassNamed: className superclass: superclass package: package [
+
+	^ ((superclass << className)
+		   installingEnvironment: environment;
+		   package: package)
+		  sourcesManager: NoSourcesManager new;
+		  install
+]
+
+{ #category : 'running' }
+AbstractExtensionTest >> createExtensionNamed: x forBehavior: y inPackage: z [
+
+	^ ((Extension << x)
+		   extendedClass: y;
+		   installingEnvironment: environment;
+		   package: z)
+		  sourcesManager: NoSourcesManager new;
+		  install
+]
+
+{ #category : 'running' }
+AbstractExtensionTest >> setUp [
+
+	super setUp.
+
+	environment := SystemEnvironment new.
+	environment codeChangeAnnouncer: SystemAnnouncer new.
+	environment undeclaredRegistry: Dictionary new.
+	
+	"We create an anonymous subclass of object.
+	Anonymous subclasses handle installation silently and leave less traces in the system.
+	All our classes should inherit from this one (or a subclass of it)"
+	isolatingRoot := Object newAnonymousSubclass.
+	
+	extendedPackage := Package named: 'Extended'.
+	definerPackage := Package named: 'Definer'.
+	userPackage := Package named: 'User'.
+]
+
+{ #category : 'running' }
+AbstractExtensionTest >> tearDown [
+	"Make sure we did not pollute the global dictionaries"
+
+	self deny: (Point methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
+	self deny: (Object methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
+	self deny: (Integer methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
+	
+	environment allClassesAndTraits do: [ :e | e removeFromSystem: false ].
+	
+	super tearDown
+]

--- a/src/Kernel-CodeModel-Tests/ExtensionConflictTest.class.st
+++ b/src/Kernel-CodeModel-Tests/ExtensionConflictTest.class.st
@@ -1,19 +1,18 @@
 Class {
 	#name : 'ExtensionConflictTest',
-	#superclass : 'TestCase',
+	#superclass : 'AbstractExtensionTest',
 	#instVars : [
 		'pointClass',
 		'extensionOnPoint',
-		'environment',
-		'definerPackage',
-		'userPackage',
 		'objectClass',
 		'coloredPointClass',
 		'stringClass',
 		'nicerStringClass',
 		'userClass',
 		'extensionOnObject',
-		'extensionOnColoredPoint'
+		'extensionOnColoredPoint',
+		'definerPackage2',
+		'anotherExtensionOnPoint'
 	],
 	#category : 'Kernel-CodeModel-Tests-Extensions',
 	#package : 'Kernel-CodeModel-Tests',
@@ -23,79 +22,29 @@ Class {
 { #category : 'running' }
 ExtensionConflictTest >> setUp [
 
-	| extendedPackage |
 	super setUp.
-	
-	environment := SystemEnvironment new.
-	extendedPackage := Package named: 'Extended'.
-	definerPackage := Package named: 'Definer'.
-	userPackage := Package named: 'User'.
 
-	objectClass := (Object << #MyObject
-		installingEnvironment: environment;
-		package: userPackage) install.
-	
-	pointClass := (Object << #MyPoint
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-
-	coloredPointClass := (Object << #MyColoredPoint
-		superclass: pointClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
+	objectClass := self createClassNamed: #MyObject superclass: isolatingRoot package: userPackage.
+	pointClass := self createClassNamed: #MyPoint superclass: objectClass package: userPackage.
+	coloredPointClass := self createClassNamed: #MyColoredPoint superclass: pointClass package: userPackage.
+	stringClass := self createClassNamed: #MyString superclass: objectClass package: userPackage.
 	
 	"String will have no extensions. It's here just for polymorphism.
 	It will thus contain aliases only"
-	stringClass := (Object << #MyString
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-	
-	nicerStringClass := (Object << #MyNicerString
-		superclass: stringClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
+	nicerStringClass := self createClassNamed: #MyNicerString superclass: stringClass package: userPackage.
+	userClass := self createClassNamed: #MyUserClass superclass: objectClass package: userPackage.
 
-	userClass := (Object << #MyUserClass
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-	
-	extensionOnObject := (Extension << #ExtensionOfObject
-		extendedClass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
 
-	extensionOnPoint := (Extension << #ExtensionOfPoint
-		extendedClass: pointClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-
-	extensionOnColoredPoint := (Extension << #ExtensionOfColoredPoint
-		extendedClass: coloredPointClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-]
-
-{ #category : 'running' }
-ExtensionConflictTest >> tearDown [
-	"Make sure we did not pollute the global dictionaries"
-
-	self deny: (Point methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	self deny: (Object methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	self deny: (Integer methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	
-	environment allClassesAndTraits do: [ :e | e removeFromSystem ].
-	
-	super tearDown
+	extensionOnObject := self createExtensionNamed: #ExtensionOfObject forBehavior: objectClass inPackage: definerPackage.
+	extensionOnPoint := self createExtensionNamed: #ExtensionOfPoint forBehavior: pointClass inPackage: definerPackage.
+	extensionOnColoredPoint := self createExtensionNamed: #ExtensionOfColoredPoint forBehavior: coloredPointClass inPackage: definerPackage
 ]
 
 { #category : 'tests' }
 ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod01NormalMethodWorksAsExpected [
 
-	pointClass compile: 'extension ^ 17'.
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 17' on: pointClass.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	self assert: pointClass new extension equals: 17
 ]
@@ -104,8 +53,8 @@ ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod01No
 ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod02ExtensionThrowsException [
 
 	| scopedSelector |
-	pointClass compile: 'extension ^ 17'.
-	scopedSelector := extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 17' on: pointClass.
+	scopedSelector := self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	self should: [ pointClass new perform: scopedSelector ] raise: ExtensionConflictError with: [ :conflict |
 			self assert: conflict messageText equals: 'Conflict: extension overwrites method #extension in MyPoint'.
@@ -116,9 +65,9 @@ ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod02Ex
 ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod03SubclassesAreStillAliased [
 
 	| scopedSelector |
-	pointClass compile: 'extension ^ 17'.
-	coloredPointClass compile: 'extension ^ 42'.
-	scopedSelector := extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 17' on: pointClass.
+	self compile: 'extension ^ 42' on: coloredPointClass.
+	scopedSelector := self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	self assert: (coloredPointClass new perform: scopedSelector) equals: 42
 ]
@@ -126,11 +75,9 @@ ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod03Su
 { #category : 'tests' }
 ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod04NormalMethodWorksAsExpectedAfterRecompilation [
 
-	pointClass compile: 'extension ^ 17'.
-	extensionOnPoint compile: 'extension ^ 73'.
-	
-	"Recompilation should not change anything"
-	pointClass compile: 'extension ^ 17'.
+	self compile: 'extension ^ 17' on: pointClass.
+	self compile: 'extension ^ 73' on: extensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 17' on: pointClass.
 
 	self assert: pointClass new extension equals: 17
 ]
@@ -139,11 +86,9 @@ ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod04No
 ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod05ExtensionThrowsExceptionAfterRecompilation [
 
 	| scopedSelector |
-	pointClass compile: 'extension ^ 17'.
-	scopedSelector := extensionOnPoint compile: 'extension ^ 73'.
-	
-	"Recompilation should not change anything"
-	pointClass compile: 'extension ^ 17'.
+	self compile: 'extension ^ 17' on: pointClass.
+	scopedSelector := self compile: 'extension ^ 73' on: extensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 17' on: pointClass.
 
 	self should: [ pointClass new perform: scopedSelector ] raise: ExtensionConflictError with: [ :conflict |
 			self assert: conflict messageText equals: 'Conflict: extension overwrites method #extension in MyPoint'.
@@ -154,12 +99,10 @@ ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod05Ex
 ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod06SubclassesAreStillAliasedAfterRecompilation [
 
 	| scopedSelector |
-	pointClass compile: 'extension ^ 17'.
-	coloredPointClass compile: 'extension ^ 42'.
-	scopedSelector := extensionOnPoint compile: 'extension ^ 73'.
-	
-	"Recompilation should not change anything"
-	pointClass compile: 'extension ^ 17'.
+	self compile: 'extension ^ 17' on: pointClass.
+	self compile: 'extension ^ 42' on: coloredPointClass.
+	scopedSelector := self compile: 'extension ^ 73' on: extensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 17' on: pointClass.
 
 	self assert: (coloredPointClass new perform: scopedSelector) equals: 42
 ]
@@ -167,8 +110,8 @@ ExtensionConflictTest >> test01ExtensionConflictsWithPreExistingNormalMethod06Su
 { #category : 'tests' }
 ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension01NormalMethodWorksAsExpected [
 
-	extensionOnPoint compile: 'extension ^ 73'.
-	pointClass compile: 'extension ^ 17'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: pointClass.
 
 	self assert: pointClass new extension equals: 17
 ]
@@ -177,8 +120,8 @@ ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension01No
 ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension02ExtensionThrowsException [
 
 	| scopedSelector |
-	scopedSelector := extensionOnPoint compile: 'extension ^ 73'.
-	pointClass compile: 'extension ^ 17'.
+	scopedSelector := self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: pointClass.
 
 	self should: [ pointClass new perform: scopedSelector ] raise: ExtensionConflictError with: [ :conflict |
 			self assert: conflict messageText equals: 'Conflict: extension overwrites method #extension in MyPoint'.
@@ -187,11 +130,11 @@ ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension02Ex
 
 { #category : 'tests' }
 ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension03SubclassesAreStillAliased [
-	
+
 	| scopedSelector |
-	scopedSelector := extensionOnPoint compile: 'extension ^ 73'.
-	pointClass compile: 'extension ^ 17'.
-	coloredPointClass compile: 'extension ^ 42'.
+	scopedSelector := self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: pointClass.
+	self compile: 'extension ^ 42' on: coloredPointClass.
 
 	self assert: (coloredPointClass new perform: scopedSelector) equals: 42
 ]
@@ -199,11 +142,9 @@ ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension03Su
 { #category : 'tests' }
 ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension04NormalMethodWorksAsExpectedAfterRecompilation [
 
-	extensionOnPoint compile: 'extension ^ 73'.
-	pointClass compile: 'extension ^ 17'.
-	
-	"Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: pointClass. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	self assert: pointClass new extension equals: 17
 ]
@@ -212,9 +153,9 @@ ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension04No
 ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension05ExtensionThrowsExceptionAfterRecompilation [
 
 	| scopedSelector |
-	scopedSelector := extensionOnPoint compile: 'extension ^ 73'.
-	pointClass compile: 'extension ^ 17'.
-	scopedSelector := extensionOnPoint compile: 'extension ^ 73'.
+	scopedSelector := self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: pointClass.
+	scopedSelector := self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	self should: [ pointClass new perform: scopedSelector ] raise: ExtensionConflictError with: [ :conflict |
 			self assert: conflict messageText equals: 'Conflict: extension overwrites method #extension in MyPoint'.
@@ -223,14 +164,12 @@ ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension05Ex
 
 { #category : 'tests' }
 ExtensionConflictTest >> test02NormalMethodConflictsWithPreExistingExtension06SubclassesAreStillAliasedAfterRecompilation [
-	
-	| scopedSelector |
-	scopedSelector := extensionOnPoint compile: 'extension ^ 73'.
-	pointClass compile: 'extension ^ 17'.
-	coloredPointClass compile: 'extension ^ 42'.
 
-	"Recompilation should not change anything"
-	scopedSelector := extensionOnPoint compile: 'extension ^ 73'.
+	| scopedSelector |
+	scopedSelector := self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: pointClass.
+	self compile: 'extension ^ 42' on: coloredPointClass. "Recompilation should not change anything"
+	scopedSelector := self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	self assert: (coloredPointClass new perform: scopedSelector) equals: 42
 ]
@@ -240,13 +179,10 @@ ExtensionConflictTest >> test03ImportExtensionMethodConflictsWithPreExistingImpo
 	"We have a first extension"
 
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'. "We have a second extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import both extensions"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: extensionOnPoint.
 	userPackage addExtensionImport: anotherExtensionOnPoint.
 
@@ -264,13 +200,10 @@ ExtensionConflictTest >> test03ImportExtensionMethodConflictsWithPreExistingImpo
 	"We have a first extension"
 
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'. "We have a second extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import both extensions"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: extensionOnPoint.
 	userPackage addExtensionImport: anotherExtensionOnPoint.
 
@@ -283,13 +216,10 @@ ExtensionConflictTest >> test03ImportExtensionMethodConflictsWithPreExistingImpo
 	"We have a first extension"
 
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'. "We have a second extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import both extensions"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: extensionOnPoint.
 	userPackage addExtensionImport: anotherExtensionOnPoint.
 
@@ -302,14 +232,11 @@ ExtensionConflictTest >> test03ImportExtensionMethodConflictsWithPreExistingImpo
 	"We have a first extension"
 
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'.
-	coloredPointClass compile: 'extension ^ 42'. "We have a second extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import both extensions"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: extensionOnPoint.
 	userPackage addExtensionImport: anotherExtensionOnPoint.
 
@@ -322,16 +249,13 @@ ExtensionConflictTest >> test03ImportExtensionMethodConflictsWithPreExistingImpo
 	"We have a first extension"
 
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'. "We have a second extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import both extensions"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: extensionOnPoint.
 	userPackage addExtensionImport: anotherExtensionOnPoint. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 
 	self should: [ pointClass new perform: scopedSelector ] raise: ExtensionConflictError with: [ :conflict |
@@ -346,16 +270,13 @@ ExtensionConflictTest >> test03ImportExtensionMethodConflictsWithPreExistingImpo
 	"We have a first extension"
 
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'. "We have a second extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import both extensions"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: extensionOnPoint.
 	userPackage addExtensionImport: anotherExtensionOnPoint. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 	self assert: (pointClass new perform: scopedSelector) equals: 73
@@ -366,16 +287,13 @@ ExtensionConflictTest >> test03ImportExtensionMethodConflictsWithPreExistingImpo
 	"We have a first extension"
 
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'. "We have a second extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import both extensions"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: extensionOnPoint.
 	userPackage addExtensionImport: anotherExtensionOnPoint. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := anotherExtensionOnPoint package visibleSelectorForSymbol: #extension.
 	self assert: (pointClass new perform: scopedSelector) equals: 17
@@ -386,17 +304,14 @@ ExtensionConflictTest >> test03ImportExtensionMethodConflictsWithPreExistingImpo
 	"We have a first extension"
 
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'.
-	coloredPointClass compile: 'extension ^ 42'. "We have a second extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import both extensions"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: extensionOnPoint.
 	userPackage addExtensionImport: anotherExtensionOnPoint. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 	self assert: (coloredPointClass new perform: scopedSelector) equals: 42
@@ -408,14 +323,11 @@ ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithP
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
 	"We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install. "We import both extensions"
-	userPackage addExtensionImport: extensionOnPoint.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	userPackage addExtensionImport: extensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: anotherExtensionOnPoint. "We define the methods on the extensions after import"
-	extensionOnPoint compile: 'extension ^ 73'.
-	anotherExtensionOnPoint compile: 'extension ^ 17'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 
@@ -429,17 +341,13 @@ ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithP
 { #category : 'tests' }
 ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithPreExistingImportedExtension02KeepFirstImportWorkingOnIsolation [
 
-	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	"We have a second extension"
-	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install. "We import both extensions"
-	userPackage addExtensionImport: extensionOnPoint.
+	| scopedSelector |
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+
+	userPackage addExtensionImport: extensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: anotherExtensionOnPoint. "We define the methods on the extensions after import"
-	extensionOnPoint compile: 'extension ^ 73'.
-	anotherExtensionOnPoint compile: 'extension ^ 17'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 	self assert: (pointClass new perform: scopedSelector) equals: 73
@@ -451,14 +359,11 @@ ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithP
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
 	"We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install. "We import both extensions"
-	userPackage addExtensionImport: extensionOnPoint.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	userPackage addExtensionImport: extensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: anotherExtensionOnPoint. "We define the methods on the extensions after import"
-	extensionOnPoint compile: 'extension ^ 73'.
-	anotherExtensionOnPoint compile: 'extension ^ 17'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
 
 	scopedSelector := anotherExtensionOnPoint package visibleSelectorForSymbol: #extension.
 	self assert: (pointClass new perform: scopedSelector) equals: 17
@@ -468,16 +373,13 @@ ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithP
 ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithPreExistingImportedExtension04SubclassesAreStillAliased [
 
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	coloredPointClass compile: 'extension ^ 42'. "We have a second extension"
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install. "We import both extensions"
-	userPackage addExtensionImport: extensionOnPoint.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	userPackage addExtensionImport: extensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: anotherExtensionOnPoint. "We define the methods on the extensions after import"
-	extensionOnPoint compile: 'extension ^ 73'.
-	anotherExtensionOnPoint compile: 'extension ^ 17'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 	self assert: (coloredPointClass new perform: scopedSelector) equals: 42
@@ -489,15 +391,12 @@ ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithP
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
 	"We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install. "We import both extensions"
-	userPackage addExtensionImport: extensionOnPoint.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	userPackage addExtensionImport: extensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: anotherExtensionOnPoint. "We define the methods on the extensions after import"
-	extensionOnPoint compile: 'extension ^ 73'.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 
@@ -514,15 +413,12 @@ ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithP
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
 	"We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install. "We import both extensions"
-	userPackage addExtensionImport: extensionOnPoint.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	userPackage addExtensionImport: extensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: anotherExtensionOnPoint. "We define the methods on the extensions after import"
-	extensionOnPoint compile: 'extension ^ 73'.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 	self assert: (pointClass new perform: scopedSelector) equals: 73
@@ -534,15 +430,12 @@ ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithP
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
 	"We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install. "We import both extensions"
-	userPackage addExtensionImport: extensionOnPoint.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	userPackage addExtensionImport: extensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: anotherExtensionOnPoint. "We define the methods on the extensions after import"
-	extensionOnPoint compile: 'extension ^ 73'.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := anotherExtensionOnPoint package visibleSelectorForSymbol: #extension.
 	self assert: (pointClass new perform: scopedSelector) equals: 17
@@ -552,17 +445,14 @@ ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithP
 ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithPreExistingImportedExtension08SubclassesAreStillAliasedAfterRecompilation [
 
 	| definerPackage2 anotherExtensionOnPoint scopedSelector |
-	coloredPointClass compile: 'extension ^ 42'. "We have a second extension"
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage2) install. "We import both extensions"
-	userPackage addExtensionImport: extensionOnPoint.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
+	userPackage addExtensionImport: extensionOnPoint. "We import both extensions"
 	userPackage addExtensionImport: anotherExtensionOnPoint. "We define the methods on the extensions after import"
-	extensionOnPoint compile: 'extension ^ 73'.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 	self assert: (coloredPointClass new perform: scopedSelector) equals: 42
@@ -573,13 +463,10 @@ ExtensionConflictTest >> test05LocalExtensionMethodConflictsWithPreExistingImpor
 	"We have a first extension"
 
 	| anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	userPackage addExtensionImport: extensionOnPoint. "We have a second extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 
@@ -595,13 +482,10 @@ ExtensionConflictTest >> test05LocalExtensionMethodConflictsWithPreExistingImpor
 	"We have a first extension"
 
 	| anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	userPackage addExtensionImport: extensionOnPoint. "We have a second extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 
@@ -612,18 +496,11 @@ ExtensionConflictTest >> test05LocalExtensionMethodConflictsWithPreExistingImpor
 ExtensionConflictTest >> test05LocalExtensionMethodConflictsWithPreExistingImportedExtension03SubclassesAreStillAliased [
 
 	| anotherExtensionOnPoint scopedSelector |
-	coloredPointClass compile: 'extension ^ 42'.
-	
-	"We have a first extension"
-	extensionOnPoint compile: 'extension ^ 73'.
-	userPackage addExtensionImport: extensionOnPoint.
-	
-	"We have a second extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'.
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a first extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	userPackage addExtensionImport: extensionOnPoint. "We have a second extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 
@@ -636,14 +513,11 @@ ExtensionConflictTest >> test05LocalExtensionMethodConflictsWithPreExistingImpor
 	"We have a first extension"
 
 	| anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	userPackage addExtensionImport: extensionOnPoint. "We have a second extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 
@@ -656,22 +530,15 @@ ExtensionConflictTest >> test05LocalExtensionMethodConflictsWithPreExistingImpor
 
 { #category : 'tests' }
 ExtensionConflictTest >> test05LocalExtensionMethodConflictsWithPreExistingImportedExtension05KeepImportWorkingOnIsolationAfterRecompilation [
-
 	"We have a first extension"
-	| anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'.
-	userPackage addExtensionImport: extensionOnPoint.
 
-	"We have a second extension"
-	anotherExtensionOnPoint := (Extension << #ExtensionOfPoint2
-		extendedClass: pointClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'.
-	
-	"Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
-	
+	| anotherExtensionOnPoint scopedSelector |
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	userPackage addExtensionImport: extensionOnPoint. "We have a second extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 
 	self assert: (pointClass new perform: scopedSelector) equals: 73
@@ -681,15 +548,12 @@ ExtensionConflictTest >> test05LocalExtensionMethodConflictsWithPreExistingImpor
 ExtensionConflictTest >> test05LocalExtensionMethodConflictsWithPreExistingImportedExtension06SubclassesAreStillAliasedAfterRecompilation [
 
 	| anotherExtensionOnPoint scopedSelector |
-	coloredPointClass compile: 'extension ^ 42'. "We have a first extension"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a first extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	userPackage addExtensionImport: extensionOnPoint. "We have a second extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 	self assert: (coloredPointClass new perform: scopedSelector) equals: 42
@@ -700,12 +564,9 @@ ExtensionConflictTest >> test06ImportedExtensionConflictsWithPreExistingLocalExt
 
 	| anotherExtensionOnPoint scopedSelector |
 	"We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "And we import a conflict"
-	extensionOnPoint compile: 'extension ^ 73'.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "And we import a conflict"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	userPackage addExtensionImport: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
@@ -722,12 +583,9 @@ ExtensionConflictTest >> test06ImportedExtensionConflictsWithPreExistingLocalExt
 
 	| anotherExtensionOnPoint scopedSelector |
 	"We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "And we import a conflict"
-	extensionOnPoint compile: 'extension ^ 73'.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "And we import a conflict"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	userPackage addExtensionImport: extensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
@@ -739,13 +597,10 @@ ExtensionConflictTest >> test06ImportedExtensionConflictsWithPreExistingLocalExt
 ExtensionConflictTest >> test06ImportedExtensionConflictsWithPreExistingLocalExtensionMethod03SubclassesAreStillAliased [
 
 	| anotherExtensionOnPoint scopedSelector |
-	coloredPointClass compile: 'extension ^ 42'. "We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "And we import a conflict"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a local extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "And we import a conflict"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	userPackage addExtensionImport: extensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
@@ -759,14 +614,11 @@ ExtensionConflictTest >> test06ImportedExtensionConflictsWithPreExistingLocalExt
 
 	| anotherExtensionOnPoint scopedSelector |
 	"We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "And we import a conflict"
-	extensionOnPoint compile: 'extension ^ 73'.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "And we import a conflict"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	userPackage addExtensionImport: extensionOnPoint. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 
@@ -782,14 +634,11 @@ ExtensionConflictTest >> test06ImportedExtensionConflictsWithPreExistingLocalExt
 
 	| anotherExtensionOnPoint scopedSelector |
 	"We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "And we import a conflict"
-	extensionOnPoint compile: 'extension ^ 73'.
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "And we import a conflict"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	userPackage addExtensionImport: extensionOnPoint. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 
@@ -800,15 +649,12 @@ ExtensionConflictTest >> test06ImportedExtensionConflictsWithPreExistingLocalExt
 ExtensionConflictTest >> test06ImportedExtensionConflictsWithPreExistingLocalExtensionMethod06SubclassesAreStillAliasedAfterRecompilation [
 
 	| anotherExtensionOnPoint scopedSelector |
-	coloredPointClass compile: 'extension ^ 42'. "We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "And we import a conflict"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a local extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "And we import a conflict"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 	userPackage addExtensionImport: extensionOnPoint. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 
@@ -821,13 +667,10 @@ ExtensionConflictTest >> test07NewExtensionOnImportExtensionMethodConflictsWithP
 
 	| anotherExtensionOnPoint scopedSelector |
 	"We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import first, then define a conflict"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import first, then define a conflict"
 	userPackage addExtensionImport: extensionOnPoint.
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 
@@ -843,13 +686,10 @@ ExtensionConflictTest >> test07NewExtensionOnImportExtensionMethodConflictsWithP
 
 	| anotherExtensionOnPoint scopedSelector |
 	"We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import first, then define a conflict"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import first, then define a conflict"
 	userPackage addExtensionImport: extensionOnPoint.
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 
@@ -860,14 +700,11 @@ ExtensionConflictTest >> test07NewExtensionOnImportExtensionMethodConflictsWithP
 ExtensionConflictTest >> test07NewExtensionOnImportExtensionMethodConflictsWithPreExistingLocalExtensionMethod03SubclassesAreStillAliased [
 
 	| anotherExtensionOnPoint scopedSelector |
-	coloredPointClass compile: 'extension ^ 42'. "We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import first, then define a conflict"
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a local extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import first, then define a conflict"
 	userPackage addExtensionImport: extensionOnPoint.
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 
@@ -880,14 +717,11 @@ ExtensionConflictTest >> test07NewExtensionOnImportExtensionMethodConflictsWithP
 
 	| anotherExtensionOnPoint scopedSelector |
 	"We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import first, then define a conflict"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import first, then define a conflict"
 	userPackage addExtensionImport: extensionOnPoint.
-	extensionOnPoint compile: 'extension ^ 73'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 
@@ -903,14 +737,11 @@ ExtensionConflictTest >> test07NewExtensionOnImportExtensionMethodConflictsWithP
 
 	| anotherExtensionOnPoint scopedSelector |
 	"We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import first, then define a conflict"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import first, then define a conflict"
 	userPackage addExtensionImport: extensionOnPoint.
-	extensionOnPoint compile: 'extension ^ 73'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 
@@ -921,15 +752,12 @@ ExtensionConflictTest >> test07NewExtensionOnImportExtensionMethodConflictsWithP
 ExtensionConflictTest >> test07NewExtensionOnImportExtensionMethodConflictsWithPreExistingLocalExtensionMethod06SubclassesAreStillAliasedAfterRecompilation [
 
 	| anotherExtensionOnPoint scopedSelector |
-	coloredPointClass compile: 'extension ^ 42'. "We have a local extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: userPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "We import first, then define a conflict"
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a local extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import first, then define a conflict"
 	userPackage addExtensionImport: extensionOnPoint.
-	extensionOnPoint compile: 'extension ^ 73'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := extensionOnPoint package visibleSelectorForSymbol: #extension.
 
@@ -942,12 +770,9 @@ ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocal
 	"We have a first extension"
 
 	| anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'. "We have a second extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'.
+	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
 
 	scopedSelector := definerPackage visibleSelectorForSymbol: #extension.
 
@@ -962,13 +787,10 @@ ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocal
 ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocalExtension02SubclassesAreStillAliased [
 
 	| anotherExtensionOnPoint scopedSelector |
-	coloredPointClass compile: 'extension ^ 42'. "We have a first extension"
-	extensionOnPoint compile: 'extension ^ 73'. "We have a second extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'.
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a first extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
 
 	scopedSelector := definerPackage visibleSelectorForSymbol: #extension.
 
@@ -981,13 +803,10 @@ ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocal
 	"We have a first extension"
 
 	| anotherExtensionOnPoint scopedSelector |
-	extensionOnPoint compile: 'extension ^ 73'. "We have a second extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := definerPackage visibleSelectorForSymbol: #extension.
 
@@ -1002,14 +821,11 @@ ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocal
 ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocalExtension04SubclassesAreStillAliasedAfterRecompilation [
 
 	| anotherExtensionOnPoint scopedSelector |
-	coloredPointClass compile: 'extension ^ 42'. "We have a first extension"
-	extensionOnPoint compile: 'extension ^ 73'. "We have a second extension"
-	anotherExtensionOnPoint := ((Extension << #ExtensionOfPoint2)
-		                            extendedClass: pointClass;
-		                            installingEnvironment: environment;
-		                            package: definerPackage) install.
-	anotherExtensionOnPoint compile: 'extension ^ 17'. "Recompilation should not change anything"
-	extensionOnPoint compile: 'extension ^ 73'.
+	self compile: 'extension ^ 42' on: coloredPointClass. "We have a first extension"
+	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "Recompilation should not change anything"
+	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 	self assert: (coloredPointClass new perform: scopedSelector) equals: 42

--- a/src/Kernel-CodeModel-Tests/ExtensionConflictTest.class.st
+++ b/src/Kernel-CodeModel-Tests/ExtensionConflictTest.class.st
@@ -10,9 +10,7 @@ Class {
 		'nicerStringClass',
 		'userClass',
 		'extensionOnObject',
-		'extensionOnColoredPoint',
-		'definerPackage2',
-		'anotherExtensionOnPoint'
+		'extensionOnColoredPoint'
 	],
 	#category : 'Kernel-CodeModel-Tests-Extensions',
 	#package : 'Kernel-CodeModel-Tests',
@@ -341,7 +339,7 @@ ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithP
 { #category : 'tests' }
 ExtensionConflictTest >> test04NewExtensionOnImportExtensionMethodConflictsWithPreExistingImportedExtension02KeepFirstImportWorkingOnIsolation [
 
-	| scopedSelector |
+	| scopedSelector anotherExtensionOnPoint |
 	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
 
 	userPackage addExtensionImport: extensionOnPoint. "We import both extensions"
@@ -769,7 +767,7 @@ ExtensionConflictTest >> test07NewExtensionOnImportExtensionMethodConflictsWithP
 ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocalExtension01ExtensionThrowsException [
 	"We have a first extension"
 
-	| scopedSelector |
+	| scopedSelector anotherExtensionOnPoint |
 	self compile: 'extension ^ 73' on: extensionOnPoint.
 	
 	"We have a second extension"
@@ -804,7 +802,7 @@ ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocal
 ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocalExtension03ExtensionThrowsExceptionAfterRecompilation [
 	"We have a first extension"
 
-	| scopedSelector |
+	| scopedSelector anotherExtensionOnPoint |
 	self compile: 'extension ^ 73' on: extensionOnPoint.
 	
 	"We have a second extension"

--- a/src/Kernel-CodeModel-Tests/ExtensionConflictTest.class.st
+++ b/src/Kernel-CodeModel-Tests/ExtensionConflictTest.class.st
@@ -769,9 +769,11 @@ ExtensionConflictTest >> test07NewExtensionOnImportExtensionMethodConflictsWithP
 ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocalExtension01ExtensionThrowsException [
 	"We have a first extension"
 
-	| anotherExtensionOnPoint scopedSelector |
-	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
-	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
+	| scopedSelector |
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	
+	"We have a second extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage.
 	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
 
 	scopedSelector := definerPackage visibleSelectorForSymbol: #extension.
@@ -802,10 +804,14 @@ ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocal
 ExtensionConflictTest >> test08LocalExtensionMethodConflictsWithPreExistingLocalExtension03ExtensionThrowsExceptionAfterRecompilation [
 	"We have a first extension"
 
-	| anotherExtensionOnPoint scopedSelector |
-	self compile: 'extension ^ 73' on: extensionOnPoint. "We have a second extension"
-	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: userPackage.
-	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "Recompilation should not change anything"
+	| scopedSelector |
+	self compile: 'extension ^ 73' on: extensionOnPoint.
+	
+	"We have a second extension"
+	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage.
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
+	
+	"Recompilation should not change anything"
 	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := definerPackage visibleSelectorForSymbol: #extension.

--- a/src/Kernel-CodeModel-Tests/ExtensionConflictTest.class.st
+++ b/src/Kernel-CodeModel-Tests/ExtensionConflictTest.class.st
@@ -306,9 +306,13 @@ ExtensionConflictTest >> test03ImportExtensionMethodConflictsWithPreExistingImpo
 	self compile: 'extension ^ 42' on: coloredPointClass. "We have a second extension"
 	definerPackage2 := Package named: 'Definer2'.
 	anotherExtensionOnPoint := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
-	self compile: 'extension ^ 17' on: anotherExtensionOnPoint. "We import both extensions"
+	self compile: 'extension ^ 17' on: anotherExtensionOnPoint.
+
+	"We import both extensions"
 	userPackage addExtensionImport: extensionOnPoint.
-	userPackage addExtensionImport: anotherExtensionOnPoint. "Recompilation should not change anything"
+	userPackage addExtensionImport: anotherExtensionOnPoint.
+	
+	"Recompilation should not change anything"
 	self compile: 'extension ^ 73' on: extensionOnPoint.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.

--- a/src/Kernel-CodeModel-Tests/ExtensionHotUpdateAliasingTest.class.st
+++ b/src/Kernel-CodeModel-Tests/ExtensionHotUpdateAliasingTest.class.st
@@ -1,10 +1,7 @@
 Class {
 	#name : 'ExtensionHotUpdateAliasingTest',
-	#superclass : 'TestCase',
+	#superclass : 'AbstractExtensionTest',
 	#instVars : [
-		'environment',
-		'definerPackage',
-		'userPackage',
 		'objectClass',
 		'pointClass',
 		'extensionOnPoint',
@@ -23,94 +20,44 @@ Class {
 { #category : 'running' }
 ExtensionHotUpdateAliasingTest >> setUp [
 
-	| extendedPackage |
 	super setUp.
-	
-	environment := SystemEnvironment new.
-	extendedPackage := Package named: 'Extended'.
-	definerPackage := Package named: 'Definer'.
-	userPackage := Package named: 'User'.
 
-	objectClass := (Object << #MyObject
-		installingEnvironment: environment;
-		package: userPackage) install.
-	
-	pointClass := (Object << #MyPoint
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-
-	coloredPointClass := (Object << #MyColoredPoint
-		superclass: pointClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
+	objectClass := self createClassNamed: #MyObject superclass: isolatingRoot package: userPackage.
+	pointClass := self createClassNamed: #MyPoint superclass: objectClass package: userPackage.
+	coloredPointClass := self createClassNamed: #MyColoredPoint superclass: pointClass package: userPackage.
+	stringClass := self createClassNamed: #MyString superclass: objectClass package: userPackage.
 	
 	"String will have no extensions. It's here just for polymorphism.
 	It will thus contain aliases only"
-	stringClass := (Object << #MyString
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-	
-	nicerStringClass := (Object << #MyNicerString
-		superclass: stringClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
+	nicerStringClass := self createClassNamed: #MyNicerString superclass: stringClass package: userPackage.
+	userClass := self createClassNamed: #MyUserClass superclass: objectClass package: userPackage.
 
-	userClass := (Object << #MyUserClass
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-	
-	extensionOnObject := (Extension << #ExtensionOfObject
-		extendedClass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-
-	extensionOnPoint := (Extension << #ExtensionOfPoint
-		extendedClass: pointClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-
-	extensionOnColoredPoint := (Extension << #ExtensionOfColoredPoint
-		extendedClass: coloredPointClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-]
-
-{ #category : 'running' }
-ExtensionHotUpdateAliasingTest >> tearDown [
-	"Make sure we did not pollute the global dictionaries"
-
-	self deny: (Point methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	self deny: (Object methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	self deny: (Integer methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	
-	environment allClassesAndTraits do: [ :e | e removeFromSystem ].
-	
-	super tearDown
+	extensionOnObject := self createExtensionNamed: #ExtensionOfObject forBehavior: objectClass inPackage: definerPackage.
+	extensionOnPoint := self createExtensionNamed: #ExtensionOfPoint forBehavior: pointClass inPackage: definerPackage.
+	extensionOnColoredPoint := self
+		                           createExtensionNamed: #ExtensionOfColoredPoint
+		                           forBehavior: coloredPointClass
+		                           inPackage: definerPackage
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateAliasingTest >> test01CompileNewExtensionMethod01InstallsExtensionInExtendedClass [
 
 	| scopedSelector |
-	scopedSelector := extensionOnObject compile: 'extension ^ 42'.
-	
+	scopedSelector := self compile: 'extension ^ 42' on: extensionOnObject.
+
 	self assert: (objectClass new perform: scopedSelector) equals: 42
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateAliasingTest >> test01CompileNewExtensionMethod02InstallsAliasInSubclasses [
-
 	"Point defines a normal method"
+
 	| scopedSelector |
-	pointClass compile: 'extension ^ 17'.
-	
-	"We extend the superclass with the same selector"
-	scopedSelector := extensionOnObject compile: 'extension ^ 42'.
-	
-	
+	self compile: 'extension ^ 17' on: pointClass. "We extend the superclass with the same selector"
+	scopedSelector := self compile: 'extension ^ 42' on: extensionOnObject.
+
+
 	self assert: (pointClass new perform: scopedSelector) equals: 17
 ]
 
@@ -118,16 +65,13 @@ ExtensionHotUpdateAliasingTest >> test01CompileNewExtensionMethod02InstallsAlias
 ExtensionHotUpdateAliasingTest >> test01CompileNewExtensionMethod03InstallsAliasInSubclassesButStopsAtFrontier [
 
 	| scopedSelector |
-	
 	"Point defines a normal method that should be aliased"
-	pointClass compile: 'extension ^ 17'.
-	extensionOnColoredPoint compile: 'extension ^ 73'.
-	
-	"We extend the superclass with the same selector"
-	scopedSelector := extensionOnObject compile: 'extension ^ 42'.
-	
+	self compile: 'extension ^ 17' on: pointClass.
+	self compile: 'extension ^ 73' on: extensionOnColoredPoint. "We extend the superclass with the same selector"
+	scopedSelector := self compile: 'extension ^ 42' on: extensionOnObject.
+
 	self assert: (pointClass new perform: scopedSelector) equals: 17.
-	self assert: (coloredPointClass new perform: scopedSelector) equals: 73.
+	self assert: (coloredPointClass new perform: scopedSelector) equals: 73
 ]
 
 { #category : 'tests' }
@@ -135,16 +79,11 @@ ExtensionHotUpdateAliasingTest >> test02OverrideAliasWithNormalMethod01ShouldAli
 
 	| scopedSelector |
 	"We extend Point"
-	scopedSelector := extensionOnPoint compile: 'extension ^ 11'.
-	"String defines a normal method with the same selector name, global"
-	stringClass compile: 'extension ^ 42'.
-	
-	"We send a message to a string to alias the method"
-	self assert: (stringClass new perform: scopedSelector) equals: 42.
-	
-	"Now we override #extension in MyNicerString and that should automatically alias it!"
-	nicerStringClass compile: 'extension ^ 73'.
-	
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnPoint. "String defines a normal method with the same selector name, global"
+	self compile: 'extension ^ 42' on: stringClass. "We send a message to a string to alias the method"
+	self assert: (stringClass new perform: scopedSelector) equals: 42. "Now we override #extension in MyNicerString and that should automatically alias it!"
+	self compile: 'extension ^ 73' on: nicerStringClass.
+
 	self assert: (nicerStringClass new perform: scopedSelector) equals: 73
 ]
 
@@ -153,12 +92,10 @@ ExtensionHotUpdateAliasingTest >> test02OverrideExtensionWithNormalMethod01Shoul
 
 	| scopedSelector |
 	"We extend Object"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
-	
-	"Now we override the extension.
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject. "Now we override the extension.
 	This should alias the one in the superclass: the scoped selector should see this method"
-	pointClass compile: 'extension ^ 42'.
-	
+	self compile: 'extension ^ 42' on: pointClass.
+
 	self assert: (pointClass new perform: scopedSelector) equals: 42
 ]
 
@@ -167,14 +104,10 @@ ExtensionHotUpdateAliasingTest >> test03OnDemandAlias01ShouldAliasSubclasses [
 
 	| scopedSelector |
 	"We extend Point"
-	scopedSelector := extensionOnPoint compile: 'extension ^ 11'.
-	"We define two methods in the hierarchy"
-	stringClass compile: 'extension ^ 42'.	
-	nicerStringClass compile: 'extension ^ 73'.
-	
-	"We send a message to a string to alias the method."
-	"In addition, it should automatically alias the subclass!"
-	self assert: (stringClass new perform: scopedSelector) equals: 42.	
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnPoint. "We define two methods in the hierarchy"
+	self compile: 'extension ^ 42' on: stringClass.
+	self compile: 'extension ^ 73' on: nicerStringClass. "We send a message to a string to alias the method." "In addition, it should automatically alias the subclass!"
+	self assert: (stringClass new perform: scopedSelector) equals: 42.
 	self assert: (nicerStringClass new perform: scopedSelector) equals: 73
 ]
 
@@ -182,9 +115,9 @@ ExtensionHotUpdateAliasingTest >> test03OnDemandAlias01ShouldAliasSubclasses [
 ExtensionHotUpdateAliasingTest >> test03OnDemandAlias02ShouldAliasConflicts [
 
 	| scopedSelector userScopedSelector |
-	pointClass compile: 'extension ^ 73'.
-	coloredPointClass compile: 'extension ^ 11'.
-	scopedSelector := extensionOnColoredPoint compile: 'extension ^ 42'.
+	self compile: 'extension ^ 73' on: pointClass.
+	self compile: 'extension ^ 11' on: coloredPointClass.
+	scopedSelector := self compile: 'extension ^ 42' on: extensionOnColoredPoint.
 
 	self assert: pointClass new extension equals: 73.
 	self assert: coloredPointClass new extension equals: 11.
@@ -192,15 +125,13 @@ ExtensionHotUpdateAliasingTest >> test03OnDemandAlias02ShouldAliasConflicts [
 	self assert: (pointClass new perform: scopedSelector) equals: 73.
 	self should: [ coloredPointClass new perform: scopedSelector ] raise: ExtensionConflictError with: [ :conflict |
 			self assert: conflict messageText equals: 'Conflict: extension overwrites method #extension in MyColoredPoint'.
-			self assertCollection: conflict conflictingExtensions hasSameElements: {
-					extensionOnColoredPoint } ].
+			self assertCollection: conflict conflictingExtensions hasSameElements: { extensionOnColoredPoint } ].
 
 	userPackage addExtensionImport: extensionOnColoredPoint.
 	userScopedSelector := userPackage visibleSelectorForSymbol: #extension.
 	self should: [ coloredPointClass new perform: userScopedSelector ] raise: ExtensionConflictError with: [ :conflict |
 			self assert: conflict messageText equals: 'Conflict: extension overwrites method #extension in MyColoredPoint'.
-			self assertCollection: conflict conflictingExtensions hasSameElements: {
-					extensionOnColoredPoint } ].
+			self assertCollection: conflict conflictingExtensions hasSameElements: { extensionOnColoredPoint } ]
 ]
 
 { #category : 'tests' }
@@ -208,17 +139,10 @@ ExtensionHotUpdateAliasingTest >> test03RemoveExtension01ShouldRemoveExtensionMe
 
 	| scopedSelector receiver |
 	"We extend Object"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
-	
-	"Now we remove the extension"
-	extensionOnObject removeSelector: scopedSelector.
-	
-	"So the message is not understood anymore"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject. "Now we remove the extension"
+	extensionOnObject removeSelector: scopedSelector logged: false. "So the message is not understood anymore"
 	receiver := objectClass new.
-	self
-		should: [ receiver perform: scopedSelector ]
-		raise: MessageNotUnderstood
-		withExceptionDo: [ :dnu |
+	self should: [ receiver perform: scopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
 			self assert: dnu message selector equals: scopedSelector ]
 ]
@@ -229,14 +153,12 @@ ExtensionHotUpdateAliasingTest >> test03RemoveExtension02ShouldKeepAliasInSubcla
 	| scopedSelector |
 	"We extend Object"
 	scopedSelector := extensionOnObject internScopedSelector: #extension.
-	extensionOnObject compile: 'extension ^ 11'.
-	
-	"Now we override the extension.
+	self compile: 'extension ^ 11' on: extensionOnObject. "Now we override the extension.
 	This should alias the one in the superclass: the scoped selector should see this method"
-	pointClass compile: 'extension ^ 42'.
-	
-	extensionOnObject removeSelector: scopedSelector.
-	
+	self compile: 'extension ^ 42' on: pointClass.
+
+	extensionOnObject removeSelector: scopedSelector logged: false.
+
 	self assert: (pointClass new perform: scopedSelector) equals: 42
 ]
 
@@ -251,34 +173,42 @@ ExtensionHotUpdateAliasingTest >> test03RemoveExtension03ShouldNotRemoveUnrelate
 	
 	We remove one of the extensions: def1.
 	This should not impact def2.
+	
 	""First package already exists.
 	Add extension method, import, send to alias"
-	extensionOnObject compile: 'extension ^ 25'.
+	self compile: 'extension ^ 25' on: extensionOnObject.
 	userPackage addExtensionImport: extensionOnObject.
 	extensionScopedSelector := definerPackage visibleSelectorForSymbol: #extension.
 	userScopedSelector := userPackage visibleSelectorForSymbol: #extension.
-	objectClass new perform: userScopedSelector. "Second package.
+	objectClass new perform: userScopedSelector.
+	
+	"Second package.
 	Create package and extension"
 	definerPackage2 := Package named: 'Definer2'.
-	extensionOnObject2 := ((Extension << #ExtensionOfObject2)
-		                       extendedClass: objectClass;
-		                       installingEnvironment: environment;
-		                       package: definerPackage2) install. "Add extension method, import, send to alias"
-	extensionOnObject2 compile: 'extension ^ 17'.
+	extensionOnObject2 := self createExtensionNamed: #ExtensionOfObject2 forBehavior: objectClass inPackage: definerPackage2.
+	
+	"Add extension method, import, send to alias"
+	self compile: 'extension ^ 17' on: extensionOnObject2.
 	userPackage2 := Package named: 'User2'.
 	userPackage2 addExtensionImport: extensionOnObject2.
 	extensionScopedSelector2 := definerPackage2 visibleSelectorForSymbol: #extension.
 	userScopedSelector2 := userPackage2 visibleSelectorForSymbol: #extension.
 	objectClass new perform: userScopedSelector2. "Now we remove the extension from the definer package 1"
-	extensionOnObject removeSelector: extensionScopedSelector.
+	extensionOnObject removeSelector: extensionScopedSelector logged: false.
 
-	receiver := objectClass new. "So the message from definer package 1 is not understood anymore"
+	receiver := objectClass new.
+	
+	"So the message from definer package 1 is not understood anymore"
 	self should: [ receiver perform: extensionScopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
-			self assert: dnu message selector equals: extensionScopedSelector ]. "Nor from the user 1 alias"
+			self assert: dnu message selector equals: extensionScopedSelector ].
+		
+	"Nor from the user 1 alias"
 	self should: [ receiver perform: userScopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
-			self assert: dnu message selector equals: userScopedSelector ]. "But it should still understand the messages from the definer package 2 and its user"
+			self assert: dnu message selector equals: userScopedSelector ].
+		
+	"But it should still understand the messages from the definer package 2 and its user"
 	self assert: (receiver perform: extensionScopedSelector2) equals: 17.
 	self assert: (receiver perform: userScopedSelector2) equals: 17
 ]
@@ -288,27 +218,18 @@ ExtensionHotUpdateAliasingTest >> test03RemoveExtension04ShouldRemoveAliasesToEx
 
 	| extensionScopedSelector receiver userScopedSelector |
 	"We extend Object"
-	extensionScopedSelector := extensionOnObject compile: 'extension ^ 11'.
-	"We import and use the extension, which will generate an alias"
+	extensionScopedSelector := self compile: 'extension ^ 11' on: extensionOnObject. "We import and use the extension, which will generate an alias"
 	userPackage addExtensionImport: extensionOnObject.
-	userClass compile: 'userMethod: anObject ^ anObject extension'.
-	
-	userScopedSelector := userPackage visibleSelectorForSymbol: #extension.
-	
-	"Send the message to create the alias"
-	userClass new perform: #userMethod: with: objectClass new.
-	
-	"Now we remove the extension"
-	extensionOnObject removeSelector: extensionScopedSelector.
-	"So the message is not understood anymore"
-	receiver := objectClass new.
-	
-	"Not from the package itself"
+	self compile: 'userMethod: anObject ^ anObject extension' on: userClass.
+
+	userScopedSelector := userPackage visibleSelectorForSymbol: #extension. "Send the message to create the alias"
+	userClass new perform: #userMethod: with: objectClass new. "Now we remove the extension"
+	extensionOnObject removeSelector: extensionScopedSelector logged: false. "So the message is not understood anymore"
+
+	receiver := objectClass new. "Not from the package itself"
 	self should: [ receiver perform: extensionScopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
-			self assert: dnu message selector equals: extensionScopedSelector ].
-
-	"Nor from the user alias"
+			self assert: dnu message selector equals: extensionScopedSelector ]. "Nor from the user alias"
 	self should: [ receiver perform: userScopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
 			self assert: dnu message selector equals: userScopedSelector ]
@@ -318,7 +239,7 @@ ExtensionHotUpdateAliasingTest >> test03RemoveExtension04ShouldRemoveAliasesToEx
 ExtensionHotUpdateAliasingTest >> test04ImportExtensionMethod01InstallsExtensionInExtendedClass [
 
 	| userScopedSelector |
-	extensionOnObject compile: 'extension ^ 42'.
+	self compile: 'extension ^ 42' on: extensionOnObject.
 	userPackage addExtensionImport: extensionOnObject.
 
 	userScopedSelector := userPackage visibleSelectorForSymbol: #extension.
@@ -332,7 +253,7 @@ ExtensionHotUpdateAliasingTest >> test05CompileNewExtensionMethodAfterImport01In
 
 	| userScopedSelector |
 	userPackage addExtensionImport: extensionOnObject.
-	extensionOnObject compile: 'extension ^ 42'.
+	self compile: 'extension ^ 42' on: extensionOnObject.
 
 	userScopedSelector := userPackage visibleSelectorForSymbol: #extension.
 	self assert: userScopedSelector owner == userPackage.
@@ -342,16 +263,14 @@ ExtensionHotUpdateAliasingTest >> test05CompileNewExtensionMethodAfterImport01In
 
 { #category : 'tests' }
 ExtensionHotUpdateAliasingTest >> test06RemoveAliasedMethod02RemovesAliases [
-
 	"Point defines a normal method"
+
 	| scopedSelector |
-	pointClass compile: 'extension ^ 17'.
-	
-	"We extend the superclass with the same selector"
-	scopedSelector := extensionOnObject compile: 'extension ^ 42'.
-	
-	pointClass removeSelector: #extension.
-	
+	self compile: 'extension ^ 17' on: pointClass. "We extend the superclass with the same selector"
+	scopedSelector := self compile: 'extension ^ 42' on: extensionOnObject.
+
+	pointClass removeSelector: #extension logged: false.
+
 	self assert: (pointClass new perform: scopedSelector) equals: 42
 ]
 
@@ -360,13 +279,13 @@ ExtensionHotUpdateAliasingTest >> test07RemoveMethodAliasedOnDemand01RemovesAlia
 
 	| scopedSelector receiver |
 	"We extend Point"
-	scopedSelector := extensionOnPoint compile: 'extension ^ 11'. "We define two methods in the hierarchy"
-	stringClass compile: 'extension ^ 42'.
-	nicerStringClass compile: 'extension ^ 73'. "We send a message to a string to alias the method." "In addition, it should automatically alias the subclass!"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnPoint. "We define two methods in the hierarchy"
+	self compile: 'extension ^ 42' on: stringClass.
+	self compile: 'extension ^ 73' on: nicerStringClass. "We send a message to a string to alias the method." "In addition, it should automatically alias the subclass!"
 	self assert: (stringClass new perform: scopedSelector) equals: 42.
 	self assert: (nicerStringClass new perform: scopedSelector) equals: 73.
 
-	stringClass removeSelector: #extension.
+	stringClass removeSelector: #extension logged: false.
 
 	receiver := stringClass new.
 	self should: [ receiver perform: scopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :ex |
@@ -379,13 +298,13 @@ ExtensionHotUpdateAliasingTest >> test07RemoveMethodAliasedOnDemand01RemovesAlia
 
 	| scopedSelector |
 	"We extend Point"
-	scopedSelector := extensionOnPoint compile: 'extension ^ 11'. "We define two methods in the hierarchy"
-	stringClass compile: 'extension ^ 42'.
-	nicerStringClass compile: 'extension ^ 73'. "We send a message to a string to alias the method." "In addition, it should automatically alias the subclass!"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnPoint. "We define two methods in the hierarchy"
+	self compile: 'extension ^ 42' on: stringClass.
+	self compile: 'extension ^ 73' on: nicerStringClass. "We send a message to a string to alias the method." "In addition, it should automatically alias the subclass!"
 	self assert: (stringClass new perform: scopedSelector) equals: 42.
 	self assert: (nicerStringClass new perform: scopedSelector) equals: 73.
 
-	nicerStringClass removeSelector: #extension.
+	nicerStringClass removeSelector: #extension logged: false.
 
 	self assert: (nicerStringClass new perform: scopedSelector) equals: 42
 ]
@@ -395,11 +314,11 @@ ExtensionHotUpdateAliasingTest >> test08RemoveExtensionMethodFromImport01ShouldR
 
 	| scopedSelector receiver |
 	"We extend Object"
-	extensionOnObject compile: 'extension ^ 11'. "We import it -> the method should be locally seen using the local scoped selector"
+	self compile: 'extension ^ 11' on: extensionOnObject. "We import it -> the method should be locally seen using the local scoped selector"
 	userPackage addExtensionImport: extensionOnObject.
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 	self assert: (objectClass new perform: scopedSelector) equals: 11. "We remove the extension. Now the object should not understand the message anymore"
-	extensionOnObject removeSelector: (definerPackage visibleSelectorForSymbol: #extension). "So the message is not understood anymore"
+	extensionOnObject removeSelector: (definerPackage visibleSelectorForSymbol: #extension) logged: false. "So the message is not understood anymore"
 	receiver := objectClass new.
 	self should: [ receiver perform: scopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
@@ -411,11 +330,11 @@ ExtensionHotUpdateAliasingTest >> test08RemoveExtensionMethodFromImport02ShouldN
 
 	| scopedSelector receiver |
 	"We extend Object"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject.
 
 	userPackage addExtensionImport: extensionOnObject.
 	self assert: (objectClass new perform: scopedSelector) equals: 11. "We remove the extension. Now the object should not understand the message anymore"
-	extensionOnObject removeSelector: (definerPackage visibleSelectorForSymbol: #extension). "So the message is not understood anymore"
+	extensionOnObject removeSelector: (definerPackage visibleSelectorForSymbol: #extension) logged: false. "So the message is not understood anymore"
 	receiver := objectClass new.
 	self should: [ receiver perform: scopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
@@ -427,7 +346,7 @@ ExtensionHotUpdateAliasingTest >> test09RemoveImport01ShouldRemoveExtensionMetho
 
 	| scopedSelector receiver |
 	"We extend Object"
-	extensionOnObject compile: 'extension ^ 11'. "We import it -> the method should be locally seen using the local scoped selector"
+	self compile: 'extension ^ 11' on: extensionOnObject. "We import it -> the method should be locally seen using the local scoped selector"
 	userPackage addExtensionImport: extensionOnObject.
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
 	self assert: (objectClass new perform: scopedSelector) equals: 11. "We remove the extension. Now the object should not understand the message anymore"
@@ -443,16 +362,12 @@ ExtensionHotUpdateAliasingTest >> test09RemoveImport02ShouldNotRemoveOriginalExt
 
 	| scopedSelector |
 	"We extend Object"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject.
 
 	userPackage addExtensionImport: extensionOnObject.
-	self assert: (objectClass new perform: scopedSelector) equals: 11.
-	
-	"We remove the extension. Now the object should not understand the message anymore"
-	userPackage removeExtensionImport: extensionOnObject.
-		
-	"So message from the extension package should still work"
-	self assert: (objectClass new perform: scopedSelector) equals: 11.
+	self assert: (objectClass new perform: scopedSelector) equals: 11. "We remove the extension. Now the object should not understand the message anymore"
+	userPackage removeExtensionImport: extensionOnObject. "So message from the extension package should still work"
+	self assert: (objectClass new perform: scopedSelector) equals: 11
 ]
 
 { #category : 'tests' }
@@ -460,11 +375,17 @@ ExtensionHotUpdateAliasingTest >> test10RemoveExtensionFromSystem01ShouldRemoveE
 
 	| scopedSelector receiver |
 	"We extend Object"
-	extensionOnObject compile: 'extension ^ 11'. "We import it -> the method should be locally seen using the local scoped selector"
+	self compile: 'extension ^ 11' on: extensionOnObject.
+	
+	"We import it -> the method should be locally seen using the local scoped selector"
 	userPackage addExtensionImport: extensionOnObject.
 	scopedSelector := userPackage visibleSelectorForSymbol: #extension.
-	self assert: (objectClass new perform: scopedSelector) equals: 11. "We remove the extension. Now the object should not understand the message anymore"
-	extensionOnObject removeFromSystem. "So the message is not understood anymore"
+	self assert: (objectClass new perform: scopedSelector) equals: 11.
+	
+	"We remove the extension. Now the object should not understand the message anymore"
+	extensionOnObject removeFromSystem: false.
+	
+	"So the message is not understood anymore"
 	receiver := objectClass new.
 	self should: [ receiver perform: scopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
@@ -476,20 +397,17 @@ ExtensionHotUpdateAliasingTest >> test10RemoveExtensionFromSystem02ShouldNotRemo
 
 	| scopedSelector receiver |
 	"We extend Object"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject.
 
 	userPackage addExtensionImport: extensionOnObject.
 	self assert: (objectClass new perform: scopedSelector) equals: 11.
 	
 	"We remove the extension. Now the object should not understand the message anymore"
-	extensionOnObject removeFromSystem.
-		
+	extensionOnObject removeFromSystem: false.
+	
 	"So the message is not understood anymore"
 	receiver := objectClass new.
-	self
-		should: [ receiver perform: scopedSelector ]
-		raise: MessageNotUnderstood
-		withExceptionDo: [ :dnu |
+	self should: [ receiver perform: scopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
 			self assert: dnu message selector equals: scopedSelector ]
 ]

--- a/src/Kernel-CodeModel-Tests/ExtensionHotUpdateAliasingTest.class.st
+++ b/src/Kernel-CodeModel-Tests/ExtensionHotUpdateAliasingTest.class.st
@@ -218,18 +218,29 @@ ExtensionHotUpdateAliasingTest >> test03RemoveExtension04ShouldRemoveAliasesToEx
 
 	| extensionScopedSelector receiver userScopedSelector |
 	"We extend Object"
-	extensionScopedSelector := self compile: 'extension ^ 11' on: extensionOnObject. "We import and use the extension, which will generate an alias"
+	extensionScopedSelector := self compile: 'extension ^ 11' on: extensionOnObject.
+	
+	"We import and use the extension, which will generate an alias"
 	userPackage addExtensionImport: extensionOnObject.
 	self compile: 'userMethod: anObject ^ anObject extension' on: userClass.
 
-	userScopedSelector := userPackage visibleSelectorForSymbol: #extension. "Send the message to create the alias"
-	userClass new perform: #userMethod: with: objectClass new. "Now we remove the extension"
-	extensionOnObject removeSelector: extensionScopedSelector logged: false. "So the message is not understood anymore"
-
-	receiver := objectClass new. "Not from the package itself"
+	userScopedSelector := userPackage visibleSelectorForSymbol: #extension.
+	
+	"Send the message to create the alias"
+	userClass new perform: #userMethod: with: objectClass new.
+	
+	"Now we remove the extension"
+	extensionOnObject removeSelector: extensionScopedSelector logged: false.
+	
+	"So the message is not understood anymore"
+	receiver := objectClass new.
+	
+	"Not from the package itself"
 	self should: [ receiver perform: extensionScopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
-			self assert: dnu message selector equals: extensionScopedSelector ]. "Nor from the user alias"
+			self assert: dnu message selector equals: extensionScopedSelector ].
+		
+	"Nor from the user alias"
 	self should: [ receiver perform: userScopedSelector ] raise: MessageNotUnderstood withExceptionDo: [ :dnu |
 			self assert: dnu receiver equals: receiver.
 			self assert: dnu message selector equals: userScopedSelector ]

--- a/src/Kernel-CodeModel-Tests/ExtensionHotUpdateCompilationTest.class.st
+++ b/src/Kernel-CodeModel-Tests/ExtensionHotUpdateCompilationTest.class.st
@@ -1,10 +1,7 @@
 Class {
 	#name : 'ExtensionHotUpdateCompilationTest',
-	#superclass : 'TestCase',
+	#superclass : 'AbstractExtensionTest',
 	#instVars : [
-		'environment',
-		'definerPackage',
-		'userPackage',
 		'objectClass',
 		'pointClass',
 		'coloredPointClass',
@@ -32,142 +29,83 @@ ExtensionHotUpdateCompilationTest >> assertDNU: scopedSelector on: selector to: 
 { #category : 'running' }
 ExtensionHotUpdateCompilationTest >> setUp [
 
-	| extendedPackage |
 	super setUp.
-	
-	environment := SystemEnvironment new.
-	extendedPackage := Package named: 'Extended'.
-	definerPackage := Package named: 'Definer'.
-	userPackage := Package named: 'User'.
 
-	objectClass := (Object << #MyObject
-		installingEnvironment: environment;
-		package: userPackage) install.
-	
-	pointClass := (Object << #MyPoint
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-
-	coloredPointClass := (Object << #MyColoredPoint
-		superclass: pointClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
+	objectClass := self createClassNamed: #MyObject superclass: isolatingRoot package: userPackage.
+	pointClass := self createClassNamed: #MyPoint superclass: objectClass package: userPackage.
+	coloredPointClass := self createClassNamed: #MyColoredPoint superclass: pointClass package: userPackage.
 	
 	"String will have no extensions. It's here just for polymorphism.
 	It will thus contain aliases only"
-	stringClass := (Object << #MyString
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-	
-	nicerStringClass := (Object << #MyNicerString
-		superclass: stringClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
+	stringClass := self createClassNamed: #MyString superclass: objectClass package: userPackage.
+	nicerStringClass := self createClassNamed: #MyNicerString superclass: stringClass package: userPackage.
+	userClass := self createClassNamed: #MyUserClass superclass: objectClass package: userPackage.
 
-	userClass := (Object << #MyUserClass
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-	
-	extensionOnObject := (Extension << #ExtensionOfObject
-		extendedClass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-
-	extensionOnPoint := (Extension << #ExtensionOfPoint
-		extendedClass: pointClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-
-	extensionOnColoredPoint := (Extension << #ExtensionOfColoredPoint
-		extendedClass: coloredPointClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-]
-
-{ #category : 'running' }
-ExtensionHotUpdateCompilationTest >> tearDown [
-	"Make sure we did not pollute the global dictionaries"
-
-	self deny: (Point methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	self deny: (Object methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	self deny: (Integer methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	
-	environment allClassesAndTraits do: [ :e | e removeFromSystem ].
-	
-	super tearDown
+	extensionOnObject := self createExtensionNamed: #ExtensionOfObject forBehavior: objectClass inPackage: definerPackage.
+	extensionOnPoint := self createExtensionNamed: #ExtensionOfPoint forBehavior: pointClass inPackage: definerPackage.
+	extensionOnColoredPoint := self
+		                           createExtensionNamed: #ExtensionOfColoredPoint
+		                           forBehavior: coloredPointClass
+		                           inPackage: definerPackage
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test01CompileNewExtensionMethod01IsVisibleForNewMethods [
-
 	"A normal method sends the (non scoped) extension message"
-	| classInDefinerPackage |
-	classInDefinerPackage := (Object << #ClassInDefinerPackage
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
 
+	| classInDefinerPackage |
+	classInDefinerPackage := self createClassNamed: #ClassInDefinerPackage superclass: objectClass package: definerPackage.
+	
 	"Now we define an extension in the scope.
 	=> the method above (foo) should see the extension!"
-	extensionOnObject compile: 'extension ^ 11'.
-
-	classInDefinerPackage compile: 'foo ^ self extension'.	
+	self compile: 'extension ^ 11' on: extensionOnObject.
+	self compile: 'foo ^ self extension' on: classInDefinerPackage.
 	self assert: classInDefinerPackage new foo equals: 11
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test01CompileNewExtensionMethod02RecompilesSendersInScope [
-
 	"A normal method sends the (non scoped) extension message"
-	| classInDefinerPackage |
-	classInDefinerPackage := (Object << #ClassInDefinerPackage
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-	classInDefinerPackage compile: 'foo ^ self extension'.
 
+	| classInDefinerPackage |
+	classInDefinerPackage := self createClassNamed: #ClassInDefinerPackage superclass: objectClass package: definerPackage.
+
+	self compile: 'foo ^ self extension' on: classInDefinerPackage.
+	
 	"Before compiling the extension, we do not see a scoped selector. We DNU on the global selector"
 	self assertDNU: #extension on: #foo to: classInDefinerPackage new.
-
+	
 	"Now we define an extension in the scope.
 	=> the method above (foo) should see the extension!"
-	extensionOnObject compile: 'extension ^ 11'.
-	
+	self compile: 'extension ^ 11' on: extensionOnObject.
+
 	self assert: classInDefinerPackage new foo equals: 11
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test02ImportNewExtensionMethod01IsVisibleForNewMethods [
-
 	"A normal method sends the (non scoped) extension message"
+
 	| scopedSelector |
 	"Now we import an extension in the scope.
 	=> the method above (foo) should see the extension!"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
-	
-	userClass package addExtensionImport: extensionOnObject.
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject.
 
-	userClass compile: 'foo ^ self extension'.
+	userClass package addExtensionImport: extensionOnObject.
+	self compile: 'foo ^ self extension' on: userClass.
 	self assert: userClass new foo equals: 11
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test02ImportNewExtensionMethod02RecompilesSendersInScope [
-
 	"A normal method sends the (non scoped) extension message"
-	| scopedSelector |
-	userClass compile: 'foo ^ self extension'.
 
-	"Now we import an extension in the scope.
+	| scopedSelector |
+	self compile: 'foo ^ self extension' on: userClass. "Now we import an extension in the scope.
 	=> the method above (foo) should see the extension!"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
-	
-	"Before importing the extension, we do not see a scoped selector. We DNU on the global selector"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject. "Before importing the extension, we do not see a scoped selector. We DNU on the global selector"
 	self assertDNU: #extension on: #foo to: userClass new.
-	
+
 	userClass package addExtensionImport: extensionOnObject.
 
 	self assert: userClass new foo equals: 11
@@ -175,196 +113,158 @@ ExtensionHotUpdateCompilationTest >> test02ImportNewExtensionMethod02RecompilesS
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test03CompileNewExtensionMethodAfterImport01IsVisibleForNewMethods [
-
 	"A normal method sends the (non scoped) extension message"
-	| scopedSelector |	
-	
+
+	| scopedSelector |
 	"We import an extension in the scope. The extension is empty"
-	userClass package addExtensionImport: extensionOnObject.
-
-	"=> the method above (foo) should see the extension!"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
-
-	userClass compile: 'foo ^ self extension'.
+	userClass package addExtensionImport: extensionOnObject. "=> the method above (foo) should see the extension!"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject.
+	self compile: 'foo ^ self extension' on: userClass.
 	self assert: userClass new foo equals: 11
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test03CompileNewExtensionMethodAfterImport02RecompilesSendersInScope [
-
 	"A normal method sends the (non scoped) extension message"
-	| scopedSelector |	
-	
+
+	| scopedSelector |
 	"We import an extension in the scope. The extension is empty"
 	userClass package addExtensionImport: extensionOnObject.
-
-	userClass compile: 'foo ^ self extension'.
-
-	"=> the method above (foo) should see the extension!"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
+	self compile: 'foo ^ self extension' on: userClass. "=> the method above (foo) should see the extension!"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject.
 	self assert: userClass new foo equals: 11
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test04ReCompileNewExtensionMethod01IsVisibleForNewMethods [
-
 	"A normal method sends the (non scoped) extension message"
-	| classInDefinerPackage |
-	classInDefinerPackage := (Object << #ClassInDefinerPackage
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
 
+	| classInDefinerPackage |
+	classInDefinerPackage := self createClassNamed: #ClassInDefinerPackage superclass: objectClass package: definerPackage.
+	
 	"Now we define an extension in the scope.
 	=> the method above (foo) should see the extension!"
-	extensionOnObject compile: 'extension ^ 11'.
+	self compile: 'extension ^ 11' on: extensionOnObject.
 	
 	"Recompilation should not change anything"
-	extensionOnObject compile: 'extension ^ 11'.
-
-	classInDefinerPackage compile: 'foo ^ self extension'.	
+	self compile: 'extension ^ 11' on: extensionOnObject.
+	
+	self compile: 'foo ^ self extension' on: classInDefinerPackage.
+	
 	self assert: classInDefinerPackage new foo equals: 11
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test04ReCompileNewExtensionMethod02RecompilesSendersInScope [
-
 	"A normal method sends the (non scoped) extension message"
-	| classInDefinerPackage |
-	classInDefinerPackage := (Object << #ClassInDefinerPackage
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-	classInDefinerPackage compile: 'foo ^ self extension'.
 
+	| classInDefinerPackage |
+	classInDefinerPackage := self createClassNamed: #ClassInDefinerPackage superclass: objectClass package: definerPackage.
+	
+	self compile: 'foo ^ self extension' on: classInDefinerPackage.
+	
 	"Before compiling the extension, we do not see a scoped selector. We DNU on the global selector"
 	self assertDNU: #extension on: #foo to: classInDefinerPackage new.
-
+	
 	"Now we define an extension in the scope.
 	=> the method above (foo) should see the extension!"
-	extensionOnObject compile: 'extension ^ 11'.
+	self compile: 'extension ^ 11' on: extensionOnObject.
 	
 	"Recompilation should not change anything"
-	extensionOnObject compile: 'extension ^ 11'.
-	
+	self compile: 'extension ^ 11' on: extensionOnObject.
+
 	self assert: classInDefinerPackage new foo equals: 11
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test05ReCompileNewExtensionMethodAfterImport01IsVisibleForNewMethods [
-
 	"A normal method sends the (non scoped) extension message"
-	| scopedSelector |	
-	
+
+	| scopedSelector |
 	"We import an extension in the scope. The extension is empty"
-	userClass package addExtensionImport: extensionOnObject.
-
-	"=> the method above (foo) should see the extension!"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
-
-	userClass compile: 'foo ^ self extension'.
-	
-	"Recompilation should not change anything"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
+	userClass package addExtensionImport: extensionOnObject. "=> the method above (foo) should see the extension!"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject.
+	self compile: 'foo ^ self extension' on: userClass. "Recompilation should not change anything"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject.
 	self assert: userClass new foo equals: 11
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test05ReCompileNewExtensionMethodAfterImport02RecompilesSendersInScope [
-
 	"A normal method sends the (non scoped) extension message"
-	| scopedSelector |	
-	
+
+	| scopedSelector |
 	"We import an extension in the scope. The extension is empty"
 	userClass package addExtensionImport: extensionOnObject.
-
-	userClass compile: 'foo ^ self extension'.
-
-	"=> the method above (foo) should see the extension!"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
-	
-	"Recompilation should not change anything"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
+	self compile: 'foo ^ self extension' on: userClass. "=> the method above (foo) should see the extension!"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject. "Recompilation should not change anything"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject.
 	self assert: userClass new foo equals: 11
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test06RedefineExtensionMethod01IsVisibleForNewMethods [
-
 	"A normal method sends the (non scoped) extension message"
-	| classInDefinerPackage |
-	classInDefinerPackage := (Object << #ClassInDefinerPackage
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
 
+	| classInDefinerPackage |
+	classInDefinerPackage := self createClassNamed: #ClassInDefinerPackage superclass: objectClass package: definerPackage.
+	
 	"Now we define an extension in the scope.
 	=> the method above (foo) should see the extension!"
-	extensionOnObject compile: 'extension ^ 11'.
+	self compile: 'extension ^ 11' on: extensionOnObject.
 	
 	"We redefine it, and this new version should be taken into account"
-	extensionOnObject compile: 'extension ^ 12'.
-
-	classInDefinerPackage compile: 'foo ^ self extension'.	
+	self compile: 'extension ^ 12' on: extensionOnObject.
+	
+	self compile: 'foo ^ self extension' on: classInDefinerPackage.
+	
 	self assert: classInDefinerPackage new foo equals: 12
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test06RedefineExtensionMethod02RecompilesSendersInScope [
-
 	"A normal method sends the (non scoped) extension message"
-	| classInDefinerPackage |
-	classInDefinerPackage := (Object << #ClassInDefinerPackage
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-	classInDefinerPackage compile: 'foo ^ self extension'.
 
+	| classInDefinerPackage |
+	classInDefinerPackage := self createClassNamed: #ClassInDefinerPackage superclass: objectClass package: definerPackage.
+	
+	self compile: 'foo ^ self extension' on: classInDefinerPackage.
+	
 	"Before compiling the extension, we do not see a scoped selector. We DNU on the global selector"
 	self assertDNU: #extension on: #foo to: classInDefinerPackage new.
-
+	
 	"Now we define an extension in the scope.
 	=> the method above (foo) should see the extension!"
-	extensionOnObject compile: 'extension ^ 11'.
+	self compile: 'extension ^ 11' on: extensionOnObject.
 	
 	"We redefine it, and this new version should be taken into account"
-	extensionOnObject compile: 'extension ^ 12'.
-	
+	self compile: 'extension ^ 12' on: extensionOnObject.
+
 	self assert: classInDefinerPackage new foo equals: 12
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test07RedefineExtensionMethodAfterImport01IsVisibleForNewMethods [
-
 	"A normal method sends the (non scoped) extension message"
-	| scopedSelector |	
 
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
-	
-	"We import an extension in the scope. The extension is empty"
-	userClass package addExtensionImport: extensionOnObject.
-
-	"We redefine it, and this new version should be taken into account"
-	extensionOnObject compile: 'extension ^ 12'.
-
-	userClass compile: 'foo ^ self extension'.
+	| scopedSelector |
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject. "We import an extension in the scope. The extension is empty"
+	userClass package addExtensionImport: extensionOnObject. "We redefine it, and this new version should be taken into account"
+	self compile: 'extension ^ 12' on: extensionOnObject.
+	self compile: 'foo ^ self extension' on: userClass.
 	self assert: userClass new foo equals: 12
 ]
 
 { #category : 'tests' }
 ExtensionHotUpdateCompilationTest >> test07RedefineExtensionMethodAfterImport02RecompilesSendersInScope [
-
 	"A normal method sends the (non scoped) extension message"
-	| scopedSelector |	
-	"=> the method above (foo) should see the extension!"
-	scopedSelector := extensionOnObject compile: 'extension ^ 11'.
-	
-	"We import an extension in the scope. The extension is empty"
-	userClass package addExtensionImport: extensionOnObject.
 
-	userClass compile: 'foo ^ self extension'.
-	
-	extensionOnObject compile: 'extension ^ 12'.
+	| scopedSelector |
+	"=> the method above (foo) should see the extension!"
+	scopedSelector := self compile: 'extension ^ 11' on: extensionOnObject. "We import an extension in the scope. The extension is empty"
+	userClass package addExtensionImport: extensionOnObject.
+	self compile: 'foo ^ self extension' on: userClass.
+	self compile: 'extension ^ 12' on: extensionOnObject.
 
 	self assert: userClass new foo equals: 12
 ]

--- a/src/Kernel-CodeModel-Tests/ExtensionTest.class.st
+++ b/src/Kernel-CodeModel-Tests/ExtensionTest.class.st
@@ -307,10 +307,10 @@ ExtensionTest >> test15ExtensionsWithIsolatedSuperSends [
 
 	| userInstance extensionOnPoint2 superSenderSelector pointObject |
 	definerPackage2 := Package named: 'Definer2'.
-	extensionOnPoint2 := self createExtensionNamed: #ExtensionOfInteger forBehavior: pointClass inPackage: definerPackage2.
+	extensionOnPoint2 := self createExtensionNamed: #ExtensionOfPoint2 forBehavior: pointClass inPackage: definerPackage2.
 
 	self compile: 'foo ^ 10' on: extensionOnObject.
-	superSenderSelector := self compile: 'foo ^ super foo + 1' on: extensionOnObject.
+	superSenderSelector := self compile: 'foo ^ super foo + 1' on: extensionOnPoint2.
 	self
 		compile: 'scopedUser: anObject
 		^ anObject foo'

--- a/src/Kernel-CodeModel-Tests/ExtensionTest.class.st
+++ b/src/Kernel-CodeModel-Tests/ExtensionTest.class.st
@@ -1,11 +1,8 @@
 Class {
 	#name : 'ExtensionTest',
-	#superclass : 'TestCase',
+	#superclass : 'AbstractExtensionTest',
 	#instVars : [
-		'environment',
 		'userClass',
-		'userPackage',
-		'definerPackage',
 		'extensionOnObject',
 		'definerPackage2',
 		'objectClass',
@@ -20,50 +17,15 @@ Class {
 { #category : 'running' }
 ExtensionTest >> setUp [
 
-	| extendedPackage |
 	super setUp.
-	
-	environment := SystemEnvironment new.
-	extendedPackage := Package named: 'Extended'.
-	definerPackage := Package named: 'Definer'.
-	userPackage := Package named: 'User'.
 
-	objectClass := (Object << #MyObject
-		installingEnvironment: environment;
-		package: userPackage) install.
-	
-	pointClass := (Object << #MyPoint
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
+	objectClass := self createClassNamed: #MyObject superclass: isolatingRoot package: userPackage.
+	pointClass := self createClassNamed: #MyPoint superclass: objectClass package: userPackage.
 
-	extensionOnPoint := (Extension << #ExtensionOfPoint
-		extendedClass: pointClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
-	
-	extensionOnObject := (Extension << #ExtensionOfObject
-		extendedClass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage) install.
+	extensionOnPoint := self createExtensionNamed: #ExtensionOfPoint forBehavior: pointClass inPackage: definerPackage.
+	extensionOnObject := self createExtensionNamed: #ExtensionOfObject forBehavior: objectClass inPackage: definerPackage.
 
-	userClass := (Object << #MyUserClass
-		superclass: objectClass;
-		installingEnvironment: environment;
-		package: userPackage) install.
-]
-
-{ #category : 'running' }
-ExtensionTest >> tearDown [
-	"Make sure we did not pollute the global dictionaries"
-
-	self deny: (Point methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	self deny: (Object methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	self deny: (Integer methodDictionary keys anySatisfy: [ :k | k isKindOf: ScopedSelector ]).
-	
-	environment allClassesAndTraits do: [ :e | e removeFromSystem ].
-	
-	super tearDown
+	userClass := self createClassNamed: #MyUserClass superclass: objectClass package: userPackage
 ]
 
 { #category : 'tests - semantic' }
@@ -98,7 +60,7 @@ ExtensionTest >> test04LookupExtendedSelectorInDefinerReturnsScopedSelector [
 
 	| scopedSelector |
 	"We define a extension method, which defines a scoped selector in the selector namespace"
-	extensionOnObject compile: 'extensionMethod ^ 42'.
+	self compile: 'extensionMethod ^ 42' on: extensionOnObject.
 
 	scopedSelector := definerPackage visibleSelectorForSymbol: #extensionMethod.
 	self assert: scopedSelector isScopedSelector.
@@ -111,7 +73,7 @@ ExtensionTest >> test05LookupExtendedSelectorInUserReturnsScopedSelector [
 
 	| scopedSelector |
 	"We define a extension method, which defines a scoped selector in the selector namespace"
-	extensionOnObject compile: 'extensionMethod ^ 42'.
+	self compile: 'extensionMethod ^ 42' on: extensionOnObject.
 	userPackage addExtensionImport: extensionOnObject.
 
 	scopedSelector := userPackage visibleSelectorForSymbol: #extensionMethod.
@@ -124,8 +86,8 @@ ExtensionTest >> test05LookupExtendedSelectorInUserReturnsScopedSelector [
 ExtensionTest >> test06ExtensionsInTheSamePackageSeeEachOther [
 
 	| receiver |
-	extensionOnObject compile: 'extension2 ^ 42'.
-	extensionOnObject compile: 'extension1 ^ self extension2'.
+	self compile: 'extension2 ^ 42' on: extensionOnObject.
+	self compile: 'extension1 ^ self extension2' on: extensionOnObject.
 
 	receiver := objectClass new.
 	self assert: (receiver perform: (definerPackage visibleSelectorForSymbol: #extension1)) equals: 42
@@ -135,8 +97,8 @@ ExtensionTest >> test06ExtensionsInTheSamePackageSeeEachOther [
 ExtensionTest >> test07ExtensionsInTheSamePackageSeeEachOtherIfDefinedBackwards [
 
 	| receiver |
-	extensionOnObject compile: 'extension1 ^ self extension2'.
-	extensionOnObject compile: 'extension2 ^ 42'.
+	self compile: 'extension1 ^ self extension2' on: extensionOnObject.
+	self compile: 'extension2 ^ 42' on: extensionOnObject.
 
 	receiver := objectClass new.
 	self assert: (receiver perform: (definerPackage visibleSelectorForSymbol: #extension1)) equals: 42
@@ -146,7 +108,7 @@ ExtensionTest >> test07ExtensionsInTheSamePackageSeeEachOtherIfDefinedBackwards 
 ExtensionTest >> test08RecursiveExtensionSeesItself [
 
 	| receiver |
-	extensionOnObject compile: 'factorial: n ^ n == 0 ifTrue: [1] ifFalse: [n * (self factorial: n - 1)]'.
+	self compile: 'factorial: n ^ n == 0 ifTrue: [1] ifFalse: [n * (self factorial: n - 1)]' on: extensionOnObject.
 
 	receiver := objectClass new.
 	self assert: (receiver perform: (definerPackage visibleSelectorForSymbol: #factorial:) with: 5) equals: 120
@@ -156,22 +118,25 @@ ExtensionTest >> test08RecursiveExtensionSeesItself [
 ExtensionTest >> test09ExtensionIsNotVisibleIfNotImported [
 
 	| receiver |
-	extensionOnObject compile: 'extensionMethod ^ 42'.
-	userClass compile: 'userMethod ^ self extensionMethod'.
-	
+	self compile: 'extensionMethod ^ 42' on: extensionOnObject.
+	self compile: 'userMethod ^ self extensionMethod' on: userClass.
+
 	receiver := userClass new.
-	[receiver perform: #userMethod. self fail]
-		on: MessageNotUnderstood do: [ :dnu |
-			self assert: dnu receiver == receiver.
-			self assert: dnu message selector equals: #extensionMethod ]
+	[
+		receiver perform: #userMethod.
+		self fail ]
+		on: MessageNotUnderstood
+		do: [ :dnu |
+				self assert: dnu receiver == receiver.
+				self assert: dnu message selector equals: #extensionMethod ]
 ]
 
 { #category : 'tests - semantic' }
 ExtensionTest >> test10ExtensionIsVisibleIfImported [
 
 	| receiver |		
-	extensionOnObject compile: 'extensionMethod ^ 42'.
-	userClass compile: 'userMethod ^ self extensionMethod'.
+	self compile: 'extensionMethod ^ 42' on: extensionOnObject.
+	self compile: 'userMethod ^ self extensionMethod' on: userClass.
 
 	userPackage addExtensionImport: extensionOnObject.
 	
@@ -183,10 +148,10 @@ ExtensionTest >> test10ExtensionIsVisibleIfImported [
 ExtensionTest >> test11ExtensionsArePolymorphicWithBaseSelectors [
 
 	| userInstance |
-	objectClass compile: 'asString ^ ''This is not an extension'''.
-	extensionOnPoint compile: 'asString ^ ''youpiii'''.
-	userClass compile: 'scopedUser: anObject
-		^ anObject asString'.
+	self compile: 'asString ^ ''This is not an extension''' on: objectClass.
+	self compile: 'asString ^ ''youpiii''' on: extensionOnPoint.
+	self compile: 'scopedUser: anObject
+		^ anObject asString' on: userClass.
 
 	userPackage addExtensionImport: extensionOnPoint.
 	userInstance := userClass new.
@@ -202,7 +167,9 @@ ExtensionTest >> test11ExtensionsArePolymorphicWithBaseSelectors [
 { #category : 'tests - runtime' }
 ExtensionTest >> test12ExtensionDefinesSelectorWithExtendedClass [
 
-	extensionOnObject compile: 'extensionMethod ^ 42'. "Now userMethod has executed, and a scoped selector for #extensionMethod has been installed in Object"
+	self compile: 'extensionMethod ^ 42' on: extensionOnObject.
+	
+	"Now userMethod has executed, and a scoped selector for #extensionMethod has been installed in Object"
 	self assert: ((definerPackage visibleSelectorForSymbol: #extensionMethod) extendedBehaviors includes: objectClass)
 ]
 
@@ -210,18 +177,20 @@ ExtensionTest >> test12ExtensionDefinesSelectorWithExtendedClass [
 ExtensionTest >> test12ExtensionsArePolymorphicBetweenThem [
 
 	| userInstance |
-	definerPackage2 := Package named: 'Definer2'.	
-	extensionOnObject compile: 'foo ^ 10'.
-	extensionOnPoint compile: 'foo ^ 42'.
-	userClass compile: 'scopedUser: anObject
-		^ anObject foo'.
+	definerPackage2 := Package named: 'Definer2'.
+	self compile: 'foo ^ 10' on: extensionOnObject.
+	self compile: 'foo ^ 42' on: extensionOnPoint.
+	self
+		compile: 'scopedUser: anObject
+		^ anObject foo'
+		on: userClass.
 
 	userPackage addExtensionImport: extensionOnObject.
 	userPackage addExtensionImport: extensionOnPoint.
 	userInstance := userClass new.
 
 	self assert: (userInstance perform: #scopedUser: with: pointClass new) equals: 42.
-	self assert: (userInstance perform: #scopedUser: with: objectClass new) equals: 10.
+	self assert: (userInstance perform: #scopedUser: with: objectClass new) equals: 10
 ]
 
 { #category : 'tests - semantic' }
@@ -229,31 +198,35 @@ ExtensionTest >> test13ConflictingExtensionsThrowError [
 
 	| userInstance anotherExtensionOnObject |
 	definerPackage2 := Package named: 'Definer2'.
-	anotherExtensionOnObject := (Extension << #AnotherExtensionOnObject
-		extendedClass: objectClass;
-		installingEnvironment: environment;
-		package: definerPackage2) install.
-	
-	extensionOnObject compile: 'foo ^ 10'.
-	anotherExtensionOnObject compile: 'foo ^ 42'.
-	userClass compile: 'scopedUser: anObject
-		^ anObject foo'.
+	anotherExtensionOnObject := self
+		                            createExtensionNamed: #AnotherExtensionOnObject
+		                            forBehavior: objectClass
+		                            inPackage: definerPackage2.
+
+	self compile: 'foo ^ 10' on: extensionOnObject.
+	self compile: 'foo ^ 42' on: anotherExtensionOnObject.
+	self
+		compile: 'scopedUser: anObject
+		^ anObject foo'
+		on: userClass.
 
 	userPackage addExtensionImport: extensionOnObject.
 	userPackage addExtensionImport: anotherExtensionOnObject.
 	userInstance := userClass new.
 
-	self should: [(userInstance perform: #scopedUser: with: objectClass new)] raise: ExtensionConflictError with: [ :ex | self assert: ex messageText equals: 'Conflict: extension overwrites method #foo in MyObject' ].
-	
+	self
+		should: [ userInstance perform: #scopedUser: with: objectClass new ]
+		raise: ExtensionConflictError
+		with: [ :ex | self assert: ex messageText equals: 'Conflict: extension overwrites method #foo in MyObject' ]
 ]
 
 { #category : 'tests - runtime' }
 ExtensionTest >> test13ExtensionDoesNotDefineAliasBeforeSend [
 
 	| userInstance scopedSelector |
-	extensionOnPoint compile: 'asString ^ ''youpiii'''.
-	userClass compile: 'scopedUser: anObject
-		^ anObject asString'.
+	self compile: 'asString ^ ''youpiii''' on: extensionOnPoint.
+	self compile: 'scopedUser: anObject
+		^ anObject asString' on: userClass.
 
 	userPackage addExtensionImport: extensionOnPoint.
 	userInstance := userClass new.
@@ -267,7 +240,7 @@ ExtensionTest >> test13ExtensionDoesNotDefineAliasBeforeSend [
 ExtensionTest >> test14DefinerAndUserSelectorAreNotTheSame [
 
 	| definerScopedSelector userScopedSelector |
-	extensionOnPoint compile: 'asString ^ ''youpiii'''.
+	self compile: 'asString ^ ''youpiii''' on: extensionOnPoint.
 
 	userPackage addExtensionImport: extensionOnPoint.
 
@@ -282,10 +255,10 @@ ExtensionTest >> test14ExtensionSuperSends [
 
 	| userInstance |
 
-	extensionOnObject compile: 'foo ^ 10'.
-	extensionOnPoint compile: 'foo ^ super foo + 1'.
-	userClass compile: 'scopedUser: anObject
-		^ anObject foo'.
+	self compile: 'foo ^ 10' on: extensionOnObject.
+	self compile: 'foo ^ super foo + 1' on: extensionOnPoint.
+	self compile: 'scopedUser: anObject
+		^ anObject foo' on: userClass.
 
 	userPackage addExtensionImport: extensionOnObject.
 	userPackage addExtensionImport: extensionOnPoint.
@@ -299,10 +272,10 @@ ExtensionTest >> test14ExtensionSuperSends [
 ExtensionTest >> test15ExtensionsInHierarchySubclassBindingFirst [
 
 	| userInstance |
-	extensionOnObject compile: 'foo ^ 10'.
-	extensionOnPoint compile: 'foo ^ 42'.
-	userClass compile: 'scopedUser: anObject
-		^ anObject foo'.
+	self compile: 'foo ^ 10' on: extensionOnObject.
+	self compile: 'foo ^ 42' on: extensionOnPoint.
+	self compile: 'scopedUser: anObject
+		^ anObject foo' on: userClass.
 
 	userPackage addExtensionImport: extensionOnObject.
 	userPackage addExtensionImport: extensionOnPoint.
@@ -316,10 +289,10 @@ ExtensionTest >> test15ExtensionsInHierarchySubclassBindingFirst [
 ExtensionTest >> test15ExtensionsInHierarchySuperclassBindingFirst [
 
 	| userInstance |
-	extensionOnObject compile: 'foo ^ 10'.
-	extensionOnPoint compile: 'foo ^ 42'.
-	userClass compile: 'scopedUser: anObject
-		^ anObject foo'.
+	self compile: 'foo ^ 10' on: extensionOnObject.
+	self compile: 'foo ^ 42' on: extensionOnPoint.
+	self compile: 'scopedUser: anObject
+		^ anObject foo' on: userClass.
 
 	userPackage addExtensionImport: extensionOnObject.
 	userPackage addExtensionImport: extensionOnPoint.
@@ -334,15 +307,14 @@ ExtensionTest >> test15ExtensionsWithIsolatedSuperSends [
 
 	| userInstance extensionOnPoint2 superSenderSelector pointObject |
 	definerPackage2 := Package named: 'Definer2'.
-	extensionOnPoint2 := ((Extension << #ExtensionOfInteger)
-		                      extendedClass: pointClass;
-		                      installingEnvironment: environment;
-		                      package: definerPackage2) install.
+	extensionOnPoint2 := self createExtensionNamed: #ExtensionOfInteger forBehavior: pointClass inPackage: definerPackage2.
 
-	extensionOnObject compile: 'foo ^ 10'.
-	superSenderSelector := extensionOnPoint2 compile: 'foo ^ super foo + 1'.
-	userClass compile: 'scopedUser: anObject
-		^ anObject foo'.
+	self compile: 'foo ^ 10' on: extensionOnObject.
+	superSenderSelector := self compile: 'foo ^ super foo + 1' on: extensionOnObject.
+	self
+		compile: 'scopedUser: anObject
+		^ anObject foo'
+		on: userClass.
 
 	userPackage addExtensionImport: extensionOnObject.
 	userPackage addExtensionImport: extensionOnPoint2.
@@ -361,7 +333,7 @@ ExtensionTest >> test15ExtensionsWithIsolatedSuperSends [
 ExtensionTest >> test15LookupAliasedSelectorInUserReturnsExtendedClass [
 
 	| definerScopedSelector userScopedSelector extendedClass1 extendedClass2 |
-	extensionOnPoint compile: 'asString ^ ''youpiii'''.
+	self compile: 'asString ^ ''youpiii''' on: extensionOnPoint.
 
 	userPackage addExtensionImport: extensionOnPoint.
 
@@ -377,9 +349,11 @@ ExtensionTest >> test15LookupAliasedSelectorInUserReturnsExtendedClass [
 ExtensionTest >> test16ExtensionDoesNotTrackAliasedClassBeforeSend [
 
 	| userInstance scopedSelector |
-	extensionOnPoint compile: 'asString ^ ''youpiii'''.
-	userClass compile: 'scopedUser: anObject
-		^ anObject asString'.
+	self compile: 'asString ^ ''youpiii''' on: extensionOnPoint.
+	self
+		compile: 'scopedUser: anObject
+		^ anObject asString'
+		on: userClass.
 
 	userPackage addExtensionImport: extensionOnPoint.
 	userInstance := userClass new.
@@ -392,10 +366,12 @@ ExtensionTest >> test16ExtensionDoesNotTrackAliasedClassBeforeSend [
 ExtensionTest >> test17ExtensionSelectorDoesNotDefineAlias [
 
 	| userInstance definerScopedSelector |
-	objectClass compile: 'asString ^ ''this is not an extension'''.
-	extensionOnPoint compile: 'asString ^ ''youpiii'''.
-	userClass compile: 'scopedUser: anObject
-		^ anObject asString'.
+	self compile: 'asString ^ ''this is not an extension''' on: objectClass.
+	self compile: 'asString ^ ''youpiii''' on: extensionOnPoint.
+	self
+		compile: 'scopedUser: anObject
+		^ anObject asString'
+		on: userClass.
 
 	userPackage addExtensionImport: extensionOnPoint.
 	userInstance := userClass new. "This sends a scoped message to a non extended class.
@@ -412,13 +388,13 @@ ExtensionTest >> test17ExtensionSelectorDoesNotDefineAlias [
 ExtensionTest >> test18CleanExtendedBehaviorsCleansExtensionMethods [
 
 	| scopedSelector |
-	scopedSelector := extensionOnObject compile: 'extensionMethod ^ 42'.
+	scopedSelector := self compile: 'extensionMethod ^ 42' on: extensionOnObject.
 	self assert: scopedSelector isScopedSelector.
 
 	self assert: (objectClass new perform: scopedSelector) equals: 42.
-	
+
 	definerPackage cleanupExtendedBehaviors.
-	
+
 	self deny: (objectClass new respondsTo: scopedSelector)
 ]
 
@@ -426,14 +402,15 @@ ExtensionTest >> test18CleanExtendedBehaviorsCleansExtensionMethods [
 ExtensionTest >> test18ScopedSelectorTracksAliasedClassAfterSend [
 
 	| userInstance userScopedSelector |
-	objectClass compile: 'asString ^ ''this is not an extension'''.
-	extensionOnPoint compile: 'asString ^ ''youpiii'''.
-	userClass compile: 'scopedUser: anObject
-		^ anObject asString'.
+	self compile: 'asString ^ ''this is not an extension''' on: objectClass.
+	self compile: 'asString ^ ''youpiii''' on: extensionOnPoint.
+	self
+		compile: 'scopedUser: anObject
+		^ anObject asString'
+		on: userClass.
 
 	userPackage addExtensionImport: extensionOnPoint.
-	userInstance := userClass new.
-	"This sends a scoped message to a non extended class.
+	userInstance := userClass new. "This sends a scoped message to a non extended class.
 	The lookup will find the global selector and alias it to the scoped one."
 	self assert: (userInstance perform: #scopedUser: with: objectClass new) equals: 'this is not an extension'.
 
@@ -449,8 +426,8 @@ ExtensionTest >> test18ScopedSelectorTracksAliasedClassAfterSend [
 ExtensionTest >> test19CleanExtendedBehaviorsRemovesTrackedBehaviors [
 
 	| receiver scopedSelector |
-	extensionOnObject compile: 'extensionMethod ^ 42'.
-	userClass compile: 'userMethod ^ self extensionMethod'.
+	self compile: 'extensionMethod ^ 42' on: extensionOnObject.
+	self compile: 'userMethod ^ self extensionMethod' on: userClass.
 
 	userPackage addExtensionImport: extensionOnObject.
 
@@ -467,10 +444,12 @@ ExtensionTest >> test19CleanExtendedBehaviorsRemovesTrackedBehaviors [
 ExtensionTest >> test20CleanExtendedBehaviorsCleansAliases [
 
 	| userInstance scopedSelector |
-	objectClass compile: 'asString ^ ''this is not an extension'''.
-	extensionOnPoint compile: 'asString ^ ''youpiii'''.
-	userClass compile: 'scopedUser: anObject
-		^ anObject asString'.
+	self compile: 'asString ^ ''this is not an extension''' on: objectClass.
+	self compile: 'asString ^ ''youpiii''' on: extensionOnPoint.
+	self
+		compile: 'scopedUser: anObject
+		^ anObject asString'
+		on: userClass.
 
 	userPackage addExtensionImport: extensionOnPoint.
 	userInstance := userClass new.

--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -983,6 +983,14 @@ Class >> subclasses [
 { #category : 'accessing - class hierarchy' }
 Class >> subclasses: aCollection [
 	<reflection: 'Class structural inspection - Hierarchy modification'>
+	((subclasses isNil or: [ subclasses isEmpty ])
+		and: [ aCollection isNil or: [ aCollection isEmpty ] ])
+			ifTrue: [ 
+				"Nothing to do"
+				^ self ].
+	
+	subclasses = aCollection ifTrue: [ "Nothing to do" ^ self ].
+	
 	subclasses := aCollection
 ]
 

--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -868,8 +868,9 @@ Class >> removeSubclass: aSubclass [
 
 	<reflection: 'Class structural modification - Hierarchy modification'>
 	self subclasses ifNotNil: [ :classes |
-		self subclasses: (classes copyWithout: aSubclass).
-		self subclasses ifEmpty: [ self subclasses: nil ] ]
+		classes ifNotEmpty: [
+			self subclasses: (classes copyWithout: aSubclass).
+			self subclasses ifEmpty: [ self subclasses: nil ] ] ]
 ]
 
 { #category : 'class name' }
@@ -983,13 +984,6 @@ Class >> subclasses [
 { #category : 'accessing - class hierarchy' }
 Class >> subclasses: aCollection [
 	<reflection: 'Class structural inspection - Hierarchy modification'>
-	((subclasses isNil or: [ subclasses isEmpty ])
-		and: [ aCollection isNil or: [ aCollection isEmpty ] ])
-			ifTrue: [ 
-				"Nothing to do"
-				^ self ].
-	
-	subclasses = aCollection ifTrue: [ "Nothing to do" ^ self ].
 	
 	subclasses := aCollection
 ]

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -850,6 +850,16 @@ ClassDescription >> removeSelector: selector [
 	dictionary of the receiver, if it is there. Answer nil otherwise."
 
 	<reflection: 'Class structural modification - Selector/Method modification'>
+	
+	^ self removeSelector: selector logged: true
+]
+
+{ #category : 'accessing - method dictionary' }
+ClassDescription >> removeSelector: selector logged: aBoolean [
+	"Remove the message whose selector is given from the method
+	dictionary of the receiver, if it is there. Answer nil otherwise."
+
+	<reflection: 'Class structural modification - Selector/Method modification'>
 	| method origin |
 	method := self compiledMethodAt: selector.
 	origin := method origin.
@@ -861,7 +871,7 @@ ClassDescription >> removeSelector: selector [
 
 	super removeSelector: selector.
 
-	self codeChangeAnnouncer methodRemoved: method origin: origin
+	aBoolean ifTrue: [ self codeChangeAnnouncer methodRemoved: method origin: origin ].
 ]
 
 { #category : 'protocols' }

--- a/src/Kernel-CodeModel/Extension.class.st
+++ b/src/Kernel-CodeModel/Extension.class.st
@@ -76,9 +76,9 @@ Extension >> removeFromSystem: logged [
 ]
 
 { #category : 'accessing - method dictionary' }
-Extension >> removeSelector: aSelector [
+Extension >> removeSelector: aSelector logged: logged [
 
-	super removeSelector: aSelector.
+	super removeSelector: aSelector logged: logged.
 	
 	"In some tests we removed the extension method by hand, breaking some invariants.
 	We should take a look a that"

--- a/src/Kernel-CodeModel/Extension.class.st
+++ b/src/Kernel-CodeModel/Extension.class.st
@@ -71,7 +71,7 @@ Extension >> methodInstaller [
 Extension >> removeFromSystem: logged [
 
 	self selectors do: [ :e |
-		self removeSelector: e ].
+		self removeSelector: e logged: logged ].
 	super removeFromSystem: logged
 ]
 

--- a/src/Kernel-CodeModel/Metaclass.class.st
+++ b/src/Kernel-CodeModel/Metaclass.class.st
@@ -242,7 +242,7 @@ Metaclass >> name [
 	"Answer a String that is the name of the receiver, either 'Metaclass' or
 	the name of the receiver's class followed by ' class'."
 
-	^ thisClass ifNil: [ 'a Metaclass' ] ifNotNil: [ thisClass name , ' class' ]
+	^ thisClass ifNil: [ 'a Metaclass' ] ifNotNil: [ thisClass name asString , ' class' ]
 ]
 
 { #category : 'instance creation' }

--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -565,8 +565,7 @@ Package >> moveClass: aClass toTag: aTag [
 
 	"If the tag is undefined, this means we are adding the class. Else we are updating the package or tag."
 	oldTag isUndefined
-		ifTrue: [ SourcesManager current ifNotNil: [ :instance | "can be nil during the bootstrap" instance writeClassCreation: aClass ].
-				self codeChangeAnnouncer  announce: (ClassAdded class: aClass) ]
+		ifTrue: [ self codeChangeAnnouncer  announce: (ClassAdded class: aClass) ]
 		ifFalse: [ self codeChangeAnnouncer  announce: (ClassRepackaged classRepackaged: aClass oldTag: oldTag newTag: newTag) ]
 ]
 

--- a/src/Kernel-CodeModel/Package.class.st
+++ b/src/Kernel-CodeModel/Package.class.st
@@ -124,11 +124,7 @@ Package >> addExtensionImport: anExtension [
 	"Recompile dependencies, so they can see the extension.
 	For now, we recompile the entire package, since every callsite may now become a scoped callsite"
 	self methods do: [ :m |
-		m methodClass
-			compile: m sourceCode
-			classified: m protocol
-			withStamp: m timeStamp
-			logSource: true ]
+		m methodClass compile: m selector from: m methodClass ]
 ]
 
 { #category : 'add method - compiled method' }
@@ -687,7 +683,7 @@ Package >> removeExtensionImport: anExtension [
 		localScopedSelector := self visibleSelectorForSymbol: e symbol.
 		(anExtension extendedClass includesSelector: localScopedSelector) ifTrue: [
 			self assert: anExtension extendedClass >> localScopedSelector == (anExtension extendedClass >> e).
-			anExtension extendedClass removeSelector: localScopedSelector ]
+			anExtension extendedClass removeSelector: localScopedSelector logged: false ]
 	]
 ]
 

--- a/src/Kernel-CodeModel/PackageOrganizer.class.st
+++ b/src/Kernel-CodeModel/PackageOrganizer.class.st
@@ -136,7 +136,7 @@ PackageOrganizer >> initialize [
 
 	packages := IdentityDictionary new.
 	undefinedPackage := UndefinedPackage new.
-	self ensurePackage: undefinedPackage
+	self basicRegisterPackage: undefinedPackage
 ]
 
 { #category : 'testing' }

--- a/src/Kernel-CodeModel/ScopedSelector.class.st
+++ b/src/Kernel-CodeModel/ScopedSelector.class.st
@@ -183,6 +183,12 @@ ScopedSelector >> isDoIt [
 ]
 
 { #category : 'testing' }
+ScopedSelector >> isKeyword [
+
+	^ self symbol isKeyword
+]
+
+{ #category : 'testing' }
 ScopedSelector >> isScopedSelector [
 
 	^ true

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -31,7 +31,9 @@ Class {
 		'terminating',
 		'level',
 		'shouldOverflow',
-		'errorHandler'
+		'errorHandler',
+		'currentDomain',
+		'currentDomainIsDefault'
 	],
 	#classVars : [
 		'InheritablePSKeys',

--- a/src/Kernel/Process.class.st
+++ b/src/Kernel/Process.class.st
@@ -31,9 +31,7 @@ Class {
 		'terminating',
 		'level',
 		'shouldOverflow',
-		'errorHandler',
-		'currentDomain',
-		'currentDomainIsDefault'
+		'errorHandler'
 	],
 	#classVars : [
 		'InheritablePSKeys',

--- a/src/OpalCompiler-Core/Behavior.extension.st
+++ b/src/OpalCompiler-Core/Behavior.extension.st
@@ -48,22 +48,26 @@ Behavior >> compile: selector from: oldClass [
 	"Compile the method associated with selector in the receiver's method dictionary."
 
 	| method newMethod compiler |
-	method := oldClass compiledMethodAt: selector.
-	
-	"The installer should not log the source code when recompiling.
+	method := oldClass compiledMethodAt: selector. "The installer should not log the source code when recompiling.
 	We will reuse the same source as the old method"
 	compiler := oldClass compiler
-		             source: method sourceCode;
-		             class: self;
-						 priorMethod: method;
-		             permitFaulty: true;
-		             logged: false.
+		            source: method sourceCode;
+		            class: self;
+		            priorMethod: method;
+		            permitFaulty: true;
+		            logged: false.
 
 	newMethod := compiler install.
-	
-	newMethod sourcePointer: method sourcePointer.
-	selector == newMethod selector ifFalse: [
-		self error: 'selector changed!' ]
+
+	method hasSourcePointer
+		ifTrue: [ newMethod sourcePointer: method sourcePointer ]
+		ifFalse: [ 
+			method
+				propertyAt: #source
+				ifPresent: [ :code | 
+					newMethod propertyAt: #source put: code ] ].
+
+	selector == newMethod selector ifFalse: [ self error: 'selector changed!' ]
 ]
 
 { #category : '*OpalCompiler-Core' }

--- a/src/Shift-ClassBuilder/ShiftAnonymousClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftAnonymousClassInstaller.class.st
@@ -29,6 +29,12 @@ ShiftAnonymousClassInstaller >> installSubclassInSuperclass: newClass [
 ShiftAnonymousClassInstaller >> notifyChanges [
 ]
 
+{ #category : 'building' }
+ShiftAnonymousClassInstaller >> storeSourceCodeOf: aClass [
+
+	"Nothing"
+]
+
 { #category : 'notifications' }
 ShiftAnonymousClassInstaller >> updatePackage: newClass [
 ]

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -56,7 +56,8 @@ Class {
 		'superclassResolver',
 		'inRemake',
 		'package',
-		'tag'
+		'tag',
+		'sourcesManager'
 	],
 	#classVars : [
 		'BuilderEnhancer'
@@ -634,6 +635,17 @@ ShiftClassBuilder >> slots: aCollection [
 ShiftClassBuilder >> slotsFromString: aString [
 	"Note: this method should not be used outside of old style class definitions"
 	self slots: aString asSlotCollection
+]
+
+{ #category : 'accessing' }
+ShiftClassBuilder >> sourcesManager [
+	^ sourcesManager
+]
+
+{ #category : 'as yet unclassified' }
+ShiftClassBuilder >> sourcesManager: aNoSourcesManager [ 
+	
+	sourcesManager := aNoSourcesManager 
 ]
 
 { #category : 'accessing' }

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -642,7 +642,7 @@ ShiftClassBuilder >> sourcesManager [
 	^ sourcesManager
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 ShiftClassBuilder >> sourcesManager: aNoSourcesManager [ 
 	
 	sourcesManager := aNoSourcesManager 

--- a/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
@@ -22,7 +22,8 @@ Class {
 	#name : 'ShiftClassInstaller',
 	#superclass : 'Object',
 	#instVars : [
-		'builder'
+		'builder',
+		'sourcesManager'
 	],
 	#category : 'Shift-ClassBuilder-Installer',
 	#package : 'Shift-ClassBuilder',
@@ -192,6 +193,7 @@ ShiftClassInstaller >> make [
 		newClass := self oldClass.
 	].
 
+	self storeSourceCodeOf: newClass.
 	self updatePackage: newClass.
 	self comment: newClass.
 
@@ -211,6 +213,7 @@ ShiftClassInstaller >> make: aBlock [
 ShiftClassInstaller >> makeWithBuilder: aBuilder [
 
 	builder := aBuilder.
+	sourcesManager := aBuilder sourcesManager.
 	^ self make
 ]
 
@@ -294,6 +297,18 @@ ShiftClassInstaller >> oldClass: anObject [
 ShiftClassInstaller >> packageOrganizer [
 
 	^ builder installingEnvironment organization
+]
+
+{ #category : 'accessing' }
+ShiftClassInstaller >> sourcesManager [
+
+	^ sourcesManager ifNil: [ SourcesManager current ]
+]
+
+{ #category : 'building' }
+ShiftClassInstaller >> storeSourceCodeOf: newClass [
+
+	self sourcesManager ifNotNil: [ :instance | instance writeClassCreation: newClass ]
 ]
 
 { #category : 'building' }

--- a/src/System-Support/SystemEnvironment.class.st
+++ b/src/System-Support/SystemEnvironment.class.st
@@ -29,7 +29,9 @@ Class {
 		'cachedClassNames',
 		'cachedNonClassNames',
 		'cachedBehaviors',
-		'pseudoVariables'
+		'pseudoVariables',
+		'undeclaredRegistry',
+		'codeChangeAnnouncer'
 	],
 	#category : 'System-Support-Utilities',
 	#package : 'System-Support',
@@ -211,16 +213,14 @@ SystemEnvironment >> codeChangeAnnouncer [
 
 	"This should not be hardcoded in the futurebut I should have my own instance."
 
-	^ SystemAnnouncer uniqueInstance
+	^ codeChangeAnnouncer ifNil: [SystemAnnouncer uniqueInstance]
 ]
 
 { #category : 'accessing' }
 SystemEnvironment >> codeChangeAnnouncer: anAnnouncer [
-	"For now the announcer is still saved in SystemAnnouncer so we access it there. In the future we should save it in the environment.
-	
-	codeChangeAnnouncer := anAnnouncer"
+	"For now the announcer is still saved in SystemAnnouncer so we access it there. In the future we should save it in the environment."
 
-	SystemAnnouncer announcer: anAnnouncer
+	codeChangeAnnouncer := anAnnouncer
 ]
 
 { #category : 'accessing' }
@@ -470,5 +470,11 @@ SystemEnvironment >> traitNames [
 SystemEnvironment >> undeclaredRegistry [
 	"For now we are referencing a global variable of the default environment of Pharo. But in the future each environments should have their undeclared registry, else we have memory leaks of the environments."
 
-	^ Undeclared
+	^ undeclaredRegistry ifNil: [ Undeclared ]
+]
+
+{ #category : 'accessing' }
+SystemEnvironment >> undeclaredRegistry: anObject [
+
+	undeclaredRegistry := anObject
 ]

--- a/src/Traits/TraitedClass.class.st
+++ b/src/Traits/TraitedClass.class.st
@@ -257,12 +257,12 @@ TraitedClass >> removeFromSystem: logged [
 ]
 
 { #category : 'removing' }
-TraitedClass >> removeSelector: aSelector [
+TraitedClass >> removeSelector: aSelector logged: logged [
 
 	"When a selector is removed it should be notified to my users.
 	Check the class TraitChange for more details"
 	<reflection: 'Class structural modification - Selector/Method modification'>
-	super removeSelector: aSelector.
+	super removeSelector: aSelector logged: logged.
 	self localMethodDict removeKey: aSelector ifAbsent: [  ].
 
 	TraitChange removeSelector: aSelector on: self

--- a/src/Traits/TraitedMetaclass.class.st
+++ b/src/Traits/TraitedMetaclass.class.st
@@ -298,12 +298,12 @@ TraitedMetaclass >> removeFromComposition: aTrait [
 ]
 
 { #category : 'accessing - method dictionary' }
-TraitedMetaclass >> removeSelector: aSelector [
+TraitedMetaclass >> removeSelector: aSelector logged: logged [
 
 	"When a selector is removed it should be notified to my users.
 	Check the class TraitChange for more details"
 	<reflection: 'Class structural modification - Selector/Method modification'>
-	super removeSelector: aSelector.
+	super removeSelector: aSelector logged: logged.
 	self localMethodDict removeKey: aSelector ifAbsent: [  ].
 
 	TraitChange removeSelector: aSelector on: self


### PR DESCRIPTION
We did a pass on extension tests to avoid them writing and leaking data in the global environment.

This is the cause of failing tests for example in PR #19760.
See

- https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/PR-19760/
- https://ci.inria.fr/pharo-ci-jenkins2/job/Test%20pending%20pull%20request%20and%20branch%20Pipeline/job/PR-19760/6/testReport/junit/MacOSX64.Tests-osx-64.HeuristicCompletion.Tests/CoCompletionEngineCodeSnippetTest/osx_64___Tests_osx_64___testCompletion__snippet__an_OCCodeSnippet__goodby__my____/