### PR TITLE
Fix wrong announcements during recompilation

### DIFF
--- a/src/Kernel-CodeModel/Class.class.st
+++ b/src/Kernel-CodeModel/Class.class.st
@@ -504,10 +504,8 @@ Class >> duplicateClassWithNewName: aSymbol [
 	copysName := aSymbol asSymbol.
 	copysName = self name ifTrue: [ ^ self ].
 	(self environment includesKey: copysName) ifTrue: [ ^ self error: copysName , ' already exists' ].
-	
-	^ self classInstaller 
-		update: self 
-		to: [ :builder | builder name: copysName ]
+
+	^ self classInstaller update: self to: [ :builder | builder name: copysName ]
 ]
 
 { #category : 'organization' }

--- a/src/Kernel-CodeModel/ClassDescription.class.st
+++ b/src/Kernel-CodeModel/ClassDescription.class.st
@@ -799,12 +799,14 @@ ClassDescription >> removeInstVarNamed: aString [
 
 { #category : 'protocols' }
 ClassDescription >> removeNonexistentSelectorsFromProtocols [
-	"For each protocol, remove the selectors that are not present in the class."
+	"For each protocol, remove the selectors that are not present in the class.
+	
+	This is used when rebuilding a class. I remove all selectors coming from traits."
 
 	self protocols do: [ :protocol |
-		protocol methodSelectors
-			reject: [ :selector | self includesSelector: selector ]
-			thenDo: [ :selector | self removeFromProtocols: selector ] ]
+			protocol methodSelectors
+				reject: [ :selector | self includesSelector: selector ]
+				thenDo: [ :selector | protocol removeMethodSelector: selector ] ]
 ]
 
 { #category : 'accessing - packages' }

--- a/src/Kernel-Tests/ClassAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ClassAnnouncementsTest.class.st
@@ -6,6 +6,14 @@ Class {
 	#tag : 'Classes'
 }
 
+{ #category : 'running' }
+ClassAnnouncementsTest >> tearDown [
+	"We need to do the tear down before to ensure we are already unsubscribed of the announcements."
+
+	super tearDown.
+	self packageOrganizer removePackage: self packageNameForTests , '2'
+]
+
 { #category : 'tests' }
 ClassAnnouncementsTest >> testDuplicatingAClassAnnouncesAddition [
 

--- a/src/Kernel-Tests/ClassAnnouncementsTest.class.st
+++ b/src/Kernel-Tests/ClassAnnouncementsTest.class.st
@@ -10,6 +10,7 @@ Class {
 ClassAnnouncementsTest >> tearDown [
 	"We need to do the tear down before to ensure we are already unsubscribed of the announcements."
 
+	<tearDownIsNotLast>
 	super tearDown.
 	self packageOrganizer removePackage: self packageNameForTests , '2'
 ]

--- a/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
+++ b/src/Kernel-Tests/ClassDescriptionProtocolsTest.class.st
@@ -370,7 +370,7 @@ ClassDescriptionProtocolsTest >> testRemoveNonexistentSelectorsFromProtocols [
 		removeKey: #king.
 	class removeNonexistentSelectorsFromProtocols.
 
-	self assertCollection: class protocolNames hasSameElements: #( human ).
+	self assertCollection: class protocolNames hasSameElements: #( human titan ). "We do not remove empty protocols because this method is a private method used by the class builder to remove selectors from Traits. If we remove the empty protocold, we will announce wrong protocol removed announcements."
 	self assertCollection: (class protocolNamed: #human) methodSelectors hasSameElements: #( luz )
 ]
 

--- a/src/ReleaseTests/ProperlyImplementedSUnitClassesTest.class.st
+++ b/src/ReleaseTests/ProperlyImplementedSUnitClassesTest.class.st
@@ -29,16 +29,10 @@ ProperlyImplementedSUnitClassesTest >> testAndMakeSureSuperSetupIsCalledAsFirstM
 ProperlyImplementedSUnitClassesTest >> testAndMakeSureSuperTearDownIsCalledAsLastMessageInTearDownMethodsOfTestCases [
 	"Verify that each tearDown method in a unit test ends with a call to super tearDown as last message sent"
 
-	| violating |
+	| violating rule |
 	violating := OrderedCollection new.
-	TestCase
-		allSubclassesDo: [ :each |
-			each
-				compiledMethodAt: #tearDown
-				ifPresent: [ :method |
-					(ReShouldSendSuperTearDownAsLastMessage
-						superTearDownNotCalledLastIn: method)
-						ifTrue: [ violating add: method ] ] ].
+	rule := ReShouldSendSuperTearDownAsLastMessage new.
+	TestCase allSubclassesDo: [ :each | each compiledMethodAt: #tearDown ifPresent: [ :method | (rule basicCheck: method) ifTrue: [ violating add: method ] ] ].
 	self assertEmpty: violating
 ]
 

--- a/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
+++ b/src/SUnit-Rules/ReShouldSendSuperTearDownAsLastMessage.class.st
@@ -51,7 +51,14 @@ ReShouldSendSuperTearDownAsLastMessage class >> superTearDownNotCalledLastIn: aC
 { #category : 'running' }
 ReShouldSendSuperTearDownAsLastMessage >> basicCheck: aMethod [
 
-	^ (self isClassToCheck: aMethod methodClass) and: [ aMethod selector = #tearDown and: [ self class superTearDownNotCalledLastIn: aMethod ] ]
+	(self isClassToCheck: aMethod methodClass) ifFalse: [ ^ false ].
+
+	aMethod selector = #tearDown ifFalse: [ ^ false ].
+
+	"Allow the user to declare some false positives. In some cases we need to execute the super tear down before."
+	(aMethod hasPragmaNamed: #tearDownIsNotLast) ifTrue: [ ^ false ].
+
+	^ self class superTearDownNotCalledLastIn: aMethod
 ]
 
 { #category : 'testing' }

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -124,9 +124,12 @@ ShiftClassBuilder >> build [
 
 	self installSlotsAndVariables.
 
-	self oldClass ifNotNil: [ self builderEnhancer compileMethodsFor: self ].
+	self oldClass ifNotNil: [ :old |
+		newClass basicTag: old packageTag.
+		self builderEnhancer compileMethodsFor: self ].
 
 	self builderEnhancer afterMethodsCompiled: self.
+	
 	^ newClass
 ]
 

--- a/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassBuilder.class.st
@@ -125,11 +125,13 @@ ShiftClassBuilder >> build [
 	self installSlotsAndVariables.
 
 	self oldClass ifNotNil: [ :old |
-		newClass basicTag: old packageTag.
-		self builderEnhancer compileMethodsFor: self ].
+			"I do not like this check. We do it because #duplicateClassWithNewName: is using the builder to make a new class but defining an old class that does nto have the same name to copy all methods.
+			This seems bad to me because them we do not announce any method creation while we create methods."
+			old name = newClass name ifTrue: [ newClass basicTag: old packageTag ].
+			self builderEnhancer compileMethodsFor: self ].
 
 	self builderEnhancer afterMethodsCompiled: self.
-	
+
 	^ newClass
 ]
 

--- a/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
@@ -188,6 +188,11 @@ ShiftClassInstaller >> make [
 
 		builder builderEnhancer propagateChangesToRelatedClasses: newClass builder: builder.
 		
+		"In the case we update the trait composition of the class, we might have to remove empty protocols. We do that after rebuilding the dictionaries so that all selectors are present."
+
+		newClass removeEmptyProtocols.
+		newClass class removeEmptyProtocols.
+		
 	] on: ShNoChangesInClass do:[
 		"If there are no changes in the building, I am not building or replacing nothing"
 		newClass := self oldClass.

--- a/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
+++ b/src/Shift-ClassBuilder/ShiftClassInstaller.class.st
@@ -324,9 +324,6 @@ ShiftClassInstaller >> updateBindings: aBinding of: newClass [
 { #category : 'notifications' }
 ShiftClassInstaller >> updatePackage: aClass [
 	"If the package is nil we leave the class unclassified"
-	builder package ifNotNil: [ :package | 
-		((self packageOrganizer
-			ensurePackage: package)
-				ensureTag: builder tag)
-					addClass: aClass ]
+
+	builder package ifNotNil: [ :package | ((self packageOrganizer ensurePackage: package) ensureTag: builder tag) addClass: aClass ]
 ]

--- a/src/Tool-Base/SystemNavigation.extension.st
+++ b/src/Tool-Base/SystemNavigation.extension.st
@@ -259,7 +259,7 @@ SystemNavigation >> browseMessageList: messageList name: labelString autoSelect:
 		  methods: methods;
 		  title: labelString;
 		  highlight: autoSelectString;
-		  refreshingBlock: aBlock;
+		  acceptBlock: aBlock;
 		  open
 ]
 

--- a/src/Traits-Tests/TraitMethodAnnouncementsTest.class.st
+++ b/src/Traits-Tests/TraitMethodAnnouncementsTest.class.st
@@ -12,6 +12,7 @@ Class {
 TraitMethodAnnouncementsTest >> tearDown [
 	"We need to do the tear down before to ensure we are already unsubscribed of the announcements."
 
+	<tearDownIsNotLast>
 	super tearDown.
 	self packageOrganizer removePackage: self packageNameForTests , '2'
 ]

--- a/src/Traits-Tests/TraitMethodAnnouncementsTest.class.st
+++ b/src/Traits-Tests/TraitMethodAnnouncementsTest.class.st
@@ -8,33 +8,38 @@ Class {
 	#package : 'Traits-Tests'
 }
 
+{ #category : 'running' }
+TraitMethodAnnouncementsTest >> tearDown [
+	"We need to do the tear down before to ensure we are already unsubscribed of the announcements."
+
+	super tearDown.
+	self packageOrganizer removePackage: self packageNameForTests , '2'
+]
+
 { #category : 'tests' }
 TraitMethodAnnouncementsTest >> testCompileMethodAnnounceAdditionOnlyInTrait [
 
 	| trait |
-	[
 	trait := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         beTrait;
-			         name: 'TraitForTest';
-			         package: self packageNameForTests , '2' ].
+			         aBuilder
+				         beTrait;
+				         name: 'TraitForTest';
+				         package: self packageNameForTests , '2' ].
 
-	class := class classInstaller 
-		update: class
-		to: [ :aBuilder | aBuilder traits: trait ].
+	class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
 
 	self when: MethodAdded do: [ :ann |
-		self assert: ann method selector equals: #king.
-		self assert: ann method protocol name equals: #titan.
-		self assert: ann methodClass name equals: 'TraitForTest'.
-		self assert: ann methodPackage name equals: self packageNameForTests , '2'.
-		self assert: ann packagesAffected equals: { (self packageNameForTests , '2') asPackage } ].
+			self assert: ann method selector equals: #king.
+			self assert: ann method protocol name equals: #titan.
+			self assert: ann methodClass name equals: 'TraitForTest'.
+			self assert: ann methodPackage name equals: self packageNameForTests , '2'.
+			self assert: ann packagesAffected equals: { (self packageNameForTests , '2') asPackage } ].
 
 	trait compiler
 		protocol: #titan;
 		install: 'king ^ 1'.
 
-	self assert: numberOfAnnouncements equals: 1 ] ensure: [ self packageOrganizer removePackage: self packageNameForTests , '2' ]
+	self assert: numberOfAnnouncements equals: 1
 ]
 
 { #category : 'tests' }
@@ -42,24 +47,23 @@ TraitMethodAnnouncementsTest >> testRebuildingMethodDictionaryDoesNotAnnounceMet
 	"At some point, recompiling a method during the rebuild of a method dictionary was announcing protocol changes flooding Epicea with a lot of unecessary changes."
 
 	| trait |
-	[
-		trait := self class classInstaller make: [ :aBuilder |
-				         aBuilder
-					         beTrait;
-					         name: 'TraitForTest';
-					         package: self packageNameForTests , '2' ].
+	trait := self class classInstaller make: [ :aBuilder |
+			         aBuilder
+				         beTrait;
+				         name: 'TraitForTest';
+				         package: self packageNameForTests , '2' ].
 
-		class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
+	class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
 
-		trait compiler
-			protocol: #titan;
-			install: 'king ^ 1'.
+	trait compiler
+		protocol: #titan;
+		install: 'king ^ 1'.
 
-		self when: MethodRecategorized do: [ :ann | self fail: 'There should be no protocol announcement here.' ].
+	self when: MethodRecategorized do: [ :ann | self fail: 'There should be no protocol announcement here.' ].
 
-		trait addSlot: #slot asSlot.
+	trait addSlot: #slot asSlot.
 
-		self assert: numberOfAnnouncements equals: 0 ] ensure: [ self packageOrganizer removePackage: self packageNameForTests , '2' ]
+	self assert: numberOfAnnouncements equals: 0
 ]
 
 { #category : 'tests' }
@@ -67,120 +71,134 @@ TraitMethodAnnouncementsTest >> testRebuildingMethodDictionaryDoesNotAnnouncePro
 	"At some point, recompiling a method during the rebuild of a method dictionary was announcing protocol changes flooding Epicea with a lot of unecessary changes."
 
 	| trait |
-	[
-		trait := self class classInstaller make: [ :aBuilder |
-				         aBuilder
-					         beTrait;
-					         name: 'TraitForTest';
-					         package: self packageNameForTests , '2' ].
+	trait := self class classInstaller make: [ :aBuilder |
+			         aBuilder
+				         beTrait;
+				         name: 'TraitForTest';
+				         package: self packageNameForTests , '2' ].
 
-		class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
+	class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
 
-		trait compiler
-			protocol: #titan;
-			install: 'king ^ 1'.
+	trait compiler
+		protocol: #titan;
+		install: 'king ^ 1'.
 
-		self when: ProtocolAdded do: [ :ann | self fail: 'There should be no protocol announcement here.' ].
+	self when: ProtocolAdded do: [ :ann | self fail: 'There should be no protocol announcement here.' ].
 
-		trait addSlot: #slot asSlot.
+	trait addSlot: #slot asSlot.
 
-		self assert: numberOfAnnouncements equals: 0 ] ensure: [ self packageOrganizer removePackage: self packageNameForTests , '2' ]
+	self assert: numberOfAnnouncements equals: 0
+]
+
+{ #category : 'tests' }
+TraitMethodAnnouncementsTest >> testRebuildingMethodDictionaryDoesNotAnnounceProtocolRemoved [
+	"At some point, recompiling a method during the rebuild of a method dictionary was announcing protocol changes flooding Epicea with a lot of unecessary changes."
+
+	| trait |
+	trait := self class classInstaller make: [ :aBuilder |
+			         aBuilder
+				         beTrait;
+				         name: 'TraitForTest';
+				         package: self packageNameForTests , '2' ].
+
+	class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
+
+	trait compiler
+		protocol: #titan;
+		install: 'king ^ 1'.
+
+	self when: ProtocolRemoved do: [ :ann | self fail: 'There should be no protocol announcement here.' ].
+
+	trait addSlot: #slot asSlot.
+
+	self assert: numberOfAnnouncements equals: 0
 ]
 
 { #category : 'tests' }
 TraitMethodAnnouncementsTest >> testRemoveMethodAnnounceRemovalOnlyInTrait [
 
 	| trait |
-	[
 	trait := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         beTrait;
-			         name: 'TraitForTest';
-			         package: self packageNameForTests , '2' ].
+			         aBuilder
+				         beTrait;
+				         name: 'TraitForTest';
+				         package: self packageNameForTests , '2' ].
 
-	class := class classInstaller 
-		update: class
-		to: [ :aBuilder | aBuilder traits: trait ].
+	class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
 
 	trait compiler
 		protocol: #titan;
 		install: 'king ^ 1'.
 
 	self when: MethodRemoved do: [ :ann |
-		self assert: ann method selector equals: #king.
-		self assert: ann method protocol name equals: #titan.
-		self assert: ann methodClass name equals: 'TraitForTest'.
-		self assert: ann methodPackage name equals: self packageNameForTests , '2'.
-		self assert: ann packagesAffected equals: { (self packageNameForTests , '2') asPackage } ].
+			self assert: ann method selector equals: #king.
+			self assert: ann method protocol name equals: #titan.
+			self assert: ann methodClass name equals: 'TraitForTest'.
+			self assert: ann methodPackage name equals: self packageNameForTests , '2'.
+			self assert: ann packagesAffected equals: { (self packageNameForTests , '2') asPackage } ].
 
 	trait removeSelector: #king.
 
-	self assert: numberOfAnnouncements equals: 1 ] ensure: [ self packageOrganizer removePackage: self packageNameForTests , '2' ]
+	self assert: numberOfAnnouncements equals: 1
 ]
 
 { #category : 'tests' }
 TraitMethodAnnouncementsTest >> testUpdateMethodAnnounceModificationOnlyInTrait [
 
 	| trait |
-	[
 	trait := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         beTrait;
-			         name: 'TraitForTest';
-			         package: self packageNameForTests , '2' ].
+			         aBuilder
+				         beTrait;
+				         name: 'TraitForTest';
+				         package: self packageNameForTests , '2' ].
 
-	class := class classInstaller 
-		update: class
-		to: [ :aBuilder | aBuilder traits: trait ].
+	class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
 
 	trait compiler
 		protocol: #titan;
 		install: 'king ^ 2'.
 
 	self when: MethodModified do: [ :ann |
-		self assert: ann method selector equals: #king.
-		self assert: ann method protocol name equals: #titan.
-		self assert: ann methodClass name equals: 'TraitForTest'.
-		self assert: ann methodPackage name equals: self packageNameForTests , '2'.
-		self assert: ann packagesAffected equals: { (self packageNameForTests , '2') asPackage } ].
+			self assert: ann method selector equals: #king.
+			self assert: ann method protocol name equals: #titan.
+			self assert: ann methodClass name equals: 'TraitForTest'.
+			self assert: ann methodPackage name equals: self packageNameForTests , '2'.
+			self assert: ann packagesAffected equals: { (self packageNameForTests , '2') asPackage } ].
 
 	trait compiler
 		protocol: #titan;
 		install: 'king ^ 1'.
 
-	self assert: numberOfAnnouncements equals: 1 ] ensure: [ self packageOrganizer removePackage: self packageNameForTests , '2' ]
+	self assert: numberOfAnnouncements equals: 1
 ]
 
 { #category : 'tests' }
 TraitMethodAnnouncementsTest >> testUpdateMethodAnnounceRecategorizationOnlyInTrait [
 
 	| trait |
-	[
 	trait := self class classInstaller make: [ :aBuilder |
-		         aBuilder
-			         beTrait;
-			         name: 'TraitForTest';
-			         package: self packageNameForTests , '2' ].
+			         aBuilder
+				         beTrait;
+				         name: 'TraitForTest';
+				         package: self packageNameForTests , '2' ].
 
-	class := class classInstaller 
-		update: class
-		to: [ :aBuilder | aBuilder traits: trait ].
+	class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
 
 	trait compiler
 		protocol: #demon;
 		install: 'king ^ 2'.
 
 	self when: MethodRecategorized do: [ :ann |
-		self assert: ann method selector equals: #king.
-		self assert: ann oldProtocol name equals: #demon.
-		self assert: ann newProtocol name equals: #titan.
-		self assert: ann methodClass name equals: 'TraitForTest'.
-		self assert: ann methodPackage name equals: self packageNameForTests , '2'.
-		self assert: ann packagesAffected equals: { (self packageNameForTests , '2') asPackage } ].
+			self assert: ann method selector equals: #king.
+			self assert: ann oldProtocol name equals: #demon.
+			self assert: ann newProtocol name equals: #titan.
+			self assert: ann methodClass name equals: 'TraitForTest'.
+			self assert: ann methodPackage name equals: self packageNameForTests , '2'.
+			self assert: ann packagesAffected equals: { (self packageNameForTests , '2') asPackage } ].
 
 	trait compiler
 		protocol: #titan;
 		install: 'king ^ 1'.
 
-	self assert: numberOfAnnouncements equals: 1 ] ensure: [ self packageOrganizer removePackage: self packageNameForTests , '2' ]
+	self assert: numberOfAnnouncements equals: 1
 ]

--- a/src/Traits-Tests/TraitMethodAnnouncementsTest.class.st
+++ b/src/Traits-Tests/TraitMethodAnnouncementsTest.class.st
@@ -43,8 +43,8 @@ TraitMethodAnnouncementsTest >> testCompileMethodAnnounceAdditionOnlyInTrait [
 ]
 
 { #category : 'tests' }
-TraitMethodAnnouncementsTest >> testRebuildingMethodDictionaryDoesNotAnnounceMethodRecategorized [
-	"At some point, recompiling a method during the rebuild of a method dictionary was announcing protocol changes flooding Epicea with a lot of unecessary changes."
+TraitMethodAnnouncementsTest >> testRecompilingAClassShouldNotAnnounceAnything [
+	"At some point, recompiling a class was announcing a lot of unneded announcements. I am here to ensure they are not announced anymore. "
 
 	| trait |
 	trait := self class classInstaller make: [ :aBuilder |
@@ -59,55 +59,12 @@ TraitMethodAnnouncementsTest >> testRebuildingMethodDictionaryDoesNotAnnounceMet
 		protocol: #titan;
 		install: 'king ^ 1'.
 
-	self when: MethodRecategorized do: [ :ann | self fail: 'There should be no protocol announcement here.' ].
-
-	trait addSlot: #slot asSlot.
-
-	self assert: numberOfAnnouncements equals: 0
-]
-
-{ #category : 'tests' }
-TraitMethodAnnouncementsTest >> testRebuildingMethodDictionaryDoesNotAnnounceProtocolAdded [
-	"At some point, recompiling a method during the rebuild of a method dictionary was announcing protocol changes flooding Epicea with a lot of unecessary changes."
-
-	| trait |
-	trait := self class classInstaller make: [ :aBuilder |
-			         aBuilder
-				         beTrait;
-				         name: 'TraitForTest';
-				         package: self packageNameForTests , '2' ].
-
-	class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
-
-	trait compiler
-		protocol: #titan;
-		install: 'king ^ 1'.
-
-	self when: ProtocolAdded do: [ :ann | self fail: 'There should be no protocol announcement here.' ].
-
-	trait addSlot: #slot asSlot.
-
-	self assert: numberOfAnnouncements equals: 0
-]
-
-{ #category : 'tests' }
-TraitMethodAnnouncementsTest >> testRebuildingMethodDictionaryDoesNotAnnounceProtocolRemoved [
-	"At some point, recompiling a method during the rebuild of a method dictionary was announcing protocol changes flooding Epicea with a lot of unecessary changes."
-
-	| trait |
-	trait := self class classInstaller make: [ :aBuilder |
-			         aBuilder
-				         beTrait;
-				         name: 'TraitForTest';
-				         package: self packageNameForTests , '2' ].
-
-	class := class classInstaller update: class to: [ :aBuilder | aBuilder traits: trait ].
-
-	trait compiler
-		protocol: #titan;
-		install: 'king ^ 1'.
-
-	self when: ProtocolRemoved do: [ :ann | self fail: 'There should be no protocol announcement here.' ].
+	"We should probably add more announcements here."
+	self when: ProtocolAdded do: [ :ann | self fail: 'There should be no announcement here.' ].
+	self when: ProtocolRemoved do: [ :ann | self fail: 'There should be no announcement here.' ].
+	self when: MethodRecategorized do: [ :ann | self fail: 'There should be no announcement here.' ].
+	self when: ClassAdded do: [ :ann | self fail: 'There should be no announcement here.' ].
+	self when: ClassRepackaged do: [ :ann | self fail: 'There should be no announcement here.' ].
 
 	trait addSlot: #slot asSlot.
 


### PR DESCRIPTION
ProtocolRemoved is wrongly announced when we recompile a class or trait using a trait. 

This fixes the problem. The problem was causing multiple problems:
- Iceberg got sometimes dirty for nothing
- Epicea had wrong events registered. In the case of moose this was making Epicea unresponsive easily
- Recompilation of traits was slower

Fixes https://github.com/pharo-project/pharo/issues/19839

Another fix is that we announced some ClassAdded announcement because the original package tag of classes got lost during recompilation.
Now I keep the package tag which prevent from losing the package if a class recompilation get interrupted midway and now no ClassAdded is announced during recompilation

Fixes https://github.com/pharo-project/pharo/issues/19842