### PR TITLE
Backport FFI struct invalidation when changing platforms

### DIFF
--- a/src/BaselineOfPharo/BaselineOfPharo.class.st
+++ b/src/BaselineOfPharo/BaselineOfPharo.class.st
@@ -210,6 +210,14 @@ BaselineOfPharo >> postload: loader package: packageSpec [
 		credential := (Smalltalk classNamed: #IceCredentialStore) current plaintextCredentialForHostname: 'github.com'.
 		credential password = token ifTrue: [ (Smalltalk classNamed: #IceCredentialStore) current removePlainTextCredential: credential ].
 		'Removing credential.' traceCr ].
+	
+	"Reset all ffi structures that may have been initialised durying bootstrap"
+	(Smalltalk classNamed: #FFIStructure) 
+		ifNotNil: [ :aClass | aClass resetLastCompilationPlatform ].
+	"Also force a reset of libgit2, because it will be annoying otherwise. 
+	 THIS IS FOR TEST. Esteban will implement correctly if it works."
+	(Smalltalk classNamed: #LGitExternalStructure) ifNotNil: [ :aClass | 
+		aClass allSubclasses do: #resetCompiledSpec ].
 
 	"Open the WelcomeBrowser as last step"
 	(self class environment classNamed: #StWelcomeBrowser)

--- a/src/UnifiedFFI/FFIMethodRegistry.class.st
+++ b/src/UnifiedFFI/FFIMethodRegistry.class.st
@@ -43,24 +43,34 @@ FFIMethodRegistry class >> resetAll [
 		- working directory change (and then libraries not found)
 		- indirect functions needs to be recalculated.
 	I am not supposed to be performed when image is just saved to avoid possible problem which can happen when we reset all caches and continue to work"
-	self uniqueInstance reset.
+	
+	
 	FFICallbackFunctionResolution reset.
 	FFIStructure resetAllStructures.
-	uniqueInstance := nil
+	self cleanUp: true
 ]
 
 { #category : 'system startup' }
-FFIMethodRegistry class >> shutDown: quitting [
-	quitting ifFalse: [ ^ self ].
+FFIMethodRegistry class >> softResetAll [
+	"I'm reseting each shutdown and startup because like that I can be sure a complete cleanup is done,
+	 because many things can change:
+		- platform change
+		- working directory change (and then libraries not found)
+		- indirect functions needs to be recalculated.
+	I am not supposed to be performed when image is just saved to avoid possible problem which can happen when we reset all caches and continue to work
+	
+	The soft version is not reseting structures if the platform did not change."
 
-	self resetAll
+	FFICallbackFunctionResolution reset.
+	FFIStructure resetAllStructuresIfPlatformChanged.
+	self cleanUp: true
 ]
 
 { #category : 'system startup' }
 FFIMethodRegistry class >> startUp: isImageStarting [
 	isImageStarting ifFalse: [ ^ self ].
 
-	self resetAll
+	self softResetAll
 ]
 
 { #category : 'instance creation' }

--- a/src/UnifiedFFI/FFIStructure.class.st
+++ b/src/UnifiedFFI/FFIStructure.class.st
@@ -341,14 +341,41 @@ FFIStructure class >> resetAllStructures [
 	Manage nested structures with a recursive approach.
 	Stop recursing using a tracking collection of already reset structures."
 
-	| alreadyReset currentCompilationPlatform |
-	currentCompilationPlatform := { OSPlatform current family . Smalltalk vm wordSize }.
-	LastCompilationPlatform = currentCompilationPlatform
-		ifTrue: [ ^ self ].
-
-	LastCompilationPlatform := currentCompilationPlatform.
+	| alreadyReset |
 	alreadyReset := IdentitySet new.
 	self allSubclassesDo: [ :each | each resetStructureIfNotIn: alreadyReset ]
+]
+
+{ #category : 'class management' }
+FFIStructure class >> resetAllStructuresIfPlatformChanged [
+	"Reset the offsets of all structures.
+	This is required when there is a platform change since type sizes and padding rules change.
+
+	Manage nested structures with a recursive approach.
+	Stop recursing using a tracking collection of already reset structures."
+
+	| currentCompilationPlatform |
+	currentCompilationPlatform := {
+		                              OSPlatform current family.
+		                              Smalltalk vm wordSize }.
+	LastCompilationPlatform = currentCompilationPlatform ifTrue: [ ^ self ].
+
+	LastCompilationPlatform := currentCompilationPlatform.
+	self resetAllStructures
+]
+
+{ #category : 'initialization' }
+FFIStructure class >> resetCompiledSpec [
+
+	compiledSpec := nil
+]
+
+{ #category : 'initialization' }
+FFIStructure class >> resetLastCompilationPlatform [
+	
+	"needed to reset compilation while building, to force a reset of structures
+	 even if bootstrap platform = current platform"
+	LastCompilationPlatform := nil
 ]
 
 { #category : 'class management' }


### PR DESCRIPTION
Bring to P13 changes from here:

https://github.com/pharo-project/pharo/commit/665bb1122c068927876c82f4a05f20a58add1f3d
https://github.com/pharo-project/pharo/commit/a37c18a3d50595ba1947dda03d7bcc6c6150e71a

This is required to invalidate structure fields/offsets/sizes when migrating an image from one system to another one.