### PR TITLE
Fix: `Expand class definition` availability

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyExpandClassDefinitionCommand.class.st
+++ b/src/Calypso-SystemTools-Core/ClyExpandClassDefinitionCommand.class.st
@@ -6,6 +6,12 @@ Class {
 	#tag : 'Commands-Classes'
 }
 
+{ #category : 'testing' }
+ClyExpandClassDefinitionCommand class >> canBeExecutedInContext: aToolContext [
+
+	^ true 
+]
+
 { #category : 'activation' }
 ClyExpandClassDefinitionCommand class >> contextMenuActivation [
 	<classAnnotation>


### PR DESCRIPTION
- This command was shown in the context menu only if the class was selected. However, this command should be available anywhere in the class definition pane
- Fixes #19867