### PR TITLE
Run the packages and tests in a predictable order

### DIFF
--- a/src/ReflectionMirrors-Primitives-Tests/MirrorPrimitivesTest.class.st
+++ b/src/ReflectionMirrors-Primitives-Tests/MirrorPrimitivesTest.class.st
@@ -178,7 +178,6 @@ MirrorPrimitivesTest >> testExecutingMethod [
 { #category : 'tests - message performing' }
 MirrorPrimitivesTest >> testExecutingPrimitive [
 	| actual |
-	<expectedFailure> "it will be supported by VM at some point"
 
 	actual := MirrorPrimitives withReceiver: 100 tryPrimitive: 1 withArguments: #(2).
 

--- a/src/SUnit-Basic-CLI/ClapTestRunner.class.st
+++ b/src/SUnit-Basic-CLI/ClapTestRunner.class.st
@@ -7,8 +7,9 @@ Class {
 	#instVars : [
 		'environment'
 	],
-	#category : 'SUnit-Basic-CLI',
-	#package : 'SUnit-Basic-CLI'
+	#category : 'SUnit-Basic-CLI-Core',
+	#package : 'SUnit-Basic-CLI',
+	#tag : 'Core'
 }
 
 { #category : 'command line' }
@@ -205,7 +206,8 @@ ClapTestRunner >> testPackagesForProject: aProjectName [
 ClapTestRunner >> testRunner [
 
 	self shouldOutputJunitXml ifTrue: [
-		HDTestReport shuffleSeed: self shuffleSeed.
+		self shuffleSeed ifNotNil: [ :seed |
+			HDTestReport shuffleSeed: seed ].
 		HDTestReport currentStageName: self stageName.
 		^ HDTestReport ].
 

--- a/src/SUnit-Basic-CLI/HDReport.class.st
+++ b/src/SUnit-Basic-CLI/HDReport.class.st
@@ -4,8 +4,12 @@ A Hudson report
 Class {
 	#name : 'HDReport',
 	#superclass : 'Object',
-	#category : 'SUnit-Basic-CLI',
-	#package : 'SUnit-Basic-CLI'
+	#classVars : [
+		'ShuffleRandom'
+	],
+	#category : 'SUnit-Basic-CLI-Core',
+	#package : 'SUnit-Basic-CLI',
+	#tag : 'Core'
 }
 
 { #category : 'running' }
@@ -21,7 +25,41 @@ HDReport class >> runPackage: aString [
 { #category : 'running' }
 HDReport class >> runPackages: aCollectionOfStrings [
 
+	"Run the packages in a predictable order.
+	We first sort them alphabetically, then we shuffle with the same seed than the tests.
+	
+	This makes that
+	 - packages are run in a random order
+	 - all tests of a package are run together, they are not mixed with other packages
+	 - tests within a package are run in a random order
+	 - all randomization happens with the same seed"
+	
+	| sortedPackageNames |
+	sortedPackageNames := aCollectionOfStrings sorted.
+	sortedPackageNames shuffleBy: self shuffleRandom.
 	^ aCollectionOfStrings collect: [ :packageName | self runPackage: packageName ]
+]
+
+{ #category : 'running' }
+HDReport class >> shuffleRandom [
+
+	"If no seed is given, initialize it.
+	All suites will use the same seed"
+	ShuffleRandom ifNil: [
+		ShuffleRandom := Random new ].
+	^ ShuffleRandom
+]
+
+{ #category : 'running' }
+HDReport class >> shuffleSeed [
+
+	^ self shuffleRandom seed
+]
+
+{ #category : 'running' }
+HDReport class >> shuffleSeed: aSeed [
+	
+	ShuffleRandom := Random seed: aSeed
 ]
 
 { #category : 'private' }

--- a/src/SUnit-Basic-CLI/HDTestReport.class.st
+++ b/src/SUnit-Basic-CLI/HDTestReport.class.st
@@ -19,11 +19,11 @@ Class {
 		'isErrorBeenLogged'
 	],
 	#classVars : [
-		'CurrentStageName',
-		'ShuffleSeed'
+		'CurrentStageName'
 	],
-	#category : 'SUnit-Basic-CLI',
-	#package : 'SUnit-Basic-CLI'
+	#category : 'SUnit-Basic-CLI-Core',
+	#package : 'SUnit-Basic-CLI',
+	#tag : 'Core'
 }
 
 { #category : 'running' }
@@ -41,21 +41,17 @@ HDTestReport class >> runClasses: aCollectionOfClasses named: packageName [
 
 	| suite classes time result |
 	suite := TestSuite named: packageName.
-	ShuffleSeed ifNotNil: [ suite shuffleSeed: ShuffleSeed asInteger ].
-	classes := (aCollectionOfClasses select: [ :class |
-		            class isTestCase and: [ class isAbstract not ] ])
-		           asSortedCollection: [ :a :b | a name <= b name ].
+	suite shuffleRandom: self shuffleRandom.
+	classes := aCollectionOfClasses select: [ :class | class isTestCase and: [ class isAbstract not ] ].
 	classes ifEmpty: [ ^ nil ].
 	classes do: [ :class | suite addTests: class buildSuite tests ].
 	time := DateAndTime now.
-	('Beginning to run tests of ' , packageName , ' with random seed '
-	 , suite shuffleSeed asString , OSPlatform current lineEnding)
+	('Beginning to run tests of ' , packageName , ' with random seed ' , self shuffleSeed asString , OSPlatform current lineEnding)
 		traceCr.
 	result := self runSuite: suite.
-	('Finished to run tests of ' , packageName , ' in '
-	 , (DateAndTime now - time) humanReadablePrintString
+	('Finished to run tests of ' , packageName , ' in ' , (DateAndTime now - time) humanReadablePrintString
 	 , OSPlatform current lineEnding) traceCr.
-	^ result 
+	^ result
 ]
 
 { #category : 'running' }
@@ -68,11 +64,6 @@ HDTestReport class >> runPackage: aString [
 HDTestReport class >> runSuite: aTestSuite [
 
 	^ self new runSuite: aTestSuite
-]
-
-{ #category : 'running' }
-HDTestReport class >> shuffleSeed: aSeed [
-	ShuffleSeed := aSeed
 ]
 
 { #category : 'private' }

--- a/src/SUnit-Core/TestSuite.class.st
+++ b/src/SUnit-Core/TestSuite.class.st
@@ -205,6 +205,18 @@ TestSuite >> setUp [
 ]
 
 { #category : 'accessing' }
+TestSuite >> shuffleRandom [
+
+	^ randomGenerator
+]
+
+{ #category : 'accessing' }
+TestSuite >> shuffleRandom: aRandomGenerator [
+
+	randomGenerator := aRandomGenerator
+]
+
+{ #category : 'accessing' }
 TestSuite >> shuffleSeed [
 
 	^ randomGenerator seed
@@ -219,7 +231,11 @@ TestSuite >> shuffleSeed: aSeed [
 { #category : 'accessing' }
 TestSuite >> shuffledTests [
 
-	^ self tests shuffledBy: randomGenerator
+	"Sort before shuffling so order is reproducible between different environments.
+
+	This happens because tests are extracted from the hashed method dictionary, so the original order is not guaranteed."
+	^ (self tests sorted: [ :a :b | a asString < b asString ])
+			shuffledBy: self shuffleRandom
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
We first sort them alphabetically, then we shuffle with the same seed than the tests.
	
This makes that
	 - packages are run in a random order
	 - all tests of a package are run together, they are not mixed with other packages
	 - tests within a package are run in a random order
	 - all randomization happens with the same seed