### PR TITLE
Fix: Wrong call to the method browser for class ref

### DIFF
--- a/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyTextEditor.extension.st
@@ -83,14 +83,10 @@ ClyTextEditor >> referencesToIt [
 { #category : '*Calypso-SystemTools-QueryBrowser' }
 ClyTextEditor >> sendersOf: selectedSelector [
 
-	self browser classSelection 
-		ifEmpty: [ ^ (Smalltalk tools 
-			toolNamed: #messageList) 
-			browseSendersOf: selectedSelector ].
-	
-	(Smalltalk tools toolNamed: #messageList) 
-		browseSendersOf: selectedSelector 
-		from: self browserTool selectedClassOrMetaClass
+	self browser classSelection ifEmpty: [
+		^ self browser browseReferencesTo: selectedSelector inNameResolver: self browserTool selectedClassOrMetaClass ].
+
+	self browser browseReferencesTo: selectedSelector inNameResolver: self browserTool selectedClassOrMetaClass 
 ]
 
 { #category : '*Calypso-SystemTools-QueryBrowser' }


### PR DESCRIPTION
- I brought back `browseReferencesTo:inNameResolver:` because it does the dispatch between all call sites of the browser depending on the selection
- Fixed Class Ref bug when doing CMD + N on it