### PR TITLE
Do not announce protocol changes while rebuilding method dictionaries from traits

### DIFF
--- a/src/Traits-Tests/TraitMethodAnnouncementsTest.class.st
+++ b/src/Traits-Tests/TraitMethodAnnouncementsTest.class.st
@@ -38,6 +38,56 @@ TraitMethodAnnouncementsTest >> testCompileMethodAnnounceAdditionOnlyInTrait [
 ]
 
 { #category : 'tests' }
+TraitMethodAnnouncementsTest >> testRebuildingMethodDictionaryDoesNotAnnounceMethodRecategorized [
+	"At some point, recompiling a method during the rebuild of a method dictionary was announcing protocol changes flooding Epicea with a lot of unecessary changes."
+
+	| trait |
+	[
+		trait := self class classInstaller make: [ :aBuilder |
+				         aBuilder
+					         beTrait;
+					         name: 'TraitForTest';
+					         package: self packageNameForTests , '2' ].
+
+		class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
+
+		trait compiler
+			protocol: #titan;
+			install: 'king ^ 1'.
+
+		self when: MethodRecategorized do: [ :ann | self fail: 'There should be no protocol announcement here.' ].
+
+		trait addSlot: #slot asSlot.
+
+		self assert: numberOfAnnouncements equals: 0 ] ensure: [ self packageOrganizer removePackage: self packageNameForTests , '2' ]
+]
+
+{ #category : 'tests' }
+TraitMethodAnnouncementsTest >> testRebuildingMethodDictionaryDoesNotAnnounceProtocolAdded [
+	"At some point, recompiling a method during the rebuild of a method dictionary was announcing protocol changes flooding Epicea with a lot of unecessary changes."
+
+	| trait |
+	[
+		trait := self class classInstaller make: [ :aBuilder |
+				         aBuilder
+					         beTrait;
+					         name: 'TraitForTest';
+					         package: self packageNameForTests , '2' ].
+
+		class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
+
+		trait compiler
+			protocol: #titan;
+			install: 'king ^ 1'.
+
+		self when: ProtocolAdded do: [ :ann | self fail: 'There should be no protocol announcement here.' ].
+
+		trait addSlot: #slot asSlot.
+
+		self assert: numberOfAnnouncements equals: 0 ] ensure: [ self packageOrganizer removePackage: self packageNameForTests , '2' ]
+]
+
+{ #category : 'tests' }
 TraitMethodAnnouncementsTest >> testRemoveMethodAnnounceRemovalOnlyInTrait [
 
 	| trait |

--- a/src/Traits/TaAbstractComposition.class.st
+++ b/src/Traits/TaAbstractComposition.class.st
@@ -147,12 +147,14 @@ TaAbstractComposition >> compile: selector into: aClass [
 		             source: sourceCode;
 		             permitUndeclared: true;
 		             compileOrFail.
-		
+
 	selector == newMethod selector ifFalse: [ self error: 'selector changed!' ].
 
 	aClass addSelectorSilently: selector withMethod: newMethod.
 
-	aClass classify: selector under: (self protocolForMethod: method).
+	"This step should not announce anything in the system since I am used to build method dictionaries of my users."
+	self class codeChangeAnnouncer suspendAllWhile: [ aClass classify: selector under: (self protocolForMethod: method) ].
+
 	(selector ~= method selector or: [ self changesSourceCode: selector ])
 		ifTrue: [ self saveSourceCode: sourceCode ofMethod: newMethod ]
 		ifFalse: [ newMethod sourcePointer: method sourcePointer ].


### PR DESCRIPTION
Currently if you rebuild the method dictionary of a class using traits, if the trait has slots or if a method source code need to be adapted (in case of alias, or renamed slot), we announce the protocol changes of those methods.

This should not happen since we are just rebuilding a dictionary. This has really bad effects because in Moose, updating some traits makes Epicea unusable really fast. On top of that, the recompilation of traits is already slow and this makes it even slower.

I took a Moose image and added one slot to TEntityMetalevelDependency. It took 72second. After the change it takes 57 seconds.

This is a nice improvement