### PR TITLE
Fix package critiques

### DIFF
--- a/src/Renraku-Tests/ReBasicScenarioExceptionStrategyTest.class.st
+++ b/src/Renraku-Tests/ReBasicScenarioExceptionStrategyTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'ReBasicScenarioExceptionStrategyTest',
 	#superclass : 'ReExceptionStrategyBaseTest',
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'tests' }

--- a/src/Renraku-Tests/ReCodeBasedTestCase.class.st
+++ b/src/Renraku-Tests/ReCodeBasedTestCase.class.st
@@ -9,8 +9,9 @@ Class {
 		'testMethod',
 		'testClass2'
 	],
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'testing' }

--- a/src/Renraku-Tests/ReCritiqueTest.class.st
+++ b/src/Renraku-Tests/ReCritiqueTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'ReCritiqueTest',
 	#superclass : 'ReCodeBasedTestCase',
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'tests' }

--- a/src/Renraku-Tests/ReExceptionStrategyBaseTest.class.st
+++ b/src/Renraku-Tests/ReExceptionStrategyBaseTest.class.st
@@ -7,8 +7,9 @@ Class {
 	#instVars : [
 		'currentStrategy'
 	],
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'testing' }

--- a/src/Renraku-Tests/ReExceptionStrategyTest.class.st
+++ b/src/Renraku-Tests/ReExceptionStrategyTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'ReExceptionStrategyTest',
 	#superclass : 'TestCase',
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'tests' }

--- a/src/Renraku-Tests/ReNoPrintStringInPrintOnRuleTest.class.st
+++ b/src/Renraku-Tests/ReNoPrintStringInPrintOnRuleTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'ReNoPrintStringInPrintOnRuleTest',
 	#superclass : 'ReCodeBasedTestCase',
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'printing' }

--- a/src/Renraku-Tests/RePackageRuleForTest.class.st
+++ b/src/Renraku-Tests/RePackageRuleForTest.class.st
@@ -1,0 +1,16 @@
+"
+I'm a package rule used during testing.
+"
+Class {
+	#name : 'RePackageRuleForTest',
+	#superclass : 'ReAbstractRule',
+	#category : 'Renraku-Tests-Utilities',
+	#package : 'Renraku-Tests',
+	#tag : 'Utilities'
+}
+
+{ #category : 'testing - interest' }
+RePackageRuleForTest class >> checksPackage [
+
+	^ true
+]

--- a/src/Renraku-Tests/ReRuleManagerTest.class.st
+++ b/src/Renraku-Tests/ReRuleManagerTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'ReRuleManagerTest',
 	#superclass : 'RenrakuBaseTestCase',
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'tests' }

--- a/src/Renraku-Tests/ReSmalllintCheckerTest.class.st
+++ b/src/Renraku-Tests/ReSmalllintCheckerTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'ReSmalllintCheckerTest',
 	#superclass : 'ReCodeBasedTestCase',
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'tests' }
@@ -17,4 +18,17 @@ ReSmalllintCheckerTest >> testRun [
 	checker run.
 
 	self assert: (checker criticsOf: ScreamerRule new) notEmpty
+]
+
+{ #category : 'tests' }
+ReSmalllintCheckerTest >> testSelectPackageRule [
+	| checker packageRule |
+
+	packageRule := RePackageRuleForTest new.
+	checker := ReSmalllintChecker new
+		rule: { packageRule };
+		environment: testPackage asEnvironment;
+		reParseRule.
+
+	self assert: (checker packageRules includes: packageRule)
 ]

--- a/src/Renraku-Tests/ReSmokeExceptionStrategyTest.class.st
+++ b/src/Renraku-Tests/ReSmokeExceptionStrategyTest.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'brokenRule'
 	],
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'running' }

--- a/src/Renraku-Tests/ReVarSearchSourceAnchorTest.class.st
+++ b/src/Renraku-Tests/ReVarSearchSourceAnchorTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'ReVarSearchSourceAnchorTest',
 	#superclass : 'TestCase',
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'tests' }

--- a/src/Renraku-Tests/RenrakuBaseTestCase.class.st
+++ b/src/Renraku-Tests/RenrakuBaseTestCase.class.st
@@ -10,8 +10,9 @@ Class {
 	#classVars : [
 		'ScreamerRule'
 	],
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'testing' }

--- a/src/Renraku-Tests/RenrakuExtensionsTest.class.st
+++ b/src/Renraku-Tests/RenrakuExtensionsTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'RenrakuExtensionsTest',
 	#superclass : 'TestCase',
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'tests' }

--- a/src/Renraku-Tests/RenrakuGlobalBanningTest.class.st
+++ b/src/Renraku-Tests/RenrakuGlobalBanningTest.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'oldRulesSettings'
 	],
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'running' }

--- a/src/Renraku-Tests/RenrakuTest.class.st
+++ b/src/Renraku-Tests/RenrakuTest.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'RenrakuTest',
 	#superclass : 'ReCodeBasedTestCase',
-	#category : 'Renraku-Tests',
-	#package : 'Renraku-Tests'
+	#category : 'Renraku-Tests-Rules',
+	#package : 'Renraku-Tests',
+	#tag : 'Rules'
 }
 
 { #category : 'tests' }

--- a/src/Renraku/ManifestRenraku.class.st
+++ b/src/Renraku/ManifestRenraku.class.st
@@ -31,3 +31,10 @@ ManifestRenraku class >> ruleBadMessageRule2V1FalsePositive [
 	<ignoreForCoverage>
 	^ #(#(#(#RGMethodDefinition #(#'ReAbstractRule class' #isVisible #true)) #'2023-09-22T10:50:00.890614+02:00') )
 ]
+
+{ #category : 'code-critics' }
+ManifestRenraku class >> ruleCollectionProtocolRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGMethodDefinition #(#ReSmalllintChecker #reParseRule #false)) #'2026-06-26T11:55:40.660161+02:00') )
+]

--- a/src/Renraku/ReSmalllintChecker.class.st
+++ b/src/Renraku/ReSmalllintChecker.class.st
@@ -184,6 +184,11 @@ ReSmalllintChecker >> manifestBuilderOfPackage: aPackage [
 		  ifAbsentPut: [ self builderManifestClass ofPackage: aPackage ]
 ]
 
+{ #category : 'accessing' }
+ReSmalllintChecker >> packageRules [
+	^ packageRules
+]
+
 { #category : 'private' }
 ReSmalllintChecker >> reParseRule [
 
@@ -195,7 +200,8 @@ ReSmalllintChecker >> reParseRule [
 	self rule do: [ :r |
 		r class checksMethod ifTrue: [ methodRules add: r ].
 		r class checksNode ifTrue: [ nodeRules add: r ].
-		r class checksClass ifTrue: [ classRules add: r ] ]
+		r class checksClass ifTrue: [ classRules add: r ].
+		r class checksPackage ifTrue: [ packageRules add: r ] ]
 ]
 
 { #category : 'manifest' }


### PR DESCRIPTION
Fix an issue when accessing the critiques browser from calypso:

<img width="401" height="130" alt="imagen" src="https://github.com/user-attachments/assets/6b49e1fe-1eff-4a60-8a94-eeff1ddca602" />

Package rules were not taken into account.

Fix + test

🫶 