### PR TITLE
Update retain blank line before comment setting of formatter

### DIFF
--- a/src/EnlumineurFormatter/EFContext.class.st
+++ b/src/EnlumineurFormatter/EFContext.class.st
@@ -151,7 +151,7 @@ EFContext >> initialize [
 	self periodAtEndOfBlock: false.
 	self periodAtEndOfMethod: false.
 	self retainBlankLinesBetweenStatements: true.
-	self retainBlankLinesBeforeComments: false.
+	self retainBlankLinesBeforeComments: true.
 	self selectorAndArgumentCombinedMaxSize: 40.
 	self numberOfSpacesInsideBlock: 1.
 	self numberOfSpacesInsideParentheses: 0.

--- a/src/EnlumineurFormatter/EFFormatter.class.st
+++ b/src/EnlumineurFormatter/EFFormatter.class.st
@@ -130,7 +130,7 @@ EFFormatter class >> indentsForKeywords: anInteger [
 
 { #category : 'class initialization' }
 EFFormatter class >> initialize [
-	"self initialize"
+
 	FormatAsYouReadPolicy := false.
 	DefaultPrettyPrintContext := EFContext new
 ]


### PR DESCRIPTION
Currently the formatter removes blank lines before comments but that makes some code unreadable. 

I propose to retain those lines.

For example this code:

<img width="1268" height="458" alt="image" src="https://github.com/user-attachments/assets/c1f502c5-40a6-4564-9948-8bb39efe8455" />


Was reformatted like this:

<img width="1294" height="392" alt="image" src="https://github.com/user-attachments/assets/b39d65ff-5b54-4661-95ef-71e7867cb298" />


After the change to this setting:

<img width="845" height="543" alt="image" src="https://github.com/user-attachments/assets/e751d4b3-18b8-4366-985b-9971c3ce63d8" />
