### PR TITLE
Simplify composition of empty trait compositions

### DIFF
--- a/src/Traits-Tests/TraitTest.class.st
+++ b/src/Traits-Tests/TraitTest.class.st
@@ -180,6 +180,13 @@ TraitTest >> testComposedBy [
 ]
 
 { #category : 'tests' }
+TraitTest >> testCompositionWithAnEmptyComposition [
+	"Adding a trait to an empty composition should not keep the empty composition"
+
+	self assert: (TaEmptyComposition new + Trait1) class equals: TaCompositionElement
+]
+
+{ #category : 'tests' }
 TraitTest >> testDefinedMethods [
 
 	[

--- a/src/Traits/TaEmptyComposition.class.st
+++ b/src/Traits/TaEmptyComposition.class.st
@@ -11,6 +11,13 @@ Class {
 }
 
 { #category : 'operations' }
+TaEmptyComposition >> + anotherTrait [
+	"Since I am a null entity, the trait composition can be my parameter"
+
+	^ anotherTrait asTraitComposition
+]
+
+{ #category : 'operations' }
 TaEmptyComposition >> , anotherTrait [
 	^ anotherTrait
 ]


### PR DESCRIPTION
We can create a sequence of traits using #+ on trait compositions. But if the receiver is an empty sequence, we return a sequence with the empty composition and the new trait composition.  This causes a lot of composition to be a TaSequence with a TaEmptyComposition and a TaCompositionElement instead of having just a TaCompositionElement.

This is accentuated by the fact that we add TraitedClass in all composition of MetaclassForTraits instances. This means that each trait users has a trait composition that is `{ } + TraitedClass` for their metaclass. Now it will just be `TraitedClass`.

This change is small but reduces the number of operations when we manipulate a trait composition which make code a little more optimized but mostly it makes debugging much easier