### PR TITLE
executable comments for method compare:caseSensitive

### DIFF
--- a/src/Collections-Strings/String.class.st
+++ b/src/Collections-Strings/String.class.st
@@ -936,6 +936,14 @@ String >> compare: aString [
 
 { #category : 'comparing' }
 String >> compare: aString caseSensitive: aBool [
+	"('cAt' compare: 'ct' caseSensitive: true) >>> 1"
+	"('CAT' compare: 'CAT' caseSensitive: true) >>> 2"
+	"('xaT' compare: 'xAT' caseSensitive: true) >>> 3"
+	
+	"('CAT' compare: 'dat' caseSensitive: false) >>> 1"
+	"('CAT' compare: 'cat' caseSensitive: false) >>> 2"
+	"('xAT' compare: 'cat' caseSensitive: false) >>> 3"
+	
 	"Answer a comparison code telling how the receiver sorts relative to aString:
 		1 - before
 		2 - equal


### PR DESCRIPTION
**Description** 

This PR adds executable comments (>>>) to the String >> compare:caseSensitive: method.

The examples showcase the three expected return values (1 for less than, 2 for equal, 3 for greater than) for both case-sensitive and case-insensitive comparison.

**Benefits**

- Improves inline documentation by providing concrete, runnable examples
- Allows developers to run and verify the method's behaviour directly from the browser code pane