### PR TITLE
Fix pull up references shared var

### DIFF
--- a/src/Refactoring-Transformations/RePullUpMethodRefactoring.class.st
+++ b/src/Refactoring-Transformations/RePullUpMethodRefactoring.class.st
@@ -185,7 +185,7 @@ RePullUpMethodRefactoring >> pullUpSharedVariable: aVariable [
 	refactoring := RePullUpSharedVariableRefactoring
 		               model: self model
 		               variable: aVariable
-		               class: targetSuperclass.
+		               class: targetSuperclass instanceSide.
 	self generateChangesFor: refactoring
 ]
 

--- a/src/Refactoring-UI/RePullUpMethodDriver.class.st
+++ b/src/Refactoring-UI/RePullUpMethodDriver.class.st
@@ -233,9 +233,9 @@ RePullUpMethodDriver >> pullUpReferencedInstVars [
 { #category : 'actions' }
 RePullUpMethodDriver >> pullUpReferencedSharedVars [
 
-	notSharedVarRefs referencedSharedVariables do: [ :sharedVar | 
-		"We add the pushUpVariable transformation to the refactoring previous transformations"
-		refactoring pullUpSharedVariable: sharedVar ]
+	notSharedVarRefs referencedSharedVariables do: [ :sharedVar | "We add the pushUpVariable transformation to the refactoring previous transformations"
+		refactoring pullUpSharedVariable: sharedVar ].
+	self pullUpMethods 
 ]
 
 { #category : 'execution' }


### PR DESCRIPTION
- Firstly the metaclass was passed instead of the instance side
- Also the choice to push up the shared var was not added to the initial pull up method. Now both are made !
- Fixes #19836 