### PR TITLE
P13-17513-ASTMessageNode-does-not-understand-sourceNodeForPC--when-renaming-parser-class

### DIFF
--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -32,12 +32,17 @@ CompiledBlock >> sourceNode [
 CompiledBlock >> sourceNodeForPC: aPC [
 
 	| blockNode |
+
 	blockNode := self outerCode sourceNodeForPC: self pcInOuter.
+
 	self method
 		propertyAt: self bcToASTCacheKey asSymbol
 		ifPresent: [ :bcToASTCache |
 			^ bcToASTCache nodeForPC: aPC ].
-	^ blockNode isBlock ifTrue: [ blockNode sourceNodeForPC: aPC]
+
+	^ blockNode isBlock 
+		ifTrue: [ blockNode sourceNodeForPC: aPC]
+		ifFalse: [ blockNode ]
 ]
 
 { #category : '*OpalCompiler-Core' }

--- a/src/OpalCompiler-Core/CompiledBlock.extension.st
+++ b/src/OpalCompiler-Core/CompiledBlock.extension.st
@@ -37,7 +37,7 @@ CompiledBlock >> sourceNodeForPC: aPC [
 		propertyAt: self bcToASTCacheKey asSymbol
 		ifPresent: [ :bcToASTCache |
 			^ bcToASTCache nodeForPC: aPC ].
-	^ blockNode sourceNodeForPC: aPC
+	^ blockNode isBlock ifTrue: [ blockNode sourceNodeForPC: aPC]
 ]
 
 { #category : '*OpalCompiler-Core' }


### PR DESCRIPTION
Fixes #17513 for P13