### PR TITLE
Refactoring: Making refactorings decorators of transformations

### DIFF
--- a/src/Refactoring-Core-Tests/ReClassesAreAbstractTest.class.st
+++ b/src/Refactoring-Core-Tests/ReClassesAreAbstractTest.class.st
@@ -6,27 +6,57 @@ Class {
 	#tag : 'Conditions'
 }
 
+{ #category : 'accessing' }
+ReClassesAreAbstractTest >> model [
+
+	^ model ifNil: [
+		  model := RBNamespace onEnvironment: (RBClassEnvironment classes: { Object }).
+		  model
+			  defineClass: [ :aBuilder |
+				  aBuilder
+					  superclass: Object;
+					  name: #ReClassesAreAbstractConcrete;
+					  package: #'Refactory-Test data' ];
+			  defineClass: [ :aBuilder |
+				  aBuilder
+					  superclass: Object;
+					  name: #ReClassesAreAbstractReference;
+					  package: #'Refactory-Test data' ];
+			  defineClass: [ :aBuilder |
+				  aBuilder
+					  superclass: Object;
+					  name: #ReClassesAreAbstractAbstract;
+					  package: #'Refactory-Test data' ].
+		  (model classNamed: #ReClassesAreAbstractReference)
+			  compile: 'reference ^ ReClassesAreAbstractConcrete'
+			  classified: #testing.
+		  (model classNamed: #ReClassesAreAbstractAbstract)
+			  compile: 'required self subclassResponsibility'
+			  classified: #testing.
+		  model ]
+]
+
 { #category : 'tests' }
 ReClassesAreAbstractTest >> testClassIsAbstract [
-	| classNumber cond |
-	classNumber := self model classNamed: #Number.
+	| abstractClass cond |
+	abstractClass := self model classNamed: #ReClassesAreAbstractAbstract.
 	
 	cond := ReClassesAreAbstractCondition new 
-		classes: { classNumber }.
+		classes: { abstractClass }.
 		
-	" Number is abstract"
+	"The fixture explicitly defines an abstract method."
 	self assert: cond check.
 	self assert: cond violators isEmpty.
-	self assert: cond nonViolators equals: { classNumber }
+	self assert: cond nonViolators equals: { abstractClass }
 ]
 
 { #category : 'tests' }
 ReClassesAreAbstractTest >> testClassIsAbstractWithMessage [
-	| classNumber cond |
-	classNumber := self model classNamed: #Number.
+	| abstractClass cond |
+	abstractClass := self model classNamed: #ReClassesAreAbstractAbstract.
 	
 	cond := ReClassesAreAbstractCondition new 
-		classes: { classNumber }.
+		classes: { abstractClass }.
 		
 	self assert: cond errorString isEmpty
 ]
@@ -35,7 +65,7 @@ ReClassesAreAbstractTest >> testClassIsAbstractWithMessage [
 ReClassesAreAbstractTest >> testNoClassIsAbstract [
 
 	| concrete cond |
-	concrete := self model classNamed: #Object.
+	concrete := self model classNamed: #ReClassesAreAbstractConcrete.
 	cond := ReClassesAreAbstractCondition new classes: { concrete }.
 
 	self deny: cond check.
@@ -47,7 +77,7 @@ ReClassesAreAbstractTest >> testNoClassIsAbstract [
 ReClassesAreAbstractTest >> testNoClassIsAbstractWithMessage [
 
 	| concrete cond |
-	concrete := self model classNamed: #Object.
+	concrete := self model classNamed: #ReClassesAreAbstractConcrete.
 	cond := ReClassesAreAbstractCondition new classes: { concrete }.
 
 	self assert: ('*' , concrete name , '*' match: cond errorString)
@@ -57,8 +87,8 @@ ReClassesAreAbstractTest >> testNoClassIsAbstractWithMessage [
 ReClassesAreAbstractTest >> testSomeClassesAreAbstract [
 
 	| abstract concrete cond |
-	abstract := self model classNamed: #Number.
-	concrete := self model classNamed: #Object.
+	abstract := self model classNamed: #ReClassesAreAbstractAbstract.
+	concrete := self model classNamed: #ReClassesAreAbstractConcrete.
 	cond := ReClassesAreAbstractCondition new classes: {
 			        abstract.
 			        concrete }.
@@ -72,8 +102,8 @@ ReClassesAreAbstractTest >> testSomeClassesAreAbstract [
 ReClassesAreAbstractTest >> testSomeClassesAreAbstractWithMessage [
 
 	| abstract concrete cond |
-	abstract := self model classNamed: #Number.
-	concrete := self model classNamed: #Object.
+	abstract := self model classNamed: #ReClassesAreAbstractAbstract.
+	concrete := self model classNamed: #ReClassesAreAbstractConcrete.
 	cond := ReClassesAreAbstractCondition new classes: {
 			        abstract.
 			        concrete }.

--- a/src/Refactoring-Core-Tests/ReNewNegatedConditionTest.class.st
+++ b/src/Refactoring-Core-Tests/ReNewNegatedConditionTest.class.st
@@ -13,16 +13,37 @@ Class {
 ReNewNegatedConditionTest >> model [
 
 	^ model ifNil: [
-			  model := RBNamespace onEnvironment: (RBClassEnvironment classes: {
-						            Number.
-						            Object }) ]
+		  model := RBNamespace onEnvironment: (RBClassEnvironment classes: { Object }).
+		  model
+			  defineClass: [ :aBuilder |
+				  aBuilder
+					  superclass: Object;
+					  name: #ReNewNegatedConditionConcrete;
+					  package: #'Refactory-Test data' ];
+			  defineClass: [ :aBuilder |
+				  aBuilder
+					  superclass: Object;
+					  name: #ReNewNegatedConditionReference;
+					  package: #'Refactory-Test data' ];
+			  defineClass: [ :aBuilder |
+				  aBuilder
+					  superclass: Object;
+					  name: #ReNewNegatedConditionAbstract;
+					  package: #'Refactory-Test data' ].
+		  (model classNamed: #ReNewNegatedConditionReference)
+			  compile: 'reference ^ ReNewNegatedConditionConcrete'
+			  classified: #testing.
+		  (model classNamed: #ReNewNegatedConditionAbstract)
+			  compile: 'required self subclassResponsibility'
+			  classified: #testing.
+		  model ]
 ]
 
 { #category : 'tests' }
 ReNewNegatedConditionTest >> testNegatedFalseConditionViolators [
 
 	| cls notcond condition |
-	cls := self model classNamed: #Object.
+	cls := self model classNamed: #ReNewNegatedConditionConcrete.
 	condition := ReClassesAreAbstractCondition new classes: { cls }.
 	notcond := condition not.
 
@@ -39,7 +60,7 @@ ReNewNegatedConditionTest >> testNegatedFalseConditionViolators [
 ReNewNegatedConditionTest >> testNegatedTrueConditionViolators [
 
 	| cls notcond condition |
-	cls := self model classNamed: #Number.
+	cls := self model classNamed: #ReNewNegatedConditionAbstract.
 	condition := ReClassesAreAbstractCondition new classes: { cls }.
 	notcond := condition not.
 

--- a/src/Refactoring-Transformations-Tests/RBPullUpClassVariableParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPullUpClassVariableParametrizedTest.class.st
@@ -43,14 +43,32 @@ RBPullUpClassVariableParametrizedTest >> testFailureNonExistantName [
 
 { #category : 'tests' }
 RBPullUpClassVariableParametrizedTest >> testPullUpClassVariable [
-	| refactoring |
+	| refactoring root firstChild secondChild |
+	model
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclass: Object;
+				name: #PullUpClassVariableRoot;
+				package: #'Refactory-Test data' ];
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclassName: #PullUpClassVariableRoot;
+				name: #PullUpClassVariableFirstChild;
+				sharedVariables: { #Foo };
+				package: #'Refactory-Test data' ];
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclassName: #PullUpClassVariableRoot;
+				name: #PullUpClassVariableSecondChild;
+				sharedVariables: { #Foo };
+				package: #'Refactory-Test data' ].
 	refactoring := self createRefactoringWithModel: model andArguments:
-		{ #RecursiveSelfRule . #RBLintRuleTestData }.
-	[ self executeRefactoring: refactoring ]
-		on: RBRefactoringWarning 
-		do: [ :e | e resume ].
-	self assert: ((refactoring model classNamed: #RBLintRuleTestData)
-		directlyDefinesClassVariable: #RecursiveSelfRule).
-	self deny: ((refactoring model classNamed: #RBTransformationRuleTestData)
-		directlyDefinesClassVariable: #RecursiveSelfRule)
+		{ #Foo . #PullUpClassVariableRoot }.
+	self executeRefactoring: refactoring.
+	root := refactoring model classNamed: #PullUpClassVariableRoot.
+	firstChild := refactoring model classNamed: #PullUpClassVariableFirstChild.
+	secondChild := refactoring model classNamed: #PullUpClassVariableSecondChild.
+	self assert: (root directlyDefinesClassVariable: #Foo).
+	self deny: (firstChild directlyDefinesClassVariable: #Foo).
+	self deny: (secondChild directlyDefinesClassVariable: #Foo)
 ]

--- a/src/Refactoring-Transformations-Tests/RBPullUpClassVariableRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPullUpClassVariableRefactoringTest.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : 'RBPullUpClassVariableRefactoringTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring-Transformations-Tests-Test',
+	#package : 'Refactoring-Transformations-Tests',
+	#tag : 'Test'
+}
+
+{ #category : 'failure tests' }
+RBPullUpClassVariableRefactoringTest >> testShouldWarnWhenNotAllSubclassesDefineVariable [
+
+	self addClassHierarchy.
+	(model classNamed: #Subclass) addClassVariable: #Foo.
+	model defineClass: [ :aBuilder |
+		aBuilder
+			superclassName: #SomeClass;
+			name: #SubclassWithoutFoo;
+			package: #'Refactory-Test data' ].
+	self shouldWarn: (RePullUpSharedVariableRefactoring
+					 model: model
+					 variable: #Foo
+					 class: #SomeClass)
+]

--- a/src/Refactoring-Transformations-Tests/RBPullUpInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPullUpInstanceVariableParametrizedTest.class.st
@@ -11,6 +11,8 @@ RBPullUpInstanceVariableParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> RePullUpInstanceVariableRefactoring .
 					  #constructor -> #variable:class: };
+		addCase: { #rbClass -> RBPullUpVariableTransformation .
+					  #constructor -> #instanceVariable:class: };
 		yourself
 ]
 
@@ -30,16 +32,35 @@ RBPullUpInstanceVariableParametrizedTest >> testFailurePullUpVariableNotDefined 
 
 { #category : 'tests' }
 RBPullUpInstanceVariableParametrizedTest >> testPullUpInstVar [
-	| refactoring |
+	| refactoring root firstChild secondChild |
+	model
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclass: Object;
+				name: #PullUpInstanceVariableRoot;
+				package: #'Refactory-Test data' ];
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclassName: #PullUpInstanceVariableRoot;
+				name: #PullUpInstanceVariableFirstChild;
+				slots: { #result };
+				package: #'Refactory-Test data' ];
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclassName: #PullUpInstanceVariableRoot;
+				name: #PullUpInstanceVariableSecondChild;
+				slots: { #result };
+				package: #'Refactory-Test data' ].
 	refactoring := self createRefactoringWithModel: model andArguments:
-			{'result' . #RBLintRuleTestData}.
-	[self executeRefactoring: refactoring]
-		on: RBRefactoringWarning
-		do: [ :e | e resume ].
-	self assert: ((refactoring model classNamed: #RBLintRuleTestData)
+			{ 'result'. #PullUpInstanceVariableRoot }.
+	self executeRefactoring: refactoring.
+	root := refactoring model classNamed: #PullUpInstanceVariableRoot.
+	firstChild := refactoring model classNamed: #PullUpInstanceVariableFirstChild.
+	secondChild := refactoring model classNamed: #PullUpInstanceVariableSecondChild.
+	self assert: (root
 		directlyDefinesInstanceVariable: 'result').
-	self deny: ((refactoring model classNamed: #RBBasicLintRuleTestData)
+	self deny: (firstChild
 		directlyDefinesInstanceVariable: 'result').
-	self deny: ((refactoring model classNamed: #RBFooLintRuleTestData)
+	self deny: (secondChild
 		directlyDefinesInstanceVariable: 'result')
 ]

--- a/src/Refactoring-Transformations-Tests/RBPullUpInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPullUpInstanceVariableParametrizedTest.class.st
@@ -64,3 +64,37 @@ RBPullUpInstanceVariableParametrizedTest >> testPullUpInstVar [
 	self deny: (secondChild
 		directlyDefinesInstanceVariable: 'result')
 ]
+
+{ #category : 'tests' }
+RBPullUpInstanceVariableParametrizedTest >> testPullUpInstVarOnMetaclass [
+	| refactoring root firstChild secondChild |
+	model
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclass: Object;
+				name: #PullUpClassSideInstanceVariableRoot;
+				package: #'Refactory-Test data' ];
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclassName: #PullUpClassSideInstanceVariableRoot;
+				name: #PullUpClassSideInstanceVariableFirstChild;
+				package: #'Refactory-Test data' ];
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclassName: #PullUpClassSideInstanceVariableRoot;
+				name: #PullUpClassSideInstanceVariableSecondChild;
+				package: #'Refactory-Test data' ].
+	root := model classNamed: #PullUpClassSideInstanceVariableRoot.
+	firstChild := model classNamed: #PullUpClassSideInstanceVariableFirstChild.
+	secondChild := model classNamed: #PullUpClassSideInstanceVariableSecondChild.
+	firstChild classSide addInstanceVariable: #result.
+	secondChild classSide addInstanceVariable: #result.
+
+	refactoring := self createRefactoringWithModel: model andArguments:
+			{ #result. root classSide }.
+	self executeRefactoring: refactoring.
+
+	self assert: (root classSide directlyDefinesInstanceVariable: #result).
+	self deny: (firstChild classSide directlyDefinesInstanceVariable: #result).
+	self deny: (secondChild classSide directlyDefinesInstanceVariable: #result)
+]

--- a/src/Refactoring-Transformations-Tests/RBPullUpInstanceVariableRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPullUpInstanceVariableRefactoringTest.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : 'RBPullUpInstanceVariableRefactoringTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring-Transformations-Tests-Test',
+	#package : 'Refactoring-Transformations-Tests',
+	#tag : 'Test'
+}
+
+{ #category : 'failure tests' }
+RBPullUpInstanceVariableRefactoringTest >> testShouldWarnWhenNotAllSubclassesDefineVariable [
+
+	self addClassHierarchy.
+	(model classNamed: #Subclass) addInstanceVariable: #result.
+	model defineClass: [ :aBuilder |
+		aBuilder
+			superclassName: #SomeClass;
+			name: #SubclassWithoutResult;
+			package: #'Refactory-Test data' ].
+	self shouldWarn: (RePullUpInstanceVariableRefactoring
+					 model: model
+					 variable: #result
+					 class: #SomeClass)
+]

--- a/src/Refactoring-Transformations-Tests/RBPushDownClassVariableRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPushDownClassVariableRefactoringTest.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : 'RBPushDownClassVariableRefactoringTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring-Transformations-Tests-Test',
+	#package : 'Refactoring-Transformations-Tests',
+	#tag : 'Test'
+}
+
+{ #category : 'failure tests' }
+RBPushDownClassVariableRefactoringTest >> testShouldWarnWhenVariableReferencedInDefiningClass [
+
+	model
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclass: Object;
+				name: #PushDownClassVariableRoot;
+				sharedVariables: { #Foo };
+				package: #'Refactory-Test data' ];
+		defineClass: [ :aBuilder |
+			aBuilder
+				superclassName: #PushDownClassVariableRoot;
+				name: #PushDownClassVariableChild;
+				package: #'Refactory-Test data' ].
+	(model classNamed: #PushDownClassVariableRoot)
+		compile: 'usesFoo ^ Foo'
+		classified: #( #accessing ).
+	self shouldWarn: (RBPushDownClassVariableRefactoring
+					 model: model
+					 variable: #Foo
+					 class: #PushDownClassVariableRoot)
+]

--- a/src/Refactoring-Transformations-Tests/RBPushDownInstanceVariableParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPushDownInstanceVariableParametrizedTest.class.st
@@ -108,11 +108,3 @@ RBPushDownInstanceVariableParametrizedTest >> testPushDownInstanceVariable [
 	(refactoring model classNamed: #RBLintRuleTestData) subclasses do:
 		[ :each | self assert: (each directlyDefinesInstanceVariable: 'foo1') ]
 ]
-
-{ #category : 'tests' }
-RBPushDownInstanceVariableParametrizedTest >> testPushDownInstanceVariableWithReferences [
-
-	| refactoring |
-	refactoring := self createRefactoringWithModel: model andArguments: { 'name'. #RBBasicLintRuleTestData }.
-	(refactoring isKindOf: RBPushDownInstanceVariableRefactoring) ifTrue: [ self shouldWarn: refactoring ]
-]

--- a/src/Refactoring-Transformations-Tests/RBPushDownInstanceVariableRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBPushDownInstanceVariableRefactoringTest.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : 'RBPushDownInstanceVariableRefactoringTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring-Transformations-Tests-Test',
+	#package : 'Refactoring-Transformations-Tests',
+	#tag : 'Test'
+}
+
+{ #category : 'running' }
+RBPushDownInstanceVariableRefactoringTest >> setUp [
+
+	super setUp.
+	model := self modelOnClasses: { RBBasicLintRuleTestData . RBLintRuleTestData }
+]
+
+{ #category : 'failure tests' }
+RBPushDownInstanceVariableRefactoringTest >> testShouldWarnWhenVariableReferenced [
+
+	self shouldWarn: (RBPushDownInstanceVariableRefactoring
+					 model: model
+					 variable: 'name'
+					 class: #RBBasicLintRuleTestData)
+]

--- a/src/Refactoring-Transformations-Tests/RBRemoveClassParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveClassParametrizedTest.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : 'RBRemoveClassParametrizedTest',
+	#superclass : 'RBWithDifferentConstructorsParametrizedTest',
+	#category : 'Refactoring-Transformations-Tests-Parametrized',
+	#package : 'Refactoring-Transformations-Tests',
+	#tag : 'Parametrized'
+}
+
+{ #category : 'tests' }
+RBRemoveClassParametrizedTest class >> testParameters [
+
+	^ ParametrizedTestMatrix new
+		addCase: { #rbClass -> ReRemoveClassRefactoring .
+					  #constructor -> #classNames: };
+		addCase: { #rbClass -> ReRemoveClassesTransformation .
+					  #constructor -> #classNames: };
+		yourself
+]
+
+{ #category : 'running' }
+RBRemoveClassParametrizedTest >> setUp [
+
+	super setUp.
+	model defineClass: [ :aBuilder |
+		aBuilder
+			superclass: Object;
+			name: #DecoratorRemovableClass;
+			package: #'Refactory-Test data' ]
+]
+
+{ #category : 'tests' }
+RBRemoveClassParametrizedTest >> testRemoveUnreferencedLeafClass [
+
+	self executeRefactoring: (self createRefactoringWithModel: model andArguments:
+			 { { #DecoratorRemovableClass } }).
+	self deny: (model includesClassNamed: #DecoratorRemovableClass)
+]

--- a/src/Refactoring-Transformations-Tests/RBRemoveClassParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveClassParametrizedTest.class.st
@@ -28,6 +28,31 @@ RBRemoveClassParametrizedTest >> setUp [
 			package: #'Refactory-Test data' ]
 ]
 
+{ #category : 'failure tests' }
+RBRemoveClassParametrizedTest >> testApplicabilityPreconditionsExposeMissingClass [
+
+	| refactoring failedPreconditions |
+	refactoring := self createRefactoringWithModel: model andArguments:
+		              { { #DecoratorMissingClass } }.
+	refactoring prepareForExecution.
+
+	self
+		shouldnt: [
+			failedPreconditions := refactoring failedApplicabilityPreconditions ]
+		raise: MessageNotUnderstood.
+
+	self assert: failedPreconditions size equals: 1.
+	self assert:
+		(failedPreconditions first isKindOf: ReClassesExistCondition)
+]
+
+{ #category : 'failure tests' }
+RBRemoveClassParametrizedTest >> testFailureNonExistentClass [
+
+	self shouldFail: (self createRefactoringWithModel: model andArguments:
+			 { { #DecoratorMissingClass } })
+]
+
 { #category : 'tests' }
 RBRemoveClassParametrizedTest >> testRemoveUnreferencedLeafClass [
 

--- a/src/Refactoring-Transformations-Tests/RBRemoveClassRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveClassRefactoringTest.class.st
@@ -84,8 +84,9 @@ RBRemoveClassRefactoringTest >> testFailureRaisesRBRefactoringErrorWhenRemovingN
 { #category : 'failure tests' }
 RBRemoveClassRefactoringTest >> testFailureRemoveClassWithBadNameRaisesRBRefactoringError [
 
-	self shouldFail:
-		(ReRemoveClassRefactoring model: model classNames: { #NonExistantClassName })
+	self shouldFail: (ReRemoveClassRefactoring
+			 model: model
+			 classNames: { #NonExistantClassName })
 ]
 
 { #category : 'tests preconditions' }

--- a/src/Refactoring-Transformations-Tests/RBRemoveInstanceVariable2ParametrizedTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveInstanceVariable2ParametrizedTest.class.st
@@ -11,6 +11,8 @@ RBRemoveInstanceVariable2ParametrizedTest class >> testParameters [
 	^ ParametrizedTestMatrix new
 		addCase: { #rbClass -> ReRemoveInstanceVariableRefactoring .
 					  #constructor -> #variable:class: };
+		addCase: { #rbClass -> RBRemoveVariableTransformation .
+					  #constructor -> #instanceVariable:class: };
 		yourself
 ]
 
@@ -77,12 +79,6 @@ RBRemoveInstanceVariable2ParametrizedTest >> testRemoveNonLocalInstanceVariableP
 	self deny: (subsubclass directlyDefinesInstanceVariable: #foo1).
 	self assert: (subsubclass definesInstanceVariable: #foo1).
 	self assert: (subclass definesInstanceVariable: #foo1)
-]
-
-{ #category : 'failure tests' }
-RBRemoveInstanceVariable2ParametrizedTest >> testShouldWarnWhenVariableReferenced [
-
-	self shouldWarn: (self createRefactoringWithModel: model andArguments:  { 'name'. #RBLintRuleTestData })
 ]
 
 { #category : 'tests' }

--- a/src/Refactoring-Transformations-Tests/RBRemoveInstanceVariableRefactoringTest.class.st
+++ b/src/Refactoring-Transformations-Tests/RBRemoveInstanceVariableRefactoringTest.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : 'RBRemoveInstanceVariableRefactoringTest',
+	#superclass : 'RBAbstractRefactoringTest',
+	#category : 'Refactoring-Transformations-Tests-Test',
+	#package : 'Refactoring-Transformations-Tests',
+	#tag : 'Test'
+}
+
+{ #category : 'running' }
+RBRemoveInstanceVariableRefactoringTest >> setUp [
+
+	super setUp.
+	model := self modelOnClasses: { RBLintRuleTestData }
+]
+
+{ #category : 'failure tests' }
+RBRemoveInstanceVariableRefactoringTest >> testShouldWarnWhenVariableReferenced [
+
+	self shouldWarn: (ReRemoveInstanceVariableRefactoring
+					 model: model
+					 variable: 'name'
+					 class: #RBLintRuleTestData)
+]

--- a/src/Refactoring-Transformations/RBPullUpVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPullUpVariableTransformation.class.st
@@ -17,26 +17,27 @@ overriden from RBRemoveVariableTransformation and RBAddVariableAccessorTransform
 Class {
 	#name : 'RBPullUpVariableTransformation',
 	#superclass : 'RBCompositeVariableTransformation',
-	#category : 'Refactoring-Transformations-Model-Unused',
+	#category : 'Refactoring-Transformations-Model',
 	#package : 'Refactoring-Transformations',
-	#tag : 'Model-Unused'
+	#tag : 'Model'
 }
 
 { #category : 'preconditions' }
 RBPullUpVariableTransformation >> applicabilityPreconditions [
 
-	^ { (isClassVariable
-		   ifTrue: [
-			   (self definingClass hierarchyDefinesClassVariable: variableName)
-				   ifFalse: [
-				   self refactoringError: 'No subclass defines ' , variableName ].
-			   (RBCondition isMetaclass: self definingClass) not ]
-		   ifFalse: [
-			   RBCondition withBlock: [
-				   (self definingClass hierarchyDefinesInstanceVariable:
-					    variableName) ifFalse: [
-					   self refactoringError: 'No subclass defines ' , variableName ].
-				   true ] ]) }
+	^ isClassVariable
+		  ifTrue: [
+			  {
+				  (RBCondition isMetaclass: self definingClass) not.
+				  (ReHierarchyDefinesSharedVariableCondition new
+					   class: self definingClass;
+					   sharedVariables: { variableName };
+					   yourself) } ]
+		  ifFalse: [
+			  { (ReHierarchyDefinesInstanceVariableCondition new
+				    class: self definingClass;
+				    instanceVariables: { variableName };
+				    yourself) } ]
 ]
 
 { #category : 'executing' }

--- a/src/Refactoring-Transformations/RBPullUpVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPullUpVariableTransformation.class.st
@@ -75,5 +75,4 @@ RBPullUpVariableTransformation >> variableDefinitionsInHierarchy [
 			isClassVariable
 				ifTrue: [ each isMeta not and: [ each directlyDefinesClassVariable: variableName ] ]
 				ifFalse: [ each directlyDefinesInstanceVariable: variableName ] ]
-		thenCollect: #name
 ]

--- a/src/Refactoring-Transformations/RBPushDownClassVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RBPushDownClassVariableRefactoring.class.st
@@ -25,16 +25,6 @@ RBPushDownClassVariableRefactoring >> breakingChangePreconditions [
 ]
 
 { #category : 'preconditions' }
-RBPushDownClassVariableRefactoring >> findDestinationClasses [
-
-	| classes |
-	classes := class withAllSubclasses reject: [ :each |
-		(each whichSelectorsReferToClassVariable: variableName) isEmpty
-			and: [ (each classSide whichSelectorsReferToClassVariable: variableName) isEmpty ] ].
-	^ classes
-]
-
-{ #category : 'preconditions' }
 RBPushDownClassVariableRefactoring >> preconditionHasNoReferences [
 
     ^ (ReSharedVariableHasReferencesInDefiningClass

--- a/src/Refactoring-Transformations/RBPushDownClassVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RBPushDownClassVariableRefactoring.class.st
@@ -6,19 +6,16 @@ My precondition verifies that the moved variable is not referenced in the method
 Class {
 	#name : 'RBPushDownClassVariableRefactoring',
 	#superclass : 'RBVariableRefactoring',
+	#instVars : [
+		'transformation'
+	],
 	#category : 'Refactoring-Transformations',
 	#package : 'Refactoring-Transformations'
 }
 
 { #category : 'preconditions' }
 RBPushDownClassVariableRefactoring >> applicabilityPreconditions [
-
-	^ {
-    	(ReDirectlyDefinesSharedVariableCondition 
-        	class: class 
-        	sharedVariables: { variableName }).
-		self preconditionHasSubclass
-	 }
+	^ transformation applicabilityPreconditions
 ]
 
 { #category : 'preconditions' }
@@ -55,10 +52,20 @@ RBPushDownClassVariableRefactoring >> preconditionHasSubclass [
 
 { #category : 'transforming' }
 RBPushDownClassVariableRefactoring >> privateTransform [
+	^ transformation privateTransform
+]
 
-	| destinationClasses |
-	class removeClassVariable: variableName.
-	destinationClasses := self findDestinationClasses.
-	destinationClasses ifEmpty: [ ^ self ].
-	destinationClasses do: [ :aClass | aClass addClassVariable: variableName ]
+{ #category : 'initialization' }
+RBPushDownClassVariableRefactoring >> model: aRBNamespace [
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
+{ #category : 'initialization' }
+RBPushDownClassVariableRefactoring >> variable: aVarName class: aClassName [
+	super variable: aVarName class: aClassName.
+	transformation := RBPushDownVariableTransformation
+		model: self model
+		classVariable: aVarName
+		class: aClassName
 ]

--- a/src/Refactoring-Transformations/RBPushDownInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RBPushDownInstanceVariableRefactoring.class.st
@@ -6,14 +6,16 @@ My precondition verifies that the moved variable is not referenced in the method
 Class {
 	#name : 'RBPushDownInstanceVariableRefactoring',
 	#superclass : 'RBVariableRefactoring',
+	#instVars : [
+		'transformation'
+	],
 	#category : 'Refactoring-Transformations',
 	#package : 'Refactoring-Transformations'
 }
 
 { #category : 'preconditions' }
 RBPushDownInstanceVariableRefactoring >> applicabilityPreconditions [
-
-	^ { (RBCondition definesInstanceVariable: variableName in: class) }
+	^ transformation applicabilityPreconditions
 ]
 
 { #category : 'preconditions' }
@@ -36,6 +38,20 @@ RBPushDownInstanceVariableRefactoring >> preconditions [
 
 { #category : 'transforming' }
 RBPushDownInstanceVariableRefactoring >> privateTransform [
-	class removeInstanceVariable: variableName.
-	class subclasses do: [:each | each addInstanceVariable: variableName]
+	^ transformation privateTransform
+]
+
+{ #category : 'initialization' }
+RBPushDownInstanceVariableRefactoring >> model: aRBNamespace [
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
+{ #category : 'initialization' }
+RBPushDownInstanceVariableRefactoring >> variable: aVarName class: aClassName [
+	super variable: aVarName class: aClassName.
+	transformation := RBPushDownVariableTransformation
+		model: self model
+		instanceVariable: aVarName
+		class: aClassName
 ]

--- a/src/Refactoring-Transformations/RBPushDownVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBPushDownVariableTransformation.class.st
@@ -17,17 +17,28 @@ overriden from RBAddVariableTransformation and RBRemoveVariableAccessorTransform
 Class {
 	#name : 'RBPushDownVariableTransformation',
 	#superclass : 'RBCompositeVariableTransformation',
-	#category : 'Refactoring-Transformations-Model-Unused',
+	#category : 'Refactoring-Transformations-Model',
 	#package : 'Refactoring-Transformations',
-	#tag : 'Model-Unused'
+	#tag : 'Model'
 }
+
+{ #category : 'preconditions' }
+RBPushDownVariableTransformation >> applicabilityPreconditions [
+
+	^ isClassVariable
+		  ifTrue: [ self applicabilityPreconditionsForClassVariable ]
+		  ifFalse: [ self applicabilityPreconditionsForInstanceVariable ]
+]
 
 { #category : 'preconditions' }
 RBPushDownVariableTransformation >> applicabilityPreconditionsForClassVariable [
 
-	^ { RBCondition
-		  definesClassVariable: variableName
-		  in: self definingClass }
+	^ {
+		  (ReDirectlyDefinesSharedVariableCondition
+			   class: self definingClass
+			   sharedVariables: { variableName }).
+		  (ReClassesHaveNoSubclassesCondition new
+			   classes: { self definingClass }) not }
 ]
 
 { #category : 'preconditions' }
@@ -60,9 +71,7 @@ RBPushDownVariableTransformation >> buildTransformations [
 { #category : 'preconditions' }
 RBPushDownVariableTransformation >> preconditions [
 
-	^ isClassVariable
-		ifTrue: [ self applicabilityPreconditionsForClassVariable ]
-		ifFalse: [ self applicabilityPreconditionsForInstanceVariable ]
+	^ self applicabilityPreconditions
 ]
 
 { #category : 'api' }

--- a/src/Refactoring-Transformations/RBRemoveVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveVariableTransformation.class.st
@@ -20,9 +20,9 @@ Preconditions:
 Class {
 	#name : 'RBRemoveVariableTransformation',
 	#superclass : 'RBVariableTransformation',
-	#category : 'Refactoring-Transformations-Model-Unused',
+	#category : 'Refactoring-Transformations-Model',
 	#package : 'Refactoring-Transformations',
-	#tag : 'Model-Unused'
+	#tag : 'Model'
 }
 
 { #category : 'preconditions' }
@@ -38,15 +38,21 @@ RBRemoveVariableTransformation >> applicabilityPreconditions [
 { #category : 'preconditions' }
 RBRemoveVariableTransformation >> applicabilityPreconditionsForClassVariable [
 
-	^ { (RBCondition isMetaclass: class) not.
-	    (RBCondition definesClassVariable: variableName in: class) }
+	^ {
+		  (ReClassesAreNotMetaClassCondition new classes: { class }).
+		  (ReDirectlyDefinesSharedVariableCondition
+			   class: class
+			   sharedVariables: { variableName }) }
 ]
 
 { #category : 'preconditions' }
 RBRemoveVariableTransformation >> applicabilityPreconditionsForInstanceVariable [
 	"For now only remove an instance variable that is locally defined in a class."
 	
-	^ { (ReDirectlyDefinesInstanceVariableCondition class: class inModel: self model instanceVariables: { variableName }) }
+	^ { (ReDirectlyDefinesInstanceVariableCondition
+		   classNamed: class name
+		   inModel: self model
+		   instanceVariables: { variableName }) }
 ]
 
 { #category : 'executing' }

--- a/src/Refactoring-Transformations/RBRemoveVariableTransformation.class.st
+++ b/src/Refactoring-Transformations/RBRemoveVariableTransformation.class.st
@@ -50,7 +50,7 @@ RBRemoveVariableTransformation >> applicabilityPreconditionsForInstanceVariable 
 	"For now only remove an instance variable that is locally defined in a class."
 	
 	^ { (ReDirectlyDefinesInstanceVariableCondition
-		   classNamed: class name
+		   class: class
 		   inModel: self model
 		   instanceVariables: { variableName }) }
 ]

--- a/src/Refactoring-Transformations/RePullUpInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RePullUpInstanceVariableRefactoring.class.st
@@ -5,22 +5,16 @@ I am a refactoring for moving an instance variable up **to** the superclass of t
 Class {
 	#name : 'RePullUpInstanceVariableRefactoring',
 	#superclass : 'RBVariableRefactoring',
+	#instVars : [
+		'transformation'
+	],
 	#category : 'Refactoring-Transformations',
 	#package : 'Refactoring-Transformations'
 }
 
 { #category : 'preconditions' }
 RePullUpInstanceVariableRefactoring >> applicabilityPreconditions [
-
-	"^ { (RBCondition withBlock: [
-		   (class hierarchyDefinesInstanceVariable: variableName) ifFalse: [
-			   self refactoringError: 'No subclass defines ' , variableName ].
-		   true ]) }"
-	
-	"we will have to handle multiple variables"
-"	^ { ReHierarchyDefinesInstanceVariableCondition new instanceVariables: { variableName } ; yourself}"
-	
-	^ { (ReHierarchyDefinesInstanceVariableCondition new class: class; instanceVariables: { variableName }; yourself) }
+	^ transformation applicabilityPreconditions
 ]
 
 { #category : 'preconditions' }
@@ -36,13 +30,22 @@ RePullUpInstanceVariableRefactoring >> breakingChangePreconditions [
 
 { #category : 'transforming' }
 RePullUpInstanceVariableRefactoring >> privateTransform [
-	"Remove all the variables in the hierarchy below the classes and define one on the top."
-	
-	class allSubclasses do:
-			[:each |
-			(each directlyDefinesInstanceVariable: variableName)
-				ifTrue: [each removeInstanceVariable: variableName]].
-	class addInstanceVariable: variableName
+	^ transformation privateTransform
+]
+
+{ #category : 'initialization' }
+RePullUpInstanceVariableRefactoring >> model: aRBNamespace [
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
+{ #category : 'initialization' }
+RePullUpInstanceVariableRefactoring >> variable: aVarName class: aClassName [
+	super variable: aVarName class: aClassName.
+	transformation := RBPullUpVariableTransformation
+		model: self model
+		instanceVariable: aVarName
+		class: aClassName
 ]
 
 { #category : 'preconditions' }

--- a/src/Refactoring-Transformations/RePullUpSharedVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/RePullUpSharedVariableRefactoring.class.st
@@ -4,19 +4,16 @@ I am a refactoring for moving a class variable up to the superclass.
 Class {
 	#name : 'RePullUpSharedVariableRefactoring',
 	#superclass : 'RBVariableRefactoring',
+	#instVars : [
+		'transformation'
+	],
 	#category : 'Refactoring-Transformations',
 	#package : 'Refactoring-Transformations'
 }
 
 { #category : 'preconditions' }
 RePullUpSharedVariableRefactoring >> applicabilityPreconditions [
-
-	^ {
-		  (RBCondition isMetaclass: class) not.
-		  (ReHierarchyDefinesSharedVariableCondition new
-			   class: class;
-			   sharedVariables: { variableName };
-			   yourself) }
+	^ transformation applicabilityPreconditions
 ]
 
 { #category : 'preconditions' }
@@ -34,11 +31,20 @@ RePullUpSharedVariableRefactoring >> breakingChangePreconditions [
 
 { #category : 'transforming' }
 RePullUpSharedVariableRefactoring >> privateTransform [
-	"Remove all the variables in the hierarchy below the classes and define one on the top."
-	
-	class allSubclasses do:
-		[:each |
-		(each directlyDefinesClassVariable: variableName)
-			ifTrue: [each removeClassVariable: variableName]].
-	class addClassVariable: variableName
+	^ transformation privateTransform
+]
+
+{ #category : 'initialization' }
+RePullUpSharedVariableRefactoring >> model: aRBNamespace [
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
+{ #category : 'initialization' }
+RePullUpSharedVariableRefactoring >> variable: aVarName class: aClassName [
+	super variable: aVarName class: aClassName.
+	transformation := RBPullUpVariableTransformation
+		model: self model
+		classVariable: aVarName
+		class: aClassName
 ]

--- a/src/Refactoring-Transformations/ReRemoveClassRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReRemoveClassRefactoring.class.st
@@ -10,7 +10,8 @@ Class {
 	#superclass : 'ReRefactoring',
 	#instVars : [
 		'classNames',
-		'classesDictionary'
+		'classesDictionary',
+		'transformation'
 	],
 	#category : 'Refactoring-Transformations',
 	#package : 'Refactoring-Transformations'
@@ -40,9 +41,7 @@ ReRemoveClassRefactoring class >> model: aRBSmalltalk classNames: aClassNameColl
 { #category : 'preconditions' }
 ReRemoveClassRefactoring >> applicabilityPreconditions [
 
-	^ {
-		  (ReClassesExistCondition new classes: classesDictionary).
-		  self preconditionAreNotMeta }
+	^ transformation applicabilityPreconditions
 ]
 
 { #category : 'preconditions' }
@@ -68,7 +67,17 @@ ReRemoveClassRefactoring >> classNames [
 
 { #category : 'initialization' }
 ReRemoveClassRefactoring >> classNames: aClassNameCollection [
-	classNames := aClassNameCollection
+	classNames := aClassNameCollection.
+	transformation := ReRemoveClassesTransformation
+				  model: self model
+				  classNames: classNames
+]
+
+{ #category : 'accessing' }
+ReRemoveClassRefactoring >> model: aRBNamespace [
+
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
 ]
 
 { #category : 'preconditions' }
@@ -118,7 +127,8 @@ ReRemoveClassRefactoring >> prepareForExecution [
 
 	classesDictionary := (classNames collect: [ :className |
 		            className -> (self model classNamed: className) ])
-		           asDictionary
+		           asDictionary.
+	transformation prepareForExecution
 ]
 
 { #category : 'preparation' }
@@ -129,9 +139,8 @@ ReRemoveClassRefactoring >> prepareForInteractiveMode [
 
 { #category : 'transforming' }
 ReRemoveClassRefactoring >> privateTransform [
-	self
-		reparentSubclasses;
-		removeClasses
+
+	transformation privateTransform
 ]
 
 { #category : 'removing' }
@@ -145,14 +154,12 @@ ReRemoveClassRefactoring >> removeClassChanges [
 
 { #category : 'transforming' }
 ReRemoveClassRefactoring >> removeClasses [
-	classNames do: [:each | self model removeClassNamed: each]
+
+	transformation removeClasses
 ]
 
 { #category : 'transforming' }
 ReRemoveClassRefactoring >> reparentSubclasses [
-	classNames do:
-			[:each |
-			| class |
-			class := self model classNamed: each.
-			self model reparentClasses: class subclasses copy to: class superclass]
+
+	transformation reparentSubclasses
 ]

--- a/src/Refactoring-Transformations/ReRemoveClassesTransformation.class.st
+++ b/src/Refactoring-Transformations/ReRemoveClassesTransformation.class.st
@@ -87,7 +87,7 @@ ReRemoveClassesTransformation >> classNames: aClassNameCollection [
 ReRemoveClassesTransformation >> preconditionAreNotMeta [
 
 	^ ReClassesAreNotMetaClassCondition new
-		  classes: classesDictionary;
+		  classes: (classesDictionary values reject: [ :class | class isNil ]);
 		  message: 'Metaclasses can be removed. Remove their class.'
 ]
 

--- a/src/Refactoring-Transformations/ReRemoveClassesTransformation.class.st
+++ b/src/Refactoring-Transformations/ReRemoveClassesTransformation.class.st
@@ -87,7 +87,7 @@ ReRemoveClassesTransformation >> classNames: aClassNameCollection [
 ReRemoveClassesTransformation >> preconditionAreNotMeta [
 
 	^ ReClassesAreNotMetaClassCondition new
-		  classes: (classesDictionary values reject: [ :class | class isNil ]);
+		  classes: (classesDictionary values reject: [ :eachClass | eachClass isNil ]);
 		  message: 'Metaclasses can be removed. Remove their class.'
 ]
 

--- a/src/Refactoring-Transformations/ReRemoveClassesTransformation.class.st
+++ b/src/Refactoring-Transformations/ReRemoveClassesTransformation.class.st
@@ -34,9 +34,9 @@ Class {
 		'classesDictionary',
 		'classNames'
 	],
-	#category : 'Refactoring-Transformations-Model-Unused',
+	#category : 'Refactoring-Transformations-Model',
 	#package : 'Refactoring-Transformations',
-	#tag : 'Model-Unused'
+	#tag : 'Model'
 }
 
 { #category : 'private' }
@@ -71,12 +71,6 @@ ReRemoveClassesTransformation >> applicabilityPreconditions [
 		  self preconditionAreNotMeta }
 ]
 
-{ #category : 'preconditions' }
-ReRemoveClassesTransformation >> breakingChangePreconditions [
-
-	^ { self preconditionHaveNoReferences }
-]
-
 { #category : 'accessing' }
 ReRemoveClassesTransformation >> classNames [
 
@@ -95,21 +89,6 @@ ReRemoveClassesTransformation >> preconditionAreNotMeta [
 	^ ReClassesAreNotMetaClassCondition new
 		  classes: classesDictionary;
 		  message: 'Metaclasses can be removed. Remove their class.'
-]
-
-{ #category : 'preconditions' }
-ReRemoveClassesTransformation >> preconditionHaveNoReferences [
-
-	^ ReClassesHaveNoReferencesCondition new
-		  model: model;
-		  classes: classesDictionary values 
-]
-
-{ #category : 'preconditions' }
-ReRemoveClassesTransformation >> preconditions [
-	"We hope in the future to push up this method to RBRefactoring"
-
-	^ self applicabilityPreconditions & self breakingChangePreconditions
 ]
 
 { #category : 'transforming' }

--- a/src/Refactoring-Transformations/ReRemoveInstanceVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReRemoveInstanceVariableRefactoring.class.st
@@ -5,6 +5,9 @@ The variable should not be used obviously.
 Class {
 	#name : 'ReRemoveInstanceVariableRefactoring',
 	#superclass : 'RBVariableRefactoring',
+	#instVars : [
+		'transformation'
+	],
 	#category : 'Refactoring-Transformations',
 	#package : 'Refactoring-Transformations'
 }
@@ -27,12 +30,8 @@ ReRemoveInstanceVariableRefactoring class >> remove: variable from: class [
 
 { #category : 'preconditions' }
 ReRemoveInstanceVariableRefactoring >> applicabilityPreconditions [
-	"we store it because the violators are computed during check so we should not recreate it each time."
 
-	^ { (ReDirectlyDefinesInstanceVariableCondition
-		   classNamed: class name
-		   inModel: self model
-		   instanceVariables: { variableName }) }
+	^ transformation applicabilityPreconditions
 ]
 
 { #category : 'preconditions' }
@@ -68,10 +67,27 @@ ReRemoveInstanceVariableRefactoring >> printOn: aStream [
 { #category : 'transforming' }
 ReRemoveInstanceVariableRefactoring >> privateTransform [
 
-	class removeInstanceVariable: variableName
+	transformation privateTransform
 ]
 
 { #category : 'accessing' }
 ReRemoveInstanceVariableRefactoring >> refactoredClass [
 	^ class
+]
+
+{ #category : 'accessing' }
+ReRemoveInstanceVariableRefactoring >> model: aRBNamespace [
+
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
+{ #category : 'initialization' }
+ReRemoveInstanceVariableRefactoring >> variable: aVarName class: aClassName [
+
+	super variable: aVarName class: aClassName.
+	transformation := RBRemoveVariableTransformation
+				  model: self model
+				  instanceVariable: aVarName
+				  class: aClassName
 ]

--- a/src/Refactoring-Transformations/ReRemoveSharedVariableRefactoring.class.st
+++ b/src/Refactoring-Transformations/ReRemoveSharedVariableRefactoring.class.st
@@ -4,6 +4,9 @@ A simple refactoring to remove a shared variable.
 Class {
 	#name : 'ReRemoveSharedVariableRefactoring',
 	#superclass : 'RBVariableRefactoring',
+	#instVars : [
+		'transformation'
+	],
 	#category : 'Refactoring-Transformations',
 	#package : 'Refactoring-Transformations'
 }
@@ -29,11 +32,7 @@ ReRemoveSharedVariableRefactoring class >> remove: variable from: class [
 { #category : 'preconditions' }
 ReRemoveSharedVariableRefactoring >> applicabilityPreconditions [
 
-	^ {
-		  (ReClassesAreNotMetaClassCondition new classes: { class }).
-		  (ReDirectlyDefinesSharedVariableCondition
-			   class: class
-			   sharedVariables: { variableName }) }
+	^ transformation applicabilityPreconditions
 ]
 
 { #category : 'preconditions' }
@@ -52,11 +51,29 @@ ReRemoveSharedVariableRefactoring >> preconditions [
 
 { #category : 'transforming' }
 ReRemoveSharedVariableRefactoring >> privateTransform [
-	class removeClassVariable: variableName
+
+	transformation privateTransform
 ]
 
 { #category : 'accessing' }
 ReRemoveSharedVariableRefactoring >> refactoredClass [
 
 	^ class
+]
+
+{ #category : 'accessing' }
+ReRemoveSharedVariableRefactoring >> model: aRBNamespace [
+
+	super model: aRBNamespace.
+	transformation ifNotNil: [ transformation model: aRBNamespace ]
+]
+
+{ #category : 'initialization' }
+ReRemoveSharedVariableRefactoring >> variable: aVarName class: aClassName [
+
+	super variable: aVarName class: aClassName.
+	transformation := RBRemoveVariableTransformation
+				  model: self model
+				  classVariable: aVarName
+				  class: aClassName
 ]


### PR DESCRIPTION
This PR continues migration and removal of duplicated code between refactorings and transformations. The idea is that refactoring is a decorator over transformation that adds behavior-preservation. Here variable refactorings are migrated (remove, push down, pull up of instance and class variables). Besides, small fixes are included:
  - Restore missing-class validation for class removal to the normal applicability precondition flow.
  - Prevent missing remove-class targets from triggering `nil isMeta` during applicability inspection.
  - Add coverage that missing classes surface as `ReClassesExistCondition` violations.
  - Remove unused push-down class-variable helper and avoid redundant class lookup in variable removal.